### PR TITLE
[CONNECT] Default refreshPhaseEnabled from spark.api.mode

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -71,13 +71,22 @@ class QueryExecution(
     val tracker: QueryPlanningTracker = new QueryPlanningTracker,
     val mode: CommandExecutionMode.Value = CommandExecutionMode.ALL,
     val shuffleCleanupModeOpt: Option[ShuffleCleanupMode] = None,
-    val refreshPhaseEnabled: Boolean = QueryExecution.refreshPhaseEnabledDefault(sparkSession),
+    // Whether the refresh phase runs. When left unset it defaults based on the session's
+    // `spark.api.mode`: enabled in Classic and disabled in Connect. A default value that
+    // references `sparkSession` cannot be expressed directly on this parameter, so callers that
+    // want the mode-based default omit it and it is resolved in [[refreshPhaseEnabled]] below.
+    refreshPhaseEnabledOpt: Option[Boolean] = None,
     val queryId: UUID = UUIDv7Generator.generate(),
     // When a transaction is active, callers creating nested QueryExecution instances MUST pass
     // the enclosing QueryExecution's analyzer here to propagate the transaction context.
     // Omitting it causes the nested QE to use sessionState.analyzer, which has no knowledge
     // of the transaction and will load tables outside the transaction's catalog scope.
     val analyzerOpt: Option[Analyzer] = None) extends LookupCatalog {
+
+  // Resolve the refresh phase flag: honor an explicit value if provided, otherwise fall back to
+  // the mode-based default (enabled in Classic, disabled in Connect).
+  val refreshPhaseEnabled: Boolean =
+    refreshPhaseEnabledOpt.getOrElse(QueryExecution.refreshPhaseEnabledDefault(sparkSession))
 
   val id: Long = QueryExecution.nextExecutionId
 
@@ -748,13 +757,13 @@ object QueryExecution {
   private[execution] def create(
       sparkSession: SparkSession,
       logical: LogicalPlan,
-      refreshPhaseEnabled: Boolean = refreshPhaseEnabledDefault(sparkSession)): QueryExecution = {
+      refreshPhaseEnabled: Boolean = true): QueryExecution = {
     new QueryExecution(
       sparkSession,
       logical,
       mode = CommandExecutionMode.ALL,
       shuffleCleanupModeOpt = Some(determineShuffleCleanupMode(sparkSession.sessionState.conf)),
-      refreshPhaseEnabled = refreshPhaseEnabled)
+      refreshPhaseEnabledOpt = Some(refreshPhaseEnabled))
   }
 
   /**
@@ -946,7 +955,7 @@ object QueryExecution {
       sparkSession: SparkSession,
       command: LogicalPlan,
       name: String,
-      refreshPhaseEnabled: Boolean = refreshPhaseEnabledDefault(sparkSession),
+      refreshPhaseEnabled: Boolean = true,
       mode: CommandExecutionMode.Value = CommandExecutionMode.SKIP,
       shuffleCleanupModeOpt: Option[ShuffleCleanupMode] = None,
       analyzerOpt: Option[Analyzer] = None)
@@ -956,7 +965,7 @@ object QueryExecution {
       command,
       mode = mode,
       shuffleCleanupModeOpt = shuffleCleanupModeOpt,
-      refreshPhaseEnabled = refreshPhaseEnabled,
+      refreshPhaseEnabledOpt = Some(refreshPhaseEnabled),
       analyzerOpt = analyzerOpt)
     val result = QueryExecution.withInternalError(s"Executed $name failed.") {
       SQLExecution.withNewExecutionId(qe, Some(name)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import java.io.{BufferedWriter, OutputStreamWriter}
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import javax.annotation.concurrent.GuardedBy
@@ -29,7 +30,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.internal.LogKeys.EXTENDED_EXPLAIN_GENERATOR
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, ExtendedExplainGenerator, Row}
+import org.apache.spark.sql.{AnalysisException, ExtendedExplainGenerator, Row, SparkSessionBuilder}
 import org.apache.spark.sql.catalyst.{InternalRow, QueryPlanningTracker}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, LazyExpression, NameParameterizedQuery, UnsupportedOperationChecker}
 import org.apache.spark.sql.catalyst.expressions.codegen.ByteCodeStats
@@ -70,7 +71,7 @@ class QueryExecution(
     val tracker: QueryPlanningTracker = new QueryPlanningTracker,
     val mode: CommandExecutionMode.Value = CommandExecutionMode.ALL,
     val shuffleCleanupModeOpt: Option[ShuffleCleanupMode] = None,
-    val refreshPhaseEnabled: Boolean = true,
+    val refreshPhaseEnabled: Boolean = QueryExecution.refreshPhaseEnabledDefault(sparkSession),
     val queryId: UUID = UUIDv7Generator.generate(),
     // When a transaction is active, callers creating nested QueryExecution instances MUST pass
     // the enclosing QueryExecution's analyzer here to propagate the transaction context.
@@ -731,10 +732,23 @@ object QueryExecution {
 
   private def nextExecutionId: Long = _nextExecutionId.getAndIncrement
 
+  // The refresh phase reloads versioned DSv2 relations from the catalog so that the plan reflects
+  // the latest table state at execution time, accounting for the delay between analysis and the
+  // subsequent phases. Spark Connect re-resolves and re-analyzes every plan per request, so by the
+  // time a plan reaches execution it already references the latest table state and the refresh is a
+  // redundant catalog round-trip. It is therefore disabled by default in Connect and enabled by
+  // default in Classic, keyed off the session's [[SparkSessionBuilder.API_MODE_KEY]].
+  private[sql] def refreshPhaseEnabledDefault(sparkSession: SparkSession): Boolean = {
+    val apiMode = sparkSession.sessionState.conf
+      .getConfString(SparkSessionBuilder.API_MODE_KEY, SparkSessionBuilder.API_MODE_CLASSIC)
+      .trim.toLowerCase(Locale.ROOT)
+    apiMode != SparkSessionBuilder.API_MODE_CONNECT
+  }
+
   private[execution] def create(
       sparkSession: SparkSession,
       logical: LogicalPlan,
-      refreshPhaseEnabled: Boolean = true): QueryExecution = {
+      refreshPhaseEnabled: Boolean = refreshPhaseEnabledDefault(sparkSession)): QueryExecution = {
     new QueryExecution(
       sparkSession,
       logical,
@@ -932,7 +946,7 @@ object QueryExecution {
       sparkSession: SparkSession,
       command: LogicalPlan,
       name: String,
-      refreshPhaseEnabled: Boolean = true,
+      refreshPhaseEnabled: Boolean = refreshPhaseEnabledDefault(sparkSession),
       mode: CommandExecutionMode.Value = CommandExecutionMode.SKIP,
       shuffleCleanupModeOpt: Option[ShuffleCleanupMode] = None,
       analyzerOpt: Option[Analyzer] = None)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -22,7 +22,7 @@ import scala.io.Source
 import scala.util.Try
 
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
-import org.apache.spark.sql.{AnalysisException, ExtendedExplainGenerator, FastOperator, SaveMode}
+import org.apache.spark.sql.{AnalysisException, ExtendedExplainGenerator, FastOperator, SaveMode, SparkSessionBuilder}
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, QueryPlanningTrackerCallback, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{CurrentNamespace, UnresolvedFunction, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Alias, UnsafeRow}
@@ -582,6 +582,31 @@ class QueryExecutionSuite extends SharedSparkSession {
       }
     } finally {
       spark.sparkContext.removeSparkListener(listener)
+    }
+  }
+
+  test("refreshPhaseEnabled defaults to true in Classic and false in Connect") {
+    // Not set: defaults to Classic, so the refresh phase is on.
+    assert(QueryExecution.refreshPhaseEnabledDefault(spark))
+    assert(spark.sessionState.executePlan(OneRowRelation()).refreshPhaseEnabled)
+
+    withSQLConf(SparkSessionBuilder.API_MODE_KEY -> SparkSessionBuilder.API_MODE_CONNECT) {
+      assert(!QueryExecution.refreshPhaseEnabledDefault(spark))
+      assert(!spark.sessionState.executePlan(OneRowRelation()).refreshPhaseEnabled)
+    }
+
+    withSQLConf(SparkSessionBuilder.API_MODE_KEY -> SparkSessionBuilder.API_MODE_CLASSIC) {
+      assert(QueryExecution.refreshPhaseEnabledDefault(spark))
+      assert(spark.sessionState.executePlan(OneRowRelation()).refreshPhaseEnabled)
+    }
+  }
+
+  test("refreshPhaseEnabled default is derived from spark.api.mode case-insensitively") {
+    withSQLConf(SparkSessionBuilder.API_MODE_KEY -> "CONNECT") {
+      assert(!QueryExecution.refreshPhaseEnabledDefault(spark))
+    }
+    withSQLConf(SparkSessionBuilder.API_MODE_KEY -> " Connect ") {
+      assert(!QueryExecution.refreshPhaseEnabledDefault(spark))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Derive the default value of `QueryExecution.refreshPhaseEnabled` from the session's `spark.api.mode` configuration instead of hardcoding it to `true`. The refresh phase stays enabled by default in Spark Classic and is disabled by default in Spark Connect.

Concretely, a small helper `QueryExecution.refreshPhaseEnabledDefault(sparkSession)` reads `spark.api.mode` (keyed off `SparkSessionBuilder.API_MODE_KEY`, case-insensitively) from the session's `SQLConf` and returns `false` only when the mode is `connect`. This helper becomes the default argument for `refreshPhaseEnabled` at the three sites that previously defaulted to `true`:

- the `QueryExecution` primary constructor,
- `QueryExecution.create`,
- `QueryExecution.runCommand`.

Because `SessionState.executePlan` builds its `QueryExecution` via `createQueryExecution` without passing `refreshPhaseEnabled` explicitly, and `Dataset.ofRows` goes through `executePlan`, every construction site that does not opt out now picks up the mode-appropriate default with no per-call-site changes.

### Why are the changes needed?

The `QueryExecution` refresh phase (`tableVersionsRefreshed`, backed by `V2TableRefreshUtil.refresh`) reloads every versioned DSv2 relation from the catalog at execution time to account for the delay between analysis and the subsequent phases. Spark Connect re-resolves and re-analyzes each plan on every request, so by the time a plan reaches execution the analyzed plan already references the latest table state. The refresh then issues redundant `catalog.loadTable` calls for tables that were just resolved in the same `QueryExecution`.

Disabling the refresh phase for Connect avoids these extra catalog round-trips. Because analysis and execution happen together in Connect, the refresh is redundant there. The refresh phase is not what keeps stored-plan temp views fresh (that is the `V2TableReference` analyzer rule), so disabling it does not regress view or table freshness.

Deriving the default from `spark.api.mode` keeps the switch in one place rather than threading `refreshPhaseEnabled = false` through every Connect-side construction site.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added unit tests in `QueryExecutionSuite`:

- `refreshPhaseEnabled defaults to true in Classic and false in Connect` verifies the default both through the `refreshPhaseEnabledDefault` helper and through an actual `sessionState.executePlan(...)`, for the unset (Classic) default, `spark.api.mode=connect`, and `spark.api.mode=classic`.
- `refreshPhaseEnabled default is derived from spark.api.mode case-insensitively` verifies `CONNECT` and `" Connect "` (mixed case and surrounding whitespace) resolve to the refresh-disabled default.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
