### PR TITLE
[SPARK-57739][SQL] Return NULL for Parquet MIN/MAX aggregate push-down over all-null row groups

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -243,6 +243,7 @@ object ParquetUtils extends Logging {
    * from Parquet file footer, and then construct an InternalRow from these aggregate results.
    *
    * NOTE: if statistics is missing from Parquet file footer, exception would be thrown.
+   * A column whose values are all null yields NULL for MIN/MAX, matching their SQL semantics.
    *
    * @return Aggregate results in the format of InternalRow
    */
@@ -278,6 +279,8 @@ object ParquetUtils extends Logging {
       NoopUpdater)
     val primitiveTypeNames = primitiveTypes.map(_.getPrimitiveTypeName)
     primitiveTypeNames.zipWithIndex.foreach {
+      case (_, i) if values(i) == null =>
+        // A null value means MIN/MAX over an all-null column, so the result field stays NULL.
       case (PrimitiveType.PrimitiveTypeName.BOOLEAN, i) =>
         val v = values(i).asInstanceOf[Boolean]
         converter.getConverter(i).asPrimitiveConverter.addBoolean(v)
@@ -347,7 +350,8 @@ object ParquetUtils extends Logging {
             index = dataSchema.fieldNames.toList.indexOf(colName)
             schemaName = "max(" + colName + ")"
             val currentMax = getCurrentBlockMaxOrMin(filePath, blockMetaData, index, true)
-            if (value == None || currentMax.asInstanceOf[Comparable[Any]].compareTo(value) > 0) {
+            if (currentMax != null &&
+              (value == None || currentMax.asInstanceOf[Comparable[Any]].compareTo(value) > 0)) {
               value = currentMax
             }
           case min: Min if V2ColumnUtils.extractV2Column(min.column).isDefined =>
@@ -355,7 +359,8 @@ object ParquetUtils extends Logging {
             index = dataSchema.fieldNames.toList.indexOf(colName)
             schemaName = "min(" + colName + ")"
             val currentMin = getCurrentBlockMaxOrMin(filePath, blockMetaData, index, false)
-            if (value == None || currentMin.asInstanceOf[Comparable[Any]].compareTo(value) < 0) {
+            if (currentMin != null &&
+              (value == None || currentMin.asInstanceOf[Comparable[Any]].compareTo(value) < 0)) {
               value = currentMin
             }
           case count: Count if V2ColumnUtils.extractV2Column(count.column).isDefined =>
@@ -383,7 +388,9 @@ object ParquetUtils extends Logging {
         valuesBuilder += rowCount
         primitiveTypeBuilder += Types.required(PrimitiveTypeName.INT64).named(schemaName);
       } else {
-        valuesBuilder += value
+        // `value` stays `None` when no block contributed a min/max, i.e. all values of the
+        // column are null. The aggregated MIN/MAX is NULL then, represented as a null value.
+        valuesBuilder += (if (value == None) null else value)
         val field = fields.get(index)
         primitiveTypeBuilder += Types.required(field.asPrimitiveType.getPrimitiveTypeName)
           .as(field.getLogicalTypeAnnotation)
@@ -397,22 +404,28 @@ object ParquetUtils extends Logging {
   /**
    * Get the Max or Min value for ith column in the current block
    *
-   * @return the Max or Min value
+   * @return the Max or Min value, or null if all values of the column in this block are null
    */
   private def getCurrentBlockMaxOrMin(
       filePath: String,
       columnChunkMetaData: util.List[ColumnChunkMetaData],
       i: Int,
       isMax: Boolean): Any = {
-    val statistics = columnChunkMetaData.get(i).getStatistics
-    if (!statistics.hasNonNullValue) {
+    val columnChunk = columnChunkMetaData.get(i)
+    val statistics = columnChunk.getStatistics
+    if (statistics.hasNonNullValue) {
+      if (isMax) statistics.genericGetMax else statistics.genericGetMin
+    } else if (statistics.isNumNullsSet && statistics.getNumNulls == columnChunk.getValueCount) {
+      // All values of the column in this block are null. MIN/MAX ignore nulls, so the block
+      // contributes nothing to the aggregate. This mirrors the ORC behavior, see
+      // `OrcUtils.getMinMaxFromColumnStatistics`.
+      null
+    } else {
       throw new SparkUnsupportedOperationException(
         errorClass = "PARQUET_AGGREGATE_PUSH_DOWN_UNSUPPORTED.NO_MIN_MAX",
         messageParameters = Map(
           "filePath" -> filePath,
           "config" -> PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key))
-    } else {
-      if (isMax) statistics.genericGetMax else statistics.genericGetMin
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceAggregatePushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceAggregatePushDownSuite.scala
@@ -631,9 +631,8 @@ trait FileSourceAggregatePushDownSuite
   test("SPARK-57568: aggregate push down - TIME over an empty file") {
     // Aggregating a TIME column over zero rows: MIN/MAX return NULL and COUNT returns 0 on every
     // engine. This pins the no-data path, which the precision test above (always >= 1 row) does
-    // not reach. An all-null but non-empty file is intentionally not asserted here: that is
-    // pre-existing, type-agnostic behavior shared by all push-down types (Parquet rejects MIN/MAX
-    // push-down on an all-null block while ORC returns NULL), unchanged by this PR.
+    // not reach. The all-null but non-empty case is type-agnostic and covered by the
+    // SPARK-57739 tests below.
     Seq(6, 9).foreach { precision =>
       val schema = StructType(Seq(StructField("TimeCol", TimeType(precision))))
       val rdd = sparkContext.parallelize(Seq.empty[Row])
@@ -651,6 +650,61 @@ trait FileSourceAggregatePushDownSuite
                 "PushedAggregation: [MIN(TimeCol), MAX(TimeCol), COUNT(TimeCol), COUNT(*)]")
               checkAnswer(df, Seq(Row(null, null, 0, 0)))
             }
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-57739: aggregate push down - MIN/MAX of an all-null column return NULL") {
+    val schema = StructType(Seq(
+      StructField("i", IntegerType),
+      StructField("j", LongType)))
+    // Column `i` contains only nulls while column `j` has values, so a single query aggregates
+    // an all-null column and a non-null column side by side.
+    val rows = Seq(Row(null, 2L), Row(null, 7L), Row(null, 5L))
+    val rdd = sparkContext.parallelize(rows)
+    withTempPath { file =>
+      spark.createDataFrame(rdd, schema).coalesce(1)
+        .write.format(format).save(file.getCanonicalPath)
+      withTempView("all_null_test") {
+        spark.read.format(format).load(file.getCanonicalPath)
+          .createOrReplaceTempView("all_null_test")
+        Seq("false", "true").foreach { enableVectorizedReader =>
+          withSQLConf(aggPushDownEnabledKey -> "true",
+            vectorizedReaderEnabledKey -> enableVectorizedReader) {
+            val df = sql("SELECT min(i), max(i), min(j), max(j), count(i), count(*) " +
+              "FROM all_null_test")
+            checkPushedInfo(df,
+              "PushedAggregation: [MIN(i), MAX(i), MIN(j), MAX(j), COUNT(i), COUNT(*)]")
+            checkAnswer(df, Seq(Row(null, null, 2L, 7L, 0, 3)))
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-57739: aggregate push down - all-null and non-null splits combine") {
+    val schema = StructType(Seq(StructField("i", IntegerType)))
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      // Two files in the same directory: one whose column is entirely null and one with values.
+      // The all-null file must contribute NULL partial MIN/MAX that the final aggregation skips.
+      spark.createDataFrame(
+          sparkContext.parallelize(Seq(Row(null), Row(null))), schema)
+        .coalesce(1).write.format(format).save(path)
+      spark.createDataFrame(
+          sparkContext.parallelize(Seq(Row(5), Row(9))), schema)
+        .coalesce(1).write.mode("append").format(format).save(path)
+      withTempView("mixed_null_test") {
+        spark.read.format(format).load(path).createOrReplaceTempView("mixed_null_test")
+        Seq("false", "true").foreach { enableVectorizedReader =>
+          withSQLConf(aggPushDownEnabledKey -> "true",
+            vectorizedReaderEnabledKey -> enableVectorizedReader) {
+            val df = sql("SELECT min(i), max(i), count(i), count(*) FROM mixed_null_test")
+            checkPushedInfo(df,
+              "PushedAggregation: [MIN(i), MAX(i), COUNT(i), COUNT(*)]")
+            checkAnswer(df, Seq(Row(5, 9, 2, 4)))
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes Parquet MIN/MAX aggregate push-down so that an all-null row group contributes `NULL` (i.e. nothing) to the aggregate instead of failing the query, and an entirely-null column yields `NULL` as MIN/MAX results:

- `ParquetUtils.getCurrentBlockMaxOrMin` now distinguishes two cases when column statistics have no min/max (`!statistics.hasNonNullValue`):
  - **All-null block** (`statistics.isNumNullsSet && statistics.getNumNulls == valueCount`): returns `null`, meaning the block contributes nothing to MIN/MAX - mirroring `OrcUtils.getMinMaxFromColumnStatistics`, which returns `null` when `getNumberOfValues == 0`.
  - **Genuinely missing statistics**: still throws `PARQUET_AGGREGATE_PUSH_DOWN_UNSUPPORTED.NO_MIN_MAX` (e.g. files written with `parquet.column.statistics.enabled=false`), preserving the behavior guarded by the SPARK-57746 test.
- The MIN/MAX accumulation loop in `getPushedDownAggResult` skips `null` block contributions, and appends `null` (instead of the `None` sentinel) when no block contributed a value.
- `createAggInternalRowFromFooter` leaves the corresponding result field `NULL` when the pushed-down value is `null` (fields of `SpecificInternalRow` start as `NULL`).

### Why are the changes needed?

`MIN`/`MAX` over a column whose values are all `NULL` must return `NULL` per SQL semantics. Before this change, Parquet aggregate push-down threw an error as soon as **any** row group of the column was all-null:

```scala
spark.range(10).selectExpr("CAST(NULL AS LONG) AS v").write.parquet("/tmp/t")
spark.conf.set("spark.sql.parquet.aggregatePushdown", true)
spark.read.parquet("/tmp/t").selectExpr("MIN(v)").show()
```

fails with:

```
[PARQUET_AGGREGATE_PUSH_DOWN_UNSUPPORTED.NO_MIN_MAX] ... No min/max value found in the column statistics. SQLSTATE: 0A000
```

while the same query succeeds and returns `NULL` with push-down disabled, and with the ORC data source (which already treats an all-null stripe as "no contribution"). Fixes SPARK-57739.

### Does this PR introduce _any_ user-facing change?

Yes. With `spark.sql.parquet.aggregatePushdown=true`, MIN/MAX aggregation over a Parquet column containing an all-null row group previously failed with `PARQUET_AGGREGATE_PUSH_DOWN_UNSUPPORTED.NO_MIN_MAX`; it now returns the correct result (`NULL` when the whole column is null), consistent with push-down disabled and with ORC. Queries on files with genuinely missing statistics still fail with the same error as before.

### How was this patch tested?

Two new tests in `FileSourceAggregatePushDownSuite`, which run across Parquet V1/V2 and ORC V1/V2:

- MIN/MAX of an all-null column return `NULL` (alongside a non-null column, COUNT unchanged).
- An all-null file and a non-null file in the same table combine correctly (all-null block contributes nothing).

Both tests fail on master with `PARQUET_AGGREGATE_PUSH_DOWN_UNSUPPORTED.NO_MIN_MAX` in the Parquet suites and pass with this change:

```
build/sbt 'sql/testOnly *AggregatePushDownSuite'
...
Tests: succeeded 105, failed 0, canceled 0, ignored 0, pending 0
```

This includes the existing SPARK-57746 test verifying that files written with statistics disabled still raise `NO_MIN_MAX`/`NO_NUM_NULLS`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)
