### PR TITLE
[SPARK-58034][DOCS] Fix `Connect Overview` doc to use `site.SPARK_VERSION`

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -228,7 +228,7 @@ Welcome to
       ____              __
      / __/__  ___ _____/ /__
     _\ \/ _ \/ _ `/ __/  '_/
-   /___/ .__/\_,_/_/ /_/\_\   version 4.1.0-SNAPSHOT
+   /___/ .__/\_,_/_/ /_/\_\   version {{site.SPARK_VERSION}}
       /_/
 
 Type in expressions to have them evaluated.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the hardcoded `version 4.1.0-SNAPSHOT` in the Scala REPL welcome banner of `docs/spark-connect-overview.md` with the Liquid template `{{site.SPARK_VERSION}}`, so the banner tracks `docs/_config.yml` instead of a literal string.

### Why are the changes needed?

Currently, Apache Spark website shows `4.1.0-SNAPSHOT` in `Spark 4.1.2`.
- https://spark.apache.org/docs/latest/spark-connect-overview.html

<img width="687" height="336" alt="Screenshot 2026-07-07 at 23 55 34" src="https://github.com/user-attachments/assets/9a43865d-df6b-49e1-8839-db59463e1043" />

Apache Spark 4.2.0 RCs are also affected.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5