### PR TITLE
[SPARK-57984][BUILD] Upgrade `lz4-java` to 1.11.1

### DIFF
--- a/core/benchmarks/LZ4TPCDSDataBenchmark-jdk21-results.txt
+++ b/core/benchmarks/LZ4TPCDSDataBenchmark-jdk21-results.txt
@@ -2,16 +2,16 @@
 Benchmark LZ4CompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Compression:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression 4 times                                2342           2349           9          0.0   585571861.0       1.0X
+Compression 4 times                                2349           2359          14          0.0   587182739.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Decompression:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decompression 4 times                               748            776          24          0.0   187029239.5       1.0X
+Decompression 4 times                               696            721          24          0.0   173988845.5       1.0X
 
 

--- a/core/benchmarks/LZ4TPCDSDataBenchmark-jdk25-results.txt
+++ b/core/benchmarks/LZ4TPCDSDataBenchmark-jdk25-results.txt
@@ -2,16 +2,16 @@
 Benchmark LZ4CompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Compression:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression 4 times                                2343           2353          15          0.0   585680834.0       1.0X
+Compression 4 times                                2366           2368           4          0.0   591406476.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Decompression:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decompression 4 times                               721            729           9          0.0   180327142.3       1.0X
+Decompression 4 times                               731            754          21          0.0   182636355.0       1.0X
 
 

--- a/core/benchmarks/LZ4TPCDSDataBenchmark-results.txt
+++ b/core/benchmarks/LZ4TPCDSDataBenchmark-results.txt
@@ -2,16 +2,16 @@
 Benchmark LZ4CompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Compression:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression 4 times                                2543           2547           6          0.0   635681307.2       1.0X
+Compression 4 times                                2544           2553          12          0.0   636048570.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Decompression:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decompression 4 times                               767            768           2          0.0   191709504.8       1.0X
+Decompression 4 times                               799            803           3          0.0   199759137.0       1.0X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -189,7 +189,7 @@ log4j-api/2.26.0//log4j-api-2.26.0.jar
 log4j-core/2.26.0//log4j-core-2.26.0.jar
 log4j-layout-template-json/2.26.0//log4j-layout-template-json-2.26.0.jar
 log4j-slf4j2-impl/2.26.0//log4j-slf4j2-impl-2.26.0.jar
-lz4-java/1.11.0//lz4-java-1.11.0.jar
+lz4-java/1.11.1//lz4-java-1.11.1.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar
 metrics-jmx/4.2.37//metrics-jmx-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.0</version>
+        <version>1.11.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `at.yawk.lz4:lz4-java` to 1.11.1.

### Why are the changes needed?

To bring the latest bug fixes from the following release.

- https://github.com/yawkat/lz4-java/releases/tag/v1.11.1 (2026-07-06)
  - [Native XXHash implementations can crash the JVM when passed invalid byte array ranges](https://github.com/yawkat/lz4-java/security/advisories/GHSA-xx22-p4ch-683r)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5