### PR TITLE
[SPARK-57869][BUILD] Remove `logging-interceptor` from `LICENSE-binary`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -220,7 +220,6 @@ com.google.flatbuffers:flatbuffers-java
 com.google.guava:guava
 com.jamesmurty.utils:java-xmlbuilder
 com.ning:compress-lzf
-com.squareup.okhttp3:logging-interceptor
 com.squareup.okhttp3:okhttp
 com.squareup.okio:okio
 com.tdunning:json


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the stale `com.squareup.okhttp3:logging-interceptor` entry from `LICENSE-binary`.

### Why are the changes needed?

`com.squareup.okhttp3:logging-interceptor` dependency was removed at Apache Spark 4.0.0 via the following.

- https://github.com/apache/spark/pull/49159

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8