### PR TITLE
[SPARK-57761][SQL] Add missing error class INVALID_XML_SCHEMA_MAP_TYPE

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5447,6 +5447,12 @@
     },
     "sqlState" : "42000"
   },
+  "INVALID_XML_SCHEMA_MAP_TYPE" : {
+    "message" : [
+      "Input schema <xmlSchema> can only contain STRING as a key type for a MAP."
+    ],
+    "sqlState" : "22032"
+  },
   "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR" : {
     "message" : [
       "JDBC external engine syntax error. The error was caused by the query <jdbcQuery>. <externalEngineError>."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5451,7 +5451,7 @@
     "message" : [
       "Input schema <xmlSchema> can only contain STRING as a key type for a MAP."
     ],
-    "sqlState" : "22032"
+    "sqlState" : "2200N"
   },
   "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR" : {
     "message" : [

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -423,6 +423,19 @@ class QueryCompilationErrorsSuite
     )
   }
 
+  test("INVALID_XML_SCHEMA_MAP_TYPE: only STRING as a key type for MAP") {
+    val schema = StructType(
+      StructField("map", MapType(IntegerType, IntegerType, true), false) :: Nil)
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.read.schema(schema).xml(spark.emptyDataset[String])
+      },
+      condition = "INVALID_XML_SCHEMA_MAP_TYPE",
+      parameters = Map("xmlSchema" -> "\"STRUCT<map: MAP<INT, INT> NOT NULL>\"")
+    )
+  }
+
   test("UNRESOLVED_MAP_KEY: string type literal should be quoted") {
     checkAnswer(sql("select m['a'] from (select map('a', 'b') as m, 'aa' as aa)"), Row("b"))
     val query = "select m[a] from (select map('a', 'b') as m, 'aa' as aa)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
`QueryCompilationErrors.invalidXmlSchema` throws the `INVALID_XML_SCHEMA_MAP_TYPE` error class (raised when reading XML with a user-specified schema that contains a MAP with a non-STRING key type), but the error class was never registered in `error-conditions.json`. This registers the error condition so it resolves correctly through the error framework, and adds a test.

### Why are the changes needed?
The error class was used but not declared. Hitting this path raised `INTERNAL_ERROR` ("Cannot find main error class 'INVALID_XML_SCHEMA_MAP_TYPE'") instead of the intended error.

### Does this PR introduce _any_ user-facing change?
No. Previously this code path raised an `INTERNAL_ERROR` because the error class was unregistered; now the intended error message is produced.

### How was this patch tested?
Added a unit test in `QueryCompilationErrorsSuite`. Also ran `SparkThrowableSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor (Claude Opus 4.8)