### PR TITLE
[CONNECT] Avoid redundant DSv2 table refresh in Spark Connect

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -83,7 +83,11 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
             sessionHolder.session,
             planner.transformRelation(request.getPlan.getRoot, cachePlan = true),
             tracker,
-            shuffleCleanupMode)
+            shuffleCleanupMode,
+            // Spark Connect re-resolves the plan on each request, so the analyzed plan already
+            // reflects the latest table state. The refresh phase would only re-issue redundant
+            // catalog loads for tables just resolved in this same QueryExecution.
+            refreshPhaseEnabled = false)
         responseObserver.onNext(createSchemaResponse(request.getSessionId, dataframe.schema))
         processAsArrowBatches(dataframe, responseObserver, executeHolder)
         responseObserver.onNext(MetricGenerator.createMetricsResponse(sessionHolder, dataframe))
@@ -95,7 +99,8 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
               session,
               transformer(tracker),
               tracker,
-              shuffleCleanupModeOpt = Some(shuffleCleanupMode))
+              shuffleCleanupModeOpt = Some(shuffleCleanupMode),
+              refreshPhaseEnabled = false)
             qe.assertCommandExecuted()
             executeHolder.eventsManager.postFinished()
           case None =>

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -242,7 +242,9 @@ private[ml] object MLUtils {
   def parseRelationProto(relation: proto.Relation, sessionHolder: SessionHolder): DataFrame = {
     val planner = new SparkConnectPlanner(sessionHolder)
     val plan = planner.transformRelation(relation)
-    Dataset.ofRows(sessionHolder.session, plan)
+    // Spark Connect re-resolves the plan on each request, so the refresh phase would only re-issue
+    // redundant catalog loads for tables just resolved in this same QueryExecution.
+    Dataset.ofRows(sessionHolder.session, plan, refreshPhaseEnabled = false)
   }
 
   /**

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -431,7 +431,8 @@ class SparkConnectPlanner(
    */
   private def transformSample(rel: proto.Sample): LogicalPlan = {
     val plan = if (rel.getDeterministicOrder) {
-      val input = Dataset.ofRows(session, transformRelation(rel.getInput))
+      val input =
+        Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
 
       // It is possible that the underlying dataframe doesn't guarantee the ordering of rows in its
       // constituent partitions each time a split is materialized which could result in
@@ -483,7 +484,8 @@ class SparkConnectPlanner(
       throw InvalidInputErrors.naFillValuesLengthMismatch()
     }
 
-    val dataset = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val dataset =
+      Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
 
     val cols = rel.getColsList.asScala.toArray
     val values = rel.getValuesList.asScala.toArray
@@ -501,7 +503,8 @@ class SparkConnectPlanner(
   }
 
   private def transformNADrop(rel: proto.NADrop): LogicalPlan = {
-    val dataset = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val dataset =
+      Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
 
     val cols = rel.getColsList.asScala.toArray
 
@@ -555,14 +558,14 @@ class SparkConnectPlanner(
   }
 
   private def transformStatCov(rel: proto.StatCov): LogicalPlan = {
-    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val df = Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
     StatFunctions
       .calculateCovImpl(df, Seq(rel.getCol1, rel.getCol2))
       .logicalPlan
   }
 
   private def transformStatCorr(rel: proto.StatCorr): LogicalPlan = {
-    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val df = Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
     if (rel.hasMethod) {
       StatFunctions
         .calculateCorrImpl(df, Seq(rel.getCol1, rel.getCol2), rel.getMethod)
@@ -597,7 +600,7 @@ class SparkConnectPlanner(
 
   private def transformStatFreqItems(rel: proto.StatFreqItems): LogicalPlan = {
     val cols = rel.getColsList.asScala.toSeq
-    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val df = Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
     if (rel.hasSupport) {
       df.stat.freqItems(cols, rel.getSupport).logicalPlan
     } else {
@@ -1752,7 +1755,7 @@ class SparkConnectPlanner(
     }
     def ds: Dataset[String] = {
       val input = transformRelation(rel.getInput)
-      val df = Dataset.ofRows(session, input)
+      val df = Dataset.ofRows(session, input, refreshPhaseEnabled = false)
       val fields = df.schema.fields
       if (fields.length != 1) {
         throw QueryCompilationErrors.dataframeInputNotSingleColumnError(fields.length)
@@ -2511,8 +2514,9 @@ class SparkConnectPlanner(
   }
 
   private def transformAsOfJoin(rel: proto.AsOfJoin): LogicalPlan = {
-    val left = Dataset.ofRows(session, transformRelation(rel.getLeft))
-    val right = Dataset.ofRows(session, transformRelation(rel.getRight))
+    val left = Dataset.ofRows(session, transformRelation(rel.getLeft), refreshPhaseEnabled = false)
+    val right =
+      Dataset.ofRows(session, transformRelation(rel.getRight), refreshPhaseEnabled = false)
     val leftAsOf = Column(transformExpression(rel.getLeftAsOf))
     val rightAsOf = Column(transformExpression(rel.getRightAsOf))
     val joinType = rel.getJoinType
@@ -2567,8 +2571,9 @@ class SparkConnectPlanner(
     assertPlan(rel.getJoinType.nonEmpty, "NearestByJoin.join_type must be set")
     assertPlan(rel.getMode.nonEmpty, "NearestByJoin.mode must be set")
     assertPlan(rel.getDirection.nonEmpty, "NearestByJoin.direction must be set")
-    val left = Dataset.ofRows(session, transformRelation(rel.getLeft))
-    val right = Dataset.ofRows(session, transformRelation(rel.getRight))
+    val left = Dataset.ofRows(session, transformRelation(rel.getLeft), refreshPhaseEnabled = false)
+    val right =
+      Dataset.ofRows(session, transformRelation(rel.getRight), refreshPhaseEnabled = false)
     val rankingExpression = Column(transformExpression(rel.getRankingExpression))
     left
       .nearestByJoin(
@@ -2632,7 +2637,8 @@ class SparkConnectPlanner(
   }
 
   private def transformDrop(rel: proto.Drop): LogicalPlan = {
-    var output = Dataset.ofRows(session, transformRelation(rel.getInput))
+    var output =
+      Dataset.ofRows(session, transformRelation(rel.getInput), refreshPhaseEnabled = false)
     if (rel.getColumnsCount > 0) {
       val cols = rel.getColumnsList.asScala.toSeq.map(expr => Column(transformExpression(expr)))
       output = output.drop(cols.head, cols.tail: _*)
@@ -2720,7 +2726,8 @@ class SparkConnectPlanner(
           rel.getPivot.getValuesList.asScala.toSeq.map(transformLiteral)
         } else {
           RelationalGroupedDataset
-            .collectPivotValues(Dataset.ofRows(session, logicalPlan), Column(pivotExpr))
+            .collectPivotValues(
+              Dataset.ofRows(session, logicalPlan, refreshPhaseEnabled = false), Column(pivotExpr))
             .map(expressions.Literal.apply)
         }
         logical.Pivot(
@@ -3337,7 +3344,7 @@ class SparkConnectPlanner(
     // Transform the input plan into the logical plan.
     val plan = transformRelation(writeOperation.getInput)
     // And create a Dataset from the plan.
-    val dataset = Dataset.ofRows(session, plan, tracker)
+    val dataset = Dataset.ofRows(session, plan, tracker, refreshPhaseEnabled = false)
 
     val w = dataset.write.asInstanceOf[DataFrameWriter[_]]
     if (writeOperation.getMode != proto.WriteOperation.SaveMode.SAVE_MODE_UNSPECIFIED) {
@@ -3397,7 +3404,9 @@ class SparkConnectPlanner(
 
   private def transformAndRunCommand(transformer: QueryPlanningTracker => LogicalPlan): Unit = {
     val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
-    val qe = new QueryExecution(session, transformer(tracker), tracker)
+    // Spark Connect re-resolves the plan on each request, so the refresh phase would only re-issue
+    // redundant catalog loads for tables just resolved in this same QueryExecution.
+    val qe = new QueryExecution(session, transformer(tracker), tracker, refreshPhaseEnabled = false)
     qe.assertCommandExecuted()
     executeHolder.eventsManager.postFinished()
   }
@@ -3416,7 +3425,7 @@ class SparkConnectPlanner(
     // Transform the input plan into the logical plan.
     val plan = transformRelation(writeOperation.getInput)
     // And create a Dataset from the plan.
-    val dataset = Dataset.ofRows(session, plan, tracker)
+    val dataset = Dataset.ofRows(session, plan, tracker, refreshPhaseEnabled = false)
 
     val w = dataset.writeTo(table = writeOperation.getTableName)
 
@@ -3479,7 +3488,7 @@ class SparkConnectPlanner(
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
     val plan = transformRelation(writeOp.getInput)
     val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
-    val dataset = Dataset.ofRows(session, plan, tracker)
+    val dataset = Dataset.ofRows(session, plan, tracker, refreshPhaseEnabled = false)
     // Call manually as writeStream does not trigger ReadyForExecution
     tracker.setReadyForExecution()
 
@@ -4012,7 +4021,8 @@ class SparkConnectPlanner(
     val notMatchedActions = transformActions(cmd.getNotMatchedActionsList)
     val notMatchedBySourceActions = transformActions(cmd.getNotMatchedBySourceActionsList)
 
-    val sourceDs = Dataset.ofRows(session, transformRelation(cmd.getSourceTablePlan), tracker)
+    val sourceDs = Dataset.ofRows(
+      session, transformRelation(cmd.getSourceTablePlan), tracker, refreshPhaseEnabled = false)
     val mergeInto = sourceDs
       .mergeInto(cmd.getTargetTableName, Column(transformExpression(cmd.getMergeCondition)))
       .asInstanceOf[MergeIntoWriter[Row]]

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -88,7 +88,10 @@ private[connect] class SparkConnectAnalyzeHandler(
     def transformRelationPlan(plan: proto.Plan) = transformRelation(plan.getRoot)
 
     def getDataFrameWithoutExecuting(rel: LogicalPlan): DataFrame = {
-      val qe = session.sessionState.executePlan(rel, CommandExecutionMode.SKIP)
+      // Spark Connect re-resolves the plan on each request, so the analyzed plan already reflects
+      // the latest table state and the refresh phase would only re-issue redundant catalog loads.
+      val qe = session.sessionState.executePlan(
+        rel, CommandExecutionMode.SKIP, refreshPhaseEnabled = false)
       new Dataset[Row](qe, () => RowEncoder.encoderFor(qe.analyzed.schema))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -114,6 +114,21 @@ private[sql] object Dataset {
       new Dataset[Row](qe, () => RowEncoder.encoderFor(qe.analyzed.schema))
     }
 
+  // A variant of ofRows that allows disabling the QueryExecution refresh phase. Spark Connect
+  // re-resolves plans on each request, so the refresh phase would only re-issue redundant catalog
+  // loads for tables just resolved in the same QueryExecution. This has no default argument
+  // because only one ofRows overload may define defaults (the tracker-taking variant below).
+  def ofRows(
+      sparkSession: SparkSession,
+      logicalPlan: LogicalPlan,
+      refreshPhaseEnabled: Boolean): DataFrame =
+    sparkSession.withActive {
+      val qe = sparkSession.sessionState.executePlan(
+        logicalPlan, refreshPhaseEnabled = refreshPhaseEnabled)
+      if (!qe.isLazyAnalysis) qe.assertAnalyzed()
+      new Dataset[Row](qe, () => RowEncoder.encoderFor(qe.analyzed.schema))
+    }
+
   def ofRows(
       sparkSession: SparkSession,
       logicalPlan: LogicalPlan,
@@ -130,10 +145,12 @@ private[sql] object Dataset {
       sparkSession: SparkSession,
       logicalPlan: LogicalPlan,
       tracker: QueryPlanningTracker,
-      shuffleCleanupMode: ShuffleCleanupMode = DoNotCleanup)
+      shuffleCleanupMode: ShuffleCleanupMode = DoNotCleanup,
+      refreshPhaseEnabled: Boolean = true)
     : DataFrame = sparkSession.withActive {
     val qe = new QueryExecution(
-      sparkSession, logicalPlan, tracker, shuffleCleanupModeOpt = Some(shuffleCleanupMode))
+      sparkSession, logicalPlan, tracker, shuffleCleanupModeOpt = Some(shuffleCleanupMode),
+      refreshPhaseEnabled = refreshPhaseEnabled)
     if (!qe.isLazyAnalysis) qe.assertAnalyzed()
     new Dataset[Row](qe, () => RowEncoder.encoderFor(qe.analyzed.schema))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -432,10 +432,11 @@ abstract class BaseSessionStateBuilder(
    * Create a query execution object.
    */
   protected def createQueryExecution:
-    (LogicalPlan, CommandExecutionMode.Value) => QueryExecution =
-      (plan, mode) => new QueryExecution(session, plan, mode = mode,
+    (LogicalPlan, CommandExecutionMode.Value, Boolean) => QueryExecution =
+      (plan, mode, refreshPhaseEnabled) => new QueryExecution(session, plan, mode = mode,
         shuffleCleanupModeOpt =
-          Some(QueryExecution.determineShuffleCleanupMode(session.sessionState.conf)))
+          Some(QueryExecution.determineShuffleCleanupMode(session.sessionState.conf)),
+        refreshPhaseEnabled = refreshPhaseEnabled)
 
   /**
    * Interface to start and stop streaming queries.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -88,7 +88,8 @@ private[sql] class SessionState(
     val streamingCheckpointManagerBuilder: () => StreamingCheckpointManager,
     val listenerManager: ExecutionListenerManager,
     resourceLoaderBuilder: () => SessionResourceLoader,
-    createQueryExecution: (LogicalPlan, CommandExecutionMode.Value) => QueryExecution,
+    createQueryExecution:
+      (LogicalPlan, CommandExecutionMode.Value, Boolean) => QueryExecution,
     createClone: (SparkSession, SessionState) => SessionState,
     val columnarRules: Seq[ColumnarRule],
     val adaptiveRulesHolder: AdaptiveRulesHolder,
@@ -141,8 +142,9 @@ private[sql] class SessionState(
 
   def executePlan(
       plan: LogicalPlan,
-      mode: CommandExecutionMode.Value = CommandExecutionMode.ALL): QueryExecution =
-    createQueryExecution(plan, mode)
+      mode: CommandExecutionMode.Value = CommandExecutionMode.ALL,
+      refreshPhaseEnabled: Boolean = true): QueryExecution =
+    createQueryExecution(plan, mode, refreshPhaseEnabled)
 }
 
 private[sql] object SessionState {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -596,8 +596,11 @@ private[hive] class TestHiveSparkSession(
 private[hive] class TestHiveQueryExecution(
     sparkSession: TestHiveSparkSession,
     logicalPlan: LogicalPlan,
-    mode: CommandExecutionMode.Value = CommandExecutionMode.ALL)
-  extends QueryExecution(sparkSession, logicalPlan, mode = mode) with Logging {
+    mode: CommandExecutionMode.Value = CommandExecutionMode.ALL,
+    refreshPhaseEnabled: Boolean = true)
+  extends QueryExecution(
+    sparkSession, logicalPlan, mode = mode, refreshPhaseEnabled = refreshPhaseEnabled)
+  with Logging {
 
   def this(sparkSession: TestHiveSparkSession, sql: String) = {
     this(sparkSession, sparkSession.sessionState.sqlParser.parsePlan(sql))
@@ -675,9 +678,10 @@ private[sql] class TestHiveSessionStateBuilder(
   extends HiveSessionStateBuilder(session, state) {
 
   override def createQueryExecution:
-    (LogicalPlan, CommandExecutionMode.Value) => QueryExecution =
-      (plan, mode) =>
-        new TestHiveQueryExecution(session.asInstanceOf[TestHiveSparkSession], plan, mode)
+    (LogicalPlan, CommandExecutionMode.Value, Boolean) => QueryExecution =
+      (plan, mode, refreshPhaseEnabled) =>
+        new TestHiveQueryExecution(
+          session.asInstanceOf[TestHiveSparkSession], plan, mode, refreshPhaseEnabled)
 
   override protected def newBuilder: NewBuilder = new TestHiveSessionStateBuilder(_, _)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Spark Connect re-resolves and re-analyzes each plan on every request, so by the time a plan reaches execution the analyzed plan already references the latest table state. The `QueryExecution` refresh phase (`tableVersionsRefreshed`, backed by `V2TableRefreshUtil.refresh`) then reloads every versioned DSv2 relation from the catalog again, issuing redundant `catalog.loadTable` calls for tables that were just resolved in the same `QueryExecution`.

This change disables the refresh phase on the Spark Connect server-side execution and analysis paths by threading `refreshPhaseEnabled = false` through the `QueryExecution` construction sites Connect uses.

Details:
- Add a `refreshPhaseEnabled` parameter to `SessionState.executePlan`, forwarded through the `createQueryExecution` factory (`BaseSessionStateBuilder`, and the `TestHive` override). Defaults preserve classic behavior.
- Add a `Dataset.ofRows` overload that accepts `refreshPhaseEnabled`, and thread the flag through the tracker-taking overload. Only one overload may define default arguments, so the new plan-only overload takes the flag without a default.
- Pass `refreshPhaseEnabled = false` at all Spark Connect server-side `QueryExecution` / `Dataset.ofRows` / `executePlan` sites (`SparkConnectPlanExecution`, `SparkConnectAnalyzeHandler`, `SparkConnectPlanner`, `MLUtils`).

### Why are the changes needed?

To avoid extra catalog round-trips in Spark Connect that do not change the outcome. In Connect, analysis and execution happen together, so the refresh phase is redundant. The refresh phase is not what keeps stored-plan temp views fresh (that is the `V2TableReference` analyzer rule), so disabling it does not regress view or table freshness.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing DSv2 freshness suites pass unchanged:
- `DataSourceV2DataFrameConnectSuite` (49 tests) verifies that repeated `sql()`/`table()` access, temp views with stored plans, incrementally constructed joins, and CACHE TABLE all still reflect session and external mutations with the refresh phase disabled.
- `DataSourceV2DataFrameSuite` (203 tests, classic) confirms classic behavior is unchanged.
- `QueryExecutionSuite` (27 tests) confirms the widened `ofRows` / `executePlan` defaults are preserved.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

Co-authored-by: Isaac

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
