### PR TITLE
[SPARK-58021][CONNECT] Integrate local server pools with SparkSession

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -345,6 +345,35 @@ backed by the shared `SparkContext` (the persistent catalog/warehouse, global te
 cached datasets) *is* shared across runs, so namespace per-run databases or clear that state
 yourself if your runs must be fully isolated.
 
+### Fully isolated runs with a pool of single-use servers
+
+If your runs must be fully isolated from each other but you still want to skip the per-run
+startup cost, a second experimental opt-in keeps a small pool of booted servers that have
+never been assigned to an application run instead of one shared one. With
+`SPARK_LOCAL_CONNECT_POOL=1` set (or
+`spark.local.connect.pool=true` on the builder), each run *claims* a fresh server from the pool,
+a replacement is booted in the background, and the claimed server is torn down when the run's
+session stops -- no server ever serves two runs, so runs are as isolated as with the default
+in-process server:
+
+```bash
+export SPARK_LOCAL_CONNECT_POOL=1
+
+# Each run claims a booted server not previously assigned to another run.
+python -c 'from pyspark.sql import SparkSession; SparkSession.builder.remote("local[*]").getOrCreate()'
+
+# Force-stop all pool servers and start over from a clean slate.
+python -m pyspark.sql.connect.local_server_pool --purge
+```
+
+The trade-off relative to the reuse mode above is memory: `spark.local.connect.pool.size`
+(default 2) idle servers stay resident while you iterate, several hundred MB each. They shut
+down on their own after sitting unclaimed for `SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT` seconds
+(default 1800), so an idle machine drains back to zero servers. Pool servers are only handed to
+runs whose master, startup configurations, working directory, and Python environment match the
+ones they were booted with; runs that differ in any of these boot their own pool members. If
+both this and `spark.local.connect.reuse` are set, the pool takes precedence.
+
 ## Use Spark Connect in standalone applications
 
 <div class="codetabs">

--- a/python/pyspark/sql/connect/local_server.py
+++ b/python/pyspark/sql/connect/local_server.py
@@ -117,12 +117,8 @@ def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
         return False
 
 
-def _is_local_connect_server(pid: int) -> Optional[bool]:
-    """Whether ``pid`` is still the managed Connect server recorded in discovery.
-
-    Returns ``None`` when the process cannot be inspected, so callers do not discard the
-    discovery information needed to retry later.
-    """
+def _process_command(pid: int) -> Optional[str]:
+    """The command of ``pid``, an empty string if it is gone, or ``None`` if inspection fails."""
     try:
         result = subprocess.run(
             ["ps", "-ww", "-p", str(pid), "-o", "command="],
@@ -132,7 +128,17 @@ def _is_local_connect_server(pid: int) -> Optional[bool]:
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    return result.returncode == 0 and _SERVER_CLASS in result.stdout
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _is_local_connect_server(pid: int) -> Optional[bool]:
+    """Whether ``pid`` is still the managed Connect server recorded in discovery.
+
+    Returns ``None`` when the process cannot be inspected, so callers do not discard the
+    discovery information needed to retry later.
+    """
+    command = _process_command(pid)
+    return None if command is None else _SERVER_CLASS in command
 
 
 def runtime_dir() -> str:

--- a/python/pyspark/sql/connect/local_server_pool.py
+++ b/python/pyspark/sql/connect/local_server_pool.py
@@ -250,6 +250,12 @@ class PoolMember(_PoolStateRecord):
         value = data.get("process_start_id") if data is not None else None
         return value if isinstance(value, str) and value else None
 
+    @staticmethod
+    def client_process_start_id_from_data(data: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Recover the claiming client's process generation from a claimed record."""
+        value = data.get("client_process_start_id") if data is not None else None
+        return value if isinstance(value, str) and value else None
+
     @property
     def url(self) -> str:
         return f"sc://{self.host}:{self.port}"
@@ -637,11 +643,19 @@ class ServerPool:
             data = self._directory.read_json(path)
             member = PoolMember.from_data(data) if data is not None else None
             if member is not None and member.fingerprint == fingerprint:
-                candidates.append((member, uid, path))
+                assert data is not None
+                candidates.append((member, uid, path, data))
         candidates.sort(key=lambda c: c[0].created)
-        for member, uid, path in candidates:
+        for member, uid, path, data in candidates:
             if not member.is_usable():
                 continue  # left for the reaping rules to retire
+            client_process_start_id = self._process_start_id(os.getpid())
+            if client_process_start_id is not None:
+                claimed_data = dict(data)
+                claimed_data["client_process_start_id"] = client_process_start_id
+                # Persist ownership before the atomic rename. If this process dies between the
+                # write and rename, the extra field is harmless on the still-unclaimed record.
+                self._directory.write_json(path, claimed_data)
             claim_path = self._directory.claimed_path(os.getpid(), uid)
             self._directory.rename(path, claim_path)
             member.claim_path = claim_path
@@ -686,7 +700,15 @@ class ServerPool:
         data = self._directory.read_json(path)
         server_pid, process_start_id = self._recover_server_handle(uid, data)
         client_pid = self._directory.claiming_pid(path)
-        client_alive = client_pid == os.getpid() or _pid_alive(client_pid)
+        client_process_start_id = PoolMember.client_process_start_id_from_data(data)
+        if client_process_start_id is None:
+            # Records written by older clients have no process generation. Preserve their
+            # liveness-only behavior rather than risking retirement of a live claim.
+            client_alive = client_pid == os.getpid() or _pid_alive(client_pid)
+        else:
+            client_alive = (
+                self._same_process_generation(client_pid, client_process_start_id) is not False
+            )
         if not client_alive or self._same_process_generation(server_pid, process_start_id) is False:
             self._retire(path, server_pid, process_start_id)
 

--- a/python/pyspark/sql/connect/local_server_pool.py
+++ b/python/pyspark/sql/connect/local_server_pool.py
@@ -15,12 +15,42 @@
 # limitations under the License.
 #
 
-"""Filesystem-backed state and lifecycle model for local Spark Connect server pools.
+"""
+Opt-in pool of single-use local Spark Connect servers
+(``spark.local.connect.pool`` / ``SPARK_LOCAL_CONNECT_POOL``).
 
-This internal foundation owns member identity, directory locking, state-file access, claiming,
-reaping, and retirement. Server acquisition is layered on top in a follow-up change.
+The reuse mode (``spark.local.connect.reuse``, see ``pyspark.sql.connect.local_server``) makes
+local runs fast by sharing one long-lived server, at the price of state backed by the shared
+``SparkContext`` carrying across runs. The pool maintains a small set of booted servers that
+have never been assigned to an application run. A client claims one exclusively, spawns a
+replacement in the background, and tears the claimed server down when the session stops or the
+client exits. No server ever serves two application runs.
+
+The pool lives in a ``pool`` subdirectory of the per-user runtime directory (override with
+``SPARK_LOCAL_CONNECT_POOL_DIR``). A member is a set of files named by a random ``<uid>``;
+every access happens under the directory's ``.lock`` file lock, so readers always observe
+complete states:
+
+    pending-<uid>.json         an in-flight launch (the attendant process booting the server)
+    conf-<uid>.json            startup confs for that launch, read once by its attendant
+    server-<uid>.json          a ready, unclaimed server (host/port/token/pid/version)
+    claimed-<pid>-<uid>.json   a server owned by the live client process <pid>
+    retired-<uid>.json         a server being torn down; hard-killed if it hangs
+    member-<uid>/              the server's pid file and logs (spark-daemon.sh directories)
+
+Each launch runs an *attendant* (``python -m pyspark.sql.connect.local_server_pool --attend``),
+a small detached process that boots the server through ``sbin/start-connect-server.sh``,
+publishes its ``server-<uid>.json``, and supervises it. It retires the server once it has sat
+unclaimed past the idle timeout, or once the client that claimed it has died without releasing
+it. A janitor pass on every acquire is the backstop for members whose attendant itself died.
+
+Servers are only handed to runs they were built for: each member carries a fingerprint of its
+master, seeded confs, working directory, and Python executable, and a run only claims members
+whose fingerprint matches its own.
 """
 
+import argparse
+import atexit
 import contextlib
 import hashlib
 import json
@@ -32,10 +62,11 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-from pyspark.errors import PySparkValueError
+from pyspark.errors import PySparkRuntimeError, PySparkValueError
 from pyspark.sql.connect.local_server import (
     Discovery,
     _is_local_connect_server,
@@ -112,6 +143,27 @@ def pool_fingerprint(master: str, seed_conf: Dict[str, Any]) -> str:
         [os.environ.get(var, "") for var in _JVM_ENV_VARS],
     ]
     return hashlib.sha256(json.dumps(identity).encode("utf-8")).hexdigest()
+
+
+# How long one acquire may wait for a member to become ready. A cold launch takes at most
+# 120s; this leaves room for one relaunch of a failed one.
+_ACQUIRE_TIMEOUT = 180
+
+_DEFAULT_POOL_SIZE = 2
+
+
+def _pool_size(opts: Dict[str, Any]) -> int:
+    """The number of warm or in-flight members to keep per fingerprint; at least one.
+    Malformed values fall back to the default rather than failing session creation over a
+    tuning knob.
+    """
+    value = opts.get(
+        "spark.local.connect.pool.size", os.environ.get("SPARK_LOCAL_CONNECT_POOL_SIZE")
+    )
+    try:
+        return max(1, int(value)) if value is not None else _DEFAULT_POOL_SIZE
+    except (TypeError, ValueError, OverflowError):
+        return _DEFAULT_POOL_SIZE
 
 
 class _PoolStateRecord:
@@ -545,7 +597,7 @@ class PoolDirectory:
 
 
 class ServerPool:
-    """Claims, reaps, and retires members of one pool directory."""
+    """Acquires, reaps, and retires members of one pool directory."""
 
     # A pending marker older than this belongs to a launch that hung. Keep this above the local
     # server startup timeout so a slow but healthy launch is never stopped by the janitor.
@@ -564,6 +616,39 @@ class ServerPool:
 
     def __init__(self, directory: Optional[PoolDirectory] = None):
         self._directory = directory or PoolDirectory()
+
+    def acquire(self, master: str, opts: Dict[str, Any]) -> PoolMember:
+        """Claim one ready, fingerprint-matching member and top the pool back up.
+
+        On a warm pool this returns after one janitor-claim-refill pass; on a cold pool
+        (first run, conf change, or all members consumed) the refill starts a full complement
+        and the loop waits for the first member to become ready, which costs one ordinary
+        cold start. The lock is released between polls so attendants can publish; launches
+        that die are relaunched by later passes, and only the overall deadline fails.
+        """
+        from pyspark.sql.connect.local_server import startup_seed_conf
+
+        seed_conf = startup_seed_conf(opts)
+        fingerprint = pool_fingerprint(master, seed_conf)
+        target = _pool_size(opts)
+        deadline = time.monotonic() + _ACQUIRE_TIMEOUT
+        while True:
+            with self._directory:
+                self.janitor()
+                member = self.claim(fingerprint)
+                self.refill(master, seed_conf, fingerprint, target)
+            if member is not None:
+                return member
+            if time.monotonic() >= deadline:
+                raise PySparkRuntimeError(
+                    errorClass="LOCAL_CONNECT_SERVER_START_FAILED",
+                    messageParameters={
+                        "reason": f"no pooled local server became ready within "
+                        f"{_ACQUIRE_TIMEOUT}s; see the attendant and server logs under "
+                        f"{self._directory.path}"
+                    },
+                )
+            time.sleep(0.25)
 
     @classmethod
     def _process_start_id(cls, pid: int) -> Optional[str]:
@@ -736,6 +821,19 @@ class ServerPool:
             member.claim_path = claim_path
             return member
         return None
+
+    def refill(self, master: str, seed_conf: Dict[str, Any], fingerprint: str, target: int) -> None:
+        """Launch members until ready or in-flight ones with this fingerprint reach
+        ``target``. Running under the directory lock is what makes concurrent cold starters
+        share one complement of launches instead of each spawning their own."""
+        available = 0
+        for kind in ("server", "pending"):
+            for _, path in self._directory.paths_of_kind(kind):
+                data = self._directory.read_json(path)
+                if data is not None and data.get("fingerprint") == fingerprint:
+                    available += 1
+        for _ in range(target - available):
+            MemberAttendant.spawn(self._directory, master, seed_conf, fingerprint)
 
     def janitor(self) -> None:
         """Reap leftovers of launches, clients, and attendants that died uncleanly. Every
@@ -1030,9 +1128,45 @@ class ServerPool:
                 self._retire(member.claim_path, member.pid, member.process_start_id)
 
 
-# The member this client process has claimed, if any. A later acquisition layer populates it;
-# keeping the idempotent release path here makes lifecycle ownership explicit.
+# The member this client process has claimed, if any. Module-level so the session's stop
+# callback and atexit share one idempotent release path.
 _claimed_member: Optional[PoolMember] = None
+_release_registered = False
+
+
+def acquire_pooled_local_connect_server(master: str, opts: Dict[str, Any]) -> str:
+    """Claim a local Connect server not previously assigned to an application run.
+
+    Returns the ``sc://host:port`` endpoint and sets ``SPARK_CONNECT_AUTHENTICATE_TOKEN`` so
+    the client authenticates against that server. Only reached for a ``local`` master when the
+    pool opt-in is set; see ``SparkSession.getOrCreate`` in ``pyspark.sql.session``.
+    """
+    global _claimed_member, _release_registered
+    if os.name != "posix":
+        raise PySparkRuntimeError(
+            errorClass="LOCAL_CONNECT_SERVER_START_FAILED",
+            messageParameters={
+                "reason": "spark.local.connect.pool relies on the POSIX scripts under sbin/; "
+                "on this platform start a server manually (sbin/start-connect-server.sh) and "
+                'connect with .remote("sc://...")'
+            },
+        )
+    # getOrCreate() may be re-entered while this process already holds a live claimed member
+    # (the connect layer then returns the existing session); claiming again would strand a
+    # second server.
+    if _claimed_member is not None and _pid_alive(_claimed_member.pid):
+        os.environ["SPARK_CONNECT_AUTHENTICATE_TOKEN"] = _claimed_member.token
+        return _claimed_member.url
+
+    member = ServerPool().acquire(master, opts)
+    _claimed_member = member
+    if not _release_registered:
+        # A client that exits without stopping its session still releases its member; the
+        # member's attendant and the janitor cover clients that die uncleanly.
+        atexit.register(release_pooled_local_connect_server)
+        _release_registered = True
+    os.environ["SPARK_CONNECT_AUTHENTICATE_TOKEN"] = member.token
+    return member.url
 
 
 def release_pooled_local_connect_server() -> None:
@@ -1046,3 +1180,175 @@ def release_pooled_local_connect_server() -> None:
         ServerPool(directory).release(member)
         if _claimed_member is member:
             _claimed_member = None
+
+
+class MemberAttendant:
+    """Boots one pool member, publishes it, and supervises it until it is gone.
+
+    Runs detached from the spawning client (``--attend``). Every phase is appended to
+    ``member-<uid>/attendant.log`` so a member that misbehaved can be debugged after the
+    fact. A failed boot reaps whatever half-started server spark-daemon.sh recorded and
+    withdraws the launch's bookkeeping, so refills stop counting it.
+    """
+
+    @classmethod
+    def spawn(
+        cls,
+        directory: PoolDirectory,
+        master: str,
+        seed_conf: Dict[str, Any],
+        fingerprint: str,
+    ) -> None:
+        """Start one detached attendant and publish its in-flight launch.
+
+        Callers hold ``directory``'s lock, so another refill sees the pending marker before it
+        can start a duplicate launch for the same pool complement.
+        """
+        uid = uuid.uuid4().hex[:12]
+        directory.write_json(directory.conf_path(uid), seed_conf)
+        cmd = [
+            sys.executable,
+            "-m",
+            "pyspark.sql.connect.local_server_pool",
+            "--attend",
+            "--pool-dir",
+            directory.path,
+            "--uid",
+            uid,
+            "--master",
+            master,
+            "--fingerprint",
+            fingerprint,
+        ]
+        env = dict(os.environ)
+        # The attendant must neither see this client's Connect mode nor inherit its auth
+        # token: each member gets its own token from LocalConnectServer.
+        for var in (
+            "SPARK_REMOTE",
+            "SPARK_LOCAL_REMOTE",
+            "SPARK_CONNECT_MODE_ENABLED",
+            "SPARK_CONNECT_AUTHENTICATE_TOKEN",
+        ):
+            env.pop(var, None)
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError:
+            directory.remove(directory.conf_path(uid))
+            raise
+        directory.write_json(
+            directory.pending_path(uid),
+            {"attendant_pid": proc.pid, "created": time.time(), "fingerprint": fingerprint},
+        )
+
+    def __init__(self, directory: PoolDirectory, uid: str, master: str, fingerprint: str):
+        self._directory = directory
+        self._pool = ServerPool(directory)
+        self._uid = uid
+        self._master = master
+        self._fingerprint = fingerprint
+        self._member_dir = directory.member_dir(uid)
+
+    def run(self) -> int:
+        os.makedirs(self._member_dir, mode=0o700, exist_ok=True)
+        member = self._boot()
+        if member is None:
+            return 1
+        self._log("supervising")
+        self._supervise(member.pid)
+        self._log("done")
+        return 0
+
+    def _log(self, message: str) -> None:
+        with open(os.path.join(self._member_dir, "attendant.log"), "a") as f:
+            f.write(f"{time.time():.3f} {message}\n")
+
+    def _boot(self) -> Optional[PoolMember]:
+        """Start the server on a fresh ephemeral port and publish it as ready-to-claim.
+        Publishing consumes the launch's pending marker and conf seed: from that moment the
+        member counts as a server, and this process's job shifts to supervising it."""
+        from pyspark.sql.connect.local_server import Discovery, LocalConnectServer
+
+        with self._directory:
+            seed_conf = self._directory.read_json(self._directory.conf_path(self._uid)) or {}
+        discovery = Discovery(os.path.join(self._member_dir, "connect-local.json"))
+        self._log(f"booting master={self._master}")
+        try:
+            with discovery:
+                server = LocalConnectServer(discovery)
+                server.start(
+                    self._master,
+                    {},
+                    use_ephemeral_port=True,
+                    seed_conf=seed_conf,
+                )
+                data = discovery.load()
+            assert data is not None  # launch() saved it
+            process_start_id = self._pool._process_start_id(data["pid"])
+            if process_start_id is None:
+                raise RuntimeError(f"could not identify launched server pid {data['pid']}")
+            data["process_start_id"] = process_start_id
+        except Exception as e:
+            self._log(f"boot failed: {e!r}")
+            with self._directory:
+                self._pool.abort_launch(self._uid)
+            return None
+        data["fingerprint"] = self._fingerprint
+        data["created"] = time.time()
+        with self._directory:
+            self._directory.write_json(self._directory.server_path(self._uid), data)
+            self._directory.remove(self._directory.pending_path(self._uid))
+            self._directory.remove(self._directory.conf_path(self._uid))
+        self._log(f"published pid={data['pid']} port={data['port']}")
+        return PoolMember(data)
+
+    def _supervise(self, server_pid: int) -> None:
+        """Watch this member until nothing of it remains, applying the pool's reaping rules.
+
+        This is what lets an idle machine drain to zero servers with no further Spark run: the
+        idle timeout, dead-client cleanup, and hard-kill escalation all fire from here even
+        when no client ever runs again.
+        """
+        while True:
+            with self._directory:
+                if self._pool.reap(self._uid):
+                    return
+                states = set(self._directory.states(self._uid))
+                if states <= {"member"} and not _pid_alive(server_pid):
+                    # Another process's janitor already tore the member down; only the young
+                    # member directory remains.
+                    self._directory.remove_member_dir(self._uid)
+                    return
+            time.sleep(2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run an internal attendant for the opt-in local Spark Connect server pool."
+    )
+    # Internal entry point spawned by ServerPool.
+    parser.add_argument("--attend", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--pool-dir", help=argparse.SUPPRESS)
+    parser.add_argument("--uid", help=argparse.SUPPRESS)
+    parser.add_argument("--master", help=argparse.SUPPRESS)
+    parser.add_argument("--fingerprint", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.attend:
+        attendant = MemberAttendant(
+            PoolDirectory(args.pool_dir), args.uid, args.master, args.fingerprint
+        )
+        sys.exit(attendant.run())
+    else:
+        parser.print_help(sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyspark/sql/connect/local_server_pool.py
+++ b/python/pyspark/sql/connect/local_server_pool.py
@@ -46,7 +46,8 @@ it. A janitor pass on every acquire is the backstop for members whose attendant 
 
 Servers are only handed to runs they were built for: each member carries a fingerprint of its
 master, seeded confs, working directory, and Python executable, and a run only claims members
-whose fingerprint matches its own.
+whose fingerprint matches its own. ``python -m pyspark.sql.connect.local_server_pool --purge``
+force-stops every member and empties the pool directory.
 """
 
 import argparse
@@ -1127,6 +1128,72 @@ class ServerPool:
             if self._directory.states(uid).get("claimed") == member.claim_path:
                 self._retire(member.claim_path, member.pid, member.process_start_id)
 
+    def purge(self) -> int:
+        """Force-stop every member -- ready, in-flight, or claimed -- and empty the pool
+        directory; the escape hatch back to a clean slate. Returns the number of processes
+        signalled. SIGKILL rather than SIGTERM because nothing tracks a member once its
+        state files are gone, so a shutdown that hangs would leak. Supervising attendants
+        hold no state file; they notice the emptied directory and exit on their own."""
+        signalled_pids: List[int] = []
+
+        def hard_kill_server(pid: Optional[int], process_start_id: Optional[str] = None) -> None:
+            if pid is None or pid in signalled_pids:
+                return
+            if process_start_id is not None:
+                signalled = self._signal_server(pid, process_start_id, signal.SIGKILL)
+            else:
+                # Malformed and half-published states can have only spark-daemon.sh's pid.
+                # Purge is explicitly destructive, but still verify the current command before
+                # signalling rather than trusting a potentially reused numeric pid alone.
+                signalled = _is_local_connect_server(pid) is True and self._signal(
+                    pid, signal.SIGKILL
+                )
+            if signalled:
+                signalled_pids.append(pid)
+
+        def hard_kill_attendant(pid: Optional[int], uid: str) -> None:
+            if (
+                pid is not None
+                and pid not in signalled_pids
+                and self._is_pool_attendant(pid, uid) is True
+                and self._signal_attendant_group(pid, signal.SIGKILL)
+            ):
+                signalled_pids.append(pid)
+
+        with self._directory:
+            uids = self._directory.uids()
+            # Iterate entries directly by kind rather than through states(uid): duplicate
+            # claimed records violate the normal state invariant, but purge is the corruption
+            # escape hatch and must still clear and stop every recoverable member.
+            for kind in ("pending", "conf", "server", "claimed", "retired"):
+                for uid, path in self._directory.paths_of_kind(kind):
+                    data = self._directory.read_json(path)
+                    if kind == "pending":
+                        pending = PendingState.from_data(data)
+                        pid = (
+                            pending.attendant_pid
+                            if pending is not None
+                            else PendingState.attendant_pid_from_data(data)
+                        )
+                        hard_kill_attendant(pid, uid)
+                    elif kind in ("server", "claimed"):
+                        pid, process_start_id = self._recover_server_handle(uid, data)
+                        hard_kill_server(pid, process_start_id)
+                    elif kind == "retired":
+                        record_pid = RetiredState.pid_from_data(data)
+                        pid = self._recover_server_pid(uid, record_pid)
+                        process_start_id = (
+                            RetiredState.process_start_id_from_data(data)
+                            if record_pid is not None
+                            else None
+                        )
+                        hard_kill_server(pid, process_start_id)
+                    self._directory.remove(path)
+            for uid in uids:
+                hard_kill_server(self._recorded_daemon_pid(uid))
+                self._directory.remove_member_dir(uid)
+        return len(signalled_pids)
+
 
 # The member this client process has claimed, if any. Module-level so the session's stop
 # callback and atexit share one idempotent release path.
@@ -1180,6 +1247,12 @@ def release_pooled_local_connect_server() -> None:
         ServerPool(directory).release(member)
         if _claimed_member is member:
             _claimed_member = None
+
+
+def purge_local_connect_pool() -> int:
+    """See :meth:`ServerPool.purge`. Also available as
+    ``python -m pyspark.sql.connect.local_server_pool --purge``."""
+    return ServerPool().purge()
 
 
 class MemberAttendant:
@@ -1321,8 +1394,8 @@ class MemberAttendant:
                     return
                 states = set(self._directory.states(self._uid))
                 if states <= {"member"} and not _pid_alive(server_pid):
-                    # Another process's janitor already tore the member down; only the young
-                    # member directory remains.
+                    # A purge or another process's janitor already tore the member down; only
+                    # the young member directory remains.
                     self._directory.remove_member_dir(self._uid)
                     return
             time.sleep(2)
@@ -1330,7 +1403,13 @@ class MemberAttendant:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run an internal attendant for the opt-in local Spark Connect server pool."
+        description="Manage the opt-in pool of single-use local Spark Connect servers "
+        "(spark.local.connect.pool)."
+    )
+    parser.add_argument(
+        "--purge",
+        action="store_true",
+        help="force-stop every pool member and empty the pool directory",
     )
     # Internal entry point spawned by ServerPool.
     parser.add_argument("--attend", action="store_true", help=argparse.SUPPRESS)
@@ -1340,7 +1419,9 @@ def main() -> None:
     parser.add_argument("--fingerprint", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
-    if args.attend:
+    if args.purge:
+        print(f"Signalled {purge_local_connect_pool()} pool process(es).")
+    elif args.attend:
         attendant = MemberAttendant(
             PoolDirectory(args.pool_dir), args.uid, args.master, args.fingerprint
         )

--- a/python/pyspark/sql/connect/local_server_pool.py
+++ b/python/pyspark/sql/connect/local_server_pool.py
@@ -149,6 +149,7 @@ class RetiredState(_PoolStateRecord):
     pid: int
     process_start_id: str
     retired: float
+    signalled: bool = False
 
     @classmethod
     def pid_from_data(cls, data: Optional[Dict[str, Any]]) -> Optional[int]:
@@ -166,6 +167,14 @@ class RetiredState(_PoolStateRecord):
         """Recover a valid retirement timestamp from a malformed state record."""
         return cls._timestamp(data.get("retired")) if data is not None else None
 
+    @staticmethod
+    def signalled_from_data(data: Optional[Dict[str, Any]]) -> Optional[bool]:
+        """Recover SIGTERM delivery state, defaulting legacy records to unsignalled."""
+        if data is None:
+            return None
+        value = data.get("signalled", False)
+        return value if isinstance(value, bool) else None
+
     @classmethod
     def from_data(cls, data: Optional[Dict[str, Any]]) -> Optional["RetiredState"]:
         if data is None:
@@ -173,15 +182,17 @@ class RetiredState(_PoolStateRecord):
         pid = cls.pid_from_data(data)
         process_start_id = cls.process_start_id_from_data(data)
         retired = cls.retired_from_data(data)
-        if pid is None or process_start_id is None or retired is None:
+        signalled = cls.signalled_from_data(data)
+        if pid is None or process_start_id is None or retired is None or signalled is None:
             return None
-        return cls(pid, process_start_id, retired)
+        return cls(pid, process_start_id, retired, signalled)
 
     def as_data(self) -> Dict[str, Any]:
         return {
             "pid": self.pid,
             "process_start_id": self.process_start_id,
             "retired": self.retired,
+            "signalled": self.signalled,
         }
 
 
@@ -227,6 +238,17 @@ class PoolMember(_PoolStateRecord):
             return cls(data)
         except (KeyError, TypeError, ValueError, OverflowError):
             return None
+
+    @classmethod
+    def pid_from_data(cls, data: Optional[Dict[str, Any]]) -> Optional[int]:
+        """Recover a valid server pid even when another member field is malformed."""
+        return cls._positive_pid(data.get("pid")) if data is not None else None
+
+    @staticmethod
+    def process_start_id_from_data(data: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Recover a process generation identifier from a malformed member record."""
+        value = data.get("process_start_id") if data is not None else None
+        return value if isinstance(value, str) and value else None
 
     @property
     def url(self) -> str:
@@ -486,13 +508,14 @@ class PoolDirectory:
 
 
 class ServerPool:
-    """Claims and retires members of one pool directory."""
+    """Claims, reaps, and retires members of one pool directory."""
 
-    # A retired server still alive after the grace period is hard-killed. After the give-up
-    # age, tracking is removed only once the process is gone, replaced, or successfully
-    # signalled.
+    # A retired server still alive after the grace period is hard-killed. With a process handle,
+    # tracking is removed only once it is gone, replaced, or successfully signalled. PID-less
+    # malformed state uses the give-up age as its bounded recovery window.
     _RETIRE_KILL_AFTER_SECONDS = 30
     _RETIRE_GIVE_UP_AFTER_SECONDS = 600
+    _DEFAULT_IDLE_TIMEOUT_SECONDS = 1800
     _PROCESS_INSPECTION_TIMEOUT_SECONDS = 5
     _PROC_STAT_START_TIME_INDEX = 19
 
@@ -543,13 +566,25 @@ class ServerPool:
         return f"ps:{started}" if result.returncode == 0 and started else None
 
     @classmethod
-    def _same_server_instance(cls, pid: int, process_start_id: str) -> Optional[bool]:
-        """Whether ``pid`` is still the recorded Connect server process generation."""
+    def _same_process_generation(
+        cls, pid: Optional[int], process_start_id: Optional[str]
+    ) -> Optional[bool]:
+        """Whether ``pid`` is alive and still has its recorded process generation."""
+        if pid is None or not _pid_alive(pid):
+            return False
+        if process_start_id is None:
+            return None
         current_start_id = cls._process_start_id(pid)
         if current_start_id is None:
             return None
-        if current_start_id != process_start_id:
-            return False
+        return current_start_id == process_start_id
+
+    @classmethod
+    def _same_server_instance(cls, pid: int, process_start_id: str) -> Optional[bool]:
+        """Whether ``pid`` is still the recorded Connect server process generation."""
+        same_generation = cls._same_process_generation(pid, process_start_id)
+        if same_generation is not True:
+            return same_generation
         return _is_local_connect_server(pid)
 
     @staticmethod
@@ -567,6 +602,18 @@ class ServerPool:
     def _signal_server(cls, pid: int, process_start_id: str, sig: int) -> bool:
         """Signal only the recorded generation of the managed Connect server."""
         return cls._same_server_instance(pid, process_start_id) is True and cls._signal(pid, sig)
+
+    @classmethod
+    def _idle_timeout(cls) -> int:
+        """Seconds an unclaimed member may sit before it is retired.
+
+        Zero or a negative value disables idle retirement. Read the environment on each pass so
+        every reaper uses the same source of truth.
+        """
+        try:
+            return int(os.environ["SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT"])
+        except (KeyError, ValueError):
+            return cls._DEFAULT_IDLE_TIMEOUT_SECONDS
 
     def claim(self, fingerprint: str) -> Optional[PoolMember]:
         """Claim the oldest usable member with this fingerprint, or ``None``. The rename to
@@ -601,12 +648,47 @@ class ServerPool:
             return member
         return None
 
+    def janitor(self) -> None:
+        """Reap unusable or orphaned pool members. Every rule is idempotent, so successive
+        passes from any process are safe."""
+        for uid in self._directory.uids():
+            self.reap(uid)
+
     def reap(self, uid: str) -> bool:
-        """Advance a retiring member and report whether nothing of it remains."""
+        """Apply the reaping rules to one member; ``True`` when nothing of it remains."""
         states = self._directory.states(uid)
-        if "retired" in states:
+        had_retired = "retired" in states
+        if "server" in states:
+            self._reap_server(uid, states["server"])
+        states = self._directory.states(uid)
+        if "claimed" in states:
+            self._reap_claimed(uid, states["claimed"])
+        states = self._directory.states(uid)
+        if had_retired and "retired" in states:
             self._reap_retired(uid, states["retired"])
         return not self._directory.states(uid)
+
+    def _reap_server(self, uid: str, path: str) -> None:
+        """A ready member that is unusable (dead, unreachable, version-mismatched after an
+        upgrade, or an unreadable record) or has sat unclaimed past the idle timeout: retire
+        it."""
+        data = self._directory.read_json(path)
+        member = PoolMember.from_data(data) if data is not None else None
+        server_pid, process_start_id = self._recover_server_handle(uid, data)
+        idle = self._idle_timeout()
+        expired = member is not None and idle > 0 and time.time() - member.created > idle
+        if member is None or expired or not member.is_usable():
+            self._retire(path, server_pid, process_start_id)
+
+    def _reap_claimed(self, uid: str, path: str) -> None:
+        """A claimed member whose client died without releasing it (e.g. SIGKILL), or whose
+        server died under its client: retire it. Claims of this live process are its own."""
+        data = self._directory.read_json(path)
+        server_pid, process_start_id = self._recover_server_handle(uid, data)
+        client_pid = self._directory.claiming_pid(path)
+        client_alive = client_pid == os.getpid() or _pid_alive(client_pid)
+        if not client_alive or self._same_process_generation(server_pid, process_start_id) is False:
+            self._retire(path, server_pid, process_start_id)
 
     def _reap_retired(self, uid: str, path: str) -> None:
         """A retiring member: drop it once its server is gone, hard-kill the server if it
@@ -615,6 +697,7 @@ class ServerPool:
         record_pid = RetiredState.pid_from_data(data)
         record_process_start_id = RetiredState.process_start_id_from_data(data)
         retired = RetiredState.retired_from_data(data)
+        signalled = RetiredState.signalled_from_data(data)
         server_pid = self._recover_server_pid(uid, record_pid)
         # A generation id is meaningful only with the pid from the same record. The daemon pid
         # file has no companion generation id, so never pair a recovered daemon pid with
@@ -622,8 +705,18 @@ class ServerPool:
         process_start_id = record_process_start_id if record_pid is not None else None
         now = time.time()
         if server_pid is None:
-            # Without a recoverable process handle, retain the state for a later read instead of
-            # declaring a potentially live server gone.
+            # A daemon pid may appear after a partial publication, so retain the state for one
+            # recovery window. After that there is no process handle left to act on or observe.
+            if retired is None or retired > now:
+                self._directory.write_json(
+                    path,
+                    {
+                        "retired": now,
+                        "signalled": False,
+                    },
+                )
+            elif now - retired > self._RETIRE_GIVE_UP_AFTER_SECONDS:
+                self._remove_retired(uid, path)
             return
         if not _pid_alive(server_pid):
             self._remove_retired(uid, path)
@@ -645,7 +738,13 @@ class ServerPool:
             # A crash while _retire rewrites the atomically renamed state can leave its old
             # payload. Restore a shutdown clock while preserving its process identity.
             self._directory.write_json(
-                path, RetiredState(server_pid, process_start_id, now).as_data()
+                path,
+                RetiredState(
+                    server_pid,
+                    process_start_id,
+                    now,
+                    signalled=signalled is True,
+                ).as_data(),
             )
             return
         age = now - retired
@@ -662,28 +761,60 @@ class ServerPool:
                 self._remove_retired(uid, path)
             elif is_server is True:
                 self._signal(server_pid, signal.SIGKILL)
-        else:
-            # Retrying SIGTERM is idempotent and recovers a transient inspection failure during
-            # _retire before the shutdown deadline escalates to SIGKILL.
-            self._signal_server(server_pid, process_start_id, signal.SIGTERM)
+        elif signalled is not True:
+            # Retry a SIGTERM that was not confirmed during retirement. Persist success without
+            # refreshing the retirement clock so repeated passes remain free and escalation is
+            # still measured from the original transition.
+            if self._signal_server(server_pid, process_start_id, signal.SIGTERM):
+                self._directory.write_json(
+                    path,
+                    RetiredState(
+                        server_pid,
+                        process_start_id,
+                        retired,
+                        signalled=True,
+                    ).as_data(),
+                )
 
     def _remove_retired(self, uid: str, path: str) -> None:
         self._directory.remove(path)
         self._directory.remove_member_dir(uid)
 
-    def _retire(self, state_path: str, server_pid: int, process_start_id: str) -> None:
+    def _retire(
+        self,
+        state_path: str,
+        server_pid: Optional[int],
+        process_start_id: Optional[str],
+    ) -> None:
         """Move a member into the retired state: signal its server and track the shutdown so
         :meth:`_reap_retired` can escalate if the JVM hangs."""
         _, uid = self._directory.parse_entry(os.path.basename(state_path))
         assert uid is not None
-        self._signal_server(server_pid, process_start_id, signal.SIGTERM)
+        signalled = False
+        if server_pid is not None and process_start_id is not None:
+            signalled = self._signal_server(server_pid, process_start_id, signal.SIGTERM)
         retired_path = self._directory.retired_path(uid)
         # Rename instead of removing the old state so a crash cannot leave a live server with
         # no state. If rewriting is interrupted, _reap_retired preserves the recoverable pid.
         self._directory.rename(state_path, retired_path)
-        self._directory.write_json(
-            retired_path, RetiredState(server_pid, process_start_id, time.time()).as_data()
-        )
+        retired_data: Dict[str, Any] = {
+            "retired": time.time(),
+            "signalled": signalled,
+        }
+        if server_pid is not None:
+            retired_data["pid"] = server_pid
+        if process_start_id is not None:
+            retired_data["process_start_id"] = process_start_id
+        self._directory.write_json(retired_path, retired_data)
+
+    def _recover_server_handle(
+        self, uid: str, data: Optional[Dict[str, Any]]
+    ) -> Tuple[Optional[int], Optional[str]]:
+        """Recover a pid and only the process identity paired with that pid's record."""
+        record_pid = PoolMember.pid_from_data(data)
+        if record_pid is None:
+            return self._recorded_daemon_pid(uid), None
+        return record_pid, PoolMember.process_start_id_from_data(data)
 
     def _recover_server_pid(self, uid: str, record_pid: Optional[int]) -> Optional[int]:
         """Use a record pid when present, otherwise fall back to the daemon pid file.
@@ -701,7 +832,7 @@ class ServerPool:
 
     def release(self, member: PoolMember) -> None:
         """Retire this process's claimed member; the shutdown completes in the background,
-        ready for a later lifecycle pass to finish.
+        ready for a later janitor pass to finish.
 
         This method acquires the pool-directory lock and must not be called while the same pool
         directory is already locked, including through a different ``PoolDirectory`` instance.

--- a/python/pyspark/sql/connect/local_server_pool.py
+++ b/python/pyspark/sql/connect/local_server_pool.py
@@ -21,10 +21,14 @@ Opt-in pool of single-use local Spark Connect servers
 
 The reuse mode (``spark.local.connect.reuse``, see ``pyspark.sql.connect.local_server``) makes
 local runs fast by sharing one long-lived server, at the price of state backed by the shared
-``SparkContext`` carrying across runs. The pool maintains a small set of booted servers that
-have never been assigned to an application run. A client claims one exclusively, spawns a
+``SparkContext`` (persistent catalog, global temp views, cached data) carrying across runs.
+The pool keeps the speed without the sharing: it maintains a small set of booted servers that
+have never been assigned to an application run, and
+``SparkSession.builder.remote("local[*]").getOrCreate()`` *claims* one exclusively, spawns a
 replacement in the background, and tears the claimed server down when the session stops or the
-client exits. No server ever serves two application runs.
+client exits. No server ever serves two application runs, so runs are as isolated from each
+other as with the default in-process server -- at the cost of the idle servers' memory while
+you iterate. If both opt-ins are set, the pool takes precedence.
 
 The pool lives in a ``pool`` subdirectory of the per-user runtime directory (override with
 ``SPARK_LOCAL_CONNECT_POOL_DIR``). A member is a set of files named by a random ``<uid>``;
@@ -48,6 +52,10 @@ Servers are only handed to runs they were built for: each member carries a finge
 master, seeded confs, working directory, and Python executable, and a run only claims members
 whose fingerprint matches its own. ``python -m pyspark.sql.connect.local_server_pool --purge``
 force-stops every member and empties the pool directory.
+
+This mode is experimental. Everything but the opt-in itself -- the pool directory layout, the
+attendant, and the ``--purge`` entry point -- is an internal detail that may change or move,
+for example into a unified ``spark connect`` CLI. POSIX only, like the reuse mode.
 """
 
 import argparse
@@ -154,7 +162,7 @@ _DEFAULT_POOL_SIZE = 2
 
 
 def _pool_size(opts: Dict[str, Any]) -> int:
-    """The number of warm or in-flight members to keep per fingerprint; at least one.
+    """The number of ready or in-flight members to keep per fingerprint; at least one.
     Malformed values fall back to the default rather than failing session creation over a
     tuning knob.
     """
@@ -621,7 +629,7 @@ class ServerPool:
     def acquire(self, master: str, opts: Dict[str, Any]) -> PoolMember:
         """Claim one ready, fingerprint-matching member and top the pool back up.
 
-        On a warm pool this returns after one janitor-claim-refill pass; on a cold pool
+        When a member is ready this returns after one janitor-claim-refill pass; on a cold pool
         (first run, conf change, or all members consumed) the refill starts a full complement
         and the loop waits for the first member to become ready, which costs one ordinary
         cold start. The lock is released between polls so attendants can publish; launches

--- a/python/pyspark/sql/connect/local_server_pool.py
+++ b/python/pyspark/sql/connect/local_server_pool.py
@@ -41,6 +41,7 @@ from pyspark.sql.connect.local_server import (
     _is_local_connect_server,
     _pid_alive,
     _port_open,
+    _process_command,
     runtime_dir,
 )
 
@@ -140,6 +141,36 @@ class _PoolStateRecord:
         if not math.isfinite(timestamp) or not 0 <= timestamp <= cls._MAX_TIMESTAMP:
             return None
         return timestamp
+
+
+@dataclass(frozen=True)
+class PendingState(_PoolStateRecord):
+    """Validated fields of a ``pending-<uid>.json`` launch record."""
+
+    attendant_pid: int
+    created: float
+    fingerprint: str
+
+    @classmethod
+    def attendant_pid_from_data(cls, data: Optional[Dict[str, Any]]) -> Optional[int]:
+        """Recover a valid attendant pid even when another record field is malformed."""
+        return cls._positive_pid(data.get("attendant_pid")) if data is not None else None
+
+    @classmethod
+    def from_data(cls, data: Optional[Dict[str, Any]]) -> Optional["PendingState"]:
+        if data is None:
+            return None
+        attendant_pid = cls.attendant_pid_from_data(data)
+        created = cls._timestamp(data.get("created"))
+        fingerprint = data.get("fingerprint")
+        if (
+            attendant_pid is None
+            or created is None
+            or not isinstance(fingerprint, str)
+            or not fingerprint
+        ):
+            return None
+        return cls(attendant_pid, created, fingerprint)
 
 
 @dataclass(frozen=True)
@@ -516,14 +547,20 @@ class PoolDirectory:
 class ServerPool:
     """Claims, reaps, and retires members of one pool directory."""
 
+    # A pending marker older than this belongs to a launch that hung. Keep this above the local
+    # server startup timeout so a slow but healthy launch is never stopped by the janitor.
+    _LAUNCH_TIMEOUT_SECONDS = 180
     # A retired server still alive after the grace period is hard-killed. With a process handle,
     # tracking is removed only once it is gone, replaced, or successfully signalled. PID-less
     # malformed state uses the give-up age as its bounded recovery window.
     _RETIRE_KILL_AFTER_SECONDS = 30
     _RETIRE_GIVE_UP_AFTER_SECONDS = 600
+    # Preserve a failed launch's logs for diagnosis before collecting its unreferenced directory.
+    _MEMBER_DIR_GC_AGE_SECONDS = 24 * 3600
     _DEFAULT_IDLE_TIMEOUT_SECONDS = 1800
     _PROCESS_INSPECTION_TIMEOUT_SECONDS = 5
     _PROC_STAT_START_TIME_INDEX = 19
+    _ATTENDANT_MODULE = "pyspark.sql.connect.local_server_pool"
 
     def __init__(self, directory: Optional[PoolDirectory] = None):
         self._directory = directory or PoolDirectory()
@@ -613,13 +650,51 @@ class ServerPool:
     def _idle_timeout(cls) -> int:
         """Seconds an unclaimed member may sit before it is retired.
 
-        Zero or a negative value disables idle retirement. Read the environment on each pass so
-        every reaper uses the same source of truth.
+        Zero or a negative value disables idle retirement. Read the environment wherever
+        reaping runs so clients and attendants use the same source of truth.
         """
         try:
             return int(os.environ["SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT"])
         except (KeyError, ValueError):
             return cls._DEFAULT_IDLE_TIMEOUT_SECONDS
+
+    @classmethod
+    def _is_pool_attendant(cls, pid: int, uid: str) -> Optional[bool]:
+        """Whether ``pid`` is still the pool attendant recorded for ``uid``.
+
+        Returns ``None`` when the process cannot be inspected. A stale pending record can
+        outlive its attendant long enough for the pid to be reused, so liveness alone is not
+        sufficient before a janitor signals it.
+        """
+        command = _process_command(pid)
+        if command is None:
+            return None
+        args = command.split()
+        try:
+            module_index = args.index(cls._ATTENDANT_MODULE)
+            uid_index = args.index("--uid")
+        except ValueError:
+            return False
+        return (
+            module_index > 0
+            and args[module_index - 1] == "-m"
+            and "--attend" in args
+            and uid_index + 1 < len(args)
+            and args[uid_index + 1] == uid
+        )
+
+    @staticmethod
+    def _signal_attendant_group(pid: int, sig: int) -> bool:
+        """Signal a detached attendant and the launch subprocesses in its process group."""
+        if pid <= 0 or pid == os.getpgrp():
+            return False
+        try:
+            if os.getpgid(pid) != pid:
+                return False
+            os.killpg(pid, sig)
+            return True
+        except (OSError, OverflowError):
+            return False
 
     def claim(self, fingerprint: str) -> Optional[PoolMember]:
         """Claim the oldest usable member with this fingerprint, or ``None``. The rename to
@@ -663,15 +738,34 @@ class ServerPool:
         return None
 
     def janitor(self) -> None:
-        """Reap unusable or orphaned pool members. Every rule is idempotent, so successive
-        passes from any process are safe."""
+        """Reap leftovers of launches, clients, and attendants that died uncleanly. Every
+        rule is idempotent, so successive passes from any process are safe."""
         for uid in self._directory.uids():
             self.reap(uid)
 
     def reap(self, uid: str) -> bool:
-        """Apply the reaping rules to one member; ``True`` when nothing of it remains."""
+        """Apply the reaping rules to one member; ``True`` when nothing of it remains.
+        Shared by the janitor (all members) and by each attendant supervising its own member.
+        """
         states = self._directory.states(uid)
+        if "conf" in states and "pending" not in states:
+            # A later state proves the attendant consumed the seed. A conf-only record can be
+            # left if its spawning client dies before starting or recording the attendant; use
+            # the launch deadline to avoid accumulating those records forever.
+            later_state = any(kind in states for kind in ("server", "claimed", "retired"))
+            try:
+                conf_expired = (
+                    time.time() - os.path.getmtime(states["conf"]) > self._LAUNCH_TIMEOUT_SECONDS
+                )
+            except FileNotFoundError:
+                conf_expired = True
+            if later_state or conf_expired:
+                self._directory.remove(states["conf"])
+                states = self._directory.states(uid)
         had_retired = "retired" in states
+        if "pending" in states:
+            self._reap_pending(uid, states["pending"])
+        states = self._directory.states(uid)
         if "server" in states:
             self._reap_server(uid, states["server"])
         states = self._directory.states(uid)
@@ -680,7 +774,70 @@ class ServerPool:
         states = self._directory.states(uid)
         if had_retired and "retired" in states:
             self._reap_retired(uid, states["retired"])
-        return not self._directory.states(uid)
+
+        remaining = self._directory.states(uid)
+        if set(remaining) == {"member"}:
+            # Nothing references the member directory anymore. The age gate keeps the logs
+            # of a freshly failed launch around long enough to be looked at.
+            try:
+                expired = (
+                    time.time() - os.path.getmtime(remaining["member"])
+                    > self._MEMBER_DIR_GC_AGE_SECONDS
+                )
+            except FileNotFoundError:
+                expired = True
+            if expired:
+                self._directory.remove_member_dir(uid)
+                remaining = self._directory.states(uid)
+        return not remaining
+
+    def _reap_pending(self, uid: str, path: str) -> None:
+        """A launch whose attendant died or hung: kill the attendant and whatever server
+        spark-daemon.sh may have recorded for it, and withdraw the launch's bookkeeping so
+        refills stop counting it."""
+        data = self._directory.read_json(path)
+        pending = PendingState.from_data(data)
+        parsed_pid = pending.attendant_pid if pending is not None else None
+        created = pending.created if pending is not None else None
+        if pending is None and data is not None:
+            # Preserve an independently valid pid when another field is corrupt.
+            parsed_pid = PendingState.attendant_pid_from_data(data)
+        age = time.time() - created if created is not None else self._LAUNCH_TIMEOUT_SECONDS + 1
+        attendant_pid = parsed_pid if parsed_pid is not None else -1
+        attendant_alive = _pid_alive(attendant_pid)
+        if not attendant_alive:
+            self.abort_launch(uid)
+        elif age > self._LAUNCH_TIMEOUT_SECONDS:
+            is_attendant = self._is_pool_attendant(attendant_pid, uid)
+            if is_attendant is None:
+                return
+            if is_attendant and not self._signal_attendant_group(attendant_pid, signal.SIGKILL):
+                # Keep the record when an attendant that still appears live could not be
+                # stopped; a later pass can retry without losing its only process handle.
+                if _pid_alive(attendant_pid):
+                    return
+            self.abort_launch(uid)
+
+    def abort_launch(self, uid: str) -> None:
+        """Withdraw a failed launch and retire any server it started before failing."""
+        states = self._directory.states(uid)
+        pending_path = states.get("pending")
+        server_path = states.get("server")
+        if server_path is not None:
+            data = self._directory.read_json(server_path)
+            server_pid, process_start_id = self._recover_server_handle(uid, data)
+        else:
+            server_pid = self._recorded_daemon_pid(uid)
+            process_start_id = None
+        retirement_source = server_path or pending_path
+        retired_source = False
+        if server_pid is not None and retirement_source is not None:
+            # Keep shutdown state so a half-started JVM that ignores SIGTERM is escalated.
+            self._retire(retirement_source, server_pid, process_start_id)
+            retired_source = True
+        if pending_path is not None and (not retired_source or pending_path != retirement_source):
+            self._directory.remove(pending_path)
+        self._directory.remove(self._directory.conf_path(uid))
 
     def _reap_server(self, uid: str, path: str) -> None:
         """A ready member that is unusable (dead, unreachable, version-mismatched after an
@@ -854,7 +1011,7 @@ class ServerPool:
 
     def release(self, member: PoolMember) -> None:
         """Retire this process's claimed member; the shutdown completes in the background,
-        ready for a later janitor pass to finish.
+        watched by the member's attendant with the janitor as backstop.
 
         This method acquires the pool-directory lock and must not be called while the same pool
         directory is already locked, including through a different ``PoolDirectory`` instance.

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -310,8 +310,19 @@ class SparkSession:
         )
         self._session_id = self._client._session_id
 
+        self._initialize_lifecycle_state()
+
+    def _initialize_lifecycle_state(self) -> None:
+        """Initialize state shared by normally constructed and derived sessions."""
+
         # Set to false to prevent client.release_session on close() (testing only)
         self.release_session_on_close = True
+        self._on_stop_callbacks: List[Callable[[], None]] = []
+
+    def _register_on_stop_callback(self, callback: Callable[[], None]) -> None:
+        """Register internal lifecycle cleanup owned by the code that created this session."""
+        if callback not in self._on_stop_callbacks:
+            self._on_stop_callbacks.append(callback)
 
     @classmethod
     def _set_default_and_active_session(cls, session: "SparkSession") -> None:
@@ -991,6 +1002,13 @@ class SparkSession:
                 if "SPARK_REMOTE" in os.environ:
                     del os.environ["SPARK_REMOTE"]
 
+            callbacks, self._on_stop_callbacks = self._on_stop_callbacks, []
+            for callback in callbacks:
+                try:
+                    callback()
+                except Exception as e:
+                    logger.warning(f"session.stop(): Cleanup callback failed. Error: {e}")
+
     def __enter__(self) -> "SparkSession":
         """
         Enable 'with SparkSession.builder.(...).getOrCreate() as session: app' syntax.
@@ -1370,7 +1388,7 @@ class SparkSession:
         new_session = object.__new__(SparkSession)
         new_session._client = cloned_client
         new_session._session_id = cloned_client._session_id
-        new_session.release_session_on_close = True
+        new_session._initialize_lifecycle_state()
         return new_session
 
     def newSession(self) -> "SparkSession":
@@ -1398,7 +1416,7 @@ class SparkSession:
         new_session = object.__new__(SparkSession)
         new_session._client = new_client
         new_session._session_id = new_client._session_id
-        new_session.release_session_on_close = True
+        new_session._initialize_lifecycle_state()
         return new_session
 
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -525,6 +525,14 @@ class SparkSession(SparkConversionMixin):
                                     messageParameters={},
                                 )
 
+                            pool_cleanup: Optional[Callable[[], None]] = None
+                            pool_local = str(
+                                opts.get(
+                                    "spark.local.connect.pool",
+                                    os.environ.get("SPARK_LOCAL_CONNECT_POOL", ""),
+                                )
+                            ).lower() in ("1", "true")
+
                             reuse_local = str(
                                 opts.get(
                                     "spark.local.connect.reuse",
@@ -532,7 +540,23 @@ class SparkSession(SparkConversionMixin):
                                 )
                             ).lower() in ("1", "true")
 
-                            if url.startswith("local") and reuse_local:
+                            if url.startswith("local") and pool_local:
+                                from pyspark.sql.connect.local_server_pool import (
+                                    acquire_pooled_local_connect_server,
+                                    release_pooled_local_connect_server,
+                                )
+
+                                # Opt-in: claim a server not previously assigned to an
+                                # application run from a pool of booted local Connect servers.
+                                # It is torn down when this run's session stops, so no state
+                                # carries across runs. Takes precedence over reuse. See
+                                # `pyspark.sql.connect.local_server_pool`.
+                                url = acquire_pooled_local_connect_server(url, opts)
+                                pool_cleanup = release_pooled_local_connect_server
+                                for k in list(opts):
+                                    if k.startswith("spark.local.connect."):
+                                        opts.pop(k)
+                            elif url.startswith("local") and reuse_local:
                                 from pyspark.sql.connect.local_server import (
                                     reuse_or_start_local_connect_server,
                                 )
@@ -553,9 +577,27 @@ class SparkSession(SparkConversionMixin):
 
                             os.environ["SPARK_CONNECT_MODE_ENABLED"] = "1"
                             opts["spark.remote"] = url
+                            try:
+                                remote_session = RemoteSparkSession.builder.config(
+                                    map=opts
+                                ).getOrCreate()
+                            except Exception:
+                                if pool_cleanup is not None:
+                                    try:
+                                        pool_cleanup()
+                                    except Exception as cleanup_error:
+                                        warnings.warn(
+                                            "Failed to clean up a pooled local Connect server "
+                                            f"after session creation failed: {cleanup_error}",
+                                            RuntimeWarning,
+                                            stacklevel=2,
+                                        )
+                                raise
+                            if pool_cleanup is not None:
+                                remote_session._register_on_stop_callback(pool_cleanup)
                             return cast(
                                 SparkSession,
-                                RemoteSparkSession.builder.config(map=opts).getOrCreate(),
+                                remote_session,
                             )
                         elif "SPARK_LOCAL_REMOTE" in os.environ:
                             url = "sc://localhost"

--- a/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
+++ b/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
@@ -636,13 +636,39 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertEqual(retired.pid, 456)
         self.assertEqual(retired.process_start_id, "process-1")
         self.assertEqual(retired.retired, 2.0)
+        self.assertFalse(retired.signalled)
         self.assertEqual(
             retired.as_data(),
-            {"pid": 456, "process_start_id": "process-1", "retired": 2.0},
+            {
+                "pid": 456,
+                "process_start_id": "process-1",
+                "retired": 2.0,
+                "signalled": False,
+            },
         )
+        delivered = RetiredState.from_data(
+            {
+                "pid": 456,
+                "process_start_id": "process-1",
+                "retired": 2,
+                "signalled": True,
+            }
+        )
+        assert delivered is not None
+        self.assertTrue(delivered.signalled)
         self.assertIsNone(
             RetiredState.from_data(
                 {"pid": 456, "process_start_id": "process-1", "retired": "not-a-time"}
+            )
+        )
+        self.assertIsNone(
+            RetiredState.from_data(
+                {
+                    "pid": 456,
+                    "process_start_id": "process-1",
+                    "retired": 2,
+                    "signalled": 1,
+                }
             )
         )
         self.assertIsNone(RetiredState.from_data({"pid": 456, "retired": 2}))
@@ -837,6 +863,143 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         for uid in records:
             self.assertEqual(set(self._states(uid)), {"server"})
 
+    def test_reap_server_unreachable_and_idle(self) -> None:
+        with self.subTest("unreachable member is retired"):
+            gone = self._live_process()
+            with _non_listening_socket() as port:
+                self._write_state(
+                    self._directory.server_path("dead"), self._server_data(port, gone.pid)
+                )
+                with self._directory:
+                    self._pool.reap("dead")
+            self.assertEqual(set(self._states("dead")), {"retired"})
+            self.assertTrue(_wait_proc_dead(gone))
+        with self.subTest("member idle past the timeout is retired"):
+            os.environ["SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT"] = "10"
+            with _listening_socket() as port:
+                idle = self._live_process()
+                self._write_state(
+                    self._directory.server_path("1d1e"),
+                    self._server_data(port, idle.pid, created=time.time() - 60),
+                )
+                fresh = self._live_process()
+                self._write_state(
+                    self._directory.server_path("f2e5"), self._server_data(port, fresh.pid)
+                )
+                with self._directory:
+                    self._pool.janitor()
+                self.assertEqual(set(self._states("1d1e")), {"retired"})
+                self.assertEqual(set(self._states("f2e5")), {"server"})
+                self.assertTrue(_wait_proc_dead(idle))
+                self.assertIsNone(fresh.poll())
+
+    def test_reap_does_not_signal_reused_server_pid(self) -> None:
+        unrelated = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.stdin.buffer.read()"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self._procs.append(unrelated)
+        with _non_listening_socket() as port:
+            self._write_state(
+                self._directory.server_path("bad6"), self._server_data(port, unrelated.pid)
+            )
+            with self._directory:
+                self._pool.reap("bad6")
+
+        self.assertEqual(set(self._states("bad6")), {"retired"})
+        self.assertIsNone(unrelated.poll())
+
+    def test_reap_malformed_member_recovers_server_pid(self) -> None:
+        # An out-of-range created value makes the full member invalid, but its independently
+        # valid pid must still be retired and tracked rather than leaving a live JVM orphaned.
+        invalid_created = self._live_process()
+        with _non_listening_socket() as port:
+            self._write_state(
+                self._directory.server_path("bad0"),
+                self._server_data(port, invalid_created.pid, created=2**100),
+            )
+            with self._directory:
+                self._pool.reap("bad0")
+        states = self._states("bad0")
+        self.assertEqual(set(states), {"retired"})
+        with self._directory as directory:
+            self.assertEqual(directory.read_json(states["retired"])["pid"], invalid_created.pid)
+        self.assertTrue(_wait_proc_dead(invalid_created))
+
+        # Claimed records use the same recovery when their client has disappeared.
+        claimed = self._live_process()
+        with _non_listening_socket() as port:
+            self._write_state(
+                self._directory.claimed_path(2**31 - 1, "bad2"),
+                self._server_data(port, claimed.pid, created=2**100),
+            )
+            with self._directory:
+                self._pool.reap("bad2")
+        states = self._states("bad2")
+        self.assertEqual(set(states), {"retired"})
+        with self._directory as directory:
+            self.assertEqual(directory.read_json(states["retired"])["pid"], claimed.pid)
+        self.assertTrue(_wait_proc_dead(claimed))
+
+        # If the record itself has no usable pid, fall back to spark-daemon.sh's pid file. The
+        # fallback keeps the shutdown tracked but lacks the process identity needed to signal it.
+        unreadable_pid = self._live_process()
+        self._write_daemon_pid("bad1", unreadable_pid.pid)
+        self._write_state(self._directory.server_path("bad1"), {"malformed": True})
+        with self._directory:
+            self._pool.reap("bad1")
+        states = self._states("bad1")
+        self.assertEqual(set(states), {"member", "retired"})
+        with self._directory as directory:
+            retired = directory.read_json(states["retired"])
+            assert retired is not None
+            self.assertEqual(retired["pid"], unreadable_pid.pid)
+            self.assertNotIn("process_start_id", retired)
+        self.assertIsNone(unreadable_pid.poll())
+
+    def test_reap_claimed_of_dead_client(self) -> None:
+        orphan = self._live_process()
+        dead_client = 2**31 - 1
+        ours = self._live_process()
+        with _non_listening_socket() as port:
+            self._write_state(
+                self._directory.claimed_path(dead_client, "0a0a"),
+                self._server_data(port, orphan.pid),
+            )
+            self._write_state(
+                self._directory.claimed_path(os.getpid(), "0b0b"),
+                self._server_data(port, ours.pid),
+            )
+            self._write_state(
+                self._directory.claimed_path(os.getpid(), "0c0c"),
+                self._server_data(port, 2**31 - 1),
+            )
+            with self._directory:
+                self._pool.janitor()
+        # The orphaned claim and our dead server are retired; our live claim is untouched.
+        self.assertEqual(set(self._states("0a0a")), {"retired"})
+        self.assertTrue(_wait_proc_dead(orphan), "the orphaned server was not stopped")
+        self.assertEqual(set(self._states("0b0b")), {"claimed"})
+        self.assertIsNone(ours.poll())
+        self.assertEqual(set(self._states("0c0c")), {"retired"})
+
+    def test_reap_claimed_detects_a_reused_server_pid(self) -> None:
+        unrelated = self._stubborn_process()
+        data = self._server_data(
+            12345,
+            unrelated.pid,
+            process_start_id="a-different-process-generation",
+        )
+        self._write_state(self._directory.claimed_path(os.getpid(), "bad6"), data)
+
+        with self._directory:
+            self.assertFalse(self._pool.reap("bad6"))
+
+        self.assertEqual(set(self._states("bad6")), {"retired"})
+        self.assertIsNone(unrelated.poll())
+
     def test_reap_retired_escalates_to_sigkill(self) -> None:
         with self.subTest("a fresh retirement is left to shut down gracefully"):
             fresh = self._stubborn_process()
@@ -875,9 +1038,11 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
 
     def test_reap_repairs_malformed_retired_state(self) -> None:
         server = self._stubborn_process()
+        malformed = self._retired_data(server.pid, "not-a-time")
+        malformed["signalled"] = True
         path = self._write_state(
             self._directory.retired_path("bad4"),
-            self._retired_data(server.pid, "not-a-time"),
+            malformed,
         )
 
         with self._directory as directory:
@@ -887,6 +1052,7 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         assert repaired is not None
         self.assertEqual(repaired["pid"], server.pid)
         self.assertIsInstance(repaired["retired"], float)
+        self.assertTrue(repaired["signalled"])
         self.assertIsNone(server.poll())
 
     def test_reap_keeps_retired_state_when_process_inspection_fails(self) -> None:
@@ -925,6 +1091,23 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertEqual(retained, original)
         self.assertIsNone(server.poll())
 
+    def test_reap_eventually_removes_state_without_a_process_handle(self) -> None:
+        uid = "fade"
+        self._write_state(self._directory.server_path(uid), {"malformed": True})
+
+        with self._directory as directory:
+            self.assertFalse(self._pool.reap(uid))
+            states = self._directory.states(uid)
+            self.assertEqual(set(states), {"retired"})
+            retired = directory.read_json(states["retired"])
+            assert retired is not None
+            self.assertNotIn("pid", retired)
+            retired["retired"] = time.time() - ServerPool._RETIRE_GIVE_UP_AFTER_SECONDS - 1
+            directory.write_json(states["retired"], retired)
+            self.assertTrue(self._pool.reap(uid))
+
+        self.assertFalse(self._states(uid))
+
     def test_reap_keeps_a_daemon_pid_without_a_process_identity(self) -> None:
         server = self._stubborn_process()
         uid = "daed"
@@ -941,6 +1124,13 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
 
         self.assertEqual(retained, original)
         self.assertIsNone(server.poll())
+
+        server.kill()
+        self.assertTrue(_wait_proc_dead(server))
+        with self._directory:
+            self.assertTrue(self._pool.reap(uid))
+        self.assertFalse(os.path.exists(path))
+        self.assertFalse(os.path.exists(self._directory.member_dir(uid)))
 
     def test_reap_prefers_the_record_pid_and_its_process_identity(self) -> None:
         recorded_server = self._stubborn_process()
@@ -1006,8 +1196,8 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertIsInstance(repaired["retired"], float)
         self.assertIsNone(server.poll())
 
-    def test_reap_retries_a_sigterm_missed_during_retirement(self) -> None:
-        server = self._live_process()
+    def test_reap_retries_sigterm_only_until_delivered(self) -> None:
+        server = self._stubborn_process()
         process_start_id = ServerPool._process_start_id(server.pid)
         assert process_start_id is not None
         state_path = self._write_state(
@@ -1015,16 +1205,32 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
             self._server_data(12345, server.pid),
         )
 
-        with mock.patch.object(local_server_pool, "_is_local_connect_server", return_value=None):
-            with self._directory:
+        with self._directory as directory:
+            with mock.patch.object(
+                ServerPool,
+                "_signal_server",
+                side_effect=[False, False, True],
+            ) as signal_server:
                 self._pool._retire(state_path, server.pid, process_start_id)
+                retired_path = self._directory.retired_path("fade")
+                initial = directory.read_json(retired_path)
+                assert initial is not None
+                self.assertFalse(initial["signalled"])
+
+                self.assertFalse(self._pool.reap("fade"))
+                failed_retry = directory.read_json(retired_path)
+                self.assertEqual(failed_retry, initial)
+
+                self.assertFalse(self._pool.reap("fade"))
+                delivered = directory.read_json(retired_path)
+                assert delivered is not None
+                self.assertTrue(delivered["signalled"])
+                self.assertEqual(delivered["retired"], initial["retired"])
+
+                self.assertFalse(self._pool.reap("fade"))
+                self.assertEqual(signal_server.call_count, 3)
 
         self.assertIsNone(server.poll())
-        with self._directory:
-            self.assertFalse(self._pool.reap("fade"))
-        self.assertTrue(_wait_proc_dead(server), "the reaper did not retry graceful shutdown")
-        with self._directory:
-            self.assertTrue(self._pool.reap("fade"))
 
     def test_release_retires_the_claimed_member(self) -> None:
         server = self._live_process()
@@ -1046,7 +1252,10 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         states = self._states("a1a1")
         self.assertEqual(set(states), {"retired"})
         with self._directory as directory:
-            self.assertEqual(directory.read_json(states["retired"])["pid"], server.pid)
+            retired = directory.read_json(states["retired"])
+            assert retired is not None
+            self.assertEqual(retired["pid"], server.pid)
+            self.assertTrue(retired["signalled"])
         self.assertTrue(_wait_proc_dead(server), "release did not stop the server")
         # Releasing again is a no-op.
         local_server_pool.release_pooled_local_connect_server()

--- a/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
+++ b/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import time
 import unittest
+from typing import Tuple
 from unittest import mock
 
 from pyspark.testing.connectutils import connect_requirement_message, should_test_connect
@@ -32,6 +33,7 @@ if should_test_connect:
     from pyspark.sql.connect.local_server import _SERVER_CLASS, _pid_alive
     from pyspark.sql.connect.local_server_pool import (
         _JVM_ENV_VARS,
+        PendingState,
         PoolDirectory,
         PoolMember,
         RetiredState,
@@ -105,6 +107,15 @@ def _wait_proc_dead(proc: "subprocess.Popen", timeout: float = 30.0) -> bool:
         return False
 
 
+def _wait_pid_dead(pid: int, timeout: float = 30.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.05)
+    return False
+
+
 _SAVED_ENV_KEYS = (
     "SPARK_LOCAL_CONNECT_POOL_DIR",
     "SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT",
@@ -159,6 +170,56 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         proc = _spawn_stubborn_process()
         self._procs.append(proc)
         return proc
+
+    def _attendant(self, uid: str) -> "subprocess.Popen":
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdin.buffer.read()",
+                "-m",
+                "pyspark.sql.connect.local_server_pool",
+                "--attend",
+                "--pool-dir",
+                self._directory.path,
+                "--uid",
+                uid,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        self._procs.append(proc)
+        return proc
+
+    def _attendant_with_launch_child(self, uid: str) -> Tuple["subprocess.Popen", int]:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import subprocess, sys\n"
+                "child = subprocess.Popen([sys.executable, '-c', "
+                "'import time; time.sleep(300)'])\n"
+                "print(child.pid, flush=True)\n"
+                "sys.stdin.buffer.read()",
+                "-m",
+                "pyspark.sql.connect.local_server_pool",
+                "--attend",
+                "--pool-dir",
+                self._directory.path,
+                "--uid",
+                uid,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+        self._procs.append(proc)
+        assert proc.stdout is not None
+        return proc, int(proc.stdout.readline())
 
     def _server_data(self, port: int, pid: int, fingerprint: str = "fp", **overrides) -> dict:
         process_start_id = None
@@ -628,7 +689,16 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIsNone(PoolMember.from_data(data))
 
-    def test_retired_state_fields_and_validation(self) -> None:
+    def test_lifecycle_state_fields_and_validation(self) -> None:
+        pending = PendingState.from_data({"attendant_pid": 123, "created": 1, "fingerprint": "fp"})
+        assert pending is not None
+        self.assertEqual(pending.attendant_pid, 123)
+        self.assertEqual(pending.created, 1.0)
+        self.assertEqual(pending.fingerprint, "fp")
+        self.assertIsNone(
+            PendingState.from_data({"attendant_pid": "123", "created": 1, "fingerprint": "fp"})
+        )
+
         retired = RetiredState.from_data(
             {"pid": 456, "process_start_id": "process-1", "retired": 2}
         )
@@ -869,6 +939,146 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertEqual(member.token, "valid-token")
         for uid in records:
             self.assertEqual(set(self._states(uid)), {"server"})
+
+    def test_reap_pending_of_dead_attendant(self) -> None:
+        # The attendant died mid-boot: its pending marker and conf seed are withdrawn, and
+        # the half-started server whose pid spark-daemon.sh recorded remains tracked. A daemon
+        # pid has no process-generation identity, so it cannot safely authorize a signal.
+        half_started = self._stubborn_process()
+        self._write_daemon_pid("b007", half_started.pid)
+        self._write_state(
+            self._directory.pending_path("b007"),
+            {"attendant_pid": 2**31 - 1, "created": time.time(), "fingerprint": "fp"},
+        )
+        self._write_state(self._directory.conf_path("b007"), {"spark.foo": "bar"})
+
+        with self._directory:
+            self._pool.reap("b007")
+
+        states = self._states("b007")
+        self.assertNotIn("pending", states)
+        self.assertNotIn("conf", states)
+        self.assertEqual(set(states), {"member", "retired"})
+        with self._directory as directory:
+            retired = directory.read_json(states["retired"])
+            assert retired is not None
+            self.assertEqual(retired["pid"], half_started.pid)
+            self.assertNotIn("process_start_id", retired)
+        self.assertIsNone(half_started.poll())
+
+        half_started.kill()
+        self.assertTrue(_wait_proc_dead(half_started))
+        with self._directory:
+            self.assertTrue(self._pool.reap("b007"))
+
+    def test_reap_malformed_pending(self) -> None:
+        attendant = self._attendant("bad3")
+        self._write_state(
+            self._directory.pending_path("bad3"),
+            {"attendant_pid": attendant.pid, "created": "not-a-time"},
+        )
+        self._write_state(self._directory.conf_path("bad3"), {"spark.foo": "bar"})
+
+        with self._directory:
+            self.assertTrue(self._pool.reap("bad3"))
+
+        self.assertTrue(_wait_proc_dead(attendant))
+
+    def test_reap_does_not_signal_reused_attendant_pid(self) -> None:
+        unrelated = self._live_process()
+        self._write_state(
+            self._directory.pending_path("bad8"),
+            {
+                "attendant_pid": unrelated.pid,
+                "created": time.time() - 181,
+                "fingerprint": "fp",
+            },
+        )
+        self._write_state(self._directory.conf_path("bad8"), {"spark.foo": "bar"})
+
+        with mock.patch.object(local_server_pool, "_process_command", return_value=None):
+            with self._directory:
+                self.assertFalse(self._pool.reap("bad8"))
+        self.assertEqual(set(self._states("bad8")), {"conf", "pending"})
+
+        with self._directory:
+            self.assertTrue(self._pool.reap("bad8"))
+
+        self.assertIsNone(unrelated.poll())
+
+    def test_reap_timed_out_attendant_kills_its_launch_group(self) -> None:
+        attendant, launch_child_pid = self._attendant_with_launch_child("bad0")
+        self._write_state(
+            self._directory.pending_path("bad0"),
+            {
+                "attendant_pid": attendant.pid,
+                "created": time.time() - 181,
+                "fingerprint": "fp",
+            },
+        )
+        self._write_state(self._directory.conf_path("bad0"), {"spark.foo": "bar"})
+
+        with self._directory:
+            self.assertTrue(self._pool.reap("bad0"))
+
+        self.assertTrue(_wait_proc_dead(attendant))
+        self.assertTrue(_wait_pid_dead(launch_child_pid))
+
+    def test_reap_pending_with_published_server_retires_server(self) -> None:
+        # Publishing writes server-* before removing pending-*. If the attendant dies between
+        # those operations, the janitor must not leave that server available to claim.
+        server = self._stubborn_process()
+        self._write_daemon_pid("bad7", server.pid)
+        with _non_listening_socket() as port:
+            self._write_state(
+                self._directory.server_path("bad7"), self._server_data(port, server.pid)
+            )
+            self._write_state(
+                self._directory.pending_path("bad7"),
+                {"attendant_pid": 2**31 - 1, "created": time.time(), "fingerprint": "fp"},
+            )
+            self._write_state(self._directory.conf_path("bad7"), {"spark.foo": "bar"})
+            with self._directory:
+                self._pool.reap("bad7")
+                self.assertIsNone(self._pool.claim("fp"))
+
+        self.assertEqual(set(self._states("bad7")), {"member", "retired"})
+        self.assertIsNone(server.poll())
+
+    def test_reap_removes_conf_left_after_publication(self) -> None:
+        server = self._live_process()
+        with _listening_socket() as port:
+            self._write_state(
+                self._directory.server_path("c0f1"), self._server_data(port, server.pid)
+            )
+            self._write_state(self._directory.conf_path("c0f1"), {"spark.foo": "bar"})
+
+            with self._directory:
+                self._pool.reap("c0f1")
+
+        self.assertEqual(set(self._states("c0f1")), {"server"})
+        self.assertIsNone(server.poll())
+
+    def test_reap_removes_stale_conf_without_an_attendant(self) -> None:
+        conf_path = self._write_state(self._directory.conf_path("c0f2"), {"spark.foo": "bar"})
+        old = time.time() - 181
+        os.utime(conf_path, (old, old))
+
+        with self._directory:
+            self.assertTrue(self._pool.reap("c0f2"))
+
+        self.assertFalse(os.path.exists(conf_path))
+
+    def test_reap_keeps_live_pending(self) -> None:
+        attendant = self._live_process()
+        self._write_state(
+            self._directory.pending_path("11ce"),
+            {"attendant_pid": attendant.pid, "created": time.time(), "fingerprint": "fp"},
+        )
+        with self._directory:
+            self._pool.reap("11ce")
+        self.assertIn("pending", self._states("11ce"))
+        self.assertIsNone(attendant.poll())
 
     def test_reap_server_unreachable_and_idle(self) -> None:
         with self.subTest("unreachable member is retired"):
@@ -1185,6 +1395,21 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
             self.assertTrue(self._pool.reap("bad8"))
 
         self.assertIsNone(other_server.poll())
+
+    def test_reap_garbage_collects_old_unreferenced_member_directory(self) -> None:
+        old_dir = self._directory.member_dir("01d0")
+        fresh_dir = self._directory.member_dir("f2e5")
+        os.makedirs(old_dir)
+        os.makedirs(fresh_dir)
+        old = time.time() - 24 * 3600 - 1
+        os.utime(old_dir, (old, old))
+
+        with self._directory:
+            self.assertTrue(self._pool.reap("01d0"))
+            self.assertFalse(self._pool.reap("f2e5"))
+
+        self.assertFalse(os.path.exists(old_dir))
+        self.assertTrue(os.path.isdir(fresh_dir))
 
     def test_retire_survives_interrupted_state_rewrite(self) -> None:
         server = self._stubborn_process()

--- a/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
+++ b/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
@@ -692,9 +692,16 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertEqual(os.path.basename(member.claim_path), claim_name)
         states = self._states("bbb")
         self.assertEqual(set(states), {"claimed"})
+        with self._directory as directory:
+            claimed = directory.read_json(states["claimed"])
+        assert claimed is not None
+        self.assertEqual(
+            claimed["client_process_start_id"], ServerPool._process_start_id(os.getpid())
+        )
         # The mismatched member is untouched, and a second claim finds nothing.
         self.assertEqual(set(self._states("aaa")), {"server"})
         with self._directory:
+            self.assertFalse(self._pool.reap("bbb"))
             self.assertIsNone(self._pool.claim("my-fp"))
 
     def test_claim_prefers_the_oldest_member(self) -> None:
@@ -984,6 +991,18 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertEqual(set(self._states("0b0b")), {"claimed"})
         self.assertIsNone(ours.poll())
         self.assertEqual(set(self._states("0c0c")), {"retired"})
+
+    def test_reap_claimed_detects_a_reused_client_pid(self) -> None:
+        server = self._live_process()
+        data = self._server_data(12345, server.pid)
+        data["client_process_start_id"] = "a-different-process-generation"
+        self._write_state(self._directory.claimed_path(os.getpid(), "bad5"), data)
+
+        with self._directory:
+            self.assertFalse(self._pool.reap("bad5"))
+
+        self.assertEqual(set(self._states("bad5")), {"retired"})
+        self.assertTrue(_wait_proc_dead(server), "the orphaned server was not stopped")
 
     def test_reap_claimed_detects_a_reused_server_pid(self) -> None:
         unrelated = self._stubborn_process()

--- a/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
+++ b/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
@@ -1130,6 +1130,8 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
 
         self.assertEqual(set(self._states("bad6")), {"retired"})
         self.assertIsNone(unrelated.poll())
+        self.assertEqual(self._pool.purge(), 0)
+        self.assertIsNone(unrelated.poll())
 
     def test_reap_malformed_member_recovers_server_pid(self) -> None:
         # An out-of-range created value makes the full member invalid, but its independently
@@ -1615,6 +1617,51 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
                 local_server_pool.acquire_pooled_local_connect_server("local[2]", {})
         self.assertIn("POSIX", str(ctx.exception))
 
+
+    def test_purge_kills_everything_and_empties_the_directory(self) -> None:
+        warm = self._live_process()
+        attendant = self._attendant("b007")
+        half_started = self._stubborn_process()
+        duplicate_a = self._live_process()
+        duplicate_b = self._live_process()
+        retiring = self._stubborn_process()
+        with _non_listening_socket() as port:
+            self._write_state(
+                self._directory.server_path("a2a2"), self._server_data(port, warm.pid)
+            )
+            self._write_state(
+                self._directory.pending_path("b007"),
+                {"attendant_pid": attendant.pid, "created": time.time(), "fingerprint": "fp"},
+            )
+            self._write_state(self._directory.conf_path("b007"), {"spark.foo": "bar"})
+            os.makedirs(self._directory.member_dir("a2a2"))
+            self._write_daemon_pid("b007", half_started.pid)
+            # Purge is the corruption escape hatch, so malformed process metadata must not
+            # prevent it from clearing the rest of the pool.
+            self._write_state(self._directory.server_path("bad5"), {"pid": "not-a-pid"})
+            self._write_state(
+                self._directory.claimed_path(111, "d00d"),
+                self._server_data(port, duplicate_a.pid),
+            )
+            self._write_state(
+                self._directory.claimed_path(222, "d00d"),
+                self._server_data(port, duplicate_b.pid),
+            )
+            self._write_state(
+                self._directory.retired_path("e7ed"),
+                {"pid": retiring.pid, "retired": time.time()},
+            )
+
+            signalled = local_server_pool.purge_local_connect_pool()
+
+        self.assertEqual(signalled, 6)
+        self.assertEqual(os.listdir(self._directory.path), [".lock"])
+        self.assertTrue(_wait_proc_dead(warm))
+        self.assertTrue(_wait_proc_dead(attendant))
+        self.assertTrue(_wait_proc_dead(half_started))
+        self.assertTrue(_wait_proc_dead(duplicate_a))
+        self.assertTrue(_wait_proc_dead(duplicate_b))
+        self.assertTrue(_wait_proc_dead(retiring))
 
 if __name__ == "__main__":
     from pyspark.testing import main

--- a/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
+++ b/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
@@ -16,17 +16,20 @@
 #
 
 import contextlib
+import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import time
 import unittest
 from typing import Tuple
 from unittest import mock
 
 from pyspark.testing.connectutils import connect_requirement_message, should_test_connect
+from pyspark.util import is_remote_only
 
 if should_test_connect:
     from pyspark.sql.connect import local_server_pool
@@ -117,7 +120,18 @@ def _wait_pid_dead(pid: int, timeout: float = 30.0) -> bool:
     return False
 
 
+def _wait_pid_gone(pid: int, timeout: float = 60.0) -> bool:
+    """Wait for a non-child pid to stop running. Linux zombies count as terminated."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not local_server_pool._pid_alive(pid):
+            return True
+        time.sleep(0.2)
+    return False
+
+
 _SAVED_ENV_KEYS = (
+    "SPARK_LOCAL_CONNECT_POOL",
     "SPARK_LOCAL_CONNECT_POOL_DIR",
     "SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT",
     "SPARK_LOCAL_CONNECT_POOL_SIZE",
@@ -1662,6 +1676,117 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         self.assertTrue(_wait_proc_dead(duplicate_a))
         self.assertTrue(_wait_proc_dead(duplicate_b))
         self.assertTrue(_wait_proc_dead(retiring))
+
+
+@unittest.skipIf(
+    not should_test_connect or is_remote_only(),
+    connect_requirement_message or "Requires JVM access to start local Connect servers",
+)
+@unittest.skipUnless(os.name == "posix", "the pool relies on the POSIX sbin scripts")
+class LocalConnectServerPoolE2ETests(unittest.TestCase):
+    """End-to-end tests that boot real pooled servers (slow)."""
+
+    CLIENT = textwrap.dedent(
+        """
+        import json
+
+        from pyspark.sql import SparkSession
+
+        spark = (
+            SparkSession.builder.remote("local[2]")
+            .config("spark.local.connect.pool", "true")
+            .getOrCreate()
+        )
+        from pyspark.sql.connect import local_server_pool
+
+        try:
+            # Pool cleanup belongs only to the builder-created session that claimed the
+            # server. Stopping another session must leave the claimed server available.
+            spark.newSession().stop()
+            count = spark.range(1).count()
+            member = local_server_pool._claimed_member
+            print(json.dumps({"count": count, "server_pid": member.pid}))
+        finally:
+            spark.stop()
+        """
+    )
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.mkdtemp()
+        self._pool_dir = os.path.join(self._tmpdir, "pool")
+        self._saved_env = {k: os.environ.get(k) for k in _SAVED_ENV_KEYS}
+        os.environ["SPARK_LOCAL_CONNECT_POOL_DIR"] = self._pool_dir
+
+    def tearDown(self) -> None:
+        try:
+            local_server_pool.purge_local_connect_pool()
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                if set(os.listdir(self._pool_dir)) <= {".lock"}:
+                    break
+                # Supervising attendants notice the purged directory and exit on their own;
+                # purge again in case one republished state in between.
+                local_server_pool.purge_local_connect_pool()
+                time.sleep(1)
+        finally:
+            for k, v in self._saved_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _run_clients(self, n: int, pool_size: str) -> list:
+        env = dict(os.environ)
+        env["SPARK_LOCAL_CONNECT_POOL_DIR"] = self._pool_dir
+        env["SPARK_LOCAL_CONNECT_POOL"] = "1"
+        env["SPARK_LOCAL_CONNECT_POOL_SIZE"] = pool_size
+        env.pop("SPARK_CONNECT_AUTHENTICATE_TOKEN", None)
+        procs = [
+            subprocess.Popen(
+                [sys.executable, "-c", self.CLIENT],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for _ in range(n)
+        ]
+        outputs = []
+        try:
+            for proc in procs:
+                stdout, stderr = proc.communicate(timeout=300)
+                self.assertEqual(proc.returncode, 0, stderr)
+                lines = stdout.strip().splitlines()
+                self.assertTrue(lines, stderr)
+                outputs.append(json.loads(lines[-1]))
+        finally:
+            for proc in procs:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.communicate()
+        return outputs
+
+    def test_sequential_runs_use_fresh_servers_and_tear_them_down(self) -> None:
+        first = self._run_clients(1, pool_size="1")[0]
+        self.assertEqual(first["count"], 1)
+        # The used server is torn down asynchronously after its run.
+        self.assertTrue(
+            _wait_pid_gone(first["server_pid"]),
+            "the server was not torn down after its run ended",
+        )
+        second = self._run_clients(1, pool_size="1")[0]
+        self.assertEqual(second["count"], 1)
+        self.assertNotEqual(
+            first["server_pid"], second["server_pid"], "a pooled server was reused across runs"
+        )
+
+    def test_concurrent_cold_clients_get_distinct_servers(self) -> None:
+        outputs = self._run_clients(2, pool_size="2")
+        self.assertEqual({o["count"] for o in outputs}, {1})
+        pids = [o["server_pid"] for o in outputs]
+        self.assertEqual(len(set(pids)), 2, "two concurrent runs shared a pooled server")
+
 
 if __name__ == "__main__":
     from pyspark.testing import main

--- a/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
+++ b/python/pyspark/sql/tests/connect/test_connect_local_server_pool.py
@@ -33,6 +33,7 @@ if should_test_connect:
     from pyspark.sql.connect.local_server import _SERVER_CLASS, _pid_alive
     from pyspark.sql.connect.local_server_pool import (
         _JVM_ENV_VARS,
+        MemberAttendant,
         PendingState,
         PoolDirectory,
         PoolMember,
@@ -119,6 +120,8 @@ def _wait_pid_dead(pid: int, timeout: float = 30.0) -> bool:
 _SAVED_ENV_KEYS = (
     "SPARK_LOCAL_CONNECT_POOL_DIR",
     "SPARK_LOCAL_CONNECT_POOL_IDLE_TIMEOUT",
+    "SPARK_LOCAL_CONNECT_POOL_SIZE",
+    "SPARK_CONNECT_AUTHENTICATE_TOKEN",
     "PYSPARK_DRIVER_PYTHON",
     "PYSPARK_PYTHON",
 )
@@ -1564,6 +1567,53 @@ class LocalConnectServerPoolUnitTests(unittest.TestCase):
         # A concurrent janitor already completed the claim -> retired transition.
         self._pool.release(member)
         self.assertEqual(set(self._states("a1a2")), {"retired"})
+
+    def test_pool_size_parsing(self) -> None:
+        from pyspark.sql.connect.local_server_pool import _pool_size
+
+        self.assertEqual(_pool_size({}), 2)
+        self.assertEqual(_pool_size({"spark.local.connect.pool.size": "3"}), 3)
+        os.environ["SPARK_LOCAL_CONNECT_POOL_SIZE"] = "5"
+        self.assertEqual(_pool_size({}), 5)
+        # Junk falls back to the default; values below one are clamped up.
+        self.assertEqual(_pool_size({"spark.local.connect.pool.size": "abc"}), 2)
+        self.assertEqual(_pool_size({"spark.local.connect.pool.size": float("inf")}), 2)
+        self.assertEqual(_pool_size({"spark.local.connect.pool.size": "0"}), 1)
+
+    def test_refill_only_counts_matching_members(self) -> None:
+        from unittest import mock
+
+        with self._directory as directory:
+            directory.write_json(
+                directory.server_path("a11"), self._server_data(1, os.getpid(), "my-fp")
+            )
+            directory.write_json(
+                directory.pending_path("b22"),
+                {"attendant_pid": os.getpid(), "created": time.time(), "fingerprint": "other"},
+            )
+            with mock.patch.object(MemberAttendant, "spawn") as spawn:
+                self._pool.refill("local[2]", {}, "my-fp", target=2)
+        # One matching member exists (the other-fingerprint launch does not count), so one
+        # launch tops the pool up to the target of two.
+        self.assertEqual(spawn.call_count, 1)
+
+    def test_acquire_returns_the_member_already_claimed_by_this_process(self) -> None:
+        member = PoolMember(self._server_data(15002, os.getpid()))
+        member.claim_path = "unused"
+        local_server_pool._claimed_member = member
+        url = local_server_pool.acquire_pooled_local_connect_server("local[2]", {})
+        self.assertEqual(url, "sc://localhost:15002")
+        self.assertEqual(os.environ.get("SPARK_CONNECT_AUTHENTICATE_TOKEN"), "t")
+
+    def test_acquire_requires_posix(self) -> None:
+        from unittest import mock
+
+        from pyspark.errors import PySparkRuntimeError
+
+        with mock.patch.object(os, "name", "nt"):
+            with self.assertRaises(PySparkRuntimeError) as ctx:
+                local_server_pool.acquire_pooled_local_connect_server("local[2]", {})
+        self.assertIn("POSIX", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is layer 9 of the ten-PR local Connect pool stack:

#57684 -> #57685 -> #57907 -> #57686 -> #58247 ->
#58367 -> #57687 -> #58248 -> #57102 -> #57688

Until lower layers merge, GitHub shows their cumulative diff. The review unit introduced here is
commit `6aa073c4ee3`. JIT warmup is isolated in follow-up #57688.

This layer wires the pool into the public SparkSession construction path:

- `SparkSession.builder.remote("local[*]")` selects the pool when
  `spark.local.connect.pool=true` or `SPARK_LOCAL_CONNECT_POOL=1` is set;
- pool mode takes precedence over persistent-server reuse;
- the claimed member is released if session construction fails;
- the owning Connect session registers an idempotent stop callback;
- cloned and new sessions do not inherit ownership of the pooled server;
- user documentation describes the experimental single-use pool and purge command; and
- real-server tests cover sequential isolation, teardown, and concurrent cold clients.

### Why are the changes needed?

Local Connect startup pays for a JVM and SparkContext in every Python process. Persistent reuse
removes that cost but can carry SparkContext-backed state across runs. The single-use pool preserves
fresh-server-per-run isolation while moving server startup off the critical path after the initial
bootstrap.

### Does this PR introduce _any_ user-facing change?

Yes, only when the experimental opt-in is enabled. With `SPARK_LOCAL_CONNECT_POOL=1` or
`spark.local.connect.pool=true`, a local remote `getOrCreate()` claims a never-used local Connect
server from the pool. The owning session retires it on stop. Behavior is unchanged when the opt-in
is disabled.

### How was this patch tested?

All 66 focused pool tests at this stack layer passed, including two real-server end-to-end tests:

```bash
PYTHONPATH=python:python/lib/pyspark.zip:python/lib/py4j-0.10.9.9-src.zip \
  SPARK_TESTING=1 \
  .venv/bin/python -m unittest -v \
  pyspark.sql.tests.connect.test_connect_local_server_pool
```

At the final stack tip, the same invocation passed all 69 tests. The rewritten stack also passed
Python compilation, Ruff checking and formatting, targeted mypy for the pool module,
`git diff --check`, and changed-file ASCII and Python 100-column checks.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Fable 5) and OpenAI Codex (GPT-5)
