### PR TITLE
[SPARK-57764][SDP] Add missing error class DUPLICATE_GRAPH_ELEMENT

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2255,6 +2255,12 @@
     ],
     "sqlState" : "42710"
   },
+  "DUPLICATE_GRAPH_ELEMENT" : {
+    "message" : [
+      "Found duplicate <graphElementType> '<graphElementName>'."
+    ],
+    "sqlState" : "42710"
+  },
   "DUPLICATE_KEY" : {
     "message" : [
       "Found duplicate keys <keyColumn>."

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -764,4 +764,15 @@ class ConnectInvalidPipelineSuite extends PipelineTest with SharedSparkSession {
       )
     )
   }
+
+  test("DUPLICATE_GRAPH_ELEMENT: duplicate graph element identifiers") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        DataflowGraph.mapUnique(Seq("a", "a"), "view")(identity)
+      },
+      condition = "DUPLICATE_GRAPH_ELEMENT",
+      parameters = Map(
+        "graphElementType" -> "view",
+        "graphElementName" -> "a"))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`DataflowGraph.mapUnique` throws the `DUPLICATE_GRAPH_ELEMENT` error class when a graph contains duplicate element identifiers (outputs, tables, sinks, views), but the error class was never registered in `error-conditions.json`. This registers the error condition so it resolves correctly through the error framework, and adds a test.

### Why are the changes needed?
The error class was used but not declared. Hitting this path raised `INTERNAL_ERROR` ("Cannot find main error class 'DUPLICATE_GRAPH_ELEMENT'") instead of the intended error.

### Does this PR introduce _any_ user-facing change?
No. Previously this code path raised an `INTERNAL_ERROR` because the error class was unregistered; now the intended error message is produced.

### How was this patch tested?
Added a unit test in `ConnectInvalidPipelineSuite`. Also ran `SparkThrowableSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor (Claude Opus 4.8)