### PR TITLE
[SPARK-58022][SQL] Remove unused legacy error conditions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -9449,11 +9449,6 @@
       "<quoted> is a permanent view, which is not supported by streaming reading API such as `DataStreamReader.table` yet."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1021" : {
-    "message" : [
-      "count(<targetString>.*) is not allowed. Please use count(*) or expand the columns manually, e.g. count(col1, col2)."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1031" : {
     "message" : [
       "It is not allowed to use a window function inside an aggregate function. Please use the inner window function in a sub-query."
@@ -10011,11 +10006,6 @@
       "<action> is not allowed on <tableName> since its partition metadata is not stored in the Hive metastore. To import this information into the metastore, run `msck repair table <tableName>`."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1255" : {
-    "message" : [
-      "Cannot drop built-in function '<functionName>'."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1256" : {
     "message" : [
       "Cannot refresh built-in function <functionName>."
@@ -10516,11 +10506,6 @@
   "_LEGACY_ERROR_TEMP_2105" : {
     "message" : [
       "Could not allocate memory to grow BytesToBytesMap."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2106" : {
-    "message" : [
-      "Can't acquire <size> bytes memory to build hash relation, got <got> bytes."
     ]
   },
   "_LEGACY_ERROR_TEMP_2107" : {
@@ -11506,11 +11491,6 @@
   "_LEGACY_ERROR_TEMP_3109" : {
     "message" : [
       "<message>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3110" : {
-    "message" : [
-      "Cannot bind a V1 function."
     ]
   },
   "_LEGACY_ERROR_TEMP_3113" : {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes four `_LEGACY_ERROR_TEMP_*` error conditions from `error-conditions.json` that are no longer referenced anywhere in the codebase:

- `_LEGACY_ERROR_TEMP_1021`
- `_LEGACY_ERROR_TEMP_1255`
- `_LEGACY_ERROR_TEMP_2106`
- `_LEGACY_ERROR_TEMP_3110`

### Why are the changes needed?

These are legacy placeholder error conditions. A full-tree scan (`.scala`, `.java`, `.py`, `.sql`, golden `.out` files) confirms none of them are referenced by any main or test code — they are dead entries. Removing them reduces noise in `error-conditions.json` and is a small step toward eliminating the `_LEGACY_ERROR_TEMP_*` placeholders, per the guidance in `common/utils/src/main/resources/error/README.md`.

### Does this PR introduce _any_ user-facing change?

No. Since these error conditions are unreachable from any code path, no user-facing error can reference them.

### How was this patch tested?

Existing `SparkThrowableSuite` passes (34/34), which validates that `error-conditions.json` is still valid JSON, alphabetically sorted, and satisfies all format/SQLSTATE invariants.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)