### PR TITLE
[SPARK-57843][SS] Support nanosecond-precision event-time in streaming stateful operators

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -650,14 +650,8 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
 
           case etw: EventTimeWatermark =>
             etw.eventTime.dataType match {
-              // Window-struct: the "end" field may be micros LTZ (TimestampType) or
-              // nanosecond-precision (AnyTimestampNanoType). The nanos path is not yet
-              // reachable (TimeWindow rejects nanos inputs until SPARK-57829), but
-              // accepting it here prevents a spurious analysis failure once window-over-
-              // nanos is enabled.
-              case s: StructType if s.find(_.name == "end").exists(f =>
-                f.dataType == TimestampType ||
-                f.dataType.isInstanceOf[AnyTimestampNanoType]) =>
+              case s: StructType
+                if s.find(_.name == "end").map(_.dataType) == Some(TimestampType) =>
               case _: TimestampType =>
               case _: AnyTimestampNanoType =>
               case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -653,6 +653,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               case s: StructType
                 if s.find(_.name == "end").map(_.dataType) == Some(TimestampType) =>
               case _: TimestampType =>
+              case _: AnyTimestampNanoType =>
               case _ =>
                 etw.failAnalysis(
                   errorClass = "EVENT_TIME_IS_NOT_ON_TIMESTAMP_TYPE",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -650,8 +650,14 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
 
           case etw: EventTimeWatermark =>
             etw.eventTime.dataType match {
-              case s: StructType
-                if s.find(_.name == "end").map(_.dataType) == Some(TimestampType) =>
+              // Window-struct: the "end" field may be micros LTZ (TimestampType) or
+              // nanosecond-precision (AnyTimestampNanoType). The nanos path is not yet
+              // reachable (TimeWindow rejects nanos inputs until SPARK-57829), but
+              // accepting it here prevents a spurious analysis failure once window-over-
+              // nanos is enabled.
+              case s: StructType if s.find(_.name == "end").exists(f =>
+                f.dataType == TimestampType ||
+                f.dataType.isInstanceOf[AnyTimestampNanoType]) =>
               case _: TimestampType =>
               case _: AnyTimestampNanoType =>
               case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
+import org.apache.spark.sql.types.AnyTimestampNanoType
 
 /**
  * Analyzes the presence of unsupported operations in a logical plan.
@@ -554,6 +555,19 @@ object UnsupportedOperationChecker extends Logging {
             throwError(
               "dropDuplicatesWithinWatermark is not supported on streaming DataFrames/DataSets " +
                 "without watermark")(plan)
+          }
+
+          // TODO(SPARK-57843): Handle nanosecond event-time columns in streaming stateful
+          //  operators incl. dropDuplicatesWithinWatermark. Until then, reject them here to
+          //  avoid silent corruption (the exec layer reads event time via getLong assuming
+          //  microsecond precision).
+          val nanoWatermarkAttributes = watermarkAttributes.filter(
+            _.dataType.isInstanceOf[AnyTimestampNanoType])
+          if (nanoWatermarkAttributes.nonEmpty) {
+            throwError(
+              "dropDuplicatesWithinWatermark does not yet support nanosecond-precision " +
+                "event-time columns (SPARK-57843). Use a microsecond-precision timestamp " +
+                "type for the watermark column instead.")(plan)
           }
 
         case c: CoGroup if c.children.exists(_.isStreaming) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -496,6 +496,25 @@ object UnsupportedOperationChecker extends Logging {
             }
           }
 
+          // SPARK-57843: Reject ALL stream-stream joins when the watermark column uses
+          // nanosecond precision. SymmetricHashJoinStateManager reads event-time via
+          // getLong (microseconds); a TimestampNanosVal would be silently misread.
+          // This check is hoisted above the per-join-type dispatch so that InnerLike
+          // (which skips checkForStreamStreamJoinWatermark) is also covered.
+          if (left.isStreaming && right.isStreaming) {
+            val allOutput = left.output ++ right.output
+            val nanoWatermarkInJoin = allOutput.exists { a =>
+              a.metadata.contains(EventTimeWatermark.delayKey) &&
+                a.dataType.isInstanceOf[AnyTimestampNanoType]
+            }
+            if (nanoWatermarkInJoin) {
+              throwError(
+                "Stream-stream joins do not yet support nanosecond-precision event-time " +
+                  "columns (SPARK-57843). Use a microsecond-precision timestamp type for " +
+                  "the watermark column instead.")(j)
+            }
+          }
+
           joinType match {
             case _: InnerLike =>
               // no further validations needed
@@ -555,19 +574,6 @@ object UnsupportedOperationChecker extends Logging {
             throwError(
               "dropDuplicatesWithinWatermark is not supported on streaming DataFrames/DataSets " +
                 "without watermark")(plan)
-          }
-
-          // TODO(SPARK-57843): Handle nanosecond event-time columns in streaming stateful
-          //  operators incl. dropDuplicatesWithinWatermark. Until then, reject them here to
-          //  avoid silent corruption (the exec layer reads event time via getLong assuming
-          //  microsecond precision).
-          val nanoWatermarkAttributes = watermarkAttributes.filter(
-            _.dataType.isInstanceOf[AnyTimestampNanoType])
-          if (nanoWatermarkAttributes.nonEmpty) {
-            throwError(
-              "dropDuplicatesWithinWatermark does not yet support nanosecond-precision " +
-                "event-time columns (SPARK-57843). Use a microsecond-precision timestamp " +
-                "type for the watermark column instead.")(plan)
           }
 
         case c: CoGroup if c.children.exists(_.isStreaming) =>
@@ -684,6 +690,21 @@ object UnsupportedOperationChecker extends Logging {
   }
 
   private def checkForStreamStreamJoinWatermark(join: Join): Unit = {
+    // TODO(SPARK-57843 follow-up): Stream-stream joins with nanosecond event-time columns
+    //  are not yet supported because SymmetricHashJoinStateManager.extractEventTimeFn reads
+    //  event time via getLong assuming microsecond precision.
+    val allOutput = join.left.output ++ join.right.output
+    val nanoWatermarkInJoin = allOutput.exists { a =>
+      a.metadata.contains(EventTimeWatermark.delayKey) &&
+        a.dataType.isInstanceOf[AnyTimestampNanoType]
+    }
+    if (nanoWatermarkInJoin) {
+      throwError(
+        "Stream-stream joins do not yet support nanosecond-precision event-time columns " +
+          "(SPARK-57843). Use a microsecond-precision timestamp type for the watermark " +
+          "column instead.")(join)
+    }
+
     val watermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(join)
 
     // Check if the nullable side has a watermark, and there's a range condition which

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -690,21 +690,6 @@ object UnsupportedOperationChecker extends Logging {
   }
 
   private def checkForStreamStreamJoinWatermark(join: Join): Unit = {
-    // TODO(SPARK-57843 follow-up): Stream-stream joins with nanosecond event-time columns
-    //  are not yet supported because SymmetricHashJoinStateManager.extractEventTimeFn reads
-    //  event time via getLong assuming microsecond precision.
-    val allOutput = join.left.output ++ join.right.output
-    val nanoWatermarkInJoin = allOutput.exists { a =>
-      a.metadata.contains(EventTimeWatermark.delayKey) &&
-        a.dataType.isInstanceOf[AnyTimestampNanoType]
-    }
-    if (nanoWatermarkInJoin) {
-      throwError(
-        "Stream-stream joins do not yet support nanosecond-precision event-time columns " +
-          "(SPARK-57843). Use a microsecond-precision timestamp type for the watermark " +
-          "column instead.")(join)
-    }
-
     val watermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(join)
 
     // Check if the nullable side has a watermark, and there's a range condition which

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -354,18 +354,37 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
     outputMode = Append
   )
 
-  // DeduplicateWithinWatermark with nanosecond event-time column should be rejected
+  // Stream-stream join with nanosecond event-time column should be rejected (SPARK-57843)
   testError(
-    "streaming plan - DeduplicateWithinWatermark with nanosecond event-time: not supported",
-    Seq("dropDuplicatesWithinWatermark", "nanosecond", "SPARK-57843")) {
+    "streaming plan - stream-stream join with nanosecond event-time: not supported",
+    Seq("Stream-stream joins", "nanosecond", "SPARK-57843")) {
     val nanoAttr = AttributeReference("ts", TimestampLTZNanosType())()
     val nanoWatermarkMetadata = new MetadataBuilder()
       .withMetadata(nanoAttr.metadata)
       .putLong(EventTimeWatermark.delayKey, 1000L)
       .build()
     val nanoAttrWithWatermark = nanoAttr.withMetadata(nanoWatermarkMetadata)
-    val nanoStreamRelation = new TestStreamingRelation(nanoAttrWithWatermark)
-    val plan = DeduplicateWithinWatermark(Seq(nanoAttrWithWatermark), nanoStreamRelation)
+    val leftRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val rightRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val plan = leftRelation.join(rightRelation, joinType = FullOuter,
+      condition = Some(nanoAttrWithWatermark > nanoAttrWithWatermark + 10))
+    UnsupportedOperationChecker.checkForStreaming(wrapInStreaming(plan), Append)
+  }
+
+  // Stream-stream INNER join with nanosecond event-time column should be rejected (SPARK-57843)
+  testError(
+    "streaming plan - stream-stream inner join with nanosecond event-time: not supported",
+    Seq("Stream-stream joins", "nanosecond", "SPARK-57843")) {
+    val nanoAttr = AttributeReference("ts", TimestampLTZNanosType())()
+    val nanoWatermarkMetadata = new MetadataBuilder()
+      .withMetadata(nanoAttr.metadata)
+      .putLong(EventTimeWatermark.delayKey, 1000L)
+      .build()
+    val nanoAttrWithWatermark = nanoAttr.withMetadata(nanoWatermarkMetadata)
+    val leftRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val rightRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val plan = leftRelation.join(rightRelation, joinType = Inner,
+      condition = Some(nanoAttrWithWatermark > nanoAttrWithWatermark + 10))
     UnsupportedOperationChecker.checkForStreaming(wrapInStreaming(plan), Append)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
-import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder}
+import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder, TimestampLTZNanosType}
 
 /** A dummy command for testing unsupported operations. */
 case class DummyCommand() extends LeafCommand
@@ -353,6 +353,21 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
     Deduplicate(Seq(att), batchRelation),
     outputMode = Append
   )
+
+  // DeduplicateWithinWatermark with nanosecond event-time column should be rejected
+  testError(
+    "streaming plan - DeduplicateWithinWatermark with nanosecond event-time: not supported",
+    Seq("dropDuplicatesWithinWatermark", "nanosecond", "SPARK-57843")) {
+    val nanoAttr = AttributeReference("ts", TimestampLTZNanosType())()
+    val nanoWatermarkMetadata = new MetadataBuilder()
+      .withMetadata(nanoAttr.metadata)
+      .putLong(EventTimeWatermark.delayKey, 1000L)
+      .build()
+    val nanoAttrWithWatermark = nanoAttr.withMetadata(nanoWatermarkMetadata)
+    val nanoStreamRelation = new TestStreamingRelation(nanoAttrWithWatermark)
+    val plan = DeduplicateWithinWatermark(Seq(nanoAttrWithWatermark), nanoStreamRelation)
+    UnsupportedOperationChecker.checkForStreaming(wrapInStreaming(plan), Append)
+  }
 
   // Inner joins: Multiple stream-stream joins supported only in append mode
   testBinaryOperationInStreamingPlan(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/EventTimeWatermarkExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/EventTimeWatermarkExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToMillis
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.{TimestampLTZNanosType, TimestampNTZNanosType}
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.AccumulatorV2
 
@@ -105,8 +106,16 @@ case class EventTimeWatermarkExec(
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions { iter =>
       val getEventTime = UnsafeProjection.create(eventTime :: Nil, child.output)
+      val toMs: InternalRow => Long = eventTime.dataType match {
+        case _: TimestampLTZNanosType =>
+          row => microsToMillis(getEventTime(row).getTimestampLTZNanos(0).epochMicros)
+        case _: TimestampNTZNanosType =>
+          row => microsToMillis(getEventTime(row).getTimestampNTZNanos(0).epochMicros)
+        case _ =>
+          row => microsToMillis(getEventTime(row).getLong(0))
+      }
       iter.map { row =>
-        eventTimeStats.add(microsToMillis(getEventTime(row).getLong(0)))
+        eventTimeStats.add(toMs(row))
         row
       }
     }
@@ -160,8 +169,16 @@ case class UpdateEventTimeColumnExec(
             val boundEventTimeExpression = bindReference[Expression](eventTime, child.output)
             val eventTimeProjection = UnsafeProjection.create(boundEventTimeExpression)
             val rowEventTime = eventTimeProjection(row)
+            val eventTimeMicros = eventTime.dataType match {
+              case _: TimestampLTZNanosType =>
+                rowEventTime.getTimestampLTZNanos(0).epochMicros
+              case _: TimestampNTZNanosType =>
+                rowEventTime.getTimestampNTZNanos(0).epochMicros
+              case _ =>
+                rowEventTime.getLong(0)
+            }
             throw QueryExecutionErrors.emittedRowsAreOlderThanWatermark(
-              eventTimeWatermarkForLateEvents.get, rowEventTime.getLong(0))
+              eventTimeWatermarkForLateEvents.get, eventTimeMicros)
           }
           row
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -1580,12 +1580,16 @@ case class StreamingDeduplicateWithinWatermarkExec(
     assert(reusedDupInfoRow.isDefined, "This should have reused row.")
     val timeoutRow = reusedDupInfoRow.get
 
-    // We expect data type of event time column to be TimestampType or TimestampNTZType which both
-    // are internally represented as Long.
-    // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
-    //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
-    //  Until then, UnsupportedOperationChecker rejects nanos event-time at analysis time.
-    val timestamp = data.getLong(eventTimeColOrdinal)
+    // Extract event-time as microseconds. For nanosecond-precision timestamp types the value
+    // is stored as a TimestampNanosVal; we extract epochMicros to keep state in micros.
+    val timestamp: Long = eventTimeCol.dataType match {
+      case _: TimestampLTZNanosType =>
+        data.getTimestampLTZNanos(eventTimeColOrdinal).epochMicros
+      case _: TimestampNTZNanosType =>
+        data.getTimestampNTZNanos(eventTimeColOrdinal).epochMicros
+      case _ =>
+        data.getLong(eventTimeColOrdinal)
+    }
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -1584,6 +1584,7 @@ case class StreamingDeduplicateWithinWatermarkExec(
     // are internally represented as Long.
     // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
     //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
+    //  Until then, UnsupportedOperationChecker rejects nanos event-time at analysis time.
     val timestamp = data.getLong(eventTimeColOrdinal)
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -47,6 +47,7 @@ import org.apache.spark.sql.execution.streaming.state._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{OutputMode, StateOperatorProgress}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 import org.apache.spark.util.{CollectionAccumulator, CompletionIterator, NextIterator, Utils}
 
 
@@ -671,15 +672,33 @@ object WatermarkSupport {
     // use the attribute itself.
     val evictionExpression =
       if (watermarkAttribute.dataType.isInstanceOf[StructType]) {
+        val structType = watermarkAttribute.dataType.asInstanceOf[StructType]
+        val endFieldType = structType("end").dataType
         LessThanOrEqual(
           GetStructField(watermarkAttribute, 1),
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, endFieldType))
       } else {
         LessThanOrEqual(
           watermarkAttribute,
-          Literal(optionalWatermarkMs.get * 1000))
+          watermarkLiteral(optionalWatermarkMs.get, watermarkAttribute.dataType))
       }
     Some(evictionExpression)
+  }
+
+  /**
+   * Build the watermark boundary literal for the given column type.
+   * For microsecond timestamps the boundary is watermarkMs * 1000 (micros).
+   * For nanosecond timestamps the boundary is a TimestampNanosVal with epochMicros =
+   * watermarkMs * 1000 and nanosWithinMicro = 0.
+   */
+  private def watermarkLiteral(watermarkMs: Long, dataType: DataType): Literal = {
+    dataType match {
+      case _: AnyTimestampNanoType =>
+        Literal.create(
+          TimestampNanosVal.fromParts(watermarkMs * 1000, 0.toShort), dataType)
+      case _ =>
+        Literal(watermarkMs * 1000)
+    }
   }
 
   /**
@@ -1563,6 +1582,8 @@ case class StreamingDeduplicateWithinWatermarkExec(
 
     // We expect data type of event time column to be TimestampType or TimestampNTZType which both
     // are internally represented as Long.
+    // TODO(SPARK-57843): Handle nanosecond event-time columns (TimestampLTZNanosType /
+    //  TimestampNTZNanosType) in streaming stateful operators incl. dropDuplicatesWithinWatermark.
     val timestamp = data.getLong(eventTimeColOrdinal)
     // The unit of timestamp in Spark is microseconds, convert the delay threshold to micros.
     val expiresAt = timestamp + DateTimeUtils.millisToMicros(delayThresholdMs)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -35,9 +35,10 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC
 import org.apache.spark.sql.execution.streaming.operators.stateful.{EventTimeStats, StateStoreSaveExec}
 import org.apache.spark.sql.execution.streaming.runtime._
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
-import org.apache.spark.sql.functions.{count, expr, struct, timestamp_seconds, to_timestamp, window}
+import org.apache.spark.sql.functions.{count, expr, struct, timestamp_nanos, timestamp_seconds, to_timestamp, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode._
+import org.apache.spark.sql.types.TimestampNTZNanosType
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.Utils
 
@@ -1050,5 +1051,93 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
 
   private def awaitTermination(): AssertOnQuery = Execute("AwaitTermination") { q =>
     q.awaitTermination()
+  }
+
+  test("SPARK-57830: withWatermark accepts TimestampLTZNanosType column") {
+    val inputData = MemoryStream[Long]
+    // Use Complete mode so we don't need window-based eviction.
+    // This verifies the type-check fix and nanos->ms conversion in EventTimeWatermarkExec.
+    val aggWithWatermark = inputData.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    testStream(aggWithWatermark, outputMode = Complete)(
+      AddData(inputData, 15L * 1000000000L),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputData, 10L * 1000000000L, 12L * 1000000000L, 14L * 1000000000L),
+      CheckAnswer(1L, 1L, 1L, 1L),
+      assertEventStats(min = 10, max = 14, avg = 12, wtrmark = 5),
+      AddData(inputData, 25L * 1000000000L),
+      CheckAnswer(1L, 1L, 1L, 1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
+  }
+
+  test("SPARK-57830: withWatermark accepts TimestampNTZNanosType column") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val inputData = MemoryStream[Long]
+      val aggWithWatermark = inputData.toDF()
+        .withColumn("eventTime",
+          timestamp_nanos($"value").cast(TimestampNTZNanosType(9)))
+        .withWatermark("eventTime", "10 seconds")
+        .groupBy($"eventTime")
+        .agg(count("*") as Symbol("count"))
+        .select($"count".as[Long])
+
+      testStream(aggWithWatermark, outputMode = Complete)(
+        AddData(inputData, 15L * 1000000000L),
+        CheckAnswer(1L),
+        assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+        AddData(inputData, 10L * 1000000000L, 12L * 1000000000L, 14L * 1000000000L),
+        CheckAnswer(1L, 1L, 1L, 1L),
+        assertEventStats(min = 10, max = 14, avg = 12, wtrmark = 5),
+        AddData(inputData, 25L * 1000000000L),
+        CheckAnswer(1L, 1L, 1L, 1L, 1L),
+        assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+      )
+    }
+  }
+
+  test("SPARK-57830: nanos watermark matches micros watermark for equivalent instants") {
+    // Compare that the watermark advancement is identical between a micros and nanos column
+    // representing the same instant.
+    val inputDataMicros = MemoryStream[Int]
+    val microsDf = inputDataMicros.toDF()
+      .withColumn("eventTime", timestamp_seconds($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    val inputDataNanos = MemoryStream[Long]
+    val nanosDf = inputDataNanos.toDF()
+      .withColumn("eventTime", timestamp_nanos($"value"))
+      .withWatermark("eventTime", "10 seconds")
+      .groupBy($"eventTime")
+      .agg(count("*") as Symbol("count"))
+      .select($"count".as[Long])
+
+    // Run both streams with the same logical timestamps and verify same watermark advancement
+    testStream(microsDf, outputMode = Complete)(
+      AddData(inputDataMicros, 15),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputDataMicros, 25),
+      CheckAnswer(1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
+
+    testStream(nanosDf, outputMode = Complete)(
+      AddData(inputDataNanos, 15L * 1000000000L),
+      CheckAnswer(1L),
+      assertEventStats(min = 15, max = 15, avg = 15, wtrmark = 0),
+      AddData(inputDataNanos, 25L * 1000000000L),
+      CheckAnswer(1L, 1L),
+      assertEventStats(min = 25, max = 25, avg = 25, wtrmark = 5)
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
@@ -22,7 +22,8 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Append
 import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorsUtils
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.functions.{timestamp_nanos, timestamp_seconds}
-import org.apache.spark.sql.types.{LongType, StringType, StructType}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{LongType, StringType, StructType, TimestampNTZNanosType}
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
@@ -332,5 +333,53 @@ class StreamingDeduplicationWithinWatermarkSuite extends StateStoreMetricsTest
       CheckNewAnswer(),
       assertNumStateRows(total = 2, updated = 0)
     )
+  }
+
+  test("SPARK-57843: dropDuplicatesWithinWatermark with NTZ nanosecond-precision event-time") {
+    // Same as the LTZ-nanos test above but using TimestampNTZNanosType for the event-time
+    // column. Verifies that the NTZ nanos path through watermark extraction and dedup
+    // expiration state works correctly.
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val inputData = MemoryStream[(String, Long)]
+      val result = inputData.toDS()
+        .withColumn("eventTime", timestamp_nanos($"_2").cast(TimestampNTZNanosType(9)))
+        .withWatermark("eventTime", "10 seconds")
+        .dropDuplicatesWithinWatermark("_1")
+        .select($"_1")
+
+      testStream(result, Append)(
+        // "a" at 17s, "b" at 22s, "c" at 21s (nanos). Watermark -> max(17,22,21) - 10 = 12s.
+        AddData(inputData,
+          ("a", 17L * 1000000000L),
+          ("b", 22L * 1000000000L),
+          ("c", 21L * 1000000000L)),
+        CheckNewAnswer("a", "b", "c"),
+        assertNumStateRows(total = 3, updated = 3),
+
+        // Duplicate "a" at 16s. Should not emit (within watermark, key exists).
+        AddData(inputData, ("a", 16L * 1000000000L)),
+        CheckNewAnswer(),
+        assertNumStateRows(total = 3, updated = 0),
+
+        // "a" at 11s: older than watermark (12s), should be dropped as late.
+        AddData(inputData, ("a", 11L * 1000000000L)),
+        CheckNewAnswer(),
+        assertNumStateRows(total = 3, updated = 0, droppedByWatermark = 1),
+
+        // "d" at 35s. Watermark advances to 25s.
+        // "a" expiresAt = 17+10=27s > 25 (kept), "b" expiresAt = 22+10=32s > 25 (kept),
+        // "c" expiresAt = 21+10=31s > 25 (kept). All kept.
+        AddData(inputData, ("d", 35L * 1000000000L)),
+        CheckNewAnswer("d"),
+        assertNumStateRows(total = 4, updated = 1),
+
+        // "e" at 55s. Watermark advances to 45s.
+        // "a" expiresAt=27 <= 45 (evicted), "b" expiresAt=32 <= 45 (evicted),
+        // "c" expiresAt=31 <= 45 (evicted), "d" expiresAt=45 <= 45 (evicted).
+        AddData(inputData, ("e", 55L * 1000000000L)),
+        CheckNewAnswer("e"),
+        assertNumStateRows(total = 1, updated = 1)
+      )
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.{AnalysisException, Dataset, SaveMode}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Append
 import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorsUtils
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
-import org.apache.spark.sql.functions.timestamp_seconds
+import org.apache.spark.sql.functions.{timestamp_nanos, timestamp_seconds}
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 import org.apache.spark.tags.SlowSQLTest
 
@@ -255,6 +255,82 @@ class StreamingDeduplicationWithinWatermarkSuite extends StateStoreMetricsTest
       // Value schema includes the expiration time
       valueSchema = new StructType().add("expiresAtMicros", LongType),
       sqlConf = spark.sessionState.conf
+    )
+  }
+
+  test("SPARK-57843: dropDuplicatesWithinWatermark with nanosecond-precision event-time") {
+    // Verify that nanosecond-precision event-time columns work correctly with
+    // dropDuplicatesWithinWatermark. Event-time values are converted to micros internally
+    // for the expiration state, ensuring correct dedup and eviction behavior.
+    val inputData = MemoryStream[(String, Long)]
+    val result = inputData.toDS()
+      .withColumn("eventTime", timestamp_nanos($"_2"))
+      .withWatermark("eventTime", "10 seconds")
+      .dropDuplicatesWithinWatermark("_1")
+      .select($"_1")
+
+    testStream(result, Append)(
+      // "a" at 17s, "b" at 22s, "c" at 21s (nanos). Watermark -> max(17,22,21) - 10 = 12s.
+      AddData(inputData,
+        ("a", 17L * 1000000000L),
+        ("b", 22L * 1000000000L),
+        ("c", 21L * 1000000000L)),
+      CheckNewAnswer("a", "b", "c"),
+      assertNumStateRows(total = 3, updated = 3),
+
+      // Duplicate "a" at 16s. Should not emit (within watermark, key exists).
+      AddData(inputData, ("a", 16L * 1000000000L)),
+      CheckNewAnswer(),
+      assertNumStateRows(total = 3, updated = 0),
+
+      // "a" at 11s: older than watermark (12s), should be dropped as late.
+      AddData(inputData, ("a", 11L * 1000000000L)),
+      CheckNewAnswer(),
+      assertNumStateRows(total = 3, updated = 0, droppedByWatermark = 1),
+
+      // "d" at 35s. Watermark advances to 25s.
+      // "a" expiresAt = 17+10=27s > 25 (kept), "b" expiresAt = 22+10=32s > 25 (kept),
+      // "c" expiresAt = 21+10=31s > 25 (kept). All kept.
+      AddData(inputData, ("d", 35L * 1000000000L)),
+      CheckNewAnswer("d"),
+      assertNumStateRows(total = 4, updated = 1),
+
+      // "e" at 55s. Watermark advances to 45s.
+      // "a" expiresAt=27 <= 45 (evicted), "b" expiresAt=32 <= 45 (evicted),
+      // "c" expiresAt=31 <= 45 (evicted), "d" expiresAt=45 <= 45 (evicted).
+      AddData(inputData, ("e", 55L * 1000000000L)),
+      CheckNewAnswer("e"),
+      assertNumStateRows(total = 1, updated = 1)
+    )
+  }
+
+  test("SPARK-57843: sub-microsecond dedup semantics - epochMicros truncation dedup key") {
+    // Two rows with the SAME epochMicros but DIFFERENT nanosWithinMicro values.
+    // dropDuplicatesWithinWatermark uses the full (key-columns) for dedup grouping,
+    // so both rows should be emitted because their _1 (key) differs, even though
+    // their timestamps truncate to the same microsecond. This documents the intent
+    // that the dedup key is NOT the truncated timestamp itself.
+    val inputData = MemoryStream[(String, Long)]
+    val result = inputData.toDS()
+      .withColumn("eventTime", timestamp_nanos($"_2"))
+      .withWatermark("eventTime", "10 seconds")
+      .dropDuplicatesWithinWatermark("_1")
+      .select($"_1")
+
+    // 20_000_000_001 ns = 20.000000001s; 20_000_000_999 ns = 20.000000999s
+    // Both truncate to the same epochMicros (20_000_000) but are distinct nanos.
+    // With different keys ("x" vs "y"), both should emit.
+    testStream(result, Append)(
+      AddData(inputData,
+        ("x", 20000000001L),
+        ("y", 20000000999L)),
+      CheckNewAnswer("x", "y"),
+      assertNumStateRows(total = 2, updated = 2),
+
+      // Same key "x" at a slightly different nano offset (same micro) -> duplicate, not emitted
+      AddData(inputData, ("x", 20000000500L)),
+      CheckNewAnswer(),
+      assertNumStateRows(total = 2, updated = 0)
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateChainingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateChainingSuite.scala
@@ -21,12 +21,13 @@ import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime, ZoneId}
 
 import org.apache.spark.{SparkRuntimeException, SparkThrowable}
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, Encoders, Row}
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamExecution}
 import org.apache.spark.sql.execution.streaming.state.{AlsoTestWithEncodingTypes, AlsoTestWithRocksDBFeatures, EnableStateStoreRowChecksum, RocksDBStateStoreProvider}
 import org.apache.spark.sql.functions.window
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType, TimestampLTZNanosType}
 import org.apache.spark.tags.SlowSQLTest
 
 case class InputEventRow(
@@ -93,6 +94,24 @@ class StatefulProcessorEmittingRowsOlderThanWatermark
         // watermark will move past 0L
         Timestamp.from(Instant.ofEpochMilli(1)),
         inputRows.size))
+  }
+}
+
+/**
+ * Emits a Row with a nanosecond-precision timestamp (1ms epoch) that will be older than the
+ * watermark after the first batch, triggering the nanos extraction path in
+ * UpdateEventTimeColumnExec.
+ */
+class StatefulProcessorEmittingOldNanosRows
+  extends StatefulProcessor[String, InputEventRow, Row] {
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {}
+
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[InputEventRow],
+      timerValues: TimerValues): Iterator[Row] = {
+    // Emit Instant at 1ms epoch; after first batch watermark advances past this value
+    Iterator.single(Row(key, Instant.ofEpochMilli(1), inputRows.size))
   }
 }
 
@@ -409,6 +428,46 @@ class TransformWithStateChainingSuite extends StreamTest
       }
 
       checkError(ex, "CANNOT_ASSIGN_EVENT_TIME_COLUMN_WITHOUT_WATERMARK")
+    }
+  }
+
+  test("SPARK-57843: UpdateEventTimeColumnExec nanos late-row error path") {
+    // Exercises the TimestampLTZNanosType branch in UpdateEventTimeColumnExec.doExecute()
+    // when a row older than the watermark is emitted. The processor outputs a Row with a
+    // nanosecond-precision outputEventTime via Encoders.row, so the exec extracts epoch
+    // micros via getTimestampLTZNanos(0).epochMicros.
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val outputSchema = new StructType()
+        .add("key", StringType)
+        .add("outputEventTime", TimestampLTZNanosType(9))
+        .add("count", IntegerType)
+      implicit val outputEnc: org.apache.spark.sql.Encoder[Row] = Encoders.row(outputSchema)
+
+      val inputData = MemoryStream[InputEventRow]
+      val result = inputData.toDS()
+        .withWatermark("eventTime", "1 minute")
+        .groupByKey(x => x.key)
+        .transformWithState[Row](
+          new StatefulProcessorEmittingOldNanosRows(),
+          "outputEventTime",
+          OutputMode.Append())
+
+      testStream(result, OutputMode.Append())(
+        AddData(inputData, InputEventRow("k1", timestamp("2024-02-01 00:00:00"), "e1")),
+        // First batch: emits row with outputEventTime = 1ms epoch (nanos).
+        // Watermark is 0 at this point, so the row passes.
+        CheckNewAnswer(Row("k1", Instant.ofEpochMilli(1), 1)),
+        // Second batch: watermark advances past 1ms, so the emitted row (1ms) is older
+        // than watermark and triggers the nanos extraction error path.
+        AddData(inputData, InputEventRow("k1", timestamp("2024-02-02 00:00:00"), "e1")),
+        ExpectFailure[SparkRuntimeException] { ex =>
+          checkError(ex.asInstanceOf[SparkThrowable],
+            "EMITTING_ROWS_OLDER_THAN_WATERMARK_NOT_ALLOWED",
+            parameters = Map("currentWatermark" -> "1706774340000",
+              "emittedRowEventTime" -> "1000"))
+        }
+      )
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds nanosecond-precision event-time support to Structured Streaming stateful operators, building on SPARK-57830 (watermark) and SPARK-57829 (window/session_window).

- `dropDuplicatesWithinWatermark` (`StreamingDeduplicateWithinWatermarkExec`) now handles a nanosecond-precision event-time column correctly: `putDupInfoIntoState` type-dispatches on `TimestampLTZNanosType`/`TimestampNTZNanosType` to read `epochMicros` (instead of `getLong`-as-micros, which misreads the variable-length `TimestampNanosVal` UnsafeRow), and `WatermarkSupport.watermarkLiteral` builds a nanosecond-typed eviction literal so late-data filtering / state eviction compare correctly. The analysis-time guard SPARK-57830 added for this operator is lifted.
- Stream-stream joins with a nanosecond-precision watermark are rejected with a clear analysis error for **all** join types (the check is hoisted above the join-type dispatch so it also covers `InnerLike`), because `SymmetricHashJoinStateManager`'s event-time reads still assume microseconds. That path is a follow-up.

### Why are the changes needed?

Part of nanosecond-precision timestamp support (SPARK-56822). SPARK-57830 enabled nanosecond event-time watermarks but had to reject `dropDuplicatesWithinWatermark` (which read the event-time as micros). This makes that operator correctly support nanoseconds, and fails loud (rather than silently mis-evicting) for the not-yet-supported stream-stream join path.

### Does this PR introduce _any_ user-facing change?

Yes - `dropDuplicatesWithinWatermark` now works with a nanosecond-precision event-time column. Stream-stream joins with a nanosecond watermark raise a clear "not yet supported" analysis error (follow-up work).

### How was this patch tested?

`StreamingDeduplicationWithinWatermarkSuite` (nanos dedup + late-drop + eviction, plus a sub-microsecond dedup-key semantics case), `UnsupportedOperationsSuite` (nanos-watermark join rejection for inner and outer join types), and `EventTimeWatermarkSuite` (microsecond-vs-nanosecond watermark equivalence). All pass; scalastyle clean.

### Was this patch authored or co-authored using generative AI tooling?

Authored with assistance by Claude Opus 4.8.
