### PR TITLE
[SPARK-57783][DOCS][R] Document the TIME data type as unsupported in SparkR

### DIFF
--- a/docs/sparkr-migration-guide.md
+++ b/docs/sparkr-migration-guide.md
@@ -26,6 +26,10 @@ Note that this migration guide describes the items specific to SparkR.
 Many items of SQL migration can be applied when migrating SparkR to higher versions.
 Please refer [Migration Guide: SQL, Datasets and DataFrame](sql-migration-guide.html).
 
+## Upgrading from SparkR 4.0 to 4.3
+
+ - In Spark 4.1, `TimeType` support was added. But SparkR does not support `TimeType` and creating or collecting `TimeType` column would raise an error.
+
 ## Upgrading from SparkR 3.5 to 4.0
 
  - In Spark 4.0, SparkR is deprecated and will be removed in a future version.

--- a/docs/sparkr-migration-guide.md
+++ b/docs/sparkr-migration-guide.md
@@ -28,7 +28,7 @@ Please refer [Migration Guide: SQL, Datasets and DataFrame](sql-migration-guide.
 
 ## Upgrading from SparkR 4.0 to 4.3
 
- - In Spark 4.1, `TimeType` support was added. But SparkR does not support `TimeType` and creating or collecting `TimeType` column would raise an error.
+ - In Spark 4.3, `TimeType` support was added. But SparkR does not support `TimeType` and creating or collecting `TimeType` column would raise an error.
 
 ## Upgrading from SparkR 3.5 to 4.0
 

--- a/docs/sparkr-migration-guide.md
+++ b/docs/sparkr-migration-guide.md
@@ -28,7 +28,7 @@ Please refer [Migration Guide: SQL, Datasets and DataFrame](sql-migration-guide.
 
 ## Upgrading from SparkR 4.0 to 4.3
 
- - In Spark 4.3, `TimeType` support was added. But SparkR does not support `TimeType` and creating or collecting `TimeType` column would raise an error.
+ - In Spark 4.3, `TimeType` support was added. But SparkR does not support `TimeType`, creating and collecting `TimeType` columns raises an error.
 
 ## Upgrading from SparkR 3.5 to 4.0
 

--- a/docs/sparkr-migration-guide.md
+++ b/docs/sparkr-migration-guide.md
@@ -28,7 +28,7 @@ Please refer [Migration Guide: SQL, Datasets and DataFrame](sql-migration-guide.
 
 ## Upgrading from SparkR 4.0 to 4.3
 
- - In Spark 4.3, `TimeType` support was added. But SparkR does not support `TimeType`, creating and collecting `TimeType` columns raises an error.
+ - In Spark 4.3, `TimeType` support was added. But SparkR does not support `TimeType`, and creating or collecting `TimeType` columns raises an error.
 
 ## Upgrading from SparkR 3.5 to 4.0
 

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -49,7 +49,7 @@ Spark SQL and DataFrames support the following data types:
   - `TimeType(precision)`: Represents values comprising values of fields hour, minute and second with the number of decimal digits `precision` following the decimal point in the seconds field, without a time-zone.
   The range of values is from `00:00:00` to `23:59:59` for min precision `0`, and to `23:59:59.999999999` for max precision `9`. The default precision is `6`.
     - Note: Apache Hive has no TIME type, so `TimeType` is not supported in Hive SerDe interop. Storing it in a Hive SerDe table (including `INSERT OVERWRITE DIRECTORY ... STORED AS`) or passing it to a Hive UDF/UDAF/UDTF raises an error rather than silently converting the value.
-    - Note: SparkR's JVM serializer handles only the legacy java.sql datetime types, so `TimeType` is not supported in SparkR as it is backed by java.time.LocalTime. Creating and collecting `TimeType` columns would raise an error.
+    - Note: SparkR's JVM serializer handles only the legacy java.sql datetime types, so `TimeType` is not supported in SparkR as it is backed by java.time.LocalTime. Creating and collecting `TimeType` columns raises an error.
   - `TimestampType`: Timestamp with local time zone(TIMESTAMP_LTZ). It represents values comprising values of fields year, month, day,
   hour, minute, and second, with the session local time-zone. The timestamp value represents an
   absolute point in time.

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -49,6 +49,7 @@ Spark SQL and DataFrames support the following data types:
   - `TimeType(precision)`: Represents values comprising values of fields hour, minute and second with the number of decimal digits `precision` following the decimal point in the seconds field, without a time-zone.
   The range of values is from `00:00:00` to `23:59:59` for min precision `0`, and to `23:59:59.999999999` for max precision `9`. The default precision is `6`.
     - Note: Apache Hive has no TIME type, so `TimeType` is not supported in Hive SerDe interop. Storing it in a Hive SerDe table (including `INSERT OVERWRITE DIRECTORY ... STORED AS`) or passing it to a Hive UDF/UDAF/UDTF raises an error rather than silently converting the value.
+    - Note: SparkR's JVM serializer handles only the legacy java.sql datetime types, so `TimeType` is not supported in SparkR as it is backed by java.time.LocalTime. Creating and collecting `TimeType` columns would raise an error.
   - `TimestampType`: Timestamp with local time zone(TIMESTAMP_LTZ). It represents values comprising values of fields year, month, day,
   hour, minute, and second, with the session local time-zone. The timestamp value represents an
   absolute point in time.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added documentation stating that SparkR does not support TIME data type and referencing it in any way from SparkR would raise an error.


### Why are the changes needed?
TIME type support has not been extended to SparkR and we should clearly document it.

### Does this PR introduce _any_ user-facing change?
Yes, documentation states that SparkR does not support TIME datatype


### How was this patch tested?
Doc changes


### Was this patch authored or co-authored using generative AI tooling?
No