### PR TITLE
[SPARK-57772][INFRA][R] Fix to use `noble-cran40` CRAN repository in SparkR test image

### DIFF
--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -65,10 +65,10 @@ RUN apt-get update && apt-get install -y \
     zstd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list
+RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu noble-cran40/' >> /etc/apt/sources.list
 RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN gpg -a --export E084DAB9 > /etc/apt/trusted.gpg.d/cran.asc
-RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/'
+RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu noble-cran40/'
 
 # See more in SPARK-39959, roxygen2 < 7.2.1
 RUN Rscript -e "install.packages(c('remotes', 'knitr', 'markdown',  \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the CRAN repository codename in the SparkR test image (`jammy-cran40/` -> `noble-cran40/`) to match its base image `ubuntu:noble` (24.04).

https://github.com/apache/spark/blob/e28edaf0480e19abca83cd2b215450b85fdaf438/dev/spark-test-image/sparkr/Dockerfile#L20

https://github.com/apache/spark/blob/e28edaf0480e19abca83cd2b215450b85fdaf438/dev/spark-test-image/sparkr/Dockerfile#L68

### Why are the changes needed?

This mismatch was introduced at
- https://github.com/apache/spark/pull/54221

The CRAN repository codename must match the base OS codename.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8