### PR TITLE
[SPARK-58026][INFRA] Bound SparkR Windows test step to avoid silent 2h job timeout

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -79,6 +79,13 @@ jobs:
         mvn -DskipTests -Psparkr -Djna.nosys=true package -Dmaven.version=3.8.7
       shell: cmd
     - name: Run SparkR tests
+      # The SparkR test launch occasionally hangs while the R process waits on the
+      # SparkR backend socket handshake on the windows-2025 runner. Without a
+      # step-level bound this silently consumes the full 120-minute job timeout and
+      # is reported as a cancellation rather than a fast, retryable failure. Cap the
+      # step so a stalled handshake fails fast; successful runs finish it in well
+      # under 60 minutes (the whole job normally completes in ~75-85 minutes).
+      timeout-minutes: 60
       run: |
         set HADOOP_HOME=%USERPROFILE%\hadoop-3.3.6
         set PATH=%HADOOP_HOME%\bin;%PATH%


### PR DESCRIPTION
### What changes were proposed in this pull request?

Split out from the flaky-test deflake work; verified in fork CI (see below).

The scheduled `build_sparkr_window` workflow (`Build / SparkR-only`, windows-2025) intermittently hangs in the **"Run SparkR tests"** step while the R process waits on the SparkR backend socket handshake during session initialization. With no step-level timeout, a stalled handshake silently consumes the full 120-minute job timeout and surfaces as a *cancellation* rather than a fast, retryable failure — this alternates roughly every other scheduled run.

This adds `timeout-minutes: 60` to the "Run SparkR tests" step so a stalled handshake fails fast; successful runs finish the step well under the cap.

### Why are the changes needed?

Convert a silent 2-hour job cancel into a fast, retryable failure, and stop the workflow from alternating red/green due to a startup hang rather than a real regression.

### Does this PR introduce _any_ user-facing change?

No. CI-workflow-only change.

### How was this patch tested?

Fork CI (`build_sparkr_window` on the fork): ✅ **PASS** — https://github.com/HyukjinKwon/spark/actions/runs/28906197544
Finished in ~1h20m with tests running to completion (`══ DONE ══`); the watchdog did not fire, confirming it is non-disruptive to healthy runs.

JIRA: https://issues.apache.org/jira/browse/SPARK-58026
