### PR TITLE
[SPARK-58074][INFRA] Mask `PYPI_API_TOKEN` in dry-run mode of `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
             GPG_PASSPHRASE="not_used"
             ASF_USERNAME="gurwls223"
             ASF_NEXUS_TOKEN="not_used"
+            PYPI_API_TOKEN="not_used"
             export SKIP_TAG=1
             unset RELEASE_VERSION
           else
@@ -184,7 +185,7 @@ jobs:
             export DRYRUN_MODE=0
           fi
 
-          export ASF_PASSWORD GPG_PRIVATE_KEY GPG_PASSPHRASE ASF_USERNAME ASF_NEXUS_TOKEN
+          export ASF_PASSWORD GPG_PRIVATE_KEY GPG_PASSPHRASE ASF_USERNAME ASF_NEXUS_TOKEN PYPI_API_TOKEN
           export GIT_BRANCH="${GIT_BRANCH:-master}"
           [ -n "$RELEASE_VERSION" ] && export RELEASE_VERSION
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mask `PYPI_API_TOKEN` with a `"not_used"` placeholder in the dry-run mode of `release.yml`, like the other secrets.

### Why are the changes needed?

In dry-run mode, all other secrets are replaced with placeholders, but `PYPI_API_TOKEN` was missing from the list. So, the real token was propagated to the release scripts and the Docker container environment although dry runs never use it.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5