### PR TITLE
[SPARK-57861][BUILD] Remove `javax.xml.bind:jaxb-api` from `LICENSE-binary`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -512,7 +512,6 @@ Common Development and Distribution License (CDDL) 1.1
 ------------------------------------------------------
 javax.transaction:jta http://www.oracle.com/technetwork/java/index.html
 javax.servlet:javax.servlet-api https://oss.oracle.com/licenses/CDDL+GPL-1.1
-javax.xml.bind:jaxb-api    https://github.com/javaee/jaxb-v2
 
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the stale `javax.xml.bind:jaxb-api` entry from the "Common Development and Distribution License (CDDL) 1.1" section of `LICENSE-binary`.

### Why are the changes needed?

`LICENSE-binary` documents the third-party dependencies bundled in the Spark binary distribution, but `javax.xml.bind:jaxb-api` is no longer shipped since Apache Spark 4.0.0:

- The bundled-jar manifest `dev/deps/spark-deps-hadoop-3-hive-2.3` contains no `javax.xml.bind:jaxb-api` jar. It only has the Jakarta replacement `jakarta.xml.bind-api-4.0.5`, plus `jaxb-core-4.0.6` and `jaxb-runtime-4.0.6`.

  - #49854

- The only build reference to `javax.xml.bind:jaxb-api` is at `test` scope in `resource-managers/yarn/pom.xml` ("Used by MiniYARNCluster"). The root `pom.xml` only manages its version in `<dependencyManagement>`; no compile/runtime dependency declares it.

https://github.com/apache/spark/blob/bdf6d814ee0930ab7b20c13c84d27d44d8251c4e/resource-managers/yarn/pom.xml#L84-L89

```
$ git grep javax.xml.bind
LICENSE-binary:javax.xml.bind:jaxb-api    https://github.com/javaee/jaxb-v2
pom.xml:        <groupId>javax.xml.bind</groupId>
resource-managers/yarn/pom.xml:      <groupId>javax.xml.bind</groupId>
```

- Test-scope dependencies are not shipped in the binary distribution, so this entry does not belong in `LICENSE-binary`. It is a leftover from before the `javax` -> `jakarta` JAXB migration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. `git diff LICENSE-binary` confirms exactly one line is removed, leaving the other CDDL 1.1 entries (`javax.transaction:jta`, `javax.servlet:javax.servlet-api`) untouched.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8