### PR TITLE
[DO-NOT-MERGE][PYTHON][TESTS] Fix flaky test_data_source_writer_with_logging on branch-4.1

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -1199,8 +1199,20 @@ class BasePythonDataSourceTestsMixin:
 
                 logs = self.spark.tvf.python_worker_logs()
 
+                # We could get either 1 or 2 "TestJsonWriter.write: abort test" logs because
+                # the operation is time sensitive. When the first partition gets aborted,
+                # the executor will cancel the rest of the tasks. Whether we are able to get
+                # the second log depends on whether the second partition starts before the
+                # cancellation. When we use simple worker, the second log is often missing
+                # because the spawn overhead is large.
+                non_abort_logs = logs.select("level", "msg", "context", "logger").filter(
+                    "msg != 'TestJsonWriter.write: abort test'"
+                )
+                abort_logs = logs.select("level", "msg", "context", "logger").filter(
+                    "msg == 'TestJsonWriter.write: abort test'"
+                )
                 assertDataFrameEqual(
-                    logs.select("level", "msg", "context", "logger"),
+                    non_abort_logs,
                     [
                         Row(
                             level="WARNING",
@@ -1246,18 +1258,21 @@ class BasePythonDataSourceTestsMixin:
                                 {"class_name": "TestJsonDataSource", "func_name": "writer"},
                             ),
                             (
-                                "TestJsonWriter.write: abort test",
-                                {"class_name": "TestJsonWriter", "func_name": "write"},
-                            ),
-                            (
-                                "TestJsonWriter.write: abort test",
-                                {"class_name": "TestJsonWriter", "func_name": "write"},
-                            ),
-                            (
                                 "TestJsonWriter.abort",
                                 {"class_name": "TestJsonWriter", "func_name": "abort"},
                             ),
                         ]
+                    ],
+                )
+                assertDataFrameEqual(
+                    abort_logs.dropDuplicates(["msg"]),
+                    [
+                        Row(
+                            level="WARNING",
+                            msg="TestJsonWriter.write: abort test",
+                            context={"class_name": "TestJsonWriter", "func_name": "write"},
+                            logger="test_datasource_writer",
+                        )
                     ],
                 )
 


### PR DESCRIPTION
[DO-NOT-MERGE] This is a flaky-test fix under CI verification; the title will be updated with the JIRA id once the fork CI run confirms the fix. Please do not merge yet.

### What changes were proposed in this pull request?

Fix the flaky test `pyspark.sql.tests.test_python_datasource.PythonDataSourceTests.test_data_source_writer_with_logging` on `branch-4.1` by backporting the assertion handling already present on `master` and `branch-4.2` (introduced with SPARK-55799).

The test writes the abort-path DataFrame with `repartitionByRange(2, "age")`, producing two write tasks that each log `"TestJsonWriter.write: abort test"`, and the expected-logs list hardcodes that warning **twice**. When the first partition's task raises, the executor cancels the remaining task, so whether the second `"abort test"` log record is captured before cancellation is timing dependent. The fix splits the assertion:

- `non_abort_logs` (everything except the abort warning) is still asserted exactly, and
- `abort_logs.dropDuplicates(["msg"])` is asserted to contain exactly one row,

so the deterministic logs are checked precisely while the abort warning is checked for presence rather than an exact, race-dependent count.

### Why are the changes needed?

`build_python_3.11.yml` on `branch-4.1` intermittently failed with `[DIFFERENT_ROWS] Results do not match: ( 8.33333 % )` (11 vs 12 rows), the missing row being one of the two identical `"TestJsonWriter.write: abort test"` entries. `master` and `branch-4.2` already handle this; `branch-4.1` was missing the backport.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Existing test `test_data_source_writer_with_logging`. The assertion block is made identical to the one already on `master`/`branch-4.2`; verified via a `build_python_3.11` run on a fork.

### Was this patch authored or co-authored using generative AI tooling?

No.
