### PR TITLE
[SPARK-57806][SQL] Fix coercion of NullTyped expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiStringPromotionTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiStringPromotionTypeCoercion.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.{
   DateAdd,
   DateSub,
   Expression,
-  Literal,
   SubtractDates,
   SubtractTimestamps,
   TimestampAddInterval,
@@ -57,7 +56,9 @@ object AnsiStringPromotionTypeCoercion {
     case b @ BinaryOperator(left, right)
         if findWiderTypeForString(left.dataType, right.dataType).isDefined =>
       val promoteType = findWiderTypeForString(left.dataType, right.dataType).get
-      b.withNewChildren(Seq(castExpr(left, promoteType), castExpr(right, promoteType)))
+      b.withNewChildren(Seq(
+        TypeCoercionHelper.castExpr(left, promoteType),
+        TypeCoercionHelper.castExpr(right, promoteType)))
 
     case Abs(e @ StringTypeExpression(), failOnError) => Abs(Cast(e, DoubleType), failOnError)
     case m @ UnaryMinus(e @ StringTypeExpression(), _) =>
@@ -108,11 +109,4 @@ object AnsiStringPromotionTypeCoercion {
     }
   }
 
-  private def castExpr(expr: Expression, targetType: DataType): Expression = {
-    expr.dataType match {
-      case NullType => Literal.create(null, targetType)
-      case l if l != targetType => Cast(expr, targetType)
-      case _ => expr
-    }
-  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/StringPromotionTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/StringPromotionTypeCoercion.scala
@@ -24,15 +24,13 @@ import org.apache.spark.sql.catalyst.expressions.{
   BinaryComparison,
   Cast,
   Equality,
-  Expression,
-  Literal
+  Expression
 }
 import org.apache.spark.sql.types.{
   AnsiIntervalType,
   CalendarIntervalType,
   DataType,
   DoubleType,
-  NullType,
   StringTypeExpression,
   TimestampType,
   TimestampTypeExpression
@@ -63,17 +61,11 @@ object StringPromotionTypeCoercion {
     case p @ BinaryComparison(left, right)
         if findCommonTypeForBinaryComparison(left.dataType, right.dataType, conf).isDefined =>
       val commonType = findCommonTypeForBinaryComparison(left.dataType, right.dataType, conf).get
-      p.withNewChildren(Seq(castExpr(left, commonType), castExpr(right, commonType)))
+      p.withNewChildren(Seq(
+        TypeCoercionHelper.castExpr(left, commonType),
+        TypeCoercionHelper.castExpr(right, commonType)))
 
     case other => other
-  }
-
-  private def castExpr(expr: Expression, targetType: DataType): Expression = {
-    (expr.dataType, targetType) match {
-      case (NullType, dt) => Literal.create(null, targetType)
-      case (l, dt) if (l != dt) => Cast(expr, targetType)
-      case _ => expr
-    }
   }
 
   private def isIntervalType(dt: DataType): Boolean = dt match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala
@@ -619,12 +619,9 @@ abstract class TypeCoercionHelper {
         // Convert NullType into some specific target type for ExpectsInputTypes that don't do
         // general implicit casting.
         val children: Seq[Expression] = e.children.zip(e.inputTypes).map {
-          case (in, expected) =>
-            if (in.dataType == NullType && !expected.acceptsType(NullType)) {
-              Literal.create(null, expected.defaultConcreteType)
-            } else {
-              in
-            }
+          case (in, expected) if in.dataType == NullType && !expected.acceptsType(NullType) =>
+            TypeCoercionHelper.castExpr(in, expected.defaultConcreteType)
+          case (in, _) => in
         }
         e.withNewChildren(children)
 
@@ -777,6 +774,22 @@ abstract class TypeCoercionHelper {
         s.copy(left = newLeft, right = newRight)
 
       case other => other
+    }
+  }
+}
+
+object TypeCoercionHelper {
+
+  /**
+   * Casts an expression to the target type. If the expression is a null literal of NullType,
+   * returns a null literal of the target type directly instead of wrapping it in a Cast.
+   * If the expression already has the target type, it is returned unchanged.
+   */
+  private[analysis] def castExpr(expr: Expression, targetType: DataType): Expression = {
+    expr match {
+      case Literal(null, NullType) => Literal(null, targetType)
+      case l if l.dataType != targetType => Cast(expr, targetType)
+      case _ => expr
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
@@ -422,6 +422,13 @@ class AnsiTypeCoercionSuite extends TypeCoercionSuiteBase {
     ruleTest(AnsiTypeCoercion.ImplicitTypeCasts,
       NumericTypeUnaryExpression(Literal.create(null, NullType)),
       NumericTypeUnaryExpression(Literal.create(null, DoubleType)))
+
+    // SPARK-57806: a NullType expression with side effects must be wrapped in Cast, not replaced
+    // by a null literal, so that the side effect is preserved.
+    val raiseError = RaiseError(Literal(""))
+    ruleTest(AnsiTypeCoercion.ImplicitTypeCasts,
+      NumericTypeUnaryExpression(raiseError),
+      NumericTypeUnaryExpression(Cast(raiseError, DoubleType)))
   }
 
   test("cast NullType for binary operators") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1021,6 +1021,13 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
     ruleTest(TypeCoercion.ImplicitTypeCasts,
       NumericTypeUnaryExpression(Literal.create(null, NullType)),
       NumericTypeUnaryExpression(Literal.create(null, DoubleType)))
+
+    // SPARK-57806: a NullType expression with side effects must be wrapped in Cast, not replaced
+    // by a null literal, so that the side effect is preserved.
+    val raiseError = RaiseError(Literal(""))
+    ruleTest(TypeCoercion.ImplicitTypeCasts,
+      NumericTypeUnaryExpression(raiseError),
+      NumericTypeUnaryExpression(Cast(raiseError, DoubleType)))
   }
 
   test("cast NullType for binary operators") {
@@ -1701,6 +1708,18 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
       EqualTo(Cast(date0301, TimestampType), timestamp0301000000))
     ruleTest(rule, LessThan(date0301, timestamp0301000001),
       LessThan(Cast(date0301, TimestampType), timestamp0301000001))
+  }
+
+  test("SPARK-57806: NullType expression with side effects is preserved in string promotion") {
+    // raise_error has NullType as its dataType. When compared with a string, the old code
+    // would replace raise_error with Literal(null, StringType), silently discarding the side
+    // effect. The rule must wrap any NullType expression in a Cast so that side effects are
+    // preserved; the optimizer will later constant-fold plain null literals if applicable.
+    val rule = TypeCoercion.PromoteStrings
+    val raiseError = RaiseError(Literal(""))
+    ruleTest(rule,
+      EqualTo(raiseError, Literal("")),
+      EqualTo(Cast(raiseError, StringType), Literal("")))
   }
 
   test("cast WindowFrame boundaries to the type they operate upon") {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/counter-diff.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/counter-diff.sql.out
@@ -176,9 +176,9 @@ ORDER BY t
 -- !query analysis
 Sort [t#x ASC NULLS FIRST], true
 +- Project [t#x, diff#x]
-   +- Project [t#x, diff#x, diff#x]
-      +- Window [counter_diff(null) windowspecdefinition(t#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS diff#x], [t#x ASC NULLS FIRST]
-         +- Project [t#x]
+   +- Project [t#x, _w0#x, diff#x, diff#x]
+      +- Window [counter_diff(_w0#x) windowspecdefinition(t#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS diff#x], [t#x ASC NULLS FIRST]
+         +- Project [t#x, cast(c#x as double) AS _w0#x]
             +- SubqueryAlias tab
                +- LocalRelation [t#x, c#x]
 
@@ -188,7 +188,13 @@ SELECT t, counter_diff(c, st) OVER (ORDER BY t) AS diff
 FROM VALUES (1, 100, NULL), (2, 200, NULL) AS tab(t, c, st)
 ORDER BY t
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+Sort [t#x ASC NULLS FIRST], true
++- Project [t#x, diff#x]
+   +- Project [t#x, c#x, _w1#x, diff#x, diff#x]
+      +- Window [counter_diff(c#x, _w1#x, Some(UTC)) windowspecdefinition(t#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS diff#x], [t#x ASC NULLS FIRST]
+         +- Project [t#x, c#x, cast(st#x as timestamp) AS _w1#x]
+            +- SubqueryAlias tab
+               +- LocalRelation [t#x, c#x, st#x]
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Instead of replacing the Nulltyped value with a literal a cast is introduced. The optimizer can later constant fold this when that safe to do.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The current behavior is not safe for expressions that might raise an error as the expression get removed.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, fixes correctness issue.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing a new tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude sonnet 4.6
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
