### PR TITLE
[SPARK-58038][DOCS] Fix to use Hadoop 3.5 in PySpark installation guide and Spark Connect overview

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -107,7 +107,7 @@ library.
 First, download Spark from the
 [Download Apache Spark](https://spark.apache.org/downloads.html) page. Choose the
 latest release in  the release drop down at the top of the page. Then choose your package type, typically
-“Pre-built for Apache Hadoop 3.3 and later”, and click the link to download.
+“Pre-built for Apache Hadoop 3.5 and later”, and click the link to download.
 
 Now extract the Spark package you just downloaded on your computer, for example:
 

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -62,7 +62,7 @@ For PySpark with/without a specific Hadoop version, you can install it by using 
 
     PYSPARK_HADOOP_VERSION=3 pip install pyspark
 
-The default distribution uses Hadoop 3.3 and Hive 2.3. If users specify different versions of Hadoop, the pip installation automatically
+The default distribution uses Hadoop 3.5 and Hive 2.3. If users specify different versions of Hadoop, the pip installation automatically
 downloads a different version and uses it in PySpark. Downloading it can take a while depending on
 the network and the mirror chosen. ``PYSPARK_RELEASE_MIRROR`` can be set to manually choose the mirror for faster downloading.
 
@@ -79,7 +79,7 @@ It is recommended to use ``-v`` option in ``pip`` to track the installation and 
 Supported values in ``PYSPARK_HADOOP_VERSION`` are:
 
 - ``without``: Spark pre-built with user-provided Apache Hadoop
-- ``3``: Spark pre-built for Apache Hadoop 3.3 and later (default)
+- ``3``: Spark pre-built for Apache Hadoop 3.5 and later (default)
 
 Note that this installation of PySpark with/without a specific Hadoop version is experimental. It can change or be removed between minor releases.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the outdated Hadoop version references from `3.3` to `3.5` in the PySpark installation guide and the Spark Connect overview.

### Why are the changes needed?

Apache Spark has used Hadoop 3.5.0 since SPARK-55657, but these documents still refer to Hadoop 3.3.
- https://github.com/apache/spark/pull/54448

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5