### PR TITLE
[SPARK-58079][INFRA] Create credential files securely and remove `~/.msmtprc` after use in `release-build.sh`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -877,6 +877,7 @@ if [[ "$1" == "publish-snapshot" ]]; then
   # Coerce the requested version
   $MVN versions:set -DnewVersion=$SPARK_VERSION
   tmp_settings="tmp-settings.xml"
+  fcreate_secure $tmp_settings
   echo "<settings><servers><server>" > $tmp_settings
   echo "<id>apache.snapshots.https</id><username>$ASF_USERNAME</username>" >> $tmp_settings
   echo "<password>$ASF_PASSWORD</password>" >> $tmp_settings
@@ -1016,6 +1017,7 @@ if [[ "$1" == "publish-release" ]]; then
       head -1)
 
     # Configure msmtp
+    fcreate_secure ~/.msmtprc
     cat > ~/.msmtprc <<EOF
 defaults
 auth           on
@@ -1032,8 +1034,6 @@ password       $ASF_PASSWORD
 
 account default : apache
 EOF
-
-    chmod 600 ~/.msmtprc
 
     # Compose and send the email
     {
@@ -1086,6 +1086,7 @@ EOF
       echo "with the RC (make sure to clean up the artifact cache before/after so"
       echo "you don't end up building with an out of date RC going forward)."
     } | msmtp -t
+    rm -f ~/.msmtprc
   fi
 
   popd


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the existing `fcreate_secure` helper to create credential files with `600` permission before writing `ASF_PASSWORD` into them in `release-build.sh`:

- `publish-release`: create `~/.msmtprc` via `fcreate_secure` (removing the after-the-fact `chmod 600`), and remove the file after sending the RC vote email.
- `publish-snapshot`: create `tmp-settings.xml` via `fcreate_secure`.

### Why are the changes needed?

Previously, these files were briefly readable by other local users because they were written with the default umask permission first. In addition, `~/.msmtprc` was never deleted, leaving the password on disk in plaintext.

### Does this PR introduce _any_ user-facing change?

No. This is a developer-only release script change.

### How was this patch tested?

Manually review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5