### PR TITLE
[SPARK-57889][CORE][3.5][FOLLOWUP][TESTS] Use JUnit 4 Assert.assertThrows in OneForOneStreamManagerSuite

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
@@ -176,7 +176,7 @@ public class OneForOneStreamManagerSuite {
     // ChunkFetchRequest path.
     TransportClient otherApp = Mockito.mock(TransportClient.class);
     Mockito.when(otherApp.getClientId()).thenReturn("app2");
-    Assertions.assertThrows(SecurityException.class,
+    Assert.assertThrows(SecurityException.class,
       () -> manager.checkAuthorization(otherApp, streamChunkId));
 
     // The owning application is allowed.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow-up build fix of https://github.com/apache/spark/pull/56970 (SPARK-57889) for `branch-3.5`.

The cherry-pick of SPARK-57889 to `branch-3.5` fails to compile because the new `OneForOneStreamManagerSuite.testStreamRequestAuthorization` test uses `Assertions.assertThrows` (JUnit 5). On `master` this suite has already been migrated to JUnit 5, but on `branch-3.5` it still uses JUnit 4 (`org.junit.Assert` / `org.junit.Test`), so `Assertions` does not resolve.

This changes the single call to JUnit 4's `Assert.assertThrows` (available since JUnit 4.13), consistent with the rest of the file on `branch-3.5`. No production code changes.

### Why are the changes needed?
Without this fix, `common/network-common` test compilation fails on `branch-3.5`, breaking the build after the SPARK-57889 cherry-pick.

### Does this PR introduce _any_ user-facing change?
No. Test-only change.

### How was this patch tested?
`build/mvn -pl common/network-common surefire:test -Dtest=OneForOneStreamManagerSuite` now compiles and passes (5 tests run, 0 failures), including `testStreamRequestAuthorization`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)
