### PR TITLE
[SPARK-57774][CORE] DriverLogger should not propagate log4j internal exception to caller

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -71,8 +71,8 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
       builder.setBufferedIo(false)
       builder.setConfiguration(config)
       builder.withFileName(localLogFile)
-      // SPARK-57774: Set to true to avoid log4j internal exception (e.g., due to log4j bugs)
-      // propagating to the caller.
+      // SPARK-57774: Set to true to avoid propagating log4j internal exception
+      // (e.g., due to log4j bugs) to the caller.
       builder.setIgnoreExceptions(true)
       builder.setLayout(layout)
       builder.setName(DriverLogger.APPENDER_NAME)

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -71,7 +71,9 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
       builder.setBufferedIo(false)
       builder.setConfiguration(config)
       builder.withFileName(localLogFile)
-      builder.setIgnoreExceptions(false)
+      // SPARK-57774: Set to true to avoid log4j internal exception (e.g., due to log4j bugs)
+      // propagating to the caller.
+      builder.setIgnoreExceptions(true)
       builder.setLayout(layout)
       builder.setName(DriverLogger.APPENDER_NAME)
       builder.build()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Flip the `setIgnoreExceptions` from false to true in `DriverLogger`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

https://logging.apache.org/log4j/2.x/plugin-reference.html

> ignoreExceptions - If "true" (default) exceptions encountered when appending events are logged; otherwise they are propagated to the caller.

The recent log4j 2.25.0 ~ 2.25.3 and 2.26.0 have [known internal bugs](https://github.com/apache/spark/pull/51719#issuecomment-3341344974) and may fail the Spark caller, this has been observed from the GHA several times.

One example https://github.com/apache/spark/actions/runs/27894816608/attempts/1
```
[info] - provider reports error after FS leaves safe mode *** FAILED *** (3 seconds, 25 milliseconds)
[info]   org.apache.logging.log4j.core.appender.AppenderLoggingException: An exception occurred processing Appender _DriverLogAppender
[info]   at org.apache.logging.log4j.core.appender.DefaultErrorHandler.error(DefaultErrorHandler.java:95)
[info]   at org.apache.logging.log4j.core.config.AppenderControl.handleAppenderError(AppenderControl.java:169)
[info]   at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:162)
[info]   at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:133)
[info]   at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:124)
[info]   at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:88)
[info]   at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:711)
[info]   at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:669)
[info]   at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:645)
[info]   at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:589)
[info]   at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:92)
[info]   at org.apache.logging.log4j.core.Logger.log(Logger.java:187)
[info]   at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2970)
[info]   at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2922)
[info]   at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2904)
[info]   at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2648)
[info]   at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:2587)
[info]   at org.apache.logging.slf4j.Log4jLogger.warn(Log4jLogger.java:253)
[info]   at org.apache.spark.internal.Logging.logWarning(Logging.scala:299)
[info]   at org.apache.spark.internal.Logging.logWarning$(Logging.scala:298)
[info]   at org.apache.spark.SparkFunSuite.logWarning(SparkFunSuite.scala:33)
...
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Review and monitor CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
GLM 5.2 is used for issue analysis.