### PR TITLE
[MINOR][CORE] Fix swapped depth/width formulas in CountMinSketch class doc

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
@@ -45,8 +45,8 @@ import java.io.OutputStream;
  * Under the cover, a {@link CountMinSketch} is essentially a two-dimensional {@code long} array
  * with depth {@code d} and width {@code w}, where
  * <ul>
- *   <li>{@code d = ceil(2 / eps)}</li>
- *   <li>{@code w = ceil(-log(1 - confidence) / log(2))}</li>
+ *   <li>{@code w = ceil(2 / eps)}</li>
+ *   <li>{@code d = ceil(-log(1 - confidence) / log(2))}</li>
  * </ul>
  *
  * This implementation is largely based on the {@code CountMinSketch} class from stream-lib.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the class-level Javadoc of `org.apache.spark.util.sketch.CountMinSketch`, which assigned the two table dimensions to the wrong symbols. The doc previously read:

```
d = ceil(2 / eps)
w = ceil(-log(1 - confidence) / log(2))
```

but the implementation (`CountMinSketchImpl`, the `(eps, confidence, seed)` constructor) actually sets:

```java
this.width = (int) Math.ceil(2 / eps);
this.depth = (int) Math.ceil(-Math.log1p(-confidence) / Math.log(2));
```

i.e. `width` is derived from `eps` and `depth` from `confidence` -- the opposite of what the doc stated. The fix swaps the two lines so the doc matches the code:

```
w = ceil(2 / eps)
d = ceil(-log(1 - confidence) / log(2))
```

### Why are the changes needed?

Doc fix

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change; no behavior, serialization, or API impact.

### How was this patch tested?

Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code