### PR TITLE
[SPARK-57830][SS] Support event-time watermark on nanosecond-precision timestamp columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -653,6 +653,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               case s: StructType
                 if s.find(_.name == "end").map(_.dataType) == Some(TimestampType) =>
               case _: TimestampType =>
+              case _: AnyTimestampNanoType =>
               case _ =>
                 etw.failAnalysis(
                   errorClass = "EVENT_TIME_IS_NOT_ON_TIMESTAMP_TYPE",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
+import org.apache.spark.sql.types.AnyTimestampNanoType
 
 /**
  * Analyzes the presence of unsupported operations in a logical plan.
@@ -554,6 +555,19 @@ object UnsupportedOperationChecker extends Logging {
             throwError(
               "dropDuplicatesWithinWatermark is not supported on streaming DataFrames/DataSets " +
                 "without watermark")(plan)
+          }
+
+          // TODO(SPARK-57843): Handle nanosecond event-time columns in streaming stateful
+          //  operators incl. dropDuplicatesWithinWatermark. Until then, reject them here to
+          //  avoid silent corruption (the exec layer reads event time via getLong assuming
+          //  microsecond precision).
+          val nanoWatermarkAttributes = watermarkAttributes.filter(
+            _.dataType.isInstanceOf[AnyTimestampNanoType])
+          if (nanoWatermarkAttributes.nonEmpty) {
+            throwError(
+              "dropDuplicatesWithinWatermark does not yet support nanosecond-precision " +
+                "event-time columns (SPARK-57843). Use a microsecond-precision timestamp " +
+                "type for the watermark column instead.")(plan)
           }
 
         case c: CoGroup if c.children.exists(_.isStreaming) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
-import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder}
+import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder, TimestampLTZNanosType}
 
 /** A dummy command for testing unsupported operations. */
 case class DummyCommand() extends LeafCommand
@@ -353,6 +353,21 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
     Deduplicate(Seq(att), batchRelation),
     outputMode = Append
   )
+
+  // DeduplicateWithinWatermark with nanosecond event-time column should be rejected
+  testError(
+    "streaming plan - DeduplicateWithinWatermark with nanosecond event-time: not supported",
+    Seq("dropDuplicatesWithinWatermark", "nanosecond", "SPARK-57843")) {
+    val nanoAttr = AttributeReference("ts", TimestampLTZNanosType())()
+    val nanoWatermarkMetadata = new MetadataBuilder()
+      .withMetadata(nanoAttr.metadata)
+      .putLong(EventTimeWatermark.delayKey, 1000L)
+      .build()
+    val nanoAttrWithWatermark = nanoAttr.withMetadata(nanoWatermarkMetadata)
+    val nanoStreamRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val plan = DeduplicateWithinWatermark(Seq(nanoAttrWithWatermark), nanoStreamRelation)
+    UnsupportedOperationChecker.checkForStreaming(wrapInStreaming(plan), Append)
+  }
 
   // Inner joins: Multiple stream-stream joins supported only in append mode
   testBinaryOperationInStreamingPlan(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/EventTimeWatermarkExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/EventTimeWatermarkExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToMillis
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.{TimestampLTZNanosType, TimestampNTZNanosType}
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.AccumulatorV2
 
@@ -105,8 +106,16 @@ case class EventTimeWatermarkExec(
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions { iter =>
       val getEventTime = UnsafeProjection.create(eventTime :: Nil, child.output)
+      val toMs: InternalRow => Long = eventTime.dataType match {
+        case _: TimestampLTZNanosType =>
+          row => microsToMillis(getEventTime(row).getTimestampLTZNanos(0).epochMicros)
+        case _: TimestampNTZNanosType =>
+          row => microsToMillis(getEventTime(row).getTimestampNTZNanos(0).epochMicros)
+        case _ =>
+          row => microsToMillis(getEventTime(row).getLong(0))
+      }
       iter.map { row =>
-        eventTimeStats.add(microsToMillis(getEventTime(row).getLong(0)))
+        eventTimeStats.add(toMs(row))
         row
       }
     }
@@ -160,8 +169,16 @@ case class UpdateEventTimeColumnExec(
             val boundEventTimeExpression = bindReference[Expression](eventTime, child.output)
             val eventTimeProjection = UnsafeProjection.create(boundEventTimeExpression)
             val rowEventTime = eventTimeProjection(row)
+            val eventTimeMicros = eventTime.dataType match {
+              case _: TimestampLTZNanosType =>
+                rowEventTime.getTimestampLTZNanos(0).epochMicros
+              case _: TimestampNTZNanosType =>
+                rowEventTime.getTimestampNTZNanos(0).epochMicros
+              case _ =>
+                rowEventTime.getLong(0)
+            }
             throw QueryExecutionErrors.emittedRowsAreOlderThanWatermark(
-              eventTimeWatermarkForLateEvents.get, rowEventTime.getLong(0))
+              eventTimeWatermarkForLateEvents.get, eventTimeMicros)
           }
           row
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -1584,6 +1584,7 @@ case class StreamingDeduplicateWithinWatermarkExec(
     // are internally represented as Long.
     // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
     //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
+    //  Until then, UnsupportedOperationChecker rejects nanos event-time at analysis time.
     val timestamp = data.getLong(eventTimeColOrdinal)
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -672,11 +672,9 @@ object WatermarkSupport {
     // use the attribute itself.
     val evictionExpression =
       if (watermarkAttribute.dataType.isInstanceOf[StructType]) {
-        val structType = watermarkAttribute.dataType.asInstanceOf[StructType]
-        val endFieldType = structType("end").dataType
         LessThanOrEqual(
           GetStructField(watermarkAttribute, 1),
-          watermarkLiteral(optionalWatermarkMs.get, endFieldType))
+          Literal(optionalWatermarkMs.get * 1000))
       } else {
         LessThanOrEqual(
           watermarkAttribute,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -47,6 +47,7 @@ import org.apache.spark.sql.execution.streaming.state._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{OutputMode, StateOperatorProgress}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 import org.apache.spark.util.{CollectionAccumulator, CompletionIterator, NextIterator, Utils}
 
 
@@ -671,15 +672,33 @@ object WatermarkSupport {
     // use the attribute itself.
     val evictionExpression =
       if (watermarkAttribute.dataType.isInstanceOf[StructType]) {
+        val structType = watermarkAttribute.dataType.asInstanceOf[StructType]
+        val endFieldType = structType("end").dataType
         LessThanOrEqual(
           GetStructField(watermarkAttribute, 1),
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, endFieldType))
       } else {
         LessThanOrEqual(
           watermarkAttribute,
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, watermarkAttribute.dataType))
       }
     Some(evictionExpression)
+  }
+
+  /**
+   * Build the watermark boundary literal for the given column type.
+   * For microsecond timestamps the boundary is watermarkMs * 1000 (micros).
+   * For nanosecond timestamps the boundary is a TimestampNanosVal with epochMicros =
+   * watermarkMs * 1000 and nanosWithinMicro = 0.
+   */
+  private def watermarkLiteral(watermarkMs: Long, dataType: DataType): Literal = {
+    dataType match {
+      case _: AnyTimestampNanoType =>
+        Literal.create(
+          TimestampNanosVal.fromParts(watermarkMs * 1000, 0.toShort), dataType)
+      case _ =>
+        Literal(watermarkMs * 1000)
+    }
   }
 
   /**
@@ -1563,6 +1582,8 @@ case class StreamingDeduplicateWithinWatermarkExec(
 
     // We expect data type of event time column to be TimestampType or TimestampNTZType which both
     // are internally represented as Long.
+    // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
+    //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
     val timestamp = data.getLong(eventTimeColOrdinal)
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -35,9 +35,10 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC
 import org.apache.spark.sql.execution.streaming.operators.stateful.{EventTimeStats, StateStoreSaveExec}
 import org.apache.spark.sql.execution.streaming.runtime._
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
-import org.apache.spark.sql.functions.{count, expr, struct, timestamp_seconds, to_timestamp, window}
+import org.apache.spark.sql.functions.{count, expr, struct, timestamp_nanos, timestamp_seconds, to_timestamp, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode._
+import org.apache.spark.sql.types.TimestampNTZNanosType
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.Utils
 
@@ -1050,5 +1051,93 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
 
   private def awaitTermination(): AssertOnQuery = Execute("AwaitTermination") { q =>
     q.awaitTermination()
+  }
+
+  test("SPARK-57830: withWatermark accepts TimestampLTZNanosType column") {
+    val inputData = MemoryStream[Long]
+    // Use Complete mode so we don't need window-based eviction.
+    // This verifies the type-check fix and nanos->ms conversion in EventTimeWatermarkExec.
+    val aggWithWatermark = inputData.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    testStream(aggWithWatermark, outputMode = Complete)(
+      AddData(inputData, 15L * 1000000000L),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputData, 10L * 1000000000L, 12L * 1000000000L, 14L * 1000000000L),
+      CheckAnswer(1L, 1L, 1L, 1L),
+      assertEventStats(min = 10, max = 14, avg = 12, wtrmark = 5),
+      AddData(inputData, 25L * 1000000000L),
+      CheckAnswer(1L, 1L, 1L, 1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
+  }
+
+  test("SPARK-57830: withWatermark accepts TimestampNTZNanosType column") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val inputData = MemoryStream[Long]
+      val aggWithWatermark = inputData.toDF()
+        .withColumn("eventTime",
+          timestamp_nanos($"value").cast(TimestampNTZNanosType(9)))
+        .withWatermark("eventTime", "10 seconds")
+        .groupBy($"eventTime")
+        .agg(count("*") as Symbol("count"))
+        .select($"count".as[Long])
+
+      testStream(aggWithWatermark, outputMode = Complete)(
+        AddData(inputData, 15L * 1000000000L),
+        CheckAnswer(1L),
+        assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+        AddData(inputData, 10L * 1000000000L, 12L * 1000000000L, 14L * 1000000000L),
+        CheckAnswer(1L, 1L, 1L, 1L),
+        assertEventStats(min = 10, max = 14, avg = 12, wtrmark = 5),
+        AddData(inputData, 25L * 1000000000L),
+        CheckAnswer(1L, 1L, 1L, 1L, 1L),
+        assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+      )
+    }
+  }
+
+  test("SPARK-57830: nanos watermark matches micros watermark for equivalent instants") {
+    // Compare that the watermark advancement is identical between a micros and nanos column
+    // representing the same instant.
+    val inputDataMicros = MemoryStream[Int]
+    val microsDf = inputDataMicros.toDF()
+      .withColumn("eventTime", timestamp_seconds($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    val inputDataNanos = MemoryStream[Long]
+    val nanosDf = inputDataNanos.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    // Run both streams with the same logical timestamps and verify same watermark advancement
+    testStream(microsDf, outputMode = Complete)(
+      AddData(inputDataMicros, 15),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputDataMicros, 25),
+      CheckAnswer(1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
+
+    testStream(nanosDf, outputMode = Complete)(
+      AddData(inputDataNanos, 15L * 1000000000L),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputDataNanos, 25L * 1000000000L),
+      CheckAnswer(1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -1140,4 +1140,35 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
       assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
     )
   }
+
+  test("SPARK-57830: nanos watermark eviction in Update mode") {
+    // Exercises the scalar watermarkLiteral eviction path (LessThanOrEqual over
+    // TimestampNanosVal ordering) which is NOT reached by Complete output mode.
+    // In Update mode, state rows whose key timestamp is at or below the watermark are evicted.
+    val inputData = MemoryStream[Long]
+    val aggWithWatermark = inputData.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    testStream(aggWithWatermark, OutputMode.Update)(
+      // Add events at t=10s, t=11s, t=12s (nanos representation)
+      AddData(inputData, 10L * 1000000000L, 11L * 1000000000L, 12L * 1000000000L),
+      CheckNewAnswer(1L, 1L, 1L),
+      assertNumStateRows(3),
+      // Add event at t=25s => watermark advances to 25-10 = 15s
+      // State rows at t=10s,11s,12s are all <= watermark and get evicted.
+      AddData(inputData, 25L * 1000000000L),
+      CheckNewAnswer(1L),
+      assertNumStateRows(1), // only t=25s remains; t=10,11,12 evicted
+      assertNumRowsDroppedByWatermark(0),
+      // Add a late event at t=10s which is below watermark => dropped
+      AddData(inputData, 10L * 1000000000L),
+      CheckNewAnswer(),
+      assertNumStateRows(1),
+      assertNumRowsDroppedByWatermark(1)
+    )
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allows nanosecond-precision timestamp columns (`TimestampNTZNanosType`, `TimestampLTZNanosType`) to be used as the event-time column for Structured Streaming watermarks. `withWatermark`'s analyzer type-check now accepts these types, and `EventTimeWatermarkExec` converts the nanosecond event-time value to milliseconds for watermark tracking on the correct scale (`epochMicros` -> `microsToMillis`), matching the existing microsecond-timestamp path. The watermark eviction literal is constructed with the correct nanosecond type.

### Why are the changes needed?

Part of nanosecond-precision timestamp support (SPARK-56822). Streaming queries using a nanosecond-precision timestamp as the event-time column previously failed the `withWatermark` type-check (`EVENT_TIME_IS_NOT_ON_TIMESTAMP_TYPE`).

### Does this PR introduce _any_ user-facing change?

Yes - `withWatermark` now accepts nanosecond-precision timestamp event-time columns; the watermark advances identically to an equivalent microsecond-timestamp column.

### How was this patch tested?

New `EventTimeWatermarkSuite` tests for LTZ-nanos and NTZ-nanos event-time columns asserting correct watermark advancement, plus a microsecond/nanosecond equivalence test. All `EventTimeWatermarkSuite` tests pass.

### Limitations / follow-ups

This PR covers the watermark itself (event-time column acceptance + advancement). `window` / `session_window` / `window_time` over nanosecond timestamps and full nanosecond support in streaming stateful operators (e.g. `dropDuplicatesWithinWatermark`) are tracked as follow-ups (SPARK-57829, SPARK-57843); using a nanosecond-precision event-time column with `dropDuplicatesWithinWatermark` now raises a clear analysis error until SPARK-57843 adds support, rather than silently mishandling it.

### Was this patch authored or co-authored using generative AI tooling?

Authored with assistance by Claude Opus 4.8.

