### PR TITLE
[SPARK-57745][SQL] Assign named error class for unsupported datatype

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -11611,11 +11611,6 @@
       "Dictionary encoding does not support String"
     ]
   },
-  "_LEGACY_ERROR_TEMP_3192" : {
-    "message" : [
-      "Datatype not supported <dt>"
-    ]
-  },
   "_LEGACY_ERROR_TEMP_3198" : {
     "message" : [
       "Cannot grow BufferHolder by size <neededSize> because the size is negative"

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.types.*;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.sql.execution.RowToColumnConverter;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarArray;
@@ -237,7 +238,7 @@ public class ColumnVectorUtils {
         dst.appendLong(DateTimeUtils.localDateTimeToMicros((LocalDateTime) o));
       } else {
         throw new SparkUnsupportedOperationException(
-          "_LEGACY_ERROR_TEMP_3192", Map.of("dt", t.toString()));
+          "UNSUPPORTED_DATATYPE", Map.of("typeName", QueryExecutionErrors.toSQLType(t)));
       }
     }
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -234,7 +235,7 @@ public final class MutableColumnarRow extends InternalRow {
       return getTimestampLTZNanos(ordinal);
     } else {
       throw new SparkUnsupportedOperationException(
-        "_LEGACY_ERROR_TEMP_3192", Map.of("dt", dataType.toString()));
+        "UNSUPPORTED_DATATYPE", Map.of("typeName", QueryExecutionErrors.toSQLType(dataType)));
     }
   }
 
@@ -267,7 +268,7 @@ public final class MutableColumnarRow extends InternalRow {
         setTimestampLTZNanos(ordinal, (TimestampNanosVal) value);
       } else {
         throw new SparkUnsupportedOperationException(
-          "_LEGACY_ERROR_TEMP_3192", Map.of("dt", dt.toString()));
+          "UNSUPPORTED_DATATYPE", Map.of("typeName", QueryExecutionErrors.toSQLType(dt)));
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.errors
 
 import java.io.{File, IOException}
+import java.lang.reflect.InvocationTargetException
 import java.net.{URI, URL}
 import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, PreparedStatement, ResultSet, ResultSetMetaData}
 import java.time.LocalDateTime
@@ -48,15 +49,32 @@ import org.apache.spark.sql.execution.datasources.orc.OrcTest
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.execution.streaming.checkpointing.FileSystemBasedCheckpointFileManager
-import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
+import org.apache.spark.sql.execution.vectorized.{
+  ColumnVectorUtils,
+  ConstantColumnVector,
+  MutableColumnarRow,
+  OnHeapColumnVector,
+  WritableColumnVector}
 import org.apache.spark.sql.functions.{lit, lower, struct, sum, udf}
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy.EXCEPTION
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, DecimalType, IntegerType, LongType, MetadataBuilder, StructField, StructType, TimestampNTZNanosType}
+import org.apache.spark.sql.types.{
+  ArrayType,
+  BooleanType,
+  DataType,
+  DecimalType,
+  IntegerType,
+  LongType,
+  MetadataBuilder,
+  ObjectType,
+  StructField,
+  StructType,
+  TimestampNTZNanosType}
 import org.apache.spark.sql.vectorized.ColumnarArray
+import org.apache.spark.sql.vectorized.ColumnVector
 import org.apache.spark.unsafe.array.ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils
@@ -867,6 +885,63 @@ class QueryExecutionErrorsSuite
           "StructType()[1.1] failure: 'TimestampType' expected but 'S' found\n\nStructType()\n^"
       ),
       sqlState = "0A000")
+  }
+
+  test("SPARK-57745: unsupported datatype in ColumnVectorUtils.appendValue") {
+    val objectType = ObjectType(classOf[java.lang.Integer])
+    val column = new OnHeapColumnVector(1, IntegerType)
+    try {
+      val appendValue = classOf[ColumnVectorUtils].getDeclaredMethod(
+        "appendValue",
+        classOf[WritableColumnVector],
+        classOf[DataType],
+        classOf[Object])
+      appendValue.setAccessible(true)
+
+      checkError(
+        exception = intercept[SparkUnsupportedOperationException] {
+          try {
+            appendValue.invoke(null, column, objectType, Integer.valueOf(1))
+          } catch {
+            case e: InvocationTargetException => throw e.getCause
+          }
+        },
+        condition = "UNSUPPORTED_DATATYPE",
+        parameters = Map("typeName" -> toSQLType(objectType)),
+        sqlState = "0A000")
+    } finally {
+      column.close()
+    }
+  }
+
+  test("SPARK-57745: unsupported datatype in MutableColumnarRow.get and update") {
+    val objectType = ObjectType(classOf[java.lang.Integer])
+    val column = new OnHeapColumnVector(1, IntegerType)
+    try {
+      val dataTypeField = classOf[ColumnVector].getDeclaredField("type")
+      dataTypeField.setAccessible(true)
+      dataTypeField.set(column, objectType)
+
+      val row = new MutableColumnarRow(Array[WritableColumnVector](column))
+
+      checkError(
+        exception = intercept[SparkUnsupportedOperationException] {
+          row.get(0, objectType)
+        },
+        condition = "UNSUPPORTED_DATATYPE",
+        parameters = Map("typeName" -> toSQLType(objectType)),
+        sqlState = "0A000")
+
+      checkError(
+        exception = intercept[SparkUnsupportedOperationException] {
+          row.update(0, Integer.valueOf(1))
+        },
+        condition = "UNSUPPORTED_DATATYPE",
+        parameters = Map("typeName" -> toSQLType(objectType)),
+        sqlState = "0A000")
+    } finally {
+      column.close()
+    }
   }
 
   test("RENAME_SRC_PATH_NOT_FOUND: rename the file which source path does not exist") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the legacy error class `_LEGACY_ERROR_TEMP_3192` with the existing named error condition `UNSUPPORTED_DATATYPE` in vectorized row/column conversion paths. It also removes the legacy error condition entry and adds regression coverage for the migrated error class.

### Why are the changes needed?

`_LEGACY_ERROR_TEMP_3192` is one of the temporary legacy error classes tracked by SPARK-57745. Reusing `UNSUPPORTED_DATATYPE` gives this unsupported datatype path a stable named error condition and SQLSTATE.

### Does this PR introduce any user-facing change?

Yes, on the `SparkThrowable` surface for these unsupported datatype errors. The error class changes from `_LEGACY_ERROR_TEMP_3192` to `UNSUPPORTED_DATATYPE`, the SQLSTATE changes from absent to `0A000`, and the message now uses the standard `UNSUPPORTED_DATATYPE` text with SQL-formatted type names.

### How was this patch tested?

Ran:

`./build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite -- -z SPARK-57745"`

Also verified the error condition JSON still parses and no `_LEGACY_ERROR_TEMP_3192` references remain in the touched files.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex

### License

This contribution is my original work and I license it to the project under the project's open source license.