### PR TITLE
[SPARK-57393][BUILD][FOLLOWUP] Clean out old PySpark sdists

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -272,11 +272,10 @@ cp -r "$SPARK_HOME/data" "$DISTDIR"
 if [ "$MAKE_PIP" == "true" ]; then
   echo "Building python distribution package"
   pushd "$SPARK_HOME/python" > /dev/null
-  # Delete the egg info file if it exists, this can cache older setup files.
-  rm -rf pyspark.egg-info || echo "No existing egg info file, skipping deletion"
-  # Remove stale sdists so the validation glob below does not trip on tarballs
-  # left over from earlier builds with a different version.
-  rm -rf dist/pyspark*.tar.gz
+  # Delete build artifacts that may be left over from earlier builds so that the build
+  # validation logic below doesn't trip on them.
+  rm -rf pyspark.egg-info
+  rm -f dist/pyspark*.tar.gz
   # Ship the Apache LICENSE and NOTICE inside the PySpark source distributions
   # (see MANIFEST.in). These are removed again after the sdists are built.
   #

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -274,6 +274,9 @@ if [ "$MAKE_PIP" == "true" ]; then
   pushd "$SPARK_HOME/python" > /dev/null
   # Delete the egg info file if it exists, this can cache older setup files.
   rm -rf pyspark.egg-info || echo "No existing egg info file, skipping deletion"
+  # Remove stale sdists so the validation glob below does not trip on tarballs
+  # left over from earlier builds with a different version.
+  rm -rf dist/pyspark*.tar.gz
   # Ship the Apache LICENSE and NOTICE inside the PySpark source distributions
   # (see MANIFEST.in). These are removed again after the sdists are built.
   #


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clear stale PySpark sdist tarballs from `python/dist/` before building new ones in `dev/make-distribution.sh`.

### Why are the changes needed?

#56453 added a post-build validation that checks every `dist/pyspark*.tar.gz` for top-level LICENSE and NOTICE files. However, if `python/dist/` already contains tarballs from a previous build, the glob picks them up and the validation fails with:

```
ERROR: dist/pyspark-4.0.0.dev0.tar.gz is missing LICENSE at the package root
```

The script already cleans `pyspark.egg-info` to avoid stale caches. This change also cleans out old sdists.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I reproduced the failure locally with a stale `pyspark-4.0.0.dev0.tar.gz` in `python/dist/`, applied the fix, and confirmed `make-distribution.sh --pip` completes successfully.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored with GitHub Copilot.
