### PR TITLE
[SPARK-57749][SQL][TESTS] Remove midnight-sensitive inline-table TIME -> TIMESTAMP_NTZ/LTZ golden cases

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cast.sql.out
@@ -1882,12 +1882,6 @@ Project [cast(cast(null as timestamp_ntz(9)) as time(6)) AS CAST(CAST(NULL AS TI
 
 
 -- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_NTZ)) t(x)
--- !query analysis
-[Analyzer test output redacted due to nondeterminism]
-
-
--- !query
 SELECT CAST(x AS TIME(6)) FROM VALUES (CAST(TIME'12:34:56.789012' AS TIMESTAMP_NTZ)) t(x)
 -- !query analysis
 Project [cast(x#x as time(6)) AS x#x]
@@ -2126,12 +2120,6 @@ SELECT CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6))
 -- !query analysis
 Project [cast(cast(null as timestamp_ltz(9)) as time(6)) AS CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6))#x]
 +- OneRowRelation
-
-
--- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_LTZ)) t(x)
--- !query analysis
-[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/cast.sql.out
@@ -1729,12 +1729,6 @@ Project [cast(cast(null as timestamp_ntz(9)) as time(6)) AS CAST(CAST(NULL AS TI
 
 
 -- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_NTZ)) t(x)
--- !query analysis
-[Analyzer test output redacted due to nondeterminism]
-
-
--- !query
 SELECT CAST(x AS TIME(6)) FROM VALUES (CAST(TIME'12:34:56.789012' AS TIMESTAMP_NTZ)) t(x)
 -- !query analysis
 Project [cast(x#x as time(6)) AS x#x]
@@ -1973,12 +1967,6 @@ SELECT CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6))
 -- !query analysis
 Project [cast(cast(null as timestamp_ltz(9)) as time(6)) AS CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6))#x]
 +- OneRowRelation
-
-
--- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_LTZ)) t(x)
--- !query analysis
-[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/cast.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cast.sql
@@ -360,10 +360,12 @@ SELECT CAST(CAST(NULL AS TIME) AS TIMESTAMP_NTZ(9));
 SELECT CAST(CAST(NULL AS TIMESTAMP_NTZ) AS TIME(6));
 SELECT CAST(CAST(NULL AS TIMESTAMP_NTZ(9)) AS TIME(6));
 
--- SPARK-57618: inside an inline table the TIME -> TIMESTAMP_NTZ cast is foldable and carries no
--- CURRENT_LIKE pattern, so it is early-evaluated before ComputeCurrentTime. Coverage stays
--- deterministic: the date anchor still equals current_date() and the value round-trips back to TIME.
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_NTZ)) t(x);
+-- SPARK-57749: inside an inline table the TIME -> TIMESTAMP_NTZ cast is foldable and carries no
+-- CURRENT_LIKE pattern, so it is early-evaluated at analysis time and is NOT stabilized by
+-- ComputeCurrentTime. Its date anchor is LocalDate.now() at analysis (not necessarily
+-- current_date()), so it is intentionally not compared against current_date() here -- that would be
+-- midnight-sensitive. Coverage stays deterministic via the round-trip back to TIME: the date
+-- cancels, so only the time-of-day is asserted.
 SELECT CAST(x AS TIME(6)) FROM VALUES (CAST(TIME'12:34:56.789012' AS TIMESTAMP_NTZ)) t(x);
 SELECT CAST(x AS TIME(9)) FROM VALUES (CAST(TIME'12:34:56.789012345' AS TIMESTAMP_NTZ(9))) t(x);
 
@@ -409,10 +411,12 @@ SELECT CAST(CAST(NULL AS TIME) AS TIMESTAMP_LTZ(9));
 SELECT CAST(CAST(NULL AS TIMESTAMP_LTZ) AS TIME(6));
 SELECT CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6));
 
--- SPARK-57660: inside an inline table the TIME -> TIMESTAMP_LTZ cast is foldable and carries no
--- CURRENT_LIKE pattern, so it is early-evaluated before ComputeCurrentTime. Coverage stays
--- deterministic: the date anchor still equals current_date() and the value round-trips back to TIME.
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_LTZ)) t(x);
+-- SPARK-57749: inside an inline table the TIME -> TIMESTAMP_LTZ cast is foldable and carries no
+-- CURRENT_LIKE pattern, so it is early-evaluated at analysis time and is NOT stabilized by
+-- ComputeCurrentTime. Its date anchor is LocalDate.now() at analysis (not necessarily
+-- current_date()), so it is intentionally not compared against current_date() here -- that would be
+-- midnight-sensitive. Coverage stays deterministic via the round-trip back to TIME: the date
+-- cancels, so only the time-of-day is asserted.
 SELECT CAST(x AS TIME(6)) FROM VALUES (CAST(TIME'12:34:56.789012' AS TIMESTAMP_LTZ)) t(x);
 SELECT CAST(x AS TIME(9)) FROM VALUES (CAST(TIME'12:34:56.789012345' AS TIMESTAMP_LTZ(9))) t(x);
 

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -3042,14 +3042,6 @@ NULL
 
 
 -- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_NTZ)) t(x)
--- !query schema
-struct<(CAST(x AS DATE) = current_date()):boolean>
--- !query output
-true
-
-
--- !query
 SELECT CAST(x AS TIME(6)) FROM VALUES (CAST(TIME'12:34:56.789012' AS TIMESTAMP_NTZ)) t(x)
 -- !query schema
 struct<x:time(6)>
@@ -3322,14 +3314,6 @@ SELECT CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6))
 struct<CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6)):time(6)>
 -- !query output
 NULL
-
-
--- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_LTZ)) t(x)
--- !query schema
-struct<(CAST(x AS DATE) = current_date()):boolean>
--- !query output
-true
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/cast.sql.out
@@ -2042,14 +2042,6 @@ NULL
 
 
 -- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_NTZ)) t(x)
--- !query schema
-struct<(CAST(x AS DATE) = current_date()):boolean>
--- !query output
-true
-
-
--- !query
 SELECT CAST(x AS TIME(6)) FROM VALUES (CAST(TIME'12:34:56.789012' AS TIMESTAMP_NTZ)) t(x)
 -- !query schema
 struct<x:time(6)>
@@ -2322,14 +2314,6 @@ SELECT CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6))
 struct<CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS TIME(6)):time(6)>
 -- !query output
 NULL
-
-
--- !query
-SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_LTZ)) t(x)
--- !query schema
-struct<(CAST(x AS DATE) = current_date()):boolean>
--- !query output
-true
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove two midnight-sensitive golden cases from `cast.sql` (and the imported `nonansi/cast.sql`):

```sql
SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_NTZ)) t(x);
SELECT CAST(x AS DATE) = current_date() FROM VALUES (CAST(TIME'12:34:56' AS TIMESTAMP_LTZ)) t(x);
```

added by SPARK-57618 (NTZ) and SPARK-57660 (LTZ). The comments are corrected and the golden files regenerated. The existing deterministic round-trip rows (`CAST(x AS TIME(6))` / `CAST(x AS TIME(9))`) are kept, so the inline-table early-evaluation path stays covered.

### Why are the changes needed?

These rows assert `true` but can flip to `false` across a midnight boundary. An inline-table row that is foldable and carries no `CURRENT_LIKE` pattern is early-evaluated at analysis time by `ResolveInlineTables` (`EvaluateUnresolvedInlineTable.earlyEvalIfPossible` -> `EvalInlineTables.eval`), which runs the interpreted cast's `currentDate(zoneId)` = `LocalDate.now(zoneId)`. The sibling `current_date()` keeps its `CURRENT_LIKE` bit, survives to the optimizer, and is stabilized separately by `ComputeCurrentTime` from a different clock read. If analysis finishes just before midnight and optimization starts just after, `x`'s date is yesterday while `current_date()` is today, so the row returns `false` and the golden fails.

The inline-table cast never reaches `ComputeCurrentTime` (the analyzer consumes it first), so it cannot be stabilized; comparing it against `current_date()` is inherently non-deterministic. The non-inline-table `CAST(CAST(TIME ... AS TIMESTAMP_NTZ) AS DATE) = current_date()` cases are unaffected — those go through `ComputeCurrentTime` and share the same date literal.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Regenerated `cast.sql` / `nonansi/cast.sql` golden files and ran `SQLQueryTestSuite -- -z cast.sql` (6 tests pass) in normal mode.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.8)