### PR TITLE
[SPARK-57756][SQL][TESTS] Add buildSQLFunctionConf ANSI-invariant tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -29,8 +29,8 @@ import org.scalatest.matchers.must.Matchers
 import org.apache.spark.SparkException
 import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{AliasIdentifier, QueryPlanningTracker, TableIdentifier}
-import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.{AliasIdentifier, FunctionIdentifier, QueryPlanningTracker, TableIdentifier}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog, SQLFunction}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -1893,6 +1893,69 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     // The expected Project (root node) should only have column "i".
     val expectedPlan = Project(Seq(UnresolvedAttribute("i")), addColumnF).analyze
     checkAnalysis(inputPlan, expectedPlan)
+  }
+
+  private def scalarSQLFunctionWithProps(
+      props: Map[String, String]): SQLFunction = {
+    val intType: DataType = IntegerType
+    val scalarReturnType: Either[DataType, StructType] = scala.Left(intType)
+    SQLFunction(
+      name = FunctionIdentifier("ansi_probe"),
+      inputParam = Some(new StructType().add("x", intType)),
+      returnType = scalarReturnType,
+      exprText = Some("x + 1"),
+      queryText = None,
+      comment = None,
+      collation = None,
+      deterministic = Some(true),
+      containsSQL = Some(true),
+      isTableFunc = false,
+      properties = props)
+  }
+
+  gridTest("SQL UDF body-resolution ANSI: persisted ANSI makes alwaysSetAnsiValue a no-op")(
+      Seq(false, true)) { applySessionOverrides =>
+    val ansiKey = SQLConf.ANSI_ENABLED.key
+    val fnWithPersistedAnsi = scalarSQLFunctionWithProps(Map(s"sqlConfig.$ansiKey" -> "false"))
+
+    withSQLConf(
+        SQLConf.ASSUME_ANSI_FALSE_IF_NOT_PERSISTED.key -> "true",
+        SQLConf.APPLY_SESSION_CONF_OVERRIDES_TO_FUNCTION_RESOLUTION.key ->
+          applySessionOverrides.toString,
+        ansiKey -> "true") {
+      val withFlag = Analyzer.buildSQLFunctionConf(
+        function = fnWithPersistedAnsi,
+        applySessionOverrides = applySessionOverrides,
+        alwaysSetAnsiValue = true)
+      val withoutFlag = Analyzer.buildSQLFunctionConf(
+        function = fnWithPersistedAnsi,
+        applySessionOverrides = applySessionOverrides,
+        alwaysSetAnsiValue = false)
+      assert(withFlag.settings.get(ansiKey) == "false")
+      assert(withoutFlag.settings.get(ansiKey) == "false")
+      assert(withFlag.settings.get(ansiKey) == withoutFlag.settings.get(ansiKey))
+    }
+  }
+
+  test("SQL UDF body-resolution ANSI: flag only bites when ANSI is unpersisted") {
+    val ansiKey = SQLConf.ANSI_ENABLED.key
+    val fnWithoutPersistedAnsi = scalarSQLFunctionWithProps(Map.empty)
+
+    withSQLConf(
+        SQLConf.ASSUME_ANSI_FALSE_IF_NOT_PERSISTED.key -> "true",
+        SQLConf.APPLY_SESSION_CONF_OVERRIDES_TO_FUNCTION_RESOLUTION.key -> "false",
+        ansiKey -> "true") {
+      val withFlag = Analyzer.buildSQLFunctionConf(
+        function = fnWithoutPersistedAnsi,
+        applySessionOverrides = false,
+        alwaysSetAnsiValue = true)
+      val withoutFlag = Analyzer.buildSQLFunctionConf(
+        function = fnWithoutPersistedAnsi,
+        applySessionOverrides = false,
+        alwaysSetAnsiValue = false)
+      assert(withFlag.settings.get(ansiKey) == "false")
+      assert(withoutFlag.settings.get(ansiKey) == null)
+    }
   }
 }
 


### PR DESCRIPTION
Add unit tests for Analyzer.buildSQLFunctionConf covering ANSI handling: a persisted ANSI value makes the alwaysSetAnsiValue flag a no-op, and the flag only takes effect when ANSI is not persisted (under ASSUME_ANSI_FALSE_IF_NOT_PERSISTED).

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Add two unit tests in `AnalysisSuite` for `Analyzer.buildSQLFunctionConf`, the helper
that constructs the throwaway `SQLConf` used to resolve a SQL UDF body. The tests pin
the interaction between the `alwaysSetAnsiValue` parameter and a SQL UDF's persisted
ANSI config:

- When `spark.sql.ansi.enabled` is persisted in the function's stored configs, the
  persisted value wins and `alwaysSetAnsiValue` is a no-op (checked with session
  overrides both on and off).
- When ANSI is not persisted, `alwaysSetAnsiValue=true` seeds it to `false` (via
  `ASSUME_ANSI_FALSE_IF_NOT_PERSISTED`) while `alwaysSetAnsiValue=false` leaves it
  unset.

### Why are the changes needed?

`buildSQLFunctionConf` was extracted in SPARK-57756 (#56895) but only had coverage
through the existing end-to-end SQL UDF resolution tests. These add direct unit
coverage for the ANSI-seeding branch, which is the subtle part of the helper.

### Does this PR introduce _any_ user-facing change?

No. Tests only.

### How was this patch tested?

New tests in `AnalysisSuite`; CI runs them.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic Claude Opus)
