### PR TITLE
[SPARK-58004][SQL][FOLLOWUP] Preserve AQE fan-in bound through local shuffle reads

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
@@ -55,12 +55,29 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
     }
   }
 
-  private def createLocalRead(plan: SparkPlan): AQEShuffleReadExec = {
-    plan match {
+  private def createLocalRead(plan: SparkPlan): SparkPlan = {
+    val (shuffleStage, advisoryParallelism) = plan match {
       case c @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _) =>
-        AQEShuffleReadExec(s, getPartitionSpecs(s, Some(c.partitionSpecs.length)))
+        (s, Some(c.partitionSpecs.length))
       case s: ShuffleQueryStageExec =>
-        AQEShuffleReadExec(s, getPartitionSpecs(s, None))
+        (s, None)
+    }
+    val partitionSpecs = getPartitionSpecs(shuffleStage, advisoryParallelism)
+    val maxReducerPartitionsPerTask =
+      conf.getConf(SQLConf.COALESCE_PARTITIONS_MAX_REDUCER_PARTITIONS_PER_TASK)
+    val exceedsReducerPartitionLimit = partitionSpecs.exists {
+      case spec: PartialMapperPartitionSpec =>
+        spec.endReducerIndex - spec.startReducerIndex > maxReducerPartitionsPerTask
+      case spec: CoalescedMapperPartitionSpec =>
+        spec.numReducers > maxReducerPartitionsPerTask
+      case _ => false
+    }
+    // Local reads use mapper-oriented specs, whose reducer spans can differ from the bounded
+    // coalesced specs they replace. Keep the existing read if the rewrite would exceed the limit.
+    if (exceedsReducerPartitionLimit) {
+      plan
+    } else {
+      AQEShuffleReadExec(shuffleStage, partitionSpecs)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
@@ -65,7 +65,7 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
     val partitionSpecs = getPartitionSpecs(shuffleStage, advisoryParallelism)
     val maxReducerPartitionsPerTask =
       conf.getConf(SQLConf.COALESCE_PARTITIONS_MAX_REDUCER_PARTITIONS_PER_TASK)
-    val exceedsReducerPartitionLimit = partitionSpecs.exists {
+    val exceedsReducerPartitionLimit = advisoryParallelism.isDefined && partitionSpecs.exists {
       case spec: PartialMapperPartitionSpec =>
         spec.endReducerIndex - spec.startReducerIndex > maxReducerPartitionsPerTask
       case spec: CoalescedMapperPartitionSpec =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -326,7 +326,8 @@ class AdaptiveQueryExecSuite
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80",
-      SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "false") {
+      SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "false",
+      SQLConf.COALESCE_PARTITIONS_MAX_REDUCER_PARTITIONS_PER_TASK.key -> "2") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a where value = '1'")
       val smj = findTopLevelSortMergeJoin(plan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -293,6 +293,35 @@ class AdaptiveQueryExecSuite
     }
   }
 
+  test("Preserve the reducer partition limit through local shuffle read optimization") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80",
+        SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "10",
+        SQLConf.COALESCE_PARTITIONS_MAX_REDUCER_PARTITIONS_PER_TASK.key -> "2") {
+      val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
+        "SELECT * FROM testData join testData2 ON key = a where value = '1'")
+      assert(findTopLevelBroadcastHashJoin(adaptivePlan).size == 1)
+
+      // The two shuffle sides exercise both mapper-oriented local-read spec types. Neither rewrite
+      // is safe with this reducer limit, so the bounded coalesced reads must remain in the plan.
+      val localReads = collect(adaptivePlan) {
+        case read: AQEShuffleReadExec if read.isLocalRead => read
+      }
+      assert(localReads.isEmpty)
+
+      val coalescedReads = collect(adaptivePlan) {
+        case read: AQEShuffleReadExec if read.hasCoalescedPartition => read
+      }
+      assert(coalescedReads.nonEmpty)
+      coalescedReads.flatMap(_.partitionSpecs).foreach {
+        case spec: CoalescedPartitionSpec =>
+          assert(spec.endReducerIndex - spec.startReducerIndex <= 2)
+        case spec => fail(s"Unexpected shuffle partition spec: $spec")
+      }
+    }
+  }
+
   test("Reuse the default parallelism in local shuffle read") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #57087.

`OptimizeShuffleWithLocalRead` now checks the mapper-oriented partition specs it proposes against `spark.sql.adaptive.coalescePartitions.maxReducerPartitionsPerTask`. If any `PartialMapperPartitionSpec` spans too many reducer partitions, or any `CoalescedMapperPartitionSpec` reads too many reducers, the rule preserves the existing bounded shuffle read. Safe local-read rewrites are unchanged.

The patch also adds an AQE regression test that exercises both mapper-oriented local-read spec forms and verifies that the bounded coalesced reads remain in the final plan.

### Why are the changes needed?

SPARK-58004 added a hard limit on the number of reducer partitions that AQE can combine into one task. However, the local shuffle reader runs after shuffle partition coalescing and can replace the bounded `CoalescedPartitionSpec` values with mapper-oriented specs whose reducer spans exceed that limit.

Without this follow-up, enabling local shuffle reads can therefore bypass the new fan-in bound and recreate the excessive per-task fetch pressure that #57087 is intended to prevent.

### Does this PR introduce _any_ user-facing change?

Yes, compared with the current unreleased `master` branch. When a proposed local shuffle read would exceed `spark.sql.adaptive.coalescePartitions.maxReducerPartitionsPerTask`, Spark now keeps the existing coalesced shuffle read instead. Released Spark versions are not affected.

### How was this patch tested?

Added and ran the focused regression test:

```
build/sbt 'sql/testOnly org.apache.spark.sql.execution.adaptive.AdaptiveQueryExecSuite -- -z "Preserve the reducer partition limit through local shuffle read optimization"'
```

Ran the adjacent positive-path local shuffle reader test:

```
build/sbt 'sql/testOnly org.apache.spark.sql.execution.adaptive.AdaptiveQueryExecSuite -- -z "Reuse the parallelism of coalesced shuffle in local shuffle read"'
```

Ran the coalescing-disabled finite-cap regression:

```
build/sbt 'sql/testOnly org.apache.spark.sql.execution.adaptive.AdaptiveQueryExecSuite -- -z "Reuse the default parallelism in local shuffle read"'
```

Ran style checks:

```
build/sbt sql/scalastyle sql/Test/scalastyle
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
