### PR TITLE
[SPARK-57972][SS] Preserve the cause when StreamingPythonRunner initialization fails

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -113,9 +113,9 @@ private[spark] class StreamingPythonRunner(
       dataIn.readInt()
     } catch {
       case e: java.net.SocketTimeoutException =>
-        throw new StreamingPythonRunnerInitializationTimeoutException(e.getMessage)
+        throw new StreamingPythonRunnerInitializationTimeoutException(e.getMessage, e)
       case e: Exception =>
-        throw new StreamingPythonRunnerInitializationCommunicationException(e.getMessage)
+        throw new StreamingPythonRunnerInitializationCommunicationException(e.getMessage, e)
     }
 
     // Set timeout back to the original timeout
@@ -132,15 +132,21 @@ private[spark] class StreamingPythonRunner(
     (dataOut, dataIn)
   }
 
-  class StreamingPythonRunnerInitializationCommunicationException(errMessage: String)
+  class StreamingPythonRunnerInitializationCommunicationException(
+      errMessage: String,
+      cause: Throwable = null)
     extends SparkPythonException(
       errorClass = "STREAMING_PYTHON_RUNNER_INITIALIZATION_COMMUNICATION_FAILURE",
-      messageParameters = Map("msg" -> errMessage))
+      messageParameters = Map("msg" -> errMessage),
+      cause = cause)
 
-  class StreamingPythonRunnerInitializationTimeoutException(errMessage: String)
+  class StreamingPythonRunnerInitializationTimeoutException(
+      errMessage: String,
+      cause: Throwable = null)
     extends SparkPythonException(
       errorClass = "STREAMING_PYTHON_RUNNER_INITIALIZATION_TIMEOUT_FAILURE",
-      messageParameters = Map("msg" -> errMessage))
+      messageParameters = Map("msg" -> errMessage),
+      cause = cause)
 
   class StreamingPythonRunnerInitializationException(resFromPython: Int, errMessage: String)
     extends SparkPythonException(


### PR DESCRIPTION
### What changes were proposed in this pull request?

After a python worker initialization exception, preserve the original exception as the cause of the thrown exception

### Why are the changes needed?

Improve observability after failures

### Does this PR introduce _any_ user-facing change?

Yes - additional error context after a python runner initialization failure.

### How was this patch tested?

Existing CI.  No behavior changes

### Was this patch authored or co-authored using generative AI tooling?

No
