### PR TITLE
[SPARK-58001] [SQL] Improve `UNSUPPORTED_EXPR_FOR_OPERATOR` error message

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8142,8 +8142,8 @@
   },
   "UNSUPPORTED_EXPR_FOR_OPERATOR" : {
     "message" : [
-      "A query operator contains one or more unsupported expressions.",
-      "Consider to rewrite it to avoid window functions, aggregate functions, and generator functions in the WHERE clause.",
+      "The query operator <operator> contains one or more unsupported expressions.",
+      "Consider to rewrite it to avoid window functions, aggregate functions, and generator functions in the <operator> operator.",
       "Invalid expressions: [<invalidExprSqls>]"
     ],
     "sqlState" : "42K0E"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1129,6 +1129,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
             other.failAnalysis(
               errorClass = "UNSUPPORTED_EXPR_FOR_OPERATOR",
               messageParameters = Map(
+                "operator" -> other.nodeName,
                 "invalidExprSqls" -> invalidExprSqls.mkString(", ")))
 
           case j @ LateralJoin(_, right, _, _)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
@@ -815,7 +815,7 @@ class Resolver(
   private def validateInvalidExpressions(operator: LogicalPlan): Unit = {
     val invalidExpressions = expressionResolver.getLastInvalidExpressionsInTheContextOfOperator
     if (invalidExpressions.nonEmpty) {
-      throwUnsupportedExprForOperator(invalidExpressions)
+      throwUnsupportedExprForOperator(operator, invalidExpressions)
     }
 
     val subqueryExpressions =
@@ -871,10 +871,13 @@ class Resolver(
       summary = operator.origin.context.summary()
     )
 
-  private def throwUnsupportedExprForOperator(invalidExpressions: Seq[Expression]): Nothing = {
+  private def throwUnsupportedExprForOperator(
+      operator: LogicalPlan,
+      invalidExpressions: Seq[Expression]): Nothing = {
     throw new AnalysisException(
       errorClass = "UNSUPPORTED_EXPR_FOR_OPERATOR",
       messageParameters = Map(
+        "operator" -> operator.nodeName,
         "invalidExprSqls" -> makeCommaSeparatedExpressionString(invalidExpressions)
       )
     )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveSubquerySuite.scala
@@ -177,7 +177,9 @@ class ResolveSubquerySuite extends AnalysisTest {
     assertAnalysisErrorCondition(
       plan,
       expectedErrorCondition = "UNSUPPORTED_EXPR_FOR_OPERATOR",
-      expectedMessageParameters = Map("invalidExprSqls" -> "\"sum(a)\", \"sum(c)\"")
+      expectedMessageParameters = Map(
+        "operator" -> "LateralJoin",
+        "invalidExprSqls" -> "\"sum(a)\", \"sum(c)\"")
     )
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/group-analytics.sql.out
@@ -1767,7 +1767,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"row_number() OVER (ORDER BY a ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
+    "invalidExprSqls" : "\"row_number() OVER (ORDER BY a ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"",
+    "operator" : "Aggregate"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/order-by-and-having-on-top-of-aggregate-with-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/order-by-and-having-on-top-of-aggregate-with-join.sql.out
@@ -2387,7 +2387,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2428,7 +2429,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2897,7 +2899,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2938,7 +2941,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
@@ -322,7 +322,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"row_number() OVER (ORDER BY salary ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
+    "invalidExprSqls" : "\"row_number() OVER (ORDER BY salary ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"",
+    "operator" : "Join"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -342,7 +343,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"RANK() OVER (ORDER BY 1 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
+    "invalidExprSqls" : "\"RANK() OVER (ORDER BY 1 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"",
+    "operator" : "Aggregate"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/window-with-aggregates.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/window-with-aggregates.sql.out
@@ -67,7 +67,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col1)\""
+    "invalidExprSqls" : "\"sum(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -122,7 +123,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -148,7 +150,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col2)\""
+    "invalidExprSqls" : "\"sum(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -176,7 +179,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\""
+    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -202,7 +206,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -230,7 +235,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -285,7 +291,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -311,7 +318,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(col2)\""
+    "invalidExprSqls" : "\"count(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -340,7 +348,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\""
+    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
@@ -2096,7 +2096,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"row_number() OVER (ORDER BY a ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
+    "invalidExprSqls" : "\"row_number() OVER (ORDER BY a ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"",
+    "operator" : "Aggregate"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/order-by-and-having-on-top-of-aggregate-with-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/order-by-and-having-on-top-of-aggregate-with-join.sql.out
@@ -1711,7 +1711,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1756,7 +1757,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2233,7 +2235,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2278,7 +2281,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"max(col1)\""
+    "invalidExprSqls" : "\"max(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
@@ -337,7 +337,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"row_number() OVER (ORDER BY salary ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
+    "invalidExprSqls" : "\"row_number() OVER (ORDER BY salary ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"",
+    "operator" : "Join"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -359,7 +360,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"RANK() OVER (ORDER BY 1 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
+    "invalidExprSqls" : "\"RANK() OVER (ORDER BY 1 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"",
+    "operator" : "Aggregate"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/window-with-aggregates.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window-with-aggregates.sql.out
@@ -73,7 +73,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col1)\""
+    "invalidExprSqls" : "\"sum(col1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -132,7 +133,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -160,7 +162,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col2)\""
+    "invalidExprSqls" : "\"sum(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -190,7 +193,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\""
+    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -218,7 +222,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -248,7 +253,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -307,7 +313,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(1)\""
+    "invalidExprSqls" : "\"count(1)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -335,7 +342,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"count(col2)\""
+    "invalidExprSqls" : "\"count(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -366,7 +374,8 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_EXPR_FOR_OPERATOR",
   "sqlState" : "42K0E",
   "messageParameters" : {
-    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\""
+    "invalidExprSqls" : "\"sum(col1)\", \"avg(col2)\"",
+    "operator" : "Sort"
   },
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?
To improve message for `UNSUPPORTED_EXPR_FOR_OPERATOR` exception.

### Why are the changes needed?
In order to improve error message.

### Does this PR introduce _any_ user-facing change?
Better error message.

### How was this patch tested?
Testing change.

### Was this patch authored or co-authored using generative AI tooling?
Yes.