### PR TITLE
[SPARK-58070][INFRA] Remove curl -v flag from Nexus staging REST calls in `release-build.sh`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -912,7 +912,7 @@ if [[ "$1" == "publish-release" ]]; then
     echo "Creating Nexus staging repository"
     repo_request="<promoteRequest><data><description>Apache Spark $SPARK_VERSION (commit $git_hash)</description></data></promoteRequest>"
     out=$(curl --retry 10 --retry-all-errors -X POST -d "$repo_request" -u $ASF_USERNAME:$ASF_PASSWORD \
-      -H "Content-Type:application/xml" -v \
+      -H "Content-Type:application/xml" \
       $NEXUS_ROOT/profiles/$NEXUS_PROFILE/start)
     staged_repo_id=$(echo $out | sed -e "s/.*\(orgapachespark-[0-9]\{4\}\).*/\1/")
     echo "Created Nexus staging repository: $staged_repo_id"
@@ -990,7 +990,7 @@ if [[ "$1" == "publish-release" ]]; then
     echo "Closing nexus staging repository"
     repo_request="<promoteRequest><data><stagedRepositoryId>$staged_repo_id</stagedRepositoryId><description>Apache Spark $SPARK_VERSION (commit $git_hash)</description></data></promoteRequest>"
     out=$(curl --retry 10 --retry-all-errors -X POST -d "$repo_request" -u $ASF_USERNAME:$ASF_PASSWORD \
-      -H "Content-Type:application/xml" -v \
+      -H "Content-Type:application/xml" \
       $NEXUS_ROOT/profiles/$NEXUS_PROFILE/finish)
     echo "Closed Nexus staging repository: $staged_repo_id"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the `-v` flag from the two `curl` calls in the `publish-release` step of `dev/create-release/release-build.sh` that create and close the Nexus staging repository.

### Why are the changes needed?

`curl -v` prints request headers to `stderr`, including the `Authorization` header with the base64-encoded ASF credentials. `do-release.sh` runs this script via `run_silent`, which writes stderr to `publish.log`, so the credentials end up in the log file.

### Does this PR introduce _any_ user-facing change?

No. This is an improvement on the scripts used by the release managers only.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5