### PR TITLE
[SPARK-57161][CONNECT][SQL] Support timestamp nanos proto conversions

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/arrow/types/ops/TimestampNanosTypeConnectOps.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/arrow/types/ops/TimestampNanosTypeConnectOps.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.client.arrow.types.ops
+
+import java.time.{Instant, LocalDateTime}
+
+import org.apache.arrow.vector.FieldVector
+
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
+import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{InstantNanosEncoder, LocalDateTimeNanosEncoder}
+import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils
+import org.apache.spark.sql.connect.client.arrow.{ArrowDeserializers, ArrowSerializer, ArrowVectorReader}
+import org.apache.spark.sql.connect.common.InvalidPlanInput
+import org.apache.spark.sql.connect.common.types.ops.ConnectTypeOps
+import org.apache.spark.sql.errors.DataTypeErrors
+import org.apache.spark.sql.types.{DataType, TimestampLTZNanosType, TimestampNTZNanosType}
+import org.apache.spark.unsafe.types.TimestampNanosVal
+
+private[connect] abstract class TimestampNanosTypeConnectOps extends ConnectTypeOps {
+
+  protected def checkTimestampNanosTypesEnabled(): Unit = {
+    DataTypeErrors.checkTimestampNanosTypesEnabled()
+  }
+
+  protected def timestampNanosVal(epochMicros: Long, nanosWithinMicro: Int): TimestampNanosVal = {
+    if (nanosWithinMicro < 0 ||
+      nanosWithinMicro > TimestampNanosVal.MAX_NANOS_WITHIN_MICRO) {
+      throw InvalidPlanInput(
+        s"Invalid nanosWithinMicro for timestamp nanos literal: $nanosWithinMicro")
+    }
+    TimestampNanosVal.fromParts(epochMicros, nanosWithinMicro.toShort)
+  }
+
+  protected def unsupportedArrow: Nothing = {
+    throw new UnsupportedOperationException(
+      s"Arrow conversion for ${dataType.sql} is not supported by Spark Connect yet.")
+  }
+
+  override def createArrowSerializer(vector: AnyRef): ArrowSerializer.Serializer =
+    unsupportedArrow
+
+  override def createArrowDeserializer(
+      enc: AgnosticEncoder[_],
+      data: AnyRef,
+      timeZoneId: String): ArrowDeserializers.Deserializer[Any] = unsupportedArrow
+
+  override def createArrowVectorReader(vector: FieldVector): ArrowVectorReader = unsupportedArrow
+}
+
+/**
+ * Spark Connect proto conversions for TimestampNTZNanosType.
+ *
+ * @param t
+ *   The TimestampNTZNanosType with precision information
+ * @since 4.3.0
+ */
+private[connect] class TimestampNTZNanosTypeConnectOps(val t: TimestampNTZNanosType)
+    extends TimestampNanosTypeConnectOps {
+
+  override def dataType: DataType = t
+
+  override def encoder: AgnosticEncoder[_] = {
+    checkTimestampNanosTypesEnabled()
+    LocalDateTimeNanosEncoder(t.precision)
+  }
+
+  override def toCatalystTypeFromProto(t: proto.DataType): DataType = {
+    val timestampNanos = t.getTimestampNtzNanos
+    val dataType =
+      if (timestampNanos.hasPrecision) {
+        TimestampNTZNanosType(timestampNanos.getPrecision)
+      } else {
+        TimestampNTZNanosType()
+      }
+    checkTimestampNanosTypesEnabled()
+    dataType
+  }
+
+  override def toConnectProtoType: proto.DataType = {
+    checkTimestampNanosTypesEnabled()
+    proto.DataType
+      .newBuilder()
+      .setTimestampNtzNanos(
+        proto.DataType.TimestampNTZNanos.newBuilder().setPrecision(t.precision).build())
+      .build()
+  }
+
+  override def toLiteralProto(
+      value: Any,
+      builder: proto.Expression.Literal.Builder): proto.Expression.Literal.Builder = {
+    toLiteralProtoWithType(value, t, builder)
+  }
+
+  override def toLiteralProtoWithType(
+      value: Any,
+      dt: DataType,
+      builder: proto.Expression.Literal.Builder): proto.Expression.Literal.Builder = {
+    checkTimestampNanosTypesEnabled()
+    val timestampType = dt.asInstanceOf[TimestampNTZNanosType]
+    val v = value match {
+      case localDateTime: LocalDateTime =>
+        SparkDateTimeUtils.localDateTimeToTimestampNanos(localDateTime, timestampType.precision)
+      case timestampNanos: TimestampNanosVal =>
+        SparkDateTimeUtils.truncateTimestampNanosToPrecision(
+          timestampNanos,
+          timestampType.precision)
+      case other =>
+        throw new IllegalArgumentException(s"literal $other not supported for ${dt.sql}.")
+    }
+    builder.setTimestampNtzNanos(
+      builder.getTimestampNtzNanosBuilder
+        .setEpochMicros(v.epochMicros)
+        .setNanosWithinMicro(v.nanosWithinMicro)
+        .setPrecision(timestampType.precision))
+  }
+
+  override def getScalaConverter: proto.Expression.Literal => Any = { literal =>
+    checkTimestampNanosTypesEnabled()
+    val timestampNanos = literal.getTimestampNtzNanos
+    val v = timestampNanosVal(timestampNanos.getEpochMicros, timestampNanos.getNanosWithinMicro)
+    SparkDateTimeUtils.timestampNanosToLocalDateTime(v)
+  }
+
+  override def getProtoDataTypeFromLiteral(literal: proto.Expression.Literal): proto.DataType = {
+    val timestampNanosBuilder = proto.DataType.TimestampNTZNanos.newBuilder()
+    if (literal.getTimestampNtzNanos.hasPrecision) {
+      timestampNanosBuilder.setPrecision(literal.getTimestampNtzNanos.getPrecision)
+    }
+    val dataType = proto.DataType.newBuilder().setTimestampNtzNanos(timestampNanosBuilder).build()
+    toCatalystTypeFromProto(dataType)
+    dataType
+  }
+}
+
+/**
+ * Spark Connect proto conversions for TimestampLTZNanosType.
+ *
+ * @param t
+ *   The TimestampLTZNanosType with precision information
+ * @since 4.3.0
+ */
+private[connect] class TimestampLTZNanosTypeConnectOps(val t: TimestampLTZNanosType)
+    extends TimestampNanosTypeConnectOps {
+
+  override def dataType: DataType = t
+
+  override def encoder: AgnosticEncoder[_] = {
+    checkTimestampNanosTypesEnabled()
+    InstantNanosEncoder(t.precision)
+  }
+
+  override def toCatalystTypeFromProto(t: proto.DataType): DataType = {
+    val timestampNanos = t.getTimestampLtzNanos
+    val dataType =
+      if (timestampNanos.hasPrecision) {
+        TimestampLTZNanosType(timestampNanos.getPrecision)
+      } else {
+        TimestampLTZNanosType()
+      }
+    checkTimestampNanosTypesEnabled()
+    dataType
+  }
+
+  override def toConnectProtoType: proto.DataType = {
+    checkTimestampNanosTypesEnabled()
+    proto.DataType
+      .newBuilder()
+      .setTimestampLtzNanos(
+        proto.DataType.TimestampLTZNanos.newBuilder().setPrecision(t.precision).build())
+      .build()
+  }
+
+  override def toLiteralProto(
+      value: Any,
+      builder: proto.Expression.Literal.Builder): proto.Expression.Literal.Builder = {
+    toLiteralProtoWithType(value, t, builder)
+  }
+
+  override def toLiteralProtoWithType(
+      value: Any,
+      dt: DataType,
+      builder: proto.Expression.Literal.Builder): proto.Expression.Literal.Builder = {
+    checkTimestampNanosTypesEnabled()
+    val timestampType = dt.asInstanceOf[TimestampLTZNanosType]
+    val v = value match {
+      case instant: Instant =>
+        SparkDateTimeUtils.instantToTimestampNanos(instant, timestampType.precision)
+      case timestampNanos: TimestampNanosVal =>
+        SparkDateTimeUtils.truncateTimestampNanosToPrecision(
+          timestampNanos,
+          timestampType.precision)
+      case other =>
+        throw new IllegalArgumentException(s"literal $other not supported for ${dt.sql}.")
+    }
+    builder.setTimestampLtzNanos(
+      builder.getTimestampLtzNanosBuilder
+        .setEpochMicros(v.epochMicros)
+        .setNanosWithinMicro(v.nanosWithinMicro)
+        .setPrecision(timestampType.precision))
+  }
+
+  override def getScalaConverter: proto.Expression.Literal => Any = { literal =>
+    checkTimestampNanosTypesEnabled()
+    val timestampNanos = literal.getTimestampLtzNanos
+    val v = timestampNanosVal(timestampNanos.getEpochMicros, timestampNanos.getNanosWithinMicro)
+    SparkDateTimeUtils.timestampNanosToInstant(v)
+  }
+
+  override def getProtoDataTypeFromLiteral(literal: proto.Expression.Literal): proto.DataType = {
+    val timestampNanosBuilder = proto.DataType.TimestampLTZNanos.newBuilder()
+    if (literal.getTimestampLtzNanos.hasPrecision) {
+      timestampNanosBuilder.setPrecision(literal.getTimestampLtzNanos.getPrecision)
+    }
+    val dataType = proto.DataType.newBuilder().setTimestampLtzNanos(timestampNanosBuilder).build()
+    toCatalystTypeFromProto(dataType)
+    dataType
+  }
+}

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.util.{SparkDateTimeUtils, SparkIntervalUtil
 import org.apache.spark.sql.connect.common.DataTypeProtoConverter._
 import org.apache.spark.sql.connect.common.types.ops.ConnectTypeOps
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.CalendarInterval
+import org.apache.spark.unsafe.types.{CalendarInterval, TimestampNanosVal}
 
 object LiteralValueProtoConverter {
 
@@ -384,6 +384,7 @@ object LiteralValueProtoConverter {
     case _ if clz == classOf[BigDecimal] => DecimalType.SYSTEM_DEFAULT
     case _ if clz == classOf[Decimal] => DecimalType.SYSTEM_DEFAULT
     case _ if clz == classOf[CalendarInterval] => CalendarIntervalType
+    case _ if clz == classOf[TimestampNanosVal] => TimestampNTZNanosType()
     case _ if clz.isArray => ArrayType(toDataType(clz.getComponentType))
     case _ =>
       throw new UnsupportedOperationException(s"Unsupported component type $clz in arrays.")
@@ -496,6 +497,14 @@ object LiteralValueProtoConverter {
             proto.DataType.KindCase.YEAR_MONTH_INTERVAL) =>
         true
       case (proto.Expression.Literal.LiteralTypeCase.TIME, proto.DataType.KindCase.TIME) =>
+        true
+      case (
+            proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_NTZ_NANOS,
+            proto.DataType.KindCase.TIMESTAMP_NTZ_NANOS) =>
+        true
+      case (
+            proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_LTZ_NANOS,
+            proto.DataType.KindCase.TIMESTAMP_LTZ_NANOS) =>
         true
       case (proto.Expression.Literal.LiteralTypeCase.ARRAY, proto.DataType.KindCase.ARRAY) =>
         true

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/types/ops/ConnectTypeOps.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/types/ops/ConnectTypeOps.scala
@@ -23,8 +23,9 @@ import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.LocalTimeEncoder
 import org.apache.spark.sql.connect.client.arrow.{ArrowDeserializers, ArrowSerializer, ArrowVectorReader}
-import org.apache.spark.sql.connect.client.arrow.types.ops.TimeTypeConnectOps
-import org.apache.spark.sql.types.{DataType, TimeType}
+import org.apache.spark.sql.connect.client.arrow.types.ops.{TimestampLTZNanosTypeConnectOps, TimestampNTZNanosTypeConnectOps, TimeTypeConnectOps}
+import org.apache.spark.sql.types.{DataType, TimestampLTZNanosType, TimestampNTZNanosType, TimeType}
+import org.apache.spark.unsafe.types.TimestampNanosVal
 
 /**
  * Optional type operations for Spark Connect infrastructure.
@@ -97,6 +98,8 @@ object ConnectTypeOps {
   /** DataType-keyed dispatch for proto conversions. */
   def apply(dt: DataType): Option[ConnectTypeOps] = dt match {
     case tt: TimeType => Some(new TimeTypeConnectOps(tt))
+    case ts: TimestampNTZNanosType => Some(new TimestampNTZNanosTypeConnectOps(ts))
+    case ts: TimestampLTZNanosType => Some(new TimestampLTZNanosTypeConnectOps(ts))
     // Add new framework types here
     case _ => None
   }
@@ -108,6 +111,10 @@ object ConnectTypeOps {
     value match {
       case v: java.time.LocalTime =>
         Some(new TimeTypeConnectOps(TimeType()).toLiteralProto(v, builder))
+      case v: TimestampNanosVal =>
+        Some(
+          new TimestampNTZNanosTypeConnectOps(TimestampNTZNanosType())
+            .toLiteralProto(v, builder))
       // Add new framework value types here
       case _ => None
     }
@@ -119,6 +126,10 @@ object ConnectTypeOps {
   private def opsForKindCase(kindCase: proto.DataType.KindCase): Option[ConnectTypeOps] =
     kindCase match {
       case proto.DataType.KindCase.TIME => Some(new TimeTypeConnectOps(TimeType()))
+      case proto.DataType.KindCase.TIMESTAMP_NTZ_NANOS =>
+        Some(new TimestampNTZNanosTypeConnectOps(TimestampNTZNanosType()))
+      case proto.DataType.KindCase.TIMESTAMP_LTZ_NANOS =>
+        Some(new TimestampLTZNanosTypeConnectOps(TimestampLTZNanosType()))
       // Add new framework proto kinds here - single registration for all KindCase lookups
       case _ => None
     }
@@ -142,6 +153,10 @@ object ConnectTypeOps {
       litCase: proto.Expression.Literal.LiteralTypeCase): proto.DataType.KindCase =
     litCase match {
       case proto.Expression.Literal.LiteralTypeCase.TIME => proto.DataType.KindCase.TIME
+      case proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_NTZ_NANOS =>
+        proto.DataType.KindCase.TIMESTAMP_NTZ_NANOS
+      case proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_LTZ_NANOS =>
+        proto.DataType.KindCase.TIMESTAMP_LTZ_NANOS
       // Add new framework literal-to-kind mappings here
       case _ => proto.DataType.KindCase.KIND_NOT_SET
     }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverterSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverterSuite.scala
@@ -17,20 +17,30 @@
 
 package org.apache.spark.sql.connect.planner
 
-import java.time.LocalTime
+import java.time.{Instant, LocalDateTime, LocalTime}
 
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
+import org.apache.spark.SparkException
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.{expressions, CatalystTypeConverters}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.apache.spark.sql.connect.common.InvalidPlanInput
+import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils
+import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, InvalidPlanInput}
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter.ToLiteralProtoOptions
 import org.apache.spark.sql.connect.planner.LiteralExpressionProtoConverter
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.TimestampNanosVal
 
 class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:ignore funsuite
+
+  private def withTimestampNanosTypesEnabled(enabled: Boolean = true)(f: => Unit): Unit = {
+    val conf = new SQLConf()
+    conf.setConfString(SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key, enabled.toString)
+    SQLConf.withExistingConf(conf)(f)
+  }
 
   private def toLiteralProto(v: Any): proto.Expression.Literal = {
     LiteralValueProtoConverter
@@ -75,6 +85,186 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
     val literalProto = toLiteralProto(LocalTime.of(1, 2, 3), TimeType(3))
     assert(literalProto.getTime.getPrecision == 3)
     assertResult(LocalTime.of(1, 2, 3))(LiteralValueProtoConverter.toScalaValue(literalProto))
+  }
+
+  test("SPARK-57161: timestamp nanos data type proto round-trip") {
+    withTimestampNanosTypesEnabled() {
+      val cases: Seq[(Int => DataType, proto.DataType.KindCase)] = Seq(
+        (p => TimestampNTZNanosType(p), proto.DataType.KindCase.TIMESTAMP_NTZ_NANOS),
+        (p => TimestampLTZNanosType(p), proto.DataType.KindCase.TIMESTAMP_LTZ_NANOS))
+
+      cases.foreach { case (factory, kindCase) =>
+        TimestampNTZNanosType.MIN_PRECISION to TimestampNTZNanosType.MAX_PRECISION foreach { p =>
+          val dataType = factory(p)
+          val protoType = DataTypeProtoConverter.toConnectProtoType(dataType)
+          assert(protoType.getKindCase === kindCase)
+          val precision = kindCase match {
+            case proto.DataType.KindCase.TIMESTAMP_NTZ_NANOS =>
+              protoType.getTimestampNtzNanos.getPrecision
+            case proto.DataType.KindCase.TIMESTAMP_LTZ_NANOS =>
+              protoType.getTimestampLtzNanos.getPrecision
+            case _ => fail(s"Unexpected kind case: $kindCase")
+          }
+          assert(precision === p)
+          assert(DataTypeProtoConverter.toCatalystType(protoType) === dataType)
+        }
+      }
+
+      val defaultNtzProto = proto.DataType
+        .newBuilder()
+        .setTimestampNtzNanos(proto.DataType.TimestampNTZNanos.newBuilder().build())
+        .build()
+      val defaultLtzProto = proto.DataType
+        .newBuilder()
+        .setTimestampLtzNanos(proto.DataType.TimestampLTZNanos.newBuilder().build())
+        .build()
+      assert(DataTypeProtoConverter.toCatalystType(defaultNtzProto) === TimestampNTZNanosType())
+      assert(DataTypeProtoConverter.toCatalystType(defaultLtzProto) === TimestampLTZNanosType())
+    }
+  }
+
+  test("SPARK-57161: timestamp nanos literal proto and catalyst value round-trip") {
+    withTimestampNanosTypesEnabled() {
+      val ntzValues = Seq(
+        LocalDateTime.parse("1969-12-31T23:59:59.999999789"),
+        LocalDateTime.parse("1970-01-01T00:00:00.000000999"))
+      val ltzValues = Seq(
+        Instant.parse("1969-12-31T23:59:59.999999789Z"),
+        Instant.parse("1970-01-01T00:00:00.000000999Z"))
+
+      TimestampNTZNanosType.MIN_PRECISION to TimestampNTZNanosType.MAX_PRECISION foreach { p =>
+        ntzValues.foreach { value =>
+          val dataType = TimestampNTZNanosType(p)
+          val expected = SparkDateTimeUtils.localDateTimeToTimestampNanos(value, p)
+          val literalProto = toLiteralProto(value, dataType)
+          assert(
+            literalProto.getLiteralTypeCase ===
+              proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_NTZ_NANOS)
+          assert(literalProto.getTimestampNtzNanos.getPrecision === p)
+          assert(literalProto.getTimestampNtzNanos.getEpochMicros === expected.epochMicros)
+          assert(
+            literalProto.getTimestampNtzNanos.getNanosWithinMicro ===
+              expected.nanosWithinMicro.toInt)
+          assert(LiteralValueProtoConverter.getDataType(literalProto) === dataType)
+          assert(
+            LiteralValueProtoConverter.toScalaValue(literalProto) ===
+              SparkDateTimeUtils.timestampNanosToLocalDateTime(expected))
+
+          val literal = LiteralExpressionProtoConverter.toCatalystExpression(literalProto)
+          assert(literal.dataType === dataType)
+          assert(literal.value === expected)
+        }
+
+        ltzValues.foreach { value =>
+          val dataType = TimestampLTZNanosType(p)
+          val expected = SparkDateTimeUtils.instantToTimestampNanos(value, p)
+          val literalProto = toLiteralProto(value, dataType)
+          assert(
+            literalProto.getLiteralTypeCase ===
+              proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_LTZ_NANOS)
+          assert(literalProto.getTimestampLtzNanos.getPrecision === p)
+          assert(literalProto.getTimestampLtzNanos.getEpochMicros === expected.epochMicros)
+          assert(
+            literalProto.getTimestampLtzNanos.getNanosWithinMicro ===
+              expected.nanosWithinMicro.toInt)
+          assert(LiteralValueProtoConverter.getDataType(literalProto) === dataType)
+          assert(
+            LiteralValueProtoConverter.toScalaValue(literalProto) ===
+              SparkDateTimeUtils.timestampNanosToInstant(expected))
+
+          val literal = LiteralExpressionProtoConverter.toCatalystExpression(literalProto)
+          assert(literal.dataType === dataType)
+          assert(literal.value === expected)
+        }
+      }
+    }
+  }
+
+  test("SPARK-57161: schema-less TimestampNanosVal literal defaults to NTZ nanos") {
+    withTimestampNanosTypesEnabled() {
+      val value = TimestampNanosVal.fromParts(-1L, 999.toShort)
+      val literalProto = toLiteralProto(value)
+      assert(
+        literalProto.getLiteralTypeCase ===
+          proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_NTZ_NANOS)
+      assert(LiteralValueProtoConverter.getDataType(literalProto) === TimestampNTZNanosType())
+      assert(
+        LiteralValueProtoConverter.toScalaValue(literalProto) ===
+          SparkDateTimeUtils.timestampNanosToLocalDateTime(value))
+    }
+  }
+
+  test("SPARK-57161: timestamp nanos literal compatibility keeps NTZ and LTZ distinct") {
+    withTimestampNanosTypesEnabled() {
+      val ntzLiteralWithLtzType = proto.Expression.Literal
+        .newBuilder()
+        .setTimestampNtzNanos(
+          proto.Expression.Literal.TimestampNTZNanos
+            .newBuilder()
+            .setEpochMicros(0L)
+            .setNanosWithinMicro(1)
+            .setPrecision(TimestampNTZNanosType.DEFAULT_PRECISION)
+            .build())
+        .setDataType(DataTypeProtoConverter.toConnectProtoType(TimestampLTZNanosType()))
+        .build()
+      val ntzError = intercept[InvalidPlanInput] {
+        LiteralValueProtoConverter.getProtoDataType(ntzLiteralWithLtzType)
+      }
+      assert(ntzError.getCondition === "CONNECT_INVALID_PLAN.INCOMPATIBLE_LITERAL_DATA_TYPE")
+
+      val ltzLiteralWithNtzType = proto.Expression.Literal
+        .newBuilder()
+        .setTimestampLtzNanos(
+          proto.Expression.Literal.TimestampLTZNanos
+            .newBuilder()
+            .setEpochMicros(0L)
+            .setNanosWithinMicro(1)
+            .setPrecision(TimestampLTZNanosType.DEFAULT_PRECISION)
+            .build())
+        .setDataType(DataTypeProtoConverter.toConnectProtoType(TimestampNTZNanosType()))
+        .build()
+      val ltzError = intercept[InvalidPlanInput] {
+        LiteralValueProtoConverter.getProtoDataType(ltzLiteralWithNtzType)
+      }
+      assert(ltzError.getCondition === "CONNECT_INVALID_PLAN.INCOMPATIBLE_LITERAL_DATA_TYPE")
+    }
+  }
+
+  test("SPARK-57161: timestamp nanos proto conversion honors the feature flag") {
+    withTimestampNanosTypesEnabled(enabled = false) {
+      val dataTypeProto = proto.DataType
+        .newBuilder()
+        .setTimestampNtzNanos(
+          proto.DataType.TimestampNTZNanos
+            .newBuilder()
+            .setPrecision(TimestampNTZNanosType.DEFAULT_PRECISION)
+            .build())
+        .build()
+      val dataTypeError = intercept[SparkException] {
+        DataTypeProtoConverter.toCatalystType(dataTypeProto)
+      }
+      assert(dataTypeError.getCondition === "FEATURE_NOT_ENABLED")
+
+      val connectProtoError = intercept[SparkException] {
+        DataTypeProtoConverter.toConnectProtoType(TimestampLTZNanosType())
+      }
+      assert(connectProtoError.getCondition === "FEATURE_NOT_ENABLED")
+
+      val literalProto = proto.Expression.Literal
+        .newBuilder()
+        .setTimestampNtzNanos(
+          proto.Expression.Literal.TimestampNTZNanos
+            .newBuilder()
+            .setEpochMicros(0L)
+            .setNanosWithinMicro(1)
+            .setPrecision(TimestampNTZNanosType.DEFAULT_PRECISION)
+            .build())
+        .build()
+      val literalError = intercept[SparkException] {
+        LiteralExpressionProtoConverter.toCatalystExpression(literalProto)
+      }
+      assert(literalError.getCondition === "FEATURE_NOT_ENABLED")
+    }
   }
 
   // The goal of this test is to check that converting a Scala value -> Proto -> Catalyst value


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Spark Connect proto conversion support for nanosecond-capable timestamp types and literals.

It wires `TimestampNTZNanosType` and `TimestampLTZNanosType` into `ConnectTypeOps`, adds conversion for the `timestamp_ntz_nanos` and `timestamp_ltz_nanos` DataType/Literal proto arms, and uses the existing `SparkDateTimeUtils` helpers for `(epochMicros, nanosWithinMicro)` conversion and precision truncation.

The PR also keeps NTZ and LTZ nanos literal compatibility distinct, maps schema-less `TimestampNanosVal` to NTZ nanos to match Catalyst literal inference, and preserves the existing timestamp nanos feature flag gate.

### Why are the changes needed?

The Connect proto definitions for nanosecond-capable timestamp types and literals already exist, but the Connect converters do not currently consume or emit them. This prevents Connect plans from round-tripping these preview timestamp nanos types and literals between proto and Catalyst.

### Does this PR introduce _any_ user-facing change?

Yes. In unreleased Spark master, when `spark.sql.timestampNanosTypes.enabled=true`, Spark Connect can convert TIMESTAMP_NTZ(p) and TIMESTAMP_LTZ(p) nanos types and literals between proto and Catalyst. When the feature flag is disabled, these conversions continue to fail with `FEATURE_NOT_ENABLED`.

### How was this patch tested?

Added regression coverage in `LiteralExpressionProtoConverterSuite` for DataType proto round-trips, literal proto/Catalyst round-trips, NTZ/LTZ compatibility checks, schema-less `TimestampNanosVal` inference, and the feature flag disabled path.

Ran locally:

```
./dev/lint-scala
./build/sbt "connect-common/compile" "connect/testOnly org.apache.spark.sql.connect.planner.LiteralExpressionProtoConverterSuite"
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)