### PR TITLE
[SPARK-57797][BUILD] Exclude `stax:stax-api` from `hive-exec` dependency

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -409,7 +409,6 @@ org.snakeyaml:snakeyaml-engine
 org.xerial.snappy:snappy-java
 org.yaml:snakeyaml
 oro:oro
-stax:stax-api
 
 core/src/main/java/org/apache/spark/util/collection/TimSort.java
 core/src/main/resources/org/apache/spark/ui/static/bootstrap*

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -266,7 +266,6 @@ spire-macros_2.13/0.18.0//spire-macros_2.13-0.18.0.jar
 spire-platform_2.13/0.18.0//spire-platform_2.13-0.18.0.jar
 spire-util_2.13/0.18.0//spire-util_2.13-0.18.0.jar
 spire_2.13/0.18.0//spire_2.13-0.18.0.jar
-stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.8.0//threeten-extra-1.8.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2000,6 +2000,11 @@
             <groupId>net.hydromatic</groupId>
             <artifactId>aggdesigner-algorithm</artifactId>
           </exclusion>
+          <!-- javax.xml.stream is provided by the JDK (java.xml module) -->
+          <exclusion>
+            <groupId>stax</groupId>
+            <artifactId>stax-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the `stax:stax-api` transitive dependency (pulled in by `org.apache.hive:hive-exec`) from the binary distribution, and updates `dev/deps` and `LICENSE-binary` accordingly for Apache Spark 5.0.0

### Why are the changes needed?

`stax:stax-api` provides the `javax.xml.stream` API, which the JDK has bundled since Java 6 (in the `java.xml` module since Java 9). On Java 17+, the jar is never loaded and is pure dead weight.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8