### PR TITLE
[SPARK-57769][SQL] Add a config to use the earliest offset for date_trunc at a DST fall-back overlap

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -28,6 +28,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.{QueryContext, SparkException, SparkIllegalArgumentException}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{Decimal, DoubleExactNumeric, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.{CalendarInterval, TimestampNanosVal, UTF8String}
 
@@ -581,6 +582,18 @@ object DateTimeUtils extends SparkDateTimeUtils {
    *     the shifted-local frame.
    *   - WEEK/MONTH/QUARTER/YEAR: convert local micros to local epoch-day, run
    *     [[truncDate]] in the local-day frame, multiply back to local micros.
+   *
+   * For the date-level units the truncated wall-clock instant is a local midnight, which
+   * at a daylight-saving fall-back transition occurs twice (e.g. `Europe/Berlin`
+   * 1916-10-01 00:00 exists at both +02:00 CEST and +01:00 CET). The fast path resolves
+   * such a midnight with the offset of the source `micros`, whereas the slow path's
+   * `daysToMicros` resolves it with the earliest valid offset. These disagree only when
+   * the truncated midnight lands exactly on a fall-back overlap, and they make the result
+   * depend on the source offset, so two timestamps in the same period can truncate to
+   * different instants. Setting [[SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST]]
+   * routes date-level truncations through the slow path so the earliest offset is always
+   * chosen, which is offset-independent (deterministic per period) at the cost of the
+   * fast path.
    */
   def truncTimestamp(micros: Long, level: Int, zoneId: ZoneId): Long = {
     // MICROSECOND / MILLISECOND / SECOND don't need zone information.
@@ -591,6 +604,13 @@ object DateTimeUtils extends SparkDateTimeUtils {
       case TRUNC_TO_SECOND =>
         return Math.subtractExact(micros, Math.floorMod(micros, MICROS_PER_SECOND))
       case _ =>
+    }
+    // For date-level units the fast path resolves the truncated local midnight with the
+    // source offset, which diverges from the slow path at a fall-back overlap. The legacy
+    // flag forces the slow path so the earliest (offset-independent) result is used.
+    if (level >= MIN_LEVEL_OF_DATE_TRUNC &&
+        SQLConf.get.getConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST)) {
+      return truncTimestampSlow(micros, level, zoneId)
     }
     val rules = zoneId.getRules
     val originalSec = Math.floorDiv(micros, MICROS_PER_SECOND)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7497,6 +7497,25 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST =
+    buildConf("spark.sql.legacy.timestampTruncateToOverlapEarliestOffset")
+      .internal()
+      .doc("At a daylight-saving fall-back transition a wall-clock local time occurs " +
+        "twice, once before and once after the clocks are turned back. When date_trunc " +
+        "with a date-level unit (WEEK, MONTH, QUARTER, or YEAR) produces a truncated " +
+        "local midnight that lands on such an overlap, the resolved instant depends on " +
+        "which of the two offsets is chosen. When set to true (legacy behavior), the " +
+        "earliest valid offset is always used (the result is independent of the source " +
+        "timestamp's offset, so all rows in the same period truncate to the same " +
+        "instant). When set to false (the default), the offset of the source timestamp " +
+        "is reused, which is faster but can map two source timestamps in the same period " +
+        "to different instants when one of them sits on the overlap. This only affects " +
+        "date-level truncations whose midnight boundary coincides with a fall-back " +
+        "overlap; all other truncations are unchanged.")
+      .version("4.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_XML_PARSER_ENABLED = {
     buildConf("spark.sql.legacy.useLegacyXMLParser")
       .internal()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.rebaseJulianToGregorianMicros
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLConf
-import org.apache.spark.sql.internal.SqlApiConf
+import org.apache.spark.sql.internal.{SqlApiConf, SQLConf}
 import org.apache.spark.sql.types.{Decimal, TimeType}
 import org.apache.spark.sql.types.DayTimeIntervalType.{HOUR, SECOND}
 import org.apache.spark.unsafe.types.{CalendarInterval, TimestampNanosVal, UTF8String}
@@ -900,6 +900,74 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     val expectedMonth = DateTimeUtils.stringToTimestamp(
       UTF8String.fromString("2024-04-01T00:00:00-07:00"), la).get
     assert(DateTimeUtils.truncTimestamp(apr, DateTimeUtils.TRUNC_TO_MONTH, la) === expectedMonth)
+  }
+
+  test("SPARK-57769: truncTimestamp date-level units at a fall-back overlap") {
+    // Europe/Berlin observed its first DST in 1916: clocks went back from 01:00 CEST
+    // (+02:00) to 00:00 CET (+01:00) on 1916-10-01, so the local time 1916-10-01 00:00
+    // (the truncated MONTH/WEEK boundary) is an overlap that exists at both +02:00 and
+    // +01:00. The fast path resolves that midnight with the source timestamp's offset,
+    // while the slow path always picks the earliest valid offset (+02:00 CEST).
+    val berlin = getZoneId("Europe/Berlin")
+    // Source is 1916-10-15, well after the transition, so its offset is +01:00 CET.
+    val src = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1916-10-15T12:00:00+01:00"), berlin).get
+    // Default (new) behavior: the truncated midnight reuses the source offset (+01:00).
+    val expectedDefault = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1916-10-01T00:00:00+01:00"), berlin).get
+    // Legacy behavior: the earliest valid offset (+02:00 CEST) is always used.
+    val expectedLegacy = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1916-10-01T00:00:00+02:00"), berlin).get
+    // MONTH truncation of the 1916-10-15 source lands on 1916-10-01, the overlap day.
+    // (WEEK truncates to Monday 1916-10-09, which is not on the overlap, so it is not
+    // affected and is covered by the QUARTER/YEAR Azores case below.)
+    assert(expectedDefault !== expectedLegacy)
+    withSQLConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST.key -> "false") {
+      assert(DateTimeUtils.truncTimestamp(src, DateTimeUtils.TRUNC_TO_MONTH, berlin)
+        === expectedDefault)
+    }
+    withSQLConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST.key -> "true") {
+      assert(DateTimeUtils.truncTimestamp(src, DateTimeUtils.TRUNC_TO_MONTH, berlin)
+        === expectedLegacy)
+    }
+
+    // Determinism: a second source whose offset is +02:00 CEST (an instant sitting in
+    // the overlap itself) truncates to the +02:00 boundary under the fast path. Under
+    // the default behavior the two October sources therefore disagree, while the legacy
+    // behavior maps both to the same instant (so GROUP BY date_trunc is stable).
+    val srcInOverlap = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1916-10-01T00:30:00+02:00"), berlin).get
+    withSQLConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST.key -> "false") {
+      assert(DateTimeUtils.truncTimestamp(srcInOverlap, DateTimeUtils.TRUNC_TO_MONTH, berlin)
+        === expectedLegacy)
+      assert(DateTimeUtils.truncTimestamp(src, DateTimeUtils.TRUNC_TO_MONTH, berlin)
+        !== DateTimeUtils.truncTimestamp(srcInOverlap, DateTimeUtils.TRUNC_TO_MONTH, berlin))
+    }
+    withSQLConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST.key -> "true") {
+      assert(DateTimeUtils.truncTimestamp(src, DateTimeUtils.TRUNC_TO_MONTH, berlin)
+        === DateTimeUtils.truncTimestamp(srcInOverlap, DateTimeUtils.TRUNC_TO_MONTH, berlin))
+    }
+
+    // Atlantic/Azores switched from LMT (-01:54:32) to -02:00 at 1912-01-01 00:00, so the
+    // YEAR/MONTH boundary 1912-01-01 00:00 is an overlap between the two offsets (a 328s
+    // difference). The fast path uses the source offset (-02:00), the slow path the
+    // earliest (-01:54:32 LMT).
+    val azores = getZoneId("Atlantic/Azores")
+    val azSrc = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1912-01-15T12:00:00-02:00"), azores).get
+    // Build the expected instants directly: the LMT offset (-01:54:32) has sub-minute
+    // precision that the timestamp string parser does not accept.
+    val azDefault = instantToMicros(Instant.parse("1912-01-01T02:00:00Z"))
+    val azLegacy = instantToMicros(Instant.parse("1912-01-01T01:54:32Z"))
+    assert(azDefault !== azLegacy)
+    for (level <- Seq(DateTimeUtils.TRUNC_TO_YEAR, DateTimeUtils.TRUNC_TO_MONTH)) {
+      withSQLConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST.key -> "false") {
+        assert(DateTimeUtils.truncTimestamp(azSrc, level, azores) === azDefault)
+      }
+      withSQLConf(SQLConf.LEGACY_TIMESTAMP_TRUNCATE_OVERLAP_EARLIEST.key -> "true") {
+        assert(DateTimeUtils.truncTimestamp(azSrc, level, azores) === azLegacy)
+      }
+    }
   }
 
   test("truncTimestamp at Pacific/Apia after the 2011 calendar shift") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`date_trunc` to a date-level unit (`WEEK` / `MONTH` / `QUARTER` / `YEAR`) uses an
offset-arithmetic fast path (added in SPARK-56769, extending SPARK-56663). The fast
path resolves the truncated local-midnight boundary back to UTC using the offset of
the *source* timestamp. At a daylight-saving fall-back transition, that local midnight
occurs twice (once before and once after the clocks go back), so the source offset is
not necessarily the offset the slow-path reference would pick: the slow path
(`daysToMicros`) resolves the midnight with the *earliest* valid offset.

Both instants are valid representations of the overlapped midnight, so this is not a
wrong result. But it does make `date_trunc` depend on the source timestamp's offset:
two timestamps in the same period can truncate to different instants when one of them
sits on the overlap, so `GROUP BY date_trunc(...)` may place them in different groups.
Some workloads prefer the offset-independent (earliest) resolution, which is
deterministic per period.

Concrete example (session time zone `Europe/Berlin`; Germany's first DST ended
1916-10-01 01:00 CEST -> 00:00 CET, so local `1916-10-01 00:00` exists at both +02:00
and +01:00):

- `date_trunc('MONTH', TIMESTAMP '1916-10-15 12:00:00')` (source offset +01:00 CET):
  fast path resolves to `1916-09-30 23:00:00Z`, while the slow-path reference resolves
  to `1916-09-30 22:00:00Z` (earliest, +02:00 CEST).
- A source sitting in the overlap, `1916-10-01 00:30 +02:00`, truncates to
  `1916-09-30 22:00:00Z` under both paths, so the two October timestamps disagree.

`Atlantic/Azores` 1912-01-01 (LMT -01:54:32 -> -02:00) is another instance, a 328s
difference.

This PR adds a kill-switch `spark.sql.legacy.timestampTruncateToOverlapEarliestOffset`
(default `false`). When `false` (the default), the behavior is unchanged: the fast
path reuses the source offset. When `true`, date-level truncations are routed through
the slow path so the earliest valid offset is always chosen, which is independent of
the source offset and therefore deterministic per period. The flag only affects
date-level truncations whose midnight boundary coincides with a fall-back overlap; all
other truncations (and `MIN`/`HOUR`/`DAY`, whose slow path already keeps the source
offset) are unchanged.

The fast path remains the default because it is the existing post-SPARK-56769 behavior
and is significantly faster; the determinism trade-off is documented in the config and
in the `truncTimestamp` scaladoc so users hitting the overlap edge case can opt into
the earliest-offset (deterministic) semantics.

### Why are the changes needed?

The fast path silently diverges from its slow-path reference at a daylight-saving
fall-back overlap, making `date_trunc` non-deterministic per `(period, zone)` and
breaking grouped aggregations. The flag gives a documented escape hatch to the
offset-independent (deterministic) result.

### Does this PR introduce _any_ user-facing change?

Yes. A new internal SQL config
`spark.sql.legacy.timestampTruncateToOverlapEarliestOffset` (default `false`) is added.
With the default value, behavior is unchanged. Setting it to `true` changes the result
of `date_trunc` for date-level units only when the truncated boundary lands exactly on
a daylight-saving fall-back overlap, selecting the earliest valid offset (the
pre-SPARK-56769 / slow-path result) so that the result no longer depends on the source
timestamp's offset.

### How was this patch tested?

New unit test in `DateTimeUtilsSuite` (`truncTimestamp date-level units at a fall-back
overlap`) that asserts both config modes for the `Europe/Berlin` 1916 and
`Atlantic/Azores` 1912 overlaps, and asserts the determinism property (two sources in
the same period truncate to the same instant under the legacy mode and to different
instants under the default). The full `DateTimeUtilsSuite` passes.

### Was this patch authored or co-authored using generative AI tooling?

Yes.

Generated-by: Claude Code