### PR TITLE
[SPARK-57966][YARN][DOCS] Update Java 17 support description in `running-on-yarn.md` for Hadoop 3.5.0

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -33,7 +33,7 @@ Please see [Spark Security](security.html) and the specific security sections in
 
 # Launching Spark on YARN
 
-Apache Hadoop does not support Java 17 as of 3.4.1, while Apache Spark requires at least Java 17 since 4.0.0, so a different JDK should be configured for Spark applications.
+Apache Hadoop supports Java 17 since 3.5.0, while Apache Spark requires at least Java 17 since 4.0.0. When running on a YARN cluster whose Hadoop version is older than 3.5.0, a different JDK should be configured for Spark applications.
 Please refer to [Configuring different JDKs for Spark Applications](#configuring-different-jdks-for-spark-applications) for details.
 
 Ensure that `HADOOP_CONF_DIR` or `YARN_CONF_DIR` points to the directory which contains the (client side) configuration files for the Hadoop cluster.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `docs/running-on-yarn.md` to reflect Apache Hadoop 3.5.0 (SPARK-55657).

- https://github.com/apache/spark/pull/54448

Before:

> Apache Hadoop does not support Java 17 as of 3.4.1, ...

After:

> Apache Hadoop supports Java 17 since 3.5.0, ...

### Why are the changes needed?

Apache Hadoop 3.5.0 supports Java 17, so the existing statement is outdated.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5