### PR TITLE
[SPARK-57751][INFRA] Fix `spark-rm` Dockerfile comments to Spark 5

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 
-# Spark master (4.2-SNAPSHOT) release image
+# Spark master (5.0.0-SNAPSHOT) release image
 # Extends the base image with:
 # - Java 17
 # - Python 3.10 with required packages
 
 FROM spark-rm-base:latest
 
-# Install Java 17 for Spark 4.x
+# Install Java 17 for Spark 5.x
 RUN apt-get update && apt-get install -y \
     openjdk-17-jdk-headless \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the stale Spark 4 references in the `dev/create-release/spark-rm/Dockerfile` comments to Spark 5.

### Why are the changes needed?

The Spark master branch version is now `5.0.0-SNAPSHOT`.

- apache/spark#55703

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A. Comment-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8