### PR TITLE
[SPARK-57944][SQL] Improve fixed-width field write performance in `UnsafeRowWriter`

### DIFF
--- a/sql/catalyst/benchmarks/UnsafeProjectionBenchmark-jdk21-results.txt
+++ b/sql/catalyst/benchmarks/UnsafeProjectionBenchmark-jdk21-results.txt
@@ -6,10 +6,10 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 unsafe projection:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single long                                        1342           1342           0        200.0           5.0       1.0X
-single nullable long                               2380           2393          19        112.8           8.9       0.6X
-7 primitive types                                  7161           7163           3         37.5          26.7       0.2X
-7 nullable primitive types                        10670          10672           3         25.2          39.7       0.1X
+single long                                        1343           1344           2        199.9           5.0       1.0X
+single nullable long                               2380           2394          20        112.8           8.9       0.6X
+7 primitive types                                  7045           7046           1         38.1          26.2       0.2X
+7 nullable primitive types                        11060          11063           3         24.3          41.2       0.1X
 
 
 ================================================================================================
@@ -20,7 +20,7 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 boolean fields:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 boolean fields                 6574           6577           4          0.6        1567.4       1.0X
+single row with 400 boolean fields                 6566           6575          12          0.6        1565.5       1.0X
 
 
 ================================================================================================
@@ -31,7 +31,7 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 byte fields:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 byte fields                    6745           6745           1          0.6        1608.1       1.0X
+single row with 400 byte fields                    6539           6539           0          0.6        1559.0       1.0X
 
 
 ================================================================================================
@@ -42,7 +42,7 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 short fields:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 short fields                   6817           6829          17          0.6        1625.2       1.0X
+single row with 400 short fields                   6445           6455          13          0.7        1536.7       1.0X
 
 
 ================================================================================================
@@ -53,7 +53,7 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 integer fields:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 integer fields                 6646           6652           8          0.6        1584.6       1.0X
+single row with 400 integer fields                 6643           6644           1          0.6        1583.8       1.0X
 
 
 ================================================================================================
@@ -64,6 +64,6 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 float fields:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 float fields                   6717           6730          19          0.6        1601.4       1.0X
+single row with 400 float fields                   6716           6721           6          0.6        1601.3       1.0X
 
 

--- a/sql/catalyst/benchmarks/UnsafeProjectionBenchmark-jdk25-results.txt
+++ b/sql/catalyst/benchmarks/UnsafeProjectionBenchmark-jdk25-results.txt
@@ -6,10 +6,10 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 unsafe projection:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single long                                        1335           1336           1        201.0           5.0       1.0X
-single nullable long                               2399           2399           0        111.9           8.9       0.6X
-7 primitive types                                  7794           7803          13         34.4          29.0       0.2X
-7 nullable primitive types                        10564          10575          15         25.4          39.4       0.1X
+single long                                        1331           1333           3        201.7           5.0       1.0X
+single nullable long                               2418           2419           2        111.0           9.0       0.6X
+7 primitive types                                  7433           7441          11         36.1          27.7       0.2X
+7 nullable primitive types                        11008          11013           7         24.4          41.0       0.1X
 
 
 ================================================================================================
@@ -20,7 +20,7 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 boolean fields:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 boolean fields                 6583           6586           4          0.6        1569.5       1.0X
+single row with 400 boolean fields                 6588           6596          11          0.6        1570.8       1.0X
 
 
 ================================================================================================
@@ -31,7 +31,7 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 byte fields:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 byte fields                    6870           6872           3          0.6        1638.0       1.0X
+single row with 400 byte fields                    6483           6488           7          0.6        1545.6       1.0X
 
 
 ================================================================================================
@@ -42,7 +42,7 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 short fields:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 short fields                   6776           6786          14          0.6        1615.4       1.0X
+single row with 400 short fields                   6498           6508          13          0.6        1549.3       1.0X
 
 
 ================================================================================================
@@ -53,7 +53,7 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 integer fields:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 integer fields                 6676           6680           6          0.6        1591.7       1.0X
+single row with 400 integer fields                 6570           6570           1          0.6        1566.3       1.0X
 
 
 ================================================================================================
@@ -64,6 +64,6 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 float fields:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 float fields                   6669           6671           2          0.6        1590.1       1.0X
+single row with 400 float fields                   6813           6814           2          0.6        1624.3       1.0X
 
 

--- a/sql/catalyst/benchmarks/UnsafeProjectionBenchmark-results.txt
+++ b/sql/catalyst/benchmarks/UnsafeProjectionBenchmark-results.txt
@@ -6,10 +6,10 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 unsafe projection:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single long                                        1296           1296           0        207.2           4.8       1.0X
-single nullable long                               2454           2454           0        109.4           9.1       0.5X
-7 primitive types                                  7017           7017           0         38.3          26.1       0.2X
-7 nullable primitive types                        10331          10337           8         26.0          38.5       0.1X
+single long                                        1302           1303           1        206.1           4.9       1.0X
+single nullable long                               2449           2452           4        109.6           9.1       0.5X
+7 primitive types                                  7017           7025          10         38.3          26.1       0.2X
+7 nullable primitive types                        10812          10815           3         24.8          40.3       0.1X
 
 
 ================================================================================================
@@ -20,7 +20,7 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 boolean fields:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 boolean fields                 6529           6536           9          0.6        1556.7       1.0X
+single row with 400 boolean fields                 6544           6546           3          0.6        1560.1       1.0X
 
 
 ================================================================================================
@@ -31,7 +31,7 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 byte fields:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 byte fields                    6689           6692           5          0.6        1594.8       1.0X
+single row with 400 byte fields                    6369           6371           2          0.7        1518.6       1.0X
 
 
 ================================================================================================
@@ -42,7 +42,7 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 short fields:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 short fields                   6701           6701           1          0.6        1597.6       1.0X
+single row with 400 short fields                   6426           6427           2          0.7        1532.0       1.0X
 
 
 ================================================================================================
@@ -53,7 +53,7 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 integer fields:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 integer fields                 6594           6596           3          0.6        1572.1       1.0X
+single row with 400 integer fields                 6522           6523           1          0.6        1554.9       1.0X
 
 
 ================================================================================================
@@ -64,6 +64,6 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 single row with 400 float fields:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-single row with 400 float fields                   6569           6572           4          0.6        1566.2       1.0X
+single row with 400 float fields                   6617           6618           1          0.6        1577.6       1.0X
 
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions.codegen;
 
+import java.nio.ByteOrder;
+
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.Platform;
@@ -36,6 +38,9 @@ import org.apache.spark.unsafe.bitset.BitSetMethods;
  * `zeroOutNullBytes` before writing new data.
  */
 public final class UnsafeRowWriter extends UnsafeWriter {
+
+  private static final boolean IS_LITTLE_ENDIAN =
+    ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   private final UnsafeRow row;
 
@@ -135,6 +140,8 @@ public final class UnsafeRowWriter extends UnsafeWriter {
     return startingOffset + nullBitsSize + 8L * ordinal;
   }
 
+  // Boolean keeps the two-store form: converting a boolean to a long requires a conditional,
+  // whose misprediction on unpredictable values costs more than the extra store.
   @Override
   public void write(int ordinal, boolean value) {
     final long offset = getFieldOffset(ordinal);
@@ -142,25 +149,26 @@ public final class UnsafeRowWriter extends UnsafeWriter {
     writeBoolean(offset, value);
   }
 
+  // The methods below write a value narrower than 8 bytes and zero out the rest of the 8-byte
+  // word with a single long store: the value bits must land at the lowest address of the word,
+  // which is the least significant bytes on little-endian and the most significant on big-endian.
+
   @Override
   public void write(int ordinal, byte value) {
-    final long offset = getFieldOffset(ordinal);
-    writeLong(offset, 0L);
-    writeByte(offset, value);
+    final long v = value & 0xFFL;
+    writeLong(getFieldOffset(ordinal), IS_LITTLE_ENDIAN ? v : v << 56);
   }
 
   @Override
   public void write(int ordinal, short value) {
-    final long offset = getFieldOffset(ordinal);
-    writeLong(offset, 0L);
-    writeShort(offset, value);
+    final long v = value & 0xFFFFL;
+    writeLong(getFieldOffset(ordinal), IS_LITTLE_ENDIAN ? v : v << 48);
   }
 
   @Override
   public void write(int ordinal, int value) {
-    final long offset = getFieldOffset(ordinal);
-    writeLong(offset, 0L);
-    writeInt(offset, value);
+    final long v = value & 0xFFFFFFFFL;
+    writeLong(getFieldOffset(ordinal), IS_LITTLE_ENDIAN ? v : v << 32);
   }
 
   @Override
@@ -170,9 +178,8 @@ public final class UnsafeRowWriter extends UnsafeWriter {
 
   @Override
   public void write(int ordinal, float value) {
-    final long offset = getFieldOffset(ordinal);
-    writeLong(offset, 0);
-    writeFloat(offset, value);
+    final long v = Float.floatToRawIntBits(value) & 0xFFFFFFFFL;
+    writeLong(getFieldOffset(ordinal), IS_LITTLE_ENDIAN ? v : v << 32);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `UnsafeRowWriter` to write `byte`/`short`/`int`/`float` fields with a single 8-byte store instead of a zero-out store followed by a narrow value store. `boolean` keeps the two-store form because converting it to a `long` requires a conditional whose misprediction costs more than the extra store.

**BEFORE (float type): writeLong + writeFloat**

https://github.com/apache/spark/blob/e6793ed7981760e585577576014c21fca5f6dc27/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeRowWriter.java#L172-L176

**AFTER (float type): writeLong**

```scala
final long v = value & 0xFFFFFFFFL;
writeLong(getFieldOffset(ordinal), IS_LITTLE_ENDIAN ? v : v << 32);
```

### Why are the changes needed?

To improve a hot path of row serialization.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. The benchmark result files will be regenerated via the GitHub Actions benchmark workflow.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5