### PR TITLE
[SPARK-57970][BUILD] Upgrade ASM to 9.10.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -281,7 +281,7 @@ volcano-client/7.8.0//volcano-client-7.8.0.jar
 volcano-model/7.8.0//volcano-model-7.8.0.jar
 wildfly-openssl-macosx-aarch64/2.3.0.Final//wildfly-openssl-macosx-aarch64-2.3.0.Final.jar
 wildfly-openssl/2.3.0.Final//wildfly-openssl-2.3.0.Final.jar
-xbean-asm9-shaded/4.30//xbean-asm9-shaded-4.30.jar
+xbean-asm9-shaded/4.31//xbean-asm9-shaded-4.31.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.12//xz-1.12.jar
 zjsonpatch/7.8.0//zjsonpatch-7.8.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <maven.version>3.9.16</maven.version>
     <exec-maven-plugin.version>3.6.1</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <asm.version>9.9.1</asm.version>
+    <asm.version>9.10.1</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.26.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
@@ -544,7 +544,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>4.30</version>
+        <version>4.31</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,9 +33,9 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "9.9.1"
+libraryDependencies += "org.ow2.asm"  % "asm" % "9.10.1"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.9.1"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.10.1"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `ASM` to 9.10.1 for Apache Spark 5.0.0.

### Why are the changes needed?

ASM 9.10.1 is the latest version, released on 2026-05-23 (following ASM 9.10 on 2026-05-14).
- https://asm.ow2.io/versions.html
  - new Opcodes.V27 constant for Java 27
- https://repo1.maven.org/maven2/org/ow2/asm/asm/9.10.1/

XBean 4.31 was released on 2026-07-06 and shades ASM 9.10.1, so both versions are aligned.
- [[ANNOUNCE] Apache Geronimo XBean 4.31 released](https://lists.apache.org/thread/t2l1360h56t0tb4cjz3m0kxdw9j27hjd)
- https://github.com/apache/geronimo-xbean/releases/tag/xbean-4.31
- https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.31/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5