### PR TITLE
[SPARK-58072][SS][PYTHON] Avoid eagerly importing numpy in StatefulProcessorApiClient

### DIFF
--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -16,6 +16,7 @@
 #
 from datetime import datetime
 from enum import Enum
+import importlib.util
 import json
 import os
 import socket
@@ -34,36 +35,39 @@ import uuid
 
 __all__ = ["StatefulProcessorApiClient", "StatefulProcessorHandleState"]
 
-try:
+# Whether numpy is available. Resolved without importing numpy so that
+# "import pyspark" stays free of unnecessary 3rd party imports (SPARK-56242).
+has_numpy: bool = importlib.util.find_spec("numpy") is not None
+
+SCALAR_TYPES = (bool, int, float, str, bytes, datetime, type(None))
+
+
+def _normalize_state_value(v: Any) -> Any:
+    if type(v) in SCALAR_TYPES:  # Fast path for common scalar values.
+        return v
+    # numpy is imported lazily here (cached in sys.modules after the first call)
+    # so that "import pyspark" does not eagerly import it.
     import numpy as np
 
-    has_numpy = True
-    SCALAR_TYPES = (bool, int, float, str, bytes, datetime, type(None))
-
-    def _normalize_state_value(v: Any) -> Any:
-        if type(v) in SCALAR_TYPES:  # Fast path for common scalar values.
-            return v
-        # Convert NumPy scalar values to Python primitive values.
-        if isinstance(v, np.generic):
-            return v.tolist()
-        # Named tuples (collections.namedtuple or typing.NamedTuple) and Row both
-        # require positional arguments and cannot be instantiated with a generator expression.
-        if isinstance(v, Row) or (isinstance(v, tuple) and hasattr(v, "_fields")):
-            return type(v)(*map(_normalize_state_value, v))
-        # List / tuple: recursively normalize each element.
-        if isinstance(v, (list, tuple)):
-            return type(v)(map(_normalize_state_value, v))
-        # Dict: normalize both keys and values.
-        if isinstance(v, dict):
-            return {_normalize_state_value(k): _normalize_state_value(val) for k, val in v.items()}
-        # Address a couple of pandas dtypes too.
-        if hasattr(v, "to_pytimedelta"):
-            return v.to_pytimedelta()
-        if hasattr(v, "to_pydatetime"):
-            return v.to_pydatetime()
-        return v
-except ImportError:
-    has_numpy = False
+    # Convert NumPy scalar values to Python primitive values.
+    if isinstance(v, np.generic):
+        return v.tolist()
+    # Named tuples (collections.namedtuple or typing.NamedTuple) and Row both
+    # require positional arguments and cannot be instantiated with a generator expression.
+    if isinstance(v, Row) or (isinstance(v, tuple) and hasattr(v, "_fields")):
+        return type(v)(*map(_normalize_state_value, v))
+    # List / tuple: recursively normalize each element.
+    if isinstance(v, (list, tuple)):
+        return type(v)(map(_normalize_state_value, v))
+    # Dict: normalize both keys and values.
+    if isinstance(v, dict):
+        return {_normalize_state_value(k): _normalize_state_value(val) for k, val in v.items()}
+    # Address a couple of pandas dtypes too.
+    if hasattr(v, "to_pytimedelta"):
+        return v.to_pytimedelta()
+    if hasattr(v, "to_pydatetime"):
+        return v.to_pydatetime()
+    return v
 
 
 class StatefulProcessorHandleState(Enum):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `numpy` a lazy import again in `pyspark/sql/streaming/stateful_processor_api_client.py`.

[SPARK-57760](https://issues.apache.org/jira/browse/SPARK-57760) hoisted `import numpy as np` to module level (to define `has_numpy` and `_normalize_state_value` once). However, that module sits on the eager `import pyspark` chain:

```
pyspark -> pyspark.sql -> pyspark.sql.context -> pyspark.sql.session
        -> pyspark.sql.dataframe -> pyspark.sql.streaming
        -> pyspark.sql.streaming.stateful_processor
        -> pyspark.sql.streaming.stateful_processor_api_client -> import numpy
```

so it caused `numpy` to be imported during `import pyspark`.

The fix:
- Resolve `has_numpy` via `importlib.util.find_spec("numpy")`, which detects numpy **without importing it**.
- Import numpy lazily inside `_normalize_state_value` (cached in `sys.modules` after the first call, so the per-call cost is negligible).

This restores the pre-SPARK-57760 behavior (numpy was previously imported lazily inside `_serialize_to_bytes`) while keeping SPARK-57760's benefit of defining `_normalize_state_value` only once.

### Why are the changes needed?

`pyspark.tests.test_import_spark` (added in [SPARK-56242](https://issues.apache.org/jira/browse/SPARK-56242)) asserts that no 3rd party package is imported during `import pyspark`, to keep import fast. Since SPARK-57760 landed, it fails with:

```
AssertionError: Unexpected 3rd party package 'numpy' imported during 'import pyspark'
```

This breaks several scheduled CI jobs that run the test with numpy installed, e.g.:
- `Build / Java25 (Scala 2.13, JDK 25)` on master — failing run: https://github.com/apache/spark/actions/runs/28995863015
- `Build / RocksDB as UI Backend (JDK 17)` on master — failing run: https://github.com/apache/spark/actions/runs/29000865707
- `Build / Python-only (Minimum dependencies of PySpark)` on master
- `Build / Java21 (Scala 2.13, JDK 21)` on branch-4.x

The offending commit is present on both master (`0af85eee8171`) and branch-4.x (`181acbd8db57`), so this needs to be backported to branch-4.x as well.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Verified `import pyspark` no longer imports numpy, `pyspark.tests.test_import_spark` passes, and `_normalize_state_value` still normalizes numpy scalars and nested containers (list/tuple/dict/namedtuple/Row) correctly.
- Validated on GitHub Actions on a fork: the `pyspark-core` module (which runs `test_import_spark`) passes with numpy installed — passing run: https://github.com/HyukjinKwon/spark/actions/runs/29021198465 (`Finished test(python3.11): pyspark.tests.test_import_spark (0s)`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
