### PR TITLE
[SPARK-57755][INFRA] Replace deprecated `apt-key` with `/etc/apt/trusted.gpg.d` keyring file

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile.base
+++ b/dev/create-release/spark-rm/Dockerfile.base
@@ -87,7 +87,7 @@ RUN apt-get update && apt-get install -y \
 # Set up R CRAN repository for latest R packages
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list && \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
-    gpg -a --export E084DAB9 | apt-key add - && \
+    gpg -a --export E084DAB9 > /etc/apt/trusted.gpg.d/cran.asc && \
     add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/'
 
 # Install R packages (same versions across all branches)

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list
 RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
-RUN gpg -a --export E084DAB9 | apt-key add -
+RUN gpg -a --export E084DAB9 > /etc/apt/trusted.gpg.d/cran.asc
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/'
 
 # See more in SPARK-39959, roxygen2 < 7.2.1

--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list
 RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
-RUN gpg -a --export E084DAB9 | apt-key add -
+RUN gpg -a --export E084DAB9 > /etc/apt/trusted.gpg.d/cran.asc
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/'
 
 # See more in SPARK-39959, roxygen2 < 7.2.1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the deprecated `apt-key add` with a keyring file under
`/etc/apt/trusted.gpg.d/` in three dev Dockerfiles
(`dev/create-release/spark-rm/Dockerfile.base`, `dev/infra/Dockerfile`,
`dev/spark-test-image/sparkr/Dockerfile`):

```diff
-RUN gpg -a --export E084DAB9 | apt-key add -
+RUN gpg -a --export E084DAB9 > /etc/apt/trusted.gpg.d/cran.asc
```

### Why are the changes needed?

`apt-key` is deprecated at `Ubuntu 20.10` over 5 years ago and removed at `Ubuntu 26.04` already. The official manpage recommends shipping keyring files in `/etc/apt/trusted.gpg.d/` directly instead.

- https://manpages.debian.org/testing/apt/apt-key.8.en.html
- https://manpages.ubuntu.com/manpages/jammy/en/man8/apt-key.8.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8