### PR TITLE
[SPARK-58083][INFRA] Pass PyPI token to twine via environment variable in `release-build.sh`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -103,6 +103,12 @@ if [[ "$1" == "finalize" ]]; then
     error 'The environment variable PYPI_API_TOKEN is not set. Exiting.'
   fi
 
+  # Pass the token to twine via an environment variable to keep it out of
+  # the process command line, which is visible to other users via ps.
+  { set +x; } 2>/dev/null
+  export TWINE_PASSWORD="$PYPI_API_TOKEN"
+  [ "$DEBUG_MODE" = 1 ] && set -x
+
   git config --global user.name "$GIT_NAME"
   git config --global user.email "$GIT_EMAIL"
 
@@ -128,19 +134,19 @@ if [[ "$1" == "finalize" ]]; then
   PYSPARK_VERSION=`echo "$RELEASE_VERSION" |  sed -e "s/-/./" -e "s/preview/dev/"`
   svn update "pyspark-$PYSPARK_VERSION.tar.gz"
   svn update "pyspark-$PYSPARK_VERSION.tar.gz.asc"
-  twine upload -u __token__  -p $PYPI_API_TOKEN \
+  twine upload -u __token__ \
     --repository-url https://upload.pypi.org/legacy/ \
     "pyspark-$PYSPARK_VERSION.tar.gz" \
     "pyspark-$PYSPARK_VERSION.tar.gz.asc"
   svn update "pyspark_connect-$PYSPARK_VERSION.tar.gz"
   svn update "pyspark_connect-$PYSPARK_VERSION.tar.gz.asc"
-  twine upload -u __token__  -p $PYPI_API_TOKEN \
+  twine upload -u __token__ \
     --repository-url https://upload.pypi.org/legacy/ \
     "pyspark_connect-$PYSPARK_VERSION.tar.gz" \
     "pyspark_connect-$PYSPARK_VERSION.tar.gz.asc"
   svn update "pyspark_client-$PYSPARK_VERSION.tar.gz"
   svn update "pyspark_client-$PYSPARK_VERSION.tar.gz.asc"
-  twine upload -u __token__ -p $PYPI_API_TOKEN \
+  twine upload -u __token__ \
     --repository-url https://upload.pypi.org/legacy/ \
     "pyspark_client-$PYSPARK_VERSION.tar.gz" \
     "pyspark_client-$PYSPARK_VERSION.tar.gz.asc"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the `finalize` step of `dev/create-release/release-build.sh` to pass the PyPI API token to `twine` via the `TWINE_PASSWORD` environment variable instead of the `-p $PYPI_API_TOKEN` command-line argument. The `export` statement is wrapped with a `set +x` guard so the token is not printed when `DEBUG_MODE=1` enables shell tracing.

### Why are the changes needed?

On Linux, `/proc/<pid>/cmdline` is world-readable, so passing the token with `-p` exposes it to every user on the host during the upload. Running inside Docker (`do-release-docker.sh`) does not help: container processes are still visible to the host's `ps`. With `DEBUG_MODE=1`, the `set -x` trace also prints the token expanded in the command line into the console output and logs. Environment variables avoid both exposure paths and are the twine-recommended way to supply credentials non-interactively.

### Does this PR introduce _any_ user-facing change?

No. This only affects the release scripts.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5