### PR TITLE
[SPARK-57922][SQL] Migrate pipeline-dataset parser guards off _LEGACY_ERROR_TEMP_0035 to named error conditions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8414,7 +8414,7 @@
       },
       "PIPELINE_DATASET_HIVE_SERDE" : {
         "message" : [
-          "Hive SerDe format options in a CREATE <pipelineDatasetType> statement."
+          "Hive SerDe format options in a CREATE <pipelineDatasetType> statement. Use the USING clause or a non-SerDe format instead."
         ]
       },
       "PIPELINE_DATASET_LOCATION" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8402,6 +8402,36 @@
           "Invalid partitioning: <cols> is missing or is in a map or array."
         ]
       },
+      "PIPELINE_DATASET_BUCKETING" : {
+        "message" : [
+          "Bucketing in a CREATE <pipelineDatasetType> statement. Remove the bucket specification from the statement."
+        ]
+      },
+      "PIPELINE_DATASET_COLUMN_CONSTRAINTS" : {
+        "message" : [
+          "Column constraints in a CREATE <pipelineDatasetType> statement. Remove the CHECK, UNIQUE, PRIMARY KEY and FOREIGN KEY constraints from the statement."
+        ]
+      },
+      "PIPELINE_DATASET_HIVE_SERDE" : {
+        "message" : [
+          "Hive SerDe format options in a CREATE <pipelineDatasetType> statement."
+        ]
+      },
+      "PIPELINE_DATASET_LOCATION" : {
+        "message" : [
+          "The LOCATION clause in a CREATE <pipelineDatasetType> statement. The storage location for a pipeline dataset is managed by the pipeline itself."
+        ]
+      },
+      "PIPELINE_DATASET_OPTIONS" : {
+        "message" : [
+          "The OPTIONS clause in a CREATE <pipelineDatasetType> statement. Remove the OPTIONS list from the statement."
+        ]
+      },
+      "PIPELINE_DATASET_STORED_AS" : {
+        "message" : [
+          "The STORED AS clause in a CREATE <pipelineDatasetType> statement. Use the Data Source based USING clause instead."
+        ]
+      },
       "PIPE_OPERATOR_AGGREGATE_UNSUPPORTED_CASE" : {
         "message" : [
           "The SQL pipe operator syntax with aggregation (using |> AGGREGATE) does not support <case>."

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -575,6 +575,60 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
+  def pipelineDatasetBucketingError(
+      pipelineDatasetType: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_BUCKETING",
+      messageParameters = Map("pipelineDatasetType" -> pipelineDatasetType),
+      ctx)
+  }
+
+  def pipelineDatasetColumnConstraintsError(
+      pipelineDatasetType: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_COLUMN_CONSTRAINTS",
+      messageParameters = Map("pipelineDatasetType" -> pipelineDatasetType),
+      ctx)
+  }
+
+  def pipelineDatasetHiveSerdeError(
+      pipelineDatasetType: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_HIVE_SERDE",
+      messageParameters = Map("pipelineDatasetType" -> pipelineDatasetType),
+      ctx)
+  }
+
+  def pipelineDatasetLocationError(
+      pipelineDatasetType: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_LOCATION",
+      messageParameters = Map("pipelineDatasetType" -> pipelineDatasetType),
+      ctx)
+  }
+
+  def pipelineDatasetOptionsError(
+      pipelineDatasetType: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_OPTIONS",
+      messageParameters = Map("pipelineDatasetType" -> pipelineDatasetType),
+      ctx)
+  }
+
+  def pipelineDatasetStoredAsError(
+      pipelineDatasetType: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_STORED_AS",
+      messageParameters = Map("pipelineDatasetType" -> pipelineDatasetType),
+      ctx)
+  }
+
   def tableSampleSystemRepeatableError(ctx: ParserRuleContext): Throwable = {
     new ParseException(
       errorClass = "UNSUPPORTED_FEATURE.TABLESAMPLE_SYSTEM_REPEATABLE",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1590,9 +1590,7 @@ class SparkSqlAstBuilder extends AstBuilder {
       .getOrElse((Nil, Nil))
 
     if (colConstraints.nonEmpty) {
-      throw operationNotAllowed("Pipeline datasets do not currently support column constraints. " +
-        "Please remove any CHECK, UNIQUE, PK, and FK constraints specified on the pipeline " +
-        "dataset.", ctx)
+      throw QueryParsingErrors.pipelineDatasetColumnConstraintsError(syntaxTypeErrorStr, ctx)
     }
 
     val (partTransforms, partCols, bucketSpec,
@@ -1607,25 +1605,18 @@ class SparkSqlAstBuilder extends AstBuilder {
     // datasets don't support bucketing, options, storage location, or Hive SerDe, validate they
     // are not set.
     if (bucketSpec.isDefined) {
-      throw operationNotAllowed(s"Bucketing is not supported for CREATE $syntaxTypeErrorStr " +
-        "statements. Please remove any bucket spec specified in the statement.", ctx)
+      throw QueryParsingErrors.pipelineDatasetBucketingError(syntaxTypeErrorStr, ctx)
     }
     if (options.options.nonEmpty) {
-      throw operationNotAllowed(s"Options are not supported for CREATE $syntaxTypeErrorStr " +
-        "statements. Please remove any OPTIONS lists specified in the statement.", ctx)
+      throw QueryParsingErrors.pipelineDatasetOptionsError(syntaxTypeErrorStr, ctx)
     }
     serdeInfoOpt.map(serdeInfo => if (serdeInfo.storedAs.nonEmpty) {
-      throw operationNotAllowed(s"The STORED AS syntax is not supported for CREATE " +
-        s"$syntaxTypeErrorStr statements. Consider using the Data Source based USING clause "
-        + "instead.", ctx)
+      throw QueryParsingErrors.pipelineDatasetStoredAsError(syntaxTypeErrorStr, ctx)
     } else {
-      throw operationNotAllowed(s"Hive SerDe format options are not supported for CREATE " +
-        s"$syntaxTypeErrorStr statements.", ctx)
+      throw QueryParsingErrors.pipelineDatasetHiveSerdeError(syntaxTypeErrorStr, ctx)
     })
     if (location.nonEmpty) {
-      throw operationNotAllowed(s"Specifying location is not supported for CREATE " +
-        s"$syntaxTypeErrorStr statements. The storage location for a pipeline dataset is " +
-        "managed by the pipeline itself.", ctx)
+      throw QueryParsingErrors.pipelineDatasetLocationError(syntaxTypeErrorStr, ctx)
     }
 
     val spec = TableSpec(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreatePipelineDatasetAsSelectParserSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreatePipelineDatasetAsSelectParserSuiteBase.scala
@@ -94,10 +94,8 @@ trait CreatePipelineDatasetAsSelectParserSuiteBase extends CommandSuiteBase {
     }
     checkError(
       exception = ex,
-      condition = "_LEGACY_ERROR_TEMP_0035",
-      parameters = Map("message" -> ("Specifying location is not supported for " +
-        s"CREATE $datasetSqlSyntax statements. The storage location for a pipeline dataset is " +
-        "managed by the pipeline itself.")),
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_LOCATION",
+      parameters = Map("pipelineDatasetType" -> datasetSqlSyntax),
       queryContext = ex.getQueryContext.map(toExpectedContext)
     )
   }
@@ -108,10 +106,8 @@ trait CreatePipelineDatasetAsSelectParserSuiteBase extends CommandSuiteBase {
     }
     checkError(
       exception = ex,
-      condition = "_LEGACY_ERROR_TEMP_0035",
-      parameters = Map("message" -> ("Pipeline datasets do not currently support column " +
-        "constraints. Please remove any CHECK, UNIQUE, PK, and FK constraints specified on the " +
-        "pipeline dataset.")),
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_COLUMN_CONSTRAINTS",
+      parameters = Map("pipelineDatasetType" -> datasetSqlSyntax),
       queryContext = ex.getQueryContext.map(toExpectedContext)
     )
   }
@@ -134,10 +130,8 @@ trait CreatePipelineDatasetAsSelectParserSuiteBase extends CommandSuiteBase {
     }
     checkError(
       exception = ex,
-      condition = "_LEGACY_ERROR_TEMP_0035",
-      parameters = Map("message" -> ("The STORED AS syntax is not supported for CREATE " +
-        s"$datasetSqlSyntax statements. Consider using the Data Source based USING clause " +
-        "instead.")),
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_STORED_AS",
+      parameters = Map("pipelineDatasetType" -> datasetSqlSyntax),
       queryContext = ex.getQueryContext.map(toExpectedContext)
     )
   }
@@ -153,9 +147,8 @@ trait CreatePipelineDatasetAsSelectParserSuiteBase extends CommandSuiteBase {
     }
     checkError(
       exception = ex,
-      condition = "_LEGACY_ERROR_TEMP_0035",
-      parameters = Map("message" -> ("Hive SerDe format options are not supported for CREATE " +
-        s"$datasetSqlSyntax statements.")),
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_HIVE_SERDE",
+      parameters = Map("pipelineDatasetType" -> datasetSqlSyntax),
       queryContext = ex.getQueryContext.map(toExpectedContext)
     )
   }
@@ -202,9 +195,8 @@ trait CreatePipelineDatasetAsSelectParserSuiteBase extends CommandSuiteBase {
     }
     checkError(
       exception = ex,
-      condition = "_LEGACY_ERROR_TEMP_0035",
-      parameters = Map("message" -> (s"Bucketing is not supported for CREATE $datasetSqlSyntax " +
-        "statements. Please remove any bucket spec specified in the statement.")),
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_BUCKETING",
+      parameters = Map("pipelineDatasetType" -> datasetSqlSyntax),
       queryContext = ex.getQueryContext.map(toExpectedContext)
     )
   }
@@ -217,9 +209,8 @@ trait CreatePipelineDatasetAsSelectParserSuiteBase extends CommandSuiteBase {
     }
     checkError(
       exception = ex,
-      condition = "_LEGACY_ERROR_TEMP_0035",
-      parameters = Map("message" -> (s"Options are not supported for CREATE $datasetSqlSyntax " +
-        "statements. Please remove any OPTIONS lists specified in the statement.")),
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_OPTIONS",
+      parameters = Map("pipelineDatasetType" -> datasetSqlSyntax),
       queryContext = ex.getQueryContext.map(toExpectedContext)
     )
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -397,7 +397,14 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       )
     }
 
-    assert(ex.getMessage.contains("Specifying location is not supported"))
+    checkError(
+      exception = ex,
+      condition = "UNSUPPORTED_FEATURE.PIPELINE_DATASET_LOCATION",
+      parameters = Map("pipelineDatasetType" -> "STREAMING TABLE"),
+      queryContext = ex.getQueryContext.map { c =>
+        ExpectedContext(c.objectType(), c.objectName(), c.startIndex(), c.stopIndex(), c.fragment())
+      }
+    )
   }
 
   test("Tables living in arbitrary schemas can be read from pipeline") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Migrate the pipeline-dataset guards in `SparkSqlParser.visitCreatePipelineDataset` off the legacy `_LEGACY_ERROR_TEMP_0035` ("Operation not allowed: ...") error onto named error conditions. Six new sub-conditions are added under `UNSUPPORTED_FEATURE` (SQLSTATE `0A000`), following the existing `UNSUPPORTED_FEATURE.CREATE_PIPELINE_DATASET_QUERY_EXECUTION` precedent, each with a `pipelineDatasetType` message parameter (`MATERIALIZED VIEW` or `STREAMING TABLE`):

- `PIPELINE_DATASET_BUCKETING`
- `PIPELINE_DATASET_COLUMN_CONSTRAINTS`
- `PIPELINE_DATASET_HIVE_SERDE`
- `PIPELINE_DATASET_LOCATION`
- `PIPELINE_DATASET_OPTIONS`
- `PIPELINE_DATASET_STORED_AS`

The guards now throw via new `QueryParsingErrors` helpers instead of `ParserUtils.operationNotAllowed`.

Scope notes:
- The column-constraints guard is included as well: it lives in the same method, has the same shape, and previously raised the same legacy condition.
- The JIRA also mentions the MATERIALIZED-VIEW-with-AUTO-CDC guard and the AUTO CDC streaming-source check; those guards are introduced by the still-open PR #56419 (SPARK-56249) and can adopt this pattern when they land.
- The "Unable to find query for CREATE ..." guard in the same method is intentionally left unchanged: a missing `AS` query is a malformed statement rather than an unsupported feature, so it deserves a differently-shaped condition and can be handled separately.

### Why are the changes needed?

Per `common/utils/src/main/resources/error/README.md`, user-facing errors should carry a proper error condition and SQLSTATE rather than a `_LEGACY_ERROR_TEMP_*` placeholder. These guards are user-reachable from pipeline SQL definitions, and named conditions make the errors machine-identifiable via `getCondition()` and consistent with the other declarative-pipelines error conditions.

### Does this PR introduce _any_ user-facing change?

Yes, but only for the declarative pipelines SQL syntax that has not shipped in a release yet (master only): the error condition and message for invalid `CREATE MATERIALIZED VIEW` / `CREATE STREAMING TABLE` pipeline statements change.

Before:

```
[_LEGACY_ERROR_TEMP_0035] Operation not allowed: Specifying location is not supported for CREATE STREAMING TABLE statements. The storage location for a pipeline dataset is managed by the pipeline itself.(line 1, pos 0)
```

After:

```
[UNSUPPORTED_FEATURE.PIPELINE_DATASET_LOCATION] The feature is not supported: The LOCATION clause in a CREATE STREAMING TABLE statement. The storage location for a pipeline dataset is managed by the pipeline itself. SQLSTATE: 0A000(line 1, pos 0)
```

### How was this patch tested?

Updated the existing tests to check the new conditions with `checkError()`:
- `CreatePipelineDatasetAsSelectParserSuiteBase` (exercised for both dataset types via `CreateMaterializedViewAsSelectParserSuite` and `CreateStreamingTableAsSelectParserSuite`)
- `SqlPipelineSuite` ("Setting dataset location is disallowed") migrated from a message-substring assertion to `checkError()`

Ran locally:

```
build/sbt 'core/testOnly *SparkThrowableSuite' \
  'sql/testOnly *CreateMaterializedViewAsSelectParserSuite *CreateStreamingTableAsSelectParserSuite' \
  'pipelines/testOnly *SqlPipelineSuite -- -z "location is disallowed"'
```

All passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)