### PR TITLE
[SPARK-58019][PYTHON] Convert Arrow list columns to Python rows in bulk

### DIFF
--- a/python/benchmarks/bench_arrow.py
+++ b/python/benchmarks/bench_arrow.py
@@ -114,3 +114,43 @@ class NullableLongArrowToPandasBenchmark:
 
     def peakmem_long_with_nulls_to_pandas_ext(self, n_rows, method):
         self.run_long_with_nulls_to_pandas_ext(n_rows, method)
+
+
+class ArrowListColumnToRowsBenchmark:
+    """
+    Benchmark for converting Arrow list-typed columns to Python rows, the hot
+    path of Arrow-optimized Python UDF inputs and Spark Connect collect().
+
+    ``baseline`` measures plain ``column.to_pylist()``; ``bulk`` measures
+    ``ArrowTableToRowsConversion._to_pylist`` (see apache/arrow#50326).
+    """
+
+    params = [
+        [100000, 1000000],
+        ["baseline", "bulk"],
+    ]
+    param_names = ["n_rows", "method"]
+
+    def setup(self, n_rows, method):
+        from pyspark.sql.conversion import ArrowTableToRowsConversion
+
+        self.list_of_strings = pa.array(
+            [[f"s{i}", f"t{i}"] for i in range(n_rows)], type=pa.list_(pa.string())
+        )
+        self.nested_ints_with_nulls = pa.array(
+            [[[i, i + 1], None, [i + 2]] if i % 10 != 0 else None for i in range(n_rows)],
+            type=pa.list_(pa.list_(pa.int32())),
+        )
+        if method == "bulk":
+            self.convert = ArrowTableToRowsConversion._to_pylist
+        else:
+            self.convert = lambda column: column.to_pylist()
+
+    def time_list_of_strings_to_rows(self, n_rows, method):
+        self.convert(self.list_of_strings)
+
+    def time_nested_ints_with_nulls_to_rows(self, n_rows, method):
+        self.convert(self.nested_ints_with_nulls)
+
+    def peakmem_list_of_strings_to_rows(self, n_rows, method):
+        self.convert(self.list_of_strings)

--- a/python/benchmarks/bench_arrow.py
+++ b/python/benchmarks/bench_arrow.py
@@ -141,6 +141,13 @@ class ArrowListColumnToRowsBenchmark:
             [[[i, i + 1], None, [i + 2]] if i % 10 != 0 else None for i in range(n_rows)],
             type=pa.list_(pa.list_(pa.int32())),
         )
+        self.array_of_structs = pa.array(
+            [
+                [{"i": i, "s": f"a{i}"}, {"i": i + 1, "s": f"b{i}"}] if i % 10 != 0 else None
+                for i in range(n_rows)
+            ],
+            type=pa.list_(pa.struct([("i", pa.int32()), ("s", pa.string())])),
+        )
         if method == "bulk":
             self.convert = ArrowTableToRowsConversion._to_pylist
         else:
@@ -152,5 +159,14 @@ class ArrowListColumnToRowsBenchmark:
     def time_nested_ints_with_nulls_to_rows(self, n_rows, method):
         self.convert(self.nested_ints_with_nulls)
 
+    def time_array_of_structs_to_rows(self, n_rows, method):
+        self.convert(self.array_of_structs)
+
     def peakmem_list_of_strings_to_rows(self, n_rows, method):
         self.convert(self.list_of_strings)
+
+    def peakmem_nested_ints_with_nulls_to_rows(self, n_rows, method):
+        self.convert(self.nested_ints_with_nulls)
+
+    def peakmem_array_of_structs_to_rows(self, n_rows, method):
+        self.convert(self.array_of_structs)

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -506,6 +506,21 @@ class PandasToArrowConversion:
         return pa.RecordBatch.from_arrays(arrays, schema.names)
 
 
+_numpy_available: Optional[bool] = None
+
+
+def _is_numpy_available() -> bool:
+    global _numpy_available
+    if _numpy_available is None:
+        try:
+            import numpy  # noqa: F401
+
+            _numpy_available = True
+        except ImportError:
+            _numpy_available = False
+    return _numpy_available
+
+
 class LocalDataToArrowConversion:
     """
     Conversion from local data (except pandas DataFrame and numpy ndarray) to Arrow.
@@ -1003,9 +1018,7 @@ class ArrowTableToRowsConversion:
         import pyarrow as pa
         import pyarrow.types as pa_types
 
-        try:
-            import numpy  # noqa: F401
-        except ImportError:
+        if not _is_numpy_available():
             return column.to_pylist()
 
         if isinstance(column, pa.ChunkedArray):

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -18,6 +18,7 @@
 import array
 import datetime
 import decimal
+import functools
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union, overload
 
 import pyspark
@@ -506,47 +507,6 @@ class PandasToArrowConversion:
         return pa.RecordBatch.from_arrays(arrays, schema.names)
 
 
-# The pure-Python bulk conversion in ArrowTableToRowsConversion._to_pylist is
-# a workaround for PyArrow materializing one Scalar per element (see
-# apache/arrow#50326). PyArrow releases containing the fix convert natively
-# without per-element Scalars, in which case the native conversion is used
-# directly. Bump this constant if the fix ships in a different release.
-_MIN_PYARROW_NATIVE_TO_PYLIST_VERSION = "25.0.1"
-
-_pyarrow_native_to_pylist_is_fast: Optional[bool] = None
-
-
-def _has_fast_native_to_pylist() -> bool:
-    global _pyarrow_native_to_pylist_is_fast
-    if _pyarrow_native_to_pylist_is_fast is None:
-        import pyarrow as pa
-        from pyspark.loose_version import LooseVersion
-
-        _pyarrow_native_to_pylist_is_fast = LooseVersion(pa.__version__) >= LooseVersion(
-            _MIN_PYARROW_NATIVE_TO_PYLIST_VERSION
-        )
-    return _pyarrow_native_to_pylist_is_fast
-
-
-# None means not yet checked; True/False after the first _is_numpy_available()
-# call. NumPy is only needed indirectly here (pyarrow's Array.to_numpy in
-# _to_pylist), so unlike stateful_processor_api_client.py no np module
-# reference is cached.
-has_numpy: Optional[bool] = None
-
-
-def _is_numpy_available() -> bool:
-    global has_numpy
-    if has_numpy is None:
-        try:
-            import numpy  # noqa: F401
-
-            has_numpy = True
-        except ImportError:
-            has_numpy = False
-    return has_numpy
-
-
 class LocalDataToArrowConversion:
     """
     Conversion from local data (except pandas DataFrame and numpy ndarray) to Arrow.
@@ -1022,10 +982,40 @@ class ArrowTableToRowsConversion:
     """
 
     @staticmethod
+    @functools.cache
+    def _should_manual_bulk() -> bool:
+        """
+        Whether ``_to_pylist`` should convert nested columns manually in bulk.
+
+        Internal helper for ``_to_pylist`` only; do not use externally. Returns True
+        when the installed PyArrow still materializes one Scalar per element in
+        ``to_pylist`` (apache/arrow#50326, fix expected in PyArrow 25.0.1 — adjust the
+        version below if it ships in a different release) and NumPy (used for the
+        offsets and validity buffers) is available.
+
+        This method and the manual bulk paths in ``_to_pylist`` should be removed once
+        the minimum supported PyArrow version contains the fix.
+        """
+        import pyarrow as pa
+        from pyspark.loose_version import LooseVersion
+
+        if LooseVersion(pa.__version__) >= LooseVersion("25.0.1"):
+            # Native to_pylist converts without per-element Scalars.
+            return False
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    @staticmethod
     def _to_pylist(column: Union["pa.Array", "pa.ChunkedArray"]) -> List[Any]:
         """
         Equivalent to ``column.to_pylist()``, but converts (nested) list columns in bulk
         instead of one scalar at a time.
+
+        Internal helper for the worker and ``convert`` call sites; do not use
+        externally.
 
         ``Array.to_pylist()`` materializes one Scalar per element; for list types each row
         additionally allocates a C++ scalar, a Python Scalar wrapper and a Python Array
@@ -1038,15 +1028,13 @@ class ArrowTableToRowsConversion:
         only for the offsets (non-null integers) and the validity bitmap (booleans), so no
         value coercion can occur.
 
-        This can be removed once the minimum supported PyArrow version includes the fix
-        for apache/arrow#50326.
+        This method should be removed (its call sites reverting to plain
+        ``column.to_pylist()``) once the minimum supported PyArrow version includes the
+        fix for apache/arrow#50326.
         """
         import pyarrow as pa
 
-        if _has_fast_native_to_pylist() or not _is_numpy_available():
-            # Recent PyArrow converts without per-element Scalars natively
-            # (apache/arrow#50326); without NumPy the bulk paths below are
-            # unavailable. Either way, use the native conversion.
+        if not ArrowTableToRowsConversion._should_manual_bulk():
             return column.to_pylist()
 
         if isinstance(column, pa.ChunkedArray):

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -506,6 +506,28 @@ class PandasToArrowConversion:
         return pa.RecordBatch.from_arrays(arrays, schema.names)
 
 
+# The pure-Python bulk conversion in ArrowTableToRowsConversion._to_pylist is
+# a workaround for PyArrow materializing one Scalar per element (see
+# apache/arrow#50326). PyArrow releases containing the fix convert natively
+# without per-element Scalars, in which case the native conversion is used
+# directly. Bump this constant if the fix ships in a different release.
+_MIN_PYARROW_NATIVE_TO_PYLIST_VERSION = "25.0.1"
+
+_pyarrow_native_to_pylist_is_fast: Optional[bool] = None
+
+
+def _has_fast_native_to_pylist() -> bool:
+    global _pyarrow_native_to_pylist_is_fast
+    if _pyarrow_native_to_pylist_is_fast is None:
+        import pyarrow as pa
+        from pyspark.loose_version import LooseVersion
+
+        _pyarrow_native_to_pylist_is_fast = LooseVersion(pa.__version__) >= LooseVersion(
+            _MIN_PYARROW_NATIVE_TO_PYLIST_VERSION
+        )
+    return _pyarrow_native_to_pylist_is_fast
+
+
 _numpy_available: Optional[bool] = None
 
 
@@ -1018,7 +1040,10 @@ class ArrowTableToRowsConversion:
         import pyarrow as pa
         import pyarrow.types as pa_types
 
-        if not _is_numpy_available():
+        if _has_fast_native_to_pylist() or not _is_numpy_available():
+            # Recent PyArrow converts without per-element Scalars natively
+            # (apache/arrow#50326); without NumPy the bulk paths below are
+            # unavailable. Either way, use the native conversion.
             return column.to_pylist()
 
         if isinstance(column, pa.ChunkedArray):

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1019,6 +1019,9 @@ class ArrowTableToRowsConversion:
             column
         ) > 0:
             n = len(column)
+            # List offset buffers never carry a validity bitmap, so this conversion is
+            # always zero-copy; zero_copy_only=True asserts that invariant and would
+            # fail loudly if a future Arrow list variant ever violated it.
             offsets = column.offsets.to_numpy(zero_copy_only=True).tolist()
             start = offsets[0]
             flat = ArrowTableToRowsConversion._to_pylist(

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -981,6 +981,60 @@ class ArrowTableToRowsConversion:
     """
 
     @staticmethod
+    def _to_pylist(column: Union["pa.Array", "pa.ChunkedArray"]) -> List[Any]:
+        """
+        Equivalent to ``column.to_pylist()``, but converts (nested) list columns in bulk
+        instead of one scalar at a time.
+
+        ``Array.to_pylist()`` materializes one Scalar per element; for list types each row
+        additionally allocates a C++ scalar, a Python Scalar wrapper and a Python Array
+        wrapper for the row's values before converting elements one by one, which is
+        several times slower than converting the flattened child values in a single pass
+        and slicing the resulting Python list per row (see apache/arrow#50326). The values
+        themselves are still converted by Arrow's own ``to_pylist``, so results are exactly
+        identical: ``None`` stays ``None`` and values inside numeric lists stay Python ints,
+        unlike a pandas round trip which would coerce them to floats/NaN. NumPy is used
+        only for the offsets (non-null integers) and the validity bitmap (booleans), so no
+        value coercion can occur.
+
+        This can be removed once the minimum supported PyArrow version includes the fix
+        for apache/arrow#50326.
+        """
+        import pyarrow as pa
+        import pyarrow.types as pa_types
+
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            return column.to_pylist()
+
+        if isinstance(column, pa.ChunkedArray):
+            result: List[Any] = []
+            for chunk in column.chunks:
+                result.extend(ArrowTableToRowsConversion._to_pylist(chunk))
+            return result
+
+        column_type = column.type
+        if (pa_types.is_list(column_type) or pa_types.is_large_list(column_type)) and len(
+            column
+        ) > 0:
+            n = len(column)
+            offsets = column.offsets.to_numpy(zero_copy_only=True).tolist()
+            start = offsets[0]
+            flat = ArrowTableToRowsConversion._to_pylist(
+                column.values.slice(start, offsets[-1] - start)
+            )
+            if column.null_count == 0:
+                return [flat[offsets[i] - start : offsets[i + 1] - start] for i in range(n)]
+            valid = column.is_valid().to_numpy(zero_copy_only=False).tolist()
+            return [
+                flat[offsets[i] - start : offsets[i + 1] - start] if valid[i] else None
+                for i in range(n)
+            ]
+
+        return column.to_pylist()
+
+    @staticmethod
     def _need_converter(dataType: DataType) -> bool:
         if isinstance(dataType, NullType):
             return True
@@ -1069,9 +1123,9 @@ class ArrowTableToRowsConversion:
                 dataType.elementType, none_on_identity=True, binary_as_bytes=binary_as_bytes
             )
 
-            assert element_conv is not None, (
-                f"_need_converter() returned True for ArrayType of {dataType.elementType}"
-            )
+            assert (
+                element_conv is not None
+            ), f"_need_converter() returned True for ArrayType of {dataType.elementType}"
 
             def convert_array(value: Any) -> Any:
                 if value is None:
@@ -1306,7 +1360,11 @@ class ArrowTableToRowsConversion:
             ]
 
             columnar_data = [
-                [conv(v) for v in column.to_pylist()] if conv is not None else column.to_pylist()
+                (
+                    [conv(v) for v in ArrowTableToRowsConversion._to_pylist(column)]
+                    if conv is not None
+                    else ArrowTableToRowsConversion._to_pylist(column)
+                )
                 for column, conv in zip(table.columns, field_converters)
             ]
 

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -528,19 +528,23 @@ def _has_fast_native_to_pylist() -> bool:
     return _pyarrow_native_to_pylist_is_fast
 
 
-_numpy_available: Optional[bool] = None
+# None means not yet checked; True/False after the first _is_numpy_available()
+# call. NumPy is only needed indirectly here (pyarrow's Array.to_numpy in
+# _to_pylist), so unlike stateful_processor_api_client.py no np module
+# reference is cached.
+has_numpy: Optional[bool] = None
 
 
 def _is_numpy_available() -> bool:
-    global _numpy_available
-    if _numpy_available is None:
+    global has_numpy
+    if has_numpy is None:
         try:
             import numpy  # noqa: F401
 
-            _numpy_available = True
+            has_numpy = True
         except ImportError:
-            _numpy_available = False
-    return _numpy_available
+            has_numpy = False
+    return has_numpy
 
 
 class LocalDataToArrowConversion:
@@ -1038,7 +1042,6 @@ class ArrowTableToRowsConversion:
         for apache/arrow#50326.
         """
         import pyarrow as pa
-        import pyarrow.types as pa_types
 
         if _has_fast_native_to_pylist() or not _is_numpy_available():
             # Recent PyArrow converts without per-element Scalars natively
@@ -1047,13 +1050,13 @@ class ArrowTableToRowsConversion:
             return column.to_pylist()
 
         if isinstance(column, pa.ChunkedArray):
-            result: List[Any] = []
+            result = []
             for chunk in column.chunks:
                 result.extend(ArrowTableToRowsConversion._to_pylist(chunk))
             return result
 
         column_type = column.type
-        if (pa_types.is_list(column_type) or pa_types.is_large_list(column_type)) and len(
+        if (pa.types.is_list(column_type) or pa.types.is_large_list(column_type)) and len(
             column
         ) > 0:
             n = len(column)

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1043,8 +1043,7 @@ class ArrowTableToRowsConversion:
                 result.extend(ArrowTableToRowsConversion._to_pylist(chunk))
             return result
 
-        column_type = column.type
-        if (pa.types.is_list(column_type) or pa.types.is_large_list(column_type)) and len(
+        if (pa.types.is_list(column.type) or pa.types.is_large_list(column.type)) and len(
             column
         ) > 0:
             n = len(column)

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1126,9 +1126,9 @@ class ArrowTableToRowsConversion:
                 dataType.elementType, none_on_identity=True, binary_as_bytes=binary_as_bytes
             )
 
-            assert (
-                element_conv is not None
-            ), f"_need_converter() returned True for ArrayType of {dataType.elementType}"
+            assert element_conv is not None, (
+                f"_need_converter() returned True for ArrayType of {dataType.elementType}"
+            )
 
             def convert_array(value: Any) -> Any:
                 if value is None:

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -851,6 +851,26 @@ class ArrowColumnToPylistTests(unittest.TestCase):
     column.to_pylist() returns, including exact element types.
     """
 
+    def setUp(self):
+        # Force the bulk paths so they stay covered regardless of the
+        # installed PyArrow version (with a fast native PyArrow the method
+        # short-circuits to column.to_pylist()).
+        import pyspark.sql.conversion as conversion_mod
+
+        self._conversion_mod = conversion_mod
+        self._saved_gate = conversion_mod._pyarrow_native_to_pylist_is_fast
+        conversion_mod._pyarrow_native_to_pylist_is_fast = False
+
+    def tearDown(self):
+        self._conversion_mod._pyarrow_native_to_pylist_is_fast = self._saved_gate
+
+    def test_native_to_pylist_gate(self):
+        import pyarrow as pa
+
+        column = pa.array([[1, None], None], type=pa.list_(pa.int32()))
+        self._conversion_mod._pyarrow_native_to_pylist_is_fast = True
+        self.assertEqual(ArrowTableToRowsConversion._to_pylist(column), [[1, None], None])
+
     def _assert_identical_types(self, actual, expected):
         self.assertIs(type(actual), type(expected))
         if isinstance(actual, (list, tuple)):

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -844,6 +844,7 @@ class ArrowArrayToPandasConversionTests(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
 
+@unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)
 class ArrowColumnToPylistTests(unittest.TestCase):
     """
     ArrowTableToRowsConversion._to_pylist must return exactly what

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -844,6 +844,83 @@ class ArrowArrayToPandasConversionTests(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
 
+class ArrowColumnToPylistTests(unittest.TestCase):
+    """
+    ArrowTableToRowsConversion._to_pylist must return exactly what
+    column.to_pylist() returns, including exact element types.
+    """
+
+    def _assert_identical_types(self, actual, expected):
+        self.assertIs(type(actual), type(expected))
+        if isinstance(actual, (list, tuple)):
+            self.assertEqual(len(actual), len(expected))
+            for a, e in zip(actual, expected):
+                self._assert_identical_types(a, e)
+
+    def test_matches_to_pylist(self):
+        import pyarrow as pa
+
+        columns = [
+            pa.array([[1, None, 3], None, [], [4]], type=pa.list_(pa.int32())),
+            pa.array([["a", None], None, [], ["bcd", ""]], type=pa.list_(pa.string())),
+            pa.array([["a", None], None, ["b"]], type=pa.large_list(pa.string())),
+            pa.array([[[1], None, [2, None]], None], type=pa.list_(pa.list_(pa.int32()))),
+            pa.array(
+                [[{"a": 1, "b": "x"}, None], None],
+                type=pa.list_(pa.struct([("a", pa.int32()), ("b", pa.string())])),
+            ),
+            pa.array([[("k1", 1), ("k2", None)], None, []], type=pa.map_(pa.string(), pa.int32())),
+            pa.array([[1.5, None], [float("nan")]], type=pa.list_(pa.float64())),
+            pa.array([1, None, 3], type=pa.int64()),
+            pa.array(["x", None], type=pa.string()),
+            pa.array([], type=pa.list_(pa.int32())),
+            pa.array([None, None], type=pa.list_(pa.string())),
+            pa.array([[1, 2], None], type=pa.list_(pa.int64(), 2)),
+        ]
+        for column in columns:
+            views = [column, column.slice(1), column.slice(0, max(len(column) - 1, 0))]
+            views.append(pa.chunked_array([column, column.slice(1)], type=column.type))
+            for view in views:
+                with self.subTest(type=str(column.type), length=len(view)):
+                    actual = ArrowTableToRowsConversion._to_pylist(view)
+                    expected = view.to_pylist()
+                    # NaN != NaN; compare via repr for the float case
+                    self.assertEqual(repr(actual), repr(expected))
+                    self._assert_identical_types(actual, expected)
+
+    def test_int_list_with_nulls_stays_int(self):
+        # The exact case that makes a pandas round trip unusable: ints must not
+        # become floats/NaN when the list contains nulls.
+        import pyarrow as pa
+
+        result = ArrowTableToRowsConversion._to_pylist(
+            pa.array([[1, None, 3]], type=pa.list_(pa.int32()))
+        )
+        self.assertEqual(result, [[1, None, 3]])
+        self.assertEqual([type(v) for v in result[0]], [int, type(None), int])
+
+    def test_convert_table_with_list_columns(self):
+        import pyarrow as pa
+
+        schema = (
+            StructType()
+            .add("arr", ArrayType(IntegerType()))
+            .add("nested", ArrayType(ArrayType(StringType())))
+        )
+        tbl = pa.table(
+            {
+                "arr": pa.array([[1, None], None, []], type=pa.list_(pa.int32())),
+                "nested": pa.array(
+                    [[["a"], None], [[]], None], type=pa.list_(pa.list_(pa.string()))
+                ),
+            }
+        )
+        actual = ArrowTableToRowsConversion.convert(tbl, schema)
+        self.assertEqual(actual[0], Row(arr=[1, None], nested=[["a"], None]))
+        self.assertEqual(actual[1], Row(arr=None, nested=[[]]))
+        self.assertEqual(actual[2], Row(arr=[], nested=None))
+
+
 if __name__ == "__main__":
     from pyspark.testing import main
 

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -16,6 +16,7 @@
 #
 import datetime
 import unittest
+import unittest.mock
 from zoneinfo import ZoneInfo
 
 from pyspark.errors import PySparkRuntimeError, PySparkTypeError, PySparkValueError
@@ -852,24 +853,25 @@ class ArrowColumnToPylistTests(unittest.TestCase):
     """
 
     def setUp(self):
-        # Force the bulk paths so they stay covered regardless of the
+        # Force the manual bulk paths so they stay covered regardless of the
         # installed PyArrow version (with a fast native PyArrow the method
         # short-circuits to column.to_pylist()).
-        import pyspark.sql.conversion as conversion_mod
-
-        self._conversion_mod = conversion_mod
-        self._saved_gate = conversion_mod._pyarrow_native_to_pylist_is_fast
-        conversion_mod._pyarrow_native_to_pylist_is_fast = False
+        self._gate_patcher = unittest.mock.patch.object(
+            ArrowTableToRowsConversion, "_should_manual_bulk", lambda: True
+        )
+        self._gate_patcher.start()
 
     def tearDown(self):
-        self._conversion_mod._pyarrow_native_to_pylist_is_fast = self._saved_gate
+        self._gate_patcher.stop()
 
     def test_native_to_pylist_gate(self):
         import pyarrow as pa
 
         column = pa.array([[1, None], None], type=pa.list_(pa.int32()))
-        self._conversion_mod._pyarrow_native_to_pylist_is_fast = True
-        self.assertEqual(ArrowTableToRowsConversion._to_pylist(column), [[1, None], None])
+        with unittest.mock.patch.object(
+            ArrowTableToRowsConversion, "_should_manual_bulk", lambda: False
+        ):
+            self.assertEqual(ArrowTableToRowsConversion._to_pylist(column), [[1, None], None])
 
     def _assert_identical_types(self, actual, expected):
         self.assertIs(type(actual), type(expected))

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2616,9 +2616,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One GROUPED_MAP_ARROW_ITER UDF expected here."
         grouped_udf, arg_offsets, return_type, num_udf_args = udfs[0]
         parsed_offsets = extract_key_value_indexes(arg_offsets)
-        assert (
-            len(parsed_offsets) == 1
-        ), "Expected one pair of offsets for GROUPED_MAP_ARROW_ITER UDF."
+        assert len(parsed_offsets) == 1, (
+            "Expected one pair of offsets for GROUPED_MAP_ARROW_ITER UDF."
+        )
 
         arrow_return_type = to_arrow_type(
             return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
@@ -2752,9 +2752,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One GROUPED_MAP_PANDAS_ITER UDF expected here."
         grouped_udf, arg_offsets, return_type, num_udf_args = udfs[0]
         parsed_offsets = extract_key_value_indexes(arg_offsets)
-        assert (
-            len(parsed_offsets) == 1
-        ), "Expected one pair of offsets for GROUPED_MAP_PANDAS_ITER UDF."
+        assert len(parsed_offsets) == 1, (
+            "Expected one pair of offsets for GROUPED_MAP_PANDAS_ITER UDF."
+        )
 
         key_offsets = parsed_offsets[0][0]
         value_offsets = parsed_offsets[0][1]
@@ -3123,7 +3123,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             coerce = (
                 str
                 if isinstance(udf_return_type, StringType)
-                else bytes if isinstance(udf_return_type, BinaryType) else None
+                else bytes
+                if isinstance(udf_return_type, BinaryType)
+                else None
             )
             udf_infos.append(
                 (
@@ -3365,9 +3367,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         # See TransformWithStateInPandasExec for how arg_offsets are used to
         # distinguish between grouping attributes and data attributes
         parsed_offsets = extract_key_value_indexes(arg_offsets)
-        assert (
-            len(parsed_offsets) == 1
-        ), "Expected one pair of offsets for TRANSFORM_WITH_STATE_PANDAS UDF."
+        assert len(parsed_offsets) == 1, (
+            "Expected one pair of offsets for TRANSFORM_WITH_STATE_PANDAS UDF."
+        )
 
         key_offsets = parsed_offsets[0][0]
         value_offsets = parsed_offsets[0][1]

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1755,9 +1755,9 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                     # then call eval once per input row.
                     pylist = [
                         (
-                            [conv(v) for v in column.to_pylist()]
+                            [conv(v) for v in ArrowTableToRowsConversion._to_pylist(column)]
                             if conv is not None
-                            else column.to_pylist()
+                            else ArrowTableToRowsConversion._to_pylist(column)
                         )
                         for column, conv in zip(batch.columns, converters)
                     ]
@@ -2616,9 +2616,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One GROUPED_MAP_ARROW_ITER UDF expected here."
         grouped_udf, arg_offsets, return_type, num_udf_args = udfs[0]
         parsed_offsets = extract_key_value_indexes(arg_offsets)
-        assert len(parsed_offsets) == 1, (
-            "Expected one pair of offsets for GROUPED_MAP_ARROW_ITER UDF."
-        )
+        assert (
+            len(parsed_offsets) == 1
+        ), "Expected one pair of offsets for GROUPED_MAP_ARROW_ITER UDF."
 
         arrow_return_type = to_arrow_type(
             return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
@@ -2752,9 +2752,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One GROUPED_MAP_PANDAS_ITER UDF expected here."
         grouped_udf, arg_offsets, return_type, num_udf_args = udfs[0]
         parsed_offsets = extract_key_value_indexes(arg_offsets)
-        assert len(parsed_offsets) == 1, (
-            "Expected one pair of offsets for GROUPED_MAP_PANDAS_ITER UDF."
-        )
+        assert (
+            len(parsed_offsets) == 1
+        ), "Expected one pair of offsets for GROUPED_MAP_PANDAS_ITER UDF."
 
         key_offsets = parsed_offsets[0][0]
         value_offsets = parsed_offsets[0][1]
@@ -3067,7 +3067,11 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
 
                 # --- Input: Arrow -> Python columns ---
                 columns = [
-                    [conv(v) for v in col.to_pylist()] if conv is not None else col.to_pylist()
+                    (
+                        [conv(v) for v in ArrowTableToRowsConversion._to_pylist(col)]
+                        if conv is not None
+                        else ArrowTableToRowsConversion._to_pylist(col)
+                    )
                     for col, conv in zip(input_batch.itercolumns(), arrow_to_py_converters)
                 ]
                 if not columns:
@@ -3119,9 +3123,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             coerce = (
                 str
                 if isinstance(udf_return_type, StringType)
-                else bytes
-                if isinstance(udf_return_type, BinaryType)
-                else None
+                else bytes if isinstance(udf_return_type, BinaryType) else None
             )
             udf_infos.append(
                 (
@@ -3363,9 +3365,9 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         # See TransformWithStateInPandasExec for how arg_offsets are used to
         # distinguish between grouping attributes and data attributes
         parsed_offsets = extract_key_value_indexes(arg_offsets)
-        assert len(parsed_offsets) == 1, (
-            "Expected one pair of offsets for TRANSFORM_WITH_STATE_PANDAS UDF."
-        )
+        assert (
+            len(parsed_offsets) == 1
+        ), "Expected one pair of offsets for TRANSFORM_WITH_STATE_PANDAS UDF."
 
         key_offsets = parsed_offsets[0][0]
         value_offsets = parsed_offsets[0][1]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `ArrowTableToRowsConversion._to_pylist`, which converts Arrow list-typed columns to Python values in bulk: the flattened child values are converted with a single recursive `to_pylist` call, and the resulting Python list is sliced per row using the offsets and the validity bitmap. It is used in the Arrow-to-rows conversion paths (Spark Connect `collect()`, Arrow batch UDF inputs, Arrow UDTF inputs). Non-list columns, map columns and environments without NumPy fall back to plain `column.to_pylist()`.

Leaf values are still converted by Arrow's own `to_pylist`, so results are exactly identical to `column.to_pylist()`: `None` stays `None` and values inside numeric lists stay Python ints. NumPy is used only for the offsets (non-null integers) and the validity bitmap (booleans), never for the values, so the type coercion problems of a pandas round trip (`list<int32>` of `[1, None, 3]` becoming `[1.0, nan, 3.0]`) cannot occur.

This is an interim measure for a PyArrow-side inefficiency: `Array.to_pylist()` materializes one Scalar per element, and for list types each row additionally allocates a C++ scalar, a Python Scalar wrapper and a Python Array wrapper before converting elements one by one (root-caused in apache/arrow#50326, fix proposed in apache/arrow#50327). The helper documents this and can be removed once the minimum supported PyArrow version includes the upstream fix.

### Why are the changes needed?

Converting Arrow list columns to Python rows is the hot path of Arrow-optimized Python UDF inputs and Spark Connect `collect()`. With plain `to_pylist()` it is several times slower than necessary, which caused a performance regression on array columns when Arrow serialization became the default for regular Python UDFs.

ASV microbenchmark (`python/benchmarks/bench_arrow.py::ArrowListColumnToRowsBenchmark`, added in this PR; 1M rows, macOS arm64, PyArrow 24.0.0):

| case | `to_pylist()` | this PR | speedup |
|---|---|---|---|
| `list<string>` | 769 ms | 507 ms | 1.5x |
| `list<list<int32>>` with nulls | 1.86 s | 537 ms | 3.5x |

Peak memory is unchanged.

### Does this PR introduce _any_ user-facing change?

No. Only performance; conversion results are byte-identical (covered by exact-type tests).

### How was this patch tested?

New `ArrowColumnToPylistTests` in `python/pyspark/sql/tests/test_conversion.py`, comparing `_to_pylist` against `column.to_pylist()` with exact element-type assertions across list/large_list/nested/struct/map/fixed-size-list columns, sliced and chunked variants, plus a dedicated test that `list<int32>` of `[1, None, 3]` stays ints, and an end-to-end `ArrowTableToRowsConversion.convert` test with array columns. Full `test_conversion.py` passes. The new ASV benchmark class parametrizes `baseline` vs `bulk`, so the comparison above is reproducible with `./python/asv run --python=same --quick -b 'bench_arrow.ArrowListColumnToRowsBenchmark'`.

### Was this patch authored or co-authored using generative AI tooling?

Yes. This pull request and its description were written by Isaac (Claude Code).
