### PR TITLE
[SPARK-XXXXX][CORE] Tolerate missing jdk.internal.ref.Cleaner on JDK 26+

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -81,18 +81,28 @@ public final class Platform {
 
       // no point continuing if the above failed:
       if (DBB_CONSTRUCTOR != null && DBB_CLEANER_FIELD != null) {
-        Class<?> cleanerClass = Class.forName("jdk.internal.ref.Cleaner");
-        Method createMethod = cleanerClass.getMethod("create", Object.class, Runnable.class);
-        // Accessing jdk.internal.ref.Cleaner should actually fail by default in JDK 9+,
-        // unfortunately, unless the user has allowed access with something like
-        // --add-opens java.base/jdk.internal.ref=ALL-UNNAMED  If not, we can't use the Cleaner
-        // hack below. It doesn't break, just means the user might run into the default JVM limit
-        // on off-heap memory and increase it or set the flag above. This tests whether it's
-        // available:
+        Method createMethod;
         try {
-          createMethod.invoke(null, null, null);
-        } catch (IllegalAccessException e) {
-          // Don't throw an exception, but can't log here?
+          // jdk.internal.ref.Cleaner has been removed on some recent JDKs (e.g. JDK 26); on
+          // such JDKs this class simply doesn't exist any more, so treat that as "unavailable"
+          // rather than a fatal initialization error.
+          Class<?> cleanerClass = Class.forName("jdk.internal.ref.Cleaner");
+          createMethod = cleanerClass.getMethod("create", Object.class, Runnable.class);
+          // Accessing jdk.internal.ref.Cleaner should actually fail by default in JDK 9+,
+          // unfortunately, unless the user has allowed access with something like
+          // --add-opens java.base/jdk.internal.ref=ALL-UNNAMED  If not, we can't use the Cleaner
+          // hack below. It doesn't break, just means the user might run into the default JVM limit
+          // on off-heap memory and increase it or set the flag above. This tests whether it's
+          // available:
+          try {
+            createMethod.invoke(null, null, null);
+          } catch (IllegalAccessException e) {
+            // Don't throw an exception, but can't log here?
+            createMethod = null;
+          }
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+          // jdk.internal.ref.Cleaner is gone (e.g. JDK 26+). Not fatal: Platform simply won't
+          // use the Cleaner-based hack to release DirectByteBuffer memory on such JDKs.
           createMethod = null;
         }
         CLEANER_CREATE_METHOD = createMethod;


### PR DESCRIPTION
on normal GC instead — the same fallback already
used when `--add-opens java.base/jdk.internal.ref=ALL-UNNAMED` isn't granted.

### How was this patch tested?

Manually verified the logic change; recommend running the existing
`PlatformSuite` in `common/unsafe` on both an older JDK and JDK 26 to confirm
`cleanerCreateMethodIsDefined()` returns `false` (rather than throwing) on JDK 26.
Platform's static initializer treated any failure to load
jdk.internal.ref.Cleaner as fatal, wrapping it in an IllegalStateException
that aborted class init. On JDK 26 the class was removed outright
(ClassNotFoundException) rather than merely made inaccessible, which wasn't
handled the same way as the existing --add-opens-denied case, so
SparkContext creation failed with ExceptionInInitializerError.

Now ClassNotFoundException/NoSuchMethodException from the Cleaner lookup
falls back to CLEANER_CREATE_METHOD = null, same as when reflective access
is denied. Direct-buffer allocation already checks for null and simply
skips the eager-cleanup optimization, relying on normal GC instead.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
