### PR TITLE
[SPARK-57555][FOLLOWUP][SQL] Add TimeType support to PostgresDialect

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -172,6 +172,11 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
     conn.prepareStatement("INSERT INTO test_bit_array VALUES (ARRAY[B'1', B'0'], " +
       "ARRAY[B'00001', B'00010'])").executeUpdate()
 
+    conn.prepareStatement("CREATE TABLE time_array_table (id integer, times time[])").
+      executeUpdate()
+    conn.prepareStatement("INSERT INTO time_array_table VALUES " +
+      "(1, ARRAY[TIME '08:30:00', TIME '17:22:31.123456'])").executeUpdate()
+
     conn.prepareStatement(
       """
         |CREATE TYPE complex AS (
@@ -649,6 +654,74 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
       assert(result.schema("t").dataType.isInstanceOf[TimeType])
       val collected = result.collect().map(_.getAs[java.time.LocalTime](0)).sorted
       assert(collected.toSeq == times.sorted)
+    }
+  }
+
+  test("SPARK-57555: Read time[] array column as ArrayType(TimeType)") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      val df = spark.read.jdbc(jdbcUrl, "time_array_table", new Properties)
+      val schema = df.schema("times")
+      assert(schema.dataType == ArrayType(TimeType(TimeType.DEFAULT_PRECISION), true))
+      val row = df.collect()(0)
+      val times = row.getSeq[java.time.LocalTime](df.schema.fieldIndex("times"))
+      assert(times == Seq(
+        java.time.LocalTime.of(8, 30, 0),
+        java.time.LocalTime.of(17, 22, 31, 123456000)))
+    }
+  }
+
+  test("SPARK-57555: Write TIME preserves precision for p<=6") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      val schema = StructType(Seq(StructField("t", TimeType(3))))
+      val data = Seq(
+        Row(java.time.LocalTime.of(10, 30, 45, 123000000)),
+        Row(java.time.LocalTime.of(22, 15, 0, 456000000))
+      )
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      df.write.jdbc(jdbcUrl, "time_precision_test", new Properties)
+      val result = spark.read.jdbc(jdbcUrl, "time_precision_test", new Properties)
+      assert(result.schema("t").dataType == TimeType(3))
+      val collected = result.collect().map(_.getAs[java.time.LocalTime](0)).sorted
+      assert(collected(0) == java.time.LocalTime.of(10, 30, 45, 123000000))
+      assert(collected(1) == java.time.LocalTime.of(22, 15, 0, 456000000))
+    }
+  }
+
+  test("SPARK-57555: End-to-end TIME type with PostgreSQL") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      // 1. Create and populate a TIME table directly via JDBC
+      val conn = java.sql.DriverManager.getConnection(jdbcUrl)
+      try {
+        conn.prepareStatement(
+          "CREATE TABLE time_e2e (id integer, wake_up time, lunch time(3))").executeUpdate()
+        conn.prepareStatement(
+          "INSERT INTO time_e2e VALUES " +
+            "(1, TIME '06:30:00', TIME '12:00:00.000'), " +
+            "(2, TIME '07:45:30.123456', TIME '13:15:30.500')").executeUpdate()
+      } finally {
+        conn.close()
+      }
+
+      // 2. Read with Spark - verify schema inference
+      val df = spark.read.jdbc(jdbcUrl, "time_e2e", new Properties)
+      assert(df.schema("wake_up").dataType == TimeType(6))
+      assert(df.schema("lunch").dataType == TimeType(3))
+
+      // 3. Verify values
+      val rows = df.collect().sortBy(_.getInt(0))
+      assert(rows(0).getAs[java.time.LocalTime](1) == java.time.LocalTime.of(6, 30, 0))
+      assert(rows(0).getAs[java.time.LocalTime](2) == java.time.LocalTime.of(12, 0, 0))
+      assert(rows(1).getAs[java.time.LocalTime](1) ==
+        java.time.LocalTime.of(7, 45, 30, 123456000))
+      assert(rows(1).getAs[java.time.LocalTime](2) ==
+        java.time.LocalTime.of(13, 15, 30, 500000000))
+
+      // 4. Write back to a new table and read again
+      df.write.jdbc(jdbcUrl, "time_e2e_copy", new Properties)
+      val result = spark.read.jdbc(jdbcUrl, "time_e2e_copy", new Properties)
+      assert(result.schema("wake_up").dataType == TimeType(6))
+      assert(result.schema("lunch").dataType == TimeType(3))
+      checkAnswer(result.orderBy("id"), df.orderBy("id"))
     }
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -724,4 +724,71 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
       checkAnswer(result.orderBy("id"), df.orderBy("id"))
     }
   }
+
+  test("SPARK-57555: Write and read time[] array column round-trip") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      val schema = StructType(Seq(
+        StructField("id", IntegerType),
+        StructField("times", ArrayType(TimeType(TimeType.DEFAULT_PRECISION)))))
+      val data = Seq(
+        Row(1, Seq(
+          java.time.LocalTime.of(8, 0, 0),
+          java.time.LocalTime.of(12, 30, 0),
+          java.time.LocalTime.of(17, 45, 30, 123456000))),
+        Row(2, Seq(
+          java.time.LocalTime.of(0, 0, 0),
+          java.time.LocalTime.of(23, 59, 59, 999999000))))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      df.write.jdbc(jdbcUrl, "time_array_roundtrip", new Properties)
+
+      val result = spark.read.jdbc(jdbcUrl, "time_array_roundtrip", new Properties)
+      assert(result.schema("times").dataType ==
+        ArrayType(TimeType(TimeType.DEFAULT_PRECISION), true))
+      checkAnswer(result.orderBy("id"), df.orderBy("id"))
+    }
+  }
+
+  test("SPARK-57555: Legacy mode reads time/time[] as TimestampType") {
+    withSQLConf(
+        SQLConf.TIME_TYPE_ENABLED.key -> "true",
+        SQLConf.LEGACY_JDBC_TIME_MAPPING_ENABLED.key -> "true") {
+      // Scalar time column
+      val df = spark.read.jdbc(jdbcUrl, "bar", new Properties)
+      val timeField = df.schema("c36")
+      assert(timeField.dataType == TimestampType || timeField.dataType == TimestampNTZType,
+        s"Expected timestamp type in legacy mode, got ${timeField.dataType}")
+
+      // time[] array column
+      val arrDf = spark.read.jdbc(jdbcUrl, "time_array_table", new Properties)
+      val arrField = arrDf.schema("times")
+      arrField.dataType match {
+        case ArrayType(elementType, _) =>
+          assert(elementType == TimestampType || elementType == TimestampNTZType,
+            s"Expected timestamp element type in legacy mode, got $elementType")
+        case other => fail(s"Expected ArrayType, got $other")
+      }
+    }
+  }
+
+  test("SPARK-57555: Nanosecond TimeType(9) write falls back to bare TIME, reads as TimeType(6)") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      // Write a TimeType(9) column - should emit bare TIME (not invalid TIME(9))
+      val schema = StructType(Seq(StructField("t", TimeType(9))))
+      val data = Seq(
+        Row(java.time.LocalTime.of(10, 30, 45, 123456789)),
+        Row(java.time.LocalTime.of(22, 15, 0, 987654321))
+      )
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      df.write.jdbc(jdbcUrl, "time_nanos_test", new Properties)
+
+      // Read back - PostgreSQL TIME max precision is 6, so reads as TimeType(6)
+      val result = spark.read.jdbc(jdbcUrl, "time_nanos_test", new Properties)
+      assert(result.schema("t").dataType == TimeType(6))
+
+      // Values are rounded to microseconds by PostgreSQL (not truncated)
+      val collected = result.collect().map(_.getAs[java.time.LocalTime](0)).sorted
+      assert(collected(0) == java.time.LocalTime.of(10, 30, 45, 123457000))
+      assert(collected(1) == java.time.LocalTime.of(22, 15, 0, 987654000))
+    }
+  }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -621,4 +621,34 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
       checkAnswer(df6, Row(LocalDateTime.of(2018, 11, 17, 13, 33, 33)))
     }
   }
+
+  test("SPARK-57555: Read TIME column as TimeType when timeType.enabled is true") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      val df = spark.read.jdbc(jdbcUrl, "bar", new Properties)
+      val rows = df.collect().sortBy(_.toString())
+      // c36 is TIME column with value '17:22:31.123'
+      val timeField = df.schema("c36")
+      assert(timeField.dataType.isInstanceOf[TimeType])
+      val localTime = rows(0).getAs[java.time.LocalTime](df.schema.fieldIndex("c36"))
+      assert(localTime == java.time.LocalTime.of(17, 22, 31, 123000000))
+    }
+  }
+
+  test("SPARK-57555: Write and read TIME column round-trip") {
+    withSQLConf(SQLConf.TIME_TYPE_ENABLED.key -> "true") {
+      val schema = StructType(Seq(StructField("t", TimeType(TimeType.DEFAULT_PRECISION))))
+      val times = Seq(
+        java.time.LocalTime.of(0, 0, 0),
+        java.time.LocalTime.of(12, 30, 45, 123456000),
+        java.time.LocalTime.of(23, 59, 59, 999999000)
+      )
+      val data = times.map(t => Row(t))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      df.write.jdbc(jdbcUrl, "time_roundtrip", new Properties)
+      val result = spark.read.jdbc(jdbcUrl, "time_roundtrip", new Properties)
+      assert(result.schema("t").dataType.isInstanceOf[TimeType])
+      val collected = result.collect().map(_.getAs[java.time.LocalTime](0)).sorted
+      assert(collected.toSeq == times.sorted)
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCValueGetter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCValueGetter.scala
@@ -254,6 +254,11 @@ private[jdbc] object JDBCValueGetter {
         (d: Date) => fromJavaDate(dialect.convertJavaDateToDate(d))
       }
 
+      case _: TimeType =>
+        // Placeholder - TimeType arrays are handled specially in apply() below
+        // because java.sql.Time from getArray() loses sub-second precision.
+        null
+
       case dt: DecimalType =>
           arrayConverter[java.math.BigDecimal](d => Decimal(d, dt.precision, dt.scale))
 
@@ -279,7 +284,24 @@ private[jdbc] object JDBCValueGetter {
       try {
         val array = nullSafeConvert[java.sql.Array](
           input = rs.getArray(pos + 1),
-          arr => new GenericArrayData(elementConversion(arrayType.elementType)(arr.getArray())))
+          arr => arrayType.elementType match {
+            case _: TimeType =>
+              // Use getResultSet() + getObject(LocalTime) per element to preserve
+              // microsecond precision. java.sql.Time from getArray() loses sub-seconds.
+              val arrRs = arr.getResultSet()
+              val buf = scala.collection.mutable.ArrayBuffer[Any]()
+              try {
+                while (arrRs.next()) {
+                  val lt = arrRs.getObject(2, classOf[java.time.LocalTime])
+                  buf += (if (lt != null) lt.toNanoOfDay else null)
+                }
+              } finally {
+                arrRs.close()
+              }
+              new GenericArrayData(buf.toArray)
+            case _ =>
+              new GenericArrayData(elementConversion(arrayType.elementType)(arr.getArray()))
+          })
         row.update(pos, array)
       } catch {
         case _: java.lang.ClassCastException =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -546,6 +546,12 @@ object JdbcUtils extends Logging with SQLConfHelper {
               getJdbcType(et, dialect).databaseTypeDefinition.split("\\(")(0),
               array.map(dialect.convertTimestampNTZToJavaTimestamp).toArray)
             stmt.setArray(pos + 1, arrayType)
+          case _: TimeType =>
+            val array = row.getSeq[java.time.LocalTime](pos)
+            val arrayType = conn.createArrayOf(
+              getJdbcType(et, dialect).databaseTypeDefinition.split("\\(")(0),
+              array.toArray)
+            stmt.setArray(pos + 1, arrayType)
           case _ =>
             @tailrec
             def getElementTypeName(dt: DataType): String = dt match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -124,7 +124,10 @@ private case class PostgresDialect()
       Some(StringType)
     case "bytea" => Some(BinaryType)
     case "timestamptz" | "timetz" => Some(TimestampType)
-    case "timestamp" | "time" => Some(getTimestampType(md.build()))
+    case "timestamp" => Some(getTimestampType(md.build()))
+    case "time" =>
+      if (conf.isTimeTypeEnabled) Some(TimeType(TimeType.DEFAULT_PRECISION))
+      else Some(getTimestampType(md.build()))
     case "date" => Some(DateType)
     case "numeric" | "decimal" if precision > 0 =>
       val scale = md.build().getLong("scale").toInt
@@ -159,6 +162,7 @@ private case class PostgresDialect()
     case ShortType | ByteType => Some(JdbcType("SMALLINT", Types.SMALLINT))
     case TimestampType if !conf.legacyPostgresDatetimeMappingEnabled =>
       Some(JdbcType("TIMESTAMP WITH TIME ZONE", Types.TIMESTAMP))
+    case _: TimeType => Some(JdbcType("TIME", Types.TIME))
     case t: DecimalType => Some(
       JdbcType(s"NUMERIC(${t.precision},${t.scale})", java.sql.Types.NUMERIC))
     case ArrayType(et, _) if et.isInstanceOf[AtomicType] || et.isInstanceOf[ArrayType] =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -126,8 +126,13 @@ private case class PostgresDialect()
     case "timestamptz" | "timetz" => Some(TimestampType)
     case "timestamp" => Some(getTimestampType(md.build()))
     case "time" =>
-      if (conf.isTimeTypeEnabled) Some(TimeType(TimeType.DEFAULT_PRECISION))
-      else Some(getTimestampType(md.build()))
+      // Use DEFAULT_PRECISION (6) because PostgreSQL does not report element typmod for
+      // array columns, and 6 is the maximum fractional-second precision for time in Postgres.
+      if (conf.isTimeTypeEnabled && !conf.legacyJdbcTimeMappingEnabled) {
+        Some(TimeType(TimeType.DEFAULT_PRECISION))
+      } else {
+        Some(getTimestampType(md.build()))
+      }
     case "date" => Some(DateType)
     case "numeric" | "decimal" if precision > 0 =>
       val scale = md.build().getLong("scale").toInt
@@ -162,7 +167,11 @@ private case class PostgresDialect()
     case ShortType | ByteType => Some(JdbcType("SMALLINT", Types.SMALLINT))
     case TimestampType if !conf.legacyPostgresDatetimeMappingEnabled =>
       Some(JdbcType("TIMESTAMP WITH TIME ZONE", Types.TIMESTAMP))
-    case _: TimeType => Some(JdbcType("TIME", Types.TIME))
+    case t: TimeType =>
+      // PostgreSQL supports TIME(p) for p in [0,6]. Use the declared precision when valid;
+      // fall back to bare TIME (= TIME(6)) for out-of-range precisions (e.g. nanosecond).
+      val ddl = if (t.precision >= 0 && t.precision <= 6) s"TIME(${t.precision})" else "TIME"
+      Some(JdbcType(ddl, Types.TIME))
     case t: DecimalType => Some(
       JdbcType(s"NUMERIC(${t.precision},${t.scale})", java.sql.Types.NUMERIC))
     case ArrayType(et, _) if et.isInstanceOf[AtomicType] || et.isInstanceOf[ArrayType] =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `TimeType` support to `PostgresDialect` and fix array-element value conversion for TIME:
- `toCatalystType`: map time array elements to TimeType when `spark.sql.timeType.enabled` is true (previously mapped to `TimestampType` via `getTimestampType`), gated by `legacyJdbcTimeMappingEnabled`
- `getJDBCType`: add `TimeType => TIME(p) for p∈[0,6]`, bare TIME for out-of-range precisions
- `JDBCValueGetter`: add `TimeType case` to `elementConversion` for array reads `(java.sql.Time → nanos-of-day)`
- `JdbcUtils makeSetter`: add `TimeType` case for array writes (`LocalTime` objects for `createArrayOf`)


### Why are the changes needed?
This is a followup to #56653 which added core JDBC TIME support in `JdbcUtils`. That PR handled scalar read/write correctly, but:

- `PostgresDialect`'s `toCatalystType` helper (used for array element type resolution) still mapped time to `TimestampType` unconditionally
- The base `JDBCValueGetter.ArrayGetter` had no `TimeType case` - `PostgreSQL returns java.sql.Time for time[]` elements but codegen expected Long (nanos-of-day), causing `ClassCastException`
- The array write path passed raw longs instead of `LocalTime` objects to `createArrayOf`

### Does this PR introduce any user-facing change?
Yes. When `spark.sql.timeType.enabled` is true, PostgreSQL time[] array columns now correctly read and write end-to-end. Non-array TIME columns were already handled by the base JdbcUtils.

### How was this patch tested?
Added integration tests in PostgresIntegrationSuite:

- **Scalar read**: verifies existing bar table `TIME` column (c36) is read as `TimeType` with correct value
- **Scalar round-trip**: writes three `LocalTime` values and reads them back
- **time[] array read**: reads `time[]` column as `ArrayType(TimeType)`
- **time[] array write + read-back**: writes `ArrayType(TimeType(6))` via `df.write.jdbc`, reads back via checkAnswer
- **Precision preservation**: `TimeType(3) → TIME(3) → read back as TimeType(3)`
- **Legacy mode**: asserts `time` / `time[]` reads as `TimestampType` when `legacyJdbcTimeMappingEnabled=true`
- **Nanosecond write**: `TimeType(9) → bare TIME → read back as TimeType(6) with micros`

Unit tests: JDBCSuite (125 tests, all passing).

### Was this patch authored or co-authored using generative AI tooling?
CoAuthored using Claude Opus 4.6