### PR TITLE
[SPARK-58033][PYTHON][DOCS] Fix `py4j` version requirement in PySpark installation guide

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -208,7 +208,7 @@ PySpark requires the following dependencies.
 ========================== ========================= =============================
 Package                    Supported version         Note
 ========================== ========================= =============================
-`py4j`                     >=0.10.9.9                Required to interact with JVM
+`py4j`                     >=0.10.9.7,<0.10.9.10     Required to interact with JVM
 ========================== ========================= =============================
 
 Additional libraries that enhance functionality but are not included in the installation packages:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the `py4j` version requirement in the PySpark installation guide from `>=0.10.9.9` to `>=0.10.9.7,<0.10.9.10`, matching `python/packaging/classic/setup.py`.

### Why are the changes needed?

SPARK-54015 relaxed the requirement in `setup.py` at Apache Spark 4.1.0, 4.0.2, and 3.5.8 but left the doc stale.
- https://github.com/apache/spark/pull/52721

https://github.com/apache/spark/blob/155adf7047bf7c0014cf35cef0c454d671287af7/python/packaging/classic/setup.py#L360

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5