### PR TITLE
[SPARK-57839][SQL] Support the nanosecond-precision timestamp types in CBO statistics estimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -49,6 +49,7 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
+import org.apache.spark.unsafe.types.TimestampNanosVal
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
@@ -1035,6 +1036,20 @@ object CatalogColumnStat extends Logging {
   }
 
   /**
+   * Returns a [[TimestampFormatter]] with nanosecond precision (9 fractional digits) for
+   * lossless serialization of nanosecond-precision timestamp column statistics.
+   */
+  private def getTimestampNanosFormatter(
+      isParsing: Boolean,
+      forTimestampNTZ: Boolean = false): TimestampFormatter = {
+    TimestampFormatter(
+      format = "yyyy-MM-dd HH:mm:ss.SSSSSSSSS",
+      zoneId = ZoneOffset.UTC,
+      isParsing = isParsing,
+      forTimestampNTZ = forTimestampNTZ)
+  }
+
+  /**
    * Converts from string representation of data type to the corresponding Catalyst data type.
    */
   def fromExternalString(s: String, name: String, dataType: DataType, version: Int): Any = {
@@ -1047,6 +1062,11 @@ object CatalogColumnStat extends Logging {
       case TimestampType => getTimestampFormatter(isParsing = true).parse(s)
       case TimestampNTZType =>
         getTimestampFormatter(isParsing = true, forTimestampNTZ = true).parse(s)
+      case t: TimestampLTZNanosType =>
+        getTimestampNanosFormatter(isParsing = true).parseNanos(s, t.precision)
+      case t: TimestampNTZNanosType =>
+        getTimestampNanosFormatter(isParsing = true, forTimestampNTZ = true)
+          .parseWithoutTimeZoneNanos(s, t.precision)
       case ByteType => s.toByte
       case ShortType => s.toShort
       case IntegerType => s.toInt
@@ -1073,6 +1093,12 @@ object CatalogColumnStat extends Logging {
       case TimestampNTZType =>
         getTimestampFormatter(isParsing = false, forTimestampNTZ = true)
           .format(v.asInstanceOf[Long])
+      case t: TimestampLTZNanosType =>
+        getTimestampNanosFormatter(isParsing = false)
+          .formatNanos(v.asInstanceOf[TimestampNanosVal], t.precision)
+      case t: TimestampNTZNanosType =>
+        getTimestampNanosFormatter(isParsing = false, forTimestampNTZ = true)
+          .formatWithoutTimeZoneNanos(v.asInstanceOf[TimestampNanosVal], t.precision)
       case BooleanType | _: IntegralType | FloatType | DoubleType => v
       case _: DecimalType => v.asInstanceOf[Decimal].toJavaBigDecimal
       // This version of Spark does not use min/max for binary/string types so we ignore it.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -152,6 +152,8 @@ object EstimationUtils {
       case DateType => double.toInt
       case TimestampType => double.toLong
       case _: AnyTimestampNanoType =>
+        // Lossy: the input Double may have lost precision in toDouble (see above).
+        // Acceptable for CBO estimation only.
         val nanos = double.toLong
         TimestampNanosVal.fromParts(Math.floorDiv(nanos, 1000L), Math.floorMod(nanos, 1000).toShort)
       case ByteType => double.toByte

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -138,6 +138,8 @@ object EstimationUtils {
     dataType match {
       case _: NumericType | DateType | TimestampType => value.toString.toDouble
       case _: AnyTimestampNanoType =>
+        // Note: epochMicros*1000+nanosWithinMicro exceeds Double's 2^53 exact-integer range for
+        // real-world dates, so this conversion is slightly lossy. Acceptable for estimation only.
         val v = value.asInstanceOf[TimestampNanosVal]
         v.epochMicros * 1000.0 + v.nanosWithinMicro
       case BooleanType => if (value.asInstanceOf[Boolean]) 1 else 0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -23,6 +23,7 @@ import scala.math.BigDecimal.RoundingMode
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, EmptyRow, Expression}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types.{DecimalType, _}
+import org.apache.spark.unsafe.types.TimestampNanosVal
 
 object EstimationUtils {
 
@@ -136,6 +137,9 @@ object EstimationUtils {
   def toDouble(value: Any, dataType: DataType): Double = {
     dataType match {
       case _: NumericType | DateType | TimestampType => value.toString.toDouble
+      case _: AnyTimestampNanoType =>
+        val v = value.asInstanceOf[TimestampNanosVal]
+        v.epochMicros * 1000.0 + v.nanosWithinMicro
       case BooleanType => if (value.asInstanceOf[Boolean]) 1 else 0
     }
   }
@@ -145,6 +149,9 @@ object EstimationUtils {
       case BooleanType => double.toInt == 1
       case DateType => double.toInt
       case TimestampType => double.toLong
+      case _: AnyTimestampNanoType =>
+        val nanos = double.toLong
+        TimestampNanosVal.fromParts(Math.floorDiv(nanos, 1000L), Math.floorMod(nanos, 1000).toShort)
       case ByteType => double.toByte
       case ShortType => double.toShort
       case IntegerType => double.toInt

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -291,7 +291,8 @@ case class FilterEstimation(plan: Filter) extends Logging {
     }
 
     attr.dataType match {
-      case _: NumericType | DateType | TimestampType | BooleanType =>
+      case _: NumericType | DateType | TimestampType | BooleanType |
+           _: AnyTimestampNanoType =>
         evaluateBinaryForNumeric(op, attr, literal, update)
       case StringType | BinaryType =>
         // TODO: It is difficult to support other binary comparisons for String/Binary
@@ -413,7 +414,8 @@ case class FilterEstimation(plan: Filter) extends Logging {
 
     // use [min, max] to filter the original hSet
     dataType match {
-      case _: NumericType | BooleanType | DateType | TimestampType =>
+      case _: NumericType | BooleanType | DateType | TimestampType |
+           _: AnyTimestampNanoType =>
         if (ndv.toDouble == 0) {
           return Some(0.0)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -38,7 +38,7 @@ object UnionEstimation {
   private def isTypeSupported(dt: DataType): Boolean = dt match {
     case ByteType | IntegerType | ShortType | FloatType | LongType |
          DoubleType | DateType | _: DecimalType | TimestampType | TimestampNTZType |
-         _: AnsiIntervalType => true
+         _: AnsiIntervalType | _: AnyTimestampNanoType => true
     case _ => false
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -1164,4 +1164,69 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 4)
   }
 
+  test("nanos filter estimation is safe when min/max collapse to same double" +
+    " (within one ULP)") {
+    // At epoch-nanos ~1.7e18 (2024 timestamps), the double ULP is ~256 ns.
+    // Two nanos bounds separated by less than one ULP collapse to the same double value
+    // when converted via toDouble, yet min != max.  This test locks the guard against future
+    // edits that might cause an AssertionError when the double range is zero.
+    val epochMicros = 1704067200000000L // 2024-01-01T00:00:00Z
+    // min and max differ by only 100 ns (< 256 ns ULP), so they collapse to the same double.
+    val ulpMin = TimestampNanosVal.fromParts(epochMicros, 0.toShort)
+    val ulpMax = TimestampNanosVal.fromParts(epochMicros, 100.toShort)
+    assert(ulpMin != ulpMax, "precondition: min and max must be distinct TimestampNanosVal values")
+
+    val ntzType = TimestampNTZNanosType(9)
+    val minDouble = toDouble(ulpMin, ntzType)
+    val maxDouble = toDouble(ulpMax, ntzType)
+    assert(minDouble == maxDouble,
+      s"precondition: toDouble(min)=$minDouble must equal toDouble(max)=$maxDouble " +
+        "(both within one ULP)")
+
+    val attrUlp = AttributeReference("ctsnanos_ulp", ntzType)()
+    val colStatUlp = ColumnStat(distinctCount = Some(10),
+      min = Some(ulpMin), max = Some(ulpMax),
+      nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+    val ulpMap = AttributeMap(Seq(attrUlp -> colStatUlp))
+
+    // Partial-overlap filter: value between min and max (logically), but since doubles collapse,
+    // the estimation must not throw and must return a sane result.
+    val filterVal = TimestampNanosVal.fromParts(epochMicros, 50.toShort)
+    val rowCount = 10L
+    val filter = Filter(LessThan(attrUlp, Literal(filterVal, ntzType)),
+      childStatsTestPlan(Seq(attrUlp), rowCount, ulpMap))
+    val estimated = filter.stats
+    assert(estimated.rowCount.isDefined, "estimation must produce a row count")
+    val estRows = estimated.rowCount.get
+    assert(estRows >= 0 && estRows <= rowCount,
+      s"estimated row count $estRows must be between 0 and $rowCount")
+  }
+
+  test("nanos filter estimation with pre-1970 negative epoch values (fromDouble floorDiv/Mod)") {
+    // Pre-1970 timestamps have negative epochMicros.  This exercises the floorDiv/floorMod path
+    // in EstimationUtils.fromDouble that reconstructs TimestampNanosVal from a negative double.
+    // 1969-12-31T23:59:50Z => epochMicros = -10000000L (10 seconds before epoch)
+    // 1969-12-31T23:59:59Z => epochMicros = -1000000L  (1 second before epoch)
+    val negMin = TimestampNanosVal.fromParts(-10000000L, 500.toShort)
+    val negMax = TimestampNanosVal.fromParts(-1000000L, 500.toShort)
+    val ntzType = TimestampNTZNanosType(9)
+    val attrNeg = AttributeReference("ctsnanos_neg", ntzType)()
+    val colStatNeg = ColumnStat(distinctCount = Some(10),
+      min = Some(negMin), max = Some(negMax),
+      nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+    val negMap = AttributeMap(Seq(attrNeg -> colStatNeg))
+
+    // Filter at ~1/3 of the range: -10000000500 to -1000000500 nanos, range = 9000000 nanos
+    // 1/3 point: -10000000500 + 3000000 = epochMicros=-7000000, nanos=500
+    val filterVal = TimestampNanosVal.fromParts(-7000000L, 500.toShort)
+    // Expected: fraction = 3/9 = 1/3, rows = ceil(10 * 1/3) = 4, ndv = 4
+    validateEstimatedStats(
+      Filter(LessThan(attrNeg, Literal(filterVal, ntzType)),
+        childStatsTestPlan(Seq(attrNeg), 10L, negMap)),
+      Seq(attrNeg -> ColumnStat(distinctCount = Some(4),
+        min = Some(negMin), max = Some(filterVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 4)
+  }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -1071,4 +1071,48 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 2)
   }
 
+  // column ctsLtzNanos: LTZ nanos type with sub-microsecond values (nanosWithinMicro != 0).
+  // Values span epochMicros=1000 nanos=500 to epochMicros=1009 nanos=500
+  // i.e. total epoch nanos 1000500..1009500 (range = 9000 nanos)
+  val tsLtzNanosMin = TimestampNanosVal.fromParts(1000L, 500.toShort)
+  val tsLtzNanosMax = TimestampNanosVal.fromParts(1009L, 500.toShort)
+  val attrTsLtzNanos = AttributeReference("ctsltznanos", TimestampLTZNanosType(9))()
+  val colStatTsLtzNanos = ColumnStat(distinctCount = Some(10),
+    min = Some(tsLtzNanosMin), max = Some(tsLtzNanosMax),
+    nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+
+  test("ctsltznanos < TimestampNanosVal(1003, 500) - LTZ type with sub-microsecond") {
+    // Range [1000500, 1009500], value = 1003500, fraction = 3000/9000 = 1/3
+    // Rows = ceil(10 * 3/9) = 4, ndv = ceil(10 * 3/9) = 4
+    val tsVal = TimestampNanosVal.fromParts(1003L, 500.toShort)
+    val ltzMap = AttributeMap(Seq(attrTsLtzNanos -> colStatTsLtzNanos))
+    validateEstimatedStats(
+      Filter(LessThan(attrTsLtzNanos, Literal(tsVal, TimestampLTZNanosType(9))),
+        childStatsTestPlan(Seq(attrTsLtzNanos), 10L, ltzMap)),
+      Seq(attrTsLtzNanos -> ColumnStat(distinctCount = Some(4),
+        min = Some(tsLtzNanosMin), max = Some(tsVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 4)
+  }
+
+  test("ctsnanos = TimestampNanosVal(1003, 456) - sub-microsecond nanosWithinMicro") {
+    // Test that sub-microsecond nanosWithinMicro term is exercised in toDouble estimation.
+    // The value 1003*1000+456 = 1003456 falls within range [1000000, 1009000].
+    val subMicroMin = TimestampNanosVal.fromParts(1000L, 0.toShort)
+    val subMicroMax = TimestampNanosVal.fromParts(1009L, 0.toShort)
+    val attrSubMicro = AttributeReference("ctssubmicro", TimestampNTZNanosType(9))()
+    val colStatSubMicro = ColumnStat(distinctCount = Some(10),
+      min = Some(subMicroMin), max = Some(subMicroMax),
+      nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+    val subMicroMap = AttributeMap(Seq(attrSubMicro -> colStatSubMicro))
+    val tsVal = TimestampNanosVal.fromParts(1003L, 456.toShort)
+    validateEstimatedStats(
+      Filter(EqualTo(attrSubMicro, Literal(tsVal, TimestampNTZNanosType(9))),
+        childStatsTestPlan(Seq(attrSubMicro), 10L, subMicroMap)),
+      Seq(attrSubMicro -> ColumnStat(distinctCount = Some(1),
+        min = Some(tsVal), max = Some(tsVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 1)
+  }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -1115,4 +1115,53 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 1)
   }
 
+  // High-magnitude nanos tests: exercise the lossy toDouble/fromDouble path where
+  // epochMicros*1000 exceeds Double's 2^53 exact-integer range (real-world 2024 timestamps).
+  // epochMicros ~1.7e15 => epoch nanos ~1.7e18 >> 2^53 (~9e15).
+  // The point is to verify estimation remains sensible despite floating-point rounding.
+
+  test("NTZ nanos filter estimation at high magnitude (2024 timestamps)") {
+    // 2024-01-01T00:00:00Z => epochMicros = 1704067200000000L
+    // 2024-01-01T00:00:09Z => epochMicros = 1704067209000000L
+    // Range in nanos = 9000000 nanos (9 ms)
+    val hiMin = TimestampNanosVal.fromParts(1704067200000000L, 0.toShort)
+    val hiMax = TimestampNanosVal.fromParts(1704067209000000L, 0.toShort)
+    val attrHiNtz = AttributeReference("ctsnanos_hi", TimestampNTZNanosType(9))()
+    val colStatHi = ColumnStat(distinctCount = Some(10),
+      min = Some(hiMin), max = Some(hiMax),
+      nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+    val hiMap = AttributeMap(Seq(attrHiNtz -> colStatHi))
+    // Filter value at ~1/3 of the range
+    val tsVal = TimestampNanosVal.fromParts(1704067203000000L, 0.toShort)
+    // Expected: fraction ~ 3/9 = 1/3, rows = ceil(10 * 1/3) = 4, ndv = 4
+    validateEstimatedStats(
+      Filter(LessThan(attrHiNtz, Literal(tsVal, TimestampNTZNanosType(9))),
+        childStatsTestPlan(Seq(attrHiNtz), 10L, hiMap)),
+      Seq(attrHiNtz -> ColumnStat(distinctCount = Some(4),
+        min = Some(hiMin), max = Some(tsVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 4)
+  }
+
+  test("LTZ nanos filter estimation at high magnitude (2024 timestamps)") {
+    // Same magnitude as above but using TimestampLTZNanosType.
+    val hiMin = TimestampNanosVal.fromParts(1704067200000000L, 0.toShort)
+    val hiMax = TimestampNanosVal.fromParts(1704067209000000L, 0.toShort)
+    val attrHiLtz = AttributeReference("ctsltznanos_hi", TimestampLTZNanosType(9))()
+    val colStatHi = ColumnStat(distinctCount = Some(10),
+      min = Some(hiMin), max = Some(hiMax),
+      nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+    val hiMap = AttributeMap(Seq(attrHiLtz -> colStatHi))
+    // Filter value at ~1/3 of the range
+    val tsVal = TimestampNanosVal.fromParts(1704067203000000L, 0.toShort)
+    // Expected: fraction ~ 3/9 = 1/3, rows = ceil(10 * 1/3) = 4, ndv = 4
+    validateEstimatedStats(
+      Filter(LessThan(attrHiLtz, Literal(tsVal, TimestampLTZNanosType(9))),
+        childStatsTestPlan(Seq(attrHiLtz), 10L, hiMap)),
+      Seq(attrHiLtz -> ColumnStat(distinctCount = Some(4),
+        min = Some(hiMin), max = Some(tsVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 4)
+  }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ColumnStatsMa
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 
 /**
  * In this test suite, we test predicates containing the following operators:
@@ -114,6 +115,16 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
   val colStatIntSkewHgm = ColumnStat(distinctCount = Some(5), min = Some(1), max = Some(10),
     nullCount = Some(0), avgLen = Some(4), maxLen = Some(4), histogram = Some(hgmIntSkew))
 
+  // column ctsnanos has 10 nanosecond-precision timestamp values.
+  // Values span from epochMicros=1000 nanosWithinMicro=0 to epochMicros=1009 nanosWithinMicro=0
+  // i.e. total epoch nanos 1000000..1009000 (range = 9000 nanos)
+  val tsNanosMin = TimestampNanosVal.fromParts(1000L, 0.toShort)
+  val tsNanosMax = TimestampNanosVal.fromParts(1009L, 0.toShort)
+  val attrTsNanos = AttributeReference("ctsnanos", TimestampNTZNanosType(9))()
+  val colStatTsNanos = ColumnStat(distinctCount = Some(10),
+    min = Some(tsNanosMin), max = Some(tsNanosMax),
+    nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
+
   val attributeMap = AttributeMap(Seq(
     attrInt -> colStatInt,
     attrBool -> colStatBool,
@@ -125,7 +136,8 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     attrInt3 -> colStatInt3,
     attrInt4 -> colStatInt4,
     attrIntHgm -> colStatIntHgm,
-    attrIntSkewHgm -> colStatIntSkewHgm
+    attrIntSkewHgm -> colStatIntSkewHgm,
+    attrTsNanos -> colStatTsNanos
   ))
 
   test("true") {
@@ -1018,6 +1030,45 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
         }
       }
     }
+  }
+
+  // Tests for nanosecond-precision timestamp types (SPARK-57839)
+  test("ctsnanos = TimestampNanosVal(1003, 0)") {
+    val tsVal = TimestampNanosVal.fromParts(1003L, 0.toShort)
+    validateEstimatedStats(
+      Filter(EqualTo(attrTsNanos, Literal(tsVal, TimestampNTZNanosType(9))),
+        childStatsTestPlan(Seq(attrTsNanos), 10L)),
+      Seq(attrTsNanos -> ColumnStat(distinctCount = Some(1),
+        min = Some(tsVal), max = Some(tsVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 1)
+  }
+
+  test("ctsnanos < TimestampNanosVal(1003, 0)") {
+    // Range [1000000, 1009000], value = 1003000, fraction = 3000/9000 = 1/3
+    // Rows = ceil(10 * 3/9) = 4 (3.33 rounds up), ndv = ceil(10 * 3/9) = 4
+    val tsVal = TimestampNanosVal.fromParts(1003L, 0.toShort)
+    validateEstimatedStats(
+      Filter(LessThan(attrTsNanos, Literal(tsVal, TimestampNTZNanosType(9))),
+        childStatsTestPlan(Seq(attrTsNanos), 10L)),
+      Seq(attrTsNanos -> ColumnStat(distinctCount = Some(4),
+        min = Some(tsNanosMin), max = Some(tsVal),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 4)
+  }
+
+  test("ctsnanos IN (TimestampNanosVal(1003, 0), TimestampNanosVal(1005, 0))") {
+    val ts3 = TimestampNanosVal.fromParts(1003L, 0.toShort)
+    val ts5 = TimestampNanosVal.fromParts(1005L, 0.toShort)
+    validateEstimatedStats(
+      Filter(In(attrTsNanos, Seq(
+        Literal(ts3, TimestampNTZNanosType(9)),
+        Literal(ts5, TimestampNTZNanosType(9)))),
+        childStatsTestPlan(Seq(attrTsNanos), 10L)),
+      Seq(attrTsNanos -> ColumnStat(distinctCount = Some(2),
+        min = Some(ts3), max = Some(ts5),
+        nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))),
+      expectedRowCount = 2)
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/JoinEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/JoinEstimationSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types.{DateType, TimestampType, _}
+import org.apache.spark.unsafe.types.TimestampNanosVal
 
 
 class JoinEstimationSuite extends StatsEstimationTestBase {
@@ -506,7 +507,12 @@ class JoinEstimationSuite extends StatsEstimationTestBase {
           nullCount = Some(0), avgLen = Some(4), maxLen = Some(4)),
         AttributeReference("ctimestamp", TimestampType)() -> ColumnStat(distinctCount = Some(1),
           min = Some(timestamp), max = Some(timestamp),
-          nullCount = Some(0), avgLen = Some(8), maxLen = Some(8))
+          nullCount = Some(0), avgLen = Some(8), maxLen = Some(8)),
+        AttributeReference("ctsnanos", TimestampNTZNanosType(9))() -> ColumnStat(
+          distinctCount = Some(1),
+          min = Some(TimestampNanosVal.fromParts(timestamp, 123.toShort)),
+          max = Some(TimestampNanosVal.fromParts(timestamp, 123.toShort)),
+          nullCount = Some(0), avgLen = Some(10), maxLen = Some(10))
       )
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReferen
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Union}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 
 class UnionEstimationSuite extends StatsEstimationTestBase {
 
@@ -60,7 +61,7 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
     val attrTimestampNTZ = AttributeReference("ctimestamp_ntz", TimestampNTZType)()
     val attrYMInterval = AttributeReference("cyminterval", YearMonthIntervalType())()
     val attrDTInterval = AttributeReference("cdtinterval", DayTimeIntervalType())()
-
+    val attrTsNanos = AttributeReference("ctsnanos", TimestampNTZNanosType(9))()
     val s1 = 1.toShort
     val s2 = 4.toShort
     val b1 = 1.toByte
@@ -90,7 +91,10 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
         attrTimestamp -> ColumnStat(min = Some(1L), max = Some(4L)),
         attrTimestampNTZ -> ColumnStat(min = Some(1L), max = Some(4L)),
         attrYMInterval -> ColumnStat(min = Some(2), max = Some(5)),
-        attrDTInterval -> ColumnStat(min = Some(2L), max = Some(5L))))
+        attrDTInterval -> ColumnStat(min = Some(2L), max = Some(5L)),
+        attrTsNanos -> ColumnStat(
+          min = Some(TimestampNanosVal.fromParts(1L, 0.toShort)),
+          max = Some(TimestampNanosVal.fromParts(4L, 0.toShort)))))
 
     val s3 = 2.toShort
     val s4 = 6.toShort
@@ -133,7 +137,10 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
           max = Some(8)),
         AttributeReference("cdttimestamp1", DayTimeIntervalType())() -> ColumnStat(
           min = Some(4L),
-          max = Some(8L))))
+          max = Some(8L)),
+        AttributeReference("ctsnanos1", TimestampNTZNanosType(9))() -> ColumnStat(
+          min = Some(TimestampNanosVal.fromParts(3L, 0.toShort)),
+          max = Some(TimestampNanosVal.fromParts(6L, 0.toShort)))))
 
     val child1 = StatsTestPlan(
       outputList = columnInfo.keys.toSeq.sortWith(_.exprId.id < _.exprId.id),
@@ -167,7 +174,10 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
           attrTimestamp -> ColumnStat(min = Some(1L), max = Some(6L)),
           attrTimestampNTZ -> ColumnStat(min = Some(1L), max = Some(6L)),
           attrYMInterval -> ColumnStat(min = Some(2), max = Some(8)),
-          attrDTInterval -> ColumnStat(min = Some(2L), max = Some(8L)))))
+          attrDTInterval -> ColumnStat(min = Some(2L), max = Some(8L)),
+          attrTsNanos -> ColumnStat(
+            min = Some(TimestampNanosVal.fromParts(1L, 0.toShort)),
+            max = Some(TimestampNanosVal.fromParts(6L, 0.toShort))))))
     assert(union.stats === expectedStats)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -371,6 +371,9 @@ object CommandUtils extends Logging {
     case _: IntegralType => true
     case _: DecimalType => true
     case DoubleType | FloatType => true
+    // Exclude nanosecond timestamp types: ApproximatePercentile and
+    // ApproxCountDistinctForIntervals do not accept them yet (separate scope).
+    case _: AnyTimestampNanoType => false
     case _: DatetimeType => true
     case _ => false
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -235,6 +235,23 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
     val map = catalogStat.toMap("ctsnanos")
     val roundtrip = CatalogColumnStat.fromMap("t", "ctsnanos", map)
     assert(roundtrip === Some(catalogStat))
+
+    // Pre-1970 (negative epochMicros) round-trip exercises floorDiv/floorMod in fromDouble.
+    // 1969-06-15T00:00:00.123456789 => epochMicros ~ -16070400000000L, nanosWithinMicro = 789
+    val pre1970Val = TimestampNanosVal.fromParts(-16070400000000L, 789.toShort)
+    val pre1970NtzStr = CatalogColumnStat.toExternalString(pre1970Val, "col", ntzNanosType)
+    val pre1970NtzParsed =
+      CatalogColumnStat.fromExternalString(pre1970NtzStr, "col", ntzNanosType, 2)
+    assert(pre1970NtzParsed === pre1970Val,
+      s"Pre-1970 NTZ nanos round-trip failed: formatted='$pre1970NtzStr', " +
+        s"parsed=$pre1970NtzParsed, expected=$pre1970Val")
+
+    val pre1970LtzStr = CatalogColumnStat.toExternalString(pre1970Val, "col", ltzNanosType)
+    val pre1970LtzParsed =
+      CatalogColumnStat.fromExternalString(pre1970LtzStr, "col", ltzNanosType, 2)
+    assert(pre1970LtzParsed === pre1970Val,
+      s"Pre-1970 LTZ nanos round-trip failed: formatted='$pre1970LtzStr', " +
+        s"parsed=$pre1970LtzParsed, expected=$pre1970Val")
   }
 
   test("SPARK-57839: ANALYZE TABLE FOR COLUMNS on nanosecond timestamp collects basic stats") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -237,6 +237,36 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
     assert(roundtrip === Some(catalogStat))
   }
 
+  test("SPARK-57839: ANALYZE TABLE FOR COLUMNS on nanosecond timestamp collects basic stats") {
+    // Nanosecond timestamp columns should collect basic stats (min/max/ndv) but skip histogram,
+    // since ApproximatePercentile and ApproxCountDistinctForIntervals do not accept nanos types.
+    val table = "nanos_analyze_test"
+    withTable(table) {
+      sql(
+        s"""CREATE TABLE $table (id INT, ts_ntz TIMESTAMP_NTZ(9), ts_ltz TIMESTAMP_LTZ(9))
+           |USING PARQUET""".stripMargin)
+      sql(s"INSERT INTO $table VALUES (1, TIMESTAMP_NTZ'2024-01-01 00:00:00.123456789', " +
+        "TIMESTAMP_LTZ'2024-01-01 00:00:00.123456789')")
+      sql(s"INSERT INTO $table VALUES (2, TIMESTAMP_NTZ'2024-06-15 12:30:00.987654321', " +
+        "TIMESTAMP_LTZ'2024-06-15 12:30:00.987654321')")
+
+      // Should succeed with histograms enabled - nanos cols get basic stats, no histogram error
+      withSQLConf(SQLConf.HISTOGRAM_ENABLED.key -> "true") {
+        sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS ts_ntz, ts_ltz")
+      }
+
+      val stats = getCatalogTable(table).stats
+      assert(stats.isDefined)
+      assert(stats.get.colStats.contains("ts_ntz"))
+      assert(stats.get.colStats.contains("ts_ltz"))
+      // Verify basic stats collected (no histogram field for nanos columns)
+      val ntzStats = stats.get.colStats("ts_ntz")
+      assert(ntzStats.distinctCount.contains(2))
+      assert(ntzStats.nullCount.contains(0))
+      assert(ntzStats.histogram.isEmpty, "Nanos columns should not have histograms")
+    }
+  }
+
   test("analyze column command - result verification") {
     // (data.head.productArity - 1) because the last column does not support stats collection.
     assert(stats.size == data.head.productArity - 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.test.SQLTestData.ArrayData
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 import org.apache.spark.util.Utils
 
 
@@ -203,6 +204,37 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
         assert(roundtrip == Some(v))
       }
     }
+  }
+
+  test("SPARK-57839: nanosecond-precision timestamp column stats lossless round trip") {
+    // Use a sub-microsecond value (nanosWithinMicro != 0) to prove nanos survive serialization.
+    val ntzNanosType = TimestampNTZNanosType(9)
+    val ltzNanosType = TimestampLTZNanosType(9)
+    val subMicroVal = TimestampNanosVal.fromParts(1640995201123456L, 789.toShort)
+
+    // NTZ nanos round-trip
+    val ntzStr = CatalogColumnStat.toExternalString(subMicroVal, "col", ntzNanosType)
+    val ntzParsed = CatalogColumnStat.fromExternalString(ntzStr, "col", ntzNanosType, 2)
+    assert(ntzParsed === subMicroVal,
+      s"NTZ nanos round-trip failed: formatted='$ntzStr', parsed=$ntzParsed, expected=$subMicroVal")
+
+    // LTZ nanos round-trip
+    val ltzStr = CatalogColumnStat.toExternalString(subMicroVal, "col", ltzNanosType)
+    val ltzParsed = CatalogColumnStat.fromExternalString(ltzStr, "col", ltzNanosType, 2)
+    assert(ltzParsed === subMicroVal,
+      s"LTZ nanos round-trip failed: formatted='$ltzStr', parsed=$ltzParsed, expected=$subMicroVal")
+
+    // Full CatalogColumnStat map round-trip
+    val catalogStat = CatalogColumnStat(
+      distinctCount = Some(1),
+      min = Some(ntzStr),
+      max = Some(ntzStr),
+      nullCount = Some(0),
+      avgLen = Some(10),
+      maxLen = Some(10))
+    val map = catalogStat.toMap("ctsnanos")
+    val roundtrip = CatalogColumnStat.fromMap("t", "ctsnanos", map)
+    assert(roundtrip === Some(catalogStat))
   }
 
   test("analyze column command - result verification") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds cost-based optimizer (CBO) statistics estimation support for the nanosecond-precision timestamp types (`TimestampNTZNanosType`, `TimestampLTZNanosType`), mirroring the existing microsecond `TimestampType` handling at every CBO site: `EstimationUtils.toDouble`/`fromDouble`, `FilterEstimation.evaluateBinary`/`evaluateInSet`, `UnionEstimation.isTypeSupported`, and `CatalogColumnStat` min/max (de)serialization. Values are converted on the nanosecond scale (`epochMicros * 1000 + nanosWithinMicro`). Column-stat min/max are serialized with a fraction-preserving 9-digit nanosecond formatter so they round-trip losslessly.

It also excludes the nanosecond timestamp types from histogram collection (`CommandUtils.supportsHistogram`) - the histogram aggregates do not yet accept them - so `ANALYZE TABLE ... FOR COLUMNS` on a nanosecond-precision column collects basic statistics (min/max/ndv) without error.

### Why are the changes needed?

Filters/joins/unions over nanosecond-precision timestamp columns previously fell back to default selectivity because these types were not among the types CBO estimates. They have a natural numeric ordering, so they can be estimated the same way as microsecond timestamps.

### Does this PR introduce _any_ user-facing change?

No. Affects CBO estimation / plan costing only; query results are unchanged.

### How was this patch tested?

New `FilterEstimationSuite` tests (range / `=` / `IN` selectivity) for the nanosecond types, nanosecond columns added to the Union/Join estimation tests, and a dedicated lossless min/max round-trip test in `StatisticsCollectionSuite` (a sub-microsecond value survives `toExternalString` -> `fromExternalString`). All CBO estimation suites pass. An `ANALYZE TABLE ... FOR COLUMNS` test on nanosecond columns confirms basic stats are collected and histograms are skipped.

### Was this patch authored or co-authored using generative AI tooling?

Authored with assistance by Claude Opus 4.8.

