### PR TITLE
[SPARK-57737][SPARK-57769][SQL] Speed up date_trunc zone offset resolution with a per-task cache

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3492,11 +3492,15 @@ case class TruncTimestamp(
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val zid = ctx.addReferenceObj("zoneId", zoneIdInEval, classOf[ZoneId].getName)
+    // Per-task offset cache so the hot path avoids a transition-array binary search per row.
+    val cacheClass = classOf[org.apache.spark.sql.catalyst.util.ZoneOffsetCache].getName
+    val cache = ctx.addMutableState(cacheClass, "zoneOffsetCache",
+      v => s"$v = new $cacheClass($zid);", forceInline = true)
     codeGenHelper(ctx, ev, minLevel = MIN_LEVEL_OF_TIMESTAMP_TRUNC, true) {
       (date: String, fmt: String) =>
         timestamp.dataType match {
-          case _: AnyTimestampNanoType => s"truncTimestampNanos($date, $fmt, $zid);"
-          case _ => s"truncTimestamp($date, $fmt, $zid);"
+          case _: AnyTimestampNanoType => s"truncTimestampNanos($date, $fmt, $cache);"
+          case _ => s"truncTimestamp($date, $fmt, $cache);"
         }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3297,11 +3297,15 @@ case class TruncTimestamp(
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val zid = ctx.addReferenceObj("zoneId", zoneIdInEval, classOf[ZoneId].getName)
+    // Per-task offset cache so the hot path avoids a transition-array binary search per row.
+    val cacheClass = classOf[org.apache.spark.sql.catalyst.util.ZoneOffsetCache].getName
+    val cache = ctx.addMutableState(cacheClass, "zoneOffsetCache",
+      v => s"$v = new $cacheClass($zid);", forceInline = true)
     codeGenHelper(ctx, ev, minLevel = MIN_LEVEL_OF_TIMESTAMP_TRUNC, true) {
       (date: String, fmt: String) =>
         timestamp.dataType match {
-          case _: AnyTimestampNanoType => s"truncTimestampNanos($date, $fmt, $zid);"
-          case _ => s"truncTimestamp($date, $fmt, $zid);"
+          case _: AnyTimestampNanoType => s"truncTimestampNanos($date, $fmt, $cache);"
+          case _ => s"truncTimestamp($date, $fmt, $cache);"
         }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3304,7 +3304,10 @@ trait TruncInstant extends BinaryExpression with ImplicitCastInputTypes {
       orderReversed: Boolean = false)(
       truncFunc: (String, String) => String)
     : ExprCode = {
-    val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
+    // Call through the module instance rather than the class's static forwarders: Scala emits no
+    // forwarder for private[sql] members, and the cache-taking truncTimestamp overloads are
+    // module-visible only.
+    val dtu = DateTimeUtils.getClass.getName + ".MODULE$"
 
     val javaType = CodeGenerator.javaType(dataType)
     if (format.foldable) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -1460,10 +1460,12 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
           hi = Long.MaxValue
         } else {
           hi = nextT.toEpochSecond
-          // `hi - 1` lies strictly inside the constant-offset window ending at `hi` (zone
-          // transitions are always more than a second apart), so its previous transition is
-          // exactly that window's start. Anchoring on an interior point avoids an off-by-one
-          // when `epochSec` sits exactly on a transition instant.
+          // Transition instants in `ZoneRules` are a strictly-increasing sequence of epoch
+          // *seconds* (`savingsInstantTransitions`, as TZif/RFC 8536 encodes them), so any two
+          // consecutive transitions are >= 1s apart by construction. So `hi - 1` is strictly
+          // inside the constant-offset window ending at `hi`, and its previous transition is that
+          // window's start -- anchoring on an interior point avoids an off-by-one when `epochSec`
+          // sits exactly on a transition instant.
           val prevT = rules.previousTransition(Instant.ofEpochSecond(hi - 1))
           lo = if (prevT == null) Long.MinValue else prevT.toEpochSecond
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -569,14 +569,28 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
+   * Truncates the timestamp `micros` to `level` in `zoneId`. `level` should be generated using
+   * `parseTruncLevel()`, between 0 and 9.
+   *
+   * Convenience variant that resolves the zone offset from a fresh single-use [[ZoneOffsetCache]];
+   * intended for one-shot callers such as interpreted evaluation and constant folding. The codegen
+   * hot path instead calls the [[ZoneOffsetCache]]-based overload directly with a per-task cache so
+   * the offset is reused across rows. The result is identical to that overload.
+   */
+  def truncTimestamp(micros: Long, level: Int, zoneId: ZoneId): Long =
+    truncTimestamp(micros, level, new ZoneOffsetCache(zoneId))
+
+  /**
    * Returns the trunc date time from original date time and trunc level.
    * Trunc level should be generated using `parseTruncLevel()`, should be between 0 and 9.
    *
-   * Uses an offset-arithmetic fast path: the zone offset at `micros` is resolved once,
-   * truncation runs in the shifted-local frame, and the result is shifted back to UTC
-   * micros. Falls back to [[truncTimestampSlow]] when the offset at the candidate
-   * truncated instant differs from the offset at `micros` (DST/historical transition
-   * spans the candidate; SPARK-30766/30857) or on arithmetic overflow.
+   * Uses an offset-arithmetic fast path: the zone offset at `micros` is resolved once through
+   * `cache`, which memoizes it over the constant-offset interval around the last lookup, so for
+   * temporally clustered data the per-row transition-array binary search collapses to two
+   * comparisons. Truncation then runs in the shifted-local frame, and the result is shifted back
+   * to UTC micros. Falls back to [[truncTimestampSlow]] when the offset at the candidate truncated
+   * instant differs from the offset at `micros` (DST/historical transition spans the candidate;
+   * SPARK-30766/30857) or on arithmetic overflow.
    *
    * Sub-minute LMT offsets (e.g. America/Los_Angeles -07:52:58 pre-1883, see
    * SPARK-33404) and 30/45-minute offsets (Asia/Kolkata +05:30, Asia/Kathmandu +05:45)
@@ -594,7 +608,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
    *   - WEEK/MONTH/QUARTER/YEAR: convert local micros to local epoch-day, run
    *     [[truncDate]] in the local-day frame, multiply back to local micros.
    */
-  def truncTimestamp(micros: Long, level: Int, zoneId: ZoneId): Long = {
+  def truncTimestamp(micros: Long, level: Int, cache: ZoneOffsetCache): Long = {
     // MICROSECOND / MILLISECOND / SECOND don't need zone information.
     level match {
       case TRUNC_TO_MICROSECOND => return micros
@@ -604,10 +618,8 @@ object DateTimeUtils extends SparkDateTimeUtils {
         return Math.subtractExact(micros, Math.floorMod(micros, MICROS_PER_SECOND))
       case _ =>
     }
-    val rules = zoneId.getRules
     val originalSec = Math.floorDiv(micros, MICROS_PER_SECOND)
-    val originalOffsetSec =
-      rules.getOffset(Instant.ofEpochSecond(originalSec)).getTotalSeconds.toLong
+    val originalOffsetSec = cache.offsetSeconds(originalSec)
     val offsetMicros = originalOffsetSec * MICROS_PER_SECOND
     try {
       val local = Math.addExact(micros, offsetMicros)
@@ -623,17 +635,16 @@ object DateTimeUtils extends SparkDateTimeUtils {
           Math.multiplyExact(truncDate(localDays, level).toLong, MICROS_PER_DAY)
       }
       val candidate = Math.subtractExact(truncatedLocal, offsetMicros)
-      if (!rules.isFixedOffset) {
+      if (!cache.isFixedOffset) {
         val candidateSec = Math.floorDiv(candidate, MICROS_PER_SECOND)
-        val candidateOffsetSec =
-          rules.getOffset(Instant.ofEpochSecond(candidateSec)).getTotalSeconds.toLong
+        val candidateOffsetSec = cache.offsetSeconds(candidateSec)
         if (candidateOffsetSec != originalOffsetSec) {
-          return truncTimestampSlow(micros, level, zoneId)
+          return truncTimestampSlow(micros, level, cache.zoneId)
         }
       }
       candidate
     } catch {
-      case _: ArithmeticException => truncTimestampSlow(micros, level, zoneId)
+      case _: ArithmeticException => truncTimestampSlow(micros, level, cache.zoneId)
     }
   }
 
@@ -669,6 +680,19 @@ object DateTimeUtils extends SparkDateTimeUtils {
       level: Int,
       zoneId: ZoneId): TimestampNanosVal = {
     val truncatedMicros = truncTimestamp(value.epochMicros, level, zoneId)
+    TimestampNanosVal.fromParts(truncatedMicros, 0.toShort)
+  }
+
+  /**
+   * Same as [[truncTimestampNanos]] above, but resolving the zone offset through a per-task
+   * [[ZoneOffsetCache]]. Used by the generated code so nanosecond `date_trunc` shares the
+   * microsecond fast path's memoization.
+   */
+  def truncTimestampNanos(
+      value: TimestampNanosVal,
+      level: Int,
+      cache: ZoneOffsetCache): TimestampNanosVal = {
+    val truncatedMicros = truncTimestamp(value.epochMicros, level, cache)
     TimestampNanosVal.fromParts(truncatedMicros, 0.toShort)
   }
 
@@ -1391,5 +1415,62 @@ object DateTimeUtils extends SparkDateTimeUtils {
       c = candidate(k)
     }
     c
+  }
+}
+
+/**
+ * Per-task memoization of a zone's UTC offset, used by the [[DateTimeUtils.truncTimestamp]] hot
+ * path. The session zone is constant for a query and the offset is piecewise-constant between DST
+ * transitions, so consecutive rows almost always resolve to the same offset. The cache holds the
+ * half-open epoch-second interval `[lo, hi)` on which the offset is provably constant -- derived
+ * from the surrounding zone transitions -- so a lookup that falls in the interval reduces to two
+ * comparisons instead of a transition-array binary search.
+ *
+ * Not thread-safe by design: a fresh instance is created per task (codegen mutable state) and used
+ * single-threaded, mirroring how stateful per-row helpers are scoped in generated code.
+ */
+class ZoneOffsetCache(val zoneId: ZoneId) {
+  private val rules = zoneId.getRules
+  val isFixedOffset: Boolean = rules.isFixedOffset
+
+  private var cached = false
+  private var lo = 0L
+  private var hi = 0L
+  private var offsetSec = 0L
+
+  /**
+   * Offset in seconds at `epochSec`, equal to
+   * `rules.getOffset(Instant.ofEpochSecond(epochSec)).getTotalSeconds`, memoized over the
+   * constant-offset interval containing the previous lookup.
+   */
+  def offsetSeconds(epochSec: Long): Long = {
+    if (cached && epochSec >= lo && epochSec < hi) {
+      offsetSec
+    } else {
+      val instant = Instant.ofEpochSecond(epochSec)
+      val o = rules.getOffset(instant).getTotalSeconds.toLong
+      if (isFixedOffset) {
+        lo = Long.MinValue
+        hi = Long.MaxValue
+      } else {
+        val nextT = rules.nextTransition(instant)
+        if (nextT == null) {
+          // No transition after `instant`: offset is constant on [epochSec, +inf).
+          lo = epochSec
+          hi = Long.MaxValue
+        } else {
+          hi = nextT.toEpochSecond
+          // `hi - 1` lies strictly inside the constant-offset window ending at `hi` (zone
+          // transitions are always more than a second apart), so its previous transition is
+          // exactly that window's start. Anchoring on an interior point avoids an off-by-one
+          // when `epochSec` sits exactly on a transition instant.
+          val prevT = rules.previousTransition(Instant.ofEpochSecond(hi - 1))
+          lo = if (prevT == null) Long.MinValue else prevT.toEpochSecond
+        }
+      }
+      offsetSec = o
+      cached = true
+      o
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -623,6 +623,13 @@ object DateTimeUtils extends SparkDateTimeUtils {
     val offsetMicros = originalOffsetSec * MICROS_PER_SECOND
     try {
       val local = Math.addExact(micros, offsetMicros)
+      // For date-level truncation keep the truncated local day: `local`'s day equals
+      // `microsToDays(micros, zoneId)` (both use the same `originalOffsetSec`), so on a DST-cross
+      // fallback `daysToMicros(truncatedDays)` reproduces the slow path exactly without re-deriving
+      // the day through a second `ZonedDateTime`.
+      val isDateLevel = level >= MIN_LEVEL_OF_DATE_TRUNC
+      val truncatedDays =
+        if (isDateLevel) truncDate(Math.floorDiv(local, MICROS_PER_DAY).toInt, level) else 0
       val truncatedLocal = level match {
         case TRUNC_TO_MINUTE =>
           Math.subtractExact(local, Math.floorMod(local, MICROS_PER_MINUTE))
@@ -631,15 +638,18 @@ object DateTimeUtils extends SparkDateTimeUtils {
         case TRUNC_TO_DAY =>
           Math.subtractExact(local, Math.floorMod(local, MICROS_PER_DAY))
         case _ => // Date-level truncation: WEEK / MONTH / QUARTER / YEAR.
-          val localDays = Math.floorDiv(local, MICROS_PER_DAY).toInt
-          Math.multiplyExact(truncDate(localDays, level).toLong, MICROS_PER_DAY)
+          Math.multiplyExact(truncatedDays.toLong, MICROS_PER_DAY)
       }
       val candidate = Math.subtractExact(truncatedLocal, offsetMicros)
       if (!cache.isFixedOffset) {
         val candidateSec = Math.floorDiv(candidate, MICROS_PER_SECOND)
         val candidateOffsetSec = cache.offsetSecondsReadOnly(candidateSec)
         if (candidateOffsetSec != originalOffsetSec) {
-          return truncTimestampSlow(micros, level, cache.zoneId)
+          // The truncation boundary crosses a transition. Date levels resolve it by mapping the
+          // already-truncated local day back through the zone; other levels defer to the reference
+          // slow path.
+          return if (isDateLevel) daysToMicros(truncatedDays, cache.zoneId)
+            else truncTimestampSlow(micros, level, cache.zoneId)
         }
       }
       candidate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -679,24 +679,26 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
-   * Truncates a nanosecond-precision timestamp to the unit given by `level`. `epochMicros` is
-   * truncated with the same [[truncTimestamp]] used by microsecond timestamps, and the
-   * sub-microsecond `nanosWithinMicro` is always dropped: `date_trunc`'s finest supported unit
-   * is MICROSECOND (see `MIN_LEVEL_OF_TIMESTAMP_TRUNC`), which already discards everything below
-   * a microsecond. NTZ vs. LTZ zone handling is the caller's responsibility via `zoneId`.
+   * Truncates the nanosecond-precision timestamp `value` to `level`. `level` should be generated
+   * using `parseTruncLevel()`, between 0 and 9.
+   *
+   * Convenience variant that resolves the zone offset from a fresh single-use [[ZoneOffsetCache]];
+   * intended for one-shot callers such as interpreted evaluation. The codegen hot path instead
+   * calls the [[ZoneOffsetCache]]-based overload directly with a per-task cache so the offset is
+   * reused across rows. The result is identical to that overload.
    */
   def truncTimestampNanos(
       value: TimestampNanosVal,
       level: Int,
-      zoneId: ZoneId): TimestampNanosVal = {
-    val truncatedMicros = truncTimestamp(value.epochMicros, level, zoneId)
-    TimestampNanosVal.fromParts(truncatedMicros, 0.toShort)
-  }
+      zoneId: ZoneId): TimestampNanosVal =
+    truncTimestampNanos(value, level, new ZoneOffsetCache(zoneId))
 
   /**
-   * Same as [[truncTimestampNanos]] above, but resolving the zone offset through a per-task
-   * [[ZoneOffsetCache]]. Used by the generated code so nanosecond `date_trunc` shares the
-   * microsecond fast path's memoization.
+   * Truncates a nanosecond-precision timestamp to the unit given by `level`. `epochMicros` is
+   * truncated with the same [[truncTimestamp]] used by microsecond timestamps, and the
+   * sub-microsecond `nanosWithinMicro` is always dropped: `date_trunc`'s finest supported unit
+   * is MICROSECOND (see `MIN_LEVEL_OF_TIMESTAMP_TRUNC`), which already discards everything below
+   * a microsecond. NTZ vs. LTZ zone handling is the caller's responsibility via the cache's zone.
    */
   def truncTimestampNanos(
       value: TimestampNanosVal,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -637,7 +637,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
       val candidate = Math.subtractExact(truncatedLocal, offsetMicros)
       if (!cache.isFixedOffset) {
         val candidateSec = Math.floorDiv(candidate, MICROS_PER_SECOND)
-        val candidateOffsetSec = cache.offsetSeconds(candidateSec)
+        val candidateOffsetSec = cache.offsetSecondsReadOnly(candidateSec)
         if (candidateOffsetSec != originalOffsetSec) {
           return truncTimestampSlow(micros, level, cache.zoneId)
         }
@@ -1419,12 +1419,83 @@ object DateTimeUtils extends SparkDateTimeUtils {
 }
 
 /**
+ * A zone's transition schedule as primitive arrays: the sorted epoch-second transition instants
+ * (`transSec`) and the UTC offset (in seconds) in effect on each window `[transSec(i),
+ * transSec(i + 1))` (`offAfter(i)`); `offBefore0` is the offset before the first transition. Built
+ * once per zone from the historical transitions plus rule-generated ones up to `horizonSec` (beyond
+ * that the rules are consulted directly). Immutable and shared read-only across tasks via
+ * [[ZoneOffsetCache.tableFor]].
+ */
+private[util] final class ZoneTransitionTable(
+    val transSec: Array[Long],
+    val offAfter: Array[Int],
+    val offBefore0: Int,
+    val horizonSec: Long) {
+
+  /** Largest `i` with `transSec(i) <= epochSec`, or -1 when before the first transition. */
+  def floorIndex(epochSec: Long): Int = {
+    var lo = 0
+    var hi = transSec.length - 1
+    var res = -1
+    while (lo <= hi) {
+      val mid = (lo + hi) >>> 1
+      if (transSec(mid) <= epochSec) {
+        res = mid
+        lo = mid + 1
+      } else {
+        hi = mid - 1
+      }
+    }
+    res
+  }
+}
+
+object ZoneOffsetCache {
+  // The transition table is the same for every task using a given zone, so build it once per JVM.
+  private val tables = new java.util.concurrent.ConcurrentHashMap[ZoneId, ZoneTransitionTable]()
+  private val tableStart = Instant.parse("1600-01-01T00:00:00Z")
+  private val tableHorizon = Instant.parse("2200-01-01T00:00:00Z")
+
+  private[util] def tableFor(zoneId: ZoneId): ZoneTransitionTable =
+    tables.computeIfAbsent(zoneId, z => buildTable(z))
+
+  private def buildTable(zoneId: ZoneId): ZoneTransitionTable = {
+    val rules = zoneId.getRules
+    val secs = scala.collection.mutable.ArrayBuffer.empty[Long]
+    val offs = scala.collection.mutable.ArrayBuffer.empty[Int]
+    var before0 = 0
+    var seen = false
+    var cur = tableStart
+    var t = rules.nextTransition(cur)
+    while (t != null && t.getInstant.isBefore(tableHorizon)) {
+      if (!seen) {
+        before0 = t.getOffsetBefore.getTotalSeconds
+        seen = true
+      }
+      secs += t.toEpochSecond
+      offs += t.getOffsetAfter.getTotalSeconds
+      // `plusNanos(1)` guarantees progress; transitions are >= 1s apart so none is skipped.
+      cur = t.getInstant.plusNanos(1)
+      t = rules.nextTransition(cur)
+    }
+    if (!seen) {
+      before0 = rules.getOffset(tableStart).getTotalSeconds
+    }
+    new ZoneTransitionTable(secs.toArray, offs.toArray, before0, tableHorizon.getEpochSecond)
+  }
+}
+
+/**
  * Per-task memoization of a zone's UTC offset, used by the [[DateTimeUtils.truncTimestamp]] hot
  * path. The session zone is constant for a query and the offset is piecewise-constant between DST
- * transitions, so consecutive rows almost always resolve to the same offset. The cache holds the
- * half-open epoch-second interval `[lo, hi)` on which the offset is provably constant -- derived
- * from the surrounding zone transitions -- so a lookup that falls in the interval reduces to two
- * comparisons instead of a transition-array binary search.
+ * transitions, so a lookup reduces to a range check against a cached constant-offset window
+ * `[lo, hi)`.
+ *
+ * The most-recently-used window is held in plain fields, a branch-only fast path that temporally
+ * clustered rows -- the common case -- keep hitting. A miss resolves the enclosing window
+ * with a single binary search over the shared [[ZoneTransitionTable]] (no allocation), which is
+ * itself cheaper than a bare `getOffset`, so even miss-heavy inputs (e.g. instants scattered over
+ * many decades in random order) stay close to the uncached path.
  *
  * Not thread-safe by design: a fresh instance is created per task (codegen mutable state) and used
  * single-threaded, mirroring how stateful per-row helpers are scoped in generated code.
@@ -1432,47 +1503,86 @@ object DateTimeUtils extends SparkDateTimeUtils {
 class ZoneOffsetCache(val zoneId: ZoneId) {
   private val rules = zoneId.getRules
   val isFixedOffset: Boolean = rules.isFixedOffset
+  private val table = if (isFixedOffset) null else ZoneOffsetCache.tableFor(zoneId)
+  private val fixedOffsetSec =
+    if (isFixedOffset) rules.getOffset(Instant.EPOCH).getTotalSeconds.toLong else 0L
 
-  private var cached = false
-  private var lo = 0L
-  private var hi = 0L
-  private var offsetSec = 0L
+  // Most-recently-used window [mruLo, mruHi) -> mruOff, in fields for a branch-only fast path.
+  private var mruLo = Long.MaxValue
+  private var mruHi = Long.MinValue
+  private var mruOff = 0L
 
   /**
    * Offset in seconds at `epochSec`, equal to
    * `rules.getOffset(Instant.ofEpochSecond(epochSec)).getTotalSeconds`, memoized over the
-   * constant-offset interval containing the previous lookup.
+   * most-recently-used constant-offset window.
    */
   def offsetSeconds(epochSec: Long): Long = {
-    if (cached && epochSec >= lo && epochSec < hi) {
-      offsetSec
-    } else {
-      val instant = Instant.ofEpochSecond(epochSec)
-      val o = rules.getOffset(instant).getTotalSeconds.toLong
-      if (isFixedOffset) {
-        lo = Long.MinValue
-        hi = Long.MaxValue
-      } else {
-        val nextT = rules.nextTransition(instant)
-        if (nextT == null) {
-          // No transition after `instant`: offset is constant on [epochSec, +inf).
-          lo = epochSec
-          hi = Long.MaxValue
-        } else {
-          hi = nextT.toEpochSecond
-          // Transition instants in `ZoneRules` are a strictly-increasing sequence of epoch
-          // *seconds* (`savingsInstantTransitions`, as TZif/RFC 8536 encodes them), so any two
-          // consecutive transitions are >= 1s apart by construction. So `hi - 1` is strictly
-          // inside the constant-offset window ending at `hi`, and its previous transition is that
-          // window's start -- anchoring on an interior point avoids an off-by-one when `epochSec`
-          // sits exactly on a transition instant.
-          val prevT = rules.previousTransition(Instant.ofEpochSecond(hi - 1))
-          lo = if (prevT == null) Long.MinValue else prevT.toEpochSecond
-        }
-      }
-      offsetSec = o
-      cached = true
-      o
+    if (epochSec >= mruLo && epochSec < mruHi) {
+      return mruOff
     }
+    resolveAndInstall(epochSec)
+  }
+
+  /**
+   * Offset in seconds at `epochSec`, served from the MRU window when it falls in one but, unlike
+   * [[offsetSeconds]], NOT installing the resolved window as the MRU one. Used for the DST-equality
+   * guard's candidate lookup so it does not evict the source window mid-row. The returned value is
+   * identical to `offsetSeconds(epochSec)`.
+   */
+  def offsetSecondsReadOnly(epochSec: Long): Long = {
+    if (epochSec >= mruLo && epochSec < mruHi) {
+      return mruOff
+    }
+    if (isFixedOffset) {
+      fixedOffsetSec
+    } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
+      rules.getOffset(Instant.ofEpochSecond(epochSec)).getTotalSeconds.toLong
+    } else {
+      val idx = table.floorIndex(epochSec)
+      (if (idx < 0) table.offBefore0 else table.offAfter(idx)).toLong
+    }
+  }
+
+  /**
+   * Resolve the constant-offset window containing `epochSec` (a single binary search over the
+   * shared transition table, no allocation), install it as the MRU window, and return the offset.
+   */
+  private def resolveAndInstall(epochSec: Long): Long = {
+    var lo = 0L
+    var hi = 0L
+    val o = if (isFixedOffset) {
+      lo = Long.MinValue
+      hi = Long.MaxValue
+      fixedOffsetSec
+    } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
+      // Beyond the materialized range (or a zone with no transitions): resolve via the rules.
+      val instant = Instant.ofEpochSecond(epochSec)
+      val nextT = rules.nextTransition(instant)
+      if (nextT == null) {
+        lo = epochSec
+        hi = Long.MaxValue
+        rules.getOffset(instant).getTotalSeconds.toLong
+      } else {
+        hi = nextT.toEpochSecond
+        val prevT = rules.previousTransition(Instant.ofEpochSecond(hi - 1))
+        lo = if (prevT == null) Long.MinValue else prevT.toEpochSecond
+        nextT.getOffsetBefore.getTotalSeconds.toLong
+      }
+    } else {
+      // In range: one binary search gives the enclosing window's start, end, and offset.
+      val idx = table.floorIndex(epochSec)
+      if (idx < 0) {
+        lo = Long.MinValue
+        hi = table.transSec(0)
+        table.offBefore0.toLong
+      } else {
+        lo = table.transSec(idx)
+        hi = if (idx + 1 < table.transSec.length) table.transSec(idx + 1) else table.horizonSec
+        table.offAfter(idx).toLong
+      }
+    }
+    mruLo = lo; mruHi = hi; mruOff = o
+    o
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -643,13 +643,21 @@ object DateTimeUtils extends SparkDateTimeUtils {
       val candidate = Math.subtractExact(truncatedLocal, offsetMicros)
       if (!cache.isFixedOffset) {
         val candidateSec = Math.floorDiv(candidate, MICROS_PER_SECOND)
-        val candidateOffsetSec = cache.offsetSecondsReadOnly(candidateSec)
-        if (candidateOffsetSec != originalOffsetSec) {
-          // The truncation boundary crosses a transition. Date levels resolve it by mapping the
-          // already-truncated local day back through the zone; other levels defer to the reference
-          // slow path.
-          return if (isDateLevel) daysToMicros(truncatedDays, cache.zoneId)
-            else truncTimestampSlow(micros, level, cache.zoneId)
+        if (isDateLevel) {
+          // Fall back when the truncation boundary crosses a transition, or when the truncated
+          // midnight lands in a fall-back overlap (the candidate is then the later of the two
+          // instants sharing that wall clock, while daysToMicros picks the earlier; SPARK-57769).
+          // The fallback maps the already-truncated local day back through the zone.
+          if (!cache.dateCandidateMatches(candidateSec, originalOffsetSec)) {
+            return daysToMicros(truncatedDays, cache.zoneId)
+          }
+        } else {
+          // MINUTE/HOUR/DAY defer to the reference slow path on a DST cross. No overlap handling
+          // is needed here: truncatedTo retains the original instant's offset, which is exactly
+          // what the arithmetic candidate carries.
+          if (cache.offsetSecondsReadOnly(candidateSec) != originalOffsetSec) {
+            return truncTimestampSlow(micros, level, cache.zoneId)
+          }
         }
       }
       candidate
@@ -1523,6 +1531,10 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
   private var mruLo = Long.MaxValue
   private var mruHi = Long.MinValue
   private var mruOff = 0L
+  // Instants in [mruLo, mruAmbiguousUntil) are treated as the later of two instants sharing one
+  // wall-clock time (the fall-back overlap at the window's start). mruLo when the window has no
+  // overlap, mruHi when the bound was not derived (conservatively marking the whole window).
+  private var mruAmbiguousUntil = Long.MinValue
 
   /**
    * Offset in seconds at `epochSec`, equal to
@@ -1557,15 +1569,56 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
   }
 
   /**
+   * True iff the offset-arithmetic result is exact for a date-level truncation candidate at
+   * `epochSec`: the candidate's window carries `offsetSec` (same offset as the original instant,
+   * the SPARK-30766/30857 DST-cross guard) AND the candidate is not inside the fall-back overlap
+   * at its window's start. In that overlap the truncated midnight occurs twice and the reference
+   * `daysToMicros`/`atStartOfDay` resolution picks the earlier instant, while the arithmetic
+   * candidate is the later one (SPARK-57769). Callers route a false result to the
+   * [[DateTimeUtils.truncTimestamp]] date-level fallback, which always produces the reference
+   * result -- so answering false conservatively (as done wholesale beyond the materialized table)
+   * costs the slow path, never correctness. Like [[offsetSecondsReadOnly]], resident state is not
+   * mutated.
+   */
+  def dateCandidateMatches(epochSec: Long, offsetSec: Long): Boolean = {
+    if (epochSec >= mruLo && epochSec < mruHi) {
+      return mruOff == offsetSec && epochSec >= mruAmbiguousUntil
+    }
+    if (isFixedOffset) {
+      // Unreachable in practice: the caller skips the guard for fixed-offset zones.
+      fixedOffsetSec == offsetSec
+    } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
+      // Beyond the materialized table: defer to the fallback rather than re-derive the window and
+      // its overlap from the rules -- that derivation would allocate about as much as the fallback.
+      false
+    } else {
+      val idx = table.floorIndex(epochSec)
+      if (idx < 0) {
+        // Before the first transition: no preceding window, so no overlap to fall into.
+        table.offBefore0.toLong == offsetSec
+      } else {
+        val off = table.offAfter(idx).toLong
+        val prev = (if (idx == 0) table.offBefore0 else table.offAfter(idx - 1)).toLong
+        off == offsetSec && epochSec >= table.transSec(idx) + (prev - off).max(0L)
+      }
+    }
+  }
+
+  /**
    * Resolve the constant-offset window containing `epochSec` (a single binary search over the
    * shared transition table, no allocation), install it as the MRU window, and return the offset.
    */
   private def resolveAndInstall(epochSec: Long): Long = {
     var lo = 0L
     var hi = 0L
+    // Upper bound of the fall-back overlap at the window's start (see [[dateCandidateMatches]]):
+    // `lo` itself when there is none, and conservatively `hi` (marking the whole window) where the
+    // bound is not derived from the table.
+    var ambiguousUntil = 0L
     val o = if (isFixedOffset) {
       lo = Long.MinValue
       hi = Long.MaxValue
+      ambiguousUntil = lo
       fixedOffsetSec
     } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
       // Beyond the materialized range (or a zone with no transitions): resolve via the rules.
@@ -1574,11 +1627,13 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
       if (nextT == null) {
         lo = epochSec
         hi = Long.MaxValue
+        ambiguousUntil = hi
         rules.getOffset(instant).getTotalSeconds.toLong
       } else {
         hi = nextT.toEpochSecond
         val prevT = rules.previousTransition(Instant.ofEpochSecond(hi - 1))
         lo = if (prevT == null) Long.MinValue else prevT.toEpochSecond
+        ambiguousUntil = hi
         nextT.getOffsetBefore.getTotalSeconds.toLong
       }
     } else {
@@ -1587,14 +1642,19 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
       if (idx < 0) {
         lo = Long.MinValue
         hi = table.transSec(0)
+        ambiguousUntil = lo
         table.offBefore0.toLong
       } else {
         lo = table.transSec(idx)
         hi = if (idx + 1 < table.transSec.length) table.transSec(idx + 1) else table.horizonSec
-        table.offAfter(idx).toLong
+        val off = table.offAfter(idx).toLong
+        val prev = (if (idx == 0) table.offBefore0 else table.offAfter(idx - 1)).toLong
+        ambiguousUntil = lo + (prev - off).max(0L)
+        off
       }
     }
     mruLo = lo; mruHi = hi; mruOff = o
+    mruAmbiguousUntil = ambiguousUntil
     o
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -588,9 +588,20 @@ object DateTimeUtils extends SparkDateTimeUtils {
    * `cache`, which memoizes it over the constant-offset interval around the last lookup, so for
    * temporally clustered data the per-row transition-array binary search collapses to two
    * comparisons. Truncation then runs in the shifted-local frame, and the result is shifted back
-   * to UTC micros. Falls back to [[truncTimestampSlow]] when the offset at the candidate truncated
-   * instant differs from the offset at `micros` (DST/historical transition spans the candidate;
-   * SPARK-30766/30857) or on arithmetic overflow.
+   * to UTC micros.
+   *
+   * The arithmetic result is rejected -- and the row re-resolved through the zone -- when it
+   * cannot be exact:
+   *   - MINUTE/HOUR/DAY fall back to [[truncTimestampSlow]] when the offset at the candidate
+   *     truncated instant differs from the offset at `micros` (a DST/historical transition spans
+   *     the candidate; SPARK-30766/30857).
+   *   - WEEK/MONTH/QUARTER/YEAR additionally fall back when the candidate sits in the fall-back
+   *     overlap at its window's start, where the truncated local midnight occurs twice: the
+   *     arithmetic candidate is the later of the two instants while the reference resolution
+   *     picks the earlier (SPARK-57769). These levels resolve the fallback by mapping the
+   *     already-truncated local day through [[daysToMicros]] (`atStartOfDay` semantics) instead
+   *     of re-deriving it via [[truncTimestampSlow]].
+   *   - Any level falls back to [[truncTimestampSlow]] on arithmetic overflow.
    *
    * Sub-minute LMT offsets (e.g. America/Los_Angeles -07:52:58 pre-1883, see
    * SPARK-33404) and 30/45-minute offsets (Asia/Kolkata +05:30, Asia/Kathmandu +05:45)
@@ -1442,14 +1453,16 @@ object DateTimeUtils extends SparkDateTimeUtils {
  * A zone's transition schedule as primitive arrays: the sorted epoch-second transition instants
  * (`transSec`) and the UTC offset (in seconds) in effect on each window `[transSec(i),
  * transSec(i + 1))` (`offAfter(i)`); `offBefore0` is the offset before the first transition. Built
- * once per zone from the historical transitions plus rule-generated ones up to `horizonSec` (beyond
- * that the rules are consulted directly). Immutable and shared read-only across tasks via
- * [[ZoneOffsetCache.tableFor]].
+ * once per zone from the transitions in `[startSec, horizonSec)` -- historical plus
+ * rule-generated; outside that range on either side the rules are consulted directly rather than
+ * assuming the table's edge windows extend indefinitely. Immutable and shared read-only across
+ * tasks via [[ZoneOffsetCache.tableFor]].
  */
 private[util] final class ZoneTransitionTable(
     val transSec: Array[Long],
     val offAfter: Array[Int],
     val offBefore0: Int,
+    val startSec: Long,
     val horizonSec: Long) {
 
   /** Largest `i` with `transSec(i) <= epochSec`, or -1 when before the first transition. */
@@ -1501,7 +1514,8 @@ object ZoneOffsetCache {
     if (!seen) {
       before0 = rules.getOffset(tableStart).getTotalSeconds
     }
-    new ZoneTransitionTable(secs.toArray, offs.toArray, before0, tableHorizon.getEpochSecond)
+    new ZoneTransitionTable(secs.toArray, offs.toArray, before0, tableStart.getEpochSecond,
+      tableHorizon.getEpochSecond)
   }
 }
 
@@ -1560,7 +1574,8 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
     }
     if (isFixedOffset) {
       fixedOffsetSec
-    } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
+    } else if (epochSec < table.startSec || epochSec >= table.horizonSec ||
+        table.transSec.length == 0) {
       rules.getOffset(Instant.ofEpochSecond(epochSec)).getTotalSeconds.toLong
     } else {
       val idx = table.floorIndex(epochSec)
@@ -1587,15 +1602,17 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
     if (isFixedOffset) {
       // Unreachable in practice: the caller skips the guard for fixed-offset zones.
       fixedOffsetSec == offsetSec
-    } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
-      // Beyond the materialized table: defer to the fallback rather than re-derive the window and
+    } else if (epochSec < table.startSec || epochSec >= table.horizonSec ||
+        table.transSec.length == 0) {
+      // Outside the materialized table: defer to the fallback rather than re-derive the window and
       // its overlap from the rules -- that derivation would allocate about as much as the fallback.
       false
     } else {
       val idx = table.floorIndex(epochSec)
       if (idx < 0) {
-        // Before the first transition: no preceding window, so no overlap to fall into.
-        table.offBefore0.toLong == offsetSec
+        // Between the table's start and its first transition, the enclosing window began before
+        // the table, so its start (and any overlap there) is not materialized: stay conservative.
+        false
       } else {
         val off = table.offAfter(idx).toLong
         val prev = (if (idx == 0) table.offBefore0 else table.offAfter(idx - 1)).toLong
@@ -1620,8 +1637,9 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
       hi = Long.MaxValue
       ambiguousUntil = lo
       fixedOffsetSec
-    } else if (epochSec >= table.horizonSec || table.transSec.length == 0) {
-      // Beyond the materialized range (or a zone with no transitions): resolve via the rules.
+    } else if (epochSec < table.startSec || epochSec >= table.horizonSec ||
+        table.transSec.length == 0) {
+      // Outside the materialized range (or a zone with no transitions): resolve via the rules.
       val instant = Instant.ofEpochSecond(epochSec)
       val nextT = rules.nextTransition(instant)
       if (nextT == null) {
@@ -1640,9 +1658,13 @@ class ZoneOffsetCache(val zoneId: ZoneId) {
       // In range: one binary search gives the enclosing window's start, end, and offset.
       val idx = table.floorIndex(epochSec)
       if (idx < 0) {
-        lo = Long.MinValue
+        // Between the table's start and its first transition. The offset is offBefore0 throughout
+        // (the true window extends back past the table's start), but the window installed here is
+        // clipped to the table so lookups before it re-resolve via the rules, and it is marked
+        // conservatively because its true start is not materialized.
+        lo = table.startSec
         hi = table.transSec(0)
-        ambiguousUntil = lo
+        ambiguousUntil = hi
         table.offBefore0.toLong
       } else {
         lo = table.transSec(idx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -619,7 +619,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
    *   - WEEK/MONTH/QUARTER/YEAR: convert local micros to local epoch-day, run
    *     [[truncDate]] in the local-day frame, multiply back to local micros.
    */
-  def truncTimestamp(micros: Long, level: Int, cache: ZoneOffsetCache): Long = {
+  private[sql] def truncTimestamp(micros: Long, level: Int, cache: ZoneOffsetCache): Long = {
     // MICROSECOND / MILLISECOND / SECOND don't need zone information.
     level match {
       case TRUNC_TO_MICROSECOND => return micros
@@ -719,7 +719,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
    * is MICROSECOND (see `MIN_LEVEL_OF_TIMESTAMP_TRUNC`), which already discards everything below
    * a microsecond. NTZ vs. LTZ zone handling is the caller's responsibility via the cache's zone.
    */
-  def truncTimestampNanos(
+  private[sql] def truncTimestampNanos(
       value: TimestampNanosVal,
       level: Int,
       cache: ZoneOffsetCache): TimestampNanosVal = {
@@ -1483,7 +1483,7 @@ private[util] final class ZoneTransitionTable(
   }
 }
 
-object ZoneOffsetCache {
+private[sql] object ZoneOffsetCache {
   // The transition table is the same for every task using a given zone, so build it once per JVM.
   private val tables = new java.util.concurrent.ConcurrentHashMap[ZoneId, ZoneTransitionTable]()
   private val tableStart = Instant.parse("1600-01-01T00:00:00Z")
@@ -1534,7 +1534,7 @@ object ZoneOffsetCache {
  * Not thread-safe by design: a fresh instance is created per task (codegen mutable state) and used
  * single-threaded, mirroring how stateful per-row helpers are scoped in generated code.
  */
-class ZoneOffsetCache(val zoneId: ZoneId) {
+private[sql] class ZoneOffsetCache(val zoneId: ZoneId) {
   private val rules = zoneId.getRules
   val isFixedOffset: Boolean = rules.isFixedOffset
   private val table = if (isFixedOffset) null else ZoneOffsetCache.tableFor(zoneId)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -949,6 +949,31 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("SPARK-57769: TruncTimestamp picks the earlier instant at a DST fall-back overlap") {
+    // When a fall-back overlap covers the truncated period-start midnight, every timestamp in the
+    // period must truncate to the earlier of the two midnight instants (the atStartOfDay
+    // convention). Exercised at the expression level so both the interpreted and the codegen path
+    // (with its per-task ZoneOffsetCache mutable state) are locked in. Epoch seconds below are the
+    // two instants sharing the period-start local midnight in each zone.
+    val cases = Seq(
+      // (zone, level, earlier midnight epoch-sec, later midnight epoch-sec)
+      ("America/Havana", "MONTH", 1446350400L, 1446354000L),
+      ("Europe/Berlin", "QUARTER", -1680487200L, -1680483600L),
+      ("Asia/Jerusalem", "WEEK", 1001278800L, 1001282400L))
+    for ((zone, fmt, earlierSec, laterSec) <- cases) {
+      val expected = Math.multiplyExact(earlierSec, MICROS_PER_SECOND)
+      // The later midnight itself (the previously-wrong case) and a row further into the period.
+      Seq(laterSec, laterSec + 86400).foreach { s =>
+        checkEvaluation(
+          TruncTimestamp(
+            Literal.create(fmt, StringType),
+            Literal.create(Math.multiplyExact(s, MICROS_PER_SECOND), TimestampType),
+            timeZoneId = Some(zone)),
+          expected)
+      }
+    }
+  }
+
   test("TruncTimestamp of Long.MinValue overflows with ArithmeticException") {
     withDefaultTimeZone(UTC) {
       // Long.MinValue is the smallest representable timestamp value (in micros). Truncating it

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -2522,13 +2522,18 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     // (atZone picks the earlier offset in an overlap, the post-gap instant in a gap), matching the
     // slow path's daysToMicros; HOUR/MINUTE keep the original offset, matching truncatedTo.
     def oracle(micros: Long, level: Int, zid: java.time.ZoneId): Long = {
-      val local = periodStartLocal(micros, level, zid)
-      val instant = if (level <= DateTimeUtils.TRUNC_TO_HOUR) {
-        DateTimeUtils.microsToInstant(micros).atZone(zid).truncatedTo(
-          if (level == DateTimeUtils.TRUNC_TO_HOUR) java.time.temporal.ChronoUnit.HOURS
-          else java.time.temporal.ChronoUnit.MINUTES).toInstant
+      // MINUTE/HOUR/DAY truncate via ZonedDateTime.truncatedTo, which retains the input instant's
+      // offset when the truncated wall clock is ambiguous; the date levels resolve the local
+      // period start via atZone/atStartOfDay, which picks the earlier offset. Both conventions
+      // mirror the reference slow path's.
+      val instant = if (level <= DateTimeUtils.TRUNC_TO_DAY) {
+        DateTimeUtils.microsToInstant(micros).atZone(zid).truncatedTo(level match {
+          case DateTimeUtils.TRUNC_TO_DAY => java.time.temporal.ChronoUnit.DAYS
+          case DateTimeUtils.TRUNC_TO_HOUR => java.time.temporal.ChronoUnit.HOURS
+          case _ => java.time.temporal.ChronoUnit.MINUTES
+        }).toInstant
       } else {
-        local.atZone(zid).toInstant
+        periodStartLocal(micros, level, zid).atZone(zid).toInstant
       }
       DateTimeUtils.instantToMicros(instant)
     }
@@ -2557,15 +2562,36 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       val cache = new ZoneOffsetCache(zid)
       for (level <- levels; s <- secs) {
         val micros = Math.multiplyExact(s, MICROS_PER_SECOND)
-        // A truncated period-start that lands on a DST fall-back overlap (local time occurs twice)
-        // is skipped: the offset-arithmetic fast path returns the later occurrence while the slow
-        // path's atStartOfDay picks the earlier one. That divergence predates and is independent of
-        // this cache work (a SPARK-56769 fast-path issue tracked separately), so it is out of scope
-        // here; every unambiguous boundary must still match exactly.
-        if (rules.getValidOffsets(periodStartLocal(micros, level, zid)).size() <= 1) {
-          assert(DateTimeUtils.truncTimestamp(micros, level, cache) === oracle(micros, level, zid),
-            s"zone=$z level=$level sec=$s")
-        }
+        assert(DateTimeUtils.truncTimestamp(micros, level, cache) === oracle(micros, level, zid),
+          s"zone=$z level=$level sec=$s")
+      }
+    }
+  }
+
+  test("SPARK-57769: date-level truncation onto a DST fall-back overlap picks the earlier " +
+    "instant") {
+    // When the truncated period-start local midnight occurs twice (a fall-back overlap covers it),
+    // date-level truncation must resolve to the earlier of the two instants -- the atStartOfDay
+    // convention the pre-fast-path implementation used -- for every input in the period, so that
+    // date_trunc stays deterministic per period. Cases: a Jan 1 overlap (Tokyo 1888, the LMT
+    // fall-back), a 1st-of-month overlap (Havana 2015), and a quarter-start overlap (Berlin 1916).
+    val cases = Seq(
+      // (zone, level, earlier midnight epoch-sec, later midnight epoch-sec)
+      ("Asia/Tokyo", DateTimeUtils.TRUNC_TO_YEAR, -2587713539L, -2587712400L),
+      ("America/Havana", DateTimeUtils.TRUNC_TO_MONTH, 1446350400L, 1446354000L),
+      ("Europe/Berlin", DateTimeUtils.TRUNC_TO_QUARTER, -1680487200L, -1680483600L))
+    for ((zone, level, earlierSec, laterSec) <- cases) {
+      val zid = getZoneId(zone)
+      val expected = Math.multiplyExact(earlierSec, MICROS_PER_SECOND)
+      // Inputs across the overlap: the earlier midnight itself, inside the overlap, the later
+      // midnight (the previously-wrong case), just after the overlap, and a day into the period.
+      val inputs = Seq(earlierSec, (earlierSec + laterSec) / 2, laterSec, laterSec + 1,
+        laterSec + 86400)
+      val cache = new ZoneOffsetCache(zid)
+      for (s <- inputs) {
+        val micros = Math.multiplyExact(s, MICROS_PER_SECOND)
+        assert(DateTimeUtils.truncTimestamp(micros, level, cache) === expected,
+          s"zone=$zone level=$level sec=$s")
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -2447,4 +2447,125 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       assert(cache.offsetSeconds(s) === 0L)
     }
   }
+
+  test("SPARK-57737: ZoneOffsetCache matches ZoneRules.getOffset across zones and instants") {
+    // ZoneOffsetCache resolves misses from a precomputed primitive transition table; check it
+    // equals rules.getOffset for a spread of zones and many instants -- exactly on transitions,
+    // one second either side, before the first transition, beyond the materialized horizon, and a
+    // deterministic pseudo-random spread.
+    val zones = Seq("America/Los_Angeles", "Europe/Berlin", "Atlantic/Azores", "Asia/Kolkata",
+      "UTC", "Pacific/Apia", "Australia/Lord_Howe", "America/Sao_Paulo", "Asia/Tokyo", "Africa/Cairo")
+    for (z <- zones) {
+      val zid = getZoneId(z)
+      val rules = zid.getRules
+      val cache = new ZoneOffsetCache(zid)
+      val secs = scala.collection.mutable.ArrayBuffer.empty[Long]
+      // A couple of points before the first transition, and one beyond the 2200 horizon.
+      secs += Instant.parse("1700-06-01T00:00:00Z").getEpochSecond
+      secs += Instant.parse("2260-06-01T00:00:00Z").getEpochSecond
+      // Every transition instant and +/- 1s (boundary cases).
+      var tr = rules.nextTransition(Instant.parse("1850-01-01T00:00:00Z"))
+      val end = Instant.parse("2250-01-01T00:00:00Z")
+      var guard = 0
+      while (tr != null && tr.getInstant.isBefore(end) && guard < 5000) {
+        val t = tr.toEpochSecond
+        secs += (t - 1); secs += t; secs += (t + 1)
+        tr = rules.nextTransition(tr.getInstant.plusNanos(1))
+        guard += 1
+      }
+      // Deterministic pseudo-random spread over ~[1900, 2250).
+      var seed = 88172645463325252L
+      var i = 0
+      while (i < 4000) {
+        seed = seed * 6364136223846793005L + 1442695040888963407L
+        secs += -2208988800L + Math.floorMod(seed, 11044771200L)
+        i += 1
+      }
+      for (s <- secs) {
+        val expected = rules.getOffset(Instant.ofEpochSecond(s)).getTotalSeconds.toLong
+        assert(cache.offsetSeconds(s) === expected, s"zone=$z sec=$s")
+      }
+    }
+  }
+
+  test("SPARK-57737: truncTimestamp fast path matches an independent oracle across DST zones") {
+    // The fast path's DST-cross guard (ZoneOffsetCache.currentWindowContains) admits the
+    // offset-arithmetic result only when the truncated candidate stays in the original instant's
+    // constant-offset window, otherwise deferring to the slow path. Pin that end-to-end: for a
+    // spread of zones, levels, and instants (transition boundaries + a pseudo-random spread),
+    // truncTimestamp must equal a ground-truth java.time truncation computed independently here.
+    val zones = Seq("America/Los_Angeles", "Europe/Berlin", "America/Sao_Paulo", "Pacific/Apia",
+      "Australia/Lord_Howe", "Asia/Kolkata", "America/Havana", "UTC")
+    val levels = Seq(DateTimeUtils.TRUNC_TO_YEAR, DateTimeUtils.TRUNC_TO_QUARTER,
+      DateTimeUtils.TRUNC_TO_MONTH, DateTimeUtils.TRUNC_TO_WEEK, DateTimeUtils.TRUNC_TO_DAY,
+      DateTimeUtils.TRUNC_TO_HOUR, DateTimeUtils.TRUNC_TO_MINUTE)
+    // The truncated period-start in wall-clock time (a LocalDateTime), computed independently.
+    def periodStartLocal(micros: Long, level: Int, zid: java.time.ZoneId): java.time.LocalDateTime = {
+      val zdt = DateTimeUtils.microsToInstant(micros).atZone(zid)
+      level match {
+        case DateTimeUtils.TRUNC_TO_YEAR => zdt.toLocalDate.withDayOfYear(1).atStartOfDay
+        case DateTimeUtils.TRUNC_TO_QUARTER =>
+          val d = zdt.toLocalDate
+          d.withMonth((d.getMonthValue - 1) / 3 * 3 + 1).withDayOfMonth(1).atStartOfDay
+        case DateTimeUtils.TRUNC_TO_MONTH => zdt.toLocalDate.withDayOfMonth(1).atStartOfDay
+        case DateTimeUtils.TRUNC_TO_WEEK =>
+          zdt.toLocalDate.`with`(java.time.DayOfWeek.MONDAY).atStartOfDay
+        case DateTimeUtils.TRUNC_TO_DAY => zdt.toLocalDate.atStartOfDay
+        case DateTimeUtils.TRUNC_TO_HOUR =>
+          zdt.toLocalDateTime.truncatedTo(java.time.temporal.ChronoUnit.HOURS)
+        case DateTimeUtils.TRUNC_TO_MINUTE =>
+          zdt.toLocalDateTime.truncatedTo(java.time.temporal.ChronoUnit.MINUTES)
+      }
+    }
+    // Ground truth micros: date-levels resolve the local start-of-period back through the zone
+    // (atZone picks the earlier offset in an overlap, the post-gap instant in a gap), matching the
+    // slow path's daysToMicros; HOUR/MINUTE keep the original offset, matching truncatedTo.
+    def oracle(micros: Long, level: Int, zid: java.time.ZoneId): Long = {
+      val local = periodStartLocal(micros, level, zid)
+      val instant = if (level <= DateTimeUtils.TRUNC_TO_HOUR) {
+        DateTimeUtils.microsToInstant(micros).atZone(zid).truncatedTo(
+          if (level == DateTimeUtils.TRUNC_TO_HOUR) java.time.temporal.ChronoUnit.HOURS
+          else java.time.temporal.ChronoUnit.MINUTES).toInstant
+      } else {
+        local.atZone(zid).toInstant
+      }
+      DateTimeUtils.instantToMicros(instant)
+    }
+    for (z <- zones) {
+      val zid = getZoneId(z)
+      val rules = zid.getRules
+      val secs = scala.collection.mutable.ArrayBuffer.empty[Long]
+      // Every transition and +/- a few seconds/hours -- the boundary cases the guard exists for.
+      var tr = rules.nextTransition(Instant.parse("1900-01-01T00:00:00Z"))
+      val end = Instant.parse("2200-01-01T00:00:00Z")
+      var guard = 0
+      while (tr != null && tr.getInstant.isBefore(end) && guard < 5000) {
+        val t = tr.toEpochSecond
+        Seq(-90000L, -3600L, -1L, 0L, 1L, 3600L, 90000L).foreach(d => secs += (t + d))
+        tr = rules.nextTransition(tr.getInstant.plusNanos(1))
+        guard += 1
+      }
+      // Deterministic pseudo-random spread over ~[1950, 2100).
+      var seed = 55572645463325111L
+      var i = 0
+      while (i < 3000) {
+        seed = seed * 6364136223846793005L + 1442695040888963407L
+        secs += -631152000L + Math.floorMod(seed, 4102444800L)
+        i += 1
+      }
+      val cache = new ZoneOffsetCache(zid)
+      for (level <- levels; s <- secs) {
+        val micros = Math.multiplyExact(s, MICROS_PER_SECOND)
+        // A truncated period-start that lands on a DST fall-back overlap (local time occurs twice)
+        // is skipped: the offset-arithmetic fast path returns the later occurrence while the slow
+        // path's atStartOfDay picks the earlier one. That divergence predates and is independent of
+        // this cache work (a SPARK-56769 fast-path issue tracked separately), so it is out of scope
+        // here; every unambiguous boundary must still match exactly.
+        if (rules.getValidOffsets(periodStartLocal(micros, level, zid)).size() <= 1) {
+          assert(DateTimeUtils.truncTimestamp(micros, level, cache) === oracle(micros, level, zid),
+            s"zone=$z level=$level sec=$s")
+        }
+      }
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -2454,7 +2454,8 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     // one second either side, before the first transition, beyond the materialized horizon, and a
     // deterministic pseudo-random spread.
     val zones = Seq("America/Los_Angeles", "Europe/Berlin", "Atlantic/Azores", "Asia/Kolkata",
-      "UTC", "Pacific/Apia", "Australia/Lord_Howe", "America/Sao_Paulo", "Asia/Tokyo", "Africa/Cairo")
+      "UTC", "Pacific/Apia", "Australia/Lord_Howe", "America/Sao_Paulo", "Asia/Tokyo",
+      "Africa/Cairo")
     for (z <- zones) {
       val zid = getZoneId(z)
       val rules = zid.getRules
@@ -2489,18 +2490,18 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
   }
 
   test("SPARK-57737: truncTimestamp fast path matches an independent oracle across DST zones") {
-    // The fast path's DST-cross guard (ZoneOffsetCache.currentWindowContains) admits the
-    // offset-arithmetic result only when the truncated candidate stays in the original instant's
-    // constant-offset window, otherwise deferring to the slow path. Pin that end-to-end: for a
-    // spread of zones, levels, and instants (transition boundaries + a pseudo-random spread),
-    // truncTimestamp must equal a ground-truth java.time truncation computed independently here.
+    // The fast path's DST-cross guard admits the offset-arithmetic result only when the truncated
+    // candidate carries the same offset as the original instant, otherwise deferring to the slow
+    // path. Pin that end-to-end: for a spread of zones, levels, and instants (transition
+    // boundaries + a pseudo-random spread), truncTimestamp must equal a ground-truth java.time
+    // truncation computed independently here.
     val zones = Seq("America/Los_Angeles", "Europe/Berlin", "America/Sao_Paulo", "Pacific/Apia",
       "Australia/Lord_Howe", "Asia/Kolkata", "America/Havana", "UTC")
     val levels = Seq(DateTimeUtils.TRUNC_TO_YEAR, DateTimeUtils.TRUNC_TO_QUARTER,
       DateTimeUtils.TRUNC_TO_MONTH, DateTimeUtils.TRUNC_TO_WEEK, DateTimeUtils.TRUNC_TO_DAY,
       DateTimeUtils.TRUNC_TO_HOUR, DateTimeUtils.TRUNC_TO_MINUTE)
     // The truncated period-start in wall-clock time (a LocalDateTime), computed independently.
-    def periodStartLocal(micros: Long, level: Int, zid: java.time.ZoneId): java.time.LocalDateTime = {
+    def periodStartLocal(micros: Long, level: Int, zid: ZoneId): LocalDateTime = {
       val zdt = DateTimeUtils.microsToInstant(micros).atZone(zid)
       level match {
         case DateTimeUtils.TRUNC_TO_YEAR => zdt.toLocalDate.withDayOfYear(1).atStartOfDay

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -2399,4 +2399,52 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       }
     }
   }
+
+  test("SPARK-57737: ZoneOffsetCache memoizes the zone offset across rows and at transitions") {
+    val zid = getZoneId("America/Los_Angeles")
+    val rules = zid.getRules
+    // A real DST transition (spring-forward), resolved from the rules so there are no hardcoded
+    // constants that could drift with tzdb updates.
+    val tr = rules.nextTransition(Instant.parse("2024-01-01T00:00:00Z"))
+    val t = tr.toEpochSecond
+    val before = tr.getOffsetBefore.getTotalSeconds.toLong
+    val after = tr.getOffsetAfter.getTotalSeconds.toLong
+    assert(before != after)
+
+    // (a) Cross-row reuse within one constant-offset window: repeated lookups hit the cache and
+    // stay correct.
+    val cache = new ZoneOffsetCache(zid)
+    assert(cache.offsetSeconds(t - 100000) === before)
+    assert(cache.offsetSeconds(t - 50000) === before)
+    assert(cache.offsetSeconds(t - 1) === before)
+    // (b) Straddle the transition: miss + window reset, then a hit in the new window, and going
+    // back resets again (no stale-window reuse).
+    assert(cache.offsetSeconds(t + 100000) === after)
+    assert(cache.offsetSeconds(t + 1) === after)
+    assert(cache.offsetSeconds(t - 1) === before)
+
+    // (c) `epochSec` exactly on the transition instant exercises the `hi - 1` anchor: looking up
+    // `t` builds a window whose lower bound is `previousTransition(hi - 1) == t`, so the following
+    // lookup of `t - 1` must reset to the previous offset. A naive `previousTransition(t)` anchor
+    // would make the window span the transition and wrongly return `after` for `t - 1`.
+    val cache2 = new ZoneOffsetCache(zid)
+    assert(cache2.offsetSeconds(t) === after)
+    assert(cache2.offsetSeconds(t - 1) === before)
+
+    // Cross-check every cell against the ground-truth offset.
+    Seq(t - 100000, t - 1, t, t + 1, t + 100000).foreach { s =>
+      assert(new ZoneOffsetCache(zid).offsetSeconds(s) ===
+        rules.getOffset(Instant.ofEpochSecond(s)).getTotalSeconds.toLong)
+    }
+  }
+
+  test("SPARK-57737: ZoneOffsetCache for a fixed-offset zone") {
+    val cache = new ZoneOffsetCache(getZoneId("UTC"))
+    assert(cache.isFixedOffset)
+    // A fixed-offset zone resolves the same offset everywhere; the first lookup caches the whole
+    // range so the rest are served from the cache.
+    Seq(-1000000000000L, -1L, 0L, 1L, 1000000000000L).foreach { s =>
+      assert(cache.offsetSeconds(s) === 0L)
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -2423,10 +2423,10 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     assert(cache.offsetSeconds(t + 1) === after)
     assert(cache.offsetSeconds(t - 1) === before)
 
-    // (c) `epochSec` exactly on the transition instant exercises the `hi - 1` anchor: looking up
-    // `t` builds a window whose lower bound is `previousTransition(hi - 1) == t`, so the following
-    // lookup of `t - 1` must reset to the previous offset. A naive `previousTransition(t)` anchor
-    // would make the window span the transition and wrongly return `after` for `t - 1`.
+    // (c) `epochSec` exactly on the transition instant: `floorIndex(t)` selects the window that
+    // STARTS at `t`, so looking up `t` builds `[t, next)` and the following lookup of `t - 1`
+    // must miss and reset to the previous offset. An off-by-one in the floor search would make
+    // the window span the transition and wrongly return `after` for `t - 1`.
     val cache2 = new ZoneOffsetCache(zid)
     assert(cache2.offsetSeconds(t) === after)
     assert(cache2.offsetSeconds(t - 1) === before)
@@ -2461,7 +2461,11 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       val rules = zid.getRules
       val cache = new ZoneOffsetCache(zid)
       val secs = scala.collection.mutable.ArrayBuffer.empty[Long]
-      // A couple of points before the first transition, and one beyond the 2200 horizon.
+      // Points on both sides of the materialized table: before its 1600 start (resolved via the
+      // rules, exercising the left edge), between the start and the zone's first transition, and
+      // beyond the 2200 horizon.
+      secs += Instant.parse("1500-06-01T00:00:00Z").getEpochSecond
+      secs += Instant.parse("1599-12-31T23:59:59Z").getEpochSecond
       secs += Instant.parse("1700-06-01T00:00:00Z").getEpochSecond
       secs += Instant.parse("2260-06-01T00:00:00Z").getEpochSecond
       // Every transition instant and +/- 1s (boundary cases).
@@ -2574,12 +2578,14 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     // date-level truncation must resolve to the earlier of the two instants -- the atStartOfDay
     // convention the pre-fast-path implementation used -- for every input in the period, so that
     // date_trunc stays deterministic per period. Cases: a Jan 1 overlap (Tokyo 1888, the LMT
-    // fall-back), a 1st-of-month overlap (Havana 2015), and a quarter-start overlap (Berlin 1916).
+    // fall-back), a 1st-of-month overlap (Havana 2015), a quarter-start overlap (Berlin 1916),
+    // and a Monday-midnight overlap (Jerusalem 2001, DST ending at midnight before a Monday).
     val cases = Seq(
       // (zone, level, earlier midnight epoch-sec, later midnight epoch-sec)
       ("Asia/Tokyo", DateTimeUtils.TRUNC_TO_YEAR, -2587713539L, -2587712400L),
       ("America/Havana", DateTimeUtils.TRUNC_TO_MONTH, 1446350400L, 1446354000L),
-      ("Europe/Berlin", DateTimeUtils.TRUNC_TO_QUARTER, -1680487200L, -1680483600L))
+      ("Europe/Berlin", DateTimeUtils.TRUNC_TO_QUARTER, -1680487200L, -1680483600L),
+      ("Asia/Jerusalem", DateTimeUtils.TRUNC_TO_WEEK, 1001278800L, 1001282400L))
     for ((zone, level, earlierSec, laterSec) <- cases) {
       val zid = getZoneId(zone)
       val expected = Math.multiplyExact(earlierSec, MICROS_PER_SECOND)

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -2,460 +2,530 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  829            906          86         12.1          82.9       1.0X
-date + interval(m, d)                               864            877          12         11.6          86.4       1.0X
-date + interval(m, d, ms)                          3716           3720           6          2.7         371.6       0.2X
-date - interval(m)                                  841            847           8         11.9          84.1       1.0X
-date - interval(m, d)                               917            918           1         10.9          91.7       0.9X
-date - interval(m, d, ms)                          3770           3774           6          2.7         377.0       0.2X
-timestamp + interval(m)                            1533           1533           1          6.5         153.3       0.5X
-timestamp + interval(m, d)                         1581           1583           3          6.3         158.1       0.5X
-timestamp + interval(m, d, ms)                     2025           2027           2          4.9         202.5       0.4X
-timestamp - interval(m)                            1812           1818           9          5.5         181.2       0.5X
-timestamp - interval(m, d)                         1866           1870           6          5.4         186.6       0.4X
-timestamp - interval(m, d, ms)                     2021           2022           2          4.9         202.1       0.4X
+date + interval(m)                                  912            949          47         11.0          91.2       1.0X
+date + interval(m, d)                               923            931           7         10.8          92.3       1.0X
+date + interval(m, d, ms)                          3817           3836          27          2.6         381.7       0.2X
+date - interval(m)                                  891            897           8         11.2          89.1       1.0X
+date - interval(m, d)                               917            922           4         10.9          91.7       1.0X
+date - interval(m, d, ms)                          3788           3791           4          2.6         378.8       0.2X
+timestamp + interval(m)                            1843           1847           5          5.4         184.3       0.5X
+timestamp + interval(m, d)                         1887           1887           0          5.3         188.7       0.5X
+timestamp + interval(m, d, ms)                     2037           2064          38          4.9         203.7       0.4X
+timestamp - interval(m)                            1834           1835           2          5.5         183.4       0.5X
+timestamp - interval(m, d)                         1913           1913           0          5.2         191.3       0.5X
+timestamp - interval(m, d, ms)                     2030           2031           2          4.9         203.0       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    202            204           2         49.4          20.2       1.0X
-cast to timestamp wholestage on                     216            221           5         46.3          21.6       0.9X
+cast to timestamp wholestage off                    204            205           2         49.0          20.4       1.0X
+cast to timestamp wholestage on                     208            213           3         48.1          20.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    637            638           1         15.7          63.7       1.0X
-year of timestamp wholestage on                     639            646           6         15.6          63.9       1.0X
+year of timestamp wholestage off                    675            679           5         14.8          67.5       1.0X
+year of timestamp wholestage on                     666            671           4         15.0          66.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 672            675           4         14.9          67.2       1.0X
-quarter of timestamp wholestage on                  676            679           2         14.8          67.6       1.0X
+quarter of timestamp wholestage off                 720            729          13         13.9          72.0       1.0X
+quarter of timestamp wholestage on                  700            707           6         14.3          70.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   657            660           4         15.2          65.7       1.0X
-month of timestamp wholestage on                    654            657           3         15.3          65.4       1.0X
+month of timestamp wholestage off                   689            694           7         14.5          68.9       1.0X
+month of timestamp wholestage on                    683            685           2         14.6          68.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              938            938           1         10.7          93.8       1.0X
-weekofyear of timestamp wholestage on              1073           1078           4          9.3         107.3       0.9X
+weekofyear of timestamp wholestage off              987            989           3         10.1          98.7       1.0X
+weekofyear of timestamp wholestage on              1069           1074           3          9.4         106.9       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     658            666          12         15.2          65.8       1.0X
-day of timestamp wholestage on                      659            663           5         15.2          65.9       1.0X
+day of timestamp wholestage off                     719            722           5         13.9          71.9       1.0X
+day of timestamp wholestage on                      689            696           7         14.5          68.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               701            702           1         14.3          70.1       1.0X
-dayofyear of timestamp wholestage on                697            701           2         14.3          69.7       1.0X
+dayofyear of timestamp wholestage off               744            746           3         13.4          74.4       1.0X
+dayofyear of timestamp wholestage on                736            740           4         13.6          73.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              681            692          17         14.7          68.1       1.0X
-dayofmonth of timestamp wholestage on               656            658           2         15.2          65.6       1.0X
+dayofmonth of timestamp wholestage off              713            713           0         14.0          71.3       1.0X
+dayofmonth of timestamp wholestage on               697            703           6         14.3          69.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               825            830           7         12.1          82.5       1.0X
-dayofweek of timestamp wholestage on                837            840           4         11.9          83.7       1.0X
+dayofweek of timestamp wholestage off               870            873           5         11.5          87.0       1.0X
+dayofweek of timestamp wholestage on                857            860           3         11.7          85.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 760            763           4         13.2          76.0       1.0X
-weekday of timestamp wholestage on                  769            773           4         13.0          76.9       1.0X
+weekday of timestamp wholestage off                 807            812           6         12.4          80.7       1.0X
+weekday of timestamp wholestage on                  807            810           3         12.4          80.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    542            544           2         18.4          54.2       1.0X
-hour of timestamp wholestage on                     560            564           3         17.8          56.0       1.0X
+hour of timestamp wholestage off                    612            613           2         16.4          61.2       1.0X
+hour of timestamp wholestage on                     591            593           2         16.9          59.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  541            542           1         18.5          54.1       1.0X
-minute of timestamp wholestage on                   556            559           2         18.0          55.6       1.0X
+minute of timestamp wholestage off                  603            611          12         16.6          60.3       1.0X
+minute of timestamp wholestage on                   593            597           4         16.9          59.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  543            548           7         18.4          54.3       1.0X
-second of timestamp wholestage on                   561            564           2         17.8          56.1       1.0X
+second of timestamp wholestage off                  608            613           6         16.4          60.8       1.0X
+second of timestamp wholestage on                   595            600           7         16.8          59.5       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         178            181           4         56.0          17.8       1.0X
-current_date wholestage on                          217            221           4         46.1          21.7       0.8X
+current_date wholestage off                         191            191           0         52.3          19.1       1.0X
+current_date wholestage on                          211            220          13         47.5          21.1       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    193            203          14         51.7          19.3       1.0X
-current_timestamp wholestage on                     231            239          10         43.4          23.1       0.8X
+current_timestamp wholestage off                    192            193           1         52.0          19.2       1.0X
+current_timestamp wholestage on                     218            221           2         45.9          21.8       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         605            605           1         16.5          60.5       1.0X
-cast to date wholestage on                          630            636           8         15.9          63.0       1.0X
+cast to date wholestage off                         642            645           3         15.6          64.2       1.0X
+cast to date wholestage on                          649            652           3         15.4          64.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             683            683           0         14.6          68.3       1.0X
-last_day wholestage on                              683            686           2         14.6          68.3       1.0X
+last_day wholestage off                             719            720           2         13.9          71.9       1.0X
+last_day wholestage on                              727            730           6         13.8          72.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             646            650           5         15.5          64.6       1.0X
-next_day wholestage on                              659            665           5         15.2          65.9       1.0X
+next_day wholestage off                             682            683           1         14.7          68.2       1.0X
+next_day wholestage on                              679            682           2         14.7          67.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             583            584           2         17.2          58.3       1.0X
-date_add wholestage on                              590            594           4         17.0          59.0       1.0X
+date_add wholestage off                             629            633           5         15.9          62.9       1.0X
+date_add wholestage on                              640            642           2         15.6          64.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             587            588           1         17.0          58.7       1.0X
-date_sub wholestage on                              589            592           4         17.0          58.9       1.0X
+date_sub wholestage off                             629            631           2         15.9          62.9       1.0X
+date_sub wholestage on                              643            645           2         15.5          64.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           833            834           1         12.0          83.3       1.0X
-add_months wholestage on                            831            836           6         12.0          83.1       1.0X
+add_months wholestage off                           886            890           5         11.3          88.6       1.0X
+add_months wholestage on                            896            900           3         11.2          89.6       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2812           2815           5          3.6         281.2       1.0X
-format date wholestage on                          2788           2830          24          3.6         278.8       1.0X
+format date wholestage off                         2893           2900          10          3.5         289.3       1.0X
+format date wholestage on                          2888           2932          85          3.5         288.8       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2588           2591           5          3.9         258.8       1.0X
-from_unixtime wholestage on                        2683           2691           6          3.7         268.3       1.0X
+from_unixtime wholestage off                       2630           2646          22          3.8         263.0       1.0X
+from_unixtime wholestage on                        2646           2658           9          3.8         264.6       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   657            666          13         15.2          65.7       1.0X
-from_utc_timestamp wholestage on                    782            786           6         12.8          78.2       0.8X
+from_utc_timestamp wholestage off                   725            725           1         13.8          72.5       1.0X
+from_utc_timestamp wholestage on                    786            788           2         12.7          78.6       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     794            794           0         12.6          79.4       1.0X
-to_utc_timestamp wholestage on                      846            852           7         11.8          84.6       0.9X
+to_utc_timestamp wholestage off                     874            874           0         11.4          87.4       1.0X
+to_utc_timestamp wholestage on                      889            890           1         11.2          88.9       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        242            262          27         41.3          24.2       1.0X
-cast interval wholestage on                         223            226           3         44.9          22.3       1.1X
+cast interval wholestage off                        227            240          19         44.1          22.7       1.0X
+cast interval wholestage on                         208            209           1         48.1          20.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             996            997           1         10.0          99.6       1.0X
-datediff wholestage on                             1046           1049           4          9.6         104.6       1.0X
+datediff wholestage off                            1063           1067           6          9.4         106.3       1.0X
+datediff wholestage on                             1046           1053          10          9.6         104.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2890           2891           1          3.5         289.0       1.0X
-months_between wholestage on                       2889           2894           5          3.5         288.9       1.0X
+months_between wholestage off                      2969           2972           4          3.4         296.9       1.0X
+months_between wholestage on                       3029           3032           4          3.3         302.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               621            628          10          1.6         620.8       1.0X
-window wholestage on                                660            680          18          1.5         660.2       0.9X
+window wholestage off                               570            574           6          1.8         569.7       1.0X
+window wholestage on                                653            675          13          1.5         653.0       0.9X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      503            529          36         19.9          50.3       1.0X
-date_trunc YEAR wholestage on                       446            450           3         22.4          44.6       1.1X
+date_trunc YEAR wholestage off                      512            512           1         19.5          51.2       1.0X
+date_trunc YEAR wholestage on                       472            478           8         21.2          47.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      503            504           1         19.9          50.3       1.0X
-date_trunc YYYY wholestage on                       446            452           5         22.4          44.6       1.1X
+date_trunc YYYY wholestage off                      514            517           5         19.5          51.4       1.0X
+date_trunc YYYY wholestage on                       471            477           7         21.2          47.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        502            511          13         19.9          50.2       1.0X
-date_trunc YY wholestage on                         447            451           7         22.4          44.7       1.1X
+date_trunc YY wholestage off                        519            519           0         19.3          51.9       1.0X
+date_trunc YY wholestage on                         471            479          12         21.2          47.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       463            463           0         21.6          46.3       1.0X
-date_trunc MON wholestage on                        417            421           2         24.0          41.7       1.1X
+date_trunc MON wholestage off                       501            502           1         20.0          50.1       1.0X
+date_trunc MON wholestage on                        461            463           1         21.7          46.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     461            461           0         21.7          46.1       1.0X
-date_trunc MONTH wholestage on                      417            421           2         24.0          41.7       1.1X
+date_trunc MONTH wholestage off                     508            509           2         19.7          50.8       1.0X
+date_trunc MONTH wholestage on                      461            463           3         21.7          46.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        464            465           1         21.5          46.4       1.0X
-date_trunc MM wholestage on                         421            425           4         23.8          42.1       1.1X
+date_trunc MM wholestage off                        499            499           0         20.0          49.9       1.0X
+date_trunc MM wholestage on                         462            465           4         21.7          46.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       343            347           6         29.2          34.3       1.0X
-date_trunc DAY wholestage on                        327            331           5         30.6          32.7       1.0X
+date_trunc DAY wholestage off                       389            395           9         25.7          38.9       1.0X
+date_trunc DAY wholestage on                        356            359           2         28.1          35.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        341            342           1         29.3          34.1       1.0X
-date_trunc DD wholestage on                         324            328           2         30.8          32.4       1.1X
+date_trunc DD wholestage off                        390            390           1         25.7          39.0       1.0X
+date_trunc DD wholestage on                         360            364           5         27.8          36.0       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      337            337           0         29.7          33.7       1.0X
-date_trunc HOUR wholestage on                       318            319           2         31.5          31.8       1.1X
+date_trunc HOUR wholestage off                      389            395           9         25.7          38.9       1.0X
+date_trunc HOUR wholestage on                       358            361           4         28.0          35.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    350            350           0         28.6          35.0       1.0X
-date_trunc MINUTE wholestage on                     316            320           6         31.6          31.6       1.1X
+date_trunc MINUTE wholestage off                    389            389           0         25.7          38.9       1.0X
+date_trunc MINUTE wholestage on                     355            357           2         28.2          35.5       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    339            340           1         29.5          33.9       1.0X
-date_trunc SECOND wholestage on                     297            299           1         33.7          29.7       1.1X
+date_trunc SECOND wholestage off                    364            364           0         27.4          36.4       1.0X
+date_trunc SECOND wholestage on                     329            332           5         30.4          32.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      413            414           1         24.2          41.3       1.0X
-date_trunc WEEK wholestage on                       372            375           3         26.9          37.2       1.1X
+date_trunc WEEK wholestage off                      449            449           0         22.3          44.9       1.0X
+date_trunc WEEK wholestage on                       418            420           3         23.9          41.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   657            659           2         15.2          65.7       1.0X
-date_trunc QUARTER wholestage on                    613            614           2         16.3          61.3       1.1X
+date_trunc QUARTER wholestage off                   633            633           0         15.8          63.3       1.0X
+date_trunc QUARTER wholestage on                    603            606           2         16.6          60.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc YEAR (shuffled 2y) wholestage off           1135           1137           3          8.8         113.5       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1108           1114           6          9.0         110.8       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc YEAR (spread 95y) wholestage off           1293           1303          15          7.7         129.3       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1247           1249           2          8.0         124.7       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+date_trunc QUARTER (shuffled 2y) wholestage off           1054           1060           8          9.5         105.4       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1025           1029           4          9.8         102.5       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+date_trunc QUARTER (spread 95y) wholestage off           1225           1228           5          8.2         122.5       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1195           1205          10          8.4         119.5       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+date_trunc MONTH (shuffled 2y) wholestage off            751            755           5         13.3          75.1       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             731            741          12         13.7          73.1       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc MONTH (spread 95y) wholestage off            804            808           6         12.4          80.4       1.0X
+date_trunc MONTH (spread 95y) wholestage on             771            773           2         13.0          77.1       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc WEEK (shuffled 2y) wholestage off            555            557           3         18.0          55.5       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             518            521           1         19.3          51.8       1.1X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc WEEK (spread 95y) wholestage off            630            636           9         15.9          63.0       1.0X
+date_trunc WEEK (spread 95y) wholestage on             597            602           4         16.7          59.7       1.1X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc DAY (shuffled 2y) wholestage off            475            481           9         21.0          47.5       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             448            450           1         22.3          44.8       1.1X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
+date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+date_trunc DAY (spread 95y) wholestage off            563            565           3         17.8          56.3       1.0X
+date_trunc DAY (spread 95y) wholestage on             523            527           3         19.1          52.3       1.1X
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           847            847           1         11.8          84.7       1.0X
-trunc year wholestage on                            792            796           3         12.6          79.2       1.1X
+trunc year wholestage off                           869            871           3         11.5          86.9       1.0X
+trunc year wholestage on                            912            915           3         11.0          91.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           842            843           1         11.9          84.2       1.0X
-trunc yyyy wholestage on                            796            798           2         12.6          79.6       1.1X
+trunc yyyy wholestage off                           869            870           1         11.5          86.9       1.0X
+trunc yyyy wholestage on                            912            917           6         11.0          91.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             844            847           5         11.9          84.4       1.0X
-trunc yy wholestage on                              793            797           4         12.6          79.3       1.1X
+trunc yy wholestage off                             869            872           4         11.5          86.9       1.0X
+trunc yy wholestage on                              911            914           2         11.0          91.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            828            829           1         12.1          82.8       1.0X
-trunc mon wholestage on                             768            769           1         13.0          76.8       1.1X
+trunc mon wholestage off                            880            880           1         11.4          88.0       1.0X
+trunc mon wholestage on                             836            838           1         12.0          83.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          829            829           0         12.1          82.9       1.0X
-trunc month wholestage on                           768            775           8         13.0          76.8       1.1X
+trunc month wholestage off                          879            879           1         11.4          87.9       1.0X
+trunc month wholestage on                           835            840           3         12.0          83.5       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             825            826           1         12.1          82.5       1.0X
-trunc mm wholestage on                              769            770           1         13.0          76.9       1.1X
+trunc mm wholestage off                             879            879           1         11.4          87.9       1.0X
+trunc mm wholestage on                              834            840           5         12.0          83.4       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     108            110           3          9.3         107.6       1.0X
-to timestamp str wholestage on                      102            105           3          9.8         102.0       1.1X
+to timestamp str wholestage off                     113            114           1          8.9         112.8       1.0X
+to timestamp str wholestage on                      105            108           4          9.5         104.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         680            680           1          1.5         679.5       1.0X
-to_timestamp wholestage on                          687            691           4          1.5         686.6       1.0X
+to_timestamp wholestage off                         587            590           3          1.7         587.5       1.0X
+to_timestamp wholestage on                          588            590           3          1.7         588.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    691            691           1          1.4         690.8       1.0X
-to_unix_timestamp wholestage on                     673            679           7          1.5         673.0       1.0X
+to_unix_timestamp wholestage off                    584            587           3          1.7         584.4       1.0X
+to_unix_timestamp wholestage on                     607            610           3          1.6         607.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          153            155           3          6.5         152.8       1.0X
-to date str wholestage on                           133            137           6          7.5         133.3       1.1X
+to date str wholestage off                          142            142           0          7.0         142.0       1.0X
+to date str wholestage on                           137            142           7          7.3         137.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              632            638           9          1.6         631.7       1.0X
-to_date wholestage on                               638            641           2          1.6         638.3       1.0X
+to_date wholestage off                              571            571           0          1.8         571.0       1.0X
+to_date wholestage on                               569            570           1          1.8         568.7       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 9V74 80-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  290            292           2         17.2          58.1       1.0X
-From java.time.LocalDate                            229            230           1         21.8          45.9       1.3X
-Collect java.sql.Date                              1179           1265          76          4.2         235.9       0.2X
-Collect java.time.LocalDate                         927           1056         117          5.4         185.5       0.3X
-From java.sql.Timestamp                             230            256          22         21.8          46.0       1.3X
-From java.time.Instant                              187            190           4         26.8          37.3       1.6X
-Collect longs                                       903           1039         132          5.5         180.5       0.3X
-Collect java.sql.Timestamp                         1068           1150          89          4.7         213.5       0.3X
-Collect java.time.Instant                           963           1083         132          5.2         192.5       0.3X
-java.sql.Date to Hive string                       4107           4124          16          1.2         821.4       0.1X
-java.time.LocalDate to Hive string                 3029           3126         103          1.7         605.7       0.1X
-java.sql.Timestamp to Hive string                  6537           6586          58          0.8        1307.3       0.0X
-java.time.Instant to Hive string                   4089           4127          47          1.2         817.7       0.1X
+From java.sql.Date                                  316            317           1         15.8          63.3       1.0X
+From java.time.LocalDate                            246            246           0         20.3          49.2       1.3X
+Collect java.sql.Date                              1271           1477         178          3.9         254.2       0.2X
+Collect java.time.LocalDate                         939           1110         172          5.3         187.8       0.3X
+From java.sql.Timestamp                             255            270          13         19.6          51.1       1.2X
+From java.time.Instant                              217            226          13         23.0          43.4       1.5X
+Collect longs                                       894           1038         196          5.6         178.9       0.4X
+Collect java.sql.Timestamp                         1164           1247          76          4.3         232.9       0.3X
+Collect java.time.Instant                           963           1123         195          5.2         192.6       0.3X
+java.sql.Date to Hive string                       4112           4192          76          1.2         822.3       0.1X
+java.time.LocalDate to Hive string                 3081           3132          47          1.6         616.2       0.1X
+java.sql.Timestamp to Hive string                  6129           6311         159          0.8        1225.9       0.1X
+java.time.Instant to Hive string                   3979           4035          52          1.3         795.9       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -3,21 +3,21 @@ datetime +/- interval
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  912            949          47         11.0          91.2       1.0X
-date + interval(m, d)                               923            931           7         10.8          92.3       1.0X
-date + interval(m, d, ms)                          3817           3836          27          2.6         381.7       0.2X
-date - interval(m)                                  891            897           8         11.2          89.1       1.0X
-date - interval(m, d)                               917            922           4         10.9          91.7       1.0X
-date - interval(m, d, ms)                          3788           3791           4          2.6         378.8       0.2X
-timestamp + interval(m)                            1843           1847           5          5.4         184.3       0.5X
-timestamp + interval(m, d)                         1887           1887           0          5.3         188.7       0.5X
-timestamp + interval(m, d, ms)                     2037           2064          38          4.9         203.7       0.4X
-timestamp - interval(m)                            1834           1835           2          5.5         183.4       0.5X
-timestamp - interval(m, d)                         1913           1913           0          5.2         191.3       0.5X
-timestamp - interval(m, d, ms)                     2030           2031           2          4.9         203.0       0.4X
+date + interval(m)                                  831            872          51         12.0          83.1       1.0X
+date + interval(m, d)                               838            850          15         11.9          83.8       1.0X
+date + interval(m, d, ms)                          4051           4097          65          2.5         405.1       0.2X
+date - interval(m)                                  838            842           5         11.9          83.8       1.0X
+date - interval(m, d)                               858            864           5         11.7          85.8       1.0X
+date - interval(m, d, ms)                          4052           4058           9          2.5         405.2       0.2X
+timestamp + interval(m)                            1687           1690           5          5.9         168.7       0.5X
+timestamp + interval(m, d)                         1730           1731           1          5.8         173.0       0.5X
+timestamp + interval(m, d, ms)                     1825           1827           2          5.5         182.5       0.5X
+timestamp - interval(m)                            1544           1552          12          6.5         154.4       0.5X
+timestamp - interval(m, d)                         1603           1604           2          6.2         160.3       0.5X
+timestamp - interval(m, d, ms)                     1809           1812           4          5.5         180.9       0.5X
 
 
 ================================================================================================
@@ -25,95 +25,95 @@ Extract components
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    204            205           2         49.0          20.4       1.0X
-cast to timestamp wholestage on                     208            213           3         48.1          20.8       1.0X
+cast to timestamp wholestage off                    204            205           2         49.1          20.4       1.0X
+cast to timestamp wholestage on                     203            204           1         49.3          20.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    675            679           5         14.8          67.5       1.0X
-year of timestamp wholestage on                     666            671           4         15.0          66.6       1.0X
+year of timestamp wholestage off                    635            637           3         15.7          63.5       1.0X
+year of timestamp wholestage on                     612            618           4         16.3          61.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 720            729          13         13.9          72.0       1.0X
-quarter of timestamp wholestage on                  700            707           6         14.3          70.0       1.0X
+quarter of timestamp wholestage off                 656            660           7         15.3          65.6       1.0X
+quarter of timestamp wholestage on                  650            653           2         15.4          65.0       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   689            694           7         14.5          68.9       1.0X
-month of timestamp wholestage on                    683            685           2         14.6          68.3       1.0X
+month of timestamp wholestage off                   639            643           5         15.6          63.9       1.0X
+month of timestamp wholestage on                    633            634           1         15.8          63.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              987            989           3         10.1          98.7       1.0X
-weekofyear of timestamp wholestage on              1069           1074           3          9.4         106.9       0.9X
+weekofyear of timestamp wholestage off              998            998           0         10.0          99.8       1.0X
+weekofyear of timestamp wholestage on              1021           1032          12          9.8         102.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     719            722           5         13.9          71.9       1.0X
-day of timestamp wholestage on                      689            696           7         14.5          68.9       1.0X
+day of timestamp wholestage off                     644            649           6         15.5          64.4       1.0X
+day of timestamp wholestage on                      643            645           1         15.6          64.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               744            746           3         13.4          74.4       1.0X
-dayofyear of timestamp wholestage on                736            740           4         13.6          73.6       1.0X
+dayofyear of timestamp wholestage off               677            677           0         14.8          67.7       1.0X
+dayofyear of timestamp wholestage on                672            674           3         14.9          67.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              713            713           0         14.0          71.3       1.0X
-dayofmonth of timestamp wholestage on               697            703           6         14.3          69.7       1.0X
+dayofmonth of timestamp wholestage off              657            659           2         15.2          65.7       1.0X
+dayofmonth of timestamp wholestage on               642            647           4         15.6          64.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               870            873           5         11.5          87.0       1.0X
-dayofweek of timestamp wholestage on                857            860           3         11.7          85.7       1.0X
+dayofweek of timestamp wholestage off               805            806           2         12.4          80.5       1.0X
+dayofweek of timestamp wholestage on                807            810           3         12.4          80.7       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 807            812           6         12.4          80.7       1.0X
-weekday of timestamp wholestage on                  807            810           3         12.4          80.7       1.0X
+weekday of timestamp wholestage off                 750            752           4         13.3          75.0       1.0X
+weekday of timestamp wholestage on                  741            742           2         13.5          74.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    612            613           2         16.4          61.2       1.0X
-hour of timestamp wholestage on                     591            593           2         16.9          59.1       1.0X
+hour of timestamp wholestage off                    540            540           1         18.5          54.0       1.0X
+hour of timestamp wholestage on                     544            546           2         18.4          54.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  603            611          12         16.6          60.3       1.0X
-minute of timestamp wholestage on                   593            597           4         16.9          59.3       1.0X
+minute of timestamp wholestage off                  542            542           1         18.5          54.2       1.0X
+minute of timestamp wholestage on                   546            549           4         18.3          54.6       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  608            613           6         16.4          60.8       1.0X
-second of timestamp wholestage on                   595            600           7         16.8          59.5       1.0X
+second of timestamp wholestage off                  542            542           1         18.5          54.2       1.0X
+second of timestamp wholestage on                   546            551           6         18.3          54.6       1.0X
 
 
 ================================================================================================
@@ -121,18 +121,18 @@ Current date and time
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         191            191           0         52.3          19.1       1.0X
-current_date wholestage on                          211            220          13         47.5          21.1       0.9X
+current_date wholestage off                         177            180           4         56.3          17.7       1.0X
+current_date wholestage on                          204            214          16         49.0          20.4       0.9X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    192            193           1         52.0          19.2       1.0X
-current_timestamp wholestage on                     218            221           2         45.9          21.8       0.9X
+current_timestamp wholestage off                    189            189           1         53.0          18.9       1.0X
+current_timestamp wholestage on                     221            225           4         45.2          22.1       0.9X
 
 
 ================================================================================================
@@ -140,46 +140,46 @@ Date arithmetic
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         642            645           3         15.6          64.2       1.0X
-cast to date wholestage on                          649            652           3         15.4          64.9       1.0X
+cast to date wholestage off                         591            592           2         16.9          59.1       1.0X
+cast to date wholestage on                          593            604          18         16.9          59.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             719            720           2         13.9          71.9       1.0X
-last_day wholestage on                              727            730           6         13.8          72.7       1.0X
+last_day wholestage off                             673            673           0         14.9          67.3       1.0X
+last_day wholestage on                              674            677           2         14.8          67.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             682            683           1         14.7          68.2       1.0X
-next_day wholestage on                              679            682           2         14.7          67.9       1.0X
+next_day wholestage off                             622            623           2         16.1          62.2       1.0X
+next_day wholestage on                              625            628           3         16.0          62.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             629            633           5         15.9          62.9       1.0X
-date_add wholestage on                              640            642           2         15.6          64.0       1.0X
+date_add wholestage off                             577            579           2         17.3          57.7       1.0X
+date_add wholestage on                              585            616          66         17.1          58.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             629            631           2         15.9          62.9       1.0X
-date_sub wholestage on                              643            645           2         15.5          64.3       1.0X
+date_sub wholestage off                             575            575           0         17.4          57.5       1.0X
+date_sub wholestage on                              586            587           1         17.1          58.6       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           886            890           5         11.3          88.6       1.0X
-add_months wholestage on                            896            900           3         11.2          89.6       1.0X
+add_months wholestage off                           798            799           2         12.5          79.8       1.0X
+add_months wholestage on                            825            826           1         12.1          82.5       1.0X
 
 
 ================================================================================================
@@ -187,11 +187,11 @@ Formatting dates
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2893           2900          10          3.5         289.3       1.0X
-format date wholestage on                          2888           2932          85          3.5         288.8       1.0X
+format date wholestage off                         3150           3174          35          3.2         315.0       1.0X
+format date wholestage on                          3073           3102          56          3.3         307.3       1.0X
 
 
 ================================================================================================
@@ -199,11 +199,11 @@ Formatting timestamps
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2630           2646          22          3.8         263.0       1.0X
-from_unixtime wholestage on                        2646           2658           9          3.8         264.6       1.0X
+from_unixtime wholestage off                       2631           2634           4          3.8         263.1       1.0X
+from_unixtime wholestage on                        2712           2721           6          3.7         271.2       1.0X
 
 
 ================================================================================================
@@ -211,18 +211,18 @@ Convert timestamps
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   725            725           1         13.8          72.5       1.0X
-from_utc_timestamp wholestage on                    786            788           2         12.7          78.6       0.9X
+from_utc_timestamp wholestage off                   657            658           1         15.2          65.7       1.0X
+from_utc_timestamp wholestage on                    780            795          18         12.8          78.0       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     874            874           0         11.4          87.4       1.0X
-to_utc_timestamp wholestage on                      889            890           1         11.2          88.9       1.0X
+to_utc_timestamp wholestage off                     809            809           1         12.4          80.9       1.0X
+to_utc_timestamp wholestage on                      857            861           6         11.7          85.7       0.9X
 
 
 ================================================================================================
@@ -230,32 +230,32 @@ Intervals
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        227            240          19         44.1          22.7       1.0X
-cast interval wholestage on                         208            209           1         48.1          20.8       1.1X
+cast interval wholestage off                        229            230           1         43.7          22.9       1.0X
+cast interval wholestage on                         203            206           5         49.2          20.3       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1063           1067           6          9.4         106.3       1.0X
-datediff wholestage on                             1046           1053          10          9.6         104.6       1.0X
+datediff wholestage off                             986            988           3         10.1          98.6       1.0X
+datediff wholestage on                              982            985           4         10.2          98.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2969           2972           4          3.4         296.9       1.0X
-months_between wholestage on                       3029           3032           4          3.3         302.9       1.0X
+months_between wholestage off                      2734           2736           4          3.7         273.4       1.0X
+months_between wholestage on                       2703           2709           8          3.7         270.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               570            574           6          1.8         569.7       1.0X
-window wholestage on                                653            675          13          1.5         653.0       0.9X
+window wholestage off                               615            630          22          1.6         615.2       1.0X
+window wholestage on                                649            692          41          1.5         649.4       0.9X
 
 
 ================================================================================================
@@ -263,207 +263,207 @@ Truncation
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      512            512           1         19.5          51.2       1.0X
-date_trunc YEAR wholestage on                       472            478           8         21.2          47.2       1.1X
+date_trunc YEAR wholestage off                      467            468           1         21.4          46.7       1.0X
+date_trunc YEAR wholestage on                       424            429           3         23.6          42.4       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      514            517           5         19.5          51.4       1.0X
-date_trunc YYYY wholestage on                       471            477           7         21.2          47.1       1.1X
+date_trunc YYYY wholestage off                      467            472           6         21.4          46.7       1.0X
+date_trunc YYYY wholestage on                       422            424           1         23.7          42.2       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        519            519           0         19.3          51.9       1.0X
-date_trunc YY wholestage on                         471            479          12         21.2          47.1       1.1X
+date_trunc YY wholestage off                        467            472           7         21.4          46.7       1.0X
+date_trunc YY wholestage on                         428            430           3         23.4          42.8       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       501            502           1         20.0          50.1       1.0X
-date_trunc MON wholestage on                        461            463           1         21.7          46.1       1.1X
+date_trunc MON wholestage off                       452            456           6         22.1          45.2       1.0X
+date_trunc MON wholestage on                        410            412           3         24.4          41.0       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     508            509           2         19.7          50.8       1.0X
-date_trunc MONTH wholestage on                      461            463           3         21.7          46.1       1.1X
+date_trunc MONTH wholestage off                     451            453           2         22.2          45.1       1.0X
+date_trunc MONTH wholestage on                      410            414           4         24.4          41.0       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        499            499           0         20.0          49.9       1.0X
-date_trunc MM wholestage on                         462            465           4         21.7          46.2       1.1X
+date_trunc MM wholestage off                        453            456           4         22.1          45.3       1.0X
+date_trunc MM wholestage on                         414            416           2         24.2          41.4       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       389            395           9         25.7          38.9       1.0X
-date_trunc DAY wholestage on                        356            359           2         28.1          35.6       1.1X
+date_trunc DAY wholestage off                       379            382           4         26.4          37.9       1.0X
+date_trunc DAY wholestage on                        340            343           3         29.4          34.0       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        390            390           1         25.7          39.0       1.0X
-date_trunc DD wholestage on                         360            364           5         27.8          36.0       1.1X
+date_trunc DD wholestage off                        388            390           3         25.8          38.8       1.0X
+date_trunc DD wholestage on                         341            345           5         29.3          34.1       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      389            395           9         25.7          38.9       1.0X
-date_trunc HOUR wholestage on                       358            361           4         28.0          35.8       1.1X
+date_trunc HOUR wholestage off                      427            428           1         23.4          42.7       1.0X
+date_trunc HOUR wholestage on                       396            399           3         25.2          39.6       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    389            389           0         25.7          38.9       1.0X
-date_trunc MINUTE wholestage on                     355            357           2         28.2          35.5       1.1X
+date_trunc MINUTE wholestage off                    421            421           1         23.8          42.1       1.0X
+date_trunc MINUTE wholestage on                     381            385           7         26.2          38.1       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    364            364           0         27.4          36.4       1.0X
-date_trunc SECOND wholestage on                     329            332           5         30.4          32.9       1.1X
+date_trunc SECOND wholestage off                    342            343           2         29.2          34.2       1.0X
+date_trunc SECOND wholestage on                     305            306           2         32.8          30.5       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      449            449           0         22.3          44.9       1.0X
-date_trunc WEEK wholestage on                       418            420           3         23.9          41.8       1.1X
+date_trunc WEEK wholestage off                      415            415           0         24.1          41.5       1.0X
+date_trunc WEEK wholestage on                       378            380           2         26.5          37.8       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   633            633           0         15.8          63.3       1.0X
-date_trunc QUARTER wholestage on                    603            606           2         16.6          60.3       1.0X
+date_trunc QUARTER wholestage off                   599            599           1         16.7          59.9       1.0X
+date_trunc QUARTER wholestage on                    565            567           2         17.7          56.5       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (shuffled 2y) wholestage off           1135           1137           3          8.8         113.5       1.0X
-date_trunc YEAR (shuffled 2y) wholestage on            1108           1114           6          9.0         110.8       1.0X
+date_trunc YEAR (shuffled 2y) wholestage off           1151           1151           0          8.7         115.1       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1127           1130           3          8.9         112.7       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (spread 95y) wholestage off           1293           1303          15          7.7         129.3       1.0X
-date_trunc YEAR (spread 95y) wholestage on            1247           1249           2          8.0         124.7       1.0X
+date_trunc YEAR (spread 95y) wholestage off           1298           1306          12          7.7         129.8       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1285           1290           5          7.8         128.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (shuffled 2y) wholestage off           1054           1060           8          9.5         105.4       1.0X
-date_trunc QUARTER (shuffled 2y) wholestage on            1025           1029           4          9.8         102.5       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage off           1019           1021           2          9.8         101.9       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on             984            989           4         10.2          98.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (spread 95y) wholestage off           1225           1228           5          8.2         122.5       1.0X
-date_trunc QUARTER (spread 95y) wholestage on            1195           1205          10          8.4         119.5       1.0X
+date_trunc QUARTER (spread 95y) wholestage off           1313           1316           4          7.6         131.3       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1261           1265           2          7.9         126.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (shuffled 2y) wholestage off            751            755           5         13.3          75.1       1.0X
-date_trunc MONTH (shuffled 2y) wholestage on             731            741          12         13.7          73.1       1.0X
+date_trunc MONTH (shuffled 2y) wholestage off            733            733           0         13.6          73.3       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             691            696           4         14.5          69.1       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (spread 95y) wholestage off            804            808           6         12.4          80.4       1.0X
-date_trunc MONTH (spread 95y) wholestage on             771            773           2         13.0          77.1       1.0X
+date_trunc MONTH (spread 95y) wholestage off            807            809           2         12.4          80.7       1.0X
+date_trunc MONTH (spread 95y) wholestage on             780            783           2         12.8          78.0       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (shuffled 2y) wholestage off            555            557           3         18.0          55.5       1.0X
-date_trunc WEEK (shuffled 2y) wholestage on             518            521           1         19.3          51.8       1.1X
+date_trunc WEEK (shuffled 2y) wholestage off            534            538           6         18.7          53.4       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             501            504           3         20.0          50.1       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (spread 95y) wholestage off            630            636           9         15.9          63.0       1.0X
-date_trunc WEEK (spread 95y) wholestage on             597            602           4         16.7          59.7       1.1X
+date_trunc WEEK (spread 95y) wholestage off            666            667           1         15.0          66.6       1.0X
+date_trunc WEEK (spread 95y) wholestage on             619            626          11         16.2          61.9       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (shuffled 2y) wholestage off            475            481           9         21.0          47.5       1.0X
-date_trunc DAY (shuffled 2y) wholestage on             448            450           1         22.3          44.8       1.1X
+date_trunc DAY (shuffled 2y) wholestage off            481            482           1         20.8          48.1       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             443            449           5         22.6          44.3       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (spread 95y) wholestage off            563            565           3         17.8          56.3       1.0X
-date_trunc DAY (spread 95y) wholestage on             523            527           3         19.1          52.3       1.1X
+date_trunc DAY (spread 95y) wholestage off            601            605           5         16.6          60.1       1.0X
+date_trunc DAY (spread 95y) wholestage on             566            568           3         17.7          56.6       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           869            871           3         11.5          86.9       1.0X
-trunc year wholestage on                            912            915           3         11.0          91.2       1.0X
+trunc year wholestage off                           795            797           3         12.6          79.5       1.0X
+trunc year wholestage on                            768            771           2         13.0          76.8       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           869            870           1         11.5          86.9       1.0X
-trunc yyyy wholestage on                            912            917           6         11.0          91.2       1.0X
+trunc yyyy wholestage off                           796            796           0         12.6          79.6       1.0X
+trunc yyyy wholestage on                            766            768           2         13.1          76.6       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             869            872           4         11.5          86.9       1.0X
-trunc yy wholestage on                              911            914           2         11.0          91.1       1.0X
+trunc yy wholestage off                             794            799           7         12.6          79.4       1.0X
+trunc yy wholestage on                              768            769           1         13.0          76.8       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            880            880           1         11.4          88.0       1.0X
-trunc mon wholestage on                             836            838           1         12.0          83.6       1.1X
+trunc mon wholestage off                            758            761           4         13.2          75.8       1.0X
+trunc mon wholestage on                             722            725           4         13.9          72.2       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          879            879           1         11.4          87.9       1.0X
-trunc month wholestage on                           835            840           3         12.0          83.5       1.1X
+trunc month wholestage off                          754            756           3         13.3          75.4       1.0X
+trunc month wholestage on                           724            739          19         13.8          72.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             879            879           1         11.4          87.9       1.0X
-trunc mm wholestage on                              834            840           5         12.0          83.4       1.1X
+trunc mm wholestage off                             754            755           1         13.3          75.4       1.0X
+trunc mm wholestage on                              722            724           2         13.9          72.2       1.0X
 
 
 ================================================================================================
@@ -471,39 +471,39 @@ Parsing
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     113            114           1          8.9         112.8       1.0X
-to timestamp str wholestage on                      105            108           4          9.5         104.9       1.1X
+to timestamp str wholestage off                     101            101           1          9.9         100.7       1.0X
+to timestamp str wholestage on                      101            104           3          9.9         100.7       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         587            590           3          1.7         587.5       1.0X
-to_timestamp wholestage on                          588            590           3          1.7         588.3       1.0X
+to_timestamp wholestage off                         676            677           0          1.5         676.5       1.0X
+to_timestamp wholestage on                          670            674           3          1.5         669.9       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    584            587           3          1.7         584.4       1.0X
-to_unix_timestamp wholestage on                     607            610           3          1.6         607.3       1.0X
+to_unix_timestamp wholestage off                    657            658           1          1.5         657.4       1.0X
+to_unix_timestamp wholestage on                     658            659           2          1.5         658.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          142            142           0          7.0         142.0       1.0X
-to date str wholestage on                           137            142           7          7.3         137.0       1.0X
+to date str wholestage off                          142            142           0          7.1         141.6       1.0X
+to date str wholestage on                           132            136           4          7.6         132.4       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              571            571           0          1.8         571.0       1.0X
-to_date wholestage on                               569            570           1          1.8         568.7       1.0X
+to_date wholestage off                              634            636           2          1.6         633.8       1.0X
+to_date wholestage on                               631            632           1          1.6         631.0       1.0X
 
 
 ================================================================================================
@@ -511,21 +511,21 @@ Conversion from/to external types
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  316            317           1         15.8          63.3       1.0X
-From java.time.LocalDate                            246            246           0         20.3          49.2       1.3X
-Collect java.sql.Date                              1271           1477         178          3.9         254.2       0.2X
-Collect java.time.LocalDate                         939           1110         172          5.3         187.8       0.3X
-From java.sql.Timestamp                             255            270          13         19.6          51.1       1.2X
-From java.time.Instant                              217            226          13         23.0          43.4       1.5X
-Collect longs                                       894           1038         196          5.6         178.9       0.4X
-Collect java.sql.Timestamp                         1164           1247          76          4.3         232.9       0.3X
-Collect java.time.Instant                           963           1123         195          5.2         192.6       0.3X
-java.sql.Date to Hive string                       4112           4192          76          1.2         822.3       0.1X
-java.time.LocalDate to Hive string                 3081           3132          47          1.6         616.2       0.1X
-java.sql.Timestamp to Hive string                  6129           6311         159          0.8        1225.9       0.1X
-java.time.Instant to Hive string                   3979           4035          52          1.3         795.9       0.1X
+From java.sql.Date                                  286            286           1         17.5          57.1       1.0X
+From java.time.LocalDate                            231            235           6         21.6          46.3       1.2X
+Collect java.sql.Date                              1332           1367          49          3.8         266.4       0.2X
+Collect java.time.LocalDate                         877            997         107          5.7         175.5       0.3X
+From java.sql.Timestamp                             232            249          16         21.5          46.4       1.2X
+From java.time.Instant                              189            190           1         26.4          37.8       1.5X
+Collect longs                                       945            989          69          5.3         188.9       0.3X
+Collect java.sql.Timestamp                         1058           1238         157          4.7         211.5       0.3X
+Collect java.time.Instant                           894           1099         194          5.6         178.7       0.3X
+java.sql.Date to Hive string                       3935           3973          58          1.3         787.0       0.1X
+java.time.LocalDate to Hive string                 3114           3205         111          1.6         622.8       0.1X
+java.sql.Timestamp to Hive string                  6706           6753          41          0.7        1341.2       0.0X
+java.time.Instant to Hive string                   4160           4252         125          1.2         832.1       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  823            851          46         12.1          82.3       1.0X
-date + interval(m, d)                               793            798           5         12.6          79.3       1.0X
-date + interval(m, d, ms)                          3512           3548          51          2.8         351.2       0.2X
-date - interval(m)                                  788            803          13         12.7          78.8       1.0X
-date - interval(m, d)                               815            818           4         12.3          81.5       1.0X
-date - interval(m, d, ms)                          3523           3526           3          2.8         352.3       0.2X
-timestamp + interval(m)                            1793           1799           9          5.6         179.3       0.5X
-timestamp + interval(m, d)                         1840           1841           2          5.4         184.0       0.4X
-timestamp + interval(m, d, ms)                     1935           1942           9          5.2         193.5       0.4X
-timestamp - interval(m)                            1699           1711          17          5.9         169.9       0.5X
-timestamp - interval(m, d)                         1745           1755          13          5.7         174.5       0.5X
-timestamp - interval(m, d, ms)                     1927           1932           7          5.2         192.7       0.4X
+date + interval(m)                                  829            906          86         12.1          82.9       1.0X
+date + interval(m, d)                               864            877          12         11.6          86.4       1.0X
+date + interval(m, d, ms)                          3716           3720           6          2.7         371.6       0.2X
+date - interval(m)                                  841            847           8         11.9          84.1       1.0X
+date - interval(m, d)                               917            918           1         10.9          91.7       0.9X
+date - interval(m, d, ms)                          3770           3774           6          2.7         377.0       0.2X
+timestamp + interval(m)                            1533           1533           1          6.5         153.3       0.5X
+timestamp + interval(m, d)                         1581           1583           3          6.3         158.1       0.5X
+timestamp + interval(m, d, ms)                     2025           2027           2          4.9         202.5       0.4X
+timestamp - interval(m)                            1812           1818           9          5.5         181.2       0.5X
+timestamp - interval(m, d)                         1866           1870           6          5.4         186.6       0.4X
+timestamp - interval(m, d, ms)                     2021           2022           2          4.9         202.1       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    200            203           5         50.0          20.0       1.0X
-cast to timestamp wholestage on                     189            199           7         52.9          18.9       1.1X
+cast to timestamp wholestage off                    202            204           2         49.4          20.2       1.0X
+cast to timestamp wholestage on                     216            221           5         46.3          21.6       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    619            620           1         16.2          61.9       1.0X
-year of timestamp wholestage on                     603            610           7         16.6          60.3       1.0X
+year of timestamp wholestage off                    637            638           1         15.7          63.7       1.0X
+year of timestamp wholestage on                     639            646           6         15.6          63.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 651            653           4         15.4          65.1       1.0X
-quarter of timestamp wholestage on                  640            644           4         15.6          64.0       1.0X
+quarter of timestamp wholestage off                 672            675           4         14.9          67.2       1.0X
+quarter of timestamp wholestage on                  676            679           2         14.8          67.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   625            626           1         16.0          62.5       1.0X
-month of timestamp wholestage on                    621            628           7         16.1          62.1       1.0X
+month of timestamp wholestage off                   657            660           4         15.2          65.7       1.0X
+month of timestamp wholestage on                    654            657           3         15.3          65.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              879            881           4         11.4          87.9       1.0X
-weekofyear of timestamp wholestage on               939            945           9         10.7          93.9       0.9X
+weekofyear of timestamp wholestage off              938            938           1         10.7          93.8       1.0X
+weekofyear of timestamp wholestage on              1073           1078           4          9.3         107.3       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     638            640           4         15.7          63.8       1.0X
-day of timestamp wholestage on                      622            629           5         16.1          62.2       1.0X
+day of timestamp wholestage off                     658            666          12         15.2          65.8       1.0X
+day of timestamp wholestage on                      659            663           5         15.2          65.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               661            661           1         15.1          66.1       1.0X
-dayofyear of timestamp wholestage on                647            654          12         15.4          64.7       1.0X
+dayofyear of timestamp wholestage off               701            702           1         14.3          70.1       1.0X
+dayofyear of timestamp wholestage on                697            701           2         14.3          69.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              648            659          16         15.4          64.8       1.0X
-dayofmonth of timestamp wholestage on               622            624           2         16.1          62.2       1.0X
+dayofmonth of timestamp wholestage off              681            692          17         14.7          68.1       1.0X
+dayofmonth of timestamp wholestage on               656            658           2         15.2          65.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               762            770          11         13.1          76.2       1.0X
-dayofweek of timestamp wholestage on                751            764          15         13.3          75.1       1.0X
+dayofweek of timestamp wholestage off               825            830           7         12.1          82.5       1.0X
+dayofweek of timestamp wholestage on                837            840           4         11.9          83.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 737            739           2         13.6          73.7       1.0X
-weekday of timestamp wholestage on                  717            719           2         13.9          71.7       1.0X
+weekday of timestamp wholestage off                 760            763           4         13.2          76.0       1.0X
+weekday of timestamp wholestage on                  769            773           4         13.0          76.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    601            616          22         16.6          60.1       1.0X
-hour of timestamp wholestage on                     581            584           5         17.2          58.1       1.0X
+hour of timestamp wholestage off                    542            544           2         18.4          54.2       1.0X
+hour of timestamp wholestage on                     560            564           3         17.8          56.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  612            617           7         16.3          61.2       1.0X
-minute of timestamp wholestage on                   571            578           5         17.5          57.1       1.1X
+minute of timestamp wholestage off                  541            542           1         18.5          54.1       1.0X
+minute of timestamp wholestage on                   556            559           2         18.0          55.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  609            610           2         16.4          60.9       1.0X
-second of timestamp wholestage on                   581            584           2         17.2          58.1       1.0X
+second of timestamp wholestage off                  543            548           7         18.4          54.3       1.0X
+second of timestamp wholestage on                   561            564           2         17.8          56.1       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         184            208          35         54.4          18.4       1.0X
-current_date wholestage on                          184            191           8         54.3          18.4       1.0X
+current_date wholestage off                         178            181           4         56.0          17.8       1.0X
+current_date wholestage on                          217            221           4         46.1          21.7       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    184            186           2         54.3          18.4       1.0X
-current_timestamp wholestage on                     200            208           9         49.9          20.0       0.9X
+current_timestamp wholestage off                    193            203          14         51.7          19.3       1.0X
+current_timestamp wholestage on                     231            239          10         43.4          23.1       0.8X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         592            593           0         16.9          59.2       1.0X
-cast to date wholestage on                          579            583           4         17.3          57.9       1.0X
+cast to date wholestage off                         605            605           1         16.5          60.5       1.0X
+cast to date wholestage on                          630            636           8         15.9          63.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             653            657           6         15.3          65.3       1.0X
-last_day wholestage on                              639            645           8         15.7          63.9       1.0X
+last_day wholestage off                             683            683           0         14.6          68.3       1.0X
+last_day wholestage on                              683            686           2         14.6          68.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             612            613           1         16.3          61.2       1.0X
-next_day wholestage on                              605            610           6         16.5          60.5       1.0X
+next_day wholestage off                             646            650           5         15.5          64.6       1.0X
+next_day wholestage on                              659            665           5         15.2          65.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             583            592          13         17.2          58.3       1.0X
-date_add wholestage on                              567            571           7         17.6          56.7       1.0X
+date_add wholestage off                             583            584           2         17.2          58.3       1.0X
+date_add wholestage on                              590            594           4         17.0          59.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             578            580           2         17.3          57.8       1.0X
-date_sub wholestage on                              561            567           6         17.8          56.1       1.0X
+date_sub wholestage off                             587            588           1         17.0          58.7       1.0X
+date_sub wholestage on                              589            592           4         17.0          58.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           797            799           3         12.5          79.7       1.0X
-add_months wholestage on                            782            796          14         12.8          78.2       1.0X
+add_months wholestage off                           833            834           1         12.0          83.3       1.0X
+add_months wholestage on                            831            836           6         12.0          83.1       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3040           3050          14          3.3         304.0       1.0X
-format date wholestage on                          2974           2989          26          3.4         297.4       1.0X
+format date wholestage off                         2812           2815           5          3.6         281.2       1.0X
+format date wholestage on                          2788           2830          24          3.6         278.8       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2812           2818           9          3.6         281.2       1.0X
-from_unixtime wholestage on                        2818           2822           4          3.5         281.8       1.0X
+from_unixtime wholestage off                       2588           2591           5          3.9         258.8       1.0X
+from_unixtime wholestage on                        2683           2691           6          3.7         268.3       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   721            722           1         13.9          72.1       1.0X
-from_utc_timestamp wholestage on                    774            782           6         12.9          77.4       0.9X
+from_utc_timestamp wholestage off                   657            666          13         15.2          65.7       1.0X
+from_utc_timestamp wholestage on                    782            786           6         12.8          78.2       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     903            903           0         11.1          90.3       1.0X
-to_utc_timestamp wholestage on                      932            938           5         10.7          93.2       1.0X
+to_utc_timestamp wholestage off                     794            794           0         12.6          79.4       1.0X
+to_utc_timestamp wholestage on                      846            852           7         11.8          84.6       0.9X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        221            225           6         45.3          22.1       1.0X
-cast interval wholestage on                         216            223           9         46.2          21.6       1.0X
+cast interval wholestage off                        242            262          27         41.3          24.2       1.0X
+cast interval wholestage on                         223            226           3         44.9          22.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             965            966           0         10.4          96.5       1.0X
-datediff wholestage on                              951            954           2         10.5          95.1       1.0X
+datediff wholestage off                             996            997           1         10.0          99.6       1.0X
+datediff wholestage on                             1046           1049           4          9.6         104.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3070           3073           3          3.3         307.0       1.0X
-months_between wholestage on                       3115           3121           4          3.2         311.5       1.0X
+months_between wholestage off                      2890           2891           1          3.5         289.0       1.0X
+months_between wholestage on                       2889           2894           5          3.5         288.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               525            534          13          1.9         525.0       1.0X
-window wholestage on                                664            669           4          1.5         663.6       0.8X
+window wholestage off                               621            628          10          1.6         620.8       1.0X
+window wholestage on                                660            680          18          1.5         660.2       0.9X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      760            762           3         13.2          76.0       1.0X
-date_trunc YEAR wholestage on                       723            727           5         13.8          72.3       1.1X
+date_trunc YEAR wholestage off                      503            529          36         19.9          50.3       1.0X
+date_trunc YEAR wholestage on                       446            450           3         22.4          44.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      759            762           4         13.2          75.9       1.0X
-date_trunc YYYY wholestage on                       725            731           8         13.8          72.5       1.0X
+date_trunc YYYY wholestage off                      503            504           1         19.9          50.3       1.0X
+date_trunc YYYY wholestage on                       446            452           5         22.4          44.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        759            759           0         13.2          75.9       1.0X
-date_trunc YY wholestage on                         722            727           7         13.8          72.2       1.1X
+date_trunc YY wholestage off                        502            511          13         19.9          50.2       1.0X
+date_trunc YY wholestage on                         447            451           7         22.4          44.7       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       755            756           2         13.2          75.5       1.0X
-date_trunc MON wholestage on                        712            715           3         14.0          71.2       1.1X
+date_trunc MON wholestage off                       463            463           0         21.6          46.3       1.0X
+date_trunc MON wholestage on                        417            421           2         24.0          41.7       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     754            761          10         13.3          75.4       1.0X
-date_trunc MONTH wholestage on                      711            714           5         14.1          71.1       1.1X
+date_trunc MONTH wholestage off                     461            461           0         21.7          46.1       1.0X
+date_trunc MONTH wholestage on                      417            421           2         24.0          41.7       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        756            758           3         13.2          75.6       1.0X
-date_trunc MM wholestage on                         717            724           7         13.9          71.7       1.1X
+date_trunc MM wholestage off                        464            465           1         21.5          46.4       1.0X
+date_trunc MM wholestage on                         421            425           4         23.8          42.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       628            628           1         15.9          62.8       1.0X
-date_trunc DAY wholestage on                        589            592           3         17.0          58.9       1.1X
+date_trunc DAY wholestage off                       343            347           6         29.2          34.3       1.0X
+date_trunc DAY wholestage on                        327            331           5         30.6          32.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        623            624           2         16.1          62.3       1.0X
-date_trunc DD wholestage on                         592            600           8         16.9          59.2       1.1X
+date_trunc DD wholestage off                        341            342           1         29.3          34.1       1.0X
+date_trunc DD wholestage on                         324            328           2         30.8          32.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      630            632           2         15.9          63.0       1.0X
-date_trunc HOUR wholestage on                       590            594           5         17.0          59.0       1.1X
+date_trunc HOUR wholestage off                      337            337           0         29.7          33.7       1.0X
+date_trunc HOUR wholestage on                       318            319           2         31.5          31.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    628            629           1         15.9          62.8       1.0X
-date_trunc MINUTE wholestage on                     581            582           2         17.2          58.1       1.1X
+date_trunc MINUTE wholestage off                    350            350           0         28.6          35.0       1.0X
+date_trunc MINUTE wholestage on                     316            320           6         31.6          31.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    327            328           1         30.6          32.7       1.0X
-date_trunc SECOND wholestage on                     283            285           2         35.3          28.3       1.2X
+date_trunc SECOND wholestage off                    339            340           1         29.5          33.9       1.0X
+date_trunc SECOND wholestage on                     297            299           1         33.7          29.7       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      694            694           0         14.4          69.4       1.0X
-date_trunc WEEK wholestage on                       645            650           7         15.5          64.5       1.1X
+date_trunc WEEK wholestage off                      413            414           1         24.2          41.3       1.0X
+date_trunc WEEK wholestage on                       372            375           3         26.9          37.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   880            881           2         11.4          88.0       1.0X
-date_trunc QUARTER wholestage on                    842            847           3         11.9          84.2       1.0X
+date_trunc QUARTER wholestage off                   657            659           2         15.2          65.7       1.0X
+date_trunc QUARTER wholestage on                    613            614           2         16.3          61.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           771            772           2         13.0          77.1       1.0X
-trunc year wholestage on                            733            737           4         13.6          73.3       1.1X
+trunc year wholestage off                           847            847           1         11.8          84.7       1.0X
+trunc year wholestage on                            792            796           3         12.6          79.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           771            772           1         13.0          77.1       1.0X
-trunc yyyy wholestage on                            736            740           4         13.6          73.6       1.0X
+trunc yyyy wholestage off                           842            843           1         11.9          84.2       1.0X
+trunc yyyy wholestage on                            796            798           2         12.6          79.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             779            782           5         12.8          77.9       1.0X
-trunc yy wholestage on                              734            737           3         13.6          73.4       1.1X
+trunc yy wholestage off                             844            847           5         11.9          84.4       1.0X
+trunc yy wholestage on                              793            797           4         12.6          79.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            736            736           1         13.6          73.6       1.0X
-trunc mon wholestage on                             692            698           4         14.4          69.2       1.1X
+trunc mon wholestage off                            828            829           1         12.1          82.8       1.0X
+trunc mon wholestage on                             768            769           1         13.0          76.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          736            738           2         13.6          73.6       1.0X
-trunc month wholestage on                           695            703           8         14.4          69.5       1.1X
+trunc month wholestage off                          829            829           0         12.1          82.9       1.0X
+trunc month wholestage on                           768            775           8         13.0          76.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             738            740           3         13.6          73.8       1.0X
-trunc mm wholestage on                              695            697           2         14.4          69.5       1.1X
+trunc mm wholestage off                             825            826           1         12.1          82.5       1.0X
+trunc mm wholestage on                              769            770           1         13.0          76.9       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     110            114           5          9.1         109.7       1.0X
-to timestamp str wholestage on                      119            122           2          8.4         119.5       0.9X
+to timestamp str wholestage off                     108            110           3          9.3         107.6       1.0X
+to timestamp str wholestage on                      102            105           3          9.8         102.0       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         667            678          15          1.5         667.1       1.0X
-to_timestamp wholestage on                          676            679           2          1.5         675.9       1.0X
+to_timestamp wholestage off                         680            680           1          1.5         679.5       1.0X
+to_timestamp wholestage on                          687            691           4          1.5         686.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    676            677           1          1.5         676.5       1.0X
-to_unix_timestamp wholestage on                     672            675           3          1.5         672.1       1.0X
+to_unix_timestamp wholestage off                    691            691           1          1.4         690.8       1.0X
+to_unix_timestamp wholestage on                     673            679           7          1.5         673.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          166            167           1          6.0         166.1       1.0X
-to date str wholestage on                           162            164           3          6.2         162.5       1.0X
+to date str wholestage off                          153            155           3          6.5         152.8       1.0X
+to date str wholestage on                           133            137           6          7.5         133.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              701            701           1          1.4         700.6       1.0X
-to_date wholestage on                               699            701           1          1.4         699.2       1.0X
+to_date wholestage off                              632            638           9          1.6         631.7       1.0X
+to_date wholestage on                               638            641           2          1.6         638.3       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  322            331           8         15.5          64.5       1.0X
-From java.time.LocalDate                            240            242           2         20.8          48.1       1.3X
-Collect java.sql.Date                              1499           1536          56          3.3         299.9       0.2X
-Collect java.time.LocalDate                        1138           1259         134          4.4         227.6       0.3X
-From java.sql.Timestamp                             228            248          19         21.9          45.6       1.4X
-From java.time.Instant                              207            224          16         24.2          41.4       1.6X
-Collect longs                                      1093           1247         142          4.6         218.6       0.3X
-Collect java.sql.Timestamp                         1289           1398         111          3.9         257.8       0.3X
-Collect java.time.Instant                          1044           1310         371          4.8         208.9       0.3X
-java.sql.Date to Hive string                       4914           5126         191          1.0         982.7       0.1X
-java.time.LocalDate to Hive string                 3469           3635         146          1.4         693.8       0.1X
-java.sql.Timestamp to Hive string                  7043           7066          22          0.7        1408.5       0.0X
-java.time.Instant to Hive string                   4376           4525         133          1.1         875.2       0.1X
+From java.sql.Date                                  290            292           2         17.2          58.1       1.0X
+From java.time.LocalDate                            229            230           1         21.8          45.9       1.3X
+Collect java.sql.Date                              1179           1265          76          4.2         235.9       0.2X
+Collect java.time.LocalDate                         927           1056         117          5.4         185.5       0.3X
+From java.sql.Timestamp                             230            256          22         21.8          46.0       1.3X
+From java.time.Instant                              187            190           4         26.8          37.3       1.6X
+Collect longs                                       903           1039         132          5.5         180.5       0.3X
+Collect java.sql.Timestamp                         1068           1150          89          4.7         213.5       0.3X
+Collect java.time.Instant                           963           1083         132          5.2         192.5       0.3X
+java.sql.Date to Hive string                       4107           4124          16          1.2         821.4       0.1X
+java.time.LocalDate to Hive string                 3029           3126         103          1.7         605.7       0.1X
+java.sql.Timestamp to Hive string                  6537           6586          58          0.8        1307.3       0.0X
+java.time.Instant to Hive string                   4089           4127          47          1.2         817.7       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -2,530 +2,530 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  831            872          51         12.0          83.1       1.0X
-date + interval(m, d)                               838            850          15         11.9          83.8       1.0X
-date + interval(m, d, ms)                          4051           4097          65          2.5         405.1       0.2X
-date - interval(m)                                  838            842           5         11.9          83.8       1.0X
-date - interval(m, d)                               858            864           5         11.7          85.8       1.0X
-date - interval(m, d, ms)                          4052           4058           9          2.5         405.2       0.2X
-timestamp + interval(m)                            1687           1690           5          5.9         168.7       0.5X
-timestamp + interval(m, d)                         1730           1731           1          5.8         173.0       0.5X
-timestamp + interval(m, d, ms)                     1825           1827           2          5.5         182.5       0.5X
-timestamp - interval(m)                            1544           1552          12          6.5         154.4       0.5X
-timestamp - interval(m, d)                         1603           1604           2          6.2         160.3       0.5X
-timestamp - interval(m, d, ms)                     1809           1812           4          5.5         180.9       0.5X
+date + interval(m)                                  840            859          27         11.9          84.0       1.0X
+date + interval(m, d)                               805            811           6         12.4          80.5       1.0X
+date + interval(m, d, ms)                          3962           3977          21          2.5         396.2       0.2X
+date - interval(m)                                  813            819           7         12.3          81.3       1.0X
+date - interval(m, d)                               848            853           5         11.8          84.8       1.0X
+date - interval(m, d, ms)                          4003           4020          24          2.5         400.3       0.2X
+timestamp + interval(m)                            1778           1787          13          5.6         177.8       0.5X
+timestamp + interval(m, d)                         1827           1832           7          5.5         182.7       0.5X
+timestamp + interval(m, d, ms)                     2008           2017          13          5.0         200.8       0.4X
+timestamp - interval(m)                            1800           1804           6          5.6         180.0       0.5X
+timestamp - interval(m, d)                         1859           1862           5          5.4         185.9       0.5X
+timestamp - interval(m, d, ms)                     2007           2007           0          5.0         200.7       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    204            205           2         49.1          20.4       1.0X
-cast to timestamp wholestage on                     203            204           1         49.3          20.3       1.0X
+cast to timestamp wholestage off                    202            209           9         49.5          20.2       1.0X
+cast to timestamp wholestage on                     206            210           3         48.4          20.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    635            637           3         15.7          63.5       1.0X
-year of timestamp wholestage on                     612            618           4         16.3          61.2       1.0X
+year of timestamp wholestage off                    644            645           1         15.5          64.4       1.0X
+year of timestamp wholestage on                     628            647          31         15.9          62.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 656            660           7         15.3          65.6       1.0X
-quarter of timestamp wholestage on                  650            653           2         15.4          65.0       1.0X
+quarter of timestamp wholestage off                 666            670           6         15.0          66.6       1.0X
+quarter of timestamp wholestage on                  664            672           8         15.1          66.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   639            643           5         15.6          63.9       1.0X
-month of timestamp wholestage on                    633            634           1         15.8          63.3       1.0X
+month of timestamp wholestage off                   649            651           2         15.4          64.9       1.0X
+month of timestamp wholestage on                    634            640           5         15.8          63.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              998            998           0         10.0          99.8       1.0X
-weekofyear of timestamp wholestage on              1021           1032          12          9.8         102.1       1.0X
+weekofyear of timestamp wholestage off              918            918           0         10.9          91.8       1.0X
+weekofyear of timestamp wholestage on              1043           1048           3          9.6         104.3       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     644            649           6         15.5          64.4       1.0X
-day of timestamp wholestage on                      643            645           1         15.6          64.3       1.0X
+day of timestamp wholestage off                     657            663           8         15.2          65.7       1.0X
+day of timestamp wholestage on                      638            642           4         15.7          63.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               677            677           0         14.8          67.7       1.0X
-dayofyear of timestamp wholestage on                672            674           3         14.9          67.2       1.0X
+dayofyear of timestamp wholestage off               687            690           4         14.5          68.7       1.0X
+dayofyear of timestamp wholestage on                674            676           3         14.8          67.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              657            659           2         15.2          65.7       1.0X
-dayofmonth of timestamp wholestage on               642            647           4         15.6          64.2       1.0X
+dayofmonth of timestamp wholestage off              672            677           7         14.9          67.2       1.0X
+dayofmonth of timestamp wholestage on               634            661          44         15.8          63.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               805            806           2         12.4          80.5       1.0X
-dayofweek of timestamp wholestage on                807            810           3         12.4          80.7       1.0X
+dayofweek of timestamp wholestage off               825            826           0         12.1          82.5       1.0X
+dayofweek of timestamp wholestage on                814            815           2         12.3          81.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 750            752           4         13.3          75.0       1.0X
-weekday of timestamp wholestage on                  741            742           2         13.5          74.1       1.0X
+weekday of timestamp wholestage off                 759            763           6         13.2          75.9       1.0X
+weekday of timestamp wholestage on                  741            750           6         13.5          74.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    540            540           1         18.5          54.0       1.0X
-hour of timestamp wholestage on                     544            546           2         18.4          54.4       1.0X
+hour of timestamp wholestage off                    559            560           0         17.9          55.9       1.0X
+hour of timestamp wholestage on                     547            549           3         18.3          54.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  542            542           1         18.5          54.2       1.0X
-minute of timestamp wholestage on                   546            549           4         18.3          54.6       1.0X
+minute of timestamp wholestage off                  538            547          12         18.6          53.8       1.0X
+minute of timestamp wholestage on                   547            576          36         18.3          54.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  542            542           1         18.5          54.2       1.0X
-second of timestamp wholestage on                   546            551           6         18.3          54.6       1.0X
+second of timestamp wholestage off                  561            561           0         17.8          56.1       1.0X
+second of timestamp wholestage on                   546            552           8         18.3          54.6       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         177            180           4         56.3          17.7       1.0X
-current_date wholestage on                          204            214          16         49.0          20.4       0.9X
+current_date wholestage off                         175            177           2         57.1          17.5       1.0X
+current_date wholestage on                          201            205           3         49.7          20.1       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    189            189           1         53.0          18.9       1.0X
-current_timestamp wholestage on                     221            225           4         45.2          22.1       0.9X
+current_timestamp wholestage off                    180            191          16         55.4          18.0       1.0X
+current_timestamp wholestage on                     224            238          18         44.5          22.4       0.8X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         591            592           2         16.9          59.1       1.0X
-cast to date wholestage on                          593            604          18         16.9          59.3       1.0X
+cast to date wholestage off                         602            606           6         16.6          60.2       1.0X
+cast to date wholestage on                          609            612           3         16.4          60.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             673            673           0         14.9          67.3       1.0X
-last_day wholestage on                              674            677           2         14.8          67.4       1.0X
+last_day wholestage off                             675            676           3         14.8          67.5       1.0X
+last_day wholestage on                              667            668           1         15.0          66.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             622            623           2         16.1          62.2       1.0X
-next_day wholestage on                              625            628           3         16.0          62.5       1.0X
+next_day wholestage off                             644            644           1         15.5          64.4       1.0X
+next_day wholestage on                              654            657           5         15.3          65.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             577            579           2         17.3          57.7       1.0X
-date_add wholestage on                              585            616          66         17.1          58.5       1.0X
+date_add wholestage off                             581            582           2         17.2          58.1       1.0X
+date_add wholestage on                              579            584           9         17.3          57.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             575            575           0         17.4          57.5       1.0X
-date_sub wholestage on                              586            587           1         17.1          58.6       1.0X
+date_sub wholestage off                             590            595           6         16.9          59.0       1.0X
+date_sub wholestage on                              578            588          12         17.3          57.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           798            799           2         12.5          79.8       1.0X
-add_months wholestage on                            825            826           1         12.1          82.5       1.0X
+add_months wholestage off                           811            813           3         12.3          81.1       1.0X
+add_months wholestage on                            811            814           2         12.3          81.1       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3150           3174          35          3.2         315.0       1.0X
-format date wholestage on                          3073           3102          56          3.3         307.3       1.0X
+format date wholestage off                         3119           3119           1          3.2         311.9       1.0X
+format date wholestage on                          3144           3166          14          3.2         314.4       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2631           2634           4          3.8         263.1       1.0X
-from_unixtime wholestage on                        2712           2721           6          3.7         271.2       1.0X
+from_unixtime wholestage off                       2738           2742           5          3.7         273.8       1.0X
+from_unixtime wholestage on                        2816           2819           3          3.6         281.6       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   657            658           1         15.2          65.7       1.0X
-from_utc_timestamp wholestage on                    780            795          18         12.8          78.0       0.8X
+from_utc_timestamp wholestage off                   659            659           0         15.2          65.9       1.0X
+from_utc_timestamp wholestage on                    774            783           8         12.9          77.4       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     809            809           1         12.4          80.9       1.0X
-to_utc_timestamp wholestage on                      857            861           6         11.7          85.7       0.9X
+to_utc_timestamp wholestage off                     797            797           0         12.5          79.7       1.0X
+to_utc_timestamp wholestage on                      848            850           2         11.8          84.8       0.9X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        229            230           1         43.7          22.9       1.0X
-cast interval wholestage on                         203            206           5         49.2          20.3       1.1X
+cast interval wholestage off                        222            222           0         45.0          22.2       1.0X
+cast interval wholestage on                         197            202           5         50.9          19.7       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             986            988           3         10.1          98.6       1.0X
-datediff wholestage on                              982            985           4         10.2          98.2       1.0X
+datediff wholestage off                            1000           1003           5         10.0         100.0       1.0X
+datediff wholestage on                             1023           1028           3          9.8         102.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2734           2736           4          3.7         273.4       1.0X
-months_between wholestage on                       2703           2709           8          3.7         270.3       1.0X
+months_between wholestage off                      2947           2955          11          3.4         294.7       1.0X
+months_between wholestage on                       3038           3044          10          3.3         303.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               615            630          22          1.6         615.2       1.0X
-window wholestage on                                649            692          41          1.5         649.4       0.9X
+window wholestage off                               632            648          23          1.6         631.6       1.0X
+window wholestage on                                869            894          14          1.2         868.8       0.7X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      467            468           1         21.4          46.7       1.0X
-date_trunc YEAR wholestage on                       424            429           3         23.6          42.4       1.1X
+date_trunc YEAR wholestage off                      471            475           6         21.2          47.1       1.0X
+date_trunc YEAR wholestage on                       444            447           3         22.5          44.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      467            472           6         21.4          46.7       1.0X
-date_trunc YYYY wholestage on                       422            424           1         23.7          42.2       1.1X
+date_trunc YYYY wholestage off                      470            476           9         21.3          47.0       1.0X
+date_trunc YYYY wholestage on                       443            447           5         22.6          44.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        467            472           7         21.4          46.7       1.0X
-date_trunc YY wholestage on                         428            430           3         23.4          42.8       1.1X
+date_trunc YY wholestage off                        468            469           1         21.4          46.8       1.0X
+date_trunc YY wholestage on                         444            447           3         22.5          44.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       452            456           6         22.1          45.2       1.0X
-date_trunc MON wholestage on                        410            412           3         24.4          41.0       1.1X
+date_trunc MON wholestage off                       463            466           4         21.6          46.3       1.0X
+date_trunc MON wholestage on                        433            438           4         23.1          43.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     451            453           2         22.2          45.1       1.0X
-date_trunc MONTH wholestage on                      410            414           4         24.4          41.0       1.1X
+date_trunc MONTH wholestage off                     462            464           3         21.6          46.2       1.0X
+date_trunc MONTH wholestage on                      433            436           2         23.1          43.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        453            456           4         22.1          45.3       1.0X
-date_trunc MM wholestage on                         414            416           2         24.2          41.4       1.1X
+date_trunc MM wholestage off                        467            479          17         21.4          46.7       1.0X
+date_trunc MM wholestage on                         433            440           6         23.1          43.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       379            382           4         26.4          37.9       1.0X
-date_trunc DAY wholestage on                        340            343           3         29.4          34.0       1.1X
+date_trunc DAY wholestage off                       372            394          32         26.9          37.2       1.0X
+date_trunc DAY wholestage on                        349            352           4         28.7          34.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        388            390           3         25.8          38.8       1.0X
-date_trunc DD wholestage on                         341            345           5         29.3          34.1       1.1X
+date_trunc DD wholestage off                        374            375           1         26.7          37.4       1.0X
+date_trunc DD wholestage on                         348            353           5         28.7          34.8       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      427            428           1         23.4          42.7       1.0X
-date_trunc HOUR wholestage on                       396            399           3         25.2          39.6       1.1X
+date_trunc HOUR wholestage off                      372            372           1         26.9          37.2       1.0X
+date_trunc HOUR wholestage on                       351            354           4         28.5          35.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    421            421           1         23.8          42.1       1.0X
-date_trunc MINUTE wholestage on                     381            385           7         26.2          38.1       1.1X
+date_trunc MINUTE wholestage off                    379            382           4         26.4          37.9       1.0X
+date_trunc MINUTE wholestage on                     349            353           4         28.7          34.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    342            343           2         29.2          34.2       1.0X
-date_trunc SECOND wholestage on                     305            306           2         32.8          30.5       1.1X
+date_trunc SECOND wholestage off                    330            330           0         30.3          33.0       1.0X
+date_trunc SECOND wholestage on                     302            306           5         33.1          30.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      415            415           0         24.1          41.5       1.0X
-date_trunc WEEK wholestage on                       378            380           2         26.5          37.8       1.1X
+date_trunc WEEK wholestage off                      442            447           7         22.6          44.2       1.0X
+date_trunc WEEK wholestage on                       433            436           2         23.1          43.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   599            599           1         16.7          59.9       1.0X
-date_trunc QUARTER wholestage on                    565            567           2         17.7          56.5       1.1X
+date_trunc QUARTER wholestage off                   626            629           3         16.0          62.6       1.0X
+date_trunc QUARTER wholestage on                    630            633           3         15.9          63.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (shuffled 2y) wholestage off           1151           1151           0          8.7         115.1       1.0X
-date_trunc YEAR (shuffled 2y) wholestage on            1127           1130           3          8.9         112.7       1.0X
+date_trunc YEAR (shuffled 2y) wholestage off           1197           1197           1          8.4         119.7       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1181           1186           4          8.5         118.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (spread 95y) wholestage off           1298           1306          12          7.7         129.8       1.0X
-date_trunc YEAR (spread 95y) wholestage on            1285           1290           5          7.8         128.5       1.0X
+date_trunc YEAR (spread 95y) wholestage off           1363           1366           3          7.3         136.3       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1296           1307           7          7.7         129.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (shuffled 2y) wholestage off           1019           1021           2          9.8         101.9       1.0X
-date_trunc QUARTER (shuffled 2y) wholestage on             984            989           4         10.2          98.4       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage off           1062           1066           6          9.4         106.2       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1087           1090           4          9.2         108.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (spread 95y) wholestage off           1313           1316           4          7.6         131.3       1.0X
-date_trunc QUARTER (spread 95y) wholestage on            1261           1265           2          7.9         126.1       1.0X
+date_trunc QUARTER (spread 95y) wholestage off           1305           1310           7          7.7         130.5       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1304           1310           6          7.7         130.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (shuffled 2y) wholestage off            733            733           0         13.6          73.3       1.0X
-date_trunc MONTH (shuffled 2y) wholestage on             691            696           4         14.5          69.1       1.1X
+date_trunc MONTH (shuffled 2y) wholestage off            779            781           4         12.8          77.9       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             744            748           4         13.4          74.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (spread 95y) wholestage off            807            809           2         12.4          80.7       1.0X
-date_trunc MONTH (spread 95y) wholestage on             780            783           2         12.8          78.0       1.0X
+date_trunc MONTH (spread 95y) wholestage off            808            808           1         12.4          80.8       1.0X
+date_trunc MONTH (spread 95y) wholestage on             803            809           8         12.5          80.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (shuffled 2y) wholestage off            534            538           6         18.7          53.4       1.0X
-date_trunc WEEK (shuffled 2y) wholestage on             501            504           3         20.0          50.1       1.1X
+date_trunc WEEK (shuffled 2y) wholestage off            544            547           4         18.4          54.4       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             521            525           4         19.2          52.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (spread 95y) wholestage off            666            667           1         15.0          66.6       1.0X
-date_trunc WEEK (spread 95y) wholestage on             619            626          11         16.2          61.9       1.1X
+date_trunc WEEK (spread 95y) wholestage off            635            647          18         15.8          63.5       1.0X
+date_trunc WEEK (spread 95y) wholestage on             640            644           4         15.6          64.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (shuffled 2y) wholestage off            481            482           1         20.8          48.1       1.0X
-date_trunc DAY (shuffled 2y) wholestage on             443            449           5         22.6          44.3       1.1X
+date_trunc DAY (shuffled 2y) wholestage off            461            461           0         21.7          46.1       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             442            445           3         22.6          44.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (spread 95y) wholestage off            601            605           5         16.6          60.1       1.0X
-date_trunc DAY (spread 95y) wholestage on             566            568           3         17.7          56.6       1.1X
+date_trunc DAY (spread 95y) wholestage off            558            559           2         17.9          55.8       1.0X
+date_trunc DAY (spread 95y) wholestage on             551            554           2         18.1          55.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           795            797           3         12.6          79.5       1.0X
-trunc year wholestage on                            768            771           2         13.0          76.8       1.0X
+trunc year wholestage off                           783            786           3         12.8          78.3       1.0X
+trunc year wholestage on                            755            758           3         13.3          75.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           796            796           0         12.6          79.6       1.0X
-trunc yyyy wholestage on                            766            768           2         13.1          76.6       1.0X
+trunc yyyy wholestage off                           785            786           2         12.7          78.5       1.0X
+trunc yyyy wholestage on                            753            757           3         13.3          75.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             794            799           7         12.6          79.4       1.0X
-trunc yy wholestage on                              768            769           1         13.0          76.8       1.0X
+trunc yy wholestage off                             783            784           1         12.8          78.3       1.0X
+trunc yy wholestage on                              757            759           2         13.2          75.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            758            761           4         13.2          75.8       1.0X
-trunc mon wholestage on                             722            725           4         13.9          72.2       1.1X
+trunc mon wholestage off                            725            725           0         13.8          72.5       1.0X
+trunc mon wholestage on                             705            707           2         14.2          70.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          754            756           3         13.3          75.4       1.0X
-trunc month wholestage on                           724            739          19         13.8          72.4       1.0X
+trunc month wholestage off                          724            725           2         13.8          72.4       1.0X
+trunc month wholestage on                           707            715          15         14.1          70.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             754            755           1         13.3          75.4       1.0X
-trunc mm wholestage on                              722            724           2         13.9          72.2       1.0X
+trunc mm wholestage off                             729            729           1         13.7          72.9       1.0X
+trunc mm wholestage on                              704            708           3         14.2          70.4       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     101            101           1          9.9         100.7       1.0X
-to timestamp str wholestage on                      101            104           3          9.9         100.7       1.0X
+to timestamp str wholestage off                     100            102           2         10.0         100.2       1.0X
+to timestamp str wholestage on                      109            111           2          9.2         109.0       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         676            677           0          1.5         676.5       1.0X
-to_timestamp wholestage on                          670            674           3          1.5         669.9       1.0X
+to_timestamp wholestage off                         681            681           0          1.5         681.0       1.0X
+to_timestamp wholestage on                          683            686           2          1.5         682.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    657            658           1          1.5         657.4       1.0X
-to_unix_timestamp wholestage on                     658            659           2          1.5         658.3       1.0X
+to_unix_timestamp wholestage off                    681            683           2          1.5         681.1       1.0X
+to_unix_timestamp wholestage on                     683            685           4          1.5         683.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 to date str wholestage off                          142            142           0          7.1         141.6       1.0X
-to date str wholestage on                           132            136           4          7.6         132.4       1.1X
+to date str wholestage on                           132            134           2          7.6         131.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              634            636           2          1.6         633.8       1.0X
-to_date wholestage on                               631            632           1          1.6         631.0       1.0X
+to_date wholestage off                              620            621           1          1.6         619.9       1.0X
+to_date wholestage on                               610            611           1          1.6         610.3       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  286            286           1         17.5          57.1       1.0X
-From java.time.LocalDate                            231            235           6         21.6          46.3       1.2X
-Collect java.sql.Date                              1332           1367          49          3.8         266.4       0.2X
-Collect java.time.LocalDate                         877            997         107          5.7         175.5       0.3X
-From java.sql.Timestamp                             232            249          16         21.5          46.4       1.2X
-From java.time.Instant                              189            190           1         26.4          37.8       1.5X
-Collect longs                                       945            989          69          5.3         188.9       0.3X
-Collect java.sql.Timestamp                         1058           1238         157          4.7         211.5       0.3X
-Collect java.time.Instant                           894           1099         194          5.6         178.7       0.3X
-java.sql.Date to Hive string                       3935           3973          58          1.3         787.0       0.1X
-java.time.LocalDate to Hive string                 3114           3205         111          1.6         622.8       0.1X
-java.sql.Timestamp to Hive string                  6706           6753          41          0.7        1341.2       0.0X
-java.time.Instant to Hive string                   4160           4252         125          1.2         832.1       0.1X
+From java.sql.Date                                  297            300           3         16.8          59.4       1.0X
+From java.time.LocalDate                            242            243           2         20.7          48.3       1.2X
+Collect java.sql.Date                              1071           1254         180          4.7         214.2       0.3X
+Collect java.time.LocalDate                         970           1002          30          5.2         194.0       0.3X
+From java.sql.Timestamp                             239            259          20         20.9          47.8       1.2X
+From java.time.Instant                              192            198           5         26.0          38.4       1.5X
+Collect longs                                       889           1067         157          5.6         177.7       0.3X
+Collect java.sql.Timestamp                         1199           1278          87          4.2         239.8       0.2X
+Collect java.time.Instant                           867           1032         232          5.8         173.3       0.3X
+java.sql.Date to Hive string                       3960           4072         108          1.3         792.1       0.1X
+java.time.LocalDate to Hive string                 2968           3118         146          1.7         593.6       0.1X
+java.sql.Timestamp to Hive string                  6552           6581          30          0.8        1310.5       0.0X
+java.time.Instant to Hive string                   4004           4101          99          1.2         800.7       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -2,460 +2,530 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  827            873          65         12.1          82.7       1.0X
-date + interval(m, d)                               816            824           9         12.2          81.6       1.0X
-date + interval(m, d, ms)                          3394           3396           3          2.9         339.4       0.2X
-date - interval(m)                                  795            801           5         12.6          79.5       1.0X
-date - interval(m, d)                               818            820           2         12.2          81.8       1.0X
-date - interval(m, d, ms)                          3347           3350           5          3.0         334.7       0.2X
-timestamp + interval(m)                            1693           1695           3          5.9         169.3       0.5X
-timestamp + interval(m, d)                         1736           1738           3          5.8         173.6       0.5X
-timestamp + interval(m, d, ms)                     2065           2067           3          4.8         206.5       0.4X
-timestamp - interval(m)                            1818           1821           5          5.5         181.8       0.5X
-timestamp - interval(m, d)                         1876           1877           2          5.3         187.6       0.4X
-timestamp - interval(m, d, ms)                     2081           2084           4          4.8         208.1       0.4X
+date + interval(m)                                  803            830          39         12.5          80.3       1.0X
+date + interval(m, d)                               802            805           5         12.5          80.2       1.0X
+date + interval(m, d, ms)                          3264           3270           9          3.1         326.4       0.2X
+date - interval(m)                                  795            801           6         12.6          79.5       1.0X
+date - interval(m, d)                               813            821           7         12.3          81.3       1.0X
+date - interval(m, d, ms)                          3291           3299          12          3.0         329.1       0.2X
+timestamp + interval(m)                            1660           1663           3          6.0         166.0       0.5X
+timestamp + interval(m, d)                         1698           1700           2          5.9         169.8       0.5X
+timestamp + interval(m, d, ms)                     2062           2064           2          4.8         206.2       0.4X
+timestamp - interval(m)                            1800           1804           5          5.6         180.0       0.4X
+timestamp - interval(m, d)                         1877           1877           1          5.3         187.7       0.4X
+timestamp - interval(m, d, ms)                     2068           2070           2          4.8         206.8       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    210            210           0         47.7          21.0       1.0X
-cast to timestamp wholestage on                     215            218           3         46.5          21.5       1.0X
+cast to timestamp wholestage off                    222            226           6         45.0          22.2       1.0X
+cast to timestamp wholestage on                     222            232          16         45.1          22.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    612            614           2         16.3          61.2       1.0X
-year of timestamp wholestage on                     606            616           9         16.5          60.6       1.0X
+year of timestamp wholestage off                    617            617           1         16.2          61.7       1.0X
+year of timestamp wholestage on                     636            639           3         15.7          63.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 651            653           4         15.4          65.1       1.0X
-quarter of timestamp wholestage on                  635            641           6         15.8          63.5       1.0X
+quarter of timestamp wholestage off                 651            653           3         15.4          65.1       1.0X
+quarter of timestamp wholestage on                  671            679          11         14.9          67.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   646            660          20         15.5          64.6       1.0X
-month of timestamp wholestage on                    628            639          21         15.9          62.8       1.0X
+month of timestamp wholestage off                   657            659           3         15.2          65.7       1.0X
+month of timestamp wholestage on                    653            655           1         15.3          65.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              910            911           1         11.0          91.0       1.0X
-weekofyear of timestamp wholestage on               951            958           9         10.5          95.1       1.0X
+weekofyear of timestamp wholestage off             1024           1025           1          9.8         102.4       1.0X
+weekofyear of timestamp wholestage on              1017           1025          11          9.8         101.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     641            644           4         15.6          64.1       1.0X
-day of timestamp wholestage on                      629            631           1         15.9          62.9       1.0X
+day of timestamp wholestage off                     637            641           6         15.7          63.7       1.0X
+day of timestamp wholestage on                      652            657           4         15.3          65.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               673            675           4         14.9          67.3       1.0X
-dayofyear of timestamp wholestage on                668            673           5         15.0          66.8       1.0X
+dayofyear of timestamp wholestage off               678            678           0         14.7          67.8       1.0X
+dayofyear of timestamp wholestage on                693            694           1         14.4          69.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              636            636           0         15.7          63.6       1.0X
-dayofmonth of timestamp wholestage on               625            631           4         16.0          62.5       1.0X
+dayofmonth of timestamp wholestage off              639            641           3         15.7          63.9       1.0X
+dayofmonth of timestamp wholestage on               656            661           8         15.2          65.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               795            799           6         12.6          79.5       1.0X
-dayofweek of timestamp wholestage on                787            790           2         12.7          78.7       1.0X
+dayofweek of timestamp wholestage off               797            800           4         12.5          79.7       1.0X
+dayofweek of timestamp wholestage on                794            800           7         12.6          79.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 733            734           1         13.6          73.3       1.0X
-weekday of timestamp wholestage on                  728            739          15         13.7          72.8       1.0X
+weekday of timestamp wholestage off                 737            738           1         13.6          73.7       1.0X
+weekday of timestamp wholestage on                  760            763           2         13.2          76.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    544            544           0         18.4          54.4       1.0X
-hour of timestamp wholestage on                     545            549           6         18.4          54.5       1.0X
+hour of timestamp wholestage off                    581            583           3         17.2          58.1       1.0X
+hour of timestamp wholestage on                     579            583           3         17.3          57.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  544            547           4         18.4          54.4       1.0X
-minute of timestamp wholestage on                   542            546           2         18.4          54.2       1.0X
+minute of timestamp wholestage off                  581            584           4         17.2          58.1       1.0X
+minute of timestamp wholestage on                   575            581           8         17.4          57.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  548            549           1         18.3          54.8       1.0X
-second of timestamp wholestage on                   561            565           7         17.8          56.1       1.0X
+second of timestamp wholestage off                  582            585           4         17.2          58.2       1.0X
+second of timestamp wholestage on                   574            578           3         17.4          57.4       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         192            192           0         52.1          19.2       1.0X
-current_date wholestage on                          206            208           1         48.5          20.6       0.9X
+current_date wholestage off                         214            217           4         46.7          21.4       1.0X
+current_date wholestage on                          216            220           3         46.3          21.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    196            199           4         51.0          19.6       1.0X
-current_timestamp wholestage on                     212            219           6         47.2          21.2       0.9X
+current_timestamp wholestage off                    229            231           2         43.6          22.9       1.0X
+current_timestamp wholestage on                     223            232           9         44.9          22.3       1.0X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         586            588           3         17.1          58.6       1.0X
-cast to date wholestage on                          578            580           2         17.3          57.8       1.0X
+cast to date wholestage off                         592            593           1         16.9          59.2       1.0X
+cast to date wholestage on                          602            606           3         16.6          60.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             664            664           1         15.1          66.4       1.0X
-last_day wholestage on                              667            669           4         15.0          66.7       1.0X
+last_day wholestage off                             661            661           0         15.1          66.1       1.0X
+last_day wholestage on                              684            689           5         14.6          68.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             613            621          12         16.3          61.3       1.0X
-next_day wholestage on                              612            618           4         16.3          61.2       1.0X
+next_day wholestage off                             622            623           2         16.1          62.2       1.0X
+next_day wholestage on                              635            638           4         15.8          63.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             566            568           2         17.7          56.6       1.0X
-date_add wholestage on                              575            576           2         17.4          57.5       1.0X
+date_add wholestage off                             581            583           3         17.2          58.1       1.0X
+date_add wholestage on                              606            612           7         16.5          60.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             569            572           3         17.6          56.9       1.0X
-date_sub wholestage on                              574            578           3         17.4          57.4       1.0X
+date_sub wholestage off                             576            578           2         17.3          57.6       1.0X
+date_sub wholestage on                              603            610           5         16.6          60.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           806            807           2         12.4          80.6       1.0X
-add_months wholestage on                            812            823          12         12.3          81.2       1.0X
+add_months wholestage off                           814            815           1         12.3          81.4       1.0X
+add_months wholestage on                            831            834           2         12.0          83.1       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2844           2846           2          3.5         284.4       1.0X
-format date wholestage on                          2853           2879          45          3.5         285.3       1.0X
+format date wholestage off                         3059           3075          22          3.3         305.9       1.0X
+format date wholestage on                          2886           2900          22          3.5         288.6       1.1X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2658           2658           1          3.8         265.8       1.0X
-from_unixtime wholestage on                        2549           2557           7          3.9         254.9       1.0X
+from_unixtime wholestage off                       2746           2746           1          3.6         274.6       1.0X
+from_unixtime wholestage on                        2980           2983           3          3.4         298.0       0.9X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   689            691           2         14.5          68.9       1.0X
-from_utc_timestamp wholestage on                    697            701           5         14.3          69.7       1.0X
+from_utc_timestamp wholestage off                   706            711           7         14.2          70.6       1.0X
+from_utc_timestamp wholestage on                    712            715           3         14.0          71.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     874            874           0         11.4          87.4       1.0X
-to_utc_timestamp wholestage on                      884            889           4         11.3          88.4       1.0X
+to_utc_timestamp wholestage off                     837            838           1         11.9          83.7       1.0X
+to_utc_timestamp wholestage on                      878            881           3         11.4          87.8       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        250            254           5         40.0          25.0       1.0X
-cast interval wholestage on                         217            223           5         46.0          21.7       1.2X
+cast interval wholestage off                        262            269          10         38.1          26.2       1.0X
+cast interval wholestage on                         218            227           8         45.8          21.8       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             964            964           0         10.4          96.4       1.0X
-datediff wholestage on                              945            950           5         10.6          94.5       1.0X
+datediff wholestage off                             960            965           6         10.4          96.0       1.0X
+datediff wholestage on                              957            959           2         10.4          95.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2589           2594           6          3.9         258.9       1.0X
-months_between wholestage on                       2613           2617           2          3.8         261.3       1.0X
+months_between wholestage off                      2598           2600           4          3.8         259.8       1.0X
+months_between wholestage on                       2591           2598           7          3.9         259.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               549            565          22          1.8         549.2       1.0X
-window wholestage on                                691            699           9          1.4         691.1       0.8X
+window wholestage off                               613            635          32          1.6         612.5       1.0X
+window wholestage on                                692            707          14          1.4         691.6       0.9X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      509            512           4         19.6          50.9       1.0X
-date_trunc YEAR wholestage on                       445            447           1         22.5          44.5       1.1X
+date_trunc YEAR wholestage off                      506            508           4         19.8          50.6       1.0X
+date_trunc YEAR wholestage on                       458            462           3         21.8          45.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      514            522          12         19.5          51.4       1.0X
-date_trunc YYYY wholestage on                       444            451           8         22.5          44.4       1.2X
+date_trunc YYYY wholestage off                      502            503           2         19.9          50.2       1.0X
+date_trunc YYYY wholestage on                       466            468           3         21.5          46.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        506            507           0         19.8          50.6       1.0X
-date_trunc YY wholestage on                         446            447           1         22.4          44.6       1.1X
+date_trunc YY wholestage off                        503            504           2         19.9          50.3       1.0X
+date_trunc YY wholestage on                         461            464           1         21.7          46.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       465            465           0         21.5          46.5       1.0X
-date_trunc MON wholestage on                        430            436           9         23.3          43.0       1.1X
+date_trunc MON wholestage off                       470            470           0         21.3          47.0       1.0X
+date_trunc MON wholestage on                        426            430           4         23.5          42.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     466            466           1         21.5          46.6       1.0X
-date_trunc MONTH wholestage on                      429            433           2         23.3          42.9       1.1X
+date_trunc MONTH wholestage off                     468            472           6         21.3          46.8       1.0X
+date_trunc MONTH wholestage on                      426            431           6         23.5          42.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        466            468           2         21.4          46.6       1.0X
-date_trunc MM wholestage on                         429            433           4         23.3          42.9       1.1X
+date_trunc MM wholestage off                        469            470           1         21.3          46.9       1.0X
+date_trunc MM wholestage on                         428            435           8         23.4          42.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       343            344           1         29.1          34.3       1.0X
-date_trunc DAY wholestage on                        333            337           3         30.0          33.3       1.0X
+date_trunc DAY wholestage off                       363            364           1         27.6          36.3       1.0X
+date_trunc DAY wholestage on                        321            326           4         31.1          32.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        346            347           1         28.9          34.6       1.0X
-date_trunc DD wholestage on                         333            337           4         30.1          33.3       1.0X
+date_trunc DD wholestage off                        362            363           1         27.6          36.2       1.0X
+date_trunc DD wholestage on                         318            321           2         31.5          31.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      357            357           0         28.0          35.7       1.0X
-date_trunc HOUR wholestage on                       325            339          23         30.8          32.5       1.1X
+date_trunc HOUR wholestage off                      361            361           0         27.7          36.1       1.0X
+date_trunc HOUR wholestage on                       318            320           2         31.4          31.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    334            334           0         29.9          33.4       1.0X
-date_trunc MINUTE wholestage on                     322            327           5         31.0          32.2       1.0X
+date_trunc MINUTE wholestage off                    360            360           0         27.8          36.0       1.0X
+date_trunc MINUTE wholestage on                     317            324           5         31.6          31.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    341            342           1         29.3          34.1       1.0X
-date_trunc SECOND wholestage on                     304            306           2         32.9          30.4       1.1X
+date_trunc SECOND wholestage off                    325            327           3         30.7          32.5       1.0X
+date_trunc SECOND wholestage on                     276            280           4         36.2          27.6       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      415            417           2         24.1          41.5       1.0X
-date_trunc WEEK wholestage on                       383            388          11         26.1          38.3       1.1X
+date_trunc WEEK wholestage off                      420            420           0         23.8          42.0       1.0X
+date_trunc WEEK wholestage on                       367            373           7         27.2          36.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   654            655           2         15.3          65.4       1.0X
-date_trunc QUARTER wholestage on                    623            629           9         16.1          62.3       1.1X
+date_trunc QUARTER wholestage off                   631            632           1         15.8          63.1       1.0X
+date_trunc QUARTER wholestage on                    591            594           3         16.9          59.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc YEAR (shuffled 2y) wholestage off           1235           1235           0          8.1         123.5       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1163           1169           9          8.6         116.3       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc YEAR (spread 95y) wholestage off           1333           1335           3          7.5         133.3       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1286           1296           8          7.8         128.6       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+date_trunc QUARTER (shuffled 2y) wholestage off           1107           1108           0          9.0         110.7       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1129           1132           3          8.9         112.9       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+date_trunc QUARTER (spread 95y) wholestage off           1442           1448           9          6.9         144.2       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1372           1377           6          7.3         137.2       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+date_trunc MONTH (shuffled 2y) wholestage off            743            745           4         13.5          74.3       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             700            709          12         14.3          70.0       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc MONTH (spread 95y) wholestage off            805            806           1         12.4          80.5       1.0X
+date_trunc MONTH (spread 95y) wholestage on             761            766           3         13.1          76.1       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc WEEK (shuffled 2y) wholestage off            520            523           4         19.2          52.0       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             489            492           3         20.4          48.9       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc WEEK (spread 95y) wholestage off            608            616          10         16.4          60.8       1.0X
+date_trunc WEEK (spread 95y) wholestage on             555            562           8         18.0          55.5       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc DAY (shuffled 2y) wholestage off            462            464           3         21.7          46.2       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             410            417           7         24.4          41.0       1.1X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+date_trunc DAY (spread 95y) wholestage off            541            542           1         18.5          54.1       1.0X
+date_trunc DAY (spread 95y) wholestage on             532            540           6         18.8          53.2       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           800            802           2         12.5          80.0       1.0X
-trunc year wholestage on                            772            773           1         13.0          77.2       1.0X
+trunc year wholestage off                           768            768           0         13.0          76.8       1.0X
+trunc year wholestage on                            727            730           4         13.8          72.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           801            801           0         12.5          80.1       1.0X
-trunc yyyy wholestage on                            771            774           3         13.0          77.1       1.0X
+trunc yyyy wholestage off                           769            770           2         13.0          76.9       1.0X
+trunc yyyy wholestage on                            723            726           2         13.8          72.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             800            801           1         12.5          80.0       1.0X
-trunc yy wholestage on                              771            777           7         13.0          77.1       1.0X
+trunc yy wholestage off                             768            773           8         13.0          76.8       1.0X
+trunc yy wholestage on                              722            728           4         13.8          72.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            789            789           0         12.7          78.9       1.0X
-trunc mon wholestage on                             746            752           4         13.4          74.6       1.1X
+trunc mon wholestage off                            732            733           1         13.7          73.2       1.0X
+trunc mon wholestage on                             695            700           3         14.4          69.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          786            788           3         12.7          78.6       1.0X
-trunc month wholestage on                           746            753           7         13.4          74.6       1.1X
+trunc month wholestage off                          739            749          14         13.5          73.9       1.0X
+trunc month wholestage on                           698            701           2         14.3          69.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             788            796          12         12.7          78.8       1.0X
-trunc mm wholestage on                              746            755          10         13.4          74.6       1.1X
+trunc mm wholestage off                             735            735           0         13.6          73.5       1.0X
+trunc mm wholestage on                              696            714          25         14.4          69.6       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      92             93           2         10.9          91.8       1.0X
-to timestamp str wholestage on                       86             87           1         11.7          85.5       1.1X
+to timestamp str wholestage off                      90             91           2         11.1          89.7       1.0X
+to timestamp str wholestage on                       83             88           7         12.1          82.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         643            646           4          1.6         643.4       1.0X
-to_timestamp wholestage on                          643            645           2          1.6         643.2       1.0X
+to_timestamp wholestage off                         627            627           0          1.6         626.8       1.0X
+to_timestamp wholestage on                          614            616           2          1.6         614.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    629            629           0          1.6         628.8       1.0X
-to_unix_timestamp wholestage on                     653            654           1          1.5         653.2       1.0X
+to_unix_timestamp wholestage off                    614            614           0          1.6         614.2       1.0X
+to_unix_timestamp wholestage on                     603            605           1          1.7         603.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          109            110           2          9.2         108.7       1.0X
-to date str wholestage on                           115            120           4          8.7         115.3       0.9X
+to date str wholestage off                          106            108           2          9.4         106.3       1.0X
+to date str wholestage on                           113            115           2          8.9         112.6       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              606            611           7          1.7         605.6       1.0X
-to_date wholestage on                               607            608           1          1.6         607.1       1.0X
+to_date wholestage off                              566            568           4          1.8         565.7       1.0X
+to_date wholestage on                               572            576           4          1.7         572.2       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  308            315          11         16.2          61.7       1.0X
-From java.time.LocalDate                            234            235           1         21.4          46.8       1.3X
-Collect java.sql.Date                              1259           1343         100          4.0         251.9       0.2X
-Collect java.time.LocalDate                        1095           1174         115          4.6         218.9       0.3X
-From java.sql.Timestamp                             263            267           4         19.0          52.6       1.2X
-From java.time.Instant                              204            225          18         24.5          40.8       1.5X
-Collect longs                                       921            995          89          5.4         184.1       0.3X
-Collect java.sql.Timestamp                         1165           1203          33          4.3         232.9       0.3X
-Collect java.time.Instant                           932            998          62          5.4         186.5       0.3X
-java.sql.Date to Hive string                       3919           3987          79          1.3         783.8       0.1X
-java.time.LocalDate to Hive string                 3084           3199         107          1.6         616.7       0.1X
-java.sql.Timestamp to Hive string                  6867           6898          27          0.7        1373.4       0.0X
-java.time.Instant to Hive string                   4199           4265          71          1.2         839.8       0.1X
+From java.sql.Date                                  292            293           2         17.1          58.4       1.0X
+From java.time.LocalDate                            225            229           5         22.2          45.1       1.3X
+Collect java.sql.Date                              1261           1325          63          4.0         252.2       0.2X
+Collect java.time.LocalDate                        1082           1179         123          4.6         216.4       0.3X
+From java.sql.Timestamp                             231            249          15         21.6          46.3       1.3X
+From java.time.Instant                              203            226          21         24.7          40.5       1.4X
+Collect longs                                       892           1055         160          5.6         178.3       0.3X
+Collect java.sql.Timestamp                         1198           1240          43          4.2         239.6       0.2X
+Collect java.time.Instant                           983           1139         171          5.1         196.5       0.3X
+java.sql.Date to Hive string                       4164           4249         133          1.2         832.9       0.1X
+java.time.LocalDate to Hive string                 3221           3284          54          1.6         644.2       0.1X
+java.sql.Timestamp to Hive string                  6852           6904          61          0.7        1370.4       0.0X
+java.time.Instant to Hive string                   4320           4383          75          1.2         864.1       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  819            843          34         12.2          81.9       1.0X
-date + interval(m, d)                               806            815           9         12.4          80.6       1.0X
-date + interval(m, d, ms)                          3459           3507          68          2.9         345.9       0.2X
-date - interval(m)                                  816            821           5         12.3          81.6       1.0X
-date - interval(m, d)                               831            833           2         12.0          83.1       1.0X
-date - interval(m, d, ms)                          3491           3494           5          2.9         349.1       0.2X
-timestamp + interval(m)                            1644           1647           6          6.1         164.4       0.5X
-timestamp + interval(m, d)                         1693           1713          29          5.9         169.3       0.5X
-timestamp + interval(m, d, ms)                     2421           2425           5          4.1         242.1       0.3X
-timestamp - interval(m)                            1995           2001           9          5.0         199.5       0.4X
-timestamp - interval(m, d)                         2050           2055           7          4.9         205.0       0.4X
-timestamp - interval(m, d, ms)                     2363           2365           2          4.2         236.3       0.3X
+date + interval(m)                                  827            873          65         12.1          82.7       1.0X
+date + interval(m, d)                               816            824           9         12.2          81.6       1.0X
+date + interval(m, d, ms)                          3394           3396           3          2.9         339.4       0.2X
+date - interval(m)                                  795            801           5         12.6          79.5       1.0X
+date - interval(m, d)                               818            820           2         12.2          81.8       1.0X
+date - interval(m, d, ms)                          3347           3350           5          3.0         334.7       0.2X
+timestamp + interval(m)                            1693           1695           3          5.9         169.3       0.5X
+timestamp + interval(m, d)                         1736           1738           3          5.8         173.6       0.5X
+timestamp + interval(m, d, ms)                     2065           2067           3          4.8         206.5       0.4X
+timestamp - interval(m)                            1818           1821           5          5.5         181.8       0.5X
+timestamp - interval(m, d)                         1876           1877           2          5.3         187.6       0.4X
+timestamp - interval(m, d, ms)                     2081           2084           4          4.8         208.1       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    224            229           6         44.6          22.4       1.0X
-cast to timestamp wholestage on                     230            237           5         43.5          23.0       1.0X
+cast to timestamp wholestage off                    210            210           0         47.7          21.0       1.0X
+cast to timestamp wholestage on                     215            218           3         46.5          21.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    623            626           4         16.1          62.3       1.0X
-year of timestamp wholestage on                     646            649           4         15.5          64.6       1.0X
+year of timestamp wholestage off                    612            614           2         16.3          61.2       1.0X
+year of timestamp wholestage on                     606            616           9         16.5          60.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 661            663           2         15.1          66.1       1.0X
-quarter of timestamp wholestage on                  672            680           6         14.9          67.2       1.0X
+quarter of timestamp wholestage off                 651            653           4         15.4          65.1       1.0X
+quarter of timestamp wholestage on                  635            641           6         15.8          63.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   642            646           7         15.6          64.2       1.0X
-month of timestamp wholestage on                    664            671           7         15.1          66.4       1.0X
+month of timestamp wholestage off                   646            660          20         15.5          64.6       1.0X
+month of timestamp wholestage on                    628            639          21         15.9          62.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              997            998           1         10.0          99.7       1.0X
-weekofyear of timestamp wholestage on              1009           1013           3          9.9         100.9       1.0X
+weekofyear of timestamp wholestage off              910            911           1         11.0          91.0       1.0X
+weekofyear of timestamp wholestage on               951            958           9         10.5          95.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     650            652           2         15.4          65.0       1.0X
-day of timestamp wholestage on                      665            668           2         15.0          66.5       1.0X
+day of timestamp wholestage off                     641            644           4         15.6          64.1       1.0X
+day of timestamp wholestage on                      629            631           1         15.9          62.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               679            679           0         14.7          67.9       1.0X
-dayofyear of timestamp wholestage on                695            700           4         14.4          69.5       1.0X
+dayofyear of timestamp wholestage off               673            675           4         14.9          67.3       1.0X
+dayofyear of timestamp wholestage on                668            673           5         15.0          66.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              646            646           1         15.5          64.6       1.0X
-dayofmonth of timestamp wholestage on               664            667           2         15.1          66.4       1.0X
+dayofmonth of timestamp wholestage off              636            636           0         15.7          63.6       1.0X
+dayofmonth of timestamp wholestage on               625            631           4         16.0          62.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               806            812           8         12.4          80.6       1.0X
-dayofweek of timestamp wholestage on                811            817           4         12.3          81.1       1.0X
+dayofweek of timestamp wholestage off               795            799           6         12.6          79.5       1.0X
+dayofweek of timestamp wholestage on                787            790           2         12.7          78.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 746            750           6         13.4          74.6       1.0X
-weekday of timestamp wholestage on                  769            774           6         13.0          76.9       1.0X
+weekday of timestamp wholestage off                 733            734           1         13.6          73.3       1.0X
+weekday of timestamp wholestage on                  728            739          15         13.7          72.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    579            582           4         17.3          57.9       1.0X
-hour of timestamp wholestage on                     582            584           2         17.2          58.2       1.0X
+hour of timestamp wholestage off                    544            544           0         18.4          54.4       1.0X
+hour of timestamp wholestage on                     545            549           6         18.4          54.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  577            578           2         17.3          57.7       1.0X
-minute of timestamp wholestage on                   589            591           1         17.0          58.9       1.0X
+minute of timestamp wholestage off                  544            547           4         18.4          54.4       1.0X
+minute of timestamp wholestage on                   542            546           2         18.4          54.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  580            587          10         17.3          58.0       1.0X
-second of timestamp wholestage on                   584            591          12         17.1          58.4       1.0X
+second of timestamp wholestage off                  548            549           1         18.3          54.8       1.0X
+second of timestamp wholestage on                   561            565           7         17.8          56.1       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         207            209           3         48.3          20.7       1.0X
-current_date wholestage on                          225            229           3         44.4          22.5       0.9X
+current_date wholestage off                         192            192           0         52.1          19.2       1.0X
+current_date wholestage on                          206            208           1         48.5          20.6       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    219            221           3         45.7          21.9       1.0X
-current_timestamp wholestage on                     241            244           4         41.5          24.1       0.9X
+current_timestamp wholestage off                    196            199           4         51.0          19.6       1.0X
+current_timestamp wholestage on                     212            219           6         47.2          21.2       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         597            597           0         16.7          59.7       1.0X
-cast to date wholestage on                          621            622           1         16.1          62.1       1.0X
+cast to date wholestage off                         586            588           3         17.1          58.6       1.0X
+cast to date wholestage on                          578            580           2         17.3          57.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             661            662           2         15.1          66.1       1.0X
-last_day wholestage on                              688            698           9         14.5          68.8       1.0X
+last_day wholestage off                             664            664           1         15.1          66.4       1.0X
+last_day wholestage on                              667            669           4         15.0          66.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             629            634           8         15.9          62.9       1.0X
-next_day wholestage on                              651            656           5         15.4          65.1       1.0X
+next_day wholestage off                             613            621          12         16.3          61.3       1.0X
+next_day wholestage on                              612            618           4         16.3          61.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             581            582           2         17.2          58.1       1.0X
-date_add wholestage on                              605            611           4         16.5          60.5       1.0X
+date_add wholestage off                             566            568           2         17.7          56.6       1.0X
+date_add wholestage on                              575            576           2         17.4          57.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             582            584           3         17.2          58.2       1.0X
-date_sub wholestage on                              606            608           3         16.5          60.6       1.0X
+date_sub wholestage off                             569            572           3         17.6          56.9       1.0X
+date_sub wholestage on                              574            578           3         17.4          57.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           807            808           1         12.4          80.7       1.0X
-add_months wholestage on                            847            851           3         11.8          84.7       1.0X
+add_months wholestage off                           806            807           2         12.4          80.6       1.0X
+add_months wholestage on                            812            823          12         12.3          81.2       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2872           2895          33          3.5         287.2       1.0X
-format date wholestage on                          2917           2943          43          3.4         291.7       1.0X
+format date wholestage off                         2844           2846           2          3.5         284.4       1.0X
+format date wholestage on                          2853           2879          45          3.5         285.3       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2509           2517          11          4.0         250.9       1.0X
-from_unixtime wholestage on                        2493           2498           8          4.0         249.3       1.0X
+from_unixtime wholestage off                       2658           2658           1          3.8         265.8       1.0X
+from_unixtime wholestage on                        2549           2557           7          3.9         254.9       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   706            707           1         14.2          70.6       1.0X
-from_utc_timestamp wholestage on                    716            729          15         14.0          71.6       1.0X
+from_utc_timestamp wholestage off                   689            691           2         14.5          68.9       1.0X
+from_utc_timestamp wholestage on                    697            701           5         14.3          69.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     868            875           9         11.5          86.8       1.0X
-to_utc_timestamp wholestage on                      891            894           4         11.2          89.1       1.0X
+to_utc_timestamp wholestage off                     874            874           0         11.4          87.4       1.0X
+to_utc_timestamp wholestage on                      884            889           4         11.3          88.4       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        260            263           4         38.4          26.0       1.0X
-cast interval wholestage on                         225            229           2         44.4          22.5       1.2X
+cast interval wholestage off                        250            254           5         40.0          25.0       1.0X
+cast interval wholestage on                         217            223           5         46.0          21.7       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             967            971           7         10.3          96.7       1.0X
-datediff wholestage on                              971            981          10         10.3          97.1       1.0X
+datediff wholestage off                             964            964           0         10.4          96.4       1.0X
+datediff wholestage on                              945            950           5         10.6          94.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2704           2708           5          3.7         270.4       1.0X
-months_between wholestage on                       2691           2696           6          3.7         269.1       1.0X
+months_between wholestage off                      2589           2594           6          3.9         258.9       1.0X
+months_between wholestage on                       2613           2617           2          3.8         261.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               588            596          11          1.7         588.2       1.0X
-window wholestage on                                717            727           9          1.4         716.7       0.8X
+window wholestage off                               549            565          22          1.8         549.2       1.0X
+window wholestage on                                691            699           9          1.4         691.1       0.8X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      718            719           1         13.9          71.8       1.0X
-date_trunc YEAR wholestage on                       695            700           6         14.4          69.5       1.0X
+date_trunc YEAR wholestage off                      509            512           4         19.6          50.9       1.0X
+date_trunc YEAR wholestage on                       445            447           1         22.5          44.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      723            727           7         13.8          72.3       1.0X
-date_trunc YYYY wholestage on                       694            699           6         14.4          69.4       1.0X
+date_trunc YYYY wholestage off                      514            522          12         19.5          51.4       1.0X
+date_trunc YYYY wholestage on                       444            451           8         22.5          44.4       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        717            718           2         13.9          71.7       1.0X
-date_trunc YY wholestage on                         697            711          22         14.4          69.7       1.0X
+date_trunc YY wholestage off                        506            507           0         19.8          50.6       1.0X
+date_trunc YY wholestage on                         446            447           1         22.4          44.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       715            722          10         14.0          71.5       1.0X
-date_trunc MON wholestage on                        666            670           3         15.0          66.6       1.1X
+date_trunc MON wholestage off                       465            465           0         21.5          46.5       1.0X
+date_trunc MON wholestage on                        430            436           9         23.3          43.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     714            716           2         14.0          71.4       1.0X
-date_trunc MONTH wholestage on                      665            668           3         15.0          66.5       1.1X
+date_trunc MONTH wholestage off                     466            466           1         21.5          46.6       1.0X
+date_trunc MONTH wholestage on                      429            433           2         23.3          42.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        716            720           6         14.0          71.6       1.0X
-date_trunc MM wholestage on                         662            665           4         15.1          66.2       1.1X
+date_trunc MM wholestage off                        466            468           2         21.4          46.6       1.0X
+date_trunc MM wholestage on                         429            433           4         23.3          42.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       617            618           2         16.2          61.7       1.0X
-date_trunc DAY wholestage on                        560            572           9         17.9          56.0       1.1X
+date_trunc DAY wholestage off                       343            344           1         29.1          34.3       1.0X
+date_trunc DAY wholestage on                        333            337           3         30.0          33.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        618            621           4         16.2          61.8       1.0X
-date_trunc DD wholestage on                         563            576           9         17.8          56.3       1.1X
+date_trunc DD wholestage off                        346            347           1         28.9          34.6       1.0X
+date_trunc DD wholestage on                         333            337           4         30.1          33.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      613            622          13         16.3          61.3       1.0X
-date_trunc HOUR wholestage on                       576            577           1         17.4          57.6       1.1X
+date_trunc HOUR wholestage off                      357            357           0         28.0          35.7       1.0X
+date_trunc HOUR wholestage on                       325            339          23         30.8          32.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    626            628           3         16.0          62.6       1.0X
-date_trunc MINUTE wholestage on                     587            591           4         17.0          58.7       1.1X
+date_trunc MINUTE wholestage off                    334            334           0         29.9          33.4       1.0X
+date_trunc MINUTE wholestage on                     322            327           5         31.0          32.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    331            331           0         30.2          33.1       1.0X
-date_trunc SECOND wholestage on                     278            281           3         36.0          27.8       1.2X
+date_trunc SECOND wholestage off                    341            342           1         29.3          34.1       1.0X
+date_trunc SECOND wholestage on                     304            306           2         32.9          30.4       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      656            662           8         15.2          65.6       1.0X
-date_trunc WEEK wholestage on                       614            625          12         16.3          61.4       1.1X
+date_trunc WEEK wholestage off                      415            417           2         24.1          41.5       1.0X
+date_trunc WEEK wholestage on                       383            388          11         26.1          38.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   899            902           4         11.1          89.9       1.0X
-date_trunc QUARTER wholestage on                    850            857           7         11.8          85.0       1.1X
+date_trunc QUARTER wholestage off                   654            655           2         15.3          65.4       1.0X
+date_trunc QUARTER wholestage on                    623            629           9         16.1          62.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           807            808           1         12.4          80.7       1.0X
-trunc year wholestage on                            761            767           4         13.1          76.1       1.1X
+trunc year wholestage off                           800            802           2         12.5          80.0       1.0X
+trunc year wholestage on                            772            773           1         13.0          77.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           816            816           1         12.3          81.6       1.0X
-trunc yyyy wholestage on                            760            764           3         13.2          76.0       1.1X
+trunc yyyy wholestage off                           801            801           0         12.5          80.1       1.0X
+trunc yyyy wholestage on                            771            774           3         13.0          77.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             805            808           4         12.4          80.5       1.0X
-trunc yy wholestage on                              760            764           3         13.2          76.0       1.1X
+trunc yy wholestage off                             800            801           1         12.5          80.0       1.0X
+trunc yy wholestage on                              771            777           7         13.0          77.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            786            800          20         12.7          78.6       1.0X
-trunc mon wholestage on                             744            748           4         13.4          74.4       1.1X
+trunc mon wholestage off                            789            789           0         12.7          78.9       1.0X
+trunc mon wholestage on                             746            752           4         13.4          74.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          786            787           2         12.7          78.6       1.0X
-trunc month wholestage on                           744            773          52         13.4          74.4       1.1X
+trunc month wholestage off                          786            788           3         12.7          78.6       1.0X
+trunc month wholestage on                           746            753           7         13.4          74.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             789            789           0         12.7          78.9       1.0X
-trunc mm wholestage on                              742            744           3         13.5          74.2       1.1X
+trunc mm wholestage off                             788            796          12         12.7          78.8       1.0X
+trunc mm wholestage on                              746            755          10         13.4          74.6       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      96             97           1         10.4          96.0       1.0X
-to timestamp str wholestage on                       85             86           2         11.8          84.8       1.1X
+to timestamp str wholestage off                      92             93           2         10.9          91.8       1.0X
+to timestamp str wholestage on                       86             87           1         11.7          85.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         659            663           6          1.5         658.6       1.0X
-to_timestamp wholestage on                          666            669           3          1.5         666.1       1.0X
+to_timestamp wholestage off                         643            646           4          1.6         643.4       1.0X
+to_timestamp wholestage on                          643            645           2          1.6         643.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    671            671           0          1.5         670.9       1.0X
-to_unix_timestamp wholestage on                     665            666           1          1.5         665.1       1.0X
+to_unix_timestamp wholestage off                    629            629           0          1.6         628.8       1.0X
+to_unix_timestamp wholestage on                     653            654           1          1.5         653.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          110            112           3          9.1         109.6       1.0X
-to date str wholestage on                           113            119           3          8.8         113.3       1.0X
+to date str wholestage off                          109            110           2          9.2         108.7       1.0X
+to date str wholestage on                           115            120           4          8.7         115.3       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              614            615           2          1.6         614.0       1.0X
-to_date wholestage on                               613            614           1          1.6         612.7       1.0X
+to_date wholestage off                              606            611           7          1.7         605.6       1.0X
+to_date wholestage on                               607            608           1          1.6         607.1       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  298            300           2         16.8          59.7       1.0X
-From java.time.LocalDate                            227            229           3         22.1          45.3       1.3X
-Collect java.sql.Date                              1289           1316          32          3.9         257.8       0.2X
-Collect java.time.LocalDate                         994           1094         109          5.0         198.8       0.3X
-From java.sql.Timestamp                             228            252          22         21.9          45.6       1.3X
-From java.time.Instant                              187            205          24         26.7          37.5       1.6X
-Collect longs                                      1031           1056          38          4.8         206.2       0.3X
-Collect java.sql.Timestamp                         1232           1242          18          4.1         246.3       0.2X
-Collect java.time.Instant                           854           1064         279          5.9         170.8       0.3X
-java.sql.Date to Hive string                       3979           4048          61          1.3         795.8       0.1X
-java.time.LocalDate to Hive string                 3121           3210         125          1.6         624.3       0.1X
-java.sql.Timestamp to Hive string                  6863           6911          58          0.7        1372.7       0.0X
-java.time.Instant to Hive string                   4221           4260          54          1.2         844.2       0.1X
+From java.sql.Date                                  308            315          11         16.2          61.7       1.0X
+From java.time.LocalDate                            234            235           1         21.4          46.8       1.3X
+Collect java.sql.Date                              1259           1343         100          4.0         251.9       0.2X
+Collect java.time.LocalDate                        1095           1174         115          4.6         218.9       0.3X
+From java.sql.Timestamp                             263            267           4         19.0          52.6       1.2X
+From java.time.Instant                              204            225          18         24.5          40.8       1.5X
+Collect longs                                       921            995          89          5.4         184.1       0.3X
+Collect java.sql.Timestamp                         1165           1203          33          4.3         232.9       0.3X
+Collect java.time.Instant                           932            998          62          5.4         186.5       0.3X
+java.sql.Date to Hive string                       3919           3987          79          1.3         783.8       0.1X
+java.time.LocalDate to Hive string                 3084           3199         107          1.6         616.7       0.1X
+java.sql.Timestamp to Hive string                  6867           6898          27          0.7        1373.4       0.0X
+java.time.Instant to Hive string                   4199           4265          71          1.2         839.8       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  803            830          39         12.5          80.3       1.0X
-date + interval(m, d)                               802            805           5         12.5          80.2       1.0X
-date + interval(m, d, ms)                          3264           3270           9          3.1         326.4       0.2X
-date - interval(m)                                  795            801           6         12.6          79.5       1.0X
-date - interval(m, d)                               813            821           7         12.3          81.3       1.0X
-date - interval(m, d, ms)                          3291           3299          12          3.0         329.1       0.2X
-timestamp + interval(m)                            1660           1663           3          6.0         166.0       0.5X
-timestamp + interval(m, d)                         1698           1700           2          5.9         169.8       0.5X
-timestamp + interval(m, d, ms)                     2062           2064           2          4.8         206.2       0.4X
-timestamp - interval(m)                            1800           1804           5          5.6         180.0       0.4X
-timestamp - interval(m, d)                         1877           1877           1          5.3         187.7       0.4X
-timestamp - interval(m, d, ms)                     2068           2070           2          4.8         206.8       0.4X
+date + interval(m)                                  803            827          28         12.5          80.3       1.0X
+date + interval(m, d)                               793            793           0         12.6          79.3       1.0X
+date + interval(m, d, ms)                          3345           3348           4          3.0         334.5       0.2X
+date - interval(m)                                  801            805           4         12.5          80.1       1.0X
+date - interval(m, d)                               814            830          16         12.3          81.4       1.0X
+date - interval(m, d, ms)                          3356           3361           6          3.0         335.6       0.2X
+timestamp + interval(m)                            1745           1746           2          5.7         174.5       0.5X
+timestamp + interval(m, d)                         1786           1790           6          5.6         178.6       0.4X
+timestamp + interval(m, d, ms)                     2153           2156           5          4.6         215.3       0.4X
+timestamp - interval(m)                            1893           1894           2          5.3         189.3       0.4X
+timestamp - interval(m, d)                         1950           1956           9          5.1         195.0       0.4X
+timestamp - interval(m, d, ms)                     2175           2176           1          4.6         217.5       0.4X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    222            226           6         45.0          22.2       1.0X
-cast to timestamp wholestage on                     222            232          16         45.1          22.2       1.0X
+cast to timestamp wholestage off                    222            223           1         45.0          22.2       1.0X
+cast to timestamp wholestage on                     223            227           6         44.8          22.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    617            617           1         16.2          61.7       1.0X
-year of timestamp wholestage on                     636            639           3         15.7          63.6       1.0X
+year of timestamp wholestage off                    609            616          10         16.4          60.9       1.0X
+year of timestamp wholestage on                     630            634           3         15.9          63.0       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 651            653           3         15.4          65.1       1.0X
-quarter of timestamp wholestage on                  671            679          11         14.9          67.1       1.0X
+quarter of timestamp wholestage off                 654            655           1         15.3          65.4       1.0X
+quarter of timestamp wholestage on                  665            668           3         15.0          66.5       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   657            659           3         15.2          65.7       1.0X
-month of timestamp wholestage on                    653            655           1         15.3          65.3       1.0X
+month of timestamp wholestage off                   631            633           3         15.9          63.1       1.0X
+month of timestamp wholestage on                    644            648           2         15.5          64.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1024           1025           1          9.8         102.4       1.0X
-weekofyear of timestamp wholestage on              1017           1025          11          9.8         101.7       1.0X
+weekofyear of timestamp wholestage off              902            905           3         11.1          90.2       1.0X
+weekofyear of timestamp wholestage on               965            972           9         10.4          96.5       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     637            641           6         15.7          63.7       1.0X
-day of timestamp wholestage on                      652            657           4         15.3          65.2       1.0X
+day of timestamp wholestage off                     667            668           1         15.0          66.7       1.0X
+day of timestamp wholestage on                      649            654           6         15.4          64.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               678            678           0         14.7          67.8       1.0X
-dayofyear of timestamp wholestage on                693            694           1         14.4          69.3       1.0X
+dayofyear of timestamp wholestage off               676            679           4         14.8          67.6       1.0X
+dayofyear of timestamp wholestage on                682            685           3         14.7          68.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              639            641           3         15.7          63.9       1.0X
-dayofmonth of timestamp wholestage on               656            661           8         15.2          65.6       1.0X
+dayofmonth of timestamp wholestage off              666            668           2         15.0          66.6       1.0X
+dayofmonth of timestamp wholestage on               643            651           5         15.6          64.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               797            800           4         12.5          79.7       1.0X
-dayofweek of timestamp wholestage on                794            800           7         12.6          79.4       1.0X
+dayofweek of timestamp wholestage off               794            794           0         12.6          79.4       1.0X
+dayofweek of timestamp wholestage on                784            786           1         12.8          78.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 737            738           1         13.6          73.7       1.0X
-weekday of timestamp wholestage on                  760            763           2         13.2          76.0       1.0X
+weekday of timestamp wholestage off                 740            743           4         13.5          74.0       1.0X
+weekday of timestamp wholestage on                  750            752           2         13.3          75.0       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    581            583           3         17.2          58.1       1.0X
-hour of timestamp wholestage on                     579            583           3         17.3          57.9       1.0X
+hour of timestamp wholestage off                    575            591          23         17.4          57.5       1.0X
+hour of timestamp wholestage on                     570            575           3         17.5          57.0       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  581            584           4         17.2          58.1       1.0X
-minute of timestamp wholestage on                   575            581           8         17.4          57.5       1.0X
+minute of timestamp wholestage off                  577            579           2         17.3          57.7       1.0X
+minute of timestamp wholestage on                   573            578           6         17.5          57.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  582            585           4         17.2          58.2       1.0X
-second of timestamp wholestage on                   574            578           3         17.4          57.4       1.0X
+second of timestamp wholestage off                  584            585           2         17.1          58.4       1.0X
+second of timestamp wholestage on                   570            573           2         17.5          57.0       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         214            217           4         46.7          21.4       1.0X
-current_date wholestage on                          216            220           3         46.3          21.6       1.0X
+current_date wholestage off                         204            206           2         48.9          20.4       1.0X
+current_date wholestage on                          220            224           4         45.5          22.0       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    229            231           2         43.6          22.9       1.0X
-current_timestamp wholestage on                     223            232           9         44.9          22.3       1.0X
+current_timestamp wholestage off                    214            217           4         46.8          21.4       1.0X
+current_timestamp wholestage on                     220            226           5         45.5          22.0       1.0X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         592            593           1         16.9          59.2       1.0X
-cast to date wholestage on                          602            606           3         16.6          60.2       1.0X
+cast to date wholestage off                         593            603          14         16.9          59.3       1.0X
+cast to date wholestage on                          605            613          10         16.5          60.5       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             661            661           0         15.1          66.1       1.0X
-last_day wholestage on                              684            689           5         14.6          68.4       1.0X
+last_day wholestage off                             656            661           7         15.2          65.6       1.0X
+last_day wholestage on                              683            688           4         14.6          68.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             622            623           2         16.1          62.2       1.0X
-next_day wholestage on                              635            638           4         15.8          63.5       1.0X
+next_day wholestage off                             617            618           0         16.2          61.7       1.0X
+next_day wholestage on                              635            642           8         15.7          63.5       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             581            583           3         17.2          58.1       1.0X
-date_add wholestage on                              606            612           7         16.5          60.6       1.0X
+date_add wholestage off                             575            577           3         17.4          57.5       1.0X
+date_add wholestage on                              593            601          11         16.9          59.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             576            578           2         17.3          57.6       1.0X
-date_sub wholestage on                              603            610           5         16.6          60.3       1.0X
+date_sub wholestage off                             573            573           0         17.4          57.3       1.0X
+date_sub wholestage on                              593            598           4         16.9          59.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           814            815           1         12.3          81.4       1.0X
-add_months wholestage on                            831            834           2         12.0          83.1       1.0X
+add_months wholestage off                           809            810           1         12.4          80.9       1.0X
+add_months wholestage on                            831            835           3         12.0          83.1       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3059           3075          22          3.3         305.9       1.0X
-format date wholestage on                          2886           2900          22          3.5         288.6       1.1X
+format date wholestage off                         3265           3278          18          3.1         326.5       1.0X
+format date wholestage on                          3130           3162          23          3.2         313.0       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2746           2746           1          3.6         274.6       1.0X
-from_unixtime wholestage on                        2980           2983           3          3.4         298.0       0.9X
+from_unixtime wholestage off                       2682           2684           3          3.7         268.2       1.0X
+from_unixtime wholestage on                        2876           2891          10          3.5         287.6       0.9X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   706            711           7         14.2          70.6       1.0X
-from_utc_timestamp wholestage on                    712            715           3         14.0          71.2       1.0X
+from_utc_timestamp wholestage off                   696            699           4         14.4          69.6       1.0X
+from_utc_timestamp wholestage on                    709            712           6         14.1          70.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     837            838           1         11.9          83.7       1.0X
-to_utc_timestamp wholestage on                      878            881           3         11.4          87.8       1.0X
+to_utc_timestamp wholestage off                     873            873           0         11.5          87.3       1.0X
+to_utc_timestamp wholestage on                      897            901           4         11.1          89.7       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        262            269          10         38.1          26.2       1.0X
-cast interval wholestage on                         218            227           8         45.8          21.8       1.2X
+cast interval wholestage off                        251            252           0         39.8          25.1       1.0X
+cast interval wholestage on                         217            221           2         46.1          21.7       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             960            965           6         10.4          96.0       1.0X
-datediff wholestage on                              957            959           2         10.4          95.7       1.0X
+datediff wholestage off                             961            970          13         10.4          96.1       1.0X
+datediff wholestage on                              954            957           3         10.5          95.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2598           2600           4          3.8         259.8       1.0X
-months_between wholestage on                       2591           2598           7          3.9         259.1       1.0X
+months_between wholestage off                      2732           2734           4          3.7         273.2       1.0X
+months_between wholestage on                       2702           2712          10          3.7         270.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               613            635          32          1.6         612.5       1.0X
-window wholestage on                                692            707          14          1.4         691.6       0.9X
+window wholestage off                               544            556          17          1.8         543.8       1.0X
+window wholestage on                                721            736          13          1.4         721.0       0.8X
 
 
 ================================================================================================
@@ -266,204 +266,204 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      506            508           4         19.8          50.6       1.0X
-date_trunc YEAR wholestage on                       458            462           3         21.8          45.8       1.1X
+date_trunc YEAR wholestage off                      484            485           0         20.7          48.4       1.0X
+date_trunc YEAR wholestage on                       416            420           3         24.0          41.6       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      502            503           2         19.9          50.2       1.0X
-date_trunc YYYY wholestage on                       466            468           3         21.5          46.6       1.1X
+date_trunc YYYY wholestage off                      483            488           8         20.7          48.3       1.0X
+date_trunc YYYY wholestage on                       428            436           7         23.4          42.8       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        503            504           2         19.9          50.3       1.0X
-date_trunc YY wholestage on                         461            464           1         21.7          46.1       1.1X
+date_trunc YY wholestage off                        480            482           2         20.8          48.0       1.0X
+date_trunc YY wholestage on                         427            433           4         23.4          42.7       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       470            470           0         21.3          47.0       1.0X
-date_trunc MON wholestage on                        426            430           4         23.5          42.6       1.1X
+date_trunc MON wholestage off                       459            466          11         21.8          45.9       1.0X
+date_trunc MON wholestage on                        433            443          16         23.1          43.3       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     468            472           6         21.3          46.8       1.0X
-date_trunc MONTH wholestage on                      426            431           6         23.5          42.6       1.1X
+date_trunc MONTH wholestage off                     460            461           1         21.7          46.0       1.0X
+date_trunc MONTH wholestage on                      434            437           3         23.0          43.4       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        469            470           1         21.3          46.9       1.0X
-date_trunc MM wholestage on                         428            435           8         23.4          42.8       1.1X
+date_trunc MM wholestage off                        460            460           0         21.8          46.0       1.0X
+date_trunc MM wholestage on                         435            439           7         23.0          43.5       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       363            364           1         27.6          36.3       1.0X
-date_trunc DAY wholestage on                        321            326           4         31.1          32.1       1.1X
+date_trunc DAY wholestage off                       367            367           0         27.3          36.7       1.0X
+date_trunc DAY wholestage on                        336            339           2         29.7          33.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        362            363           1         27.6          36.2       1.0X
-date_trunc DD wholestage on                         318            321           2         31.5          31.8       1.1X
+date_trunc DD wholestage off                        367            370           4         27.2          36.7       1.0X
+date_trunc DD wholestage on                         337            339           2         29.7          33.7       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      361            361           0         27.7          36.1       1.0X
-date_trunc HOUR wholestage on                       318            320           2         31.4          31.8       1.1X
+date_trunc HOUR wholestage off                      370            370           0         27.1          37.0       1.0X
+date_trunc HOUR wholestage on                       336            339           2         29.7          33.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    360            360           0         27.8          36.0       1.0X
-date_trunc MINUTE wholestage on                     317            324           5         31.6          31.7       1.1X
+date_trunc MINUTE wholestage off                    370            371           2         27.1          37.0       1.0X
+date_trunc MINUTE wholestage on                     336            338           1         29.7          33.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    325            327           3         30.7          32.5       1.0X
-date_trunc SECOND wholestage on                     276            280           4         36.2          27.6       1.2X
+date_trunc SECOND wholestage off                    330            331           1         30.3          33.0       1.0X
+date_trunc SECOND wholestage on                     293            295           2         34.1          29.3       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      420            420           0         23.8          42.0       1.0X
-date_trunc WEEK wholestage on                       367            373           7         27.2          36.7       1.1X
+date_trunc WEEK wholestage off                      422            423           1         23.7          42.2       1.0X
+date_trunc WEEK wholestage on                       393            394           1         25.5          39.3       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   631            632           1         15.8          63.1       1.0X
-date_trunc QUARTER wholestage on                    591            594           3         16.9          59.1       1.1X
+date_trunc QUARTER wholestage off                   598            610          17         16.7          59.8       1.0X
+date_trunc QUARTER wholestage on                    566            569           3         17.7          56.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (shuffled 2y) wholestage off           1235           1235           0          8.1         123.5       1.0X
-date_trunc YEAR (shuffled 2y) wholestage on            1163           1169           9          8.6         116.3       1.1X
+date_trunc YEAR (shuffled 2y) wholestage off           1159           1165           9          8.6         115.9       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1143           1147           5          8.8         114.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (spread 95y) wholestage off           1333           1335           3          7.5         133.3       1.0X
-date_trunc YEAR (spread 95y) wholestage on            1286           1296           8          7.8         128.6       1.0X
+date_trunc YEAR (spread 95y) wholestage off           1312           1317           8          7.6         131.2       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1283           1292           7          7.8         128.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (shuffled 2y) wholestage off           1107           1108           0          9.0         110.7       1.0X
-date_trunc QUARTER (shuffled 2y) wholestage on            1129           1132           3          8.9         112.9       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage off           1040           1043           3          9.6         104.0       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on             991            993           2         10.1          99.1       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (spread 95y) wholestage off           1442           1448           9          6.9         144.2       1.0X
-date_trunc QUARTER (spread 95y) wholestage on            1372           1377           6          7.3         137.2       1.1X
+date_trunc QUARTER (spread 95y) wholestage off           1355           1359           6          7.4         135.5       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1368           1375           8          7.3         136.8       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (shuffled 2y) wholestage off            743            745           4         13.5          74.3       1.0X
-date_trunc MONTH (shuffled 2y) wholestage on             700            709          12         14.3          70.0       1.1X
+date_trunc MONTH (shuffled 2y) wholestage off            744            744           1         13.4          74.4       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             712            716           3         14.0          71.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (spread 95y) wholestage off            805            806           1         12.4          80.5       1.0X
-date_trunc MONTH (spread 95y) wholestage on             761            766           3         13.1          76.1       1.1X
+date_trunc MONTH (spread 95y) wholestage off            831            835           6         12.0          83.1       1.0X
+date_trunc MONTH (spread 95y) wholestage on             790            793           3         12.7          79.0       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (shuffled 2y) wholestage off            520            523           4         19.2          52.0       1.0X
-date_trunc WEEK (shuffled 2y) wholestage on             489            492           3         20.4          48.9       1.1X
+date_trunc WEEK (shuffled 2y) wholestage off            540            540           1         18.5          54.0       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             514            519           3         19.4          51.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (spread 95y) wholestage off            608            616          10         16.4          60.8       1.0X
-date_trunc WEEK (spread 95y) wholestage on             555            562           8         18.0          55.5       1.1X
+date_trunc WEEK (spread 95y) wholestage off            655            656           1         15.3          65.5       1.0X
+date_trunc WEEK (spread 95y) wholestage on             626            630           4         16.0          62.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (shuffled 2y) wholestage off            462            464           3         21.7          46.2       1.0X
-date_trunc DAY (shuffled 2y) wholestage on             410            417           7         24.4          41.0       1.1X
+date_trunc DAY (shuffled 2y) wholestage off            478            478           1         20.9          47.8       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             449            451           2         22.3          44.9       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (spread 95y) wholestage off            541            542           1         18.5          54.1       1.0X
-date_trunc DAY (spread 95y) wholestage on             532            540           6         18.8          53.2       1.0X
+date_trunc DAY (spread 95y) wholestage off            592            593           1         16.9          59.2       1.0X
+date_trunc DAY (spread 95y) wholestage on             560            565           4         17.8          56.0       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           768            768           0         13.0          76.8       1.0X
-trunc year wholestage on                            727            730           4         13.8          72.7       1.1X
+trunc year wholestage off                           801            801           1         12.5          80.1       1.0X
+trunc year wholestage on                            754            760           9         13.3          75.4       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           769            770           2         13.0          76.9       1.0X
-trunc yyyy wholestage on                            723            726           2         13.8          72.3       1.1X
+trunc yyyy wholestage off                           801            802           1         12.5          80.1       1.0X
+trunc yyyy wholestage on                            754            758           4         13.3          75.4       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             768            773           8         13.0          76.8       1.0X
-trunc yy wholestage on                              722            728           4         13.8          72.2       1.1X
+trunc yy wholestage off                             801            805           7         12.5          80.1       1.0X
+trunc yy wholestage on                              752            756           4         13.3          75.2       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            732            733           1         13.7          73.2       1.0X
-trunc mon wholestage on                             695            700           3         14.4          69.5       1.1X
+trunc mon wholestage off                            759            769          14         13.2          75.9       1.0X
+trunc mon wholestage on                             716            721           5         14.0          71.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          739            749          14         13.5          73.9       1.0X
-trunc month wholestage on                           698            701           2         14.3          69.8       1.1X
+trunc month wholestage off                          764            764           0         13.1          76.4       1.0X
+trunc month wholestage on                           714            719           4         14.0          71.4       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             735            735           0         13.6          73.5       1.0X
-trunc mm wholestage on                              696            714          25         14.4          69.6       1.1X
+trunc mm wholestage off                             762            765           4         13.1          76.2       1.0X
+trunc mm wholestage on                              717            720           3         13.9          71.7       1.1X
 
 
 ================================================================================================
@@ -474,36 +474,36 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      90             91           2         11.1          89.7       1.0X
-to timestamp str wholestage on                       83             88           7         12.1          82.9       1.1X
+to timestamp str wholestage off                      91             92           2         11.0          91.1       1.0X
+to timestamp str wholestage on                       89             91           2         11.2          88.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         627            627           0          1.6         626.8       1.0X
-to_timestamp wholestage on                          614            616           2          1.6         614.3       1.0X
+to_timestamp wholestage off                         631            633           3          1.6         631.5       1.0X
+to_timestamp wholestage on                          621            623           4          1.6         620.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    614            614           0          1.6         614.2       1.0X
-to_unix_timestamp wholestage on                     603            605           1          1.7         603.2       1.0X
+to_unix_timestamp wholestage off                    620            620           1          1.6         619.6       1.0X
+to_unix_timestamp wholestage on                     634            635           1          1.6         633.7       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          106            108           2          9.4         106.3       1.0X
-to date str wholestage on                           113            115           2          8.9         112.6       0.9X
+to date str wholestage off                          104            107           3          9.6         104.3       1.0X
+to date str wholestage on                           118            120           2          8.5         118.3       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              566            568           4          1.8         565.7       1.0X
-to_date wholestage on                               572            576           4          1.7         572.2       1.0X
+to_date wholestage off                              575            575           1          1.7         574.7       1.0X
+to_date wholestage on                               578            580           1          1.7         578.2       1.0X
 
 
 ================================================================================================
@@ -514,18 +514,18 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  292            293           2         17.1          58.4       1.0X
-From java.time.LocalDate                            225            229           5         22.2          45.1       1.3X
-Collect java.sql.Date                              1261           1325          63          4.0         252.2       0.2X
-Collect java.time.LocalDate                        1082           1179         123          4.6         216.4       0.3X
-From java.sql.Timestamp                             231            249          15         21.6          46.3       1.3X
-From java.time.Instant                              203            226          21         24.7          40.5       1.4X
-Collect longs                                       892           1055         160          5.6         178.3       0.3X
-Collect java.sql.Timestamp                         1198           1240          43          4.2         239.6       0.2X
-Collect java.time.Instant                           983           1139         171          5.1         196.5       0.3X
-java.sql.Date to Hive string                       4164           4249         133          1.2         832.9       0.1X
-java.time.LocalDate to Hive string                 3221           3284          54          1.6         644.2       0.1X
-java.sql.Timestamp to Hive string                  6852           6904          61          0.7        1370.4       0.0X
-java.time.Instant to Hive string                   4320           4383          75          1.2         864.1       0.1X
+From java.sql.Date                                  299            300           1         16.7          59.7       1.0X
+From java.time.LocalDate                            233            236           3         21.5          46.5       1.3X
+Collect java.sql.Date                              1213           1360         127          4.1         242.7       0.2X
+Collect java.time.LocalDate                        1035           1108          73          4.8         206.9       0.3X
+From java.sql.Timestamp                             231            249          16         21.6          46.3       1.3X
+From java.time.Instant                              192            208          19         26.0          38.4       1.6X
+Collect longs                                       966           1148         161          5.2         193.3       0.3X
+Collect java.sql.Timestamp                          918           1207         280          5.4         183.6       0.3X
+Collect java.time.Instant                           938           1014         126          5.3         187.5       0.3X
+java.sql.Date to Hive string                       4022           4073          45          1.2         804.5       0.1X
+java.time.LocalDate to Hive string                 3301           3426         109          1.5         660.2       0.1X
+java.sql.Timestamp to Hive string                  6741           6792          44          0.7        1348.3       0.0X
+java.time.Instant to Hive string                   4188           4265          93          1.2         837.7       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -2,530 +2,530 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  803            827          28         12.5          80.3       1.0X
-date + interval(m, d)                               793            793           0         12.6          79.3       1.0X
-date + interval(m, d, ms)                          3345           3348           4          3.0         334.5       0.2X
-date - interval(m)                                  801            805           4         12.5          80.1       1.0X
-date - interval(m, d)                               814            830          16         12.3          81.4       1.0X
-date - interval(m, d, ms)                          3356           3361           6          3.0         335.6       0.2X
-timestamp + interval(m)                            1745           1746           2          5.7         174.5       0.5X
-timestamp + interval(m, d)                         1786           1790           6          5.6         178.6       0.4X
-timestamp + interval(m, d, ms)                     2153           2156           5          4.6         215.3       0.4X
-timestamp - interval(m)                            1893           1894           2          5.3         189.3       0.4X
-timestamp - interval(m, d)                         1950           1956           9          5.1         195.0       0.4X
-timestamp - interval(m, d, ms)                     2175           2176           1          4.6         217.5       0.4X
+date + interval(m)                                  806            825          23         12.4          80.6       1.0X
+date + interval(m, d)                               798            803           5         12.5          79.8       1.0X
+date + interval(m, d, ms)                          3507           3511           6          2.9         350.7       0.2X
+date - interval(m)                                  793            796           3         12.6          79.3       1.0X
+date - interval(m, d)                               809            812           2         12.4          80.9       1.0X
+date - interval(m, d, ms)                          3569           3574           7          2.8         356.9       0.2X
+timestamp + interval(m)                            1677           1681           6          6.0         167.7       0.5X
+timestamp + interval(m, d)                         1694           1698           7          5.9         169.4       0.5X
+timestamp + interval(m, d, ms)                     2094           2094           0          4.8         209.4       0.4X
+timestamp - interval(m)                            1885           1888           4          5.3         188.5       0.4X
+timestamp - interval(m, d)                         1948           1949           1          5.1         194.8       0.4X
+timestamp - interval(m, d, ms)                     2091           2097           9          4.8         209.1       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    222            223           1         45.0          22.2       1.0X
-cast to timestamp wholestage on                     223            227           6         44.8          22.3       1.0X
+cast to timestamp wholestage off                    223            226           3         44.8          22.3       1.0X
+cast to timestamp wholestage on                     221            224           3         45.1          22.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    609            616          10         16.4          60.9       1.0X
-year of timestamp wholestage on                     630            634           3         15.9          63.0       1.0X
+year of timestamp wholestage off                    612            613           1         16.3          61.2       1.0X
+year of timestamp wholestage on                     634            638           5         15.8          63.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 654            655           1         15.3          65.4       1.0X
-quarter of timestamp wholestage on                  665            668           3         15.0          66.5       1.0X
+quarter of timestamp wholestage off                 641            648           9         15.6          64.1       1.0X
+quarter of timestamp wholestage on                  667            671           3         15.0          66.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   631            633           3         15.9          63.1       1.0X
-month of timestamp wholestage on                    644            648           2         15.5          64.4       1.0X
+month of timestamp wholestage off                   627            629           3         16.0          62.7       1.0X
+month of timestamp wholestage on                    649            676          33         15.4          64.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              902            905           3         11.1          90.2       1.0X
-weekofyear of timestamp wholestage on               965            972           9         10.4          96.5       0.9X
+weekofyear of timestamp wholestage off              922            927           6         10.8          92.2       1.0X
+weekofyear of timestamp wholestage on               968            974           8         10.3          96.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     667            668           1         15.0          66.7       1.0X
-day of timestamp wholestage on                      649            654           6         15.4          64.9       1.0X
+day of timestamp wholestage off                     635            638           5         15.7          63.5       1.0X
+day of timestamp wholestage on                      657            661           3         15.2          65.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               676            679           4         14.8          67.6       1.0X
-dayofyear of timestamp wholestage on                682            685           3         14.7          68.2       1.0X
+dayofyear of timestamp wholestage off               677            680           5         14.8          67.7       1.0X
+dayofyear of timestamp wholestage on                690            693           2         14.5          69.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              666            668           2         15.0          66.6       1.0X
-dayofmonth of timestamp wholestage on               643            651           5         15.6          64.3       1.0X
+dayofmonth of timestamp wholestage off              633            634           2         15.8          63.3       1.0X
+dayofmonth of timestamp wholestage on               654            658           4         15.3          65.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               794            794           0         12.6          79.4       1.0X
-dayofweek of timestamp wholestage on                784            786           1         12.8          78.4       1.0X
+dayofweek of timestamp wholestage off               793            794           1         12.6          79.3       1.0X
+dayofweek of timestamp wholestage on                791            793           3         12.6          79.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 740            743           4         13.5          74.0       1.0X
-weekday of timestamp wholestage on                  750            752           2         13.3          75.0       1.0X
+weekday of timestamp wholestage off                 744            754          14         13.4          74.4       1.0X
+weekday of timestamp wholestage on                  755            758           2         13.3          75.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    575            591          23         17.4          57.5       1.0X
-hour of timestamp wholestage on                     570            575           3         17.5          57.0       1.0X
+hour of timestamp wholestage off                    579            581           3         17.3          57.9       1.0X
+hour of timestamp wholestage on                     576            578           2         17.4          57.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  577            579           2         17.3          57.7       1.0X
-minute of timestamp wholestage on                   573            578           6         17.5          57.3       1.0X
+minute of timestamp wholestage off                  578            578           1         17.3          57.8       1.0X
+minute of timestamp wholestage on                   578            583           5         17.3          57.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  584            585           2         17.1          58.4       1.0X
-second of timestamp wholestage on                   570            573           2         17.5          57.0       1.0X
+second of timestamp wholestage off                  581            585           5         17.2          58.1       1.0X
+second of timestamp wholestage on                   579            581           1         17.3          57.9       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         204            206           2         48.9          20.4       1.0X
-current_date wholestage on                          220            224           4         45.5          22.0       0.9X
+current_date wholestage off                         212            214           2         47.2          21.2       1.0X
+current_date wholestage on                          262            265           3         38.2          26.2       0.8X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    214            217           4         46.8          21.4       1.0X
-current_timestamp wholestage on                     220            226           5         45.5          22.0       1.0X
+current_timestamp wholestage off                    214            224          14         46.7          21.4       1.0X
+current_timestamp wholestage on                     221            227           4         45.2          22.1       1.0X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         593            603          14         16.9          59.3       1.0X
-cast to date wholestage on                          605            613          10         16.5          60.5       1.0X
+cast to date wholestage off                         598            602           5         16.7          59.8       1.0X
+cast to date wholestage on                          600            604           5         16.7          60.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             656            661           7         15.2          65.6       1.0X
-last_day wholestage on                              683            688           4         14.6          68.3       1.0X
+last_day wholestage off                             659            673          20         15.2          65.9       1.0X
+last_day wholestage on                              686            692           7         14.6          68.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             617            618           0         16.2          61.7       1.0X
-next_day wholestage on                              635            642           8         15.7          63.5       1.0X
+next_day wholestage off                             641            643           2         15.6          64.1       1.0X
+next_day wholestage on                              630            636           4         15.9          63.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             575            577           3         17.4          57.5       1.0X
-date_add wholestage on                              593            601          11         16.9          59.3       1.0X
+date_add wholestage off                             582            582           1         17.2          58.2       1.0X
+date_add wholestage on                              595            600           4         16.8          59.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             573            573           0         17.4          57.3       1.0X
-date_sub wholestage on                              593            598           4         16.9          59.3       1.0X
+date_sub wholestage off                             583            584           0         17.1          58.3       1.0X
+date_sub wholestage on                              596            597           1         16.8          59.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           809            810           1         12.4          80.9       1.0X
-add_months wholestage on                            831            835           3         12.0          83.1       1.0X
+add_months wholestage off                           815            816           1         12.3          81.5       1.0X
+add_months wholestage on                            837            841           4         11.9          83.7       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3265           3278          18          3.1         326.5       1.0X
-format date wholestage on                          3130           3162          23          3.2         313.0       1.0X
+format date wholestage off                         3055           3059           5          3.3         305.5       1.0X
+format date wholestage on                          3005           3036          57          3.3         300.5       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2682           2684           3          3.7         268.2       1.0X
-from_unixtime wholestage on                        2876           2891          10          3.5         287.6       0.9X
+from_unixtime wholestage off                       2622           2624           3          3.8         262.2       1.0X
+from_unixtime wholestage on                        2533           2538           7          3.9         253.3       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   696            699           4         14.4          69.6       1.0X
-from_utc_timestamp wholestage on                    709            712           6         14.1          70.9       1.0X
+from_utc_timestamp wholestage off                   701            703           2         14.3          70.1       1.0X
+from_utc_timestamp wholestage on                    708            711           2         14.1          70.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     873            873           0         11.5          87.3       1.0X
-to_utc_timestamp wholestage on                      897            901           4         11.1          89.7       1.0X
+to_utc_timestamp wholestage off                     846            846           0         11.8          84.6       1.0X
+to_utc_timestamp wholestage on                      902            907           3         11.1          90.2       0.9X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        251            252           0         39.8          25.1       1.0X
-cast interval wholestage on                         217            221           2         46.1          21.7       1.2X
+cast interval wholestage off                        255            255           1         39.3          25.5       1.0X
+cast interval wholestage on                         214            216           2         46.6          21.4       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             961            970          13         10.4          96.1       1.0X
-datediff wholestage on                              954            957           3         10.5          95.4       1.0X
+datediff wholestage off                             982            987           6         10.2          98.2       1.0X
+datediff wholestage on                              964            973          10         10.4          96.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2732           2734           4          3.7         273.2       1.0X
-months_between wholestage on                       2702           2712          10          3.7         270.2       1.0X
+months_between wholestage off                      2717           2718           2          3.7         271.7       1.0X
+months_between wholestage on                       2702           2706           4          3.7         270.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               544            556          17          1.8         543.8       1.0X
-window wholestage on                                721            736          13          1.4         721.0       0.8X
+window wholestage off                               611            621          14          1.6         611.3       1.0X
+window wholestage on                                782            786           3          1.3         781.7       0.8X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      484            485           0         20.7          48.4       1.0X
-date_trunc YEAR wholestage on                       416            420           3         24.0          41.6       1.2X
+date_trunc YEAR wholestage off                      473            473           0         21.1          47.3       1.0X
+date_trunc YEAR wholestage on                       420            424           3         23.8          42.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      483            488           8         20.7          48.3       1.0X
-date_trunc YYYY wholestage on                       428            436           7         23.4          42.8       1.1X
+date_trunc YYYY wholestage off                      469            470           1         21.3          46.9       1.0X
+date_trunc YYYY wholestage on                       421            427           6         23.7          42.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        480            482           2         20.8          48.0       1.0X
-date_trunc YY wholestage on                         427            433           4         23.4          42.7       1.1X
+date_trunc YY wholestage off                        485            501          23         20.6          48.5       1.0X
+date_trunc YY wholestage on                         420            423           3         23.8          42.0       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       459            466          11         21.8          45.9       1.0X
-date_trunc MON wholestage on                        433            443          16         23.1          43.3       1.1X
+date_trunc MON wholestage off                       460            469          13         21.7          46.0       1.0X
+date_trunc MON wholestage on                        413            417           4         24.2          41.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     460            461           1         21.7          46.0       1.0X
-date_trunc MONTH wholestage on                      434            437           3         23.0          43.4       1.1X
+date_trunc MONTH wholestage off                     474            475           2         21.1          47.4       1.0X
+date_trunc MONTH wholestage on                      411            416           4         24.3          41.1       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        460            460           0         21.8          46.0       1.0X
-date_trunc MM wholestage on                         435            439           7         23.0          43.5       1.1X
+date_trunc MM wholestage off                        474            474           0         21.1          47.4       1.0X
+date_trunc MM wholestage on                         412            417           4         24.3          41.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       367            367           0         27.3          36.7       1.0X
-date_trunc DAY wholestage on                        336            339           2         29.7          33.6       1.1X
+date_trunc DAY wholestage off                       371            372           2         27.0          37.1       1.0X
+date_trunc DAY wholestage on                        325            328           4         30.7          32.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        367            370           4         27.2          36.7       1.0X
-date_trunc DD wholestage on                         337            339           2         29.7          33.7       1.1X
+date_trunc DD wholestage off                        372            373           1         26.9          37.2       1.0X
+date_trunc DD wholestage on                         323            327           5         30.9          32.3       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      370            370           0         27.1          37.0       1.0X
-date_trunc HOUR wholestage on                       336            339           2         29.7          33.6       1.1X
+date_trunc HOUR wholestage off                      394            395           1         25.4          39.4       1.0X
+date_trunc HOUR wholestage on                       330            338           5         30.3          33.0       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    370            371           2         27.1          37.0       1.0X
-date_trunc MINUTE wholestage on                     336            338           1         29.7          33.6       1.1X
+date_trunc MINUTE wholestage off                    368            368           1         27.2          36.8       1.0X
+date_trunc MINUTE wholestage on                     325            326           1         30.8          32.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    330            331           1         30.3          33.0       1.0X
-date_trunc SECOND wholestage on                     293            295           2         34.1          29.3       1.1X
+date_trunc SECOND wholestage off                    342            342           1         29.3          34.2       1.0X
+date_trunc SECOND wholestage on                     290            292           1         34.5          29.0       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      422            423           1         23.7          42.2       1.0X
-date_trunc WEEK wholestage on                       393            394           1         25.5          39.3       1.1X
+date_trunc WEEK wholestage off                      450            451           1         22.2          45.0       1.0X
+date_trunc WEEK wholestage on                       409            412           2         24.4          40.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   598            610          17         16.7          59.8       1.0X
-date_trunc QUARTER wholestage on                    566            569           3         17.7          56.6       1.1X
+date_trunc QUARTER wholestage off                   619            620           1         16.1          61.9       1.0X
+date_trunc QUARTER wholestage on                    587            588           2         17.0          58.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (shuffled 2y) wholestage off           1159           1165           9          8.6         115.9       1.0X
-date_trunc YEAR (shuffled 2y) wholestage on            1143           1147           5          8.8         114.3       1.0X
+date_trunc YEAR (shuffled 2y) wholestage off           1210           1210           0          8.3         121.0       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1176           1181           4          8.5         117.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (spread 95y) wholestage off           1312           1317           8          7.6         131.2       1.0X
-date_trunc YEAR (spread 95y) wholestage on            1283           1292           7          7.8         128.3       1.0X
+date_trunc YEAR (spread 95y) wholestage off           1363           1375          18          7.3         136.3       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1312           1328          18          7.6         131.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (shuffled 2y) wholestage off           1040           1043           3          9.6         104.0       1.0X
-date_trunc QUARTER (shuffled 2y) wholestage on             991            993           2         10.1          99.1       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage off           1014           1016           4          9.9         101.4       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1050           1053           2          9.5         105.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (spread 95y) wholestage off           1355           1359           6          7.4         135.5       1.0X
-date_trunc QUARTER (spread 95y) wholestage on            1368           1375           8          7.3         136.8       1.0X
+date_trunc QUARTER (spread 95y) wholestage off           1333           1336           3          7.5         133.3       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1314           1319           4          7.6         131.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (shuffled 2y) wholestage off            744            744           1         13.4          74.4       1.0X
-date_trunc MONTH (shuffled 2y) wholestage on             712            716           3         14.0          71.2       1.0X
+date_trunc MONTH (shuffled 2y) wholestage off            767            769           3         13.0          76.7       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             723            730           6         13.8          72.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (spread 95y) wholestage off            831            835           6         12.0          83.1       1.0X
-date_trunc MONTH (spread 95y) wholestage on             790            793           3         12.7          79.0       1.1X
+date_trunc MONTH (spread 95y) wholestage off            829            830           1         12.1          82.9       1.0X
+date_trunc MONTH (spread 95y) wholestage on             857            858           1         11.7          85.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (shuffled 2y) wholestage off            540            540           1         18.5          54.0       1.0X
-date_trunc WEEK (shuffled 2y) wholestage on             514            519           3         19.4          51.4       1.0X
+date_trunc WEEK (shuffled 2y) wholestage off            538            543           8         18.6          53.8       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             505            506           1         19.8          50.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (spread 95y) wholestage off            655            656           1         15.3          65.5       1.0X
-date_trunc WEEK (spread 95y) wholestage on             626            630           4         16.0          62.6       1.0X
+date_trunc WEEK (spread 95y) wholestage off            626            626           0         16.0          62.6       1.0X
+date_trunc WEEK (spread 95y) wholestage on             590            595           5         16.9          59.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (shuffled 2y) wholestage off            478            478           1         20.9          47.8       1.0X
-date_trunc DAY (shuffled 2y) wholestage on             449            451           2         22.3          44.9       1.1X
+date_trunc DAY (shuffled 2y) wholestage off            458            458           0         21.9          45.8       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             419            420           1         23.9          41.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (spread 95y) wholestage off            592            593           1         16.9          59.2       1.0X
-date_trunc DAY (spread 95y) wholestage on             560            565           4         17.8          56.0       1.1X
+date_trunc DAY (spread 95y) wholestage off            544            579          49         18.4          54.4       1.0X
+date_trunc DAY (spread 95y) wholestage on             506            510           3         19.8          50.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           801            801           1         12.5          80.1       1.0X
-trunc year wholestage on                            754            760           9         13.3          75.4       1.1X
+trunc year wholestage off                           827            834           9         12.1          82.7       1.0X
+trunc year wholestage on                            782            786           3         12.8          78.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           801            802           1         12.5          80.1       1.0X
-trunc yyyy wholestage on                            754            758           4         13.3          75.4       1.1X
+trunc yyyy wholestage off                           824            826           3         12.1          82.4       1.0X
+trunc yyyy wholestage on                            781            786           6         12.8          78.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             801            805           7         12.5          80.1       1.0X
-trunc yy wholestage on                              752            756           4         13.3          75.2       1.1X
+trunc yy wholestage off                             824            825           1         12.1          82.4       1.0X
+trunc yy wholestage on                              781            785           2         12.8          78.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            759            769          14         13.2          75.9       1.0X
-trunc mon wholestage on                             716            721           5         14.0          71.6       1.1X
+trunc mon wholestage off                            774            774           0         12.9          77.4       1.0X
+trunc mon wholestage on                             730            733           3         13.7          73.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          764            764           0         13.1          76.4       1.0X
-trunc month wholestage on                           714            719           4         14.0          71.4       1.1X
+trunc month wholestage off                          774            774           0         12.9          77.4       1.0X
+trunc month wholestage on                           727            734           9         13.8          72.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             762            765           4         13.1          76.2       1.0X
-trunc mm wholestage on                              717            720           3         13.9          71.7       1.1X
+trunc mm wholestage off                             774            777           4         12.9          77.4       1.0X
+trunc mm wholestage on                              730            737           8         13.7          73.0       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      91             92           2         11.0          91.1       1.0X
-to timestamp str wholestage on                       89             91           2         11.2          88.9       1.0X
+to timestamp str wholestage off                      91             92           1         11.0          91.3       1.0X
+to timestamp str wholestage on                       83             84           1         12.1          82.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         631            633           3          1.6         631.5       1.0X
-to_timestamp wholestage on                          621            623           4          1.6         620.6       1.0X
+to_timestamp wholestage off                         632            638           8          1.6         632.5       1.0X
+to_timestamp wholestage on                          607            610           2          1.6         607.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    620            620           1          1.6         619.6       1.0X
-to_unix_timestamp wholestage on                     634            635           1          1.6         633.7       1.0X
+to_unix_timestamp wholestage off                    618            619           2          1.6         618.1       1.0X
+to_unix_timestamp wholestage on                     634            640           9          1.6         634.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          104            107           3          9.6         104.3       1.0X
-to date str wholestage on                           118            120           2          8.5         118.3       0.9X
+to date str wholestage off                          109            110           2          9.2         108.8       1.0X
+to date str wholestage on                           112            113           2          9.0         111.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              575            575           1          1.7         574.7       1.0X
-to_date wholestage on                               578            580           1          1.7         578.2       1.0X
+to_date wholestage off                              593            595           2          1.7         593.2       1.0X
+to_date wholestage on                               602            603           1          1.7         601.8       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  299            300           1         16.7          59.7       1.0X
-From java.time.LocalDate                            233            236           3         21.5          46.5       1.3X
-Collect java.sql.Date                              1213           1360         127          4.1         242.7       0.2X
-Collect java.time.LocalDate                        1035           1108          73          4.8         206.9       0.3X
-From java.sql.Timestamp                             231            249          16         21.6          46.3       1.3X
-From java.time.Instant                              192            208          19         26.0          38.4       1.6X
-Collect longs                                       966           1148         161          5.2         193.3       0.3X
-Collect java.sql.Timestamp                          918           1207         280          5.4         183.6       0.3X
-Collect java.time.Instant                           938           1014         126          5.3         187.5       0.3X
-java.sql.Date to Hive string                       4022           4073          45          1.2         804.5       0.1X
-java.time.LocalDate to Hive string                 3301           3426         109          1.5         660.2       0.1X
-java.sql.Timestamp to Hive string                  6741           6792          44          0.7        1348.3       0.0X
-java.time.Instant to Hive string                   4188           4265          93          1.2         837.7       0.1X
+From java.sql.Date                                  293            296           3         17.1          58.6       1.0X
+From java.time.LocalDate                            228            229           1         21.9          45.6       1.3X
+Collect java.sql.Date                              1257           1340          75          4.0         251.4       0.2X
+Collect java.time.LocalDate                        1184           1265         127          4.2         236.9       0.2X
+From java.sql.Timestamp                             251            260           8         19.9          50.2       1.2X
+From java.time.Instant                              187            188           0         26.7          37.4       1.6X
+Collect longs                                      1047           1110          65          4.8         209.3       0.3X
+Collect java.sql.Timestamp                         1173           1202          48          4.3         234.5       0.3X
+Collect java.time.Instant                           969           1115         213          5.2         193.8       0.3X
+java.sql.Date to Hive string                       4017           4143         158          1.2         803.5       0.1X
+java.time.LocalDate to Hive string                 3236           3313         101          1.5         647.1       0.1X
+java.sql.Timestamp to Hive string                  6646           6813         161          0.8        1329.2       0.0X
+java.time.Instant to Hive string                   4253           4373         137          1.2         850.6       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,460 +2,530 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1003           1065          87         10.0         100.3       1.0X
-date + interval(m, d)                               993            995           2         10.1          99.3       1.0X
-date + interval(m, d, ms)                          3990           3999          13          2.5         399.0       0.3X
-date - interval(m)                                  956            965          11         10.5          95.6       1.0X
-date - interval(m, d)                              1011           1042          44          9.9         101.1       1.0X
-date - interval(m, d, ms)                          4031           4039          11          2.5         403.1       0.2X
-timestamp + interval(m)                            1812           1826          19          5.5         181.2       0.6X
-timestamp + interval(m, d)                         1873           1877           6          5.3         187.3       0.5X
-timestamp + interval(m, d, ms)                     2069           2071           4          4.8         206.9       0.5X
-timestamp - interval(m)                            1808           1809           1          5.5         180.8       0.6X
-timestamp - interval(m, d)                         1868           1869           2          5.4         186.8       0.5X
-timestamp - interval(m, d, ms)                     2042           2046           5          4.9         204.2       0.5X
+date + interval(m)                                  970           1004          47         10.3          97.0       1.0X
+date + interval(m, d)                               990            992           3         10.1          99.0       1.0X
+date + interval(m, d, ms)                          4042           4054          16          2.5         404.2       0.2X
+date - interval(m)                                  960            985          27         10.4          96.0       1.0X
+date - interval(m, d)                               990            995           6         10.1          99.0       1.0X
+date - interval(m, d, ms)                          4088           4092           6          2.4         408.8       0.2X
+timestamp + interval(m)                            1822           1822           0          5.5         182.2       0.5X
+timestamp + interval(m, d)                         1874           1874           0          5.3         187.4       0.5X
+timestamp + interval(m, d, ms)                     2133           2137           5          4.7         213.3       0.5X
+timestamp - interval(m)                            1870           1872           2          5.3         187.0       0.5X
+timestamp - interval(m, d)                         1946           1952           8          5.1         194.6       0.5X
+timestamp - interval(m, d, ms)                     2126           2128           3          4.7         212.6       0.5X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    205            208           5         48.9          20.5       1.0X
-cast to timestamp wholestage on                     217            226          15         46.1          21.7       0.9X
+cast to timestamp wholestage off                    198            207          12         50.4          19.8       1.0X
+cast to timestamp wholestage on                     205            212           5         48.8          20.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    776            778           3         12.9          77.6       1.0X
-year of timestamp wholestage on                     775            781           7         12.9          77.5       1.0X
+year of timestamp wholestage off                    768            774           8         13.0          76.8       1.0X
+year of timestamp wholestage on                     767            776           6         13.0          76.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 792            794           2         12.6          79.2       1.0X
-quarter of timestamp wholestage on                  785            791           5         12.7          78.5       1.0X
+quarter of timestamp wholestage off                 784            785           1         12.8          78.4       1.0X
+quarter of timestamp wholestage on                  785            789           4         12.7          78.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   764            766           2         13.1          76.4       1.0X
-month of timestamp wholestage on                    773            779           4         12.9          77.3       1.0X
+month of timestamp wholestage off                   767            769           3         13.0          76.7       1.0X
+month of timestamp wholestage on                    768            771           6         13.0          76.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1144           1146           2          8.7         114.4       1.0X
-weekofyear of timestamp wholestage on              1163           1166           3          8.6         116.3       1.0X
+weekofyear of timestamp wholestage off             1117           1117           0          9.0         111.7       1.0X
+weekofyear of timestamp wholestage on              1143           1151          11          8.7         114.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     767            769           2         13.0          76.7       1.0X
-day of timestamp wholestage on                      774            778           4         12.9          77.4       1.0X
+day of timestamp wholestage off                     766            768           3         13.1          76.6       1.0X
+day of timestamp wholestage on                      763            767           5         13.1          76.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               795            803          12         12.6          79.5       1.0X
-dayofyear of timestamp wholestage on                797            801           3         12.6          79.7       1.0X
+dayofyear of timestamp wholestage off               803            805           3         12.4          80.3       1.0X
+dayofyear of timestamp wholestage on                802            806           3         12.5          80.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              777            781           6         12.9          77.7       1.0X
-dayofmonth of timestamp wholestage on               775            778           2         12.9          77.5       1.0X
+dayofmonth of timestamp wholestage off              779            781           2         12.8          77.9       1.0X
+dayofmonth of timestamp wholestage on               762            769           6         13.1          76.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               927            928           2         10.8          92.7       1.0X
-dayofweek of timestamp wholestage on                924            929           6         10.8          92.4       1.0X
+dayofweek of timestamp wholestage off               898            899           3         11.1          89.8       1.0X
+dayofweek of timestamp wholestage on                905            907           2         11.0          90.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 877            884          10         11.4          87.7       1.0X
-weekday of timestamp wholestage on                  868            870           2         11.5          86.8       1.0X
+weekday of timestamp wholestage off                 852            855           4         11.7          85.2       1.0X
+weekday of timestamp wholestage on                  865            870           5         11.6          86.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    615            617           2         16.3          61.5       1.0X
-hour of timestamp wholestage on                     621            625           4         16.1          62.1       1.0X
+hour of timestamp wholestage off                    608            608           0         16.4          60.8       1.0X
+hour of timestamp wholestage on                     605            608           2         16.5          60.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  621            622           1         16.1          62.1       1.0X
-minute of timestamp wholestage on                   616            623           5         16.2          61.6       1.0X
+minute of timestamp wholestage off                  615            617           4         16.3          61.5       1.0X
+minute of timestamp wholestage on                   605            609           3         16.5          60.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  622            624           2         16.1          62.2       1.0X
-second of timestamp wholestage on                   616            620           4         16.2          61.6       1.0X
+second of timestamp wholestage off                  600            600           1         16.7          60.0       1.0X
+second of timestamp wholestage on                   606            613           6         16.5          60.6       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         185            186           1         54.0          18.5       1.0X
-current_date wholestage on                          219            228          10         45.7          21.9       0.8X
+current_date wholestage off                         184            186           2         54.2          18.4       1.0X
+current_date wholestage on                          205            212           9         48.7          20.5       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    192            196           5         52.0          19.2       1.0X
-current_timestamp wholestage on                     229            261          43         43.7          22.9       0.8X
+current_timestamp wholestage off                    199            204           8         50.3          19.9       1.0X
+current_timestamp wholestage on                     215            227          13         46.5          21.5       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         677            678           2         14.8          67.7       1.0X
-cast to date wholestage on                          674            679           4         14.8          67.4       1.0X
+cast to date wholestage off                         659            664           7         15.2          65.9       1.0X
+cast to date wholestage on                          670            673           5         14.9          67.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             774            774           0         12.9          77.4       1.0X
-last_day wholestage on                              788            796           9         12.7          78.8       1.0X
+last_day wholestage off                             789            789           1         12.7          78.9       1.0X
+last_day wholestage on                              770            773           1         13.0          77.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             699            700           2         14.3          69.9       1.0X
-next_day wholestage on                              702            708           6         14.2          70.2       1.0X
+next_day wholestage off                             697            698           2         14.3          69.7       1.0X
+next_day wholestage on                              698            700           2         14.3          69.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             666            668           2         15.0          66.6       1.0X
-date_add wholestage on                              681            684           2         14.7          68.1       1.0X
+date_add wholestage off                             653            654           1         15.3          65.3       1.0X
+date_add wholestage on                              649            653           3         15.4          64.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             657            658           2         15.2          65.7       1.0X
-date_sub wholestage on                              657            663           4         15.2          65.7       1.0X
+date_sub wholestage off                             641            642           2         15.6          64.1       1.0X
+date_sub wholestage on                              652            659          14         15.3          65.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           911            912           1         11.0          91.1       1.0X
-add_months wholestage on                            920            922           2         10.9          92.0       1.0X
+add_months wholestage off                           921            922           1         10.9          92.1       1.0X
+add_months wholestage on                            915            918           2         10.9          91.5       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3336           3339           5          3.0         333.6       1.0X
-format date wholestage on                          3254           3264           8          3.1         325.4       1.0X
+format date wholestage off                         3382           3423          58          3.0         338.2       1.0X
+format date wholestage on                          3386           3392           4          3.0         338.6       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3834           3839           8          2.6         383.4       1.0X
-from_unixtime wholestage on                        3765           3772           8          2.7         376.5       1.0X
+from_unixtime wholestage off                       3454           3457           4          2.9         345.4       1.0X
+from_unixtime wholestage on                        3545           3567          35          2.8         354.5       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   738            738           0         13.6          73.8       1.0X
-from_utc_timestamp wholestage on                    825            829           4         12.1          82.5       0.9X
+from_utc_timestamp wholestage off                   720            721           3         13.9          72.0       1.0X
+from_utc_timestamp wholestage on                    821            827           5         12.2          82.1       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1088           1095          10          9.2         108.8       1.0X
-to_utc_timestamp wholestage on                     1073           1077           3          9.3         107.3       1.0X
+to_utc_timestamp wholestage off                    1126           1129           4          8.9         112.6       1.0X
+to_utc_timestamp wholestage on                     1073           1076           4          9.3         107.3       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        227            234           9         44.0          22.7       1.0X
-cast interval wholestage on                         219            267          95         45.8          21.9       1.0X
+cast interval wholestage off                        221            224           4         45.2          22.1       1.0X
+cast interval wholestage on                         204            210          11         48.9          20.4       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1121           1124           3          8.9         112.1       1.0X
-datediff wholestage on                             1119           1122           3          8.9         111.9       1.0X
+datediff wholestage off                            1123           1123           1          8.9         112.3       1.0X
+datediff wholestage on                             1173           1178           3          8.5         117.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2943           2946           4          3.4         294.3       1.0X
-months_between wholestage on                       2945           2950           5          3.4         294.5       1.0X
+months_between wholestage off                      3596           3600           5          2.8         359.6       1.0X
+months_between wholestage on                       3581           3588           7          2.8         358.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               643            645           4          1.6         642.9       1.0X
-window wholestage on                                663            674           9          1.5         662.6       1.0X
+window wholestage off                               641            642           1          1.6         641.4       1.0X
+window wholestage on                                632            657          20          1.6         632.5       1.0X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      520            521           2         19.2          52.0       1.0X
-date_trunc YEAR wholestage on                       506            509           2         19.8          50.6       1.0X
+date_trunc YEAR wholestage off                      512            516           7         19.5          51.2       1.0X
+date_trunc YEAR wholestage on                       468            471           2         21.4          46.8       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      519            520           1         19.3          51.9       1.0X
-date_trunc YYYY wholestage on                       505            509           4         19.8          50.5       1.0X
+date_trunc YYYY wholestage off                      511            512           1         19.6          51.1       1.0X
+date_trunc YYYY wholestage on                       471            474           3         21.2          47.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        518            519           1         19.3          51.8       1.0X
-date_trunc YY wholestage on                         508            512           5         19.7          50.8       1.0X
+date_trunc YY wholestage off                        510            519          13         19.6          51.0       1.0X
+date_trunc YY wholestage on                         471            501          52         21.2          47.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       519            521           3         19.3          51.9       1.0X
-date_trunc MON wholestage on                        483            484           1         20.7          48.3       1.1X
+date_trunc MON wholestage off                       514            515           1         19.4          51.4       1.0X
+date_trunc MON wholestage on                        474            480           7         21.1          47.4       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     509            512           4         19.7          50.9       1.0X
-date_trunc MONTH wholestage on                      482            483           1         20.7          48.2       1.1X
+date_trunc MONTH wholestage off                     514            516           3         19.5          51.4       1.0X
+date_trunc MONTH wholestage on                      476            479           2         21.0          47.6       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        508            509           1         19.7          50.8       1.0X
-date_trunc MM wholestage on                         480            486           5         20.8          48.0       1.1X
+date_trunc MM wholestage off                        514            522          11         19.5          51.4       1.0X
+date_trunc MM wholestage on                         475            479           3         21.1          47.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       396            399           3         25.2          39.6       1.0X
-date_trunc DAY wholestage on                        359            361           2         27.9          35.9       1.1X
+date_trunc DAY wholestage off                       365            365           0         27.4          36.5       1.0X
+date_trunc DAY wholestage on                        333            335           2         30.1          33.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        395            396           2         25.3          39.5       1.0X
-date_trunc DD wholestage on                         356            363          10         28.1          35.6       1.1X
+date_trunc DD wholestage off                        367            368           1         27.2          36.7       1.0X
+date_trunc DD wholestage on                         335            350          29         29.9          33.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      377            378           1         26.5          37.7       1.0X
-date_trunc HOUR wholestage on                       337            340           4         29.6          33.7       1.1X
+date_trunc HOUR wholestage off                      353            354           2         28.3          35.3       1.0X
+date_trunc HOUR wholestage on                       325            333           9         30.8          32.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    376            377           1         26.6          37.6       1.0X
-date_trunc MINUTE wholestage on                     336            339           2         29.8          33.6       1.1X
+date_trunc MINUTE wholestage off                    350            355           7         28.6          35.0       1.0X
+date_trunc MINUTE wholestage on                     320            322           1         31.2          32.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    317            317           0         31.6          31.7       1.0X
-date_trunc SECOND wholestage on                     276            279           3         36.2          27.6       1.1X
+date_trunc SECOND wholestage off                    325            335          13         30.8          32.5       1.0X
+date_trunc SECOND wholestage on                     280            285           4         35.7          28.0       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      427            428           1         23.4          42.7       1.0X
-date_trunc WEEK wholestage on                       381            383           1         26.2          38.1       1.1X
+date_trunc WEEK wholestage off                      404            404           1         24.8          40.4       1.0X
+date_trunc WEEK wholestage on                       368            372           4         27.1          36.8       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   655            655           0         15.3          65.5       1.0X
-date_trunc QUARTER wholestage on                    623            625           2         16.1          62.3       1.1X
+date_trunc QUARTER wholestage off                   625            632           9         16.0          62.5       1.0X
+date_trunc QUARTER wholestage on                    600            603           2         16.7          60.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc YEAR (shuffled 2y) wholestage off           1179           1180           2          8.5         117.9       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1149           1153           3          8.7         114.9       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc YEAR (spread 95y) wholestage off           1306           1307           2          7.7         130.6       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1259           1265           5          7.9         125.9       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+date_trunc QUARTER (shuffled 2y) wholestage off           1029           1034           7          9.7         102.9       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1009           1011           2          9.9         100.9       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+date_trunc QUARTER (spread 95y) wholestage off           1331           1343          17          7.5         133.1       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1275           1281           3          7.8         127.5       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+date_trunc MONTH (shuffled 2y) wholestage off            748            748           1         13.4          74.8       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             727            734           9         13.8          72.7       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc MONTH (spread 95y) wholestage off            812            813           1         12.3          81.2       1.0X
+date_trunc MONTH (spread 95y) wholestage on             777            783           7         12.9          77.7       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+date_trunc WEEK (shuffled 2y) wholestage off            504            506           2         19.8          50.4       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             476            480           3         21.0          47.6       1.1X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc WEEK (spread 95y) wholestage off            585            585           0         17.1          58.5       1.0X
+date_trunc WEEK (spread 95y) wholestage on             554            558           5         18.0          55.4       1.1X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+date_trunc DAY (shuffled 2y) wholestage off            443            444           1         22.6          44.3       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             413            416           2         24.2          41.3       1.1X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+date_trunc DAY (spread 95y) wholestage off            518            520           3         19.3          51.8       1.0X
+date_trunc DAY (spread 95y) wholestage on             491            496           7         20.4          49.1       1.1X
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           922            923           2         10.8          92.2       1.0X
-trunc year wholestage on                            898            902           2         11.1          89.8       1.0X
+trunc year wholestage off                           921            923           2         10.9          92.1       1.0X
+trunc year wholestage on                            905            908           3         11.1          90.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           920            923           4         10.9          92.0       1.0X
-trunc yyyy wholestage on                            898            900           2         11.1          89.8       1.0X
+trunc yyyy wholestage off                           924            924           0         10.8          92.4       1.0X
+trunc yyyy wholestage on                            904            906           2         11.1          90.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             921            921           1         10.9          92.1       1.0X
-trunc yy wholestage on                              899            904           5         11.1          89.9       1.0X
+trunc yy wholestage off                             924            931           9         10.8          92.4       1.0X
+trunc yy wholestage on                              903            908           5         11.1          90.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            899            900           0         11.1          89.9       1.0X
-trunc mon wholestage on                             868            872           3         11.5          86.8       1.0X
+trunc mon wholestage off                            893            895           2         11.2          89.3       1.0X
+trunc mon wholestage on                             870            872           2         11.5          87.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          900            913          18         11.1          90.0       1.0X
-trunc month wholestage on                           870            872           2         11.5          87.0       1.0X
+trunc month wholestage off                          898            899           1         11.1          89.8       1.0X
+trunc month wholestage on                           871            874           3         11.5          87.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             896            897           2         11.2          89.6       1.0X
-trunc mm wholestage on                              871            872           1         11.5          87.1       1.0X
+trunc mm wholestage off                             894            896           2         11.2          89.4       1.0X
+trunc mm wholestage on                              867            869           2         11.5          86.7       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     108            108           0          9.2         108.2       1.0X
-to timestamp str wholestage on                      103            108           5          9.7         102.7       1.1X
+to timestamp str wholestage off                     106            110           5          9.4         106.3       1.0X
+to timestamp str wholestage on                      101            103           3          9.9         100.8       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         748            749           2          1.3         747.5       1.0X
-to_timestamp wholestage on                          744            750           8          1.3         744.1       1.0X
+to_timestamp wholestage off                         779            780           0          1.3         779.3       1.0X
+to_timestamp wholestage on                          783            785           2          1.3         782.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    741            743           2          1.3         741.2       1.0X
-to_unix_timestamp wholestage on                     750            752           2          1.3         750.2       1.0X
+to_unix_timestamp wholestage off                    797            797           1          1.3         796.7       1.0X
+to_unix_timestamp wholestage on                     767            769           2          1.3         766.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          149            149           1          6.7         148.8       1.0X
-to date str wholestage on                           143            144           1          7.0         143.1       1.0X
+to date str wholestage off                          155            155           1          6.5         154.8       1.0X
+to date str wholestage on                           137            141           6          7.3         137.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              654            656           3          1.5         653.6       1.0X
-to_date wholestage on                               648            650           3          1.5         647.8       1.0X
+to_date wholestage off                              662            662           1          1.5         662.1       1.0X
+to_date wholestage on                               642            644           2          1.6         641.7       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  290            292           2         17.2          58.1       1.0X
-From java.time.LocalDate                            252            255           5         19.9          50.3       1.2X
-Collect java.sql.Date                              1265           1312          73          4.0         253.0       0.2X
-Collect java.time.LocalDate                         893           1040         127          5.6         178.7       0.3X
-From java.sql.Timestamp                             233            239           6         21.4          46.7       1.2X
-From java.time.Instant                              214            230          27         23.4          42.8       1.4X
-Collect longs                                       833            961         120          6.0         166.5       0.3X
-Collect java.sql.Timestamp                          840           1097         237          6.0         167.9       0.3X
-Collect java.time.Instant                           950            974          22          5.3         190.0       0.3X
-java.sql.Date to Hive string                       3994           4091          98          1.3         798.9       0.1X
-java.time.LocalDate to Hive string                 3295           3359          56          1.5         659.0       0.1X
-java.sql.Timestamp to Hive string                  6313           6475         141          0.8        1262.7       0.0X
-java.time.Instant to Hive string                   5043           5078          52          1.0        1008.5       0.1X
+From java.sql.Date                                  290            292           2         17.2          58.0       1.0X
+From java.time.LocalDate                            249            250           1         20.1          49.8       1.2X
+Collect java.sql.Date                              1126           1269         170          4.4         225.2       0.3X
+Collect java.time.LocalDate                         866            997         151          5.8         173.2       0.3X
+From java.sql.Timestamp                             240            255          21         20.8          48.0       1.2X
+From java.time.Instant                              215            221           7         23.3          42.9       1.4X
+Collect longs                                       936            995          89          5.3         187.2       0.3X
+Collect java.sql.Timestamp                          834           1208         325          6.0         166.8       0.3X
+Collect java.time.Instant                           836           1017         188          6.0         167.2       0.3X
+java.sql.Date to Hive string                       3794           3981         185          1.3         758.7       0.1X
+java.time.LocalDate to Hive string                 3357           3467         118          1.5         671.4       0.1X
+java.sql.Timestamp to Hive string                  6536           6623         113          0.8        1307.1       0.0X
+java.time.Instant to Hive string                   5125           5314         192          1.0        1025.0       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  970           1004          47         10.3          97.0       1.0X
-date + interval(m, d)                               990            992           3         10.1          99.0       1.0X
-date + interval(m, d, ms)                          4042           4054          16          2.5         404.2       0.2X
-date - interval(m)                                  960            985          27         10.4          96.0       1.0X
-date - interval(m, d)                               990            995           6         10.1          99.0       1.0X
-date - interval(m, d, ms)                          4088           4092           6          2.4         408.8       0.2X
-timestamp + interval(m)                            1822           1822           0          5.5         182.2       0.5X
-timestamp + interval(m, d)                         1874           1874           0          5.3         187.4       0.5X
-timestamp + interval(m, d, ms)                     2133           2137           5          4.7         213.3       0.5X
-timestamp - interval(m)                            1870           1872           2          5.3         187.0       0.5X
-timestamp - interval(m, d)                         1946           1952           8          5.1         194.6       0.5X
-timestamp - interval(m, d, ms)                     2126           2128           3          4.7         212.6       0.5X
+date + interval(m)                                 1006           1022          22          9.9         100.6       1.0X
+date + interval(m, d)                              1003           1006           5         10.0         100.3       1.0X
+date + interval(m, d, ms)                          3825           3826           1          2.6         382.5       0.3X
+date - interval(m)                                  977            979           3         10.2          97.7       1.0X
+date - interval(m, d)                              1000           1000           1         10.0         100.0       1.0X
+date - interval(m, d, ms)                          3879           3879           1          2.6         387.9       0.3X
+timestamp + interval(m)                            1755           1758           4          5.7         175.5       0.6X
+timestamp + interval(m, d)                         1813           1833          28          5.5         181.3       0.6X
+timestamp + interval(m, d, ms)                     1979           1981           2          5.1         197.9       0.5X
+timestamp - interval(m)                            1753           1753           0          5.7         175.3       0.6X
+timestamp - interval(m, d)                         1815           1818           5          5.5         181.5       0.6X
+timestamp - interval(m, d, ms)                     1992           1992           0          5.0         199.2       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    198            207          12         50.4          19.8       1.0X
-cast to timestamp wholestage on                     205            212           5         48.8          20.5       1.0X
+cast to timestamp wholestage off                    200            214          20         50.0          20.0       1.0X
+cast to timestamp wholestage on                     209            213           3         47.8          20.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    768            774           8         13.0          76.8       1.0X
-year of timestamp wholestage on                     767            776           6         13.0          76.7       1.0X
+year of timestamp wholestage off                    754            758           6         13.3          75.4       1.0X
+year of timestamp wholestage on                     764            774          17         13.1          76.4       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 784            785           1         12.8          78.4       1.0X
-quarter of timestamp wholestage on                  785            789           4         12.7          78.5       1.0X
+quarter of timestamp wholestage off                 802            803           1         12.5          80.2       1.0X
+quarter of timestamp wholestage on                  783            788           7         12.8          78.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   767            769           3         13.0          76.7       1.0X
-month of timestamp wholestage on                    768            771           6         13.0          76.8       1.0X
+month of timestamp wholestage off                   764            765           1         13.1          76.4       1.0X
+month of timestamp wholestage on                    773            777           7         12.9          77.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1117           1117           0          9.0         111.7       1.0X
-weekofyear of timestamp wholestage on              1143           1151          11          8.7         114.3       1.0X
+weekofyear of timestamp wholestage off             1107           1111           5          9.0         110.7       1.0X
+weekofyear of timestamp wholestage on              1171           1180          10          8.5         117.1       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     766            768           3         13.1          76.6       1.0X
-day of timestamp wholestage on                      763            767           5         13.1          76.3       1.0X
+day of timestamp wholestage off                     791            796           8         12.6          79.1       1.0X
+day of timestamp wholestage on                      771            776           4         13.0          77.1       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               803            805           3         12.4          80.3       1.0X
-dayofyear of timestamp wholestage on                802            806           3         12.5          80.2       1.0X
+dayofyear of timestamp wholestage off               802            805           4         12.5          80.2       1.0X
+dayofyear of timestamp wholestage on                790            796          10         12.7          79.0       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              779            781           2         12.8          77.9       1.0X
-dayofmonth of timestamp wholestage on               762            769           6         13.1          76.2       1.0X
+dayofmonth of timestamp wholestage off              794            795           2         12.6          79.4       1.0X
+dayofmonth of timestamp wholestage on               767            772           3         13.0          76.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               898            899           3         11.1          89.8       1.0X
-dayofweek of timestamp wholestage on                905            907           2         11.0          90.5       1.0X
+dayofweek of timestamp wholestage off               915            918           5         10.9          91.5       1.0X
+dayofweek of timestamp wholestage on                914            917           3         10.9          91.4       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 852            855           4         11.7          85.2       1.0X
-weekday of timestamp wholestage on                  865            870           5         11.6          86.5       1.0X
+weekday of timestamp wholestage off                 888            889           1         11.3          88.8       1.0X
+weekday of timestamp wholestage on                  863            866           2         11.6          86.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    608            608           0         16.4          60.8       1.0X
-hour of timestamp wholestage on                     605            608           2         16.5          60.5       1.0X
+hour of timestamp wholestage off                    596            599           5         16.8          59.6       1.0X
+hour of timestamp wholestage on                     610            613           2         16.4          61.0       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  615            617           4         16.3          61.5       1.0X
-minute of timestamp wholestage on                   605            609           3         16.5          60.5       1.0X
+minute of timestamp wholestage off                  592            593           0         16.9          59.2       1.0X
+minute of timestamp wholestage on                   607            608           2         16.5          60.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  600            600           1         16.7          60.0       1.0X
-second of timestamp wholestage on                   606            613           6         16.5          60.6       1.0X
+second of timestamp wholestage off                  593            596           4         16.9          59.3       1.0X
+second of timestamp wholestage on                   612            619           4         16.3          61.2       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         184            186           2         54.2          18.4       1.0X
-current_date wholestage on                          205            212           9         48.7          20.5       0.9X
+current_date wholestage off                         186            187           0         53.6          18.6       1.0X
+current_date wholestage on                          204            209           4         49.0          20.4       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    199            204           8         50.3          19.9       1.0X
-current_timestamp wholestage on                     215            227          13         46.5          21.5       0.9X
+current_timestamp wholestage off                    193            198           7         51.8          19.3       1.0X
+current_timestamp wholestage on                     216            241          33         46.4          21.6       0.9X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         659            664           7         15.2          65.9       1.0X
-cast to date wholestage on                          670            673           5         14.9          67.0       1.0X
+cast to date wholestage off                         661            663           2         15.1          66.1       1.0X
+cast to date wholestage on                          662            665           2         15.1          66.2       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             789            789           1         12.7          78.9       1.0X
-last_day wholestage on                              770            773           1         13.0          77.0       1.0X
+last_day wholestage off                             765            765           1         13.1          76.5       1.0X
+last_day wholestage on                              769            770           2         13.0          76.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             697            698           2         14.3          69.7       1.0X
-next_day wholestage on                              698            700           2         14.3          69.8       1.0X
+next_day wholestage off                             690            691           1         14.5          69.0       1.0X
+next_day wholestage on                              699            703           2         14.3          69.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             653            654           1         15.3          65.3       1.0X
-date_add wholestage on                              649            653           3         15.4          64.9       1.0X
+date_add wholestage off                             639            639           1         15.7          63.9       1.0X
+date_add wholestage on                              644            648           5         15.5          64.4       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             641            642           2         15.6          64.1       1.0X
-date_sub wholestage on                              652            659          14         15.3          65.2       1.0X
+date_sub wholestage off                             646            649           3         15.5          64.6       1.0X
+date_sub wholestage on                              638            643           4         15.7          63.8       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           921            922           1         10.9          92.1       1.0X
-add_months wholestage on                            915            918           2         10.9          91.5       1.0X
+add_months wholestage off                           914            915           2         10.9          91.4       1.0X
+add_months wholestage on                            900            904           2         11.1          90.0       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3382           3423          58          3.0         338.2       1.0X
-format date wholestage on                          3386           3392           4          3.0         338.6       1.0X
+format date wholestage off                         3419           3425           9          2.9         341.9       1.0X
+format date wholestage on                          3261           3273          11          3.1         326.1       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3454           3457           4          2.9         345.4       1.0X
-from_unixtime wholestage on                        3545           3567          35          2.8         354.5       1.0X
+from_unixtime wholestage off                       3658           3678          28          2.7         365.8       1.0X
+from_unixtime wholestage on                        3607           3624          31          2.8         360.7       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   720            721           3         13.9          72.0       1.0X
-from_utc_timestamp wholestage on                    821            827           5         12.2          82.1       0.9X
+from_utc_timestamp wholestage off                   728            728           0         13.7          72.8       1.0X
+from_utc_timestamp wholestage on                    836            840           4         12.0          83.6       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1126           1129           4          8.9         112.6       1.0X
-to_utc_timestamp wholestage on                     1073           1076           4          9.3         107.3       1.0X
+to_utc_timestamp wholestage off                    1088           1092           6          9.2         108.8       1.0X
+to_utc_timestamp wholestage on                     1081           1085           3          9.2         108.1       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        221            224           4         45.2          22.1       1.0X
-cast interval wholestage on                         204            210          11         48.9          20.4       1.1X
+cast interval wholestage off                        226            227           2         44.2          22.6       1.0X
+cast interval wholestage on                         204            207           3         49.0          20.4       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1123           1123           1          8.9         112.3       1.0X
-datediff wholestage on                             1173           1178           3          8.5         117.3       1.0X
+datediff wholestage off                            1117           1118           1          8.9         111.7       1.0X
+datediff wholestage on                             1153           1165          10          8.7         115.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3596           3600           5          2.8         359.6       1.0X
-months_between wholestage on                       3581           3588           7          2.8         358.1       1.0X
+months_between wholestage off                      3589           3591           4          2.8         358.9       1.0X
+months_between wholestage on                       3557           3563           6          2.8         355.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               641            642           1          1.6         641.4       1.0X
-window wholestage on                                632            657          20          1.6         632.5       1.0X
+window wholestage off                               590            595           6          1.7         590.3       1.0X
+window wholestage on                                666            677          12          1.5         665.8       0.9X
 
 
 ================================================================================================
@@ -266,204 +266,204 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      512            516           7         19.5          51.2       1.0X
-date_trunc YEAR wholestage on                       468            471           2         21.4          46.8       1.1X
+date_trunc YEAR wholestage off                      517            518           1         19.3          51.7       1.0X
+date_trunc YEAR wholestage on                       466            468           2         21.5          46.6       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      511            512           1         19.6          51.1       1.0X
-date_trunc YYYY wholestage on                       471            474           3         21.2          47.1       1.1X
+date_trunc YYYY wholestage off                      515            518           4         19.4          51.5       1.0X
+date_trunc YYYY wholestage on                       468            472           3         21.4          46.8       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        510            519          13         19.6          51.0       1.0X
-date_trunc YY wholestage on                         471            501          52         21.2          47.1       1.1X
+date_trunc YY wholestage off                        517            518           2         19.3          51.7       1.0X
+date_trunc YY wholestage on                         472            476           6         21.2          47.2       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       514            515           1         19.4          51.4       1.0X
-date_trunc MON wholestage on                        474            480           7         21.1          47.4       1.1X
+date_trunc MON wholestage off                       496            499           3         20.2          49.6       1.0X
+date_trunc MON wholestage on                        456            465          11         21.9          45.6       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     514            516           3         19.5          51.4       1.0X
-date_trunc MONTH wholestage on                      476            479           2         21.0          47.6       1.1X
+date_trunc MONTH wholestage off                     498            498           1         20.1          49.8       1.0X
+date_trunc MONTH wholestage on                      457            461           5         21.9          45.7       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        514            522          11         19.5          51.4       1.0X
-date_trunc MM wholestage on                         475            479           3         21.1          47.5       1.1X
+date_trunc MM wholestage off                        495            495           0         20.2          49.5       1.0X
+date_trunc MM wholestage on                         457            460           4         21.9          45.7       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       365            365           0         27.4          36.5       1.0X
-date_trunc DAY wholestage on                        333            335           2         30.1          33.3       1.1X
+date_trunc DAY wholestage off                       383            384           2         26.1          38.3       1.0X
+date_trunc DAY wholestage on                        342            347           9         29.3          34.2       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        367            368           1         27.2          36.7       1.0X
-date_trunc DD wholestage on                         335            350          29         29.9          33.5       1.1X
+date_trunc DD wholestage off                        383            384           1         26.1          38.3       1.0X
+date_trunc DD wholestage on                         340            344           3         29.4          34.0       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      353            354           2         28.3          35.3       1.0X
-date_trunc HOUR wholestage on                       325            333           9         30.8          32.5       1.1X
+date_trunc HOUR wholestage off                      375            375           1         26.7          37.5       1.0X
+date_trunc HOUR wholestage on                       329            334           5         30.4          32.9       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    350            355           7         28.6          35.0       1.0X
-date_trunc MINUTE wholestage on                     320            322           1         31.2          32.0       1.1X
+date_trunc MINUTE wholestage off                    361            363           3         27.7          36.1       1.0X
+date_trunc MINUTE wholestage on                     322            325           2         31.0          32.2       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    325            335          13         30.8          32.5       1.0X
-date_trunc SECOND wholestage on                     280            285           4         35.7          28.0       1.2X
+date_trunc SECOND wholestage off                    321            322           1         31.1          32.1       1.0X
+date_trunc SECOND wholestage on                     277            280           3         36.1          27.7       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      404            404           1         24.8          40.4       1.0X
-date_trunc WEEK wholestage on                       368            372           4         27.1          36.8       1.1X
+date_trunc WEEK wholestage off                      419            422           3         23.8          41.9       1.0X
+date_trunc WEEK wholestage on                       383            386           2         26.1          38.3       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   625            632           9         16.0          62.5       1.0X
-date_trunc QUARTER wholestage on                    600            603           2         16.7          60.0       1.0X
+date_trunc QUARTER wholestage off                   649            653           5         15.4          64.9       1.0X
+date_trunc QUARTER wholestage on                    621            624           3         16.1          62.1       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (shuffled 2y) wholestage off           1179           1180           2          8.5         117.9       1.0X
-date_trunc YEAR (shuffled 2y) wholestage on            1149           1153           3          8.7         114.9       1.0X
+date_trunc YEAR (shuffled 2y) wholestage off           1226           1226           1          8.2         122.6       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1216           1220           4          8.2         121.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (spread 95y) wholestage off           1306           1307           2          7.7         130.6       1.0X
-date_trunc YEAR (spread 95y) wholestage on            1259           1265           5          7.9         125.9       1.0X
+date_trunc YEAR (spread 95y) wholestage off           1454           1456           3          6.9         145.4       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1378           1380           2          7.3         137.8       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (shuffled 2y) wholestage off           1029           1034           7          9.7         102.9       1.0X
-date_trunc QUARTER (shuffled 2y) wholestage on            1009           1011           2          9.9         100.9       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage off           1077           1082           7          9.3         107.7       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1036           1038           2          9.7         103.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (spread 95y) wholestage off           1331           1343          17          7.5         133.1       1.0X
-date_trunc QUARTER (spread 95y) wholestage on            1275           1281           3          7.8         127.5       1.0X
+date_trunc QUARTER (spread 95y) wholestage off           1384           1385           2          7.2         138.4       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1311           1313           2          7.6         131.1       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (shuffled 2y) wholestage off            748            748           1         13.4          74.8       1.0X
-date_trunc MONTH (shuffled 2y) wholestage on             727            734           9         13.8          72.7       1.0X
+date_trunc MONTH (shuffled 2y) wholestage off            795            815          28         12.6          79.5       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             757            770          15         13.2          75.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (spread 95y) wholestage off            812            813           1         12.3          81.2       1.0X
-date_trunc MONTH (spread 95y) wholestage on             777            783           7         12.9          77.7       1.0X
+date_trunc MONTH (spread 95y) wholestage off            947            947           1         10.6          94.7       1.0X
+date_trunc MONTH (spread 95y) wholestage on             820            824           5         12.2          82.0       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (shuffled 2y) wholestage off            504            506           2         19.8          50.4       1.0X
-date_trunc WEEK (shuffled 2y) wholestage on             476            480           3         21.0          47.6       1.1X
+date_trunc WEEK (shuffled 2y) wholestage off            530            532           3         18.9          53.0       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             489            491           1         20.4          48.9       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (spread 95y) wholestage off            585            585           0         17.1          58.5       1.0X
-date_trunc WEEK (spread 95y) wholestage on             554            558           5         18.0          55.4       1.1X
+date_trunc WEEK (spread 95y) wholestage off            674            674           0         14.8          67.4       1.0X
+date_trunc WEEK (spread 95y) wholestage on             640            643           2         15.6          64.0       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (shuffled 2y) wholestage off            443            444           1         22.6          44.3       1.0X
-date_trunc DAY (shuffled 2y) wholestage on             413            416           2         24.2          41.3       1.1X
+date_trunc DAY (shuffled 2y) wholestage off            479            480           2         20.9          47.9       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             445            449           5         22.5          44.5       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (spread 95y) wholestage off            518            520           3         19.3          51.8       1.0X
-date_trunc DAY (spread 95y) wholestage on             491            496           7         20.4          49.1       1.1X
+date_trunc DAY (spread 95y) wholestage off            623            624           1         16.0          62.3       1.0X
+date_trunc DAY (spread 95y) wholestage on             527            535           7         19.0          52.7       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           921            923           2         10.9          92.1       1.0X
-trunc year wholestage on                            905            908           3         11.1          90.5       1.0X
+trunc year wholestage off                           941            957          22         10.6          94.1       1.0X
+trunc year wholestage on                            912            924          23         11.0          91.2       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           924            924           0         10.8          92.4       1.0X
-trunc yyyy wholestage on                            904            906           2         11.1          90.4       1.0X
+trunc yyyy wholestage off                           933            934           2         10.7          93.3       1.0X
+trunc yyyy wholestage on                            913            917           4         10.9          91.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             924            931           9         10.8          92.4       1.0X
-trunc yy wholestage on                              903            908           5         11.1          90.3       1.0X
+trunc yy wholestage off                             934            935           2         10.7          93.4       1.0X
+trunc yy wholestage on                              913            924          18         10.9          91.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            893            895           2         11.2          89.3       1.0X
-trunc mon wholestage on                             870            872           2         11.5          87.0       1.0X
+trunc mon wholestage off                            905            907           3         11.1          90.5       1.0X
+trunc mon wholestage on                             875            885          10         11.4          87.5       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          898            899           1         11.1          89.8       1.0X
-trunc month wholestage on                           871            874           3         11.5          87.1       1.0X
+trunc month wholestage off                          899            901           3         11.1          89.9       1.0X
+trunc month wholestage on                           876            878           1         11.4          87.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             894            896           2         11.2          89.4       1.0X
-trunc mm wholestage on                              867            869           2         11.5          86.7       1.0X
+trunc mm wholestage off                             902            903           3         11.1          90.2       1.0X
+trunc mm wholestage on                              878            882           3         11.4          87.8       1.0X
 
 
 ================================================================================================
@@ -474,36 +474,36 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     106            110           5          9.4         106.3       1.0X
-to timestamp str wholestage on                      101            103           3          9.9         100.8       1.1X
+to timestamp str wholestage off                     104            105           2          9.7         103.5       1.0X
+to timestamp str wholestage on                      101            103           2          9.9         100.8       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         779            780           0          1.3         779.3       1.0X
-to_timestamp wholestage on                          783            785           2          1.3         782.9       1.0X
+to_timestamp wholestage off                         762            762           0          1.3         761.5       1.0X
+to_timestamp wholestage on                          753            758           3          1.3         753.2       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    797            797           1          1.3         796.7       1.0X
-to_unix_timestamp wholestage on                     767            769           2          1.3         766.9       1.0X
+to_unix_timestamp wholestage off                    757            759           4          1.3         756.7       1.0X
+to_unix_timestamp wholestage on                     756            757           2          1.3         755.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          155            155           1          6.5         154.8       1.0X
-to date str wholestage on                           137            141           6          7.3         137.1       1.1X
+to date str wholestage off                          143            143           0          7.0         142.6       1.0X
+to date str wholestage on                           134            138           4          7.5         133.8       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              662            662           1          1.5         662.1       1.0X
-to_date wholestage on                               642            644           2          1.6         641.7       1.0X
+to_date wholestage off                              662            667           6          1.5         662.3       1.0X
+to_date wholestage on                               661            662           1          1.5         660.9       1.0X
 
 
 ================================================================================================
@@ -514,18 +514,18 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  290            292           2         17.2          58.0       1.0X
-From java.time.LocalDate                            249            250           1         20.1          49.8       1.2X
-Collect java.sql.Date                              1126           1269         170          4.4         225.2       0.3X
-Collect java.time.LocalDate                         866            997         151          5.8         173.2       0.3X
-From java.sql.Timestamp                             240            255          21         20.8          48.0       1.2X
-From java.time.Instant                              215            221           7         23.3          42.9       1.4X
-Collect longs                                       936            995          89          5.3         187.2       0.3X
-Collect java.sql.Timestamp                          834           1208         325          6.0         166.8       0.3X
-Collect java.time.Instant                           836           1017         188          6.0         167.2       0.3X
-java.sql.Date to Hive string                       3794           3981         185          1.3         758.7       0.1X
-java.time.LocalDate to Hive string                 3357           3467         118          1.5         671.4       0.1X
-java.sql.Timestamp to Hive string                  6536           6623         113          0.8        1307.1       0.0X
-java.time.Instant to Hive string                   5125           5314         192          1.0        1025.0       0.1X
+From java.sql.Date                                  287            290           3         17.4          57.3       1.0X
+From java.time.LocalDate                            246            250           4         20.3          49.3       1.2X
+Collect java.sql.Date                              1154           1265         105          4.3         230.8       0.2X
+Collect java.time.LocalDate                         985           1111         119          5.1         197.1       0.3X
+From java.sql.Timestamp                             232            235           3         21.5          46.4       1.2X
+From java.time.Instant                              213            221           7         23.4          42.7       1.3X
+Collect longs                                       981           1059         112          5.1         196.2       0.3X
+Collect java.sql.Timestamp                         1152           1156           6          4.3         230.3       0.2X
+Collect java.time.Instant                          1012           1032          22          4.9         202.4       0.3X
+java.sql.Date to Hive string                       4069           4281         196          1.2         813.8       0.1X
+java.time.LocalDate to Hive string                 3323           3492         148          1.5         664.6       0.1X
+java.sql.Timestamp to Hive string                  6699           6783         119          0.7        1339.7       0.0X
+java.time.Instant to Hive string                   5207           5320         109          1.0        1041.3       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1209           1231          31          8.3         120.9       1.0X
-date + interval(m, d)                              1211           1235          35          8.3         121.1       1.0X
-date + interval(m, d, ms)                          4003           4014          16          2.5         400.3       0.3X
-date - interval(m)                                 1061           1064           4          9.4         106.1       1.1X
-date - interval(m, d)                              1087           1096          13          9.2         108.7       1.1X
-date - interval(m, d, ms)                          4051           4068          23          2.5         405.1       0.3X
-timestamp + interval(m)                            1847           1850           4          5.4         184.7       0.7X
-timestamp + interval(m, d)                         1868           1869           1          5.4         186.8       0.6X
-timestamp + interval(m, d, ms)                     2203           2205           3          4.5         220.3       0.5X
-timestamp - interval(m)                            1947           1949           3          5.1         194.7       0.6X
-timestamp - interval(m, d)                         2021           2025           6          4.9         202.1       0.6X
-timestamp - interval(m, d, ms)                     2214           2215           2          4.5         221.4       0.5X
+date + interval(m)                                 1003           1065          87         10.0         100.3       1.0X
+date + interval(m, d)                               993            995           2         10.1          99.3       1.0X
+date + interval(m, d, ms)                          3990           3999          13          2.5         399.0       0.3X
+date - interval(m)                                  956            965          11         10.5          95.6       1.0X
+date - interval(m, d)                              1011           1042          44          9.9         101.1       1.0X
+date - interval(m, d, ms)                          4031           4039          11          2.5         403.1       0.2X
+timestamp + interval(m)                            1812           1826          19          5.5         181.2       0.6X
+timestamp + interval(m, d)                         1873           1877           6          5.3         187.3       0.5X
+timestamp + interval(m, d, ms)                     2069           2071           4          4.8         206.9       0.5X
+timestamp - interval(m)                            1808           1809           1          5.5         180.8       0.6X
+timestamp - interval(m, d)                         1868           1869           2          5.4         186.8       0.5X
+timestamp - interval(m, d, ms)                     2042           2046           5          4.9         204.2       0.5X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    212            215           4         47.2          21.2       1.0X
-cast to timestamp wholestage on                     212            224          17         47.2          21.2       1.0X
+cast to timestamp wholestage off                    205            208           5         48.9          20.5       1.0X
+cast to timestamp wholestage on                     217            226          15         46.1          21.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    865            865           1         11.6          86.5       1.0X
-year of timestamp wholestage on                     843            847           3         11.9          84.3       1.0X
+year of timestamp wholestage off                    776            778           3         12.9          77.6       1.0X
+year of timestamp wholestage on                     775            781           7         12.9          77.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 878            881           4         11.4          87.8       1.0X
-quarter of timestamp wholestage on                  866            883          20         11.5          86.6       1.0X
+quarter of timestamp wholestage off                 792            794           2         12.6          79.2       1.0X
+quarter of timestamp wholestage on                  785            791           5         12.7          78.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   864            865           2         11.6          86.4       1.0X
-month of timestamp wholestage on                    843            852          11         11.9          84.3       1.0X
+month of timestamp wholestage off                   764            766           2         13.1          76.4       1.0X
+month of timestamp wholestage on                    773            779           4         12.9          77.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1245           1246           1          8.0         124.5       1.0X
-weekofyear of timestamp wholestage on              1265           1267           3          7.9         126.5       1.0X
+weekofyear of timestamp wholestage off             1144           1146           2          8.7         114.4       1.0X
+weekofyear of timestamp wholestage on              1163           1166           3          8.6         116.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     877            877           1         11.4          87.7       1.0X
-day of timestamp wholestage on                      849            854           7         11.8          84.9       1.0X
+day of timestamp wholestage off                     767            769           2         13.0          76.7       1.0X
+day of timestamp wholestage on                      774            778           4         12.9          77.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               906            912           8         11.0          90.6       1.0X
-dayofyear of timestamp wholestage on                882            889           6         11.3          88.2       1.0X
+dayofyear of timestamp wholestage off               795            803          12         12.6          79.5       1.0X
+dayofyear of timestamp wholestage on                797            801           3         12.6          79.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              879            881           3         11.4          87.9       1.0X
-dayofmonth of timestamp wholestage on               846            852          14         11.8          84.6       1.0X
+dayofmonth of timestamp wholestage off              777            781           6         12.9          77.7       1.0X
+dayofmonth of timestamp wholestage on               775            778           2         12.9          77.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1037           1037           0          9.6         103.7       1.0X
-dayofweek of timestamp wholestage on               1012           1037          46          9.9         101.2       1.0X
+dayofweek of timestamp wholestage off               927            928           2         10.8          92.7       1.0X
+dayofweek of timestamp wholestage on                924            929           6         10.8          92.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 986            988           3         10.1          98.6       1.0X
-weekday of timestamp wholestage on                  965            967           2         10.4          96.5       1.0X
+weekday of timestamp wholestage off                 877            884          10         11.4          87.7       1.0X
+weekday of timestamp wholestage on                  868            870           2         11.5          86.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    681            687           9         14.7          68.1       1.0X
-hour of timestamp wholestage on                     667            672           5         15.0          66.7       1.0X
+hour of timestamp wholestage off                    615            617           2         16.3          61.5       1.0X
+hour of timestamp wholestage on                     621            625           4         16.1          62.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  674            674           1         14.8          67.4       1.0X
-minute of timestamp wholestage on                   661            665           5         15.1          66.1       1.0X
+minute of timestamp wholestage off                  621            622           1         16.1          62.1       1.0X
+minute of timestamp wholestage on                   616            623           5         16.2          61.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  672            674           2         14.9          67.2       1.0X
-second of timestamp wholestage on                   667            674           6         15.0          66.7       1.0X
+second of timestamp wholestage off                  622            624           2         16.1          62.2       1.0X
+second of timestamp wholestage on                   616            620           4         16.2          61.6       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         205            207           3         48.8          20.5       1.0X
-current_date wholestage on                          204            212           6         49.0          20.4       1.0X
+current_date wholestage off                         185            186           1         54.0          18.5       1.0X
+current_date wholestage on                          219            228          10         45.7          21.9       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    218            235          24         45.8          21.8       1.0X
-current_timestamp wholestage on                     217            256          54         46.2          21.7       1.0X
+current_timestamp wholestage off                    192            196           5         52.0          19.2       1.0X
+current_timestamp wholestage on                     229            261          43         43.7          22.9       0.8X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         751            767          22         13.3          75.1       1.0X
-cast to date wholestage on                          737            738           1         13.6          73.7       1.0X
+cast to date wholestage off                         677            678           2         14.8          67.7       1.0X
+cast to date wholestage on                          674            679           4         14.8          67.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             870            873           3         11.5          87.0       1.0X
-last_day wholestage on                              873            878           7         11.5          87.3       1.0X
+last_day wholestage off                             774            774           0         12.9          77.4       1.0X
+last_day wholestage on                              788            796           9         12.7          78.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             781            782           2         12.8          78.1       1.0X
-next_day wholestage on                              767            769           3         13.0          76.7       1.0X
+next_day wholestage off                             699            700           2         14.3          69.9       1.0X
+next_day wholestage on                              702            708           6         14.2          70.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             734            734           0         13.6          73.4       1.0X
-date_add wholestage on                              728            734           5         13.7          72.8       1.0X
+date_add wholestage off                             666            668           2         15.0          66.6       1.0X
+date_add wholestage on                              681            684           2         14.7          68.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             723            723           0         13.8          72.3       1.0X
-date_sub wholestage on                              727            731           3         13.8          72.7       1.0X
+date_sub wholestage off                             657            658           2         15.2          65.7       1.0X
+date_sub wholestage on                              657            663           4         15.2          65.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1025           1025           0          9.8         102.5       1.0X
-add_months wholestage on                           1027           1030           3          9.7         102.7       1.0X
+add_months wholestage off                           911            912           1         11.0          91.1       1.0X
+add_months wholestage on                            920            922           2         10.9          92.0       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3065           3075          15          3.3         306.5       1.0X
-format date wholestage on                          3015           3021           5          3.3         301.5       1.0X
+format date wholestage off                         3336           3339           5          3.0         333.6       1.0X
+format date wholestage on                          3254           3264           8          3.1         325.4       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3415           3441          36          2.9         341.5       1.0X
-from_unixtime wholestage on                        3450           3460          15          2.9         345.0       1.0X
+from_unixtime wholestage off                       3834           3839           8          2.6         383.4       1.0X
+from_unixtime wholestage on                        3765           3772           8          2.7         376.5       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   796            796           1         12.6          79.6       1.0X
-from_utc_timestamp wholestage on                    842            845           1         11.9          84.2       0.9X
+from_utc_timestamp wholestage off                   738            738           0         13.6          73.8       1.0X
+from_utc_timestamp wholestage on                    825            829           4         12.1          82.5       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1055           1057           2          9.5         105.5       1.0X
-to_utc_timestamp wholestage on                     1051           1061          16          9.5         105.1       1.0X
+to_utc_timestamp wholestage off                    1088           1095          10          9.2         108.8       1.0X
+to_utc_timestamp wholestage on                     1073           1077           3          9.3         107.3       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        235            238           3         42.5          23.5       1.0X
-cast interval wholestage on                         213            235          42         46.9          21.3       1.1X
+cast interval wholestage off                        227            234           9         44.0          22.7       1.0X
+cast interval wholestage on                         219            267          95         45.8          21.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1242           1243           1          8.0         124.2       1.0X
-datediff wholestage on                             1232           1241          14          8.1         123.2       1.0X
+datediff wholestage off                            1121           1124           3          8.9         112.1       1.0X
+datediff wholestage on                             1119           1122           3          8.9         111.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3124           3127           4          3.2         312.4       1.0X
-months_between wholestage on                       3151           3156           4          3.2         315.1       1.0X
+months_between wholestage off                      2943           2946           4          3.4         294.3       1.0X
+months_between wholestage on                       2945           2950           5          3.4         294.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               585            593          11          1.7         584.8       1.0X
-window wholestage on                                638            668          37          1.6         638.1       0.9X
+window wholestage off                               643            645           4          1.6         642.9       1.0X
+window wholestage on                                663            674           9          1.5         662.6       1.0X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      858            858           1         11.7          85.8       1.0X
-date_trunc YEAR wholestage on                       850            860          19         11.8          85.0       1.0X
+date_trunc YEAR wholestage off                      520            521           2         19.2          52.0       1.0X
+date_trunc YEAR wholestage on                       506            509           2         19.8          50.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      856            857           2         11.7          85.6       1.0X
-date_trunc YYYY wholestage on                       852            855           2         11.7          85.2       1.0X
+date_trunc YYYY wholestage off                      519            520           1         19.3          51.9       1.0X
+date_trunc YYYY wholestage on                       505            509           4         19.8          50.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        858            872          20         11.7          85.8       1.0X
-date_trunc YY wholestage on                         856            862           8         11.7          85.6       1.0X
+date_trunc YY wholestage off                        518            519           1         19.3          51.8       1.0X
+date_trunc YY wholestage on                         508            512           5         19.7          50.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       865            867           3         11.6          86.5       1.0X
-date_trunc MON wholestage on                        826            830           3         12.1          82.6       1.0X
+date_trunc MON wholestage off                       519            521           3         19.3          51.9       1.0X
+date_trunc MON wholestage on                        483            484           1         20.7          48.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     864            864           1         11.6          86.4       1.0X
-date_trunc MONTH wholestage on                      827            832           6         12.1          82.7       1.0X
+date_trunc MONTH wholestage off                     509            512           4         19.7          50.9       1.0X
+date_trunc MONTH wholestage on                      482            483           1         20.7          48.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        867            868           1         11.5          86.7       1.0X
-date_trunc MM wholestage on                         828            840          17         12.1          82.8       1.0X
+date_trunc MM wholestage off                        508            509           1         19.7          50.8       1.0X
+date_trunc MM wholestage on                         480            486           5         20.8          48.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       651            657           8         15.4          65.1       1.0X
-date_trunc DAY wholestage on                        611            613           1         16.4          61.1       1.1X
+date_trunc DAY wholestage off                       396            399           3         25.2          39.6       1.0X
+date_trunc DAY wholestage on                        359            361           2         27.9          35.9       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        654            677          33         15.3          65.4       1.0X
-date_trunc DD wholestage on                         612            613           1         16.3          61.2       1.1X
+date_trunc DD wholestage off                        395            396           2         25.3          39.5       1.0X
+date_trunc DD wholestage on                         356            363          10         28.1          35.6       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      676            679           4         14.8          67.6       1.0X
-date_trunc HOUR wholestage on                       625            629           4         16.0          62.5       1.1X
+date_trunc HOUR wholestage off                      377            378           1         26.5          37.7       1.0X
+date_trunc HOUR wholestage on                       337            340           4         29.6          33.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    680            683           5         14.7          68.0       1.0X
-date_trunc MINUTE wholestage on                     641            646           9         15.6          64.1       1.1X
+date_trunc MINUTE wholestage off                    376            377           1         26.6          37.6       1.0X
+date_trunc MINUTE wholestage on                     336            339           2         29.8          33.6       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    323            324           1         30.9          32.3       1.0X
-date_trunc SECOND wholestage on                     294            296           2         34.0          29.4       1.1X
+date_trunc SECOND wholestage off                    317            317           0         31.6          31.7       1.0X
+date_trunc SECOND wholestage on                     276            279           3         36.2          27.6       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      704            717          18         14.2          70.4       1.0X
-date_trunc WEEK wholestage on                       677            702          47         14.8          67.7       1.0X
+date_trunc WEEK wholestage off                      427            428           1         23.4          42.7       1.0X
+date_trunc WEEK wholestage on                       381            383           1         26.2          38.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  1018           1019           1          9.8         101.8       1.0X
-date_trunc QUARTER wholestage on                    978            982           3         10.2          97.8       1.0X
+date_trunc QUARTER wholestage off                   655            655           0         15.3          65.5       1.0X
+date_trunc QUARTER wholestage on                    623            625           2         16.1          62.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                          1037           1037           0          9.6         103.7       1.0X
-trunc year wholestage on                            982            985           2         10.2          98.2       1.1X
+trunc year wholestage off                           922            923           2         10.8          92.2       1.0X
+trunc year wholestage on                            898            902           2         11.1          89.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                          1040           1043           5          9.6         104.0       1.0X
-trunc yyyy wholestage on                            982            995          16         10.2          98.2       1.1X
+trunc yyyy wholestage off                           920            923           4         10.9          92.0       1.0X
+trunc yyyy wholestage on                            898            900           2         11.1          89.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                            1035           1061          37          9.7         103.5       1.0X
-trunc yy wholestage on                              985            987           2         10.2          98.5       1.1X
+trunc yy wholestage off                             921            921           1         10.9          92.1       1.0X
+trunc yy wholestage on                              899            904           5         11.1          89.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                           1007           1007           0          9.9         100.7       1.0X
-trunc mon wholestage on                             948            952           3         10.5          94.8       1.1X
+trunc mon wholestage off                            899            900           0         11.1          89.9       1.0X
+trunc mon wholestage on                             868            872           3         11.5          86.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                         1003           1004           1         10.0         100.3       1.0X
-trunc month wholestage on                           950            954           5         10.5          95.0       1.1X
+trunc month wholestage off                          900            913          18         11.1          90.0       1.0X
+trunc month wholestage on                           870            872           2         11.5          87.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                            1008           1008           0          9.9         100.8       1.0X
-trunc mm wholestage on                              950            953           3         10.5          95.0       1.1X
+trunc mm wholestage off                             896            897           2         11.2          89.6       1.0X
+trunc mm wholestage on                              871            872           1         11.5          87.1       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     113            115           3          8.8         113.3       1.0X
-to timestamp str wholestage on                      107            109           2          9.4         106.7       1.1X
+to timestamp str wholestage off                     108            108           0          9.2         108.2       1.0X
+to timestamp str wholestage on                      103            108           5          9.7         102.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         664            666           2          1.5         664.4       1.0X
-to_timestamp wholestage on                          676            683           5          1.5         675.8       1.0X
+to_timestamp wholestage off                         748            749           2          1.3         747.5       1.0X
+to_timestamp wholestage on                          744            750           8          1.3         744.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    675            677           2          1.5         675.5       1.0X
-to_unix_timestamp wholestage on                     668            679          12          1.5         668.1       1.0X
+to_unix_timestamp wholestage off                    741            743           2          1.3         741.2       1.0X
+to_unix_timestamp wholestage on                     750            752           2          1.3         750.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          147            147           0          6.8         147.2       1.0X
-to date str wholestage on                           140            146           7          7.1         140.1       1.1X
+to date str wholestage off                          149            149           1          6.7         148.8       1.0X
+to date str wholestage on                           143            144           1          7.0         143.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              584            587           4          1.7         584.3       1.0X
-to_date wholestage on                               577            580           5          1.7         576.8       1.0X
+to_date wholestage off                              654            656           3          1.5         653.6       1.0X
+to_date wholestage on                               648            650           3          1.5         647.8       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  303            309           5         16.5          60.6       1.0X
-From java.time.LocalDate                            262            265           3         19.1          52.5       1.2X
-Collect java.sql.Date                              1343           1409          60          3.7         268.5       0.2X
-Collect java.time.LocalDate                         901           1081         160          5.6         180.1       0.3X
-From java.sql.Timestamp                             215            216           1         23.2          43.1       1.4X
-From java.time.Instant                              192            193           1         26.1          38.4       1.6X
-Collect longs                                       941            949           7          5.3         188.2       0.3X
-Collect java.sql.Timestamp                          976           1133         144          5.1         195.2       0.3X
-Collect java.time.Instant                           915           1011          93          5.5         182.9       0.3X
-java.sql.Date to Hive string                       3943           4043         111          1.3         788.7       0.1X
-java.time.LocalDate to Hive string                 3240           3272          28          1.5         648.1       0.1X
-java.sql.Timestamp to Hive string                  6281           6329          62          0.8        1256.1       0.0X
-java.time.Instant to Hive string                   4610           4704         113          1.1         922.0       0.1X
+From java.sql.Date                                  290            292           2         17.2          58.1       1.0X
+From java.time.LocalDate                            252            255           5         19.9          50.3       1.2X
+Collect java.sql.Date                              1265           1312          73          4.0         253.0       0.2X
+Collect java.time.LocalDate                         893           1040         127          5.6         178.7       0.3X
+From java.sql.Timestamp                             233            239           6         21.4          46.7       1.2X
+From java.time.Instant                              214            230          27         23.4          42.8       1.4X
+Collect longs                                       833            961         120          6.0         166.5       0.3X
+Collect java.sql.Timestamp                          840           1097         237          6.0         167.9       0.3X
+Collect java.time.Instant                           950            974          22          5.3         190.0       0.3X
+java.sql.Date to Hive string                       3994           4091          98          1.3         798.9       0.1X
+java.time.LocalDate to Hive string                 3295           3359          56          1.5         659.0       0.1X
+java.sql.Timestamp to Hive string                  6313           6475         141          0.8        1262.7       0.0X
+java.time.Instant to Hive string                   5043           5078          52          1.0        1008.5       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,530 +2,530 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1006           1022          22          9.9         100.6       1.0X
-date + interval(m, d)                              1003           1006           5         10.0         100.3       1.0X
-date + interval(m, d, ms)                          3825           3826           1          2.6         382.5       0.3X
-date - interval(m)                                  977            979           3         10.2          97.7       1.0X
-date - interval(m, d)                              1000           1000           1         10.0         100.0       1.0X
-date - interval(m, d, ms)                          3879           3879           1          2.6         387.9       0.3X
-timestamp + interval(m)                            1755           1758           4          5.7         175.5       0.6X
-timestamp + interval(m, d)                         1813           1833          28          5.5         181.3       0.6X
-timestamp + interval(m, d, ms)                     1979           1981           2          5.1         197.9       0.5X
-timestamp - interval(m)                            1753           1753           0          5.7         175.3       0.6X
-timestamp - interval(m, d)                         1815           1818           5          5.5         181.5       0.6X
-timestamp - interval(m, d, ms)                     1992           1992           0          5.0         199.2       0.5X
+date + interval(m)                                 1205           1253          68          8.3         120.5       1.0X
+date + interval(m, d)                              1199           1200           2          8.3         119.9       1.0X
+date + interval(m, d, ms)                          4173           4176           5          2.4         417.3       0.3X
+date - interval(m)                                 1151           1157           8          8.7         115.1       1.0X
+date - interval(m, d)                              1176           1188          17          8.5         117.6       1.0X
+date - interval(m, d, ms)                          4196           4212          23          2.4         419.6       0.3X
+timestamp + interval(m)                            1776           1776           0          5.6         177.6       0.7X
+timestamp + interval(m, d)                         1863           1868           7          5.4         186.3       0.6X
+timestamp + interval(m, d, ms)                     2141           2144           5          4.7         214.1       0.6X
+timestamp - interval(m)                            1870           1881          16          5.3         187.0       0.6X
+timestamp - interval(m, d)                         1948           1949           2          5.1         194.8       0.6X
+timestamp - interval(m, d, ms)                     2125           2131           8          4.7         212.5       0.6X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    200            214          20         50.0          20.0       1.0X
-cast to timestamp wholestage on                     209            213           3         47.8          20.9       1.0X
+cast to timestamp wholestage off                    199            201           2         50.2          19.9       1.0X
+cast to timestamp wholestage on                     207            209           2         48.2          20.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    754            758           6         13.3          75.4       1.0X
-year of timestamp wholestage on                     764            774          17         13.1          76.4       1.0X
+year of timestamp wholestage off                    872            876           6         11.5          87.2       1.0X
+year of timestamp wholestage on                     833            837           3         12.0          83.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 802            803           1         12.5          80.2       1.0X
-quarter of timestamp wholestage on                  783            788           7         12.8          78.3       1.0X
+quarter of timestamp wholestage off                 885            887           3         11.3          88.5       1.0X
+quarter of timestamp wholestage on                  854            859           3         11.7          85.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   764            765           1         13.1          76.4       1.0X
-month of timestamp wholestage on                    773            777           7         12.9          77.3       1.0X
+month of timestamp wholestage off                   866            869           4         11.5          86.6       1.0X
+month of timestamp wholestage on                    837            842           5         11.9          83.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1107           1111           5          9.0         110.7       1.0X
-weekofyear of timestamp wholestage on              1171           1180          10          8.5         117.1       0.9X
+weekofyear of timestamp wholestage off             1225           1229           5          8.2         122.5       1.0X
+weekofyear of timestamp wholestage on              1277           1283           5          7.8         127.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     791            796           8         12.6          79.1       1.0X
-day of timestamp wholestage on                      771            776           4         13.0          77.1       1.0X
+day of timestamp wholestage off                     872            876           6         11.5          87.2       1.0X
+day of timestamp wholestage on                      835            844           5         12.0          83.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               802            805           4         12.5          80.2       1.0X
-dayofyear of timestamp wholestage on                790            796          10         12.7          79.0       1.0X
+dayofyear of timestamp wholestage off               895            897           3         11.2          89.5       1.0X
+dayofyear of timestamp wholestage on                871            874           4         11.5          87.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              794            795           2         12.6          79.4       1.0X
-dayofmonth of timestamp wholestage on               767            772           3         13.0          76.7       1.0X
+dayofmonth of timestamp wholestage off              884            886           3         11.3          88.4       1.0X
+dayofmonth of timestamp wholestage on               835            841           6         12.0          83.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               915            918           5         10.9          91.5       1.0X
-dayofweek of timestamp wholestage on                914            917           3         10.9          91.4       1.0X
+dayofweek of timestamp wholestage off               986            990           5         10.1          98.6       1.0X
+dayofweek of timestamp wholestage on               1000           1004           5         10.0         100.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 888            889           1         11.3          88.8       1.0X
-weekday of timestamp wholestage on                  863            866           2         11.6          86.3       1.0X
+weekday of timestamp wholestage off                 984            986           3         10.2          98.4       1.0X
+weekday of timestamp wholestage on                  939            944           4         10.6          93.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    596            599           5         16.8          59.6       1.0X
-hour of timestamp wholestage on                     610            613           2         16.4          61.0       1.0X
+hour of timestamp wholestage off                    603            605           2         16.6          60.3       1.0X
+hour of timestamp wholestage on                     621            628           8         16.1          62.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  592            593           0         16.9          59.2       1.0X
-minute of timestamp wholestage on                   607            608           2         16.5          60.7       1.0X
+minute of timestamp wholestage off                  602            606           5         16.6          60.2       1.0X
+minute of timestamp wholestage on                   608            616           7         16.4          60.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  593            596           4         16.9          59.3       1.0X
-second of timestamp wholestage on                   612            619           4         16.3          61.2       1.0X
+second of timestamp wholestage off                  605            607           3         16.5          60.5       1.0X
+second of timestamp wholestage on                   606            608           3         16.5          60.6       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         186            187           0         53.6          18.6       1.0X
-current_date wholestage on                          204            209           4         49.0          20.4       0.9X
+current_date wholestage off                         185            186           2         54.2          18.5       1.0X
+current_date wholestage on                          207            213           6         48.3          20.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    193            198           7         51.8          19.3       1.0X
-current_timestamp wholestage on                     216            241          33         46.4          21.6       0.9X
+current_timestamp wholestage off                    198            207          12         50.4          19.8       1.0X
+current_timestamp wholestage on                     218            250          30         45.9          21.8       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         661            663           2         15.1          66.1       1.0X
-cast to date wholestage on                          662            665           2         15.1          66.2       1.0X
+cast to date wholestage off                         766            769           5         13.1          76.6       1.0X
+cast to date wholestage on                          767            770           4         13.0          76.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             765            765           1         13.1          76.5       1.0X
-last_day wholestage on                              769            770           2         13.0          76.9       1.0X
+last_day wholestage off                             860            864           6         11.6          86.0       1.0X
+last_day wholestage on                              850            854           3         11.8          85.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             690            691           1         14.5          69.0       1.0X
-next_day wholestage on                              699            703           2         14.3          69.9       1.0X
+next_day wholestage off                             787            789           3         12.7          78.7       1.0X
+next_day wholestage on                              794            796           2         12.6          79.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             639            639           1         15.7          63.9       1.0X
-date_add wholestage on                              644            648           5         15.5          64.4       1.0X
+date_add wholestage off                             748            751           3         13.4          74.8       1.0X
+date_add wholestage on                              757            760           2         13.2          75.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             646            649           3         15.5          64.6       1.0X
-date_sub wholestage on                              638            643           4         15.7          63.8       1.0X
+date_sub wholestage off                             749            751           3         13.4          74.9       1.0X
+date_sub wholestage on                              756            760           3         13.2          75.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           914            915           2         10.9          91.4       1.0X
-add_months wholestage on                            900            904           2         11.1          90.0       1.0X
+add_months wholestage off                          1079           1085           8          9.3         107.9       1.0X
+add_months wholestage on                           1104           1107           2          9.1         110.4       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3419           3425           9          2.9         341.9       1.0X
-format date wholestage on                          3261           3273          11          3.1         326.1       1.0X
+format date wholestage off                         3824           3826           3          2.6         382.4       1.0X
+format date wholestage on                          3651           3660           8          2.7         365.1       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3658           3678          28          2.7         365.8       1.0X
-from_unixtime wholestage on                        3607           3624          31          2.8         360.7       1.0X
+from_unixtime wholestage off                       3625           3636          16          2.8         362.5       1.0X
+from_unixtime wholestage on                        3593           3620          44          2.8         359.3       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   728            728           0         13.7          72.8       1.0X
-from_utc_timestamp wholestage on                    836            840           4         12.0          83.6       0.9X
+from_utc_timestamp wholestage off                   734            738           5         13.6          73.4       1.0X
+from_utc_timestamp wholestage on                    830            837           5         12.1          83.0       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1088           1092           6          9.2         108.8       1.0X
-to_utc_timestamp wholestage on                     1081           1085           3          9.2         108.1       1.0X
+to_utc_timestamp wholestage off                    1097           1098           2          9.1         109.7       1.0X
+to_utc_timestamp wholestage on                     1078           1079           2          9.3         107.8       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        226            227           2         44.2          22.6       1.0X
-cast interval wholestage on                         204            207           3         49.0          20.4       1.1X
+cast interval wholestage off                        223            225           3         44.8          22.3       1.0X
+cast interval wholestage on                         206            208           2         48.6          20.6       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1117           1118           1          8.9         111.7       1.0X
-datediff wholestage on                             1153           1165          10          8.7         115.3       1.0X
+datediff wholestage off                            1309           1322          18          7.6         130.9       1.0X
+datediff wholestage on                             1310           1318          10          7.6         131.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3589           3591           4          2.8         358.9       1.0X
-months_between wholestage on                       3557           3563           6          2.8         355.7       1.0X
+months_between wholestage off                      3133           3134           2          3.2         313.3       1.0X
+months_between wholestage on                       3119           3125           4          3.2         311.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               590            595           6          1.7         590.3       1.0X
-window wholestage on                                666            677          12          1.5         665.8       0.9X
+window wholestage off                               612            614           3          1.6         611.5       1.0X
+window wholestage on                                824            842          17          1.2         824.1       0.7X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      517            518           1         19.3          51.7       1.0X
-date_trunc YEAR wholestage on                       466            468           2         21.5          46.6       1.1X
+date_trunc YEAR wholestage off                      521            524           3         19.2          52.1       1.0X
+date_trunc YEAR wholestage on                       485            492          10         20.6          48.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      515            518           4         19.4          51.5       1.0X
-date_trunc YYYY wholestage on                       468            472           3         21.4          46.8       1.1X
+date_trunc YYYY wholestage off                      526            526           1         19.0          52.6       1.0X
+date_trunc YYYY wholestage on                       487            490           5         20.6          48.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        517            518           2         19.3          51.7       1.0X
-date_trunc YY wholestage on                         472            476           6         21.2          47.2       1.1X
+date_trunc YY wholestage off                        523            525           3         19.1          52.3       1.0X
+date_trunc YY wholestage on                         483            488           4         20.7          48.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       496            499           3         20.2          49.6       1.0X
-date_trunc MON wholestage on                        456            465          11         21.9          45.6       1.1X
+date_trunc MON wholestage off                       482            484           2         20.7          48.2       1.0X
+date_trunc MON wholestage on                        457            465          10         21.9          45.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     498            498           1         20.1          49.8       1.0X
-date_trunc MONTH wholestage on                      457            461           5         21.9          45.7       1.1X
+date_trunc MONTH wholestage off                     487            498          16         20.5          48.7       1.0X
+date_trunc MONTH wholestage on                      453            457           3         22.1          45.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        495            495           0         20.2          49.5       1.0X
-date_trunc MM wholestage on                         457            460           4         21.9          45.7       1.1X
+date_trunc MM wholestage off                        483            484           1         20.7          48.3       1.0X
+date_trunc MM wholestage on                         455            459           3         22.0          45.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       383            384           2         26.1          38.3       1.0X
-date_trunc DAY wholestage on                        342            347           9         29.3          34.2       1.1X
+date_trunc DAY wholestage off                       386            387           1         25.9          38.6       1.0X
+date_trunc DAY wholestage on                        454            465           7         22.0          45.4       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        383            384           1         26.1          38.3       1.0X
-date_trunc DD wholestage on                         340            344           3         29.4          34.0       1.1X
+date_trunc DD wholestage off                        385            385           0         26.0          38.5       1.0X
+date_trunc DD wholestage on                         464            467           4         21.6          46.4       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      375            375           1         26.7          37.5       1.0X
-date_trunc HOUR wholestage on                       329            334           5         30.4          32.9       1.1X
+date_trunc HOUR wholestage off                      374            381          11         26.8          37.4       1.0X
+date_trunc HOUR wholestage on                       327            329           1         30.5          32.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    361            363           3         27.7          36.1       1.0X
-date_trunc MINUTE wholestage on                     322            325           2         31.0          32.2       1.1X
+date_trunc MINUTE wholestage off                    361            364           4         27.7          36.1       1.0X
+date_trunc MINUTE wholestage on                     321            323           1         31.1          32.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    321            322           1         31.1          32.1       1.0X
-date_trunc SECOND wholestage on                     277            280           3         36.1          27.7       1.2X
+date_trunc SECOND wholestage off                    331            332           2         30.2          33.1       1.0X
+date_trunc SECOND wholestage on                     274            278           6         36.4          27.4       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      419            422           3         23.8          41.9       1.0X
-date_trunc WEEK wholestage on                       383            386           2         26.1          38.3       1.1X
+date_trunc WEEK wholestage off                      410            410           1         24.4          41.0       1.0X
+date_trunc WEEK wholestage on                       375            377           2         26.7          37.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   649            653           5         15.4          64.9       1.0X
-date_trunc QUARTER wholestage on                    621            624           3         16.1          62.1       1.0X
+date_trunc QUARTER wholestage off                   716            717           2         14.0          71.6       1.0X
+date_trunc QUARTER wholestage on                    724            725           2         13.8          72.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (shuffled 2y) wholestage off           1226           1226           1          8.2         122.6       1.0X
-date_trunc YEAR (shuffled 2y) wholestage on            1216           1220           4          8.2         121.6       1.0X
+date_trunc YEAR (shuffled 2y) wholestage off           1280           1282           3          7.8         128.0       1.0X
+date_trunc YEAR (shuffled 2y) wholestage on            1342           1346           4          7.4         134.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR (spread 95y) wholestage off           1454           1456           3          6.9         145.4       1.0X
-date_trunc YEAR (spread 95y) wholestage on            1378           1380           2          7.3         137.8       1.1X
+date_trunc YEAR (spread 95y) wholestage off           1421           1435          21          7.0         142.1       1.0X
+date_trunc YEAR (spread 95y) wholestage on            1409           1414           6          7.1         140.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (shuffled 2y) wholestage off           1077           1082           7          9.3         107.7       1.0X
-date_trunc QUARTER (shuffled 2y) wholestage on            1036           1038           2          9.7         103.6       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage off           1166           1169           4          8.6         116.6       1.0X
+date_trunc QUARTER (shuffled 2y) wholestage on            1134           1143          12          8.8         113.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER (spread 95y) wholestage off           1384           1385           2          7.2         138.4       1.0X
-date_trunc QUARTER (spread 95y) wholestage on            1311           1313           2          7.6         131.1       1.1X
+date_trunc QUARTER (spread 95y) wholestage off           1460           1464           5          6.8         146.0       1.0X
+date_trunc QUARTER (spread 95y) wholestage on            1448           1457           9          6.9         144.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (shuffled 2y) wholestage off            795            815          28         12.6          79.5       1.0X
-date_trunc MONTH (shuffled 2y) wholestage on             757            770          15         13.2          75.7       1.0X
+date_trunc MONTH (shuffled 2y) wholestage off            787            787           1         12.7          78.7       1.0X
+date_trunc MONTH (shuffled 2y) wholestage on             756            761           5         13.2          75.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH (spread 95y) wholestage off            947            947           1         10.6          94.7       1.0X
-date_trunc MONTH (spread 95y) wholestage on             820            824           5         12.2          82.0       1.2X
+date_trunc MONTH (spread 95y) wholestage off            884            884           1         11.3          88.4       1.0X
+date_trunc MONTH (spread 95y) wholestage on             839            844           4         11.9          83.9       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (shuffled 2y) wholestage off            530            532           3         18.9          53.0       1.0X
-date_trunc WEEK (shuffled 2y) wholestage on             489            491           1         20.4          48.9       1.1X
+date_trunc WEEK (shuffled 2y) wholestage off            533            534           1         18.8          53.3       1.0X
+date_trunc WEEK (shuffled 2y) wholestage on             507            511           5         19.7          50.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK (spread 95y) wholestage off            674            674           0         14.8          67.4       1.0X
-date_trunc WEEK (spread 95y) wholestage on             640            643           2         15.6          64.0       1.1X
+date_trunc WEEK (spread 95y) wholestage off            653            657           6         15.3          65.3       1.0X
+date_trunc WEEK (spread 95y) wholestage on             629            631           3         15.9          62.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (shuffled 2y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (shuffled 2y) wholestage off            479            480           2         20.9          47.9       1.0X
-date_trunc DAY (shuffled 2y) wholestage on             445            449           5         22.5          44.5       1.1X
+date_trunc DAY (shuffled 2y) wholestage off            471            473           3         21.2          47.1       1.0X
+date_trunc DAY (shuffled 2y) wholestage on             441            445           3         22.7          44.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY (spread 95y):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY (spread 95y) wholestage off            623            624           1         16.0          62.3       1.0X
-date_trunc DAY (spread 95y) wholestage on             527            535           7         19.0          52.7       1.2X
+date_trunc DAY (spread 95y) wholestage off            586            587           2         17.1          58.6       1.0X
+date_trunc DAY (spread 95y) wholestage on             564            566           2         17.7          56.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           941            957          22         10.6          94.1       1.0X
-trunc year wholestage on                            912            924          23         11.0          91.2       1.0X
+trunc year wholestage off                          1020           1021           2          9.8         102.0       1.0X
+trunc year wholestage on                            998           1000           2         10.0          99.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           933            934           2         10.7          93.3       1.0X
-trunc yyyy wholestage on                            913            917           4         10.9          91.3       1.0X
+trunc yyyy wholestage off                          1020           1021           1          9.8         102.0       1.0X
+trunc yyyy wholestage on                            997           1001           3         10.0          99.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             934            935           2         10.7          93.4       1.0X
-trunc yy wholestage on                              913            924          18         10.9          91.3       1.0X
+trunc yy wholestage off                            1023           1024           1          9.8         102.3       1.0X
+trunc yy wholestage on                              994           1002           7         10.1          99.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            905            907           3         11.1          90.5       1.0X
-trunc mon wholestage on                             875            885          10         11.4          87.5       1.0X
+trunc mon wholestage off                            979            981           3         10.2          97.9       1.0X
+trunc mon wholestage on                             942            945           2         10.6          94.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          899            901           3         11.1          89.9       1.0X
-trunc month wholestage on                           876            878           1         11.4          87.6       1.0X
+trunc month wholestage off                          978            982           5         10.2          97.8       1.0X
+trunc month wholestage on                           942            944           4         10.6          94.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             902            903           3         11.1          90.2       1.0X
-trunc mm wholestage on                              878            882           3         11.4          87.8       1.0X
+trunc mm wholestage off                             983            984           1         10.2          98.3       1.0X
+trunc mm wholestage on                              942            946           3         10.6          94.2       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     104            105           2          9.7         103.5       1.0X
-to timestamp str wholestage on                      101            103           2          9.9         100.8       1.0X
+to timestamp str wholestage off                     104            108           6          9.7         103.5       1.0X
+to timestamp str wholestage on                      100            102           2         10.0          99.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         762            762           0          1.3         761.5       1.0X
-to_timestamp wholestage on                          753            758           3          1.3         753.2       1.0X
+to_timestamp wholestage off                         773            775           3          1.3         773.0       1.0X
+to_timestamp wholestage on                          769            771           1          1.3         769.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    757            759           4          1.3         756.7       1.0X
-to_unix_timestamp wholestage on                     756            757           2          1.3         755.6       1.0X
+to_unix_timestamp wholestage off                    778            781           4          1.3         777.8       1.0X
+to_unix_timestamp wholestage on                     771            773           3          1.3         770.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          143            143           0          7.0         142.6       1.0X
-to date str wholestage on                           134            138           4          7.5         133.8       1.1X
+to date str wholestage off                          136            136           0          7.4         135.5       1.0X
+to date str wholestage on                           133            137           3          7.5         133.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              662            667           6          1.5         662.3       1.0X
-to_date wholestage on                               661            662           1          1.5         660.9       1.0X
+to_date wholestage off                              686            686           1          1.5         686.1       1.0X
+to_date wholestage on                               675            677           2          1.5         675.2       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  287            290           3         17.4          57.3       1.0X
-From java.time.LocalDate                            246            250           4         20.3          49.3       1.2X
-Collect java.sql.Date                              1154           1265         105          4.3         230.8       0.2X
-Collect java.time.LocalDate                         985           1111         119          5.1         197.1       0.3X
-From java.sql.Timestamp                             232            235           3         21.5          46.4       1.2X
-From java.time.Instant                              213            221           7         23.4          42.7       1.3X
-Collect longs                                       981           1059         112          5.1         196.2       0.3X
-Collect java.sql.Timestamp                         1152           1156           6          4.3         230.3       0.2X
-Collect java.time.Instant                          1012           1032          22          4.9         202.4       0.3X
-java.sql.Date to Hive string                       4069           4281         196          1.2         813.8       0.1X
-java.time.LocalDate to Hive string                 3323           3492         148          1.5         664.6       0.1X
-java.sql.Timestamp to Hive string                  6699           6783         119          0.7        1339.7       0.0X
-java.time.Instant to Hive string                   5207           5320         109          1.0        1041.3       0.1X
+From java.sql.Date                                  293            295           2         17.1          58.6       1.0X
+From java.time.LocalDate                            284            285           1         17.6          56.9       1.0X
+Collect java.sql.Date                              1231           1374         130          4.1         246.1       0.2X
+Collect java.time.LocalDate                         957           1182         213          5.2         191.4       0.3X
+From java.sql.Timestamp                             205            209           5         24.4          41.0       1.4X
+From java.time.Instant                              184            187           3         27.2          36.8       1.6X
+Collect longs                                       850            972         146          5.9         170.0       0.3X
+Collect java.sql.Timestamp                         1016           1159         163          4.9         203.3       0.3X
+Collect java.time.Instant                          1052           1131          83          4.8         210.4       0.3X
+java.sql.Date to Hive string                       3677           3805         111          1.4         735.5       0.1X
+java.time.LocalDate to Hive string                 3319           3418         110          1.5         663.8       0.1X
+java.sql.Timestamp to Hive string                  6505           6599         157          0.8        1301.0       0.0X
+java.time.Instant to Hive string                   4995           5141         158          1.0         999.1       0.1X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -165,11 +165,12 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
             "SECOND", "WEEK", "QUARTER").foreach { level =>
             run(N, s"date_trunc $level", s"date_trunc('$level', $timestampExpr)")
           }
-          // date_trunc memoizes the zone offset over the most-recently-used constant-offset window
-          // (SPARK-57737), so its per-row cost depends on how temporally clustered the input is. The
-          // cases above are sequential (best case); these cover timestamps arriving out of order --
-          // shuffled over a bounded ~2-year span (e.g. after a shuffle on a non-time key) and spread
-          // uniformly over ~95 years (the adversarial case, working set far exceeding one window).
+          // date_trunc memoizes the zone offset over the most-recently-used constant-offset
+          // window (SPARK-57737), so its per-row cost depends on how temporally clustered the
+          // input is. The cases above are sequential (best case); these cover timestamps arriving
+          // out of order -- shuffled over a bounded ~2-year span (e.g. after a shuffle on a
+          // non-time key) and spread uniformly over ~95 years (the adversarial case, working set
+          // far exceeding one window).
           val shuffled2y = "timestamp_seconds(1600000000 + pmod(id * 2654435761, 63072000))"
           val spread95y = "timestamp_seconds(pmod(id * 2654435761, 3000000000))"
           Seq("YEAR", "QUARTER", "MONTH", "WEEK", "DAY").foreach { level =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -172,7 +172,7 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
           // uniformly over ~95 years (the adversarial case, working set far exceeding one window).
           val shuffled2y = "timestamp_seconds(1600000000 + pmod(id * 2654435761, 63072000))"
           val spread95y = "timestamp_seconds(pmod(id * 2654435761, 3000000000))"
-          Seq("YEAR", "MONTH", "DAY").foreach { level =>
+          Seq("YEAR", "QUARTER", "MONTH", "WEEK", "DAY").foreach { level =>
             run(N, s"date_trunc $level (shuffled 2y)", s"date_trunc('$level', $shuffled2y)")
             run(N, s"date_trunc $level (spread 95y)", s"date_trunc('$level', $spread95y)")
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -165,6 +165,17 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
             "SECOND", "WEEK", "QUARTER").foreach { level =>
             run(N, s"date_trunc $level", s"date_trunc('$level', $timestampExpr)")
           }
+          // date_trunc memoizes the zone offset over the most-recently-used constant-offset window
+          // (SPARK-57737), so its per-row cost depends on how temporally clustered the input is. The
+          // cases above are sequential (best case); these cover timestamps arriving out of order --
+          // shuffled over a bounded ~2-year span (e.g. after a shuffle on a non-time key) and spread
+          // uniformly over ~95 years (the adversarial case, working set far exceeding one window).
+          val shuffled2y = "timestamp_seconds(1600000000 + pmod(id * 2654435761, 63072000))"
+          val spread95y = "timestamp_seconds(pmod(id * 2654435761, 3000000000))"
+          Seq("YEAR", "MONTH", "DAY").foreach { level =>
+            run(N, s"date_trunc $level (shuffled 2y)", s"date_trunc('$level', $shuffled2y)")
+            run(N, s"date_trunc $level (spread 95y)", s"date_trunc('$level', $spread95y)")
+          }
           val dateExpr = "cast(timestamp_seconds(id) as date)"
           Seq("year", "yyyy", "yy", "mon", "month", "mm").foreach { level =>
             run(N, s"trunc $level", s"trunc($dateExpr, '$level')")


### PR DESCRIPTION
### What changes were proposed in this pull request?

`date_trunc` (`TruncTimestamp`) resolves the session zone offset for each row via `ZoneRules.getOffset(Instant)` -- an allocating binary search over the zone's transition history -- and for non-fixed-offset zones it does so twice per row (the input instant, and the candidate truncated instant used by the DST-equality guard from SPARK-56663 / SPARK-56769). When the guard rejects the candidate, the fallback additionally re-derives the result from scratch through `ZonedDateTime`.

This PR removes that per-row overhead with three cooperating pieces:

1. **A per-task `ZoneOffsetCache`** holding the most-recently-used constant-offset window `[lo, hi) -> offset` in plain fields, created as codegen mutable state and threaded into `DateTimeUtils.truncTimestamp`.

2. **A shared per-JVM `ZoneTransitionTable`**: each zone's transitions are materialized once into primitive arrays (sorted transition epoch-seconds, and the offset in effect on each interval) and shared read-only across tasks. A cache miss is a single allocation-free binary search over those arrays: cheaper than a bare `getOffset`. Instants outside the materialized range (before 1600 or past 2200) are resolved through `ZoneRules` on both edges.

3. **Truncated-day reuse on the DST-cross fallback**: when the guard does fall back, the date levels (WEEK/MONTH/QUARTER/YEAR) map the already-computed truncated local day back through `daysToMicros` instead of re-deriving it via a second `ZonedDateTime`.

On top of these, it also fixes a SPARK-56769 regression:

4. **Deterministic date-level truncation at DST fall-back overlaps (SPARK-57769)**: when the truncated period-start midnight falls in a fall-back overlap (the local midnight occurs twice), the fast path used to return the later of the two instants while the reference slow path picks the earlier, so `date_trunc` was not a deterministic function of the period. Examples: `Asia/Tokyo` 1888 (YEAR), `Europe/Berlin` 1916 Q4 (QUARTER), `America/Havana` 2015-11 (MONTH). The date-level DST-cross guard now also detects this case and routes it to the fallback in (3).

### Why are the changes needed?

The session time zone is constant for a query and a zone's offset is piecewise-constant between DST/historical transitions, so re-resolving it per row is redundant work on a hot path. Analytic data is typically temporally clustered (time series, date-partitioned tables, post-sort), which the MRU window serves in two comparisons; the transition table keeps even the adversarial orderings ahead of the uncached path.

`DateTimeBenchmark` Truncation, whole-stage codegen on, session zone `America/Los_Angeles`, N=10M, OpenJDK 17 on a 12th Gen Intel i7-1260P, ns/row (lower is better). `clustered` is sequential input; `shuffled 2y` is a random order over a bounded ~2-year span (e.g. after a shuffle on a non-time key); `spread 95y` is uniform over ~95 years (adversarial, no window reuse):

| level | input | before PR | this PR | speedup |
|-------|-------|----------:|--------:|--------:|
| YEAR    | clustered   |  99.1 |  53.5 | 1.9x |
| YEAR    | shuffled 2y | 248.1 | 115.3 | 2.2x |
| YEAR    | spread 95y  | 268.9 | 217.4 | 1.2x |
| QUARTER | clustered   | 112.5 |  69.2 | 1.6x |
| QUARTER | shuffled 2y | 213.6 | 114.5 | 1.9x |
| QUARTER | spread 95y  | 233.5 | 172.9 | 1.4x |
| MONTH   | clustered   |  95.7 |  52.9 | 1.8x |
| MONTH   | shuffled 2y | 169.8 |  82.0 | 2.1x |
| MONTH   | spread 95y  | 150.0 |  93.9 | 1.6x |
| WEEK    | clustered   |  77.0 |  39.1 | 2.0x |
| WEEK    | shuffled 2y | 131.3 |  50.6 | 2.6x |
| WEEK    | spread 95y  | 113.5 |  62.7 | 1.8x |
| DAY     | clustered   |  65.9 |  32.8 | 2.0x |
| DAY     | shuffled 2y | 115.4 |  45.0 | 2.6x |
| DAY     | spread 95y  | 102.4 |  56.9 | 1.8x |

### Does this PR introduce _any_ user-facing change?

Yes, this also fixes a bug SPARK-57769 (see (4) of "What changes were proposed in this pull request?" section for more details).

### How was this patch tested?

- New `ZoneOffsetCache` unit tests: within-window reuse, a lookup straddling a transition, a lookup exactly on a transition instant, and a fixed-offset zone.
- New differential test: `ZoneOffsetCache` offsets vs `ZoneRules.getOffset` across 10 zones and thousands of instants (on transitions, +/-1s, on both sides of the materialized table -- pre-1600 and beyond 2200 -- and a pseudo-random spread).
- New end-to-end differential test: `truncTimestamp` vs an independent `java.time` truncation oracle across 8 DST zones and all levels, concentrated on transition boundaries including fall-back overlaps.
- Date-level truncation onto a fall-back overlap picks the earlier instant, at the `DateTimeUtils` level (Tokyo 1888 YEAR, Havana 2015 MONTH, Berlin 1916 QUARTER, Jerusalem 2001 WEEK; inputs on both sides of the transition) and at the expression level via `checkEvaluation` (interpreted + codegen, locking the per-task cache codegen wiring).
- Existing `DateTimeUtilsSuite` and `DateExpressionsSuite` pass.
- The fallback-reuse equivalence was additionally verified with a one-off sweep over all 555 non-fixed TZDB zones (transition-adjacent and random instants; 1.28M guard-firing rows) against the previous fallback expression, with zero mismatches.
- Added `date_trunc` benchmark cases for the shuffled/spread access patterns; benchmark results regenerated via the GitHub Actions workflow (JDK 17/21/25).

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with Claude Code.
