### PR TITLE
[SPARK-57752][SPARK-57753][SPARK-57754][SQL][4.X] Assign names to Hive UDF Java type error conditions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8641,6 +8641,29 @@
     ],
     "sqlState" : "42K0E"
   },
+  "UNSUPPORTED_HIVE_FUNCTION_TYPE" : {
+    "message" : [
+      "Unsupported Hive UDF/UDAF/UDTF Java type:"
+    ],
+    "subClass" : {
+      "RAW_LIST" : {
+        "message" : [
+          "raw java.util.List. Spark cannot infer the element type."
+        ]
+      },
+      "RAW_MAP" : {
+        "message" : [
+          "raw java.util.Map. Spark cannot infer the key and value types."
+        ]
+      },
+      "WILDCARD" : {
+        "message" : [
+          "wildcard type parameter. Spark cannot infer a concrete data type for wildcard type parameters, such as List<?> or Map<?, ?>."
+        ]
+      }
+    },
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_HIVE_TYPE" : {
     "message" : [
       "Cannot read the Hive type <fieldType> of the column <fieldName> because Spark SQL does not support this data type."
@@ -11387,21 +11410,6 @@
   "_LEGACY_ERROR_TEMP_3089" : {
     "message" : [
       "Corrupted <typeName> in catalog: <numCols> parts expected, but part <index> is missing."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3090" : {
-    "message" : [
-      "Raw list type in java is unsupported because Spark cannot infer the element type."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3091" : {
-    "message" : [
-      "Raw map type in java is unsupported because Spark cannot infer key and value types."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3092" : {
-    "message" : [
-      "Collection types with wildcards (e.g. List<?> or Map<?, ?>) are unsupported because Spark cannot infer the data type for these type parameters."
     ]
   },
   "_LEGACY_ERROR_TEMP_3093" : {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -241,16 +241,19 @@ private[hive] trait HiveInspectors {
     // raw java list type unsupported
     case c: Class[_] if isSubClassOf(c, classOf[java.util.List[_]]) =>
       throw new AnalysisException(
-        errorClass = "_LEGACY_ERROR_TEMP_3090", messageParameters = Map.empty)
+        errorClass = "UNSUPPORTED_HIVE_FUNCTION_TYPE.RAW_LIST",
+        messageParameters = Map.empty)
 
     // raw java map type unsupported
     case c: Class[_] if isSubClassOf(c, classOf[java.util.Map[_, _]]) =>
       throw new AnalysisException(
-        errorClass = "_LEGACY_ERROR_TEMP_3091", messageParameters = Map.empty)
+        errorClass = "UNSUPPORTED_HIVE_FUNCTION_TYPE.RAW_MAP",
+        messageParameters = Map.empty)
 
     case _: WildcardType =>
       throw new AnalysisException(
-        errorClass = "_LEGACY_ERROR_TEMP_3092", messageParameters = Map.empty)
+        errorClass = "UNSUPPORTED_HIVE_FUNCTION_TYPE.WILDCARD",
+        messageParameters = Map.empty)
 
     case c => throw new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_3093", messageParameters = Map("c" -> c.toString))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -293,7 +293,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
     val err = intercept[AnalysisException](sql("SELECT testUDFRawList(s) FROM inputTable"))
     checkError(
       exception = err.getCause.asInstanceOf[AnalysisException],
-      condition = "_LEGACY_ERROR_TEMP_3090",
+      condition = "UNSUPPORTED_HIVE_FUNCTION_TYPE.RAW_LIST",
       parameters = Map.empty)
 
     sql("DROP TEMPORARY FUNCTION IF EXISTS testUDFRawList")
@@ -309,7 +309,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
     val err = intercept[AnalysisException](sql("SELECT testUDFRawMap(s) FROM inputTable"))
     checkError(
       exception = err.getCause.asInstanceOf[AnalysisException],
-      condition = "_LEGACY_ERROR_TEMP_3091",
+      condition = "UNSUPPORTED_HIVE_FUNCTION_TYPE.RAW_MAP",
       parameters = Map.empty)
 
     sql("DROP TEMPORARY FUNCTION IF EXISTS testUDFRawMap")
@@ -325,7 +325,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
     val err = intercept[AnalysisException](sql("SELECT testUDFWildcardList(s) FROM inputTable"))
     checkError(
       exception = err.getCause.asInstanceOf[AnalysisException],
-      condition = "_LEGACY_ERROR_TEMP_3092",
+      condition = "UNSUPPORTED_HIVE_FUNCTION_TYPE.WILDCARD",
       parameters = Map.empty)
 
     sql("DROP TEMPORARY FUNCTION IF EXISTS testUDFWildcardList")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This backports apache/spark#56905 to branch-4.x.

It assigns named error conditions and SQLSTATEs for three Hive UDF/UDAF/UDTF Java type legacy error classes:
- `_LEGACY_ERROR_TEMP_3090` -> `UNSUPPORTED_HIVE_FUNCTION_TYPE.RAW_LIST`
- `_LEGACY_ERROR_TEMP_3091` -> `UNSUPPORTED_HIVE_FUNCTION_TYPE.RAW_MAP`
- `_LEGACY_ERROR_TEMP_3092` -> `UNSUPPORTED_HIVE_FUNCTION_TYPE.WILDCARD`

The branch-4.x backport required resolving an `error-conditions.json` conflict by preserving branch-4.x's existing `UNSUPPORTED_HIVE_TYPE` entry and inserting `UNSUPPORTED_HIVE_FUNCTION_TYPE` before it.

### Why are the changes needed?

To keep branch-4.x aligned with master for the named error condition migration from apache/spark#56905.

### Does this PR introduce _any_ user-facing change?

Yes. The affected Hive UDF/UDAF/UDTF Java type errors now report named error conditions and SQLSTATEs on branch-4.x, matching master.

### How was this patch tested?

```
./build/sbt "core/testOnly org.apache.spark.SparkThrowableSuite"
./build/sbt "hive/testOnly org.apache.spark.sql.hive.execution.HiveUDFSuite -- -z UDFRaw"
./build/sbt "hive/testOnly org.apache.spark.sql.hive.execution.HiveUDFSuite -- -z UDFWildcardList"
jq empty common/utils/src/main/resources/error/error-conditions.json
git diff --check origin/branch-4.x...HEAD
```
### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
