### PR TITLE
[MINOR][DOCS] Fix typos in comments and docstrings across multiple files

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -81,7 +81,7 @@ private[v2] trait V2JDBCTest
     // nullable is true in the expectedSchema because Spark always sets nullable to true
     // regardless of the JDBC metadata https://github.com/apache/spark/pull/18445
     var expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     var expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     var schemaWithoutJdbcClientType =
@@ -91,7 +91,7 @@ private[v2] trait V2JDBCTest
     t = spark.table(s"$catalogName.alt_table")
     expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     schemaWithoutJdbcClientType =
@@ -118,7 +118,7 @@ private[v2] trait V2JDBCTest
       .add("ID1", StringType, true, defaultMetadata())
       .add("ID2", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     val expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     val schemaWithoutJdbcClientType =

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2718,8 +2718,8 @@ private[spark] class DAGScheduler(
       log"shuffle checksum mismatch stage ${MDC(STAGE, mapStage)} in active jobs")
     val stagesCanRollback = filterAndAbortUnrollbackableStages(stagesToRollback)
 
-    // stages which cannot be rolled back were aborted which leads to removing the
-    // the dependant job(s) from the active jobs set, there could be no active jobs
+    // stages which cannot be rolled back were aborted which leads to removing
+    // the dependent job(s) from the active jobs set, there could be no active jobs
     // left depending on the indeterminate stage and hence no need to roll back any stages.
     val numActiveJobsWithStageAfterRollback =
       activeJobs.count(job => stagesToRollback.contains(job.finalStage))

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -141,7 +141,7 @@ class MockProtocolWriter:
     ) -> None:
         """Write the initial message with header, length + its data."""
 
-        # Write everything to a seperate buffer so we can
+        # Write everything to a separate buffer so we can
         # determine the length of the initial message.
         buf = io.BytesIO()
         cls.write_preamble(buf)

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -1882,7 +1882,7 @@ class Frame(object, metaclass=ABCMeta):
             where N represents the number of elements.
 
             .. versionchanged:: 3.4.0
-               Supported including arbitary integers.
+               Supported including arbitrary integers.
         numeric_only: bool, default None
             Include only float, int, boolean columns. False is not supported. This parameter
             is mainly for pandas compatibility.
@@ -1981,7 +1981,7 @@ class Frame(object, metaclass=ABCMeta):
             where N represents the number of elements.
 
             .. versionchanged:: 3.4.0
-               Supported including arbitary integers.
+               Supported including arbitrary integers.
         numeric_only: bool, default None
             Include only float, int, boolean columns. False is not supported. This parameter
             is mainly for pandas compatibility.
@@ -2213,7 +2213,7 @@ class Frame(object, metaclass=ABCMeta):
             where N represents the number of elements.
 
             .. versionchanged:: 3.4.0
-               Supported including arbitary integers.
+               Supported including arbitrary integers.
         numeric_only: bool, default None
             Include only float, int, boolean columns. False is not supported. This parameter
             is mainly for pandas compatibility.

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -851,7 +851,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             where N represents the number of elements.
 
             .. versionchanged:: 3.4.0
-               Supported including arbitary integers.
+               Supported including arbitrary integers.
 
         Examples
         --------
@@ -986,7 +986,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             where N represents the number of elements.
 
             .. versionchanged:: 3.4.0
-               Supported including arbitary integers.
+               Supported including arbitrary integers.
 
         numeric_only : bool, default False
              Include only float, int, boolean columns.

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -579,7 +579,7 @@ class BasePythonStreamingDataSourceTestsMixin:
 
             # Test stream writer write and commit.
             # The first microbatch contain 30 rows and 2 partitions.
-            # Number of rows and partitions is writen by StreamWriter.commit().
+            # Number of rows and partitions is written by StreamWriter.commit().
             assertDataFrameEqual(self.spark.read.json(output_dir.name), [Row(2, 30)])
 
             self.spark.range(50, 80).repartition(2).write.format("json").mode("append").save(

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -856,7 +856,8 @@ private[spark] class Client(
    * The archive also contains some Spark configuration. Namely, it saves the contents of
    * SparkConf in a file to be loaded by the AM process.
    *
-   * @param confsToOverride configs that should overriden when creating the final spark conf file
+   * @param confsToOverride configs that should be overridden when creating the final spark
+   *                        conf file
    */
   private def createConfArchive(confsToOverride: Map[String, String]): File = {
     val hadoopConfFiles = new HashMap[String, File]()

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -329,21 +329,21 @@ private[yarn] class YarnAllocator(
       // to request YARN containers with extra resources without Spark scheduling on
       // them, the user can specify resources via the <code>spark.yarn.executor.resource.</code>
       // config. Those configs are only used in the base default profile though and do
-      // not get propogated into any other custom ResourceProfiles. This is because
+      // not get propagated into any other custom ResourceProfiles. This is because
       // there would be no way to remove them if you wanted a stage to not have them.
       // This results in your default profile getting custom resources defined in
       // <code>spark.yarn.executor.resource.</code> plus spark defined resources of
       // GPU or FPGA. Spark converts GPU and FPGA resources into the YARN built in
       // types <code>yarn.io/gpu</code>) and <code>yarn.io/fpga</code>, but does not
       // know the mapping of any other resources. Any other Spark custom resources
-      // are not propogated to YARN for the default profile. So if you want Spark
+      // are not propagated to YARN for the default profile. So if you want Spark
       // to schedule based off a custom resource and have it requested from YARN, you
       // must specify it in both YARN (<code>spark.yarn.{driver/executor}.resource.</code>)
       // and Spark (<code>spark.{driver/executor}.resource.</code>) configs. Leave the Spark
       // config off if you only want YARN containers with the extra resources but Spark not to
       // schedule using them. Now for custom ResourceProfiles, it doesn't currently have a way
       // to only specify YARN resources without Spark scheduling off of them. This means for
-      // custom ResourceProfiles we propogate all the resources defined in the ResourceProfile
+      // custom ResourceProfiles we propagate all the resources defined in the ResourceProfile
       // to YARN. We still convert GPU and FPGA to the YARN build in types as well. This requires
       // that the name of any custom resources you specify match what they are defined as in YARN.
       val customResources = if (rp.id == DEFAULT_RESOURCE_PROFILE_ID) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
@@ -1213,7 +1213,7 @@ class ExpressionResolver(
    *
    * -- GetViewColumnByNameAndOrdinal helps us to disambiguate the column names from different
    * -- tables by matching the same attribute names from those tables by their ordinal in the
-   * -- Project list, which is dependant on the order of tables in the inner join operator from
+   * -- Project list, which is dependent on the order of tables in the inner join operator from
    * -- the view plan:
    * -- getviewcolumnbynameandordinal(`spark_catalog`.`default`.`all_columns`, col1, 0, 2)
    * -- getviewcolumnbynameandordinal(`spark_catalog`.`default`.`all_columns`, col2, 0, 2)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/HavingResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/HavingResolver.scala
@@ -91,7 +91,7 @@ class HavingResolver(resolver: Resolver, expressionResolver: ExpressionResolver)
    * Window [col1#0, sum(col1#0) windowspec...#2]
    * +- Aggregate [col1#0], [col1#0]
    *
-   * Since [[Filter]] is not dependant on the [[Window]], we push a [[Filter]] operator down to
+   * Since [[Filter]] is not dependent on the [[Window]], we push a [[Filter]] operator down to
    * the nearest [[Aggregate]] and perform the rest of resolution using its output:
    *
    * Window [col1#0, sum(col1#0) windowspec...#1]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2695,7 +2695,7 @@ case class Get(left: Expression, right: Expression)
 
   override def inputTypes: Seq[AbstractDataType] = left.dataType match {
     case _: ArrayType => Seq(ArrayType, IntegerType)
-    // Do not apply implicit cast if the first arguement is not array type.
+    // Do not apply implicit cast if the first argument is not array type.
     case _ => Nil
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 
 /**
- * A statement for Stream writing. It contains all neccessary param and will be resolved in the
+ * A statement for Stream writing. It contains all necessary param and will be resolved in the
  * rule [[ResolveStreamWrite]].
  *
  * @param userSpecifiedName  Query name optionally specified by the user.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -206,7 +206,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("SPARK-22226: group splitted expressions into one method per nested class") {
+  test("SPARK-22226: group split expressions into one method per nested class") {
     val length = 10000
     val expressions = Seq.fill(length) {
       ToUTCTimestamp(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
@@ -85,7 +85,7 @@ object DataWritingCommand {
    * or [[InsertIntoHiveTable]] command to write data, they both inherit metrics from
    * [[DataWritingCommand]], but after running [[InsertIntoHadoopFsRelationCommand]]
    * or [[InsertIntoHiveTable]], we only update metrics in these two command through
-   * [[BasicWriteJobStatsTracker]], we also need to propogate metrics to the command
+   * [[BasicWriteJobStatsTracker]], we also need to propagate metrics to the command
    * that actually calls [[InsertIntoHadoopFsRelationCommand]] or [[InsertIntoHiveTable]].
    *
    * @param sparkContext Current SparkContext.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -80,7 +80,7 @@ class HadoopTableReader(
   //
   // In order keep consistency with Hive, we will let it be 0 in local mode also.
   private val _minSplitsPerRDD = if (sparkSession.sparkContext.isLocal) {
-    0 // will splitted based on block by default.
+    0 // will be split based on block by default.
   } else {
     math.max(hadoopConf.getInt("mapreduce.job.maps", 1),
       sparkSession.sparkContext.defaultMinPartitions)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                            
  Fix typos and minor grammar errors in code comments, docstrings, and one test name across 15 files: 22 misspellings plus one duplicated word, for 23 changed lines. No identifier, API, or behavior changes.                                                                                                              
                                                                                                                                                                                                                                                                                                                            
  Typos fixed:                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                            
  | Typo | Fixed | Spots |                                                                                                                                                                                                                                                                                                  
  |---|---|---|                                                                                                                                                                                                                                                                                                             
  | `arbitary` | `arbitrary` | 5 |                                                                                                                                                                                                                                                                                          
  | `propogate` | `propagate` | 4 |                                                                                                                                                                                                                                                                                         
  | `overriden` | `overridden` | 4 |                                                                                                                                                                                                                                                                                        
  | `dependant` | `dependent` | 3 |                                                                                                                                                                                                                                                                                         
  | `splitted` | `split` | 2 |                                                                                                                                                                                                                                                                                              
  | `neccessary` | `necessary` | 1 |                                                                                                                                                                                                                                                                                        
  | `arguement` | `argument` | 1 |                                                                                                                                                                                                                                                                                          
  | `writen` | `written` | 1 |                                                                                                                                                                                                                                                                                              
  | `seperate` | `separate` | 1 |                                                                                                                                                                                                                                                                                           
  | | **total** | **22** |                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                            
  Adjacent grammar issues found during the same scan were fixed as well:                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  - `should overriden` -> `should be overridden` (`Client.scala`)                                                                                                                                                                                                                                                           
  - a duplicated `the` spanning two lines (`DAGScheduler.scala`) -- this is the 23rd changed line, on top of the 22 misspellings above
 
Two notes on the diff, so it is easy to follow:                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  - In `YarnAllocator.scala`, one comment block contained three occurrences of `propogate`. All three are fixed so the spelling is consistent within that block.                                                                                                                                                            
  - The `@param confsToOverride` line in `Client.scala` exceeds the 100-character limit once `overriden` becomes `be overridden`, so it is wrapped onto two lines. This is why the diff is +24/-23 rather than +23/-23.                                                                                                     
                                                                                                                                                                                                                                                                                                                            
  Identifiers and public API names are deliberately left alone. For example `AbstractFileRegion.transfered()` and `DataWritingCommand.propogateMetrics()` carry the same misspelling but are method names, so renaming them is out of scope for a `[MINOR][DOCS]` change.                                                   
                                                                                                                                                                                                                                                                                                                            
  ### Why are the changes needed?                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  To improve readability and correctness of code comments and docstrings. Some of the fixes are in user-visible API docstrings (e.g. `pyspark.pandas` `generic.py` / `groupby.py`), where `arbitary` appears in rendered documentation.                                                                                     
                                                                                                                                                                                                                                                                                                                            
  ### Does this PR introduce _any_ user-facing change?                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                            
  No. Documentation/comment-only changes. The only rendered-output difference is the corrected spelling in the pandas-on-Spark docstrings noted above.                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                            
  ### How was this patch tested?                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
  No behavior change; existing CI.                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                            
  Locally verified before pushing:                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                            
  - `build/sbt -Pyarn -Pdocker-integration-tests` compile plus `scalastyle` for `core`, `catalyst`, `sql`, `hive`, `yarn`, `catalyst/Test` and `docker-integration-tests/Test` -- 0 errors, 0 warnings.                                                                                                                     
  - `ruff check` and `ruff format --check` on the four changed Python files -- clean.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  The only non-comment edit is a test name in `CodeGenerationSuite.scala` (`splitted` -> `split`), covered by the existing suite.                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  ### Was this patch authored or co-authored using generative AI tooling?                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
  Generated-by: Claude Code (Claude Opus 4.8, Claude Opus 5) 
