### PR TITLE
[MINOR][PS][DOC] Fix typos in pandas-on-Spark docstrings

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1136,7 +1136,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         There is a behavior difference between pandas-on-Spark and pandas:
 
         * when there is no aggregation column, and `n` not equal to 0 or -1,
-            the returned empty dataframe may have an index with different lenght `__len__`.
+            the returned empty dataframe may have an index with different length `__len__`.
 
         Examples
         --------

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6000,7 +6000,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         -----
         Indices are assumed to be sorted. Raises if this is not the case and config
         'compute.eager_check' is True. If 'compute.eager_check' is False pandas-on-Spark just
-        proceeds and performs by ignoring the indeces's order
+        proceeds and performs by ignoring the indices' order
 
         Examples
         --------


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix two typos in pandas-on-Spark docstrings:
- `groupby.py`: `lenght` -> `length`
- `series.py`: `indeces's` -> `indices'`

### Why are the changes needed?
The typos appear in the published API documentation.

### Does this PR introduce _any_ user-facing change?
No, docstring-only.

### How was this patch tested?
N/A, doc-only change.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code