### PR TITLE
[SPARK-58027][SQL] Avoid unnecessary Matcher allocation in getZoneId for region-based zone IDs

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -43,10 +43,20 @@ trait SparkDateTimeUtils {
 
   def getZoneId(timeZoneId: String): ZoneId = {
     try {
-      // To support the (+|-)h:mm format because it was supported before Spark 3.0.
-      var formattedZoneId = singleHourTz.matcher(timeZoneId).replaceFirst("$10$2:")
-      // To support the (+|-)hh:m format because it was supported before Spark 3.0.
-      formattedZoneId = singleMinuteTz.matcher(formattedZoneId).replaceFirst("$1$2:0$3")
+      // The (+|-)h:mm and (+|-)hh:m formats (supported before Spark 3.0) both start with a sign
+      // character, and the two patterns below are anchored on that leading (+|-). Region-based IDs
+      // ("UTC", "America/New_York", "GMT+8", ...) can never match, so only run the regex
+      // normalization when the input starts with a sign and skip the Matcher allocations otherwise.
+      val formattedZoneId =
+        if (timeZoneId.nonEmpty &&
+          (timeZoneId.charAt(0) == '+' || timeZoneId.charAt(0) == '-')) {
+          // To support the (+|-)h:mm format because it was supported before Spark 3.0.
+          val withHour = singleHourTz.matcher(timeZoneId).replaceFirst("$10$2:")
+          // To support the (+|-)hh:m format because it was supported before Spark 3.0.
+          singleMinuteTz.matcher(withHour).replaceFirst("$1$2:0$3")
+        } else {
+          timeZoneId
+        }
       ZoneId.of(formattedZoneId, ZoneId.SHORT_IDS)
     } catch {
       case e: java.time.DateTimeException =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -361,6 +361,24 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     }
   }
 
+  test("SPARK-58027: getZoneId normalizes legacy sign-prefixed offsets, passes others through") {
+    // Sign-prefixed legacy formats are normalized: (+|-)h:mm -> (+|-)0h:mm, (+|-)hh:m -> (+|-)hh:0m.
+    assert(getZoneId("+7:30") === ZoneId.of("+07:30"))
+    assert(getZoneId("-7:30") === ZoneId.of("-07:30"))
+    assert(getZoneId("+07:3") === ZoneId.of("+07:03"))
+    assert(getZoneId("-1:0") === ZoneId.of("-01:00"))
+    // Already-canonical sign offsets are unaffected by the normalization.
+    assert(getZoneId("+07:30") === ZoneId.of("+07:30"))
+    assert(getZoneId("-08:00") === ZoneId.of("-08:00"))
+    // Region-based IDs and other non-sign inputs bypass the regex normalization unchanged. In
+    // particular "GMT+8" contains a '+' that is not the leading character, so it must not be
+    // rewritten (matching the pre-guard behavior, where the sign-anchored patterns never matched).
+    assert(getZoneId("UTC") === ZoneId.of("UTC"))
+    assert(getZoneId("Z") === ZoneId.of("Z"))
+    assert(getZoneId("America/New_York") === ZoneId.of("America/New_York"))
+    assert(getZoneId("GMT+8") === ZoneId.of("GMT+8", ZoneId.SHORT_IDS))
+  }
+
   test("SPARK-35780: support full range of timestamp string") {
     def checkStringToTimestamp(str: String, expected: Option[Long]): Unit = {
       assert(toTimestamp(str, UTC) === expected)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkDateTimeUtils.getZoneId` runs two regex `replaceFirst` calls on every invocation to normalize the legacy `(+|-)h:mm` and `(+|-)hh:m` zone-offset formats (supported before Spark 3.0):

```scala
var formattedZoneId = singleHourTz.matcher(timeZoneId).replaceFirst("$10$2:")
formattedZoneId = singleMinuteTz.matcher(formattedZoneId).replaceFirst("$1$2:0$3")
ZoneId.of(formattedZoneId, ZoneId.SHORT_IDS)
```

Both patterns are anchored on a leading sign character `(+|-)`. This guards the normalization so the two regexes only run when the input starts with `+` or `-`, and otherwise passes the id straight to `ZoneId.of`.

### Why are the changes needed?

Region-based IDs such as `UTC`, `America/New_York`, or `GMT+8` -- the overwhelming majority of inputs -- can never match the sign-anchored patterns, yet each call still allocates two `Matcher` instances and scans the string twice before `ZoneId.of` does the real work. The guard skips those allocations for the common case. It also makes explicit that the two regexes exist only to normalize the sign-prefixed legacy formats.

This is a small clarity and allocation cleanup on the shared `getZoneId` helper, not a headline performance change.

### Does this PR introduce _any_ user-facing change?

No. The change is behavior-preserving: both patterns are anchored on the leading sign, so an input that does not start with `+`/`-` is returned unchanged by `replaceFirst` today, which is exactly what the guarded `else` branch returns.

### How was this patch tested?

A new test in `DateTimeUtilsSuite` asserts `getZoneId` directly:

- sign-prefixed offsets are still normalized (`+7:30` -> `+07:30`, `+07:3` -> `+07:03`, `-1:0` -> `-01:00`)
- already-canonical sign offsets are unaffected (`+07:30`, `-08:00`)
- region-based / non-sign inputs pass through unchanged (`UTC`, `Z`, `America/New_York`, and `GMT+8` -- whose `+` is not the leading character, so it must not be rewritten)

The existing `getZoneId` normalization is also covered indirectly by the "string to timestamp" test. `catalyst/testOnly *DateTimeUtilsSuite` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
