### PR TITLE
[SPARK-54937][PYTHON][TESTS][FOLLOW-UP] Fix pytz-specific tz assertion for pandas 3 zoneinfo

### DIFF
--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_ignore_timezone.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_ignore_timezone.py
@@ -112,7 +112,9 @@ class PyArrowIgnoreTimeZoneTests(unittest.TestCase):
         # The corresponding numpy type np.datetime64 is timezone-naive, so no need to test
         ser1 = pd.Series([ts1], dtype=pd.DatetimeTZDtype("us", tz=tz))
         self.assertEqual(ser1.dtype.unit, "us")
-        self.assertEqual(ser1.dtype.tz.zone, tz)
+        # Use str() rather than the pytz-specific .zone attribute: pandas 3 defaults to
+        # zoneinfo.ZoneInfo, which has no .zone. str() yields the zone name for both.
+        self.assertEqual(str(ser1.dtype.tz), tz)
 
         # pyarrow-backed series
         ser2 = pd.Series([ts1], dtype=pd.ArrowDtype(pa_type))


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `test_timezone_with_pandas`, compare the series timezone via `str(dtype.tz)` instead of the pytz-specific `dtype.tz.zone` attribute.

### Why are the changes needed?

pandas 3 defaults tz-aware dtypes to `zoneinfo.ZoneInfo` instead of `pytz`. `ZoneInfo` has no `.zone` attribute, so `ser1.dtype.tz.zone` raised `AttributeError: 'zoneinfo.ZoneInfo' object has no attribute 'zone'` under pandas 3. `str(dtype.tz)` yields the zone name (e.g. "Asia/Singapore") for both `pytz` (pandas 2) and `zoneinfo` (pandas 3). 

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

`test_pyarrow_ignore_timezone` passes under pandas 3 + pyarrow 23, pandas 2 + pyarrow 23, and pandas 2 + pyarrow 22.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8