### PR TITLE
[SPARK-57786][CORE] Disable Spark History Server log access from UI by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -113,8 +113,12 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
             }
           }
         </a>
-        <p><a href={UIUtils.prependBaseUri(request, "/logPage/?self&logType=out")}>
-          Show server log</a></p>
+        {
+          if (parent.historyServerLogEnabled) {
+            <p><a href={UIUtils.prependBaseUri(request, "/logPage/?self&logType=out")}>
+              Show server log</a></p>
+          } else Seq.empty
+        }
       </div>
     val content =
       <script type="module" src={UIUtils.prependBaseUri(

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -68,6 +68,8 @@ class HistoryServer(
   // How many applications the summary ui displays
   private[history] val maxApplications = conf.get(History.HISTORY_UI_MAX_APPS);
 
+  private[history] val historyServerLogEnabled = conf.get(History.HISTORY_SERVER_UI_LOG_ENABLED)
+
   // application
   private val appCache = new ApplicationCache(this, retainedApplications, new SystemClock())
 
@@ -150,12 +152,14 @@ class HistoryServer(
    */
   def initialize(): Unit = {
     attachPage(new HistoryPage(this))
-    attachPage(new LogPage(conf))
+    if (historyServerLogEnabled) {
+      attachPage(new LogPage(conf))
+      addRenderLogHandler(this, conf)
+    }
 
     attachHandler(ApiRootResource.getServletHandler(this))
 
     addStaticHandler(SparkUI.STATIC_RESOURCE_DIR)
-    addRenderLogHandler(this, conf)
 
     val contextHandler = new ServletContextHandler
     contextHandler.setContextPath(HistoryServer.UI_PATH_PREFIX)

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -148,6 +148,13 @@ private[spark] object History {
     .intConf
     .createWithDefault(18080)
 
+  val HISTORY_SERVER_UI_LOG_ENABLED = ConfigBuilder("spark.history.ui.log.enable")
+    .version("4.2.0")
+    .doc("Specifies whether to enable access to the History Server log in the History " +
+      "Server UI.")
+    .booleanConf
+    .createWithDefault(false)
+
   val FAST_IN_PROGRESS_PARSING =
     ConfigBuilder("spark.history.fs.inProgressOptimization.enabled")
       .doc("Enable optimized handling of in-progress logs. This option may leave finished " +

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerPageSuite.scala
@@ -116,4 +116,16 @@ class HistoryServerPageSuite extends SparkFunSuite with BeforeAndAfter {
       stopHistoryServer()
     }
   }
+
+  test("SPARK-57786: History Server log is inaccessible by default") {
+    startHistoryServer(logDirs.head)
+
+    val (_, htmlOpt, _) = HistoryServerSuite.getContentAndCode(
+      new URI(s"http://$localhost:$port/").toURL)
+    assert(htmlOpt.isDefined && !htmlOpt.get.contains("Show server log"))
+
+    val handlerPaths = server.get.getHandlers.map(_.getContextPath)
+    assert(!handlerPaths.contains("/logPage"))
+    assert(!handlerPaths.contains("/log"))
+  }
 }


### PR DESCRIPTION
What changes were proposed in this pull request?
Server logs may contain sensitive information, so exposing them through the History Server UI by default can be a security risk.
Add the spark.history.ui.log.enable configuration, defaulting to false.

Why are the changes needed?
To improve security.

Does this PR introduce any user-facing change?
No.

How was this patch tested?
Manually and unit test

Was this patch authored or co-authored using generative AI tooling?
No.


