### PR TITLE
[SPARK-57920][CORE][SQL][YARN] Use `Files.createTempFile` to create temporary files with owner-only permissions

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -21,6 +21,7 @@ import java.io._
 import java.net._
 import java.nio.channels.{Channels, SocketChannel}
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 
 import scala.collection.mutable
@@ -852,7 +853,7 @@ private[spark] class PythonBroadcast(@transient var path: String) extends Serial
     if (!diskBlockManager.containsBlock(blockId)) {
       Utils.tryOrIOException {
         val dir = new File(Utils.getLocalDir(SparkEnv.get.conf))
-        val file = File.createTempFile("broadcast", "", dir)
+        val file = Files.createTempFile(dir.toPath, "broadcast", "").toFile
         val out = new FileOutputStream(file)
         Utils.tryWithSafeFinally {
           val size = Utils.copyStream(in, out)

--- a/core/src/main/scala/org/apache/spark/deploy/StandaloneResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/StandaloneResourceUtils.scala
@@ -109,7 +109,8 @@ private[spark] object StandaloneResourceUtils extends Logging {
         logError(errMsg, e)
         throw new SparkException(errMsg.message, e)
     }
-    val resourcesFile = File.createTempFile(s"resource-$compShortName-", ".json", dir)
+    val resourcesFile = Files.createTempFile(dir.toPath, s"resource-$compShortName-", ".json")
+      .toFile
     tmpFile.renameTo(resourcesFile)
     Some(resourcesFile)
   }

--- a/core/src/main/scala/org/apache/spark/storage/LogBlockWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/LogBlockWriter.scala
@@ -20,6 +20,7 @@ package org.apache.spark.storage
 import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.file.Files
 
 import org.apache.commons.io.output.CountingOutputStream
 
@@ -61,7 +62,7 @@ private[spark] class LogBlockWriter(
   private def initialize(): Unit = {
     try {
       val dir = new File(Utils.getLocalDir(sparkConf))
-      tmpFile = File.createTempFile(s"spark_log_$logBlockType", "", dir)
+      tmpFile = Files.createTempFile(dir.toPath, s"spark_log_$logBlockType", "").toFile
       val fos = new FileOutputStream(tmpFile, false)
       val bos = new BufferedOutputStream(fos, bufferSize)
       cos = new CountingOutputStream(bos)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -517,8 +517,8 @@ private[spark] object Utils
       in: InputStream,
       destFile: File,
       fileOverwrite: Boolean): Unit = {
-    val tempFile = File.createTempFile("fetchFileTemp", null,
-      new File(destFile.getParentFile.getAbsolutePath))
+    val tempFile = Files.createTempFile(
+      new File(destFile.getParentFile.getAbsolutePath).toPath, "fetchFileTemp", null).toFile
     logInfo(log"Fetching ${MDC(LogKeys.URL, url)} to ${MDC(FILE_ABSOLUTE_PATH, tempFile)}")
 
     try {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -710,8 +710,8 @@ private[spark] class Client(
               log"libraries under SPARK_HOME.")
           val jarsDir = new File(YarnCommandBuilderUtils.findJarsDir(
             sparkConf.getenv("SPARK_HOME")))
-          val jarsArchive = File.createTempFile(LOCALIZED_LIB_DIR, ".zip",
-            new File(Utils.getLocalDir(sparkConf)))
+          val jarsArchive = Files.createTempFile(
+            Paths.get(Utils.getLocalDir(sparkConf)), LOCALIZED_LIB_DIR, ".zip").toFile
           val bufferSize = sparkConf.get(BUFFER_SIZE)
           Using.resource(new ZipOutputStream(
             new BufferedOutputStream(new FileOutputStream(jarsArchive), bufferSize))) {
@@ -898,8 +898,8 @@ private[spark] class Client(
       }
     }
 
-    val confArchive = File.createTempFile(LOCALIZED_CONF_DIR, ".zip",
-      new File(Utils.getLocalDir(sparkConf)))
+    val confArchive = Files.createTempFile(
+      Paths.get(Utils.getLocalDir(sparkConf)), LOCALIZED_CONF_DIR, ".zip").toFile
     val confStream = new ZipOutputStream(new FileOutputStream(confArchive))
 
     logDebug(s"Creating an archive with the config files for distribution at $confArchive.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/RowQueue.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/RowQueue.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.python
 
 import java.io._
+import java.nio.file.Files
 
 import com.google.common.io.Closeables
 
@@ -190,7 +191,7 @@ case class HybridRowQueue(
   extends HybridQueue[UnsafeRow, RowQueue](memManager, tempDir, serMgr) {
 
   override protected def createDiskQueue(): RowQueue = {
-    DiskRowQueue(File.createTempFile("buffer", "", tempDir), numFields, serMgr)
+    DiskRowQueue(Files.createTempFile(tempDir.toPath, "buffer", "").toFile, numFields, serMgr)
   }
 
   override protected def createInMemoryQueue(page: MemoryBlock): RowQueue = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `java.nio.file.Files.createTempFile` instead of `java.io.File.createTempFile` in the main source code (`Utils`, `yarn.Client`, `PythonRDD`, `RowQueue`, `LogBlockWriter`, `StandaloneResourceUtils`) to create temporary files with owner-only permissions (`600`) on POSIX file systems.

### Why are the changes needed?

`File.createTempFile` creates files with umask-based default permissions (typically `644`), while `Files.createTempFile` guarantees `600`. Some of these temp files may contain sensitive data (fetched keytabs, YARN conf archives) and are not always created under a `chmod 700` directory.

### Does this PR introduce _any_ user-facing change?

No functional change. On POSIX systems, these temporary files are now created with owner-only permissions.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5