### PR TITLE
[SPARK-57765][R] Support Java 25 in SparkR

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
 License: Apache License (== 2.0)
 URL: https://www.apache.org https://spark.apache.org
 BugReports: https://spark.apache.org/contributing.html
-SystemRequirements: Java (>= 17, < 22)
+SystemRequirements: Java (>= 17, < 26)
 Depends:
     R (>= 3.5),
     methods


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `SparkR` by bumping the `SystemRequirements` upper bound in `R/pkg/DESCRIPTION` from `< 22` to `< 26`.

- [SPARK-51167 Build and Run Spark on Java 25](https://issues.apache.org/jira/browse/SPARK-51167)

### Why are the changes needed?

Like the following, Spark already supports Java 17/21/25, but `SparkR`'s `checkJavaVersion()` rejects Java `>= 22`. This aligns SparkR with the rest of Spark.

- https://github.com/apache/spark/actions/workflows/build_branch42_java25.yml
  - https://github.com/apache/spark/actions/runs/28284378586/job/83806614082

### Does this PR introduce _any_ user-facing change?

No change on the existing SparkR behavior. This will allow to install on Java 25 additionally.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8