### PR TITLE
[SPARK-57779][INFRA] Upgrade GitHub Actions artifact actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1629,7 +1629,7 @@ jobs:
       id: download-precompiled
       if: needs.precompile.result == 'success'
       continue-on-error: true
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: spark-compile-${{ inputs.branch }}-${{ github.run_id }}
     - name: Extract precompiled artifact
@@ -1720,7 +1720,7 @@ jobs:
         id: download-precompiled
         if: needs.precompile.result == 'success'
         continue-on-error: true
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: spark-compile-${{ inputs.branch }}-${{ github.run_id }}
       - name: Extract precompiled artifact

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -128,7 +128,7 @@ jobs:
             | tar --null -cf - -T - | zstd -c -T0 > compile-artifact.tar.zst
           ls -lh compile-artifact.tar.zst
       - name: Upload compile artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: spark-compile-${{ inputs.os }}-${{ inputs.branch }}-${{ github.run_id }}
           path: compile-artifact.tar.zst
@@ -245,7 +245,7 @@ jobs:
         id: download-precompiled
         if: needs.precompile.result == 'success'
         continue-on-error: true
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: spark-compile-${{ inputs.os }}-${{ inputs.branch }}-${{ github.run_id }}
       - name: Extract precompiled artifact


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the remaining `actions/upload-artifact` and `actions/download-artifact` pins that were left behind a recent bulk upgrade, so all artifact actions in the workflows are on a single version:

- `actions/upload-artifact@v6` -> `@v7` (`python_hosted_runner_test.yml`)
- `actions/download-artifact@v6` -> `@v8` (`python_hosted_runner_test.yml`, `build_and_test.yml` x2)

After this change there are no `@v6` artifact action pins left in `.github/workflows/`; everything is uniformly `upload-artifact@v7` / `download-artifact@v8`.

### Why are the changes needed?

These four steps (the shared SBT precompile artifact upload/download added in SPARK-56830 / SPARK-57069) were missed when the rest of the workflows were bumped to `upload-artifact@v7` / `download-artifact@v8`. Notably, in `build_and_test.yml` the same `spark-compile-*` artifact is uploaded with `@v7` but downloaded with `@v6`. Aligning the versions keeps the actions consistent and on the current major.

### Does this PR introduce _any_ user-facing change?

No. CI-only change.

### How was this patch tested?

Manual review. Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)