### PR TITLE
[SPARK-57995][BUILD] Upgrade `ammonite` to 3.0.9 and `semanticdb-shared` to 4.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     ./python/packaging/client/setup.py, and ./python/packaging/connect/setup.py too.
     -->
     <arrow.version>19.0.0</arrow.version>
-    <ammonite.version>3.0.8</ammonite.version>
+    <ammonite.version>3.0.9</ammonite.version>
     <jjwt.version>0.13.0</jjwt.version>
 
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->

--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.scalameta</groupId>
       <artifactId>semanticdb-shared_${scala.binary.version}</artifactId>
-      <version>4.13.10</version>
+      <version>4.15.2</version>
       <exclusions>
         <exclusion>
           <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades `ammonite` to `3.0.9` and `semanticdb-shared` to 4.15.2

### Why are the changes needed?
The full release notes for `ammonite` 3.0.9 as follows:
https://github.com/com-lihaoyi/Ammonite/releases/tag/3.0.9

`semanticdb-shared` should be upgraded correspondingly.
https://mvnrepository.com/artifact/com.lihaoyi/ammonite-interp_2.13.18/3.0.9/dependencies

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
