### PR TITLE
[SPARK-57852][SQL] Support TIME endpoints in the sequence function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3327,6 +3327,9 @@ case class Sequence(
             stepOpt.isEmpty || CalendarIntervalType.acceptsType(stepType) ||
               YearMonthIntervalType.acceptsType(stepType) ||
               DayTimeIntervalType.acceptsType(stepType)
+          case _: TimeType =>
+            // TIME lives within a single day, so only a day-time interval step is meaningful.
+            stepOpt.isEmpty || DayTimeIntervalType.acceptsType(stepType)
           case _: IntegralType =>
             stepOpt.isEmpty || DataTypeUtils.sameType(stepType, startType)
           case _ => false
@@ -3339,7 +3342,8 @@ case class Sequence(
         errorSubClass = "SEQUENCE_WRONG_INPUT_TYPES",
         messageParameters = Map(
           "functionName" -> toSQLId(prettyName),
-          "startType" -> toSQLType(TypeCollection(TimestampType, TimestampNTZType, DateType)),
+          "startType" -> toSQLType(
+            TypeCollection(TimestampType, TimestampNTZType, DateType, AnyTimeType)),
           "stepType" -> toSQLType(
             TypeCollection(CalendarIntervalType, YearMonthIntervalType, DayTimeIntervalType)),
           "otherStartType" -> toSQLType(IntegralType)
@@ -3386,6 +3390,9 @@ case class Sequence(
       } else {
         new DurationSequenceImpl[Int](IntegerType, start.dataType, MICROS_PER_DAY, _.toInt, zoneId)
       }
+
+    case TimeType(precision) =>
+      new TimeSequenceImpl(precision)
   }
 
   override def eval(input: InternalRow): Any = {
@@ -3548,6 +3555,55 @@ object Sequence {
          |while ($i > 0) {
          |  $i--;
          |  $arr[$i] = ($elemType) ($start + $step * $i);
+         |}
+         """.stripMargin
+    }
+  }
+
+  private class TimeSequenceImpl(precision: Int) extends InternalSequence {
+
+    // A sequence over TIME stays within the day domain [0, NANOS_PER_DAY) by construction: every
+    // produced value lies between the in-day start and stop endpoints. So a plain integral walk in
+    // nanoseconds is sufficient - no calendar, DST, or time zone arithmetic is involved.
+    override val defaultStep: DefaultStep = new DefaultStep(
+      PhysicalDataType.ordering(LongType).lteq _,
+      DayTimeIntervalType(),
+      // Default increment when no step is given: 1 second, expressed as the interval's micros.
+      MICROS_PER_SECOND)
+
+    override def eval(input1: Any, input2: Any, input3: Any): Array[Long] = {
+      val start = input1.asInstanceOf[Long]
+      val stop = input2.asInstanceOf[Long]
+      // TIME is stored as nanos-of-day, while a day-time interval is stored as microseconds.
+      val stepNanos = Math.multiplyExact(input3.asInstanceOf[Long], NANOS_PER_MICROS)
+
+      var i: Int = getSequenceLength(start, stop, stepNanos, stepNanos)
+      val arr = new Array[Long](i)
+      while (i > 0) {
+        i -= 1
+        arr(i) = truncateTimeToPrecision(start + stepNanos * i, precision)
+      }
+      arr
+    }
+
+    private val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
+
+    override def genCode(
+        ctx: CodegenContext,
+        start: String,
+        stop: String,
+        step: String,
+        arr: String,
+        elemType: String): String = {
+      val i = ctx.freshName("i")
+      val stepNanos = ctx.freshName("stepNanos")
+      s"""
+         |final long $stepNanos = $step * ${NANOS_PER_MICROS}L;
+         |${genSequenceLengthCode(ctx, start, stop, stepNanos, stepNanos, i)}
+         |$arr = new $elemType[$i];
+         |while ($i > 0) {
+         |  $i--;
+         |  $arr[$i] = $dtu.truncateTimeToPrecision($start + $stepNanos * $i, $precision);
          |}
          """.stripMargin
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3243,12 +3243,14 @@ case class Flatten(child: Expression) extends UnaryExpression
       incrementing by step. The type of the returned elements is the same as the type of argument
       expressions.
 
-      Supported types are: byte, short, integer, long, date, timestamp.
+      Supported types are: byte, short, integer, long, date, timestamp, time.
 
       The start and stop expressions must resolve to the same type.
       If start and stop expressions resolve to the 'date' or 'timestamp' type
       then the step expression must resolve to the 'interval' or 'year-month interval' or
-      'day-time interval' type, otherwise to the same type as the start and stop expressions.
+      'day-time interval' type. If they resolve to the 'time' type then the step expression
+      must resolve to the 'day-time interval' type. Otherwise the step expression must
+      resolve to the same type as the start and stop expressions.
   """,
   arguments = """
     Arguments:
@@ -3256,7 +3258,8 @@ case class Flatten(child: Expression) extends UnaryExpression
       * stop - an expression. The end the range (inclusive).
       * step - an optional expression. The step of the range.
           By default step is 1 if start is less than or equal to stop, otherwise -1.
-          For the temporal sequences it's 1 day and -1 day respectively.
+          For the date and timestamp sequences it's 1 day and -1 day respectively,
+          and for the time sequences it's 1 second and -1 second respectively.
           If start is greater than stop then the step must be negative, and vice versa.
   """,
   examples = """
@@ -3269,6 +3272,8 @@ case class Flatten(child: Expression) extends UnaryExpression
        [2018-01-01,2018-02-01,2018-03-01]
       > SELECT _FUNC_(to_date('2018-01-01'), to_date('2018-03-01'), interval '0-1' year to month);
        [2018-01-01,2018-02-01,2018-03-01]
+      > SELECT _FUNC_(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE);
+       [08:00:00,08:30:00,09:00:00,09:30:00,10:00:00]
   """,
   group = "array_funcs",
   since = "2.4.0"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3598,7 +3598,7 @@ object Sequence {
       val i = ctx.freshName("i")
       val stepNanos = ctx.freshName("stepNanos")
       s"""
-         |final long $stepNanos = $step * ${NANOS_PER_MICROS}L;
+         |final long $stepNanos = Math.multiplyExact($step, ${NANOS_PER_MICROS}L);
          |${genSequenceLengthCode(ctx, start, stop, stepNanos, stepNanos, i)}
          |$arr = new $elemType[$i];
          |while ($i > 0) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1296,6 +1296,69 @@ class CollectionExpressionsSuite
         Timestamp.valueOf("2018-01-01 00:00:00.000")))
   }
 
+  test("SPARK-57852: Sequence of times") {
+    val timeType = TimeType()
+    def tm(h: Int, m: Int, s: Int, micros: Int = 0): Long =
+      DateTimeTestUtils.localTime(h.toByte, m.toByte, s.toByte, micros)
+
+    // Null in any argument yields null.
+    checkEvaluation(new Sequence(
+      Literal(null, timeType), Literal(tm(10, 0, 0), timeType)), null)
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0), timeType), Literal(null, timeType)), null)
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(10, 0, 0), timeType),
+      Literal(null, DayTimeIntervalType())), null)
+
+    // Ascending with an explicit 30-minute step (the ticket's acceptance criterion).
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(10, 0, 0), timeType),
+      Literal(Duration.ofMinutes(30))),
+      Seq(tm(8, 0, 0), tm(8, 30, 0), tm(9, 0, 0), tm(9, 30, 0), tm(10, 0, 0)))
+
+    // Descending with a negative step.
+    checkEvaluation(new Sequence(
+      Literal(tm(10, 0, 0), timeType),
+      Literal(tm(8, 0, 0), timeType),
+      Literal(Duration.ofMinutes(-30))),
+      Seq(tm(10, 0, 0), tm(9, 30, 0), tm(9, 0, 0), tm(8, 30, 0), tm(8, 0, 0)))
+
+    // Stop not exactly reachable by the step: stops at the last value within bounds.
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(9, 10, 0), timeType),
+      Literal(Duration.ofMinutes(30))),
+      Seq(tm(8, 0, 0), tm(8, 30, 0), tm(9, 0, 0)))
+
+    // Single element when start equals stop.
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(8, 0, 0), timeType),
+      Literal(Duration.ofMinutes(30))),
+      Seq(tm(8, 0, 0)))
+
+    // No step defaults to 1 second.
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(8, 0, 3), timeType)),
+      Seq(tm(8, 0, 0), tm(8, 0, 1), tm(8, 0, 2), tm(8, 0, 3)))
+
+    // Sub-second steps preserve the endpoint precision exactly.
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0, 0), timeType),
+      Literal(tm(8, 0, 0, 300000), timeType),
+      Literal(Duration.ofMillis(100))),
+      Seq(tm(8, 0, 0, 0), tm(8, 0, 0, 100000), tm(8, 0, 0, 200000), tm(8, 0, 0, 300000)))
+
+    // A non day-time interval step (year-month) is rejected at analysis time.
+    assert(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(10, 0, 0), timeType),
+      Literal(Period.ofMonths(1))).checkInputDataTypes().isFailure)
+  }
+
   test("Sequence on DST boundaries") {
     val timeZone = TimeZone.getTimeZone("Europe/Prague")
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1352,11 +1352,33 @@ class CollectionExpressionsSuite
       Literal(Duration.ofMillis(100))),
       Seq(tm(8, 0, 0, 0), tm(8, 0, 0, 100000), tm(8, 0, 0, 200000), tm(8, 0, 0, 300000)))
 
-    // A non day-time interval step (year-month) is rejected at analysis time.
+    // A non-day-time interval step (year-month) is rejected at analysis time.
     assert(new Sequence(
       Literal(tm(8, 0, 0), timeType),
       Literal(tm(10, 0, 0), timeType),
       Literal(Period.ofMonths(1))).checkInputDataTypes().isFailure)
+
+    // Only a day-time interval step is accepted: a calendar interval step (here 30 minutes as
+    // microseconds) is rejected at analysis time, just like the year-month interval above.
+    assert(new Sequence(
+      Literal(tm(8, 0, 0), timeType),
+      Literal(tm(10, 0, 0), timeType),
+      Literal(new org.apache.spark.unsafe.types.CalendarInterval(0, 0, 1800000000L)))
+      .checkInputDataTypes().isFailure)
+
+    // No step, descending range: the default step flips to -1 second.
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 3), timeType),
+      Literal(tm(8, 0, 0), timeType)),
+      Seq(tm(8, 0, 3), tm(8, 0, 2), tm(8, 0, 1), tm(8, 0, 0)))
+
+    // A step finer than the endpoint precision truncates every element to that precision, so
+    // TIME(3) with a 1-microsecond step yields repeated values rather than distinct sub-ms points.
+    checkEvaluation(new Sequence(
+      Literal(tm(8, 0, 0, 0), TimeType(3)),
+      Literal(tm(8, 0, 0, 3), TimeType(3)),
+      Literal(Duration.ofNanos(1000))), // 1 microsecond step, finer than TIME(3)
+      Seq(tm(8, 0, 0, 0), tm(8, 0, 0, 0), tm(8, 0, 0, 0), tm(8, 0, 0, 0)))
 
     // TIME sequences do not wrap around midnight: a positive step from a later start to an
     // earlier stop is an illegal boundary, not a wrap. (Relevant once SPARK-57853 lands.)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1357,6 +1357,15 @@ class CollectionExpressionsSuite
       Literal(tm(8, 0, 0), timeType),
       Literal(tm(10, 0, 0), timeType),
       Literal(Period.ofMonths(1))).checkInputDataTypes().isFailure)
+
+    // TIME sequences do not wrap around midnight: a positive step from a later start to an
+    // earlier stop is an illegal boundary, not a wrap. (Relevant once SPARK-57853 lands.)
+    checkExceptionInExpression[Exception](
+      new Sequence(
+        Literal(tm(23, 0, 0), timeType),
+        Literal(tm(1, 0, 0), timeType),
+        Literal(Duration.ofHours(1))),
+      EmptyRow, "boundaries")
   }
 
   test("Sequence on DST boundaries") {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
@@ -2513,3 +2513,48 @@ DROP TABLE time_narrow_tbl
 -- !query analysis
 DropTable false, false
 +- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.time_narrow_tbl
+
+
+-- !query
+SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE)
+-- !query analysis
+Project [sequence(08:00:00, 10:00:00, Some(INTERVAL '30' MINUTE), Some(America/Los_Angeles)) AS sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT sequence(TIME '10:00:00', TIME '08:00:00', INTERVAL '-30' MINUTE)
+-- !query analysis
+Project [sequence(10:00:00, 08:00:00, Some(INTERVAL '-30' MINUTE), Some(America/Los_Angeles)) AS sequence(TIME '10:00:00', TIME '08:00:00', INTERVAL '-30' MINUTE)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT sequence(TIME '08:00:00', TIME '08:00:03')
+-- !query analysis
+Project [sequence(08:00:00, 08:00:03, None, Some(America/Los_Angeles)) AS sequence(TIME '08:00:00', TIME '08:00:03')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.SEQUENCE_WRONG_INPUT_TYPES",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "functionName" : "`sequence`",
+    "otherStartType" : "\"INTEGRAL\"",
+    "sqlExpr" : "\"sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH)\"",
+    "startType" : "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\" or \"TIME\")",
+    "stepType" : "(\"INTERVAL\" or \"INTERVAL YEAR TO MONTH\" or \"INTERVAL DAY TO SECOND\")"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 69,
+    "fragment" : "sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH)"
+  } ]
+}

--- a/sql/core/src/test/resources/sql-tests/inputs/time.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/time.sql
@@ -426,3 +426,11 @@ INSERT INTO time_narrow_tbl SELECT '01:02:03.456789' :: TIME(6);
 INSERT INTO time_narrow_tbl SELECT CAST('01:02:03.456789' :: TIME(6) AS TIME(3));
 SELECT typeof(t3), t3 FROM time_narrow_tbl;
 DROP TABLE time_narrow_tbl;
+
+-- sequence() over TIME endpoints with a day-time interval step.
+SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE);
+SELECT sequence(TIME '10:00:00', TIME '08:00:00', INTERVAL '-30' MINUTE);
+-- The step defaults to 1 second when omitted.
+SELECT sequence(TIME '08:00:00', TIME '08:00:03');
+-- A year-month interval step is not accepted for TIME endpoints.
+SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH);

--- a/sql/core/src/test/resources/sql-tests/results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time.sql.out
@@ -3018,3 +3018,53 @@ DROP TABLE time_narrow_tbl
 struct<>
 -- !query output
 
+
+
+-- !query
+SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE)
+-- !query schema
+struct<sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE):array<time(6)>>
+-- !query output
+[08:00:00,08:30:00,09:00:00,09:30:00,10:00:00]
+
+
+-- !query
+SELECT sequence(TIME '10:00:00', TIME '08:00:00', INTERVAL '-30' MINUTE)
+-- !query schema
+struct<sequence(TIME '10:00:00', TIME '08:00:00', INTERVAL '-30' MINUTE):array<time(6)>>
+-- !query output
+[10:00:00,09:30:00,09:00:00,08:30:00,08:00:00]
+
+
+-- !query
+SELECT sequence(TIME '08:00:00', TIME '08:00:03')
+-- !query schema
+struct<sequence(TIME '08:00:00', TIME '08:00:03'):array<time(6)>>
+-- !query output
+[08:00:00,08:00:01,08:00:02,08:00:03]
+
+
+-- !query
+SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.SEQUENCE_WRONG_INPUT_TYPES",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "functionName" : "`sequence`",
+    "otherStartType" : "\"INTEGRAL\"",
+    "sqlExpr" : "\"sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH)\"",
+    "startType" : "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\" or \"TIME\")",
+    "stepType" : "(\"INTERVAL\" or \"INTERVAL YEAR TO MONTH\" or \"INTERVAL DAY TO SECOND\")"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 69,
+    "fragment" : "sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '1' MONTH)"
+  } ]
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -2136,7 +2136,7 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
       parameters = Map(
         "sqlExpr" -> "\"sequence(_1, _2)\"",
         "functionName" -> "`sequence`",
-        "startType" -> "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\")",
+        "startType" -> "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\" or \"TIME\")",
         "stepType" -> "(\"INTERVAL\" or \"INTERVAL YEAR TO MONTH\" or \"INTERVAL DAY TO SECOND\")",
         "otherStartType" -> "\"INTEGRAL\""
       ),
@@ -2150,7 +2150,7 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
       parameters = Map(
         "sqlExpr" -> "\"sequence(_1, _2, _3)\"",
         "functionName" -> "`sequence`",
-        "startType" -> "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\")",
+        "startType" -> "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\" or \"TIME\")",
         "stepType" -> "(\"INTERVAL\" or \"INTERVAL YEAR TO MONTH\" or \"INTERVAL DAY TO SECOND\")",
         "otherStartType" -> "\"INTEGRAL\""
       ),
@@ -2164,7 +2164,7 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
       parameters = Map(
         "sqlExpr" -> "\"sequence(_1, _2, _3)\"",
         "functionName" -> "`sequence`",
-        "startType" -> "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\")",
+        "startType" -> "(\"TIMESTAMP\" or \"TIMESTAMP_NTZ\" or \"DATE\" or \"TIME\")",
         "stepType" -> "(\"INTERVAL\" or \"INTERVAL YEAR TO MONTH\" or \"INTERVAL DAY TO SECOND\")",
         "otherStartType" -> "\"INTEGRAL\""
       ),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extend `sequence(start, stop[, step])` to accept TIME endpoints with a day-time interval step. Previously, `Sequence.checkInputDataTypes` in collectionOperations.scala only allowed integral, DATE, TIMESTAMP, and TIMESTAMP_NTZ endpoints. TIME fell through to the catch-all rejection branch, so any call like `sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE)` raised an analysis error.

Changes:

1. `Sequence.checkInputDataTypes` now recognizes TIME endpoints paired with an optional day-time interval step.
2. A new `TimeSequenceImpl` generates the array via a plain integer walk in nanoseconds.
3. The `SEQUENCE_WRONG_INPUT_TYPES` error message is extended to mention TIME.

TIME is stored internally as nanoseconds-of-day while a day-time interval is stored as microseconds, so `TimeSequenceImpl` converts the step from microseconds to nanoseconds and walks the range, truncating each element to the start endpoint's declared precision. It does not reuse the DATE/TIMESTAMP temporal machinery (no calendar, DST, or time-zone arithmetic) because a TIME sequence stays within the single-day domain [0, 24:00) by construction.

When no step is given the default is INTERVAL '1' SECOND. This is open to reviewer feedback since DATE defaults to 1 day and TIMESTAMP defaults to 1 month, but TIME has no obvious natural default.

SPARK-57853 (defines TIME +/- INTERVAL out-of-range semantics, open PR #57044) does not conflict with this implementation because all produced values are within-day by construction.

### Why are the changes needed?

The TIME type was added by SPIP SPARK-51162 (shipped in Spark 4.1.0) and works in the engine, but `sequence()` rejected TIME endpoints at analysis time because the type check had no branch for it. This is a sub-task of the TIME umbrella SPARK-57550.

### Does this PR introduce any user-facing change?

Yes. Users can now generate TIME arrays with `sequence`:

```sql
SELECT sequence(TIME '08:00:00', TIME '10:00:00', INTERVAL '30' MINUTE);
-- [08:00:00, 08:30:00, 09:00:00, 09:30:00, 10:00:00]
```

### How was this patch tested?

Added test("SPARK-57852: Sequence of times") to CollectionExpressionsSuite covering null arguments, ascending 30-minute step, descending negative step, stop not exactly reachable, single element (start == stop), default 1-second step, sub-second step preserving precision, and a negative case asserting a year-month interval step is rejected at analysis time. All 62 tests in CollectionExpressionsSuite pass locally.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated using Kiro (Claude Opus 4.8)