### PR TITLE
[SPARK-57795][INFRA][FOLLOWUP] Refine the merge summary comment in merge_spark_pr.py

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -450,7 +450,7 @@ def post_merge_comment(pr_num, merged_commits):
         "- merged into %s %s/%s" % (ref, GITHUB_COMMIT_BASE, commit_hash)
         for ref, commit_hash in merged_commits
     ]
-    body = "**Merge summary** (posted by `merge_spark_pr.py`):\n" + "\n".join(lines)
+    body = "**Merge Summary:**\n" + "\n".join(lines) + "\n\n*Posted by `merge_spark_pr.py`*"
     print("Posting merge comment on PR #%s:\n%s" % (pr_num, body))
     if not GITHUB_OAUTH_KEY:
         print_error("GITHUB_OAUTH_KEY is not set; skipping the merge comment.")
@@ -560,7 +560,7 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, pr_author, co_author
         clean_up()
         print_error("Exception while pushing: %s" % e)
 
-    merge_hash = run_cmd("git rev-parse %s" % target_branch_name)[:8]
+    merge_hash = run_cmd("git rev-parse %s" % target_branch_name).strip()
     clean_up()
     print("Pull request #%s merged!" % pr_num)
     print("Merge hash: %s" % merge_hash)
@@ -594,7 +594,7 @@ def _do_cherry_pick(pr_num, merge_hash, pick_ref):
     except Exception as e:
         fail("Exception while pushing: %s" % e)
 
-    pick_hash = run_cmd("git rev-parse %s" % pick_branch_name)[:8]
+    pick_hash = run_cmd("git rev-parse %s" % pick_branch_name).strip()
     clean_up()
 
     print("Pull request #%s picked into %s!" % (pr_num, pick_ref))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #56917 (SPARK-57795), which added a merge summary comment posted by `merge_spark_pr.py`. This PR refines the format of that comment:

1. Rename the header from `**Merge summary** (posted by `merge_spark_pr.py`):` to `**Merge Summary:**`.
2. Use the full commit SHA in the commit links (previously truncated to 8 characters). The `[:8]` truncation is dropped in `merge_pr` and `_do_cherry_pick`, with `.strip()` added since `run_cmd` does not strip the trailing newline.
3. Move the `merge_spark_pr.py` attribution to a trailing italic line: `*Posted by `merge_spark_pr.py`*`.

Example rendered comment:

> **Merge Summary:**
> - merged into master https://github.com/apache/spark/commit/&lt;full-sha&gt;
> - merged into branch-4.x https://github.com/apache/spark/commit/&lt;full-sha&gt;
>
> *Posted by `merge_spark_pr.py`*

### Why are the changes needed?

A cleaner, more readable merge summary comment. Full SHAs are unambiguous and link-stable, and moving the tool attribution to the end keeps the summary itself front and center.

### Does this PR introduce _any_ user-facing change?

No. This only affects the developer merge tooling.

### How was this patch tested?

Manually verified the generated comment body and confirmed the full SHA is carried through. Existing lint (`ruff`) passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-8)