### PR TITLE
[SPARK-58071][SS][PYTHON] Do not import numpy at 'import pyspark' time in stateful_processor_api_client

### DIFF
--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -34,36 +34,50 @@ import uuid
 
 __all__ = ["StatefulProcessorApiClient", "StatefulProcessorHandleState"]
 
-try:
+# Whether NumPy is available is resolved lazily rather than at import time. Importing NumPy
+# here would pull it into "import pyspark", which is expected to stay free of 3rd party
+# libraries (see python/pyspark/tests/test_import_spark.py).
+SCALAR_TYPES = (bool, int, float, str, bytes, datetime, type(None))
+
+_has_numpy: Optional[bool] = None
+
+
+def has_numpy() -> bool:
+    global _has_numpy
+    if _has_numpy is None:
+        try:
+            import numpy  # noqa: F401
+
+            _has_numpy = True
+        except ImportError:
+            _has_numpy = False
+    return _has_numpy
+
+
+def _normalize_state_value(v: Any) -> Any:
+    if type(v) in SCALAR_TYPES:  # Fast path for common scalar values.
+        return v
+    # Convert NumPy scalar values to Python primitive values.
     import numpy as np
 
-    has_numpy = True
-    SCALAR_TYPES = (bool, int, float, str, bytes, datetime, type(None))
-
-    def _normalize_state_value(v: Any) -> Any:
-        if type(v) in SCALAR_TYPES:  # Fast path for common scalar values.
-            return v
-        # Convert NumPy scalar values to Python primitive values.
-        if isinstance(v, np.generic):
-            return v.tolist()
-        # Named tuples (collections.namedtuple or typing.NamedTuple) and Row both
-        # require positional arguments and cannot be instantiated with a generator expression.
-        if isinstance(v, Row) or (isinstance(v, tuple) and hasattr(v, "_fields")):
-            return type(v)(*map(_normalize_state_value, v))
-        # List / tuple: recursively normalize each element.
-        if isinstance(v, (list, tuple)):
-            return type(v)(map(_normalize_state_value, v))
-        # Dict: normalize both keys and values.
-        if isinstance(v, dict):
-            return {_normalize_state_value(k): _normalize_state_value(val) for k, val in v.items()}
-        # Address a couple of pandas dtypes too.
-        if hasattr(v, "to_pytimedelta"):
-            return v.to_pytimedelta()
-        if hasattr(v, "to_pydatetime"):
-            return v.to_pydatetime()
-        return v
-except ImportError:
-    has_numpy = False
+    if isinstance(v, np.generic):
+        return v.tolist()
+    # Named tuples (collections.namedtuple or typing.NamedTuple) and Row both
+    # require positional arguments and cannot be instantiated with a generator expression.
+    if isinstance(v, Row) or (isinstance(v, tuple) and hasattr(v, "_fields")):
+        return type(v)(*map(_normalize_state_value, v))
+    # List / tuple: recursively normalize each element.
+    if isinstance(v, (list, tuple)):
+        return type(v)(map(_normalize_state_value, v))
+    # Dict: normalize both keys and values.
+    if isinstance(v, dict):
+        return {_normalize_state_value(k): _normalize_state_value(val) for k, val in v.items()}
+    # Address a couple of pandas dtypes too.
+    if hasattr(v, "to_pytimedelta"):
+        return v.to_pytimedelta()
+    if hasattr(v, "to_pydatetime"):
+        return v.to_pydatetime()
+    return v
 
 
 class StatefulProcessorHandleState(Enum):
@@ -520,7 +534,7 @@ class StatefulProcessorApiClient:
         return self.utf8_deserializer.loads(self.sockfile)
 
     def _serialize_to_bytes(self, schema: StructType, data: Tuple) -> bytes:
-        if has_numpy:
+        if has_numpy():
             converted = tuple(map(_normalize_state_value, data))
         else:
             converted = data


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-58071

### What changes were proposed in this pull request?

This PR makes `pyspark/sql/streaming/stateful_processor_api_client.py` resolve NumPy lazily instead of importing it at module load time.

SPARK-57760 moved `import numpy as np` to the module top level (inside a `try/except ImportError` block). This module is transitively imported by `import pyspark` (`pyspark` -> `pyspark.sql` -> `pyspark.sql.streaming` -> `stateful_processor_api_client`), so NumPy is now imported during `import pyspark`.

Instead of the top-level import, this PR:
- adds a cached `has_numpy()` helper that performs the availability check on first use, and
- imports `numpy` locally inside `_normalize_state_value` (only invoked when normalizing state values).

The observable behavior is unchanged.

### Why are the changes needed?

`import pyspark` is expected to stay fast and free of 3rd party libraries. `python/pyspark/tests/test_import_spark.py::ImportSparkTest::test_import_spark_libraries` enforces this and is currently failing on `master` / `branch-4.x`:

```
AssertionError: Unexpected 3rd party package 'numpy' imported during 'import pyspark'
```

This has been failing the scheduled Non-ANSI builds (e.g. `build_non_ansi.yml` on `branch-4.x`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -X importtime -c "import pyspark"` no longer shows `numpy` in the import trace.
- `python/pyspark/tests/test_import_spark.py` passes.
- Verified `_normalize_state_value` still converts NumPy scalars and nested containers correctly, and the scalar fast-path is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
