### PR TITLE
[SPARK-57883][CORE][TESTS] Fix `PluginContainerSuite` to check executor memory correctly

### DIFF
--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -259,8 +259,12 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
       TestUtils.waitUntilExecutorsUp(sc, 1, 60000)
 
       // Check executor memory is also updated
-      val execInfo = sc.statusTracker.getExecutorInfos.head
-      assert(execInfo.totalOffHeapStorageMemory() == MemoryOverridePlugin.offHeapMemory)
+      eventually(timeout(10.seconds), interval(100.milliseconds)) {
+        val execs = sc.statusStore.executorList(true).filter(_.id != SparkContext.DRIVER_IDENTIFIER)
+        assert(execs.nonEmpty)
+        assert(execs.forall(_.memoryMetrics.exists(
+          _.totalOffHeapStorageMemory == MemoryOverridePlugin.offHeapMemory)))
+      }
     } finally {
       if (sc != null) {
         sc.stop()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `PluginContainerSuite` to check executor memory correctly.

### Why are the changes needed?

Previously, it checks `driver` accidentally because it didn't filter out driver from the executor list.

https://github.com/apache/spark/blob/e3e6d9eb31012244692c043eb92a582ae3c3751b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala#L261-L263

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.