### PR TITLE
[SPARK-57873][CORE] Support disabling ContextCleaner periodic GC via non-positive interval

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -129,8 +129,10 @@ private[spark] class ContextCleaner(
     cleaningThread.setDaemon(true)
     cleaningThread.setName("Spark Context Cleaner")
     cleaningThread.start()
-    periodicGCService.scheduleAtFixedRate(() => System.gc(),
-      periodicGCInterval, periodicGCInterval, TimeUnit.SECONDS)
+    if (periodicGCInterval > 0) {
+      periodicGCService.scheduleAtFixedRate(() => System.gc(),
+        periodicGCInterval, periodicGCInterval, TimeUnit.SECONDS)
+    }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -336,6 +336,16 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
       case _ => false
     }, askStorageEndpoints = true).isEmpty)
   }
+
+  test("SPARK-57873: non-positive spark.cleaner.periodicGC.interval disables periodic GC") {
+    sc.stop()
+    val conf = new SparkConf()
+      .setMaster("local[2]")
+      .setAppName("periodicGCDisabled")
+      .set(CLEANER_PERIODIC_GC_INTERVAL.key, "0s")
+    sc = new SparkContext(conf)
+    assert(sc.cleaner.isDefined)
+  }
 }
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2224,7 +2224,8 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.cleaner.periodicGC.interval</code></td>
   <td>30min</td>
   <td>
-    Controls how often to trigger a garbage collection.<br><br>
+    Controls how often to trigger a garbage collection. Setting this to 0 or a negative
+    value disables the periodic garbage collection.<br><br>
     This context cleaner triggers cleanups only when weak references are garbage collected.
     In long-running applications with large driver JVMs, where there is little memory pressure
     on the driver, this may happen very occasionally or not at all. Not cleaning at all may


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip scheduling the periodic GC task in `ContextCleaner.start()` when `spark.cleaner.periodicGC.interval` is non-positive, and documents that such a value disables the periodic GC.

### Why are the changes needed?

Previously, `spark.cleaner.periodicGC.interval=0s` causes `SparkContext` creation failures because the value was passed directly to `scheduleAtFixedRate`, which throws `IllegalArgumentException` when `period <= 0`. This change makes a non-positive value a way to disable the periodic `System.gc()` according to the user's intention instead of naive underlying Java error.

```
$ bin/spark-shell -c spark.cleaner.periodicGC.interval=0s
...
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.2.0
      /_/

Using Scala version 2.13.18 (OpenJDK 64-Bit Server VM, Java 25.0.3)
...
26/07/01 21:19:41 ERROR SparkContext: Error initializing SparkContext.
java.lang.IllegalArgumentException
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.scheduleAtFixedRate(ScheduledThreadPoolExecutor.java:610)
	at org.apache.spark.ContextCleaner.start(ContextCleaner.scala:133)
```

### Does this PR introduce _any_ user-facing change?

No because this is a new feature. Previously, it fails with `IllegalArgumentException` at the start-up.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5