### PR TITLE
[SPARK-57458][SQL][FOLLOWUP] Avoid non-local return in XmlInferSchema.tryParseTimestampNTZ

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -542,14 +542,13 @@ class XmlInferSchema(private val options: XmlOptions, private val caseSensitive:
       if ((SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY ||
         timestampType == TimestampNTZType) &&
         timestampNTZFormatter.parseWithoutTimeZoneOptional(field, false).isDefined) {
-        if (SQLConf.get.timestampNanosTypesEnabled) {
-          // Prefer nanosecond type when the fractional seconds part has more than 6 digits,
-          // indicating sub-microsecond precision that cannot be represented by TimestampNTZType.
-          val nanosOpt =
-            timestampNTZFormatter.parseWithoutTimeZoneNanosOptional(field, 9, false)
-          nanosOpt.filter(_.nanosWithinMicro != 0).foreach { _ =>
-            return Some(TimestampNTZNanosType(9))
-          }
+        // Prefer nanosecond type when there is a nonzero sub-microsecond component
+        // (nanosWithinMicro != 0) that TimestampNTZType cannot represent.
+        val hasSubMicro = SQLConf.get.timestampNanosTypesEnabled &&
+          timestampNTZFormatter.parseWithoutTimeZoneNanosOptional(field, 9, false)
+            .exists(_.nanosWithinMicro != 0)
+        if (hasSubMicro) {
+          return Some(TimestampNTZNanosType(9))
         }
         return Some(timestampType)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of [SPARK-57458](https://issues.apache.org/jira/browse/SPARK-57458). The nanosecond-precision timestamp inference in `XmlInferSchema.tryParseTimestampNTZ` used a `return` statement inside an `Option.foreach` closure, which is a non-local return implemented via a control-flow exception. This replaces it with a plain boolean check plus a local `return`, keeping the behavior identical while avoiding the non-local return.

### Why are the changes needed?

Non-local returns rely on throwing/catching a `NonLocalReturnControl` exception, which is discouraged and flagged by lint tooling. The rewrite is equivalent and clearer.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing tests for nanosecond timestamp inference in the XML datasource cover this code path.

### Was this patch authored or co-authored using generative AI tooling?

Yes, this patch was co-authored using generative AI tooling.
