### PR TITLE
[SPARK-57561][SQL] Reject TIME inputs for unsupported datetime functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -189,6 +189,12 @@ object AnsiTypeCoercion extends TypeCoercionBase {
       // If a function expects integral type, fractional input is not allowed.
       case (_: FractionalType, IntegralType) => None
 
+      // TIME values should not be silently coerced into date/timestamp inputs, or vice versa.
+      case (_: TimeType, AnyTimestampType | AnyTimestampNanoType) => None
+      case (_: TimeType, d: DatetimeType) if !d.isInstanceOf[TimeType] => None
+      case (d: DatetimeType, AnyTimeType) if !d.isInstanceOf[TimeType] => None
+      case (d: DatetimeType, _: TimeType) if !d.isInstanceOf[TimeType] => None
+
       // Ideally the implicit cast rule should be the same as `Cast.canANSIStoreAssign` so that it's
       // consistent with table insertion. To avoid breaking too many existing Spark SQL queries,
       // we make the system to allow implicitly converting String type as other primitive types.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -220,6 +220,9 @@ object TypeCoercion extends TypeCoercionBase {
       case (_: NumericType, target: NumericType) => target
 
       // Implicit cast between date time types
+      case (_: TimeType, AnyTimestampType) => null
+      case (_: TimeType, d: DatetimeType) if !d.isInstanceOf[TimeType] => null
+      case (d: DatetimeType, _: TimeType) if !d.isInstanceOf[TimeType] => null
       case (_: DatetimeType, d: DatetimeType) => d
       case (_: DatetimeType, AnyTimestampType) => AnyTimestampType.defaultConcreteType
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WindowTime.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WindowTime.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
+import org.apache.spark.sql.catalyst.expressions.Cast.{ordinalNumber, toSQLExpr, toSQLType}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, WINDOW_TIME}
 import org.apache.spark.sql.types._
 
@@ -50,6 +53,31 @@ case class WindowTime(windowColumn: Expression)
 
   override def child: Expression = windowColumn
   override def inputTypes: Seq[AbstractDataType] = Seq(StructType)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val dataTypeCheck = super.checkInputDataTypes()
+    if (dataTypeCheck.isFailure) {
+      dataTypeCheck
+    } else {
+      child.dataType match {
+        case StructType(fields) if fields.exists(_.dataType.isInstanceOf[TimeType]) =>
+          DataTypeMismatch(
+            errorSubClass = "UNEXPECTED_INPUT_TYPE",
+            messageParameters = Map(
+              "paramIndex" -> ordinalNumber(0),
+              "requiredType" -> toSQLType(TypeCollection(
+                new StructType()
+                  .add(StructField("start", TimestampType))
+                  .add(StructField("end", TimestampType)),
+                new StructType()
+                  .add(StructField("start", TimestampNTZType))
+                  .add(StructField("end", TimestampNTZType)))),
+              "inputSql" -> toSQLExpr(child),
+              "inputType" -> toSQLType(child.dataType)))
+        case _ => TypeCheckSuccess
+      }
+    }
+  }
 
   override def dataType: DataType = child.dataType.asInstanceOf[StructType].head.dataType
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2631,15 +2631,40 @@ case class ParseToDate(
 
   override def children: Seq[Expression] = left +: format.toSeq
 
+  private def inputTypeForDate: AbstractDataType = {
+    TypeCollection(
+      StringTypeWithCollation(supportsTrimCollation = true),
+      DateType,
+      TimestampType,
+      TimestampNTZType)
+  }
+
   override def inputTypes: Seq[AbstractDataType] = {
     // Note: ideally this function should only take string input, but we allow more types here to
     // be backward compatible.
-    TypeCollection(
-      StringTypeWithCollation(supportsTrimCollation = true),
-        DateType,
-        TimestampType,
-        TimestampNTZType) +:
-      format.map(_ => StringTypeWithCollation(supportsTrimCollation = true)).toSeq
+    inputTypeForDate +: format.map(_ =>
+      StringTypeWithCollation(supportsTrimCollation = true)).toSeq
+  }
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    def timeInput(expression: Expression): Option[Expression] = expression match {
+      // Reject analyzer-inserted casts from TIME, while honoring explicit user-written casts.
+      case cast @ Cast(child, _, _, _)
+          if child.dataType.isInstanceOf[TimeType] && cast.origin == origin =>
+        Some(child)
+      case other if other.dataType.isInstanceOf[TimeType] => Some(other)
+      case _ => None
+    }
+
+    timeInput(left).map { input =>
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_INPUT_TYPE",
+        messageParameters = Map(
+          "paramIndex" -> ordinalNumber(0),
+          "requiredType" -> toSQLType(inputTypeForDate),
+          "inputSql" -> toSQLExpr(input),
+          "inputType" -> toSQLType(input.dataType)))
+    }.getOrElse(super.checkInputDataTypes())
   }
 
   override protected def withNewChildrenInternal(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -194,6 +194,7 @@ abstract class TypeCoercionSuiteBase extends AnalysisTest {
     val checkedType = DateType
     checkTypeCasting(checkedType, castableTypes = Seq(checkedType, StringType) ++ datetimeTypes)
     shouldCast(checkedType, AnyTimestampType, AnyTimestampType.defaultConcreteType)
+    shouldNotCast(checkedType, AnyTimeType)
     shouldNotCast(checkedType, DecimalType)
     shouldNotCast(checkedType, NumericType)
     shouldNotCast(checkedType, IntegralType)
@@ -203,6 +204,7 @@ abstract class TypeCoercionSuiteBase extends AnalysisTest {
     val checkedType = TimestampType
     checkTypeCasting(checkedType, castableTypes = Seq(checkedType, StringType) ++ datetimeTypes)
     shouldCast(checkedType, AnyTimestampType, checkedType)
+    shouldNotCast(checkedType, AnyTimeType)
     shouldNotCast(checkedType, DecimalType)
     shouldNotCast(checkedType, NumericType)
     shouldNotCast(checkedType, IntegralType)
@@ -212,6 +214,7 @@ abstract class TypeCoercionSuiteBase extends AnalysisTest {
     val checkedType = TimestampNTZType
     checkTypeCasting(checkedType, castableTypes = Seq(checkedType, StringType) ++ datetimeTypes)
     shouldCast(checkedType, AnyTimestampType, checkedType)
+    shouldNotCast(checkedType, AnyTimeType)
     shouldNotCast(checkedType, DecimalType)
     shouldNotCast(checkedType, NumericType)
     shouldNotCast(checkedType, IntegralType)
@@ -219,8 +222,10 @@ abstract class TypeCoercionSuiteBase extends AnalysisTest {
 
   test("SPARK-56152: implicit type cast - TimeType") {
     val checkedType = TimeType()
-    checkTypeCasting(checkedType, castableTypes = Seq(checkedType, StringType) ++ datetimeTypes)
+    checkTypeCasting(checkedType, castableTypes = Seq(checkedType, StringType))
     shouldCast(checkedType, AnyTimeType, AnyTimeType.defaultConcreteType)
+    shouldNotCast(checkedType, AnyTimestampType)
+    shouldNotCast(checkedType, AnyTimestampNanoType)
     shouldNotCast(checkedType, DecimalType)
     shouldNotCast(checkedType, NumericType)
     shouldNotCast(checkedType, IntegralType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -783,6 +783,78 @@ abstract class TimeFunctionsSuiteBase extends SharedSparkSession {
     checkAnswer(result1, expected)
     checkAnswer(result2, expected)
   }
+
+  test("SPARK-57561: datetime functions reject TIME inputs") {
+    val unexpectedInputType = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE"
+    val timeType = Some("\"TIME(6)\"")
+    val cases = Seq(
+      ("date_add(TIME'12:34:56', 1)", unexpectedInputType, timeType),
+      ("date_sub(TIME'12:34:56', 1)", unexpectedInputType, timeType),
+      ("datediff(TIME'12:34:56', DATE'2025-01-01')", unexpectedInputType, timeType),
+      ("add_months(TIME'12:34:56', 1)", unexpectedInputType, timeType),
+      ("months_between(TIME'12:34:56', TIMESTAMP'2025-01-01 00:00:00')",
+        unexpectedInputType, timeType),
+      ("last_day(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("next_day(TIME'12:34:56', 'MON')", unexpectedInputType, timeType),
+      ("year(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("quarter(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("month(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("day(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("dayofmonth(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("dayofyear(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("dayofweek(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("weekday(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("weekofyear(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("monthname(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("dayname(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("extract(YEAR FROM TIME'12:34:56')", "INVALID_EXTRACT_FIELD", None),
+      ("extract(DAY FROM TIME'12:34:56')", "INVALID_EXTRACT_FIELD", None),
+      ("date_part('YEAR', TIME'12:34:56')", "INVALID_EXTRACT_FIELD", None),
+      ("date_part('DAY', TIME'12:34:56')", "INVALID_EXTRACT_FIELD", None),
+      ("to_date(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("try_to_date(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("make_date(TIME'12:34:56', 1, 1)", unexpectedInputType, timeType),
+      ("trunc(TIME'12:34:56', 'YEAR')", unexpectedInputType, timeType),
+      ("unix_timestamp(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("to_unix_timestamp(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("from_unixtime(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("timestamp_seconds(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("timestamp_millis(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("timestamp_micros(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("unix_seconds(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("unix_millis(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("unix_micros(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("unix_date(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("date_from_unix_date(TIME'12:34:56')", unexpectedInputType, timeType),
+      ("from_utc_timestamp(TIME'12:34:56', 'UTC')", unexpectedInputType, timeType),
+      ("to_utc_timestamp(TIME'12:34:56', 'UTC')", unexpectedInputType, timeType),
+      ("convert_timezone('UTC', 'Europe/Paris', TIME'12:34:56')",
+        unexpectedInputType, timeType),
+      ("window(TIME'12:34:56', '5 minutes')", unexpectedInputType, timeType),
+      ("session_window(TIME'12:34:56', '5 minutes')", unexpectedInputType, timeType),
+      ("window_time(named_struct('start', TIME'12:00:00', 'end', TIME'12:05:00'))",
+        unexpectedInputType,
+        Some("\"STRUCT<start: TIME(6) NOT NULL, end: TIME(6) NOT NULL>\""))
+    )
+
+    cases.foreach { case (expr, expectedCondition, expectedInputType) =>
+      withClue(s"$expr: ") {
+        val e = intercept[AnalysisException] {
+          spark.sql(s"SELECT $expr").queryExecution.analyzed
+        }
+        assert(e.getCondition === expectedCondition)
+        expectedInputType.foreach { inputType =>
+          assert(e.getMessageParameters.get("inputType") === inputType)
+        }
+      }
+    }
+
+    Seq("to_date", "try_to_date").foreach { func =>
+      checkAnswer(
+        spark.sql(s"SELECT $func(CAST(TIME'12:34:56' AS TIMESTAMP)) = current_date()"),
+        Row(true))
+    }
+  }
 }
 
 // This class is used to run the same tests with ANSI mode enabled explicitly.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes unsupported datetime functions reject `TIME` inputs consistently instead of accepting them through implicit date/timestamp/string coercion paths.

The change blocks implicit `TIME` <-> non-`TIME` datetime coercion in the SQL type coercion rules, adds a local guard for `to_date`/`try_to_date`, and returns a named type-mismatch error for `window_time` structs containing `TIME` fields.

It also adds negative coverage for the date, calendar, epoch, time-zone, and event-time windowing functions listed in SPARK-57561.

### Why are the changes needed?

SPARK-57561 tracks that date/zone/epoch-bound datetime functions should stay unsupported for `TIME`. Without explicit checks, some functions can silently accept `TIME` after related `TIME` <-> `TIMESTAMP` work, which makes unsupported behavior harder to detect and produces inconsistent errors.

### Does this PR introduce _any_ user-facing change?

Yes. On unreleased `master`, unsupported datetime functions now reject `TIME` inputs consistently during analysis instead of silently accepting them through implicit coercion in some paths.

### How was this patch tested?

Added tests.

```
./build/sbt "sql/testOnly org.apache.spark.sql.TimeFunctionsAnsiOnSuite -- -z SPARK-57561"
./build/sbt "sql/testOnly org.apache.spark.sql.TimeFunctionsAnsiOffSuite -- -z SPARK-57561"
./build/sbt "sql/testOnly org.apache.spark.sql.TimeFunctionsAnsiOnSuite org.apache.spark.sql.TimeFunctionsAnsiOffSuite"
./build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.analysis.TypeCoercionSuite org.apache.spark.sql.catalyst.analysis.AnsiTypeCoercionSuite"
./dev/scalastyle
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
