### PR TITLE
[SPARK-58075][INFRA] Add `--rm` to docker run in `do-release-docker.sh`

### DIFF
--- a/dev/create-release/do-release-docker.sh
+++ b/dev/create-release/do-release-docker.sh
@@ -173,7 +173,7 @@ if [ -n "$JAVA" ]; then
 fi
 
 echo "Building $RELEASE_TAG; output will be at $WORKDIR/output"
-docker run $([ -z "$GITHUB_ACTIONS" ] && echo "-ti") \
+docker run --rm $([ -z "$GITHUB_ACTIONS" ] && echo "-ti") \
   --env-file "$ENVFILE" \
   --volume "$WORKDIR:/opt/spark-rm" \
   $JAVA_VOL \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add the `--rm` flag to the `docker run` invocation in `dev/create-release/do-release-docker.sh` so that the release container is removed automatically when it exits.

### Why are the changes needed?

The container is started with `--env-file`, which injects secrets such as `ASF_PASSWORD`, `GPG_PASSPHRASE`, `PYPI_API_TOKEN`, and `ASF_NEXUS_TOKEN`. Without `--rm`, the stopped container remains on the host and the secrets can be read in plain text via `docker inspect`.

This is safe because nothing references the container after it exits, and all outputs are written to the host via the `$WORKDIR` volume mount.

### Does this PR introduce _any_ user-facing change?

No. This is a release script which is used by release managers.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5