### PR TITLE
[SPARK-57862][INFRA] Allow create_spark_jira.py to set the issue description

### DIFF
--- a/dev/create_spark_jira.py
+++ b/dev/create_spark_jira.py
@@ -39,6 +39,16 @@ def main():
     )
     parser.add_argument("-c", "--component", help="Component for the issue")
     parser.add_argument(
+        "-d",
+        "--description",
+        help="Description text for the issue.",
+    )
+    parser.add_argument(
+        "--description-file",
+        help="Path to a file whose contents are used as the issue description "
+        "(mutually exclusive with --description).",
+    )
+    parser.add_argument(
         "--list-components", action="store_true", help="List available components and exit"
     )
     args = parser.parse_args()
@@ -60,9 +70,25 @@ def main():
     if not args.parent and not args.type:
         parser.error("-t/--type is required when not creating a subtask")
 
+    if args.description and args.description_file:
+        parser.error("--description and --description-file cannot be used together")
+
+    description = args.description or ""
+    if args.description_file:
+        try:
+            with open(args.description_file, encoding="utf-8") as f:
+                description = f.read()
+        except OSError as e:
+            parser.error("cannot read --description-file: %s" % e)
+
     asf_jira = get_jira_client()
     jira_id = create_jira_issue(
-        asf_jira, args.title, args.component, parent=args.parent, issue_type=args.type
+        asf_jira,
+        args.title,
+        args.component,
+        parent=args.parent,
+        issue_type=args.type,
+        description=description,
     )
     print(jira_id)
 

--- a/dev/spark_jira_utils.py
+++ b/dev/spark_jira_utils.py
@@ -78,14 +78,16 @@ def list_components(asf_jira):
         print(c.name)
 
 
-def create_jira_issue(asf_jira, title, component, parent=None, issue_type=None, version=None):
+def create_jira_issue(
+    asf_jira, title, component, parent=None, issue_type=None, version=None, description=""
+):
     """Create a JIRA issue and return the issue key (e.g. SPARK-12345)."""
     affected_version = version if version else detect_affected_version(asf_jira)
 
     issue_dict = {
         "project": {"key": "SPARK"},
         "summary": title,
-        "description": "",
+        "description": description or "",
         "versions": [{"name": affected_version}],
         "components": [{"name": component}],
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR extends `dev/create_spark_jira.py` (and its helper `dev/spark_jira_utils.py`) so the JIRA description can be set at creation time:
- Add `-d`/`--description` and `--description-file` options (mutually exclusive) to `create_spark_jira.py`.
- Add a `description` parameter to `create_jira_issue` and use it in the issue payload (previously hardcoded to an empty string).

Backward compatible: without the new flags the behavior is unchanged.

### Why are the changes needed?
`create_jira_issue` hardcoded `"description": ""`, so **tickets created via the script had no body** and the description had to be added manually afterwards. When creating many issues at once (e.g. a batch of sub-tasks under an umbrella), populating the description at creation time is much more efficient.

### Does this PR introduce _any_ user-facing change?
No. This is a developer tooling change; without the new flags the behavior is unchanged.

### How was this patch tested?
Manually created JIRA sub-tasks with `--description-file` and verified the description on the resulting issues.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor