### PR TITLE
[SPARK-57872][INFRA][4.1] Pin `lxml==4.9.4` in Dockerfile for PyPy to recover branch-4.1 CI

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -94,7 +94,7 @@ RUN mkdir -p /usr/local/pypy/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib lxml
+RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib 'lxml==4.9.4'
 
 
 ARG BASIC_PIP_PKGS="numpy pyarrow>=18.0.0 six==1.16.0 pandas==2.3.3 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"

--- a/dev/spark-test-image/pypy-310/Dockerfile
+++ b/dev/spark-test-image/pypy-310/Dockerfile
@@ -70,4 +70,4 @@ RUN mkdir -p /usr/local/pypy/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib lxml
+RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib 'lxml==4.9.4'


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR pins `lxml==4.9.4` in the PyPy `pip install` commands in `dev/infra/Dockerfile` and `dev/spark-test-image/pypy-310/Dockerfile` on branch-4.1.

### Why are the changes needed?
The branch-4.1 base image build fails because pip pulls the newest `lxml`, which builds from source and requires the libxml2/libxslt development headers that are not available in the PyPy build stage:
```
Error: Please make sure the libxml2 and libxslt development packages are installed.
ERROR: Failed to build 'lxml' when getting requirements to build wheel
ERROR: process "/bin/sh -c pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib lxml" did not complete successfully: exit code: 1
```
See https://github.com/apache/spark/actions/runs/28551790149/job/84650425805

This is the same failure fixed on master by [SPARK-56513](https://github.com/apache/spark/pull/55369), which pinned both `meson<1.11.0` and `lxml==4.9.4`. `meson` has since been fixed upstream, so only the `lxml` pin is needed here. `4.9.4` is consistent with the version specified in `.github/workflows/build_and_test.yml`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)