### PR TITLE
[SPARK-49580][CONNECT] Add config to limit concurrent executions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1286,6 +1286,11 @@
       "Generic Spark Connect error."
     ],
     "subClass" : {
+      "EXECUTE_CONCURRENT_LIMIT_TIMEOUT" : {
+        "message" : [
+          "Could not acquire an execution slot within <timeout> because the maximum number of concurrent queries (<limit>) has been reached. Please retry."
+        ]
+      },
       "INTERCEPTOR_CTOR_MISSING" : {
         "message" : [
           "Cannot instantiate GRPC interceptor because <cls> is missing a default constructor without arguments."

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3643,6 +3643,22 @@ Command types in proto.</td>
   <td>4.0.0</td>
 </tr>
 <tr>
+  <td><code>spark.connect.execute.maxConcurrentQueries</code></td>
+  <td>
+    0
+  </td>
+  <td>Maximum number of concurrent queries that can be executed. When this limit is reached, new queries will wait in a queue until a slot becomes available. Set to 0 or negative to disable the limit (unlimited concurrency). This only affects Spark Connect executions. When using FAIR scheduling mode, this prevents resource fragmentation by limiting how many queries can run simultaneously.</td>
+  <td>4.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.connect.execute.maxConcurrentQueries.timeout</code></td>
+  <td>
+    0
+  </td>
+  <td>Maximum time a query waits for an execution slot when <code>spark.connect.execute.maxConcurrentQueries</code> is reached. Waiters are served in FIFO order. If a slot does not become available within this time, the query fails with a retryable error so the client re-submits it. Set to 0 to wait indefinitely. Has no effect when the concurrency limit is disabled.</td>
+  <td>4.3.0</td>
+</tr>
+<tr>
   <td><code>spark.connect.jvmStacktrace.maxSize</code></td>
   <td>
     1024

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -493,4 +493,29 @@ object Connect {
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(ConnectPlanCompressionAlgorithm.values.map(_.toString))
       .createWithDefault(ConnectPlanCompressionAlgorithm.ZSTD.toString)
+
+  val CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES =
+    buildStaticConf("spark.connect.execute.maxConcurrentQueries")
+      .doc(
+        "Maximum number of concurrent queries that can be executed. When this limit is reached, " +
+          "new queries will wait in a queue until a slot becomes available. Set to 0 or negative " +
+          "to disable the limit (unlimited concurrency). This only affects Spark Connect " +
+          "executions.")
+      .version("4.3.0")
+      .internal()
+      .intConf
+      .createWithDefault(0)
+
+  val CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES_TIMEOUT =
+    buildStaticConf("spark.connect.execute.maxConcurrentQueries.timeout")
+      .doc(
+        "Maximum time a query waits for an execution slot when " +
+          "spark.connect.execute.maxConcurrentQueries is reached. Waiters are served in FIFO " +
+          "order. If a slot does not become available within this time, the query fails with a " +
+          "retryable error so the client re-submits it. Set to 0 (default) to wait " +
+          "indefinitely. Has no effect when the concurrency limit is disabled.")
+      .version("4.3.0")
+      .internal()
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(0)
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -157,6 +157,7 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
     logDebug(
       s"Execution opId=${executeHolder.operationId} produced error. " +
         s"Last stream index is $lastProducedIndex.")
+    executeHolder.releaseExecutionPermit()
     responseLock.notifyAll()
   }
 
@@ -168,6 +169,7 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
     logDebug(
       s"Execution opId=${executeHolder.operationId} completed stream. " +
         s"Last stream index is $lastProducedIndex.")
+    executeHolder.releaseExecutionPermit()
     responseLock.notifyAll()
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -39,7 +39,8 @@ import org.apache.spark.util.SystemClock
 private[connect] class ExecuteHolder(
     val executeKey: ExecuteKey,
     val request: proto.ExecutePlanRequest,
-    val sessionHolder: SessionHolder)
+    val sessionHolder: SessionHolder,
+    private val executionPermit: Option[ExecutionPermit] = None)
     extends Logging {
 
   val session = sessionHolder.session
@@ -341,6 +342,11 @@ private[connect] class ExecuteHolder(
 
   /** Get key used by SparkConnectExecutionManager global tracker. */
   def key: ExecuteKey = executeKey
+
+  /** Release the execution permit, if this holder owns one. */
+  private[connect] def releaseExecutionPermit(): Unit = {
+    executionPermit.foreach(_.release())
+  }
 
   /** Get the operation ID. */
   def operationId: String = key.operationId

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -18,14 +18,16 @@
 package org.apache.spark.sql.connect.service
 
 import java.util.UUID
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, Executors, ScheduledExecutorService, TimeUnit}
-import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, Executor, Executors, Semaphore}
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 import com.google.common.cache.CacheBuilder
+import io.grpc.{Context, Status}
 import io.grpc.stub.StreamObserver
 
 import org.apache.spark.{SparkEnv, SparkSQLException}
@@ -33,7 +35,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_MILLIS
 import org.apache.spark.sql.connect.IllegalStateErrors
-import org.apache.spark.sql.connect.config.Connect.{CONNECT_EXECUTE_MANAGER_ABANDONED_TOMBSTONES_SIZE, CONNECT_EXECUTE_MANAGER_DETACHED_TIMEOUT, CONNECT_EXECUTE_MANAGER_MAINTENANCE_INTERVAL}
+import org.apache.spark.sql.connect.config.Connect.{CONNECT_EXECUTE_MANAGER_ABANDONED_TOMBSTONES_SIZE, CONNECT_EXECUTE_MANAGER_DETACHED_TIMEOUT, CONNECT_EXECUTE_MANAGER_MAINTENANCE_INTERVAL, CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES, CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES_TIMEOUT}
 import org.apache.spark.sql.connect.execution.ExecuteGrpcResponseSender
 import org.apache.spark.sql.connect.planner.InvalidInputErrors
 import org.apache.spark.util.ThreadUtils
@@ -60,12 +62,46 @@ object ExecuteKey {
 }
 
 /**
+ * Marker trait for exceptions that should be surfaced to the client as retryable. When an error
+ * carrying this trait is converted to a gRPC status, a `google.rpc.RetryInfo` detail is attached
+ * so that Spark Connect clients transparently re-submit the request. See
+ * `ErrorUtils.buildStatusFromThrowable`.
+ */
+private[connect] trait RetryableGrpcError { self: Throwable => }
+
+/**
+ * Thrown when a query cannot acquire an execution slot within
+ * `spark.connect.execute.maxConcurrentQueries.timeout` while the concurrency limit is reached. It
+ * is retryable: the client re-submits the request, re-joining the FIFO wait queue.
+ */
+private[connect] class SparkConnectConcurrentExecutionsTimeoutException(
+    limit: Int,
+    timeout: String)
+    extends SparkSQLException(
+      errorClass = "CONNECT.EXECUTE_CONCURRENT_LIMIT_TIMEOUT",
+      messageParameters = Map("limit" -> limit.toString, "timeout" -> timeout))
+    with RetryableGrpcError
+
+/** A semaphore permit that can be released at most once. */
+private[connect] class ExecutionPermit(private val semaphore: Semaphore) {
+  private val released = new AtomicBoolean(false)
+
+  def release(): Unit = {
+    if (released.compareAndSet(false, true)) {
+      semaphore.release()
+    }
+  }
+}
+
+/**
  * Global tracker of all ExecuteHolder executions.
  *
  * All ExecuteHolders are created, and removed through it. It keeps track of all the executions,
  * and removes executions that have been abandoned.
  */
 private[connect] class SparkConnectExecutionManager() extends Logging {
+
+  private var acceptingExecutions = true
 
   /** Concurrent hash table containing all the current executions. */
   private val executions: ConcurrentMap[ExecuteKey, ExecuteHolder] =
@@ -84,13 +120,131 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
   private val scheduledExecutor: AtomicReference[ScheduledExecutorService] =
     new AtomicReference[ScheduledExecutorService]()
 
+  /** Configured maximum number of concurrent executions (<= 0 means unlimited). */
+  private val maxConcurrentQueries: Int =
+    SparkEnv.get.conf.get(CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES)
+
+  /**
+   * Time in milliseconds a query waits for an execution slot before giving up with a retryable
+   * error. 0 means wait indefinitely. Only relevant when the concurrency limit is enabled.
+   */
+  private val acquireTimeoutMs: Long =
+    SparkEnv.get.conf.get(CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES_TIMEOUT)
+
+  /**
+   * Semaphore to control the maximum number of concurrent executions. When maxConcurrentQueries >
+   * 0, this semaphore limits concurrent executions. Acquiring a permit means an execution slot is
+   * available. The semaphore is fair so that, up to the acquire timeout, waiters are served in
+   * FIFO order.
+   */
+  private val executionSemaphore =
+    new Semaphore(if (maxConcurrentQueries > 0) maxConcurrentQueries else Int.MaxValue, true)
+
+  private val directExecutor: Executor = (command: Runnable) => command.run()
+
+  locally {
+    logInfo(
+      log"Spark Connect execution semaphore initialized with maxConcurrentQueries=" +
+        log"${MDC(LogKeys.MAX_SLOTS, maxConcurrentQueries)} " +
+        log"(${MDC(LogKeys.NUM_SLOTS, getAvailableExecutionSlots)} permits)")
+  }
+
+  /**
+   * Get the current number of permits available in the execution semaphore. Exposed for testing.
+   */
+  private[connect] def getAvailableExecutionSlots: Int = {
+    executionSemaphore.availablePermits()
+  }
+
+  /** Get the approximate number of queries waiting for an execution slot. Exposed for testing. */
+  private[connect] def getExecutionQueueLength: Int = {
+    executionSemaphore.getQueueLength
+  }
+
+  /**
+   * Acquire a permit from the execution semaphore before starting a new execution. Waiters are
+   * served in FIFO order. If `acquireTimeoutMs` is 0, this blocks until a slot is available.
+   * Otherwise it waits at most that long and, on timeout, throws a retryable
+   * [[SparkConnectConcurrentExecutionsTimeoutException]] so the client re-submits the request.
+   */
+  private[connect] def acquireExecutionSlot(): ExecutionPermit = {
+    val availableBefore = executionSemaphore.availablePermits()
+    if (availableBefore == 0) {
+      val queueLength = executionSemaphore.getQueueLength
+      logInfo(
+        log"All execution slots are in use. Query will wait in queue. " +
+          log"Queue length: ${MDC(LogKeys.THREAD_POOL_WAIT_QUEUE_SIZE, queueLength)}")
+    }
+
+    val grpcContext = Context.current()
+    if (grpcContext.isCancelled) {
+      throw cancelledException()
+    }
+
+    val waitingThread = Thread.currentThread()
+    val cancellationListener: Context.CancellationListener =
+      (_: Context) => waitingThread.interrupt()
+    grpcContext.addListener(cancellationListener, directExecutor)
+
+    var acquired = false
+    try {
+      acquired = if (acquireTimeoutMs > 0) {
+        executionSemaphore.tryAcquire(acquireTimeoutMs, TimeUnit.MILLISECONDS)
+      } else {
+        executionSemaphore.acquire()
+        true
+      }
+    } catch {
+      case _: InterruptedException if grpcContext.isCancelled =>
+        Thread.interrupted()
+        throw cancelledException()
+      case e: InterruptedException =>
+        Thread.currentThread().interrupt()
+        throw e
+    } finally {
+      grpcContext.removeListener(cancellationListener)
+    }
+
+    if (grpcContext.isCancelled) {
+      if (acquired) {
+        executionSemaphore.release()
+      }
+      Thread.interrupted()
+      throw cancelledException()
+    }
+
+    if (!acquired) {
+      logInfo(
+        log"Query gave up waiting for an execution slot after " +
+          log"${MDC(LogKeys.TIMEOUT, acquireTimeoutMs)} ms and will be asked to retry.")
+      throw new SparkConnectConcurrentExecutionsTimeoutException(
+        maxConcurrentQueries,
+        s"$acquireTimeoutMs ms")
+    }
+
+    if (availableBefore == 0) {
+      logInfo(log"Query acquired execution slot and will start")
+    }
+    new ExecutionPermit(executionSemaphore)
+  }
+
+  private def cancelledException() = {
+    Status.CANCELLED
+      .withDescription("ExecutePlan RPC was cancelled while queued")
+      .asRuntimeException()
+  }
+
+  private def serviceUnavailableException() =
+    Status.UNAVAILABLE.withDescription("Spark Connect service is stopping").asRuntimeException()
+
   /**
    * Create a new ExecuteHolder and register it with this global manager and with its session.
    */
   private[connect] def createExecuteHolder(
       executeKey: ExecuteKey,
       request: proto.ExecutePlanRequest,
-      sessionHolder: SessionHolder): ExecuteHolder = {
+      sessionHolder: SessionHolder,
+      executionPermit: Option[ExecutionPermit] = None): ExecuteHolder = {
     val opId = executeKey.operationId
     val executeHolder = executions.compute(
       executeKey,
@@ -118,7 +272,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
             errorClass = "INVALID_HANDLE.OPERATION_ABANDONED",
             messageParameters = Map("handle" -> opId))
         }
-        new ExecuteHolder(executeKey, request, sessionHolder)
+        new ExecuteHolder(executeKey, request, sessionHolder, executionPermit)
       })
 
     sessionHolder.addOperationId(opId)
@@ -149,31 +303,40 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
    * execution if still running, free all resources.
    */
   private[connect] def removeExecuteHolder(key: ExecuteKey, abandoned: Boolean = false): Unit = {
-    val executeHolder = executions.get(key)
+    var removedHolder: ExecuteHolder = null
+    executions.computeIfPresent(
+      key,
+      (_, executeHolder) => {
+        // Put into abandonedTombstones before removing it from executions, so that the client ends
+        // up getting an INVALID_HANDLE.OPERATION_ABANDONED error on a retry.
+        if (abandoned) {
+          abandonedTombstones.put(key, executeHolder.getExecuteInfo)
+          executeHolder.sessionHolder.closeOperation(executeHolder)
+        }
+        removedHolder = executeHolder
+        null
+      })
 
-    if (executeHolder == null) {
+    if (removedHolder == null) {
       return
     }
+    val executeHolder = removedHolder
 
-    // Put into abandonedTombstones before removing it from executions, so that the client ends up
-    // getting an INVALID_HANDLE.OPERATION_ABANDONED error on a retry.
-    if (abandoned) {
-      abandonedTombstones.put(key, executeHolder.getExecuteInfo)
+    try {
       executeHolder.sessionHolder.closeOperation(executeHolder)
-    }
+      updateLastExecutionTime()
+      logInfo(log"ExecuteHolder ${MDC(LogKeys.EXECUTE_KEY, key)} is removed.")
+      executeHolder.close()
 
-    // Remove the execution from the map *after* putting it in abandonedTombstones.
-    executions.remove(key)
-    executeHolder.sessionHolder.closeOperation(executeHolder)
-
-    updateLastExecutionTime()
-
-    logInfo(log"ExecuteHolder ${MDC(LogKeys.EXECUTE_KEY, key)} is removed.")
-
-    executeHolder.close()
-    if (abandoned) {
-      // Update in abandonedTombstones: above it wasn't yet updated with closedTime etc.
-      abandonedTombstones.put(key, executeHolder.getExecuteInfo)
+      if (abandoned) {
+        // Update in abandonedTombstones: above it wasn't yet updated with closedTime etc.
+        abandonedTombstones.put(key, executeHolder.getExecuteInfo)
+      }
+    } finally {
+      executeHolder.releaseExecutionPermit()
+      logDebug(
+        log"Execution slot released. Available slots: " +
+          log"${MDC(LogKeys.NUM_SLOTS, getAvailableExecutionSlots)}")
     }
   }
 
@@ -190,7 +353,24 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       request: proto.ExecutePlanRequest,
       sessionHolder: SessionHolder,
       responseObserver: StreamObserver[proto.ExecutePlanResponse]): ExecuteHolder = {
-    val executeHolder = createExecuteHolder(executeKey, request, sessionHolder)
+    // Acquire a slot from the semaphore before starting execution.
+    // This blocks if max concurrent queries limit is reached.
+    val executionPermit = acquireExecutionSlot()
+
+    val executeHolder =
+      try {
+        synchronized {
+          if (!acceptingExecutions) {
+            throw serviceUnavailableException()
+          }
+          createExecuteHolder(executeKey, request, sessionHolder, Some(executionPermit))
+        }
+      } catch {
+        case t: Throwable =>
+          executionPermit.release()
+          throw t
+      }
+
     try {
       // SPARK-53339: Validate the plan before starting the execution thread.
       // postStarted() was moved into executeInternal(), so invalid plans that previously
@@ -288,16 +468,23 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
   }
 
   private[connect] def shutdown(): Unit = {
+    synchronized {
+      acceptingExecutions = false
+    }
+
     val executor = scheduledExecutor.getAndSet(null)
     if (executor != null) {
       ThreadUtils.shutdown(executor, FiniteDuration(1, TimeUnit.MINUTES))
     }
 
-    // note: this does not cleanly shut down the executions, but the server is shutting down.
-    executions.clear()
+    executions.keySet().asScala.foreach(key => removeExecuteHolder(key))
     abandonedTombstones.invalidateAll()
 
     updateLastExecutionTime()
+  }
+
+  private[connect] def start(): Unit = synchronized {
+    acceptingExecutions = true
   }
 
   /**

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -481,6 +481,7 @@ object SparkConnectService extends Logging {
 
     sessionManager.initializeBaseSession(() =>
       SparkSession.builder().sparkContext(sc).getOrCreate().newSession())
+    executionManager.start()
     startGRPCService()
     createListenerAndUI(sc)
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 import com.google.protobuf.{Any => ProtoAny}
-import com.google.rpc.{Code => RPCCode, ErrorInfo, Status => RPCStatus}
+import com.google.rpc.{Code => RPCCode, ErrorInfo, RetryInfo, Status => RPCStatus}
 import io.grpc.{Metadata, ServerCall, Status, StatusRuntimeException}
 import io.grpc.protobuf.StatusProto
 import io.grpc.stub.StreamObserver
@@ -39,7 +39,7 @@ import org.apache.spark.connect.proto.FetchErrorDetailsResponse
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{OP_TYPE, SESSION_ID, USER_ID}
 import org.apache.spark.sql.connect.config.Connect
-import org.apache.spark.sql.connect.service.{ExecuteEventsManager, SessionHolder, SessionKey, SparkConnectService}
+import org.apache.spark.sql.connect.service.{ExecuteEventsManager, RetryableGrpcError, SessionHolder, SessionKey, SparkConnectService}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
@@ -272,12 +272,20 @@ private[connect] object ErrorUtils extends Logging {
         errorInfo
       }
 
-    RPCStatus
+    val statusBuilder = RPCStatus
       .newBuilder()
       .setCode(RPCCode.INTERNAL_VALUE)
       .addDetails(ProtoAny.pack(withStackTrace.build()))
       .setMessage(errorDescription(st))
-      .build()
+
+    // Attach a RetryInfo detail for errors that are safe to retry, so that Spark Connect clients
+    // transparently re-submit the request. The retry delay is left unset (0), letting the client
+    // pace retries with its own backoff.
+    if (st.isInstanceOf[RetryableGrpcError]) {
+      statusBuilder.addDetails(ProtoAny.pack(RetryInfo.newBuilder().build()))
+    }
+
+    statusBuilder.build()
   }
 
   private def isPythonExecutionException(se: SparkException): Boolean = {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -68,6 +68,8 @@ class SparkConnectServiceSuite
 
   override def beforeEach(): Unit = {
     super.beforeEach()
+    // This suite invokes SparkConnectService directly without SparkConnectService.start().
+    SparkConnectService.executionManager.start()
     SparkConnectService.sessionManager.invalidateAllSessions()
     SparkConnectService.sessionManager.initializeBaseSession(() => spark.newSession())
   }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
@@ -16,8 +16,19 @@
  */
 package org.apache.spark.sql.connect.service
 
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.jdk.CollectionConverters._
+
+import com.google.rpc.RetryInfo
+import io.grpc.{Context, Status}
+
+import org.apache.spark.{SparkConf, SparkSQLException}
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.connect.utils.ErrorUtils
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -114,5 +125,183 @@ class SparkConnectExecutionManagerSuite extends SharedSparkSession {
     assert(
       info.status == ExecuteStatus.Closed,
       s"Expected Closed status in inactive cache, got ${info.status}")
+  }
+
+  test("unlimited concurrency and unowned holders preserve execution permits") {
+    val initialSlots = executionManager.getAvailableExecutionSlots
+    val permit = executionManager.acquireExecutionSlot()
+    assert(initialSlots == Int.MaxValue)
+    assert(executionManager.getAvailableExecutionSlots == initialSlots - 1)
+    permit.release()
+
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    executionManager.removeExecuteHolder(executeHolder.key)
+    executionManager.removeExecuteHolder(executeHolder.key)
+    assert(executionManager.getAvailableExecutionSlots == initialSlots)
+  }
+
+  test("execution concurrency configurations are static") {
+    assert(SQLConf.isStaticConfigKey(Connect.CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES.key))
+    assert(SQLConf.isStaticConfigKey(Connect.CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES_TIMEOUT.key))
+  }
+}
+
+/**
+ * Tests for the bounded, FIFO execution-slot acquisition, exercised with a concrete concurrency
+ * limit and acquire timeout set through the SparkConf.
+ */
+class SparkConnectExecutionManagerConcurrencyLimitSuite extends SharedSparkSession {
+
+  private val acquireTimeoutMs = 300
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set(Connect.CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES.key, "1")
+      .set(Connect.CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES_TIMEOUT.key, s"${acquireTimeoutMs}ms")
+
+  private def createHolder(
+      manager: SparkConnectExecutionManager,
+      permit: ExecutionPermit): ExecuteHolder = {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    sessionHolder.eventManager.status_(SessionStatus.Started)
+    val request = proto.ExecutePlanRequest
+      .newBuilder()
+      .setPlan(proto.Plan.newBuilder().setCommand(proto.Command.newBuilder()).build())
+      .setSessionId(sessionHolder.sessionId)
+      .setUserContext(proto.UserContext.newBuilder().setUserId(sessionHolder.userId).build())
+      .build()
+    val executeKey = ExecuteKey(request, sessionHolder)
+    val executeHolder =
+      manager.createExecuteHolder(executeKey, request, sessionHolder, Some(permit))
+    executeHolder.eventsManager.status_(ExecuteStatus.Started)
+    executeHolder
+  }
+
+  test("acquireExecutionSlot throws a retryable error when a slot is not available in time") {
+    val manager = new SparkConnectExecutionManager()
+    // Take the only available slot.
+    val permit = manager.acquireExecutionSlot()
+    try {
+      val e = intercept[SparkConnectConcurrentExecutionsTimeoutException] {
+        manager.acquireExecutionSlot()
+      }
+      assert(e.isInstanceOf[RetryableGrpcError], "Timeout error should be marked retryable")
+      assert(e.getCondition == "CONNECT.EXECUTE_CONCURRENT_LIMIT_TIMEOUT")
+    } finally {
+      permit.release()
+    }
+  }
+
+  test("a retryable error carries a RetryInfo detail, a regular error does not") {
+    val retryable =
+      new SparkConnectConcurrentExecutionsTimeoutException(1, s"$acquireTimeoutMs ms")
+    val status = ErrorUtils.buildStatusFromThrowable(retryable, None)
+    assert(
+      status.getDetailsList.asScala.exists(_.is(classOf[RetryInfo])),
+      "Retryable error status should contain a RetryInfo detail")
+
+    val nonRetryable = new SparkSQLException(
+      errorClass = "INVALID_HANDLE.FORMAT",
+      messageParameters = Map("handle" -> "abc"))
+    val nonRetryableStatus = ErrorUtils.buildStatusFromThrowable(nonRetryable, None)
+    assert(
+      !nonRetryableStatus.getDetailsList.asScala.exists(_.is(classOf[RetryInfo])),
+      "Non-retryable error status should not contain a RetryInfo detail")
+  }
+
+  test("a query waiting for a slot proceeds once one is released within the timeout") {
+    val manager = new SparkConnectExecutionManager()
+    val firstPermit = manager.acquireExecutionSlot()
+
+    val releaser = new Thread(() => {
+      Thread.sleep(acquireTimeoutMs / 3)
+      firstPermit.release()
+    })
+    releaser.start()
+
+    // Should block until the releaser frees the slot, well within the acquire timeout, and not
+    // raise a timeout error.
+    val secondPermit = manager.acquireExecutionSlot()
+    releaser.join()
+    secondPermit.release()
+  }
+
+  test("an execution permit is released exactly once") {
+    val manager = new SparkConnectExecutionManager()
+    val permit = manager.acquireExecutionSlot()
+    val executeHolder = createHolder(manager, permit)
+
+    manager.removeExecuteHolder(executeHolder.key)
+    manager.removeExecuteHolder(executeHolder.key)
+
+    assert(manager.getAvailableExecutionSlots == 1)
+  }
+
+  test("a completed execution releases its permit before its holder is removed") {
+    val manager = new SparkConnectExecutionManager()
+    val permit = manager.acquireExecutionSlot()
+    val executeHolder = createHolder(manager, permit)
+
+    executeHolder.responseObserver.onCompleted()
+
+    assert(manager.getAvailableExecutionSlots == 1)
+  }
+
+  test("shutdown closes holders and restores their execution permits") {
+    val manager = new SparkConnectExecutionManager()
+    val permit = manager.acquireExecutionSlot()
+    createHolder(manager, permit)
+    assert(manager.getAvailableExecutionSlots == 0)
+
+    manager.shutdown()
+    assert(manager.getAvailableExecutionSlots == 1)
+
+    manager.start()
+    val permitAfterRestart = manager.acquireExecutionSlot()
+    permitAfterRestart.release()
+  }
+}
+
+class SparkConnectExecutionManagerCancellationSuite extends SharedSparkSession {
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set(Connect.CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES.key, "1")
+      .set(Connect.CONNECT_EXECUTE_MAX_CONCURRENT_QUERIES_TIMEOUT.key, "0")
+
+  test("a cancelled ExecutePlan RPC stops waiting for an execution slot") {
+    val manager = new SparkConnectExecutionManager()
+    val firstPermit = manager.acquireExecutionSlot()
+    val cancellableContext = Context.current().withCancellation()
+    val failure = new AtomicReference[Throwable]()
+    val waiter = new Thread(() => {
+      cancellableContext.run(() => {
+        try {
+          manager.acquireExecutionSlot()
+        } catch {
+          case t: Throwable => failure.set(t)
+        }
+      })
+    })
+
+    try {
+      waiter.start()
+      eventually {
+        assert(manager.getExecutionQueueLength == 1)
+      }
+
+      cancellableContext.cancel(null)
+      waiter.join(10000)
+
+      assert(!waiter.isAlive)
+      assert(Status.fromThrowable(failure.get()).getCode == Status.Code.CANCELLED)
+      assert(manager.getExecutionQueueLength == 0)
+    } finally {
+      cancellableContext.cancel(null)
+      firstPermit.release()
+      waiter.join(10000)
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This is a first attempt at [SPARK-49580](https://issues.apache.org/jira/browse/SPARK-49580?jql=project%20%3D%20SPARK%20AND%20component%20%3D%20%22Connect%22%20AND%20text%20~%20%22concurrent%22), adding a maximum number of concurrent executions.

### Why are the changes needed?

With Spark Connect, it is more common to have many users running possibly many queries concurrently against a single driver, and it would be useful to have some control over the maximum number of executions that can occur.



### Does this PR introduce _any_ user-facing change?

Yes, new configuration parameters:

- `spark.connect.execute.maxConcurrentQueries`: maximum number of concurrent queries that can be executed. When this limit is reached, new queries will wait in a queue until a slot becomes available. Set to 0 or negative to disable the limit (unlimited concurrency). This only affects Spark Connect executions.

- `spark.connect.execute.maxConcurrentQueries.timeout`: aximum time a query waits for an execution slot when <code>spark.connect.execute.maxConcurrentQueries</code> is reached. Waiters are served in FIFO order. If a slot does not become available within this time, the query fails with a retryable error so the client re-submits it. Set to 0 to wait indefinitely. 

Note: maybe 'maxConcurrentExecutions' would be more precise here? Not sure what the best naming would be.

### How was this patch tested?

Added tests, will do more testing once we confirm the plan makes sense.

### Was this patch authored or co-authored using generative AI tooling?

Yes, modified changes provided by Claude.

Generated-by: 2.1.159 (Claude Code)