### PR TITLE
[SPARK-57560][SQL][TESTS][FOLLOWUP] Update the Java 21 golden file for TIME try arithmetic tests

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
@@ -168,6 +168,54 @@ struct<try_add(INTERVAL '02' SECOND, TIMESTAMP_NTZ '2021-01-01 00:00:00'):timest
 
 
 -- !query
+SELECT try_add(time'08:00:00', interval 1 hour)
+-- !query schema
+struct<try_add(TIME '08:00:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_add(interval 1 hour, time'08:00:00')
+-- !query schema
+struct<try_add(INTERVAL '01' HOUR, TIME '08:00:00'):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_add(time'23:59:59.999999', interval 1 hour)
+-- !query schema
+struct<try_add(TIME '23:59:59.999999', INTERVAL '01' HOUR):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(time'00:00:00', interval -1 second)
+-- !query schema
+struct<try_add(TIME '00:00:00', INTERVAL '-01' SECOND):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(time'08:30:00', null)
+-- !query schema
+struct<try_add(TIME '08:30:00', NULL):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(null, interval 1 hour)
+-- !query schema
+struct<try_add(NULL, INTERVAL '01' HOUR):interval hour>
+-- !query output
+NULL
+
+
+-- !query
 SELECT try_add(interval 2 year, interval 2 year)
 -- !query schema
 struct<try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR):interval year>
@@ -461,6 +509,62 @@ NULL
 SELECT try_subtract(interval 106751991 day, interval -3 day)
 -- !query schema
 struct<try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY):interval day>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', interval 1 hour)
+-- !query schema
+struct<try_subtract(TIME '10:00:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_subtract(time'00:30:00', interval 1 hour)
+-- !query schema
+struct<try_subtract(TIME '00:30:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'00:00:00', interval 1 second)
+-- !query schema
+struct<try_subtract(TIME '00:00:00', INTERVAL '01' SECOND):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', null)
+-- !query schema
+struct<try_subtract(TIME '10:00:00', NULL):interval hour to second>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', time'08:00:00')
+-- !query schema
+struct<try_subtract(TIME '10:00:00', TIME '08:00:00'):interval hour to second>
+-- !query output
+0 02:00:00.000000000
+
+
+-- !query
+SELECT try_subtract(time'08:00:00.123456', time'10:00:00')
+-- !query schema
+struct<try_subtract(TIME '08:00:00.123456', TIME '10:00:00'):interval hour to second>
+-- !query output
+-0 01:59:59.876544000
+
+
+-- !query
+SELECT try_subtract(null, time'08:00:00')
+-- !query schema
+struct<try_subtract(NULL, TIME '08:00:00'):interval hour to second>
 -- !query output
 NULL
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow-up of #56819, addressing the Java 21/25 build failures reported there.

#56819 added TIME cases to `try_arithmetic.sql` and regenerated the base golden files. However, `nonansi/try_arithmetic.sql.out` has a Java-21-specific variant `nonansi/try_arithmetic.sql.out.java21` (the suite reads it when `Utils.isJavaVersionAtLeast21`, because JDK-4511638 changes the `toString` of `Float`/`Double`). That `.java21` variant was left stale -- it was missing the new TIME rows -- so on Java 21+ the test compared actual output (with TIME rows) against the stale golden file and failed.

This PR adds the new TIME rows to `nonansi/try_arithmetic.sql.out.java21`. The only genuine Java 21 difference in this file remains the `try_divide(1, (2147483647 + 1))` double output:

- Java 8/11/17: `-4.6566128730773926E-10`
- Java 21+: `-4.656612873077393E-10`

The new TIME outputs (time values, NULLs, and day-time intervals) are Java-version stable, so they are identical in the base and `.java21` files. The ANSI `try_arithmetic.sql.out` needs no `.java21` variant because that `try_divide` double query only appears in non-ANSI mode (in ANSI mode the inner `2147483647 + 1` overflows).

### Why are the changes needed?
To fix the Java 21/25 build failures observed after #56819 was merged, e.g.:
- https://github.com/apache/spark/actions/runs/28359601002/job/84013737500
- https://github.com/apache/spark/actions/runs/28406731869/job/84173152434

### Does this PR introduce _any_ user-facing change?
No. Test-only.

### How was this patch tested?
- Verified `nonansi/try_arithmetic.sql.out.java21` differs from the base `nonansi/try_arithmetic.sql.out` by exactly the one `try_divide` double line, consistent with the existing Java 21 golden file convention.
- `build/sbt 'sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z try_arithmetic'`

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor