### PR TITLE
[SPARK-57965][CONNECT][PYSPARK] Fix UNSUPPORTED_PIPELINES_DATASET_TYPE parameter name mismatch

### DIFF
--- a/python/pyspark/pipelines/spark_connect_graph_element_registry.py
+++ b/python/pyspark/pipelines/spark_connect_graph_element_registry.py
@@ -79,7 +79,7 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
             else:
                 raise PySparkTypeError(
                     errorClass="UNSUPPORTED_PIPELINES_DATASET_TYPE",
-                    messageParameters={"output_type": type(output).__name__},
+                    messageParameters={"dataset_type": type(output).__name__},
                 )
         elif isinstance(output, TemporaryView):
             output_type = pb2.OutputType.TEMPORARY_VIEW
@@ -93,7 +93,7 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
         else:
             raise PySparkTypeError(
                 errorClass="UNSUPPORTED_PIPELINES_DATASET_TYPE",
-                messageParameters={"output_type": type(output).__name__},
+                messageParameters={"dataset_type": type(output).__name__},
             )
 
         inner_command = pb2.PipelineCommand.DefineOutput(

--- a/python/pyspark/pipelines/tests/test_graph_element_registry.py
+++ b/python/pyspark/pipelines/tests/test_graph_element_registry.py
@@ -130,6 +130,19 @@ class GraphElementRegistryTest(unittest.TestCase):
         )
 
 
+    def test_unsupported_pipelines_dataset_type_error(self):
+        """Regression test: UNSUPPORTED_PIPELINES_DATASET_TYPE should raise PySparkTypeError,
+        not AssertionError due to mismatched message parameter names."""
+        from pyspark.errors import PySparkTypeError
+
+        err = PySparkTypeError(
+            errorClass="UNSUPPORTED_PIPELINES_DATASET_TYPE",
+            messageParameters={"dataset_type": "UnsupportedClass"},
+        )
+        self.assertEqual(err.getCondition(), "UNSUPPORTED_PIPELINES_DATASET_TYPE")
+        self.assertIn("UnsupportedClass", err.getMessage())
+
+
 if __name__ == "__main__":
     from pyspark.testing import main
 

--- a/python/pyspark/pipelines/tests/test_graph_element_registry.py
+++ b/python/pyspark/pipelines/tests/test_graph_element_registry.py
@@ -129,7 +129,6 @@ class GraphElementRegistryTest(unittest.TestCase):
             "GRAPH_ELEMENT_DEFINED_OUTSIDE_OF_DECLARATIVE_PIPELINE",
         )
 
-
     def test_unsupported_pipelines_dataset_type_error(self):
         """Regression test: UNSUPPORTED_PIPELINES_DATASET_TYPE should raise PySparkTypeError,
         not AssertionError due to mismatched message parameter names."""


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the `messageParameters` key in `SparkConnectGraphElementRegistry.register_output` from `output_type` to `dataset_type` at both raise sites, matching the `UNSUPPORTED_PIPELINES_DATASET_TYPE` error template which interpolates `<dataset_type>`.

### Why are the changes needed?

The mismatch between the template placeholder (`<dataset_type>`) and the provided parameter key (`output_type`) causes `ErrorClassesReader.get_error_message` to fire an assertion, replacing the intended `PySparkTypeError` with an opaque `AssertionError`. Users see a confusing internal crash instead of the helpful "Unsupported pipelines dataset type: X" message.

### Does this PR introduce _any_ user-facing change?

Yes. Users who pass an unsupported output type to Declarative Pipelines will now see:

```
PySparkTypeError: [UNSUPPORTED_PIPELINES_DATASET_TYPE] Unsupported pipelines dataset type: SomeClass.
```

Instead of the previous opaque `AssertionError`.

### How was this patch tested?

Added a regression test in `test_graph_element_registry.py` that constructs `PySparkTypeError` with `UNSUPPORTED_PIPELINES_DATASET_TYPE` and verifies the error message is produced without assertion failures.

### Was this patch authored or co-authored using generative AI tooling?

Generative AI tooling (Claude Code) was used as an assistive tool for implementation guidance.