### PR TITLE
[SPARK-38632][CORE] Use `FileUtil.unTar` for `.tar` files at `Utils.unpack`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -455,38 +455,13 @@ private[spark] object Utils
     } else if (lowerSrc.endsWith(".zip")) {
       // After issue HADOOP-18145, unzip could keep file permissions.
       FileUtil.unZip(source, dest)
-    } else if (lowerSrc.endsWith(".tar.gz") || lowerSrc.endsWith(".tgz")) {
+    } else if (
+      lowerSrc.endsWith(".tar.gz") || lowerSrc.endsWith(".tgz") || lowerSrc.endsWith(".tar")) {
       FileUtil.unTar(source, dest)
-    } else if (lowerSrc.endsWith(".tar")) {
-      // TODO(SPARK-38632): should keep file permissions. Java implementation doesn't.
-      unTarUsingJava(source, dest)
     } else {
       logWarning(log"Cannot unpack ${MDC(LogKeys.FILE_NAME, source)}, " +
         log"just copying it to ${MDC(FILE_NAME2, dest)}.")
       copyRecursive(source, dest)
-    }
-  }
-
-  /**
-   * The method below was copied from `FileUtil.unTar` but uses Java-based implementation
-   * to work around a security issue, see also SPARK-38631.
-   */
-  private def unTarUsingJava(source: File, dest: File): Unit = {
-    if (!Utils.createDirectory(dest) && !dest.isDirectory) {
-      throw new IOException(s"Mkdirs failed to create $dest")
-    } else {
-      try {
-        // Should not fail because all Hadoop 2.1+ (from HADOOP-9264)
-        // have 'unTarUsingJava'.
-        val mth = classOf[FileUtil].getDeclaredMethod(
-          "unTarUsingJava", classOf[File], classOf[File], classOf[Boolean])
-        mth.setAccessible(true)
-        mth.invoke(null, source, dest, java.lang.Boolean.FALSE)
-      } catch {
-        // Re-throw the original exception.
-        case e: java.lang.reflect.InvocationTargetException if e.getCause != null =>
-          throw e.getCause
-      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the Java-based un-tarring workaround (`unTarUsingJava`) from `Utils.unpack` and use Hadoop's `FileUtil.unTar` for `.tar` files again, like `.tar.gz` and `.tgz` files.

### Why are the changes needed?

SPARK-38631 introduced this workaround because Hadoop's `FileUtil.unTar` did not escape the file name before passing it to a shell command, which allowed arbitrary shell command injection. This was fixed by [HADOOP-18136](https://issues.apache.org/jira/browse/HADOOP-18136) via `FileUtil.makeSecureShellPath` and shipped in Apache Hadoop 3.2.4, 3.3.3 or upper. Since Apache Spark requires Hadoop 3.4.0 or later (SPARK-58053) and the master branch uses Hadoop 3.5.0, the workaround is no longer needed.

Removing it also has the following benefits.
- `.tar` files keep the original file permissions and symlinks because the un-tarring is delegated to the native `tar` utility, which resolves the original TODO of SPARK-38632.
- The `setAccessible(true)` reflection hack on a Hadoop private method is removed.

### Does this PR introduce _any_ user-facing change?

Yes, unpacking `.tar` archives now preserves file permissions and symlinks like `.tar.gz` and `.tgz` archives. This is the original behavior.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5