### PR TITLE
[SPARK-57767][R] Drop R 3.x Support

### DIFF
--- a/R/WINDOWS.md
+++ b/R/WINDOWS.md
@@ -22,7 +22,7 @@ To build SparkR on Windows, the following steps are required
 
 1. Make sure `bash` is available and in `PATH` if you already have a built-in `bash` on Windows. If you do not have, install [Cygwin](https://www.cygwin.com/).
 
-2. Install R (>= 3.5) and [Rtools](https://cloud.r-project.org/bin/windows/Rtools/). Make sure to
+2. Install R (>= 4.0) and [Rtools](https://cloud.r-project.org/bin/windows/Rtools/). Make sure to
 include Rtools and R in `PATH`.
 
 3. Install JDK that SparkR supports (see `R/pkg/DESCRIPTION`), and set `JAVA_HOME` in the system environment variables.

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -12,7 +12,7 @@ URL: https://www.apache.org https://spark.apache.org
 BugReports: https://spark.apache.org/contributing.html
 SystemRequirements: Java (>= 17, < 22)
 Depends:
-    R (>= 3.5),
+    R (>= 4.0),
     methods
 Suggests:
     knitr,

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ source, visit [Building Spark](building-spark.html).
 
 Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS), and it should run on any platform that runs a supported version of Java. This should include JVMs on x86_64 and ARM64. It's easy to run locally on one machine --- all you need is to have `java` installed on your system `PATH`, or the `JAVA_HOME` environment variable pointing to a Java installation.
 
-Spark runs on Java 17/21/25, Scala 2.13, Python 3.11+, and R 3.5+ (Deprecated).
+Spark runs on Java 17/21/25, Scala 2.13, Python 3.11+, and R 4.0+ (Deprecated).
 Java 25 prior to version 25.0.3 support is deprecated as of Spark 4.2.0.
 When using the Scala API, it is necessary for applications to use the same version of Scala that Spark was compiled for. Since Spark 4.0.0, it's Scala 2.13.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR raises SparkR's minimum supported R version `4.0`.

### Why are the changes needed?

R 3.6.3 was released on 2020-02-29 before Apache Spark 3.0.0 was released on 2020-06-18. Technically, R 3.x is already deprecated and is no longer tested even in the Apache SparkR 3.5 CI -- SparkR is built and tested with R `4.x` only. We had better narrow down the scope because we don't test it for multi years.

https://github.com/apache/spark/blob/be6e0a417126b67fc42353256e8252a97d6dded6/dev/spark-test-image/sparkr/Dockerfile#L68

https://github.com/apache/spark/blob/be6e0a417126b67fc42353256e8252a97d6dded6/dev/create-release/spark-rm/Dockerfile.base#L88

### Does this PR introduce _any_ user-facing change?

Yes, but `SparkR` itself is a deprecated already. This is only the removal of un-tested version to narrow down the scope.

### How was this patch tested?

Pass the CIs although the existing SparkR CI already runs on R `4.x`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8