### PR TITLE
[SPARK-57981][PYTHON][TESTS] Move packaging test with test-install

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -792,7 +792,7 @@ jobs:
           export SKIP_SCALA_BUILD=true
           echo "Reusing precompiled artifact, skipping local SBT build."
         fi
-        if [[ "$MODULES_TO_TEST" == *"pyspark-pipelines"* ]]; then
+        if [[ "$MODULES_TO_TEST" == *"pyspark-install"* ]]; then
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,7 +100,7 @@ jobs:
       id: set-outputs
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
-          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas')))"`
+          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-install'))"`
           pyspark_pandas_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark-pandas')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           pandas=`./dev/is-changed.py -m $pyspark_pandas_modules`

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -817,8 +817,12 @@ pyspark_ml = Module(
 
 pyspark_install = Module(
     name="pyspark-install",
-    dependencies=[core],
+    dependencies=[],
     source_file_regexes=[
+        # Python package tests will be triggered with this module
+        # Any changes in python/ should trigger this module
+        # This module won't be executed for post-commit CIs so it's cheap
+        "python/",
         "python/pyspark/install.py",
         "python/pyspark/tests/test_install_spark.py",
     ],
@@ -1559,13 +1563,8 @@ pyspark_pandas_slow_connect = Module(
 
 pyspark_errors = Module(
     name="pyspark-errors",
-    dependencies=[],
+    dependencies=[pyspark_core],
     source_file_regexes=[
-        # SPARK-44544: Force the execution of pyspark_errors when there are any changes
-        # in PySpark, since the Python Packaging Tests is only enabled within this module.
-        # This module is the smallest Python test module, it contains only 1 test file
-        # and normally takes < 2 seconds, so the additional cost is small.
-        "python/",
         "python/pyspark/errors",
     ],
     python_test_goals=[

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -36,7 +36,7 @@ def determine_modules_for_files(filenames):
     file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
-    ['pyspark-core', 'pyspark-errors', 'sql']
+    ['pyspark-core', 'pyspark-install', 'sql']
     >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
     ['root']
     """
@@ -123,7 +123,7 @@ def determine_modules_to_test(changed_modules, deduplicated=True):
     ... # doctest: +NORMALIZE_WHITESPACE
     ['avro', 'catalyst', 'connect', 'core', 'docker-integration-tests', 'examples', 'graphx',
      'hive', 'hive-thriftserver', 'mllib', 'mllib-local', 'pipelines', 'protobuf',
-     'pyspark-connect', 'pyspark-core', 'pyspark-install', 'pyspark-ml', 'pyspark-ml-connect',
+     'pyspark-connect', 'pyspark-core', 'pyspark-errors', 'pyspark-ml', 'pyspark-ml-connect',
      'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
      'pyspark-pandas-slow-connect', 'pyspark-pipelines', 'pyspark-resource', 'pyspark-sql',
      'pyspark-streaming', 'pyspark-structured-streaming', 'pyspark-structured-streaming-connect',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

1. We have a python packaging test which used to run with `pyspark-pipelines`. We move it to run with `pyspark-install`.
2. A few month ago, the packaging test executed with `pyspark-errors` so there's some legacy code to trigger `pyspark-errors` for any changes in `python` - that was removed.
3. We don't trigger `pyspark` tests anymore for `pyspark-install`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Python packaging test takes about 5 minutes. It's a low risk test which does not really test any functionality. Running it for every commit is not necessary. With this change, this test will run pre-merge for each PR, and in scheduled CI if it's explicitly specified (`build_coverage` for now). This will save us some minutes for workers.

Also, it's very natural to run packaging tests with installation tests - running it with either pipeline or error is just very arbitrary.

More importantly, the current CI setup will run all pyspark tests if any of the pyspark test needs to run. With the existing dependency, all pyspark tests will run if anything changes in `python/`, including `python/docs` or `python/packaging`, which is unnecessary.

After this change, we can skip post-merge pyspark tests if the change is not in python/pyspark, which will save us some minutes too.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, this is CI only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI should confirm that packaging test does not run with `pyspark-pipelines` anymore.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.