### PR TITLE
[SPARK-57953][INFRA] Pin lxml==4.9.4 in branch-4.0 pypy-310 image to fix PyPy build

### DIFF
--- a/dev/spark-test-image/pypy-310/Dockerfile
+++ b/dev/spark-test-image/pypy-310/Dockerfile
@@ -70,4 +70,4 @@ RUN mkdir -p /usr/local/pypy/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.3' scipy coverage matplotlib lxml
+RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.3' scipy coverage matplotlib 'lxml==4.9.4'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin `lxml==4.9.4` in the branch-4.0 PyPy 3.10 test image
(`dev/spark-test-image/pypy-310/Dockerfile`), instead of installing an unpinned `lxml`.

### Why are the changes needed?

`build_python_pypy3.10` on branch-4.0 fails intermittently while building the `pypy-310`
Docker image:

```
#12 ... process "/bin/sh -c pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.3' \
     scipy coverage matplotlib lxml" did not complete successfully: exit code: 1
      Error: Please make sure the libxml2 and libxslt development packages are installed.
ERROR: Failed to build 'lxml' when getting requirements to build wheel
```

Recent `lxml` releases (5.x+) dropped prebuilt PyPy wheels, so `pip` builds `lxml` from
source under PyPy. The source build needs both `libxml2` and `libxslt` development
packages, but the image installs only `libxml2-dev` (not `libxslt1-dev`), so the build
fails. It is intermittent only because the image is cached and rebuilt on cache miss (or
when a newer `lxml` is published).

`branch-4.1`'s `pypy-310` image already pins `lxml==4.9.4` — a version that ships PyPy
wheels, so no source build is needed — and its `build_python_pypy3.10` is green. This
change mirrors that on branch-4.0. (Pinning is preferred over adding `libxslt1-dev`
because it keeps the image consistent with branch-4.1 and avoids a from-source build.)

### Does this PR introduce _any_ user-facing change?

No. Test-infrastructure (CI image) change only.

### How was this patch tested?

Built the `pypy-310` image on a fork via GitHub Actions and confirmed the `lxml` install
step succeeds and `lxml` imports under PyPy.

**CI evidence**

- Failing run (apache/spark, branch-4.0 `build_python_pypy3.10`):
  https://github.com/apache/spark/actions/runs/28747314955
- Passing validation (fork, builds the `pypy-310` image + imports `lxml`):
  https://github.com/HyukjinKwon/spark-agent6/actions/runs/28766514977

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
