### PR TITLE
[SPARK-57904][WEBUI] Change default value of `spark.ui.xXssProtection` to `0`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -119,10 +119,13 @@ private[spark] object UI {
     .createWithDefault(true)
 
   val UI_X_XSS_PROTECTION = ConfigBuilder("spark.ui.xXssProtection")
-    .doc("Value for HTTP X-XSS-Protection response header")
+    .doc("Value for HTTP X-XSS-Protection response header. The default is '0' which disables " +
+      "the browser's XSS Auditor. The XSS Auditor is deprecated and removed from modern " +
+      "browsers (Chrome, Edge, Firefox) and can introduce side-channel vulnerabilities " +
+      "in browsers that still support it (Safari). Use Content-Security-Policy instead.")
     .version("2.3.0")
     .stringConf
-    .createWithDefaultString("1; mode=block")
+    .createWithDefaultString("0")
 
   val UI_X_CONTENT_TYPE_OPTIONS = ConfigBuilder("spark.ui.xContentTypeOptions.enabled")
     .doc("Set to 'true' for setting X-Content-Type-Options HTTP response header to 'nosniff'")

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -120,8 +120,8 @@ private[spark] object UI {
 
   val UI_X_XSS_PROTECTION = ConfigBuilder("spark.ui.xXssProtection")
     .doc("Value for HTTP X-XSS-Protection response header. The default is '0' which disables " +
-      "the browser's XSS Auditor. The XSS Auditor is deprecated and removed from modern " +
-      "browsers (Chrome, Edge, Firefox) and can introduce side-channel vulnerabilities " +
+      "the browser's XSS Auditor. The XSS Auditor has been removed from Chrome and Edge, " +
+      "and was never implemented in Firefox. It can introduce side-channel vulnerabilities " +
       "in browsers that still support it (Safari). Use Content-Security-Policy instead.")
     .version("2.3.0")
     .stringConf

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -163,6 +163,19 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
   }
 
+  test("X-XSS-Protection defaults to 0") {
+    val conf = new SparkConf(false)
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    verify(res).setHeader(meq("X-XSS-Protection"), meq("0"))
+  }
+
   test("doAs impersonation") {
     val conf = new SparkConf(false)
       .set(ACLS_ENABLE, true)

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -30,6 +30,8 @@ license: |
 
 - Since Spark 4.3, Spark sets `allowPrivilegeEscalation` to `false` on the driver and executor containers' security context by default. To restore the legacy behavior, you can set `spark.kubernetes.securityContext.allowPrivilegeEscalation` to `true`.
 
+- Since Spark 4.3, the default value of `spark.ui.xXssProtection` has been changed from `1; mode=block` to `0`. The XSS Auditor is deprecated and has been removed from modern browsers (Chrome, Edge, Firefox), and can introduce side-channel vulnerabilities in browsers that still support it. To restore the legacy behavior, you can set `spark.ui.xXssProtection` to `1; mode=block`. For modern XSS protection, consider enabling `spark.ui.contentSecurityPolicy.enabled`.
+
 ## Upgrading from Core 4.1 to 4.2
 
 - Since Spark 4.2, Spark Master REST API uses Java 21 virtual threads by default when running on Java 21 or later. To restore the legacy behavior, you can set `spark.master.rest.virtualThread.enabled` to `false`.

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -30,7 +30,7 @@ license: |
 
 - Since Spark 4.3, Spark sets `allowPrivilegeEscalation` to `false` on the driver and executor containers' security context by default. To restore the legacy behavior, you can set `spark.kubernetes.securityContext.allowPrivilegeEscalation` to `true`.
 
-- Since Spark 4.3, the default value of `spark.ui.xXssProtection` has been changed from `1; mode=block` to `0`. The XSS Auditor is deprecated and has been removed from modern browsers (Chrome, Edge, Firefox), and can introduce side-channel vulnerabilities in browsers that still support it. To restore the legacy behavior, you can set `spark.ui.xXssProtection` to `1; mode=block`. For modern XSS protection, consider enabling `spark.ui.contentSecurityPolicy.enabled`.
+- Since Spark 4.3, the default value of `spark.ui.xXssProtection` has been changed from `1; mode=block` to `0`. The XSS Auditor has been removed from Chrome and Edge, and was never implemented in Firefox. It can introduce side-channel vulnerabilities in browsers that still support it (Safari). To restore the legacy behavior, you can set `spark.ui.xXssProtection` to `1; mode=block`. For modern XSS protection, consider enabling `spark.ui.contentSecurityPolicy.enabled`.
 
 ## Upgrading from Core 4.1 to 4.2
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -769,11 +769,11 @@ Security.
   <td><code>0</code></td>
   <td>
     Value for HTTP X-XSS-Protection response header. The default is <code>0</code> which
-    disables the browser's XSS Auditor. The XSS Auditor is deprecated and has been removed
-    from modern browsers (Chrome, Edge, Firefox). In browsers that still support it (Safari),
+    disables the browser's XSS Auditor. The XSS Auditor has been removed from Chrome and
+    Edge, and was never implemented in Firefox. In browsers that still support it (Safari),
     it can introduce side-channel vulnerabilities. Use Content-Security-Policy instead.
     <ul>
-      <li><code>0</code> (Disables XSS filtering — recommended)</li>
+      <li><code>0</code> (Disables XSS filtering. Recommended.)</li>
       <li><code>1</code> (Enables XSS filtering. If a cross-site scripting attack is detected,
         the browser will sanitize the page.)</li>
       <li><code>1; mode=block</code> (Enables XSS filtering. The browser will prevent rendering

--- a/docs/security.md
+++ b/docs/security.md
@@ -766,12 +766,14 @@ Security.
 <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
 <tr>
   <td><code>spark.ui.xXssProtection</code></td>
-  <td><code>1; mode=block</code></td>
+  <td><code>0</code></td>
   <td>
-    Value for HTTP X-XSS-Protection response header. You can choose appropriate value
-    from below:
+    Value for HTTP X-XSS-Protection response header. The default is <code>0</code> which
+    disables the browser's XSS Auditor. The XSS Auditor is deprecated and has been removed
+    from modern browsers (Chrome, Edge, Firefox). In browsers that still support it (Safari),
+    it can introduce side-channel vulnerabilities. Use Content-Security-Policy instead.
     <ul>
-      <li><code>0</code> (Disables XSS filtering)</li>
+      <li><code>0</code> (Disables XSS filtering — recommended)</li>
       <li><code>1</code> (Enables XSS filtering. If a cross-site scripting attack is detected,
         the browser will sanitize the page.)</li>
       <li><code>1; mode=block</code> (Enables XSS filtering. The browser will prevent rendering


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the default value of `spark.ui.xXssProtection` from `1; mode=block` to `0`.

### Why are the changes needed?

The `X-XSS-Protection` header controls the browser's built-in XSS Auditor. However, the XSS Auditor has been deprecated and removed from modern browsers:

- **Chrome**: Removed in Chrome 78 (2019)
- **Edge**: Removed after migrating to Chromium
- **Firefox**: Never implemented

In browsers that still support it (Safari), the XSS Auditor can introduce **side-channel vulnerabilities** — attackers can exploit the filter's behavior to leak page content. This is why the Chrome team removed it entirely rather than just disabling it by default.

Setting the value to `0` explicitly disables the XSS Auditor in Safari, eliminating this attack surface. MDN and OWASP both recommend either `0` or not sending the header at all.

For modern XSS protection, `spark.ui.contentSecurityPolicy.enabled` should be used instead.

References:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
- https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection

### Does this PR introduce _any_ user-facing change?
Yes. The `X-XSS-Protection` response header value changes from `1; mode=block` to `0`. This has no effect on Chrome, Edge, or Firefox (which have already removed XSS Auditor support). In Safari, this disables the XSS Auditor, which is a security improvement. To restore the legacy behavior, set `spark.ui.xXssProtection` to `1; mode=block`.

### How was this patch tested?
A new test case was added to `HttpSecurityFilterSuite` to verify the default value.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude