### PR TITLE
[SPARK-57911][DOCS] Upgrade Sphinx version to 8.2.3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1339,11 +1339,9 @@ jobs:
         Rscript -e "install.packages(c('remotes', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'e1071', 'roxygen2', 'ggplot2', 'mvtnorm', 'statmod'), repos='https://cloud.r-project.org/')"
         Rscript -e "remotes::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
         Rscript -e "remotes::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
-        # Should unpin 'sphinxcontrib-*' after upgrading sphinx>5
-        python3.9 -m pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' 'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5'
+        python3.9 -m pip install 'sphinx==8.2.3' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0'
         python3.9 -m pip install ipython_genutils # See SPARK-38517
         python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.22' pyarrow pandas 'plotly<6.0.0'
-        python3.9 -m pip install 'docutils<0.18.0' # See SPARK-39421
     - name: List Python packages for branch-3.5 and branch-4.0
       if: inputs.branch == 'branch-3.5' || inputs.branch == 'branch-4.0'
       run: python3.9 -m pip list

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,11 +60,10 @@ jobs:
           cache: 'pip'
       - name: Install Python dependencies
         run: |
-         pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
-            ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.23.2' pyarrow 'pandas==2.3.3' 'plotly>=4.8' 'docutils<0.18.0' \
+         pip install 'sphinx==8.2.3' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
+            ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.23.2' pyarrow 'pandas==2.3.3' 'plotly>=4.8' \
             'flake8==3.9.0' 'mypy==1.8.0' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'ruff==0.14.8' \
-            'pandas-stubs==1.2.0.53' 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.5' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
-            'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5'
+            'pandas-stubs==1.2.0.53' 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.5' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
       - name: Install Ruby for documentation generation
         uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1
         with:

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -45,14 +45,7 @@ ipython
 nbsphinx
 numpydoc
 jinja2
-sphinx==4.5.0
-# With sphinx 4.5.0, we need to set the upperbound version of sphinxcontrib*, it should be removed after upgrading sphinx>=5
-sphinxcontrib-applehelp<=1.0.4
-sphinxcontrib-devhelp<=1.0.2
-sphinxcontrib-htmlhelp<=2.0.1
-sphinxcontrib-jsmath<=1.0.1
-sphinxcontrib-qthelp<=1.0.3
-sphinxcontrib-serializinghtml<=1.1.5
+sphinx==8.2.3
 sphinx-plotly-directive
 sphinx-copybutton
 docutils<0.18.0

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -89,12 +89,9 @@ ENV VIRTUAL_ENV=/opt/spark-venv
 RUN python3.12 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Should unpin 'sphinxcontrib-*' after upgrading sphinx>5
 # See 'ipython_genutils' in SPARK-38517
-# See 'docutils<0.18.0' in SPARK-39421
-RUN python3.12 -m pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe \
-  ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.23.2' 'pyarrow>=23.0.0' 'pandas==2.3.3' 'plotly>=4.8' 'docutils<0.18.0' \
+RUN python3.12 -m pip install 'sphinx==8.2.3' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe \
+  ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.23.2' 'pyarrow>=23.0.0' 'pandas==2.3.3' 'plotly>=4.8' \
   'flake8==3.9.0' 'mypy==1.19.1' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'ruff==0.14.8' \
   'pandas-stubs==1.2.0.53' 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.5' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
-  'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5' \
   && python3.12 -m pip cache purge

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -58,7 +58,7 @@ for gen_rst_dir in gen_rst_dirs:
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.2'
+needs_sphinx = '8.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -120,8 +120,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The root toctree document.
+root_doc = 'index'
 
 # General information about the project.
 project = 'PySpark'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade Sphinx from 4.5.0 to 8.2.3 for PySpark documentation generation:

- Bump `sphinx==4.5.0` to `sphinx==8.2.3` in `dev/requirements.txt`
- Remove `sphinxcontrib-*` upper bound pins that were only needed for Sphinx 4.x
- Update `master_doc` to `root_doc` in `conf.py` (renamed in Sphinx 4+)
- Update `needs_sphinx` from `'1.2'` to `'8.2'`

### Why are the changes needed?

Sphinx 4.5.0 is from 2022 and is significantly outdated. Upgrading to 8.2.3 provides faster builds, better error messages, modern Python support, and compatibility with newer Sphinx extensions and themes. The `sphinxcontrib-*` upper bounds were a workaround for Sphinx 4.x compatibility and are no longer needed.

### Does this PR introduce _any_ user-facing change?

No. Build tooling change only — does not affect generated documentation content or Spark runtime behavior.

### How was this patch tested?

- Verified Sphinx 8.2.3 loads correctly and `conf.py` compiles without errors
- Confirmed `root_doc` and `needs_sphinx` are valid configuration for Sphinx 8.x
- Full documentation build to be verified in CI (requires complete environment with pandoc, pyarrow, etc.)

### Was this patch authored or co-authored using generative AI tooling?

Generative AI tooling (Claude Code) was used as an assistive tool for implementation guidance.