### PR TITLE
[SPARK-58077][INFRA] Add `--no-auth-cache` to svn ci/rm commands in `release-build.sh`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -490,7 +490,7 @@ EOF
   echo "Sync'ing KEYS"
   svn co --depth=files "$RELEASE_LOCATION" svn-spark
   curl "$RELEASE_STAGING_LOCATION/KEYS" > svn-spark/KEYS
-  (cd svn-spark && svn ci --username $ASF_USERNAME --password "$ASF_PASSWORD" -m"Update KEYS")
+  (cd svn-spark && svn ci --username $ASF_USERNAME --password "$ASF_PASSWORD" -m"Update KEYS" --no-auth-cache)
   echo "KEYS sync'ed"
   rm -rf svn-spark
 
@@ -565,7 +565,7 @@ EOF
   
   if [[ -n "$OLD_VERSION" ]]; then
     echo "Removing old version: spark-$OLD_VERSION"
-    svn rm "https://dist.apache.org/repos/dist/release/spark/spark-$OLD_VERSION" --username "$ASF_USERNAME" --password "$ASF_PASSWORD" --non-interactive -m "Remove older $RELEASE_SERIES release after $RELEASE_VERSION"
+    svn rm "https://dist.apache.org/repos/dist/release/spark/spark-$OLD_VERSION" --username "$ASF_USERNAME" --password "$ASF_PASSWORD" --non-interactive --no-auth-cache -m "Remove older $RELEASE_SERIES release after $RELEASE_VERSION"
   else
     echo "No previous $RELEASE_SERIES version found to remove. Manually remove it if there is."
   fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the missing `--no-auth-cache` flag to two credentialed `svn` commands in the `finalize` step of `dev/create-release/release-build.sh`: the `svn ci` for the KEYS file sync and the `svn rm` for removing the older release.

### Why are the changes needed?

All other `svn` commands using `--username`/`--password` in this script already pass `--no-auth-cache`. Without it, these two commands could leave the ASF password cached in plaintext under `~/.subversion/auth`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually reviewed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5