### PR TITLE
[DO-NOT-MERGE] Retry Docker image pull in DockerJDBCIntegrationSuite to avoid transient 502 aborts

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -111,6 +111,11 @@ abstract class DockerJDBCIntegrationSuite
     sys.props.getOrElse("spark.test.docker.removePulledImage", "true").toBoolean
   protected val imagePullTimeout: Long =
     timeStringAsSeconds(sys.props.getOrElse("spark.test.docker.imagePullTimeout", "5min"))
+  // Number of attempts to pull the Docker image before giving up. Image pulls occasionally fail
+  // with transient registry/proxy errors (e.g. HTTP 502 Bad Gateway) that abort the whole suite
+  // in beforeAll even though a retry would succeed, so retry a few times with backoff.
+  protected val imagePullAttempts: Int =
+    sys.props.getOrElse("spark.test.docker.imagePullAttempts", "3").toInt
   protected val startContainerTimeout: Long =
     timeStringAsSeconds(sys.props.getOrElse("spark.test.docker.startContainerTimeout", "5min"))
   protected val connectionTimeout: PatienceConfiguration.Timeout = {
@@ -153,27 +158,48 @@ abstract class DockerJDBCIntegrationSuite
       } catch {
         case e: NotFoundException =>
           log.warn(s"Docker image ${db.imageName} not found; pulling image from registry")
-          val callback = new PullImageResultCallback {
-            override def onNext(item: PullResponseItem): Unit = {
-              super.onNext(item)
-              val status = item.getStatus
-              if (status != null && status != "Downloading" && status != "Extracting") {
-                logInfo(s"$status ${item.getId}")
+          // Retry the pull a few times: it can fail with transient registry/proxy errors
+          // (e.g. HTTP 502 Bad Gateway) or a timeout that would otherwise abort the suite.
+          var attempt = 0
+          var lastError: Throwable = null
+          while (!pulled && attempt < imagePullAttempts) {
+            attempt += 1
+            val callback = new PullImageResultCallback {
+              override def onNext(item: PullResponseItem): Unit = {
+                super.onNext(item)
+                val status = item.getStatus
+                if (status != null && status != "Downloading" && status != "Extracting") {
+                  logInfo(s"$status ${item.getId}")
+                }
               }
             }
+            try {
+              val (success, time) = Utils.timeTakenMs(
+                docker.pullImageCmd(db.imageName)
+                  .exec(callback)
+                  .awaitCompletion(imagePullTimeout, TimeUnit.SECONDS))
+
+              if (success) {
+                pulled = true
+                logInfo(s"Successfully pulled image ${db.imageName} in $time ms")
+              } else {
+                lastError = new TimeoutException(
+                  s"Timeout('$imagePullTimeout secs') waiting for image ${db.imageName} " +
+                    "to be pulled")
+              }
+            } catch {
+              case NonFatal(e) =>
+                lastError = e
+            }
+            if (!pulled && attempt < imagePullAttempts) {
+              log.warn(s"Failed to pull image ${db.imageName} " +
+                s"(attempt $attempt/$imagePullAttempts); retrying", lastError)
+              // Linear backoff between attempts to let a transient registry issue recover.
+              Thread.sleep(TimeUnit.SECONDS.toMillis(5L * attempt))
+            }
           }
-
-          val (success, time) = Utils.timeTakenMs(
-            docker.pullImageCmd(db.imageName)
-              .exec(callback)
-              .awaitCompletion(imagePullTimeout, TimeUnit.SECONDS))
-
-          if (success) {
-            pulled = success
-            logInfo(s"Successfully pulled image ${db.imageName} in $time ms")
-          } else {
-            throw new TimeoutException(
-              s"Timeout('$imagePullTimeout secs') waiting for image ${db.imageName} to be pulled")
+          if (!pulled) {
+            throw lastError
           }
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

**[DO-NOT-MERGE draft — flaky-test deflake, verification in progress]**

Fixes a flaky failure in the `build_java17` scheduled workflow on `branch-4.1`.
`PostgresKrbIntegrationSuite` aborted in `beforeAll` because the Docker image pull hit a transient registry error (`HTTP 502 Bad Gateway`). `DockerJDBCIntegrationSuite` pulled the image with a single attempt, so one transient 502 (or a one-off pull timeout) aborts the entire suite even though the rest of the run had zero test failures.

This wraps the image pull in a bounded retry loop (`spark.test.docker.imagePullAttempts`, default `3`) with linear backoff. Transient failures are retried; the last failure is rethrown once all attempts are exhausted.

### Why are the changes needed?

A single transient registry hiccup should not abort a whole Docker integration suite that otherwise passes.

### Does this PR introduce _any_ user-facing change?

No. Test-infrastructure change only.

### How was this patch tested?

Existing Docker integration suites exercise this path; verified via fork CI (linked below). The change uses only symbols already imported/used in the file and stays within scalastyle limits.

### CI verification

- branch-4.1 (build_java17, docker-integration-tests): _pending_
