### PR TITLE
[SPARK-58032][BUILD][DOCS][4.x] Update `docs/_config.yml` version to 4.3.0-SNAPSHOT

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,8 +19,8 @@ include:
 
 # These allow the documentation to be updated with newer releases
 # of Spark, Scala.
-SPARK_VERSION: 4.1.0-SNAPSHOT
-SPARK_VERSION_SHORT: 4.1.0
+SPARK_VERSION: 4.3.0-SNAPSHOT
+SPARK_VERSION_SHORT: 4.3.0
 SCALA_BINARY_VERSION: "2.13"
 SCALA_VERSION: "2.13.18"
 SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `SPARK_VERSION` and `SPARK_VERSION_SHORT` in `docs/_config.yml` from `4.1.0-SNAPSHOT`/`4.1.0` to `4.3.0-SNAPSHOT`/`4.3.0`.

### Why are the changes needed?

SPARK-57443 bumped the branch version to `4.3.0-SNAPSHOT` but missed the documentation config.
- https://github.com/apache/spark/pull/56503

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5