### PR TITLE
[SPARK-57993][SS][TEST][branch-4.1] Fix flaky RocksDBStateStoreIntegrationSuite bounded memory usage test by isolating global RocksDBMemoryManager

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -392,6 +392,17 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
         (SQLConf.SHUFFLE_PARTITIONS.key -> "2"), // Use 2 partitions to test multiple providers
         (s"${RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX}.boundedMemoryUsage" -> "true")) {
 
+        // Fully unload state store providers left over from previous tests before touching the
+        // global RocksDBMemoryManager singleton. A preceding test may still be asynchronously
+        // tearing down its (unbounded) query when this test starts; its providers only call
+        // RocksDBMemoryManager.unregisterInstance() from RocksDBStateStoreProvider.close(), which
+        // StreamTest does not force between tests (only afterAll() calls StateStore.stop()). If a
+        // lingering unbounded provider re-reports its memory usage after the reset below, it stays
+        // in the singleton and the "0 unbounded instances" assertion flakes (observed as
+        // "1 did not equal 0", especially under the row-checksum variant whose extra per-row work
+        // widens the teardown window). Stopping first makes close()/unregister run synchronously.
+        StateStore.stop()
+
         // Clear any existing providers from previous tests
         RocksDBMemoryManager.resetWriteBufferManagerAndCache
 


### PR DESCRIPTION
Backport of #57021 / [SPARK-57993](https://issues.apache.org/jira/browse/SPARK-57993) to `branch-4.1`.

### What changes were proposed in this pull request?

Cherry-pick (`-x`) of the merged master commit 05728c8fa3978e3ba6d57e68c7388d22e02904ea, which fixes the flaky `bounded memory usage calculation` test in `RocksDBStateStoreIntegrationSuite` (most visibly its `RocksDBStateStoreIntegrationSuiteWithRowChecksum` variant) by calling `StateStore.stop()` before touching the process-global `RocksDBMemoryManager` singleton, so leftover unbounded providers from the preceding test are unregistered synchronously.

Applies cleanly to `branch-4.1` (no conflicts).

### Why are the changes needed?

Same flake exists on this maintenance branch's CI lanes. See #57021 / SPARK-57993 for the full root-cause analysis.

### Does this PR introduce _any_ user-facing change?

No — test-only.

### How was this patch tested?

Clean cherry-pick of an already-validated master change (validated on the ARM `sql#core` lane in #57021). Existing test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
