### PR TITLE
[SPARK-57240][CORE] Avoid unnecessary String conversion in UTF8String.splitSQL

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -21,12 +21,13 @@ import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
@@ -1662,15 +1663,21 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   public UTF8String[] splitSQL(UTF8String delimiter, int limit) {
     // if delimiter is empty string, skip the regex based splitting directly as regex
     // treats empty string as matching anything, thus use the input directly.
-    if (delimiter.numBytes() == 0) {
+    if (delimiter.numBytes == 0) {
       return new UTF8String[]{this};
-    } else {
-      // we do not treat delimiter as a regex but consider the whole string of delimiter
-      // as the separator to split string. Java String's split, however, only accept
-      // regex as the pattern to split, thus we can quote the delimiter to escape special
-      // characters in the string.
-      return split(Pattern.quote(delimiter.toString()), limit);
     }
+    List<UTF8String> splits = new ArrayList<>();
+    int start = 0;
+    while (limit <= 0 || splits.size() < limit - 1) {
+      int match = find(delimiter, start);
+      if (match < 0) {
+        break;
+      }
+      splits.add(copyUTF8String(start, match - 1));
+      start = match + delimiter.numBytes;
+    }
+    splits.add(copyUTF8String(start, numBytes - 1));
+    return splits.toArray(new UTF8String[0]);
   }
 
   private UTF8String[] split(String delimiter, int limit) {

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -527,6 +527,41 @@ public class UTF8StringSuite {
   }
 
   @Test
+  public void splitSQL() {
+    assertArrayEquals(
+      new UTF8String[]{fromString("a"), fromString("b"), fromString(""), fromString("c"),
+        fromString("")},
+      fromString("a.b..c.").splitSQL(fromString("."), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("a"), fromString("b"), fromString("c")},
+      fromString("a|b|c").splitSQL(fromString("|"), 0));
+    assertArrayEquals(
+      new UTF8String[]{fromString("a"), fromString("b.c")},
+      fromString("a.b.c").splitSQL(fromString("."), 2));
+    assertArrayEquals(
+      new UTF8String[]{fromString("a.b.c")},
+      fromString("a.b.c").splitSQL(fromString("."), 1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("a"), fromString("b"), fromString(""), fromString("c")},
+      fromString("a数b数数c").splitSQL(fromString("数"), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString(""), fromString("")},
+      fromString("abc").splitSQL(fromString("abc"), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("abc")},
+      fromString("abc").splitSQL(fromString(""), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("abc")},
+      fromString("abc").splitSQL(fromString("x"), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("")},
+      fromString("").splitSQL(fromString("."), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("a"), fromString("b"), fromString("c")},
+      fromString("aXYbXYc").splitSQL(fromString("XY"), -1));
+  }
+
+  @Test
   public void replace() {
     assertEquals(
       fromString("re123ace"),


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR optimizes the UTF8String.splitSQL() method by performing direct splitting over UTF-8 bytes instead of decoding those bytes into Java Strings.
This approach mirrors the pattern introduced in [SPARK-27839](https://github.com/apache/spark/pull/24707). 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid unnecessary Java String allocations and Regex compilation

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Added regression and edge-case tests to UTF8StringSuite.java
- Ran and passed all existing unit tests in UTF8StringSuite.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Google Antigravity (Claude Opus 4.6)
