### PR TITLE
[SPARK-57849][SQL] Support the TIME data type in DataFrame approxQuantile, summary and describe

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -69,6 +69,10 @@ abstract class DataFrameStatFunctions {
    *   null and NaN values will be removed from the numerical column before calculation. If the
    *   dataframe is empty or the column only contains null or NaN, an empty array is returned.
    *
+   * @note
+   *   TIME columns are also supported. Their quantiles are returned as seconds since midnight
+   *   (with a fractional part preserving full nanosecond-of-day precision), not as TIME values.
+   *
    * @since 2.0.0
    */
   def approxQuantile(
@@ -98,6 +102,10 @@ abstract class DataFrameStatFunctions {
    * @note
    *   null and NaN values will be ignored in numerical columns before calculation. For columns
    *   only containing null or NaN values, an empty array is returned.
+   *
+   * @note
+   *   TIME columns are also supported. Their quantiles are returned as seconds since midnight
+   *   (with a fractional part preserving full nanosecond-of-day precision), not as TIME values.
    *
    * @since 2.2.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -59,6 +59,10 @@ object StatFunctions extends Logging {
    *
    * @note null and NaN values will be ignored in numerical columns before calculation. For
    *   a column only containing null or NaN values, an empty array is returned.
+   *
+   * @note TIME columns are also supported. Their quantiles are computed and returned as
+   *   seconds since midnight (with a fractional part preserving full nanosecond-of-day
+   *   precision), not as TIME values.
    */
   def multipleApproxQuantiles(
       df: DataFrame,
@@ -71,10 +75,16 @@ object StatFunctions extends Logging {
       "percentile should be in the range [0.0, 1.0]")
     val columns: Seq[Column] = cols.map { colName =>
       val field = df.resolve(colName)
-      require(field.dataType.isInstanceOf[NumericType],
+      require(field.dataType.isInstanceOf[NumericType] || field.dataType.isInstanceOf[TimeType],
         s"Quantile calculation for column $colName with data type ${field.dataType}" +
         " is not supported.")
-      col(colName).cast(DoubleType)
+      if (field.dataType.isInstanceOf[TimeType]) {
+        // TimeType -> LongType truncates to whole seconds (Cast.timeToLong). Route through
+        // DecimalType(14, 9) instead, which preserves the full nanosecond-of-day value.
+        col(colName).cast(DecimalType(14, 9)).cast(DoubleType)
+      } else {
+        col(colName).cast(DoubleType)
+      }
     }
 
     // approx_percentile needs integer accuracy
@@ -192,12 +202,17 @@ object StatFunctions extends Logging {
     var columnNames = Seq.empty[String]
 
     ds.schema.fields.foreach { field =>
-      if (field.dataType.isInstanceOf[NumericType] || field.dataType.isInstanceOf[StringType]) {
+      if (field.dataType.isInstanceOf[NumericType] || field.dataType.isInstanceOf[StringType] ||
+          field.dataType.isInstanceOf[TimeType]) {
         val column = col(field.name)
         var casted = column
         if (field.dataType.isInstanceOf[StringType]) {
           casted = column.try_cast(DoubleType)
         }
+        // avg/stddev require a numeric input; TIME has no meaningful numeric mean, so those
+        // statistics are left null for TIME columns. percentile_approx supports TimeType
+        // directly and returns a typed TIME result, so `casted` (== the raw column) is used as-is.
+        val isTimeColumn = field.dataType.isInstanceOf[TimeType]
 
         val percentilesCol = if (percentiles.nonEmpty) {
           percentile_approx(casted, lit(percentiles),
@@ -216,9 +231,11 @@ object StatFunctions extends Logging {
 
             case "approx_count_distinct" => aggColumns :+= approx_count_distinct(column)
 
-            case "mean" => aggColumns :+= avg(casted)
+            case "mean" =>
+              aggColumns :+= (if (isTimeColumn) lit(null).cast(StringType) else avg(casted))
 
-            case "stddev" => aggColumns :+= stddev(casted)
+            case "stddev" =>
+              aggColumns :+= (if (isTimeColumn) lit(null).cast(StringType) else stddev(casted))
 
             case "min" => aggColumns :+= min(column)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -605,6 +605,50 @@ class DataFrameStatSuite extends SharedSparkSession {
     val df = spark.range(1).selectExpr("CAST(id as DECIMAL) as x").selectExpr("percentile(x, 0.5)")
     checkAnswer(df, Row(BigDecimal(0)) :: Nil)
   }
+
+  test("SPARK-57849: DataFrame approxQuantile should support time type columns") {
+    val df = sql(
+      "SELECT * FROM VALUES (CAST('06:00:00' AS TIME(9))), (CAST('06:00:00' AS TIME(9))), " +
+        "(CAST('08:00:00' AS TIME(9))), (CAST('08:00:00' AS TIME(9))), " +
+        "(CAST('08:00:00' AS TIME(9))), (CAST('10:00:00' AS TIME(9)));"
+    )
+
+    val res = df.stat.approxQuantile("col1", Array(0.1, 0.5, 0.9), 0.01)
+    assert(res.length === 3)
+    assert(res.count(_.isNaN) === 0)
+    assert(res(1) === 28800.0)
+  }
+
+  test("SPARK-57849: DataFrame approxQuantile on TIME preserves sub-second precision") {
+    val df = sql(
+      "SELECT * FROM VALUES (CAST('00:00:00.000000001' AS TIME(9))), " +
+        "(CAST('23:59:59.999999999' AS TIME(9)));"
+    )
+
+    val Array(min, max) = df.stat.approxQuantile("col1", Array(0.0, 1.0), 0.0)
+    assert(min === 1e-9 +- 1e-12)
+    assert(max === 86399.999999999 +- 1e-6)
+  }
+
+  test("SPARK-57849: summary() computes typed TIME percentiles") {
+    val df = sql(
+      "SELECT * FROM VALUES (CAST('06:00:00' AS TIME(9))), (CAST('08:00:00' AS TIME(9))), " +
+        "(CAST('10:00:00' AS TIME(9))) AS tab(t);"
+    )
+    val expectedMedian = df.selectExpr("CAST(t AS STRING)").as[String].collect().sorted.apply(1)
+
+    val summaryDf = df.summary("min", "50%", "max")
+    val median = summaryDf.filter($"summary" === "50%").select("t").head().getString(0)
+    assert(median === expectedMedian)
+  }
+
+  test("SPARK-57849: summary() nulls out mean/stddev for TIME columns") {
+    val df = sql("SELECT * FROM VALUES (CAST('06:00:00' AS TIME(9))) AS tab(t);")
+
+    val summaryDf = df.summary("mean", "stddev")
+    val values = summaryDf.select("t").collect().map(_.getString(0))
+    assert(values === Array(null, null))
+  }
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -649,6 +649,19 @@ class DataFrameStatSuite extends SharedSparkSession {
     val values = summaryDf.select("t").collect().map(_.getString(0))
     assert(values === Array(null, null))
   }
+
+  test("SPARK-57849: describe() includes TIME columns") {
+    val df = sql(
+      "SELECT * FROM VALUES (CAST('06:00:00' AS TIME(9))), (CAST('08:00:00' AS TIME(9))), " +
+        "(CAST('10:00:00' AS TIME(9))) AS tab(t);"
+    )
+
+    val describeDf = df.describe("t")
+    val min = describeDf.filter($"summary" === "min").select("t").head().getString(0)
+    val max = describeDf.filter($"summary" === "max").select("t").head().getString(0)
+    assert(min === "06:00:00")
+    assert(max === "10:00:00")
+  }
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend `StatFunctions.multipleApproxQuantiles` to accept TimeType columns. TimeType columns are casted to DecimalType(14,9) before being casted to DoubleType to preserve nanosecond-of-day precision. `StatFunctions.multipleApproxQuantiles` returns `Seq[Seq[Double]]`, hence TimeType column's quantiles are returned as seconds since midnight. 

Extended `StatFunctions.summary` to accept TimeType columns. `avg` and `stddev` does not operate on TimeType columns and hence their output is `NULL`.


### Why are the changes needed?
The DataFrame stat APIs do not handle TIME. StatFunctions.multipleApproxQuantiles requires NumericType and casts to DoubleType, and summary includes only numeric/string columns. SQL approx_percentile already supports TIME , but df.stat.approxQuantile / df.summary() / df.describe() do not route TIME there. 

### Does this PR introduce _any_ user-facing change?
Yes. `df.stat. approxQuantile` now accepts TimeType columns. df.summary() and df.describe() also accepts TimeType columns.


### How was this patch tested?
UTs added.


### Was this patch authored or co-authored using generative AI tooling?
No