### PR TITLE
[SPARK-58047][DOCS][4.2] Fix the required NumPy version to 1.21 in MLlib guide

### DIFF
--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -69,7 +69,7 @@ However, native acceleration libraries can't be distributed with Spark. See [MLl
 WARNING: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS
 ```
 
-To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.
+To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.21 or newer.
 
 [^1]: To learn more about the benefits and background of system optimised natives, you may wish to
     watch Sam Halliday's ScalaX talk on [High Performance Linear Algebra in Scala](http://fommil.github.io/scalax14/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the minimum NumPy version in `docs/ml-guide.md` from `1.4` to `1.21`.

### Why are the changes needed?

SPARK-45179 raised the minimum NumPy version to `1.21` at Apache Spark 4.0.0.
- https://github.com/apache/spark/pull/42944

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5