### PR TITLE
[SPARK-58020][PYTHON][TESTS][4.1] Fix flaky test_data_source_writer_with_logging

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -1199,8 +1199,20 @@ class BasePythonDataSourceTestsMixin:
 
                 logs = self.spark.tvf.python_worker_logs()
 
+                # We could get either 1 or 2 "TestJsonWriter.write: abort test" logs because
+                # the operation is time sensitive. When the first partition gets aborted,
+                # the executor will cancel the rest of the tasks. Whether we are able to get
+                # the second log depends on whether the second partition starts before the
+                # cancellation. When we use simple worker, the second log is often missing
+                # because the spawn overhead is large.
+                non_abort_logs = logs.select("level", "msg", "context", "logger").filter(
+                    "msg != 'TestJsonWriter.write: abort test'"
+                )
+                abort_logs = logs.select("level", "msg", "context", "logger").filter(
+                    "msg == 'TestJsonWriter.write: abort test'"
+                )
                 assertDataFrameEqual(
-                    logs.select("level", "msg", "context", "logger"),
+                    non_abort_logs,
                     [
                         Row(
                             level="WARNING",
@@ -1246,18 +1258,21 @@ class BasePythonDataSourceTestsMixin:
                                 {"class_name": "TestJsonDataSource", "func_name": "writer"},
                             ),
                             (
-                                "TestJsonWriter.write: abort test",
-                                {"class_name": "TestJsonWriter", "func_name": "write"},
-                            ),
-                            (
-                                "TestJsonWriter.write: abort test",
-                                {"class_name": "TestJsonWriter", "func_name": "write"},
-                            ),
-                            (
                                 "TestJsonWriter.abort",
                                 {"class_name": "TestJsonWriter", "func_name": "abort"},
                             ),
                         ]
+                    ],
+                )
+                assertDataFrameEqual(
+                    abort_logs.dropDuplicates(["msg"]),
+                    [
+                        Row(
+                            level="WARNING",
+                            msg="TestJsonWriter.write: abort test",
+                            context={"class_name": "TestJsonWriter", "func_name": "write"},
+                            logger="test_datasource_writer",
+                        )
                     ],
                 )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a test-only fix that isolates the flake fix from SPARK-55799 for `branch-4.1`. `test_data_source_writer_with_logging` asserted exactly two `"TestJsonWriter.write: abort test"` log rows. That count is not guaranteed: when the first partition is aborted, the executor cancels the remaining tasks, so whether the second partition logs before cancellation is time sensitive. The assertion is split so abort logs are matched with `dropDuplicates(["msg"])`, tolerating either 1 or 2 abort logs.

Note: SPARK-55799 on master also changed `python/pyspark/logger/worker_io.py` and added a `PythonDataSourceTestsWithSimpleWorker` suite. Those are intentionally **not** included here -- the simple-worker suite depends on the `worker_io.py` change, and this PR is scoped to just de-flaking the existing test on `branch-4.1`.

### Why are the changes needed?
The test is flaky on `branch-4.1` (e.g. [this run](https://github.com/apache/spark/actions/runs/28858827107/job/85596316246) failed with `[DIFFERENT_ROWS]`, missing the second abort log). master and branch-4.2 already carry the fix via SPARK-55799; branch-4.1 was never backported.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing `test_data_source_writer_with_logging` in `pyspark.sql.tests.test_python_datasource`. The revised assertion passes whether the race produces 1 or 2 abort logs.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)
