### PR TITLE
[SQL] Support reading Parquet UUID logical type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -382,6 +382,7 @@ class ParquetToSparkSchemaConverter(
           case _: DecimalLogicalTypeAnnotation =>
             makeDecimalType(Decimal.maxPrecisionForBytes(parquetType.getTypeLength))
           case _: IntervalLogicalTypeAnnotation => typeNotImplemented()
+          case _: UUIDLogicalTypeAnnotation => BinaryType
           case null => BinaryType
           case _ => illegalType()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -133,7 +133,7 @@ class ParquetIOSuite extends ParquetTest with SharedSparkSession {
           val record = new SimpleGroup(schema)
           record.add(0, Binary.fromString(n))
           record.add(1, Binary.fromString(n + n + n))
-          record.add(2, Binary.fromConstantByteArray(Array.fill(16)(n.toByte)))
+          record.add(2, Binary.fromConstantByteArray(Array.fill(16)(n.head.toByte)))
           writer.write(record)
         }
         writer.close()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -122,6 +122,7 @@ class ParquetIOSuite extends ParquetTest with SharedSparkSession {
           """message root {
             |  required FIXED_LEN_BYTE_ARRAY(1) a;
             |  required FIXED_LEN_BYTE_ARRAY(3) b;
+            |  required FIXED_LEN_BYTE_ARRAY(16) c (UUID);
             |}
         """.stripMargin
         val schema = MessageTypeParser.parseMessageType(schemaStr)
@@ -132,6 +133,7 @@ class ParquetIOSuite extends ParquetTest with SharedSparkSession {
           val record = new SimpleGroup(schema)
           record.add(0, Binary.fromString(n))
           record.add(1, Binary.fromString(n + n + n))
+          record.add(2, Binary.fromConstantByteArray(Array.fill(16)(n.toByte)))
           writer.write(record)
         }
         writer.close()
@@ -143,7 +145,7 @@ class ParquetIOSuite extends ParquetTest with SharedSparkSession {
         Seq(true, false).foreach { vectorizedReaderEnabled =>
           readParquetFile(path.toString, vectorizedReaderEnabled) { df =>
             checkAnswer(df, (48 until 58).map(n => // char '0' is 48 in ascii
-              Row(Array(n), Array(n, n, n))))
+              Row(Array(n), Array(n, n, n), Array.fill[Byte](16)(n.toByte))))
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -218,6 +218,17 @@ abstract class ParquetSchemaTest extends ParquetTest with SharedSparkSession {
 }
 
 class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
+  testParquetToCatalyst(
+    "UUID logical type",
+    StructType(Seq(StructField("id", BinaryType, nullable = false))),
+    """
+      |message root {
+      |  required fixed_len_byte_array(16) id (UUID);
+      |}
+    """.stripMargin,
+    binaryAsString = false,
+    int96AsTimestamp = true)
+
   testSchemaInference[Tuple1[Long]](
     "timestamp nanos",
     """


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR maps Parquet `UUID` logical annotations on `FIXED_LEN_BYTE_ARRAY(16)` columns to Spark SQL `BinaryType`.

It also adds schema conversion coverage and extends the fixed-length byte array IO test with a UUID-annotated column for both vectorized and non-vectorized readers.

Closes #55684.

### Why are the changes needed?

Spark currently rejects Parquet UUID columns with `PARQUET_TYPE_ILLEGAL`, even though their 16-byte physical representation can be preserved as binary data. Spark does not expose a UUID SQL type, so `BinaryType` retains the value without losing information and matches the handling of unannotated fixed-length byte arrays.

### Does this PR introduce _any_ user-facing change?

Yes. Spark can read Parquet files containing UUID logical annotations. The UUID values are exposed as 16-byte binary values instead of failing during schema inference.

### How was this patch tested?

- Added a Parquet-to-Catalyst schema conversion test for `FIXED_LEN_BYTE_ARRAY(16) (UUID)`; the test passed.
- Extended `SPARK-41096: FIXED_LEN_BYTE_ARRAY support` to write and read a UUID-annotated field with vectorized and non-vectorized readers.
- `build/sbt "sql/scalastyle"` passed with zero findings.
- `git diff --check` passed.
- On this Windows environment, the shared Spark SQL test harness reports that `HADOOP_HOME` / `winutils.exe` is unavailable. The schema test itself passed, while the IO suite aborted during shared setup before the targeted test could run.