### PR TITLE
[SPARK-57768][K8S][R][DOCS] Fix R version comment to 4.5.2 in R Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -30,7 +30,7 @@ USER 0
 
 RUN mkdir ${SPARK_HOME}/R
 
-# Install R 4.1.2 (http://cloud.r-project.org/bin/linux/debian/)
+# Install R 4.5.2
 RUN \
   apt-get update && \
   apt install -y r-base r-base-dev && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the R version comment in the Kubernetes R binding `Dockerfile` from `4.1.2` to `4.5.2`, and removes the stale CRAN Debian link from the comment.

### Why are the changes needed?

The base image (`eclipse-temurin:25-jre`) is now Ubuntu 26.04 LTS (resolute), whose default `r-base` is `4.5.2`. The `apt install` step already installs this version, but the comment still said `4.1.2`. The CRAN Debian link no longer matches how R is installed (from the Ubuntu archive), so it is removed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
$ docker run --rm eclipse-temurin:25-jre bash -c '. /etc/os-release; echo "$VERSION_CODENAME"; apt-get update -qq; apt-cache policy r-base | grep Candidate'
resolute
  Candidate: 4.5.2-1ubuntu2
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8