### PR TITLE
[SPARK-57971][K8S][DOCS] Drop K8s v1.34 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use the [Pod Security Admission Controller](https:
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.34 with access configured to it using
+* A running Kubernetes cluster at version >= 1.35 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.35+ at Apache Spark 5.0.0 (scheduled in 2027) to utilize
more stable features like the following example features at K8s v1.35.

- [In-Place Pod Resize (GA)](https://kubernetes.io/blog/2025/12/19/kubernetes-v1-35-in-place-pod-resize-ga/)

### Why are the changes needed?

**1. K8s v1.34 will enter the maintenance mode soon (2026-08-27) and will reach the end of support on 2026-10-27**
- https://kubernetes.io/releases/patch-releases/#1-34

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.35+ like the following.

- EKS: v1.36 (Default, supported since 2026-06)
- AKS: v1.36 (GA since 2026-06)
- GKE: v1.36 (`Regular` channel in 2026-06)

**3. End Of Support in Public Cloud environments**

In addition, K8s 1.34 will reach the end of standard support.

| K8s  |   AKS   |   EKS   |   GKE   |
| ---- | ------- | ------- | ------- |
| 1.34 | 2026-10 | 2026-12 | 2027-01 |

- [AKS EOL Schedule](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5