### PR TITLE
[SPARK-57879][STREAMING] Add missing error class UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8749,6 +8749,12 @@
     },
     "sqlState" : "42K0E"
   },
+  "UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK" : {
+    "message" : [
+      "Operation <operation> is not supported for ContinuousMemorySink."
+    ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_OVERWRITE" : {
     "message" : [
       "Can't overwrite the target that is also being read from."

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
@@ -21,6 +21,7 @@ import scala.language.implicitConversions
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
@@ -341,6 +342,28 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     checkAnswer(
       sqlContext.createDataFrame(sparkContext.makeRDD(rows), schema),
       intsToDF(expected)(schema))
+  }
+
+  test("SPARK-57879: ContinuousMemorySink throws UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK") {
+    val sink = new ContinuousMemorySink()
+    checkError(
+      exception = intercept[SparkUnsupportedOperationException] {
+        sink.latestBatchData
+      },
+      condition = "UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK",
+      parameters = Map("operation" -> "latestBatchData"))
+    checkError(
+      exception = intercept[SparkUnsupportedOperationException] {
+        sink.dataSinceBatch(0L)
+      },
+      condition = "UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK",
+      parameters = Map("operation" -> "dataSinceBatch"))
+    checkError(
+      exception = intercept[SparkUnsupportedOperationException] {
+        sink.write(0L, needTruncate = false, newRows = Array.empty)
+      },
+      condition = "UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK",
+      parameters = Map("operation" -> "write"))
   }
 
   private implicit def intsToDF(seq: Seq[Int])(implicit schema: StructType): DataFrame = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ContinuousMemorySink` overrides three `MemorySink` methods and throws `SparkUnsupportedOperationException` with `errorClass = "UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK"`:

- `latestBatchData` (ContinuousMemory.scala:84)
- `dataSinceBatch(sinceBatchId: Long)` (ContinuousMemory.scala:91)
- `write(batchId: Long, needTruncate: Boolean, newRows: Array[Row])` (ContinuousMemory.scala:102)

However, `UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK` was never registered in `error-conditions.json`. Hitting any of these paths produced a misleading `INTERNAL_ERROR`: _"Cannot find main error class 'UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK'"_ instead of the intended message.

This PR:
1. Registers `UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK` in `error-conditions.json` with `sqlState = "0A000"` and a `<operation>` parameter placeholder matching the `Map("operation" -> "...")` all three throw sites pass.
2. Adds tests in `MemorySinkSuite` that directly instantiate `ContinuousMemorySink` and call all three throwing methods, verifying the correct error class and `operation` parameter.

### Why are the changes needed?

Without the registration, calling `latestBatchData` or `dataSinceBatch` on a `ContinuousMemorySink` (e.g. via `CheckLastBatch` or `CheckNewAnswer` actions in `StreamTest`) produces an opaque `INTERNAL_ERROR` instead of the intended `UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK`. The three throw sites have existed since the class was introduced; only the registration was missing.

### Does this PR introduce _any_ user-facing change?

No. The error message produced by these three paths changes from `INTERNAL_ERROR: Cannot find main error class '...'` to the intended `UNSUPPORTED_OPERATION_FOR_CONTINUOUS_MEMORY_SINK` message. `ContinuousMemorySink` is internal test infrastructure, not a public API.

### How was this patch tested?

Added three `checkError` assertions in `MemorySinkSuite` — one per throwing method — that directly instantiate `ContinuousMemorySink` and verify the correct `errorClass` and `operation` parameter. Manually compiled with `build/sbt sql/Test/compile`.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude (Anthropic).