### PR TITLE
[SPARK-57965][PYTHON][CONNECT] Fix UNSUPPORTED_PIPELINES_DATASET_TYPE error parameter name

### DIFF
--- a/python/pyspark/pipelines/spark_connect_graph_element_registry.py
+++ b/python/pyspark/pipelines/spark_connect_graph_element_registry.py
@@ -79,7 +79,7 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
             else:
                 raise PySparkTypeError(
                     errorClass="UNSUPPORTED_PIPELINES_DATASET_TYPE",
-                    messageParameters={"output_type": type(output).__name__},
+                    messageParameters={"dataset_type": type(output).__name__},
                 )
         elif isinstance(output, TemporaryView):
             output_type = pb2.OutputType.TEMPORARY_VIEW
@@ -93,7 +93,7 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
         else:
             raise PySparkTypeError(
                 errorClass="UNSUPPORTED_PIPELINES_DATASET_TYPE",
-                messageParameters={"output_type": type(output).__name__},
+                messageParameters={"dataset_type": type(output).__name__},
             )
 
         inner_command = pb2.PipelineCommand.DefineOutput(

--- a/python/pyspark/pipelines/tests/test_spark_connect.py
+++ b/python/pyspark/pipelines/tests/test_spark_connect.py
@@ -22,6 +22,9 @@ Tests that run Pipelines against a Spark Connect server.
 import unittest
 
 from pyspark import pipelines as dp
+from pyspark.errors import PySparkTypeError
+from pyspark.pipelines.output import Output
+from pyspark.pipelines.source_code_location import SourceCodeLocation
 from pyspark.testing.connectutils import (
     ReusedConnectTestCase,
     should_test_connect,
@@ -89,6 +92,20 @@ class SparkConnectPipelinesTest(ReusedConnectTestCase):
         self.assertIn(
             "INVALID_FLOW_QUERY_TYPE.BATCH_RELATION_FOR_STREAMING_TABLE", str(context.exception)
         )
+
+    def test_register_output_unsupported_dataset_type(self):
+        registry = SparkConnectGraphElementRegistry(self.spark, "test_dataflow_graph_id")
+
+        unsupported_output = Output(
+            name="unsupported",
+            comment=None,
+            source_code_location=SourceCodeLocation(filename="test.py", line_number=1),
+        )
+        with self.assertRaises(PySparkTypeError) as context:
+            registry.register_output(unsupported_output)
+
+        self.assertEqual(context.exception.getCondition(), "UNSUPPORTED_PIPELINES_DATASET_TYPE")
+        self.assertEqual(context.exception.getMessageParameters(), {"dataset_type": "Output"})
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pipelines/tests/test_spark_connect.py
+++ b/python/pyspark/pipelines/tests/test_spark_connect.py
@@ -23,7 +23,7 @@ import unittest
 
 from pyspark import pipelines as dp
 from pyspark.errors import PySparkTypeError
-from pyspark.pipelines.output import Output
+from pyspark.pipelines.output import Output, Table
 from pyspark.pipelines.source_code_location import SourceCodeLocation
 from pyspark.testing.connectutils import (
     ReusedConnectTestCase,
@@ -96,16 +96,26 @@ class SparkConnectPipelinesTest(ReusedConnectTestCase):
     def test_register_output_unsupported_dataset_type(self):
         registry = SparkConnectGraphElementRegistry(self.spark, "test_dataflow_graph_id")
 
-        unsupported_output = Output(
-            name="unsupported",
-            comment=None,
-            source_code_location=SourceCodeLocation(filename="test.py", line_number=1),
-        )
-        with self.assertRaises(PySparkTypeError) as context:
-            registry.register_output(unsupported_output)
+        class CustomTable(Table):
+            pass
 
-        self.assertEqual(context.exception.getCondition(), "UNSUPPORTED_PIPELINES_DATASET_TYPE")
-        self.assertEqual(context.exception.getMessageParameters(), {"dataset_type": "Output"})
+        source_code_location = SourceCodeLocation(filename="test.py", line_number=1)
+        unsupported_outputs = [
+            Output("unsupported", None, source_code_location),
+            CustomTable("unsupported", None, source_code_location, {}, None, None, None, None),
+        ]
+        for unsupported_output in unsupported_outputs:
+            with self.subTest(dataset_type=type(unsupported_output).__name__):
+                with self.assertRaises(PySparkTypeError) as context:
+                    registry.register_output(unsupported_output)
+
+                self.assertEqual(
+                    context.exception.getCondition(), "UNSUPPORTED_PIPELINES_DATASET_TYPE"
+                )
+                self.assertEqual(
+                    context.exception.getMessageParameters(),
+                    {"dataset_type": type(unsupported_output).__name__},
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### What changes were proposed in this pull request?

`SparkConnectGraphElementRegistry.register_output`
(`python/pyspark/pipelines/spark_connect_graph_element_registry.py`) has two
`else`-branch raise sites that report an unsupported pipeline output type. Both
raised:

```python
raise PySparkTypeError(
    errorClass="UNSUPPORTED_PIPELINES_DATASET_TYPE",
    messageParameters={"output_type": type(output).__name__},
)
```

but the `UNSUPPORTED_PIPELINES_DATASET_TYPE` template in
`python/pyspark/errors/error-conditions.json` interpolates `<dataset_type>`:

```
"Unsupported pipelines dataset type: <dataset_type>."
```

`ErrorClassesReader.get_error_message` (`python/pyspark/errors/utils.py`) asserts
that the set of template placeholders equals the set of provided message
parameters. Since `{"dataset_type"} != {"output_type"}`, the assertion fired
inside `PySparkException.__init__`, so the intended `PySparkTypeError` was
replaced by an opaque `AssertionError`.

This PR renames the message parameter key from `"output_type"` to
`"dataset_type"` at both raise sites (the value, `type(output).__name__`, is
unchanged), so it matches the template placeholder. The error class is
referenced only at these two Python sites plus the template, so the change is
fully local. A regression test is added.

### Why are the changes needed?

Registering a pipeline output of an unsupported type is meant to surface a clear
`PySparkTypeError` with condition `UNSUPPORTED_PIPELINES_DATASET_TYPE`. Because of
the parameter-name mismatch it instead raised an unrelated `AssertionError` from
the error-formatting layer, hiding the real cause from the user:

```
AssertionError: Undefined error message parameter for error class:
UNSUPPORTED_PIPELINES_DATASET_TYPE. Parameters: {'output_type': 'Output'}
```

The intended error is never constructed, so callers cannot catch
`PySparkTypeError` or read the intended message.

### Does this PR introduce _any_ user-facing change?

Yes, an error-behavior change on the failure path only. Registering a pipeline
output whose type is unsupported now raises the intended, documented error.

Before:

```
AssertionError: Undefined error message parameter for error class:
UNSUPPORTED_PIPELINES_DATASET_TYPE. Parameters: {'output_type': 'Output'}
```

After:

```
pyspark.errors.exceptions.base.PySparkTypeError:
[UNSUPPORTED_PIPELINES_DATASET_TYPE] Unsupported pipelines dataset type: Output.
```

This is a fix relative to the unreleased `master` behavior (the affected
`messageParameters={"output_type": ...}` code path); no released Spark version
behavior changes here.

### How was this patch tested?

Added `SparkConnectPipelinesTest.test_register_output_unsupported_dataset_type`
in `python/pyspark/pipelines/tests/test_spark_connect.py`, which builds a
`SparkConnectGraphElementRegistry`, calls `register_output` with both a bare `Output` and a custom `Table`
subclass that is neither `MaterializedView` nor `StreamingTable`. These cases
exercise both unsupported-type raise sites and assert `PySparkTypeError` with
the expected condition and dataset type parameter.

The test extends `ReusedConnectTestCase`, so CI runs it against a real Spark
Connect server. Verified locally against a live Connect server:

- New test on this change: `Ran 1 test ... OK`.
- Temporarily reverting the fix (restoring the `"output_type"` key) makes the
  same test fail with the `AssertionError` above, confirming it is a genuine
  RED -> GREEN regression test.
- Full `pyspark.pipelines.tests.test_spark_connect` module: `Ran 5 tests ... OK`,
  no regressions.

Lint: `ruff==0.14.8` check and format validation pass on both changed files.
The PySpark custom error checker also passes.

### Was this patch authored or co-authored using generative AI tooling?

No