### PR TITLE
[SPARK-57829][SQL] Support window, session_window and window_time over nanosecond-precision timestamps

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -653,6 +653,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               case s: StructType
                 if s.find(_.name == "end").map(_.dataType) == Some(TimestampType) =>
               case _: TimestampType =>
+              case _: AnyTimestampNanoType =>
               case _ =>
                 etw.failAnalysis(
                   errorClass = "EVENT_TIME_IS_NOT_ON_TIMESTAMP_TYPE",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -651,7 +651,8 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
           case etw: EventTimeWatermark =>
             etw.eventTime.dataType match {
               case s: StructType
-                if s.find(_.name == "end").map(_.dataType) == Some(TimestampType) =>
+                if s.find(_.name == "end").map(_.dataType).exists(dt =>
+                  dt == TimestampType || dt.isInstanceOf[AnyTimestampNanoType]) =>
               case _: TimestampType =>
               case _: AnyTimestampNanoType =>
               case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeWindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeWindowResolution.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, Cast, CreateNamedStruct, ExpectsInputTypes, Expression, GetStructField, IsNotNull, LessThan, Literal, NamedExpression, PreciseTimestampConversion, PreciseTimestampNanosConversion, SessionWindow, Subtract, TimeWindow, UnaryExpression, WindowTime}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, Cast, CreateNamedStruct, ExpectsInputTypes, Expression, GetStructField, IsNotNull, LessThan, Literal, NamedExpression, PreciseTimestampConversion, PreciseTimestampNanosConversion, SessionWindow, Subtract, TimestampAddInterval, TimeWindow, UnaryExpression, WindowTime}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.logical.{Expand, Filter, LogicalPlan, Project}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{AbstractDataType, AnyTimestampNanoType, CalendarIntervalType, DataType, LongType, Metadata, MetadataBuilder, TimestampLTZNanosType, TimestampNTZNanosType}
+import org.apache.spark.sql.types.{AbstractDataType, AnyTimestampNanoType, CalendarIntervalType, DataType, DayTimeIntervalType, LongType, Metadata, MetadataBuilder, TimestampLTZNanosType, TimestampNTZNanosType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
@@ -193,11 +193,13 @@ object TimeWindowResolution {
         throw QueryCompilationErrors.sessionWindowGapDurationDataTypeError(other.dataType)
     }
     val sessionEnd = if (isNanosType(session.timeColumn.dataType)) {
-      // For nanosecond-precision timestamps, TimestampAddInterval does not support
-      // CalendarIntervalType. Compute session end in the epoch-nanos Long domain directly:
-      // sessionStart + (interval.days * NANOS_PER_DAY + interval.microseconds * 1000)
-      val gapNanos = CalendarIntervalToNanos(gapDuration)
-      sessionStart + gapNanos
+      // For nanosecond-precision timestamps, convert the CalendarInterval gap to
+      // DayTimeIntervalType (microseconds) and use TimestampAddInterval which natively
+      // supports DayTimeIntervalType + nanos timestamps (timezone-aware).
+      val gapAsDayTime = CalendarIntervalToMicros(gapDuration)
+      timestampToLong(
+        TimestampAddInterval(session.timeColumn, gapAsDayTime),
+        session.timeColumn.dataType)
     } else {
       timestampToLong(session.timeColumn + gapDuration, session.timeColumn.dataType)
     }
@@ -322,26 +324,27 @@ object TimeWindowResolution {
 }
 
 /**
- * Internal expression that converts a [[CalendarInterval]] to total nanoseconds as a [[Long]].
- * Used by session window rewrite for nanosecond-precision timestamp types where
- * [[TimestampAddInterval]] does not support [[CalendarIntervalType]] operands.
+ * Internal expression that converts a [[CalendarInterval]] to total microseconds, typed as
+ * [[DayTimeIntervalType]]. Used by session window rewrite for nanosecond-precision timestamp
+ * types so that [[TimestampAddInterval]] can be used (it supports DayTimeIntervalType + nanos
+ * timestamps natively with timezone awareness).
  *
- * Computes: `interval.days * NANOS_PER_DAY + interval.microseconds * NANOS_PER_MICROS`.
+ * Computes: `interval.days * MICROS_PER_DAY + interval.microseconds`.
  * Months are assumed to be zero (session window rejects monthly intervals).
  */
-private[analysis] case class CalendarIntervalToNanos(child: Expression)
+private[analysis] case class CalendarIntervalToMicros(child: Expression)
   extends UnaryExpression with ExpectsInputTypes {
-  import org.apache.spark.sql.catalyst.util.DateTimeConstants.{NANOS_PER_DAY, NANOS_PER_MICROS}
+  import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_DAY
 
   override def nullIntolerant: Boolean = true
   override def inputTypes: Seq[AbstractDataType] = Seq(CalendarIntervalType)
-  override def dataType: DataType = LongType
+  override def dataType: DataType = DayTimeIntervalType()
 
   override def nullSafeEval(input: Any): Any = {
     val interval = input.asInstanceOf[CalendarInterval]
     Math.addExact(
-      Math.multiplyExact(interval.days.toLong, NANOS_PER_DAY),
-      Math.multiplyExact(interval.microseconds, NANOS_PER_MICROS))
+      Math.multiplyExact(interval.days.toLong, MICROS_PER_DAY),
+      interval.microseconds)
   }
 
   override def doGenCode(
@@ -352,11 +355,11 @@ private[analysis] case class CalendarIntervalToNanos(child: Expression)
       code"""boolean ${ev.isNull} = ${eval.isNull};
          |long ${ev.value} = ${eval.isNull} ? 0L :
          |  Math.addExact(
-         |    Math.multiplyExact((long) ${eval.value}.days, ${NANOS_PER_DAY}L),
-         |    Math.multiplyExact(${eval.value}.microseconds, ${NANOS_PER_MICROS}L));
+         |    Math.multiplyExact((long) ${eval.value}.days, ${MICROS_PER_DAY}L),
+         |    ${eval.value}.microseconds);
        """.stripMargin)
   }
 
-  override protected def withNewChildInternal(newChild: Expression): CalendarIntervalToNanos =
+  override protected def withNewChildInternal(newChild: Expression): CalendarIntervalToMicros =
     copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeWindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeWindowResolution.scala
@@ -19,10 +19,12 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, Cast, CreateNamedStruct, Expression, GetStructField, IsNotNull, LessThan, Literal, NamedExpression, PreciseTimestampConversion, SessionWindow, Subtract, TimeWindow, WindowTime}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, Cast, CreateNamedStruct, ExpectsInputTypes, Expression, GetStructField, IsNotNull, LessThan, Literal, NamedExpression, PreciseTimestampConversion, PreciseTimestampNanosConversion, SessionWindow, Subtract, TimeWindow, UnaryExpression, WindowTime}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.logical.{Expand, Filter, LogicalPlan, Project}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{CalendarIntervalType, DataType, LongType, Metadata, MetadataBuilder}
+import org.apache.spark.sql.types.{AbstractDataType, AnyTimestampNanoType, CalendarIntervalType, DataType, LongType, Metadata, MetadataBuilder, TimestampLTZNanosType, TimestampNTZNanosType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
@@ -39,6 +41,46 @@ object TimeWindowResolution {
   final val WINDOW_END = "end"
   final val SESSION_START = "start"
   final val SESSION_END = "end"
+
+  /** Scale factor from microseconds to nanoseconds. */
+  private final val NANOS_PER_MICRO = 1000L
+
+  /** Returns true if the given data type is a nanosecond-precision timestamp type. */
+  private def isNanosType(dt: DataType): Boolean = dt.isInstanceOf[AnyTimestampNanoType]
+
+  /** Extracts the precision from a nanosecond timestamp type. Defaults to 9 for non-nanos. */
+  private def nanosPrecision(dt: DataType): Int = dt match {
+    case t: TimestampNTZNanosType => t.precision
+    case t: TimestampLTZNanosType => t.precision
+    case _ => 9
+  }
+
+  /** Converts a timestamp expression to Long (epoch micros or epoch nanos). */
+  private def timestampToLong(expr: Expression, dataType: DataType): Expression = {
+    if (isNanosType(dataType)) {
+      PreciseTimestampNanosConversion(expr, dataType, LongType, nanosPrecision(dataType))
+    } else {
+      PreciseTimestampConversion(expr, dataType, LongType)
+    }
+  }
+
+  /** Converts a Long expression (epoch micros or epoch nanos) back to timestamp type. */
+  private def longToTimestamp(expr: Expression, dataType: DataType): Expression = {
+    if (isNanosType(dataType)) {
+      PreciseTimestampNanosConversion(expr, LongType, dataType, nanosPrecision(dataType))
+    } else {
+      PreciseTimestampConversion(expr, LongType, dataType)
+    }
+  }
+
+  /** Scales a duration in microseconds to the appropriate unit for the given timestamp type. */
+  private def scaleDuration(microsDuration: Long, dataType: DataType): Long = {
+    if (isNanosType(dataType)) {
+      Math.multiplyExact(microsDuration, NANOS_PER_MICRO)
+    } else {
+      microsDuration
+    }
+  }
 
   /**
    * Synthesizes the [[Project]]/[[Expand]]+[[Filter]] sub-plan for a resolved [[TimeWindow]] and
@@ -60,20 +102,23 @@ object TimeWindowResolution {
       .build()
 
     def getWindow(i: Int, dataType: DataType): Expression = {
-      val timestamp = PreciseTimestampConversion(window.timeColumn, dataType, LongType)
-      val remainder = (timestamp - window.startTime) % window.slideDuration
+      val timestamp = timestampToLong(window.timeColumn, dataType)
+      val windowDuration = scaleDuration(window.windowDuration, dataType)
+      val slideDuration = scaleDuration(window.slideDuration, dataType)
+      val startTime = scaleDuration(window.startTime, dataType)
+      val remainder = (timestamp - startTime) % slideDuration
       val lastStart = timestamp - CaseWhen(Seq((LessThan(remainder, 0),
-        remainder + window.slideDuration)), Some(remainder))
-      val windowStart = lastStart - i * window.slideDuration
-      val windowEnd = windowStart + window.windowDuration
+        remainder + slideDuration)), Some(remainder))
+      val windowStart = lastStart - i * slideDuration
+      val windowEnd = windowStart + windowDuration
 
       // We make sure value fields are nullable since the dataType of TimeWindow defines them
       // as nullable.
       CreateNamedStruct(
         Literal(WINDOW_START) ::
-          PreciseTimestampConversion(windowStart, LongType, dataType).castNullable() ::
+          longToTimestamp(windowStart, dataType).castNullable() ::
           Literal(WINDOW_END) ::
-          PreciseTimestampConversion(windowEnd, LongType, dataType).castNullable() ::
+          longToTimestamp(windowEnd, dataType).castNullable() ::
           Nil)
     }
 
@@ -138,7 +183,7 @@ object TimeWindowResolution {
       SESSION_COL_NAME, session.dataType, metadata = newMetadata)()
 
     val sessionStart =
-      PreciseTimestampConversion(session.timeColumn, session.timeColumn.dataType, LongType)
+      timestampToLong(session.timeColumn, session.timeColumn.dataType)
     val gapDuration = session.gapDuration match {
       case expr if expr.dataType == CalendarIntervalType =>
         expr
@@ -147,17 +192,24 @@ object TimeWindowResolution {
       case other =>
         throw QueryCompilationErrors.sessionWindowGapDurationDataTypeError(other.dataType)
     }
-    val sessionEnd = PreciseTimestampConversion(session.timeColumn + gapDuration,
-      session.timeColumn.dataType, LongType)
+    val sessionEnd = if (isNanosType(session.timeColumn.dataType)) {
+      // For nanosecond-precision timestamps, TimestampAddInterval does not support
+      // CalendarIntervalType. Compute session end in the epoch-nanos Long domain directly:
+      // sessionStart + (interval.days * NANOS_PER_DAY + interval.microseconds * 1000)
+      val gapNanos = CalendarIntervalToNanos(gapDuration)
+      sessionStart + gapNanos
+    } else {
+      timestampToLong(session.timeColumn + gapDuration, session.timeColumn.dataType)
+    }
 
     // We make sure value fields are nullable since the dataType of SessionWindow defines them
     // as nullable.
     val literalSessionStruct = CreateNamedStruct(
       Literal(SESSION_START) ::
-        PreciseTimestampConversion(sessionStart, LongType, session.timeColumn.dataType)
+        longToTimestamp(sessionStart, session.timeColumn.dataType)
           .castNullable() ::
         Literal(SESSION_END) ::
-        PreciseTimestampConversion(sessionEnd, LongType, session.timeColumn.dataType)
+        longToTimestamp(sessionEnd, session.timeColumn.dataType)
           .castNullable() ::
         Nil)
 
@@ -234,20 +286,23 @@ object TimeWindowResolution {
   }
 
   /**
-   * Builds the expression extracting a [[WindowTime]]'s timestamp: the last microsecond of the
-   * source window (`window.end - 1us`). `window.end` is the exclusive upper bound, so using it
-   * as-is would bind the result to the next window under the same window spec.
+   * Builds the expression extracting a [[WindowTime]]'s timestamp: the last unit of the
+   * source window (`window.end - 1us` for microsecond types, `window.end - 1ns` for nanosecond
+   * types). `window.end` is the exclusive upper bound, so using it as-is would bind the result
+   * to the next window under the same window spec.
    */
-  def windowTimeExtractionExpression(windowTime: WindowTime): Expression =
-    PreciseTimestampConversion(
+  def windowTimeExtractionExpression(windowTime: WindowTime): Expression = {
+    val dt = windowTime.dataType
+    // For nanos types, we subtract 1 (nanosecond in epoch-nanos space).
+    // For micros types, we subtract 1 (microsecond in epoch-micros space).
+    // Both subtraction amounts are Literal(1L) because the conversion to Long already handles
+    // the appropriate unit (epoch-nanos vs epoch-micros).
+    longToTimestamp(
       Subtract(
-        PreciseTimestampConversion(
-          GetStructField(windowTime.windowColumn, 1),
-          windowTime.dataType,
-          LongType),
+        timestampToLong(GetStructField(windowTime.windowColumn, 1), dt),
         Literal(1L)),
-      LongType,
-      windowTime.dataType)
+      dt)
+  }
 
   /** Number of overlapping sliding windows a single row can fall into. */
   def overlappingWindowCount(window: TimeWindow): Int =
@@ -264,4 +319,44 @@ object TimeWindowResolution {
     } else {
       true
     }
+}
+
+/**
+ * Internal expression that converts a [[CalendarInterval]] to total nanoseconds as a [[Long]].
+ * Used by session window rewrite for nanosecond-precision timestamp types where
+ * [[TimestampAddInterval]] does not support [[CalendarIntervalType]] operands.
+ *
+ * Computes: `interval.days * NANOS_PER_DAY + interval.microseconds * NANOS_PER_MICROS`.
+ * Months are assumed to be zero (session window rejects monthly intervals).
+ */
+private[analysis] case class CalendarIntervalToNanos(child: Expression)
+  extends UnaryExpression with ExpectsInputTypes {
+  import org.apache.spark.sql.catalyst.util.DateTimeConstants.{NANOS_PER_DAY, NANOS_PER_MICROS}
+
+  override def nullIntolerant: Boolean = true
+  override def inputTypes: Seq[AbstractDataType] = Seq(CalendarIntervalType)
+  override def dataType: DataType = LongType
+
+  override def nullSafeEval(input: Any): Any = {
+    val interval = input.asInstanceOf[CalendarInterval]
+    Math.addExact(
+      Math.multiplyExact(interval.days.toLong, NANOS_PER_DAY),
+      Math.multiplyExact(interval.microseconds, NANOS_PER_MICROS))
+  }
+
+  override def doGenCode(
+      ctx: CodegenContext,
+      ev: ExprCode): ExprCode = {
+    val eval = child.genCode(ctx)
+    ev.copy(code = eval.code +
+      code"""boolean ${ev.isNull} = ${eval.isNull};
+         |long ${ev.value} = ${eval.isNull} ? 0L :
+         |  Math.addExact(
+         |    Math.multiplyExact((long) ${eval.value}.days, ${NANOS_PER_DAY}L),
+         |    Math.multiplyExact(${eval.value}.microseconds, ${NANOS_PER_MICROS}L));
+       """.stripMargin)
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): CalendarIntervalToNanos =
+    copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
+import org.apache.spark.sql.types.AnyTimestampNanoType
 
 /**
  * Analyzes the presence of unsupported operations in a logical plan.
@@ -554,6 +555,19 @@ object UnsupportedOperationChecker extends Logging {
             throwError(
               "dropDuplicatesWithinWatermark is not supported on streaming DataFrames/DataSets " +
                 "without watermark")(plan)
+          }
+
+          // TODO(SPARK-57843): Handle nanosecond event-time columns in streaming stateful
+          //  operators incl. dropDuplicatesWithinWatermark. Until then, reject them here to
+          //  avoid silent corruption (the exec layer reads event time via getLong assuming
+          //  microsecond precision).
+          val nanoWatermarkAttributes = watermarkAttributes.filter(
+            _.dataType.isInstanceOf[AnyTimestampNanoType])
+          if (nanoWatermarkAttributes.nonEmpty) {
+            throwError(
+              "dropDuplicatesWithinWatermark does not yet support nanosecond-precision " +
+                "event-time columns (SPARK-57843). Use a microsecond-precision timestamp " +
+                "type for the watermark column instead.")(plan)
           }
 
         case c: CoGroup if c.children.exists(_.isStreaming) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SessionWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SessionWindow.scala
@@ -70,14 +70,21 @@ case class SessionWindow(timeColumn: Expression, gapDuration: Expression) extend
   private def inputTypeOnTimeColumn: AbstractDataType = {
     TypeCollection(
       AnyTimestampType,
-      // Below two types cover both time window & session window, since they produce the same type
+      AnyTimestampNanoType,
+      // Below types cover both time window & session window, since they produce the same type
       // of output as window column.
       new StructType()
         .add(StructField("start", TimestampType))
         .add(StructField("end", TimestampType)),
       new StructType()
         .add(StructField("start", TimestampNTZType))
-        .add(StructField("end", TimestampNTZType))
+        .add(StructField("end", TimestampNTZType)),
+      new StructType()
+        .add(StructField("start", TimestampNTZNanosType()))
+        .add(StructField("end", TimestampNTZNanosType())),
+      new StructType()
+        .add(StructField("start", TimestampLTZNanosType()))
+        .add(StructField("end", TimestampLTZNanosType()))
     )
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -100,14 +100,21 @@ case class TimeWindow(
   private def inputTypeOnTimeColumn: AbstractDataType = {
     TypeCollection(
       AnyTimestampType,
-      // Below two types cover both time window & session window, since they produce the same type
+      AnyTimestampNanoType,
+      // Below types cover both time window & session window, since they produce the same type
       // of output as window column.
       new StructType()
         .add(StructField("start", TimestampType))
         .add(StructField("end", TimestampType)),
       new StructType()
         .add(StructField("start", TimestampNTZType))
-        .add(StructField("end", TimestampNTZType))
+        .add(StructField("end", TimestampNTZType)),
+      new StructType()
+        .add(StructField("start", TimestampNTZNanosType()))
+        .add(StructField("end", TimestampNTZNanosType())),
+      new StructType()
+        .add(StructField("start", TimestampLTZNanosType()))
+        .add(StructField("end", TimestampLTZNanosType()))
     )
   }
 
@@ -251,5 +258,66 @@ case class PreciseTimestampConversion(
   override def nullSafeEval(input: Any): Any = input
 
   override protected def withNewChildInternal(newChild: Expression): PreciseTimestampConversion =
+    copy(child = newChild)
+}
+
+/**
+ * Expression used internally to convert nanosecond-precision timestamp types
+ * ([[TimestampNTZNanosType]] / [[TimestampLTZNanosType]]) to [[LongType]] (total epoch
+ * nanoseconds) and back. Used in time windowing for nanosecond-precision inputs.
+ *
+ * Forward direction (nanos type -> Long): packs [[TimestampNanosVal]] into a single int64 of
+ * epoch-nanoseconds via `epochMicros * 1000 + nanosWithinMicro`.
+ *
+ * Reverse direction (Long -> nanos type): reconstructs [[TimestampNanosVal]] from
+ * epoch-nanoseconds via `floorDiv/floorMod`, preserving full precision.
+ */
+case class PreciseTimestampNanosConversion(
+    child: Expression,
+    fromType: DataType,
+    toType: DataType,
+    precision: Int) extends UnaryExpression with ExpectsInputTypes {
+  import org.apache.spark.unsafe.types.TimestampNanosVal
+
+  override def nullIntolerant: Boolean = true
+  override def inputTypes: Seq[AbstractDataType] = Seq(fromType)
+  override def dataType: DataType = toType
+
+  private val isToLong: Boolean = toType == LongType
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val eval = child.genCode(ctx)
+    if (isToLong) {
+      // TimestampNanosVal → Long (epoch nanos)
+      ev.copy(code = eval.code +
+        code"""boolean ${ev.isNull} = ${eval.isNull};
+           |long ${ev.value} = ${eval.isNull} ? 0L :
+           |  Math.addExact(
+           |    Math.multiplyExact(${eval.value}.epochMicros, 1000L),
+           |    (long) ${eval.value}.nanosWithinMicro);
+         """.stripMargin)
+    } else {
+      // Long (epoch nanos) → TimestampNanosVal
+      ev.copy(code = eval.code +
+        code"""boolean ${ev.isNull} = ${eval.isNull};
+           |org.apache.spark.unsafe.types.TimestampNanosVal ${ev.value} = ${eval.isNull} ? null :
+           |  org.apache.spark.sql.catalyst.util.DateTimeUtils
+           |    .epochNanosToTimestampNanos(${eval.value}, $precision);
+         """.stripMargin)
+    }
+  }
+
+  override def nullSafeEval(input: Any): Any = {
+    if (isToLong) {
+      val v = input.asInstanceOf[TimestampNanosVal]
+      Math.addExact(Math.multiplyExact(v.epochMicros, 1000L), v.nanosWithinMicro.toLong)
+    } else {
+      org.apache.spark.sql.catalyst.util.DateTimeUtils
+        .epochNanosToTimestampNanos(input.asInstanceOf[Long], precision)
+    }
+  }
+
+  override protected def withNewChildInternal(
+      newChild: Expression): PreciseTimestampNanosConversion =
     copy(child = newChild)
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
-import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder}
+import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder, TimestampLTZNanosType}
 
 /** A dummy command for testing unsupported operations. */
 case class DummyCommand() extends LeafCommand
@@ -353,6 +353,21 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
     Deduplicate(Seq(att), batchRelation),
     outputMode = Append
   )
+
+  // DeduplicateWithinWatermark with nanosecond event-time column should be rejected
+  testError(
+    "streaming plan - DeduplicateWithinWatermark with nanosecond event-time: not supported",
+    Seq("dropDuplicatesWithinWatermark", "nanosecond", "SPARK-57843")) {
+    val nanoAttr = AttributeReference("ts", TimestampLTZNanosType())()
+    val nanoWatermarkMetadata = new MetadataBuilder()
+      .withMetadata(nanoAttr.metadata)
+      .putLong(EventTimeWatermark.delayKey, 1000L)
+      .build()
+    val nanoAttrWithWatermark = nanoAttr.withMetadata(nanoWatermarkMetadata)
+    val nanoStreamRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val plan = DeduplicateWithinWatermark(Seq(nanoAttrWithWatermark), nanoStreamRelation)
+    UnsupportedOperationChecker.checkForStreaming(wrapInStreaming(plan), Append)
+  }
 
   // Inner joins: Multiple stream-stream joins supported only in append mode
   testBinaryOperationInStreamingPlan(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/MergingSessionsIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/MergingSessionsIterator.scala
@@ -200,17 +200,34 @@ class MergingSessionsIterator(
     firstRowInNextGroup = currentRow.copy()
   }
 
+  // Detect whether the session struct uses nanosecond-precision timestamps. If so, session
+  // start/end must be read as TimestampNanosVal and converted to epoch-nanos Long for comparison.
+  private[this] val sessionIsNanos: Boolean =
+    SessionNanosHelper.isSessionNanos(sessionExpression)
+
   private def getSessionStart(sessionStruct: UnsafeRow): Long = {
-    sessionStruct.getLong(0)
+    if (sessionIsNanos) {
+      SessionNanosHelper.getSessionStartNanos(sessionStruct)
+    } else {
+      sessionStruct.getLong(0)
+    }
   }
 
   private def getSessionEnd(sessionStruct: UnsafeRow): Long = {
-    sessionStruct.getLong(1)
+    if (sessionIsNanos) {
+      SessionNanosHelper.getSessionEndNanos(sessionStruct)
+    } else {
+      sessionStruct.getLong(1)
+    }
   }
 
   private def expandEndOfCurrentSession(sessionEnd: Long): Unit = {
     if (sessionEnd > getSessionEnd(currentSession)) {
-      currentSession.setLong(1, sessionEnd)
+      if (sessionIsNanos) {
+        SessionNanosHelper.setSessionEnd(currentSession, sessionEnd, sessionExpression)
+      } else {
+        currentSession.setLong(1, sessionEnd)
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SessionNanosHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SessionNanosHelper.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.aggregate
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, UnsafeRow}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.types.{AnyTimestampNanoType, StructType, TimestampLTZNanosType, TimestampNTZNanosType}
+
+/**
+ * Shared helpers for reading/writing nanosecond-precision session window timestamps
+ * in [[MergingSessionsIterator]] and [[UpdatingSessionsIterator]].
+ */
+private[aggregate] object SessionNanosHelper {
+
+  /** Returns true if the session struct uses nanosecond-precision timestamps. */
+  def isSessionNanos(sessionExpression: Expression): Boolean = {
+    val sessionType = sessionExpression.dataType.asInstanceOf[StructType]
+    sessionType.fields(0).dataType.isInstanceOf[AnyTimestampNanoType]
+  }
+
+  /** Reads the session start as epoch-nanos (Long) from a nanosecond session struct. */
+  def getSessionStartNanos(sessionStruct: UnsafeRow): Long = {
+    val v = sessionStruct.getTimestampNTZNanos(0)
+    DateTimeUtils.timestampNanosToEpochNanos(v)
+  }
+
+  /** Reads the session end as epoch-nanos (Long) from a nanosecond session struct. */
+  def getSessionEndNanos(sessionStruct: UnsafeRow): Long = {
+    val v = sessionStruct.getTimestampNTZNanos(1)
+    DateTimeUtils.timestampNanosToEpochNanos(v)
+  }
+
+  /**
+   * Extracts the precision from the session-end field's nanosecond timestamp type.
+   * Defaults to 9 if the type is an unexpected [[AnyTimestampNanoType]] subtype.
+   */
+  def sessionEndPrecision(sessionExpression: Expression): Int = {
+    sessionExpression.dataType.asInstanceOf[StructType]
+      .fields(1).dataType match {
+      case t: TimestampNTZNanosType => t.precision
+      case t: TimestampLTZNanosType => t.precision
+      case _ => 9
+    }
+  }
+
+  /** Writes an epoch-nanos value into the session-end field of the struct. */
+  def setSessionEnd(sessionStruct: UnsafeRow, sessionEnd: Long,
+      sessionExpression: Expression): Unit = {
+    val precision = sessionEndPrecision(sessionExpression)
+    val v = DateTimeUtils.epochNanosToTimestampNanos(sessionEnd, precision)
+    sessionStruct.setTimestampNTZNanos(1, v)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
@@ -161,16 +161,32 @@ class UpdatingSessionsIterator(
     rowsForCurrentSession.add(currentRow.asInstanceOf[UnsafeRow])
   }
 
+  // Detect whether the session struct uses nanosecond-precision timestamps.
+  private[this] val sessionIsNanos: Boolean =
+    SessionNanosHelper.isSessionNanos(sessionExpression)
+
   private def getSessionStart(sessionStruct: UnsafeRow): Long = {
-    sessionStruct.getLong(0)
+    if (sessionIsNanos) {
+      SessionNanosHelper.getSessionStartNanos(sessionStruct)
+    } else {
+      sessionStruct.getLong(0)
+    }
   }
 
   private def getSessionEnd(sessionStruct: UnsafeRow): Long = {
-    sessionStruct.getLong(1)
+    if (sessionIsNanos) {
+      SessionNanosHelper.getSessionEndNanos(sessionStruct)
+    } else {
+      sessionStruct.getLong(1)
+    }
   }
 
   def updateSessionEnd(sessionStruct: UnsafeRow, sessionEnd: Long): Unit = {
-    sessionStruct.setLong(1, sessionEnd)
+    if (sessionIsNanos) {
+      SessionNanosHelper.setSessionEnd(sessionStruct, sessionEnd, sessionExpression)
+    } else {
+      sessionStruct.setLong(1, sessionEnd)
+    }
   }
 
   private def expandEndOfCurrentSession(sessionEnd: Long): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/EventTimeWatermarkExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/EventTimeWatermarkExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToMillis
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.{TimestampLTZNanosType, TimestampNTZNanosType}
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.AccumulatorV2
 
@@ -105,8 +106,16 @@ case class EventTimeWatermarkExec(
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions { iter =>
       val getEventTime = UnsafeProjection.create(eventTime :: Nil, child.output)
+      val toMs: InternalRow => Long = eventTime.dataType match {
+        case _: TimestampLTZNanosType =>
+          row => microsToMillis(getEventTime(row).getTimestampLTZNanos(0).epochMicros)
+        case _: TimestampNTZNanosType =>
+          row => microsToMillis(getEventTime(row).getTimestampNTZNanos(0).epochMicros)
+        case _ =>
+          row => microsToMillis(getEventTime(row).getLong(0))
+      }
       iter.map { row =>
-        eventTimeStats.add(microsToMillis(getEventTime(row).getLong(0)))
+        eventTimeStats.add(toMs(row))
         row
       }
     }
@@ -160,8 +169,16 @@ case class UpdateEventTimeColumnExec(
             val boundEventTimeExpression = bindReference[Expression](eventTime, child.output)
             val eventTimeProjection = UnsafeProjection.create(boundEventTimeExpression)
             val rowEventTime = eventTimeProjection(row)
+            val eventTimeMicros = eventTime.dataType match {
+              case _: TimestampLTZNanosType =>
+                rowEventTime.getTimestampLTZNanos(0).epochMicros
+              case _: TimestampNTZNanosType =>
+                rowEventTime.getTimestampNTZNanos(0).epochMicros
+              case _ =>
+                rowEventTime.getLong(0)
+            }
             throw QueryExecutionErrors.emittedRowsAreOlderThanWatermark(
-              eventTimeWatermarkForLateEvents.get, rowEventTime.getLong(0))
+              eventTimeWatermarkForLateEvents.get, eventTimeMicros)
           }
           row
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -1584,6 +1584,7 @@ case class StreamingDeduplicateWithinWatermarkExec(
     // are internally represented as Long.
     // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
     //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
+    //  Until then, UnsupportedOperationChecker rejects nanos event-time at analysis time.
     val timestamp = data.getLong(eventTimeColOrdinal)
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -672,11 +672,9 @@ object WatermarkSupport {
     // use the attribute itself.
     val evictionExpression =
       if (watermarkAttribute.dataType.isInstanceOf[StructType]) {
-        val structType = watermarkAttribute.dataType.asInstanceOf[StructType]
-        val endFieldType = structType("end").dataType
         LessThanOrEqual(
           GetStructField(watermarkAttribute, 1),
-          watermarkLiteral(optionalWatermarkMs.get, endFieldType))
+          Literal(optionalWatermarkMs.get * 1000))
       } else {
         LessThanOrEqual(
           watermarkAttribute,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -672,9 +672,11 @@ object WatermarkSupport {
     // use the attribute itself.
     val evictionExpression =
       if (watermarkAttribute.dataType.isInstanceOf[StructType]) {
+        val endFieldType =
+          watermarkAttribute.dataType.asInstanceOf[StructType]("end").dataType
         LessThanOrEqual(
           GetStructField(watermarkAttribute, 1),
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, endFieldType))
       } else {
         LessThanOrEqual(
           watermarkAttribute,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -47,6 +47,7 @@ import org.apache.spark.sql.execution.streaming.state._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{OutputMode, StateOperatorProgress}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 import org.apache.spark.util.{CollectionAccumulator, CompletionIterator, NextIterator, Utils}
 
 
@@ -671,15 +672,33 @@ object WatermarkSupport {
     // use the attribute itself.
     val evictionExpression =
       if (watermarkAttribute.dataType.isInstanceOf[StructType]) {
+        val structType = watermarkAttribute.dataType.asInstanceOf[StructType]
+        val endFieldType = structType("end").dataType
         LessThanOrEqual(
           GetStructField(watermarkAttribute, 1),
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, endFieldType))
       } else {
         LessThanOrEqual(
           watermarkAttribute,
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, watermarkAttribute.dataType))
       }
     Some(evictionExpression)
+  }
+
+  /**
+   * Build the watermark boundary literal for the given column type.
+   * For microsecond timestamps the boundary is watermarkMs * 1000 (micros).
+   * For nanosecond timestamps the boundary is a TimestampNanosVal with epochMicros =
+   * watermarkMs * 1000 and nanosWithinMicro = 0.
+   */
+  private def watermarkLiteral(watermarkMs: Long, dataType: DataType): Literal = {
+    dataType match {
+      case _: AnyTimestampNanoType =>
+        Literal.create(
+          TimestampNanosVal.fromParts(watermarkMs * 1000, 0.toShort), dataType)
+      case _ =>
+        Literal(watermarkMs * 1000)
+    }
   }
 
   /**
@@ -1563,6 +1582,8 @@ case class StreamingDeduplicateWithinWatermarkExec(
 
     // We expect data type of event time column to be TimestampType or TimestampNTZType which both
     // are internally represented as Long.
+    // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
+    //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
     val timestamp = data.getLong(eventTimeColOrdinal)
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/time-window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/time-window.sql.out
@@ -878,7 +878,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"x\"",
     "inputType" : "\"INT\"",
     "paramIndex" : "first",
-    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"STRUCT<start: TIMESTAMP, end: TIMESTAMP>\" or \"STRUCT<start: TIMESTAMP_NTZ, end: TIMESTAMP_NTZ>\")",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\" or \"STRUCT<start: TIMESTAMP, end: TIMESTAMP>\" or \"STRUCT<start: TIMESTAMP_NTZ, end: TIMESTAMP_NTZ>\" or \"STRUCT<start: TIMESTAMP_NTZ(9), end: TIMESTAMP_NTZ(9)>\" or \"STRUCT<start: TIMESTAMP_LTZ(9), end: TIMESTAMP_LTZ(9)>\")",
     "sqlExpr" : "\"window(x, 300000000, 300000000, 0)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/time-window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time-window.sql.out
@@ -819,7 +819,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"x\"",
     "inputType" : "\"INT\"",
     "paramIndex" : "first",
-    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"STRUCT<start: TIMESTAMP, end: TIMESTAMP>\" or \"STRUCT<start: TIMESTAMP_NTZ, end: TIMESTAMP_NTZ>\")",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\" or \"STRUCT<start: TIMESTAMP, end: TIMESTAMP>\" or \"STRUCT<start: TIMESTAMP_NTZ, end: TIMESTAMP_NTZ>\" or \"STRUCT<start: TIMESTAMP_NTZ(9), end: TIMESTAMP_NTZ(9)>\" or \"STRUCT<start: TIMESTAMP_LTZ(9), end: TIMESTAMP_LTZ(9)>\")",
     "sqlExpr" : "\"window(x, 300000000, 300000000, 0)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala
@@ -595,4 +595,69 @@ class DataFrameSessionWindowingSuite extends SharedSparkSession {
       )
     }
   }
+
+  test("SPARK-57829: Support TimestampNTZNanos type in expression SessionWindow") {
+    val schema = new StructType()
+      .add("time", TimestampNTZNanosType(9))
+      .add("value", IntegerType)
+      .add("id", StringType)
+    val data = Seq(
+      Row(LocalDateTime.parse("2016-03-27T19:39:30"), 1, "a"),
+      Row(LocalDateTime.parse("2016-03-27T19:39:25"), 2, "a"))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    val aggDF =
+      df.groupBy(session_window($"time", "10 seconds"))
+        .agg(count("*").as("counts"))
+        .orderBy($"session_window.start".asc)
+        .select($"session_window.start".cast("string"),
+          $"session_window.end".cast("string"), $"counts")
+
+    val aggregate = aggDF.queryExecution.analyzed.children(0).children(0)
+    assert(aggregate.isInstanceOf[Aggregate])
+
+    val timeWindow = aggregate.asInstanceOf[Aggregate].groupingExpressions(0)
+    assert(timeWindow.isInstanceOf[AttributeReference])
+
+    val attributeReference = timeWindow.asInstanceOf[AttributeReference]
+    assert(attributeReference.name == "session_window")
+
+    val expectedSchema = StructType(
+      Seq(StructField("start", TimestampNTZNanosType(9)),
+        StructField("end", TimestampNTZNanosType(9))))
+    assert(attributeReference.dataType == expectedSchema)
+
+    checkAnswer(aggDF, Seq(Row("2016-03-27 19:39:25", "2016-03-27 19:39:40", 2)))
+  }
+
+  test("SPARK-57829: Support TimestampLTZNanos type in expression SessionWindow") {
+    import java.time.Instant
+    withSQLConf("spark.sql.session.timeZone" -> "UTC") {
+      val schema = new StructType()
+        .add("time", TimestampLTZNanosType(9))
+        .add("value", IntegerType)
+      val data = Seq(
+        Row(Instant.parse("2016-03-27T19:39:30Z"), 1),
+        Row(Instant.parse("2016-03-27T19:39:25Z"), 2))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+      val aggDF =
+        df.groupBy(session_window($"time", "10 seconds"))
+          .agg(count("*").as("counts"))
+          .orderBy($"session_window.start".asc)
+
+      // Verify the session window struct has the expected nanos type
+      val sessionWindowField = aggDF.schema.find(_.name == "session_window").get
+      val expectedType = StructType(Seq(
+        StructField("start", TimestampLTZNanosType(9)),
+        StructField("end", TimestampLTZNanosType(9))))
+      assert(sessionWindowField.dataType == expectedType)
+
+      // Value-level assertion: verify LTZ session merging arithmetic
+      checkAnswer(
+        aggDF.select($"session_window.start".cast("string"),
+          $"session_window.end".cast("string"), $"counts"),
+        Seq(Row("2016-03-27 19:39:25", "2016-03-27 19:39:40", 2)))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala
@@ -768,4 +768,138 @@ class DataFrameTimeWindowingSuite extends SharedSparkSession {
       )
     }
   }
+
+  test("SPARK-57829: Support TimestampNTZNanos type in expression TimeWindow") {
+    import java.time.LocalDateTime
+    val schema = new StructType()
+      .add("time", TimestampNTZNanosType(9))
+      .add("value", IntegerType)
+      .add("id", StringType)
+    val data = Seq(
+      Row(LocalDateTime.parse("2016-03-27T19:39:30"), 1, "a"),
+      Row(LocalDateTime.parse("2016-03-27T19:39:25"), 2, "a"))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    val logicalPlan =
+      df.groupBy(window($"time", "10 seconds", "10 seconds", "-5 seconds"))
+        .agg(count("*").as("counts"))
+        .orderBy($"window.start".asc)
+        .select($"window.start".cast("string"), $"window.end".cast("string"), $"counts")
+    val aggregate = logicalPlan.queryExecution.analyzed.children(0).children(0)
+    assert(aggregate.isInstanceOf[Aggregate])
+    val timeWindow = aggregate.asInstanceOf[Aggregate].groupingExpressions(0)
+    assert(timeWindow.isInstanceOf[AttributeReference])
+    val attributeReference = timeWindow.asInstanceOf[AttributeReference]
+    assert(attributeReference.name == "window")
+    val expectedType = StructType(Seq(
+      StructField("start", TimestampNTZNanosType(9)),
+      StructField("end", TimestampNTZNanosType(9))))
+    assert(attributeReference.dataType == expectedType)
+
+    checkAnswer(logicalPlan, Seq(
+      Row("2016-03-27 19:39:25", "2016-03-27 19:39:35", 2)))
+  }
+
+  test("SPARK-57829: Support TimestampLTZNanos type in expression TimeWindow") {
+    import java.time.Instant
+    withSQLConf("spark.sql.session.timeZone" -> "UTC") {
+      val schema = new StructType()
+        .add("time", TimestampLTZNanosType(9))
+        .add("value", IntegerType)
+      val data = Seq(
+        Row(Instant.parse("2016-03-27T19:39:30Z"), 1),
+        Row(Instant.parse("2016-03-27T19:39:25Z"), 2))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+      val logicalPlan =
+        df.groupBy(window($"time", "10 seconds"))
+          .agg(count("*").as("counts"))
+          .orderBy($"window.start".asc)
+          .select($"window.start".cast("string"), $"window.end".cast("string"), $"counts")
+
+      val aggregate = logicalPlan.queryExecution.analyzed.children(0).children(0)
+      assert(aggregate.isInstanceOf[Aggregate])
+      val timeWindow = aggregate.asInstanceOf[Aggregate].groupingExpressions(0)
+      assert(timeWindow.isInstanceOf[AttributeReference])
+      val expectedType = StructType(Seq(
+        StructField("start", TimestampLTZNanosType(9)),
+        StructField("end", TimestampLTZNanosType(9))))
+      assert(timeWindow.asInstanceOf[AttributeReference].dataType == expectedType)
+
+      // Value-level assertion: verify LTZ time-window arithmetic
+      checkAnswer(logicalPlan, Seq(
+        Row("2016-03-27 19:39:20", "2016-03-27 19:39:30", 1),
+        Row("2016-03-27 19:39:30", "2016-03-27 19:39:40", 1)))
+    }
+  }
+
+  test("SPARK-57829: Nanosecond-precision window boundaries preserve sub-microsecond precision") {
+    import java.time.LocalDateTime
+    // Use a timestamp with sub-microsecond digits: 19:39:30.000000123
+    val schema = new StructType()
+      .add("time", TimestampNTZNanosType(9))
+      .add("value", IntegerType)
+    val data = Seq(
+      Row(LocalDateTime.parse("2016-03-27T19:39:30.000000123"), 1),
+      Row(LocalDateTime.parse("2016-03-27T19:39:35.000000456"), 2))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    // 10-second tumbling window: boundaries at :30 and :40
+    val result = df.groupBy(window($"time", "10 seconds"))
+      .agg(count("*").as("counts"))
+      .orderBy($"window.start".asc)
+      .select($"window.start".cast("string"), $"window.end".cast("string"), $"counts")
+
+    checkAnswer(result, Seq(
+      Row("2016-03-27 19:39:30", "2016-03-27 19:39:40", 2)))
+  }
+
+  test("SPARK-57829: window_time with nanosecond-precision timestamps") {
+    import java.time.LocalDateTime
+    val schema = new StructType()
+      .add("time", TimestampNTZNanosType(9))
+    val data = Seq(
+      Row(LocalDateTime.parse("2016-03-27T19:38:18")),
+      Row(LocalDateTime.parse("2016-03-27T19:39:25")))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    // window_time should return window.end - 1 nanosecond (not 1 microsecond)
+    checkAnswer(
+      df.select(window($"time", "10 seconds").as("window"))
+        .select(
+          $"window.end".cast("string"),
+          window_time($"window").cast("string")
+        ),
+      Seq(
+        // end = :20, window_time = :19.999999999 (minus 1 nanosecond)
+        Row("2016-03-27 19:38:20", "2016-03-27 19:38:19.999999999"),
+        Row("2016-03-27 19:39:30", "2016-03-27 19:39:29.999999999")
+      )
+    )
+  }
+
+  test("SPARK-57829: sliding window with nanosecond-precision NTZ") {
+    import java.time.LocalDateTime
+    val schema = new StructType()
+      .add("time", TimestampNTZNanosType(9))
+      .add("value", IntegerType)
+    val data = Seq(
+      Row(LocalDateTime.parse("2016-03-27T19:39:34"), 1),
+      Row(LocalDateTime.parse("2016-03-27T19:39:56"), 2),
+      Row(LocalDateTime.parse("2016-03-27T19:39:27"), 4))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    val result = df.select(window($"time", "10 seconds", "5 seconds"), $"value")
+      .orderBy($"window.start".asc, $"value".desc)
+      .select($"window.start".cast("string"), $"window.end".cast("string"), $"value")
+
+    checkAnswer(result, Seq(
+      Row("2016-03-27 19:39:20", "2016-03-27 19:39:30", 4),
+      Row("2016-03-27 19:39:25", "2016-03-27 19:39:35", 4),
+      Row("2016-03-27 19:39:25", "2016-03-27 19:39:35", 1),
+      Row("2016-03-27 19:39:30", "2016-03-27 19:39:40", 1),
+      Row("2016-03-27 19:39:50", "2016-03-27 19:40:00", 2),
+      Row("2016-03-27 19:39:55", "2016-03-27 19:40:05", 2)
+    ))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -35,9 +35,10 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC
 import org.apache.spark.sql.execution.streaming.operators.stateful.{EventTimeStats, StateStoreSaveExec}
 import org.apache.spark.sql.execution.streaming.runtime._
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
-import org.apache.spark.sql.functions.{count, expr, struct, timestamp_seconds, to_timestamp, window}
+import org.apache.spark.sql.functions.{count, expr, struct, timestamp_nanos, timestamp_seconds, to_timestamp, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode._
+import org.apache.spark.sql.types.TimestampNTZNanosType
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.Utils
 
@@ -1050,5 +1051,93 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
 
   private def awaitTermination(): AssertOnQuery = Execute("AwaitTermination") { q =>
     q.awaitTermination()
+  }
+
+  test("SPARK-57830: withWatermark accepts TimestampLTZNanosType column") {
+    val inputData = MemoryStream[Long]
+    // Use Complete mode so we don't need window-based eviction.
+    // This verifies the type-check fix and nanos->ms conversion in EventTimeWatermarkExec.
+    val aggWithWatermark = inputData.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    testStream(aggWithWatermark, outputMode = Complete)(
+      AddData(inputData, 15L * 1000000000L),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputData, 10L * 1000000000L, 12L * 1000000000L, 14L * 1000000000L),
+      CheckAnswer(1L, 1L, 1L, 1L),
+      assertEventStats(min = 10, max = 14, avg = 12, wtrmark = 5),
+      AddData(inputData, 25L * 1000000000L),
+      CheckAnswer(1L, 1L, 1L, 1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
+  }
+
+  test("SPARK-57830: withWatermark accepts TimestampNTZNanosType column") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val inputData = MemoryStream[Long]
+      val aggWithWatermark = inputData.toDF()
+        .withColumn("eventTime",
+          timestamp_nanos($"value").cast(TimestampNTZNanosType(9)))
+        .withWatermark("eventTime", "10 seconds")
+        .groupBy($"eventTime")
+        .agg(count("*") as Symbol("count"))
+        .select($"count".as[Long])
+
+      testStream(aggWithWatermark, outputMode = Complete)(
+        AddData(inputData, 15L * 1000000000L),
+        CheckAnswer(1L),
+        assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+        AddData(inputData, 10L * 1000000000L, 12L * 1000000000L, 14L * 1000000000L),
+        CheckAnswer(1L, 1L, 1L, 1L),
+        assertEventStats(min = 10, max = 14, avg = 12, wtrmark = 5),
+        AddData(inputData, 25L * 1000000000L),
+        CheckAnswer(1L, 1L, 1L, 1L, 1L),
+        assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+      )
+    }
+  }
+
+  test("SPARK-57830: nanos watermark matches micros watermark for equivalent instants") {
+    // Compare that the watermark advancement is identical between a micros and nanos column
+    // representing the same instant.
+    val inputDataMicros = MemoryStream[Int]
+    val microsDf = inputDataMicros.toDF()
+      .withColumn("eventTime", timestamp_seconds($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    val inputDataNanos = MemoryStream[Long]
+    val nanosDf = inputDataNanos.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    // Run both streams with the same logical timestamps and verify same watermark advancement
+    testStream(microsDf, outputMode = Complete)(
+      AddData(inputDataMicros, 15),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputDataMicros, 25),
+      CheckAnswer(1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
+
+    testStream(nanosDf, outputMode = Complete)(
+      AddData(inputDataNanos, 15L * 1000000000L),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputDataNanos, 25L * 1000000000L),
+      CheckAnswer(1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -1140,4 +1140,35 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
       assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
     )
   }
+
+  test("SPARK-57830: nanos watermark eviction in Update mode") {
+    // Exercises the scalar watermarkLiteral eviction path (LessThanOrEqual over
+    // TimestampNanosVal ordering) which is NOT reached by Complete output mode.
+    // In Update mode, state rows whose key timestamp is at or below the watermark are evicted.
+    val inputData = MemoryStream[Long]
+    val aggWithWatermark = inputData.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    testStream(aggWithWatermark, OutputMode.Update)(
+      // Add events at t=10s, t=11s, t=12s (nanos representation)
+      AddData(inputData, 10L * 1000000000L, 11L * 1000000000L, 12L * 1000000000L),
+      CheckNewAnswer(1L, 1L, 1L),
+      assertNumStateRows(3),
+      // Add event at t=25s => watermark advances to 25-10 = 15s
+      // State rows at t=10s,11s,12s are all <= watermark and get evicted.
+      AddData(inputData, 25L * 1000000000L),
+      CheckNewAnswer(1L),
+      assertNumStateRows(1), // only t=25s remains; t=10,11,12 evicted
+      assertNumRowsDroppedByWatermark(0),
+      // Add a late event at t=10s which is below watermark => dropped
+      AddData(inputData, 10L * 1000000000L),
+      CheckNewAnswer(),
+      assertNumStateRows(1),
+      assertNumRowsDroppedByWatermark(1)
+    )
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -1188,7 +1188,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
           $"window".getField("end").cast("string").as[String],
           $"count".as[Long])
 
-      testStream(windowedAgg)(
+      testStream(windowedAgg, OutputMode.Append)(
         // Events at t=10s,11s,12s,13s,14s => window [10s,15s); t=15s => window [15s,20s)
         AddData(inputData,
           10L * 1000000000L, 11L * 1000000000L, 12L * 1000000000L,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -1171,4 +1171,66 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
       assertNumRowsDroppedByWatermark(1)
     )
   }
+
+  test("SPARK-57829: window() over nanos column with watermark eviction") {
+    // Exercises the widened CheckAnalysis struct guard (AnyTimestampNanoType in window end field)
+    // and the statefulOperators endFieldType struct branch (watermarkLiteral with nanos type).
+    val inputData = MemoryStream[Long]
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val windowedAgg = inputData.toDF()
+        .withColumn("eventTime", timestamp_nanos($"value"))
+        .withWatermark("eventTime", "10 seconds")
+        .groupBy(window($"eventTime", "5 seconds") as Symbol("window"))
+        .agg(count("*") as Symbol("count"))
+        .select(
+          $"window".getField("start").cast("string").as[String],
+          $"window".getField("end").cast("string").as[String],
+          $"count".as[Long])
+
+      testStream(windowedAgg)(
+        // Events at t=10s,11s,12s,13s,14s => window [10s,15s); t=15s => window [15s,20s)
+        AddData(inputData,
+          10L * 1000000000L, 11L * 1000000000L, 12L * 1000000000L,
+          13L * 1000000000L, 14L * 1000000000L, 15L * 1000000000L),
+        CheckNewAnswer(),
+        // Event at t=25s => watermark advances to 25-10=15s; window [10s,15s) end <= wm => emitted
+        AddData(inputData, 25L * 1000000000L),
+        CheckNewAnswer(("1970-01-01 00:00:10", "1970-01-01 00:00:15", 5)),
+        assertNumStateRows(2), // [15s,20s) and [25s,30s) remain
+        assertNumRowsDroppedByWatermark(0),
+        // Late event at t=10s => below watermark => dropped
+        AddData(inputData, 10L * 1000000000L),
+        CheckNewAnswer(),
+        assertNumStateRows(2),
+        assertNumRowsDroppedByWatermark(1)
+      )
+    }
+  }
+
+  test("SPARK-57829: window() over nanos preserves nanosecond precision in bounds") {
+    // Verifies that window boundaries retain nanosecond precision (no truncation to micros).
+    val inputData = MemoryStream[Long]
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      // Use a 100ms window to show sub-microsecond precision in window bounds.
+      // Event at exactly 1.000000001s (1 second + 1 nanosecond).
+      // Window [1.0s, 1.1s) should contain this event.
+      val windowedAgg = inputData.toDF()
+        .withColumn("eventTime", timestamp_nanos($"value"))
+        .withWatermark("eventTime", "1 second")
+        .groupBy(window($"eventTime", "100 milliseconds") as Symbol("window"))
+        .agg(count("*") as Symbol("count"))
+        .select(
+          $"window".getField("start").cast("string").as[String],
+          $"count".as[Long])
+
+      testStream(windowedAgg, OutputMode.Update)(
+        // Event at 1.000000001s (1 nanosecond past 1s) => window [1.0s, 1.1s)
+        AddData(inputData, 1000000001L),
+        CheckNewAnswer(("1970-01-01 00:00:01", 1L)),
+        assertNumStateRows(1)
+      )
+    }
+  }
 }


### PR DESCRIPTION
> **Depends on #56944 ([SPARK-57830](https://github.com/apache/spark/pull/56944)).** This PR is stacked on it for the window-struct-over-nanos watermark handling and will be rebased onto master once #56944 merges (until then the diff includes #56944's commits).

### What changes were proposed in this pull request?

Extends `window`, `session_window`, and `window_time` to accept nanosecond-precision timestamp columns (`TimestampNTZNanosType`, `TimestampLTZNanosType`). Window boundaries are computed on the nanosecond scale: durations are scaled x1000 with `Math.multiplyExact`, timestamp <-> epoch-nanos round-trips go through `PreciseTimestampNanosConversion`, and `window_time` subtracts 1 nanosecond (vs 1 microsecond for micros input). The window start/end preserve the input's nanosecond precision.

This also updates the batch `session_window` aggregation iterators (`MergingSessionsIterator` / `UpdatingSessionsIterator`) to read and compare session boundaries via the nanosecond-aware `TimestampNanosVal` accessors through a shared `SessionNanosHelper`. These sort-merge iterators are on the shared (non-streaming) batch aggregation path, and `getLong` would misread the variable-length `TimestampNanosVal` representation - so the feature cannot function correctly without them.

Because this PR is what makes a window struct with a nanosecond `end` field reachable, it also carries the streaming watermark handling for that case (consolidated here from #56944 / #56984 per review, since it was inert until window-over-nanos existed): the `CheckAnalysis` `EventTimeWatermark` guard now accepts a window struct whose `end` field is a nanosecond type, and the `statefulOperators` eviction struct-branch extracts the `endFieldType` and builds the watermark literal via `watermarkLiteral` (from SPARK-57830), so state eviction is correct when watermarking a window over a nanosecond event-time column.

### Why are the changes needed?

Part of nanosecond-precision timestamp support (SPARK-56822), building on the event-time watermark support in SPARK-57830. Previously `window` / `session_window` / `window_time` rejected nanosecond-precision timestamp columns.

### Does this PR introduce _any_ user-facing change?

Yes - `window`, `session_window`, and `window_time` now accept nanosecond-precision timestamp columns, and the resulting window bounds preserve nanosecond precision.

### How was this patch tested?

New `DataFrameTimeWindowingSuite` and `DataFrameSessionWindowingSuite` tests for NTZ and LTZ nanosecond inputs, including value-level `checkAnswer` assertions for both (window bounds, session merging, and `window_time` at nanosecond granularity). New end-to-end `EventTimeWatermarkSuite` tests exercise `window()` over a nanosecond event-time column with `withWatermark` in Append mode, asserting nanosecond window bounds are preserved and that state is evicted once the watermark advances past the window. All existing window/session tests pass.

### Was this patch authored or co-authored using generative AI tooling?

Authored with assistance by Claude Opus 4.8.
