### PR TITLE
[SPARK-57762][SQL] Add missing error class COLUMN_IS_NOT_VARIANT_TYPE

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1064,6 +1064,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "COLUMN_IS_NOT_VARIANT_TYPE" : {
+    "message" : [
+      "The semi-structured extraction operator (`:`) can only be applied to a column of the VARIANT type."
+    ],
+    "sqlState" : "42K09"
+  },
   "COLUMN_NOT_DEFINED_IN_TABLE" : {
     "message" : [
       "<colType> column <colName> is not defined in table <tableName>, defined table columns are: <tableCols>."

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/type-coercion-edge-cases.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/type-coercion-edge-cases.sql.out
@@ -24,13 +24,10 @@ Project [col2#x[cast(field as bigint)] AS field#x]
 -- !query
 SELECT NULL:a AS b
 -- !query analysis
-org.apache.spark.SparkException
+org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "Cannot find main error class 'COLUMN_IS_NOT_VARIANT_TYPE'"
-  }
+  "errorClass" : "COLUMN_IS_NOT_VARIANT_TYPE",
+  "sqlState" : "42K09"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/type-coercion-edge-cases.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/type-coercion-edge-cases.sql.out
@@ -45,13 +45,10 @@ SELECT NULL:a AS b
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "Cannot find main error class 'COLUMN_IS_NOT_VARIANT_TYPE'"
-  }
+  "errorClass" : "COLUMN_IS_NOT_VARIANT_TYPE",
+  "sqlState" : "42K09"
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -413,6 +413,16 @@ class QueryCompilationErrorsSuite
     )
   }
 
+  test("COLUMN_IS_NOT_VARIANT_TYPE: semi-structured extraction on non-variant column") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql("SELECT id:field FROM range(1)")
+      },
+      condition = "COLUMN_IS_NOT_VARIANT_TYPE",
+      parameters = Map.empty[String, String]
+    )
+  }
+
   test("UNRESOLVED_MAP_KEY: string type literal should be quoted") {
     checkAnswer(sql("select m['a'] from (select map('a', 'b') as m, 'aa' as aa)"), Row("b"))
     val query = "select m[a] from (select map('a', 'b') as m, 'aa' as aa)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
The semi-structured extraction operator (`:`) throws the `COLUMN_IS_NOT_VARIANT_TYPE` error class (from `ExtractSemiStructuredFields` and `SemiStructuredExtractResolver`) when applied to a column that is not of the VARIANT type, but the error class was never registered in `error-conditions.json`. This registers the error condition so it resolves correctly through the error framework, and adds a test.

### Why are the changes needed?
The error class was used but not declared. Hitting this path raised `INTERNAL_ERROR` ("Cannot find main error class 'COLUMN_IS_NOT_VARIANT_TYPE'") instead of the intended error.

### Does this PR introduce _any_ user-facing change?
No. Previously this code path raised an `INTERNAL_ERROR` because the error class was unregistered; now the intended error message is produced.

### How was this patch tested?
Added a unit test in `QueryCompilationErrorsSuite`. Also ran `SparkThrowableSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor (Claude Opus 4.8)