### PR TITLE
[SPARK-57882][SQL] Enforce AuthV2 metadata authorization on GetPrimaryKeys and GetCrossReference operations

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetCrossReferenceOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetCrossReferenceOperation.java
@@ -134,6 +134,12 @@ public class GetCrossReferenceOperation extends MetadataOperation {
         String cmdStr = "catalog : " + parentCatalogName
             + ", parentSchema : " + parentSchemaName + ", parentTable : " + parentTableName
             + ", foreignSchema : " + foreignSchemaName + ", foreignTable : " + foreignTableName;
+        if (privObjs.isEmpty()) {
+          // Neither table is specified, so the request cannot be scoped to any privilege object;
+          // reject it instead of skipping the authorization check.
+          throw new HiveSQLException(
+              "Access denied: neither parent nor foreign table specified. " + cmdStr);
+        }
         authorizeMetaGets(HiveOperationType.GET_COLUMNS, privObjs, cmdStr);
       }
      ForeignKeysRequest fkReq = new ForeignKeysRequest(parentSchemaName, parentTableName, foreignSchemaName, foreignTableName);

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetCrossReferenceOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetCrossReferenceOperation.java
@@ -20,12 +20,16 @@ package org.apache.hive.service.cli.operation;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.ForeignKeysRequest;
 import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject.HivePrivilegeObjectType;
 import org.apache.hadoop.hive.serde2.thrift.Type;
 import org.apache.hive.service.cli.*;
 import org.apache.hive.service.cli.session.HiveSession;
 import org.apache.hive.service.rpc.thrift.TRowSet;
 import org.apache.hive.service.rpc.thrift.TTableSchema;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -117,6 +121,21 @@ public class GetCrossReferenceOperation extends MetadataOperation {
     setState(OperationState.RUNNING);
     try {
        IMetaStoreClient metastoreClient = getParentSession().getMetaStoreClient();
+      if (isAuthV2Enabled()) {
+        List<HivePrivilegeObject> privObjs = new ArrayList<>();
+        if (parentTableName != null) {
+          privObjs.add(new HivePrivilegeObject(
+              HivePrivilegeObjectType.TABLE_OR_VIEW, parentSchemaName, parentTableName));
+        }
+        if (foreignTableName != null) {
+          privObjs.add(new HivePrivilegeObject(
+              HivePrivilegeObjectType.TABLE_OR_VIEW, foreignSchemaName, foreignTableName));
+        }
+        String cmdStr = "catalog : " + parentCatalogName
+            + ", parentSchema : " + parentSchemaName + ", parentTable : " + parentTableName
+            + ", foreignSchema : " + foreignSchemaName + ", foreignTable : " + foreignTableName;
+        authorizeMetaGets(HiveOperationType.GET_COLUMNS, privObjs, cmdStr);
+      }
      ForeignKeysRequest fkReq = new ForeignKeysRequest(parentSchemaName, parentTableName, foreignSchemaName, foreignTableName);
      List<SQLForeignKey> fks = metastoreClient.getForeignKeys(fkReq);
       if (fks == null) {

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java
@@ -80,10 +80,15 @@ public class GetPrimaryKeysOperation extends MetadataOperation {
     try {
       IMetaStoreClient metastoreClient = getParentSession().getMetaStoreClient();
       if (isAuthV2Enabled()) {
-        List<HivePrivilegeObject> privObjs = Collections.singletonList(
-            new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, schemaName, tableName));
         String cmdStr = "catalog : " + catalogName + ", schema : " + schemaName
             + ", table : " + tableName;
+        if (tableName == null) {
+          // The request cannot be scoped to a privilege object without a table name; reject it
+          // instead of skipping the authorization check.
+          throw new HiveSQLException("Access denied: no table specified. " + cmdStr);
+        }
+        List<HivePrivilegeObject> privObjs = Collections.singletonList(
+            new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, schemaName, tableName));
         authorizeMetaGets(HiveOperationType.GET_COLUMNS, privObjs, cmdStr);
       }
       PrimaryKeysRequest sqlReq = new PrimaryKeysRequest(schemaName, tableName);

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java
@@ -20,12 +20,16 @@ package org.apache.hive.service.cli.operation;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.PrimaryKeysRequest;
 import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject.HivePrivilegeObjectType;
 import org.apache.hadoop.hive.serde2.thrift.Type;
 import org.apache.hive.service.cli.*;
 import org.apache.hive.service.cli.session.HiveSession;
 import org.apache.hive.service.rpc.thrift.TRowSet;
 import org.apache.hive.service.rpc.thrift.TTableSchema;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -75,6 +79,13 @@ public class GetPrimaryKeysOperation extends MetadataOperation {
     setState(OperationState.RUNNING);
     try {
       IMetaStoreClient metastoreClient = getParentSession().getMetaStoreClient();
+      if (isAuthV2Enabled()) {
+        List<HivePrivilegeObject> privObjs = Collections.singletonList(
+            new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, schemaName, tableName));
+        String cmdStr = "catalog : " + catalogName + ", schema : " + schemaName
+            + ", table : " + tableName;
+        authorizeMetaGets(HiveOperationType.GET_COLUMNS, privObjs, cmdStr);
+      }
       PrimaryKeysRequest sqlReq = new PrimaryKeysRequest(schemaName, tableName);
       List<SQLPrimaryKey> pks = metastoreClient.getPrimaryKeys(sqlReq);
       if (pks == null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the `isAuthV2Enabled()/authorizeMetaGets()` authorization gate to `GetPrimaryKeysOperation.runInternal()` and `GetCrossReferenceOperation.runInternal()` in the Hive Thrift server, mirroring the pattern already used by the sibling `MetadataOperation` subclasses (`GetTablesOperation`, `GetColumnsOperation`, etc.). The check uses table-scoped `TABLE_OR_VIEW` privilege objects for the referenced table(s); `GetCrossReferenceOperation` handles the `getImportedKeys`/`getExportedKeys` cases where one side is null.

### Why are the changes needed?
When Hive AuthV2 authorization is configured (`hive.security.authorization.manager` set to a `HiveAuthorizerFactory` with authorization enabled), metadata operations gate metastore access through `authorizeMetaGets`. Every sibling `MetadataOperation` subclass does this, and Spark's own `SparkGet*Operation` classes do too. `GetPrimaryKeysOperation` and `GetCrossReferenceOperation` are the only metadata operations that omit the gate, and `SparkSQLOperationManager` does not override them, so the ungated Hive base implementations run. Consequently, with AuthV2 enabled, an authenticated client can read primary-/foreign-key schema metadata (table/column/key names, FK relationships) for tables that an AuthV2 policy denies via `getTables()`/`getColumns()`. This restores consistent authorization across all metadata operations.

### Does this PR introduce _any_ user-facing change?
Only when Hive AuthV2 authorization is enabled: `DatabaseMetaData.getPrimaryKeys`/`getImportedKeys`/`getExportedKeys`/`getCrossReference` now perform the same authorization check as the other metadata calls, and access to unauthorized tables' key metadata is rejected. With authorization disabled (the default), behavior is unchanged.

### How was this patch tested?
Compiled `hive-thriftserver` and ran the existing `SparkMetadataOperationSuite` (15 tests, all passing). The gate is a no-op when authorization is disabled, which is the path the suite exercises, so behavior is unchanged there.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)
