### PR TITLE
[SPARK-58046][DOCS] Fix the required NumPy version to 1.23.2 in MLlib guide

### DIFF
--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -69,7 +69,7 @@ However, native acceleration libraries can't be distributed with Spark. See [MLl
 WARNING: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS
 ```
 
-To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
+To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.23.2 or newer.
 
 [^1]: To learn more about the benefits and background of system optimised natives, you may wish to
     watch Sam Halliday's ScalaX talk on [High Performance Linear Algebra in Scala](http://fommil.github.io/scalax14/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the minimum NumPy version in `docs/ml-guide.md` from `1.4` to `1.23.2`.

### Why are the changes needed?

SPARK-56928 raised the minimum NumPy version to `1.23.2` 
- https://github.com/apache/spark/pull/55959

https://github.com/apache/spark/blob/5ca6b1062887664b16b11f2bfcc015c9e616dc49/python/packaging/classic/setup.py#L162

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5