### PR TITLE
[SPARK-58054][CORE] Enable `spark.ui.contentSecurityPolicy.enabled` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -147,7 +147,7 @@ private[spark] object UI {
       .version("4.2.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED =
     ConfigBuilder("spark.ui.contentSecurityPolicy.frameAncestors.enabled")

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -155,6 +155,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
 
   test("no CSP header when CSP is disabled regardless of frameAncestors setting") {
     val conf = new SparkConf(false)
+      .set(UI_CONTENT_SECURITY_POLICY_ENABLED, false)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()
     val res = mock(classOf[HttpServletResponse])
@@ -163,7 +164,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     val filter = new HttpSecurityFilter(conf, secMgr)
     filter.doFilter(req, res, chain)
 
-    // CSP is disabled by default, so no CSP header should be emitted
+    // CSP is disabled explicitly, so no CSP header should be emitted
     verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
   }
 

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -30,9 +30,11 @@ license: |
 
 - Since Spark 4.3, Spark sets `allowPrivilegeEscalation` to `false` on the driver and executor containers' security context by default. To restore the legacy behavior, you can set `spark.kubernetes.securityContext.allowPrivilegeEscalation` to `true`.
 
-- Since Spark 4.3, the default value of `spark.ui.xXssProtection` has been changed from `1; mode=block` to `0`. The XSS Auditor has been removed from Chrome and Edge, and was never implemented in Firefox. It can introduce side-channel vulnerabilities in browsers that still support it (Safari). To restore the legacy behavior, you can set `spark.ui.xXssProtection` to `1; mode=block`. For modern XSS protection, consider enabling `spark.ui.contentSecurityPolicy.enabled`.
+- Since Spark 4.3, Spark sets the HTTP `Content-Security-Policy` (CSP) response header for the Spark UI by default, restricting the sources from which the browser is allowed to load resources. To restore the legacy behavior, you can set `spark.ui.contentSecurityPolicy.enabled` to `false`.
 
-- Since Spark 4.3, `spark.ui.allowFramingFrom` now uses CSP `frame-ancestors` instead of the deprecated `X-Frame-Options: ALLOW-FROM` (which was ignored by all modern browsers). This setting only takes effect when `spark.ui.contentSecurityPolicy.enabled=true`. When CSP is disabled (the default), `X-Frame-Options: SAMEORIGIN` is always used regardless of the `allowFramingFrom` value. To allow framing from a specific origin, set both `spark.ui.contentSecurityPolicy.enabled=true` and `spark.ui.allowFramingFrom=<uri>`.
+- Since Spark 4.3, the default value of `spark.ui.xXssProtection` has been changed from `1; mode=block` to `0`. The XSS Auditor has been removed from Chrome and Edge, and was never implemented in Firefox. It can introduce side-channel vulnerabilities in browsers that still support it (Safari). To restore the legacy behavior, you can set `spark.ui.xXssProtection` to `1; mode=block`.
+
+- Since Spark 4.3, `spark.ui.allowFramingFrom` now uses CSP `frame-ancestors` instead of the deprecated `X-Frame-Options: ALLOW-FROM` (which was ignored by all modern browsers). This setting only takes effect when `spark.ui.contentSecurityPolicy.enabled=true` (the default). When CSP is disabled, `X-Frame-Options: SAMEORIGIN` is always used regardless of the `allowFramingFrom` value.
 
 ## Upgrading from Core 4.1 to 4.2
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -813,7 +813,7 @@ Security.
 </tr>
 <tr>
   <td><code>spark.ui.contentSecurityPolicy.enabled</code></td>
-  <td><code>false</code></td>
+  <td><code>true</code></td>
   <td>
     When enabled, the Content-Security-Policy (CSP) HTTP response header is set for the Spark UI,
     restricting the sources from which the browser is allowed to load resources as a


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.ui.contentSecurityPolicy.enabled` by default from Apache Spark 4.3.0.

### Why are the changes needed?

The `Content-Security-Policy` (CSP) header provides defense-in-depth against XSS on the Spark UI. All UI pages already emit CSP nonces for their inline scripts, so enabling it by default hardens the Web UI out of the box.

### Does this PR introduce _any_ user-facing change?

Yes, the Spark UI sets the `Content-Security-Policy` header by default. To restore the previous behavior, set `spark.ui.contentSecurityPolicy.enabled` to `false`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5