### PR TITLE
[SPARK-57954][INFRA] Install libxslt1-dev in the PyPy 3.10 test image so lxml builds from source

### DIFF
--- a/dev/spark-test-image/pypy-310/Dockerfile
+++ b/dev/spark-test-image/pypy-310/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && apt-get install -y \
     libtiff5-dev \
     libwebp-dev \
     libxml2-dev \
+    libxslt1-dev \
     openjdk-17-jdk-headless \
     pkg-config \
     qpdf \
@@ -70,4 +71,4 @@ RUN mkdir -p /usr/local/pypy/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3.10 && \
     ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib 'lxml==4.9.4'
+RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.3.3' scipy coverage matplotlib lxml


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `libxslt1-dev` to the apt-get packages in `dev/spark-test-image/pypy-310/Dockerfile` and drop the `lxml==4.9.4` pin (install plain `lxml` again, consistent with the CPython test images).

### Why are the changes needed?
PyPI does not publish a PyPy wheel for the current lxml, so `pypy3 -m pip install ... lxml` builds lxml from the sdist. The source build needs both the libxml2 and libxslt development headers; the image installs `libxml2-dev` but not `libxslt1-dev`, so an unpinned build fails with `Error: Please make sure the libxml2 and libxslt development packages are installed.` That fails the PyPy 3.10 base image build (`build_python_pypy3.10`) and every downstream `pyspark-*` job. Installing `libxslt1-dev` fixes the root cause and lets lxml build from source for any version, so the `lxml==4.9.4` pin can be dropped and pypy stays consistent with the CPython images. Alternative to #57031 / SPARK-57953 (which pins lxml).

### Does this PR introduce _any_ user-facing change?
No, test-image only.

### How was this patch tested?
CI (the PyPy 3.10 base image build).

### Was this patch authored or co-authored using generative AI tooling?
Yes.

This pull request and its description were written by Isaac.