### PR TITLE
[SPARK-57877][CORE] DirectByteBuffer cleaner support Java 26

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -81,16 +81,22 @@ public final class Platform {
 
       // no point continuing if the above failed:
       if (DBB_CONSTRUCTOR != null && DBB_CLEANER_FIELD != null) {
-        Class<?> cleanerClass = Class.forName("jdk.internal.ref.Cleaner");
-        Method createMethod = cleanerClass.getMethod("create", Object.class, Runnable.class);
-        // Accessing jdk.internal.ref.Cleaner should actually fail by default in JDK 9+,
+        // JDK-8344332 (JDK 26) migrate DirectByteBuffer away from jdk.internal.ref.Cleaner
+        Class<?> cleanerClass = (majorVersion < 26) ?
+            Class.forName("jdk.internal.ref.Cleaner") :
+            Class.forName("java.nio.BufferCleaner");
+        Method createMethod = (majorVersion < 26) ?
+            cleanerClass.getMethod("create", Object.class, Runnable.class) :
+            cleanerClass.getMethod("register", Object.class, Runnable.class);
+        // Accessing jdk.internal.ref.Cleaner should actually fail by default in JDK 9~25,
         // unfortunately, unless the user has allowed access with something like
         // --add-opens java.base/jdk.internal.ref=ALL-UNNAMED  If not, we can't use the Cleaner
         // hack below. It doesn't break, just means the user might run into the default JVM limit
         // on off-heap memory and increase it or set the flag above. This tests whether it's
         // available:
         try {
-          createMethod.invoke(null, null, null);
+          createMethod.setAccessible(true);
+          createMethod.invoke(null, new Object(), (Runnable) () -> {});
         } catch (IllegalAccessException e) {
           // Don't throw an exception, but can't log here?
           createMethod = null;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -88,15 +88,19 @@ public final class Platform {
         Method createMethod = (majorVersion < 26) ?
             cleanerClass.getMethod("create", Object.class, Runnable.class) :
             cleanerClass.getMethod("register", Object.class, Runnable.class);
-        // Accessing jdk.internal.ref.Cleaner should actually fail by default in JDK 9~25,
-        // unfortunately, unless the user has allowed access with something like
-        // --add-opens java.base/jdk.internal.ref=ALL-UNNAMED  If not, we can't use the Cleaner
-        // hack below. It doesn't break, just means the user might run into the default JVM limit
-        // on off-heap memory and increase it or set the flag above. This tests whether it's
-        // available:
+        // Accessing jdk.internal.ref.Cleaner (JDK 9~25) / java.nio.BufferCleaner (JDK 26+)
+        // should actually fail by default, unless the user has allowed access with something like
+        //   --add-opens java.base/jdk.internal.ref=ALL-UNNAMED  (JDK 9~25)
+        //   --add-opens java.base/java.nio=ALL-UNNAMED          (JDK 26+)
+        // If not, we can't use the Cleaner hack below. It doesn't break, just means the user might
+        // run into the default JVM limit on off-heap memory and increase it or set the flag above.
+        // This tests whether it's available:
         try {
-          createMethod.setAccessible(true);
-          createMethod.invoke(null, new Object(), (Runnable) () -> {});
+          if (createMethod.trySetAccessible()) {
+            createMethod.invoke(null, new Object(), (Runnable) () -> {});
+          } else {
+            createMethod = null;
+          }
         } catch (IllegalAccessException e) {
           // Don't throw an exception, but can't log here?
           createMethod = null;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
[JDK-8344332](https://bugs.openjdk.org/browse/JDK-8344332) migrates `DirectByteBuffer` away from `jdk.internal.ref.Cleaner` to a new `java.nio.BufferCleaner`, and [JDK-8361426](https://bugs.openjdk.org/browse/JDK-8361426) removes `jdk.internal.ref.Cleaner` entirely in JDK 26. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Adapt to upstream JDK change.

Close #56939

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

#### Run PlatformUtilSuite with JDK 26
```
JAVA_HOME=/path/of/openjdk-26 build/sbt "unsafe/testOnly *PlatformUtilSuite"
```

before
```
[info] Test run started (JUnit Jupiter)
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#freeingOnHeapMemoryBlockResetsBaseObjectAndOffset() started
[error] Test org.apache.spark.unsafe.PlatformUtilSuite.freeingOnHeapMemoryBlockResetsBaseObjectAndOffset failed: java.lang.ExceptionInInitializerError: null, took 0.022s
[error]     at org.apache.spark.unsafe.memory.HeapMemoryAllocator.allocate(HeapMemoryAllocator.java:73)
[error]     at org.apache.spark.unsafe.PlatformUtilSuite.freeingOnHeapMemoryBlockResetsBaseObjectAndOffset(PlatformUtilSuite.java:79)
[error] Caused by: java.lang.IllegalStateException: java.lang.ClassNotFoundException: jdk.internal.ref.Cleaner
[error]     at org.apache.spark.unsafe.Platform.<clinit>(Platform.java:104)
[error]     ... 2 more
[error] Caused by: java.lang.ClassNotFoundException: jdk.internal.ref.Cleaner
[error]     at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
[error]     at java.lang.ClassLoader.loadClass(ClassLoader.java:502)
[error]     at java.lang.Class.forName0(Native Method)
[error]     at java.lang.Class.forName(Class.java:478)
[error]     at java.lang.Class.forName(Class.java:468)
[error]     at org.apache.spark.unsafe.Platform.<clinit>(Platform.java:84)
[error]     ... 2 more
...
```
after
```
[info] Test run started (JUnit Jupiter)
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#freeingOnHeapMemoryBlockResetsBaseObjectAndOffset() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#overlappingCopyMemory() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#memoryDebugFillEnabledInTest() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#offHeapMemoryAllocatorThrowsAssertionErrorOnDoubleFree() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#heapMemoryReuse() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#onHeapMemoryAllocatorPoolingReUsesLongArrays() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#onHeapMemoryAllocatorThrowsAssertionErrorOnDoubleFree() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#freeingOffHeapMemoryBlockResetsOffset() started
[info] Test org.apache.spark.unsafe.PlatformUtilSuite#cleanerCreateMethodIsDefined() started
[info] Test run finished: 0 failed, 0 ignored, 9 total, 0.104s
[info] Passed: Total 9, Failed 0, Errors 0, Passed 9
[success] Total time: 9 s, completed Jul 2, 2026, 2:56:53 PM
```

#### Manually verify with JPMS args

```
cat > /tmp/CheckPlatform.java <<EOF
public class CheckPlatform {
  public static void main(String[] a) {
    int m = Integer.parseInt(System.getProperty("java.specification.version"));
    Throwable err = null; boolean def = false;
    try { def = org.apache.spark.unsafe.Platform.cleanerCreateMethodIsDefined(); }
    catch (Throwable t) { err = t; }
    String s = "JDK " + m + " | cleanerCreateMethodIsDefined=" + def;
    if (err != null) { Throwable c = err.getCause() != null ? err.getCause() : err;
      s += " | init threw " + err.getClass().getSimpleName() + " <- " + c.getClass().getName() + ": " + c.getMessage(); }
    System.out.println(s);
  }
}
EOF
```

```
build/sbt 'unsafe/package'
```

```
NIO='--add-opens=java.base/java.nio=ALL-UNNAMED'
REF='--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED'
```

master branch
```
printf '%-46s ' "JDK25 / no add-opens";                "$JAVA25_HOME/bin/java"           -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK25 / java.nio + jdk.internal.ref"; "$JAVA25_HOME/bin/java" $NIO $REF -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK26 / no add-opens";                "$JAVA26_HOME/bin/java"           -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK26 / java.nio + jdk.internal.ref"; "$JAVA26_HOME/bin/java" $NIO $REF -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
```
```
JDK25 / no add-opens                           JDK 25 | cleanerCreateMethodIsDefined=false
JDK25 / java.nio + jdk.internal.ref            JDK 25 | cleanerCreateMethodIsDefined=true
JDK26 / no add-opens                           JDK 26 | cleanerCreateMethodIsDefined=false
JDK26 / java.nio + jdk.internal.ref            JDK 26 | cleanerCreateMethodIsDefined=false | init threw ExceptionInInitializerError <- java.lang.IllegalStateException: java.lang.ClassNotFoundException: jdk.internal.ref.Cleaner
```

this PR
```
printf '%-46s ' "JDK25 / no add-opens";                "$JAVA25_HOME/bin/java"           -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK25 / java.nio only";               "$JAVA25_HOME/bin/java" $NIO      -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK25 / java.nio + jdk.internal.ref"; "$JAVA25_HOME/bin/java" $NIO $REF -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK26 / no add-opens";                "$JAVA26_HOME/bin/java"           -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
printf '%-46s ' "JDK26 / java.nio only";               "$JAVA26_HOME/bin/java" $NIO      -cp common/unsafe/target/scala-2.13/spark-unsafe_2.13-5.0.0-SNAPSHOT.jar /tmp/CheckPlatform.java 2>/dev/null
```
```
JDK25 / no add-opens                           JDK 25 | cleanerCreateMethodIsDefined=false
JDK25 / java.nio only                          JDK 25 | cleanerCreateMethodIsDefined=false
JDK25 / java.nio + jdk.internal.ref            JDK 25 | cleanerCreateMethodIsDefined=true
JDK26 / no add-opens                           JDK 26 | cleanerCreateMethodIsDefined=false
JDK26 / java.nio only                          JDK 26 | cleanerCreateMethodIsDefined=true
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, GLM 5.2 is used to construct manual test cases.