### PR TITLE
[SPARK-57770][INFRA][R] Upgrade `r-lib/actions/setup-r` to run on Node.js 24

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -52,7 +52,7 @@ jobs:
         distribution: zulu
         java-version: 17
     - name: Install R 4.4.3
-      uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+      uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
       with:
         r-version: 4.4.3
     - name: Install R dependencies

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -52,7 +52,7 @@ jobs:
         distribution: zulu
         java-version: 17
     - name: Install R 4.4.3
-      uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
       with:
         r-version: 4.4.3
     - name: Install R dependencies


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `r-lib/actions/setup-r` in `build_sparkr_window.yml` from the commit pinned as `6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590` to `d3c5be51b12e724e68f33216ca3c148b66d5f0b6`. Both are tagged `v2`, and the newer one runs on Node.js 24.

### Why are the changes needed?

The old commit targets the deprecated Node.js 20 runtime, which produces a CI warning. See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

- https://github.com/apache/spark/actions/workflows/build_sparkr_window.yml

<img width="751" height="192" alt="Screenshot 2026-06-29 at 20 02 25" src="https://github.com/user-attachments/assets/92dc0ed8-4555-47cb-b840-e48ba2d89721" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. The new commit's `setup-r/action.yml` declares `using: 'node24'`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8