### PR TITLE
[SPARK-54938][PYTHON][TEST][FOLLOW-UP] Fix inferred time unit for ns Timestamp/Timedelta under pandas 3

### DIFF
--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_type_inference.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_type_inference.py
@@ -328,12 +328,15 @@ class PyArrowArrayTypeInferenceTests(unittest.TestCase):
             (pd.Series([date1, date2]), pa.date32()),
             (pd.Series(pd.to_datetime(["2024-01-01", "2024-01-02"])), pa.timestamp(ts_unit)),
             (pd.Series([pd.Timestamp("1970-01-01")]), pa.timestamp(ts_unit)),
-            (pd.Series([pd.Timestamp.min]), pa.timestamp(ts_unit)),
-            (pd.Series([pd.Timestamp.max]), pa.timestamp(ts_unit)),
+            # Timestamp.min/max carry nanosecond precision, so they stay ns-resolution
+            # even under the pandas 3 microsecond default.
+            (pd.Series([pd.Timestamp.min]), pa.timestamp("ns")),
+            (pd.Series([pd.Timestamp.max]), pa.timestamp("ns")),
             (pd.Series(pd.to_timedelta(["1 day", "2 hours"])), pa.duration(ts_unit)),
-            (pd.Series([pd.Timedelta(0)]), pa.duration(ts_unit)),
-            (pd.Series([pd.Timedelta.min]), pa.duration(ts_unit)),
-            (pd.Series([pd.Timedelta.max]), pa.duration(ts_unit)),
+            # Likewise Timedelta(0)/min/max are constructed at nanosecond resolution.
+            (pd.Series([pd.Timedelta(0)]), pa.duration("ns")),
+            (pd.Series([pd.Timedelta.min]), pa.duration("ns")),
+            (pd.Series([pd.Timedelta.max]), pa.duration("ns")),
             # Timezone-aware
             (pd.Series([dt1_sg, dt2_sg]), pa.timestamp(ts_unit, tz="Asia/Singapore")),
             (pd.Series([ts1_la, ts2_la]), pa.timestamp(ts_unit, tz=la)),


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `test_pandas_series_numpy_backed`, expect nanosecond resolution for the `pd.Timestamp.min` / `pd.Timestamp.max` and `pd.Timedelta(0)` / `.min` / `.max` cases instead of following the pandas-3 `us` default used for the other temporal cases.

### Why are the changes needed?

Align with pandas 3.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

`test_pyarrow_array_type_inference` passes under pandas 3 + pyarrow 23 and under pandas 2 + pyarrow 22.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
