### PR TITLE
[SPARK-58055][CONNECT] Don't drop streaming listener events on a transient send failure

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
@@ -568,18 +568,28 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
       .format("console")
       .start()
 
+    // Diagnostic context attached to assertion failures so that, if this test ever flakes again in
+    // a scheduled job, the log pinpoints which event was missing and the surrounding client state
+    // (e.g. whether the client-side listener is still registered, whether the query errored). The
+    // server-side listener can silently self-remove on a send failure, dropping later events.
+    def diag(stage: String): String =
+      s"[$stage] q.isActive=${q.isActive}, q.exception=${q.exception}, " +
+        s"start=${listener.start.size}, progress=${listener.progress.size}, " +
+        s"terminate=${listener.terminate.size}, " +
+        s"clientListeners=${spark.streams.listListeners().length}"
+
     try {
       q.processAllAvailable()
       eventually(timeout(30.seconds)) {
-        assert(q.isActive)
-        assert(listener.start.length == 1)
-        assert(listener.progress.nonEmpty)
+        assert(q.isActive, diag("active"))
+        assert(listener.start.length == 1, diag("start"))
+        assert(listener.progress.nonEmpty, diag("progress"))
       }
     } finally {
       q.stop()
       eventually(timeout(60.seconds), interval(1.seconds)) {
-        assert(!q.isActive)
-        assert(listener.terminate.nonEmpty)
+        assert(!q.isActive, diag("stopped"))
+        assert(listener.terminate.nonEmpty, diag("terminate"))
       }
     }
   }
@@ -746,9 +756,10 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
   }
 
   class MyListener extends StreamingQueryListener {
-    var start: Seq[String] = Seq.empty
-    var progress: Seq[String] = Seq.empty
-    var terminate: Seq[String] = Seq.empty
+    // @volatile so the test thread reliably observes updates made on the listener dispatch thread.
+    @volatile var start: Seq[String] = Seq.empty
+    @volatile var progress: Seq[String] = Seq.empty
+    @volatile var terminate: Seq[String] = Seq.empty
 
     override def onQueryStarted(event: QueryStartedEvent): Unit = {
       start = start :+ event.json

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
@@ -99,11 +99,19 @@ private[sql] class SparkConnectListenerBusListener(
     with Logging {
 
   val sessionHolder = serverSideListenerHolder.sessionHolder
+
+  // Number of attempts to transmit an event to the client before giving up. A single transient
+  // onNext failure (e.g. a momentary gRPC hiccup) should not permanently remove the listener and
+  // silently drop all subsequent events for the session, including the terminal
+  // QueryTerminatedEvent; only tear down when sending keeps failing across retries.
+  private val maxSendAttempts = 3
+  private val sendRetryBackoffMs = 200L
+
   // The method used to stream back the events to the client.
   // The event is serialized to json and sent to the client.
-  // If any exception is thrown while transmitting back the event, the listener is removed,
-  // all related sources are cleaned up, and the long-running thread will proceed to send
-  // the final ResultComplete response.
+  // If any exception is thrown while transmitting back the event (after a few retries), the
+  // listener is removed, all related sources are cleaned up, and the long-running thread will
+  // proceed to send the final ResultComplete response.
   private def send(eventJson: String, eventType: StreamingQueryEventType): Unit = {
     try {
       val event = StreamingQueryListenerEvent
@@ -117,7 +125,7 @@ private[sql] class SparkConnectListenerBusListener(
         .addAllEvents(Array[StreamingQueryListenerEvent](event).toImmutableArraySeq.asJava)
         .build()
 
-      responseObserver.onNext(
+      sendWithRetry(
         ExecutePlanResponse
           .newBuilder()
           .setSessionId(sessionHolder.sessionId)
@@ -134,6 +142,22 @@ private[sql] class SparkConnectListenerBusListener(
         // remove this listener and cleanup resources.
         serverSideListenerHolder.cleanUp()
     }
+  }
+
+  // Sends a response, retrying onNext a bounded number of times on a transient failure. The
+  // exception from the final attempt propagates to send()'s handler, which removes the listener.
+  private def sendWithRetry(response: ExecutePlanResponse): Unit = {
+    var attempt = 1
+    while (attempt < maxSendAttempts) {
+      try {
+        responseObserver.onNext(response)
+        return
+      } catch {
+        case NonFatal(_) => Thread.sleep(sendRetryBackoffMs)
+      }
+      attempt += 1
+    }
+    responseObserver.onNext(response)
   }
 
   def sendResultComplete(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Deflake `ClientStreamingQuerySuite."listener events"`, which intermittently fails the
`Build / Java21 (Scala 2.13, JDK 21)` scheduled workflow (in the
`streaming, sql-kafka-0-10, ..., connect, avro` module job) with:

```
- listener events *** FAILED ***
  The code passed to eventually never returned normally. Attempted 70 times over
  1.0033581898666666 minutes. Last failure message: List() was empty.
  (ClientStreamingQuerySuite.scala:580)
```

Two independent changes:

1. **Server (`SparkConnectListenerBusListener.send`)** — previously, any `onNext` exception removed
   the listener and cleaned up all resources, so the long-running thread stopped forwarding **all**
   subsequent events. A single transient failure on a frequent `QueryProgressEvent` therefore
   silently dropped the later terminal `QueryTerminatedEvent`, and the client's `listener.terminate`
   stayed empty forever. `onNext` is now retried a bounded number of times (`maxSendAttempts = 3`,
   200ms backoff) before falling through to the existing cleanup path, so a momentary gRPC hiccup no
   longer tears the listener down.

2. **Test (`ClientStreamingQuerySuite` / `MyListener`)** — the listener's `start`/`progress`/
   `terminate` fields are mutated on the listener dispatch thread and read on the test thread, so
   they are now `@volatile` to guarantee visibility. Assertions also carry a `diag(stage)` message
   reporting `q.isActive`, `q.exception`, event counts, and the client-side listener count, so a
   future flake in a scheduled job is diagnosable from the log (the connect server runs in a
   separate process whose logs are not captured in CI).

### Why are the changes needed?

`ClientStreamingQuerySuite."listener events"` is a genuine non-deterministic flake (a lost terminal
event plus a cross-thread visibility gap), not a logic breakage, and it periodically reddens the
`build_java21` badge. The bounded retry hardens the server against transient send failures while
still cleaning up when the client is genuinely unresponsive.

### Does this PR introduce _any_ user-facing change?

No. The server change only adds a bounded retry on a transient transmit failure before the existing
teardown; the rest is test-only.

### How was this patch tested?

Existing `ClientStreamingQuerySuite` (`connect-client-jvm`).

CI evidence:

- **Failing (before this fix)** — `build_java21` run, `...connect, avro` module job, where
  `ClientStreamingQuerySuite."listener events"` failed with the empty-`terminate` timeout:
  https://github.com/apache/spark/actions/runs/28004202389/job/82884598238

- **Passing (with this fix)** — focused JDK 21 validation on the fork: built the `connect` module
  and re-ran `ClientStreamingQuerySuite."listener events"` 10x, all green:
  https://github.com/HyukjinKwon/spark/actions/runs/28983105679/job/86006115168

(Local full compilation is not possible in the authoring environment because Maven Central is
network-restricted, so validation was done on the fork CI above.)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
