### PR TITLE
[BACKPORT][MINOR][UI] Encode query parameters when generating log page scripts

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/log-view.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/log-view.js
@@ -131,18 +131,8 @@ function loadNew() {
   });
 }
 
-function encodeLogParams(params) {
-  // baseParams is only ever concatenated into the /log request URL (see loadMore/loadNew), never
-  // written to the DOM, so URL-encode it for that context rather than stripping characters.
-  // encodeURI keeps the ?, &, = and / separators intact while percent-encoding characters such as
-  // spaces, angle brackets, quotes, backslash and CR/LF that have no place in the query string.
-  // The server decodes the values again, so this is lossless for legitimate parameters (the
-  // executor/app/driver ids and the allowlisted logType).
-  return encodeURI(String(params)).replace(/'/g, "%27");
-}
-
 function initLogPage(params, logLen, start, end, totLogLen, defaultLen) {
-  baseParams = encodeLogParams(params);
+  baseParams = params;
   curLogLength = logLen;
   startByte = start;
   endByte = end;

--- a/core/src/main/resources/org/apache/spark/ui/static/log-view.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/log-view.js
@@ -131,8 +131,18 @@ function loadNew() {
   });
 }
 
+function encodeLogParams(params) {
+  // baseParams is only ever concatenated into the /log request URL (see loadMore/loadNew), never
+  // written to the DOM, so URL-encode it for that context rather than stripping characters.
+  // encodeURI keeps the ?, &, = and / separators intact while percent-encoding characters such as
+  // spaces, angle brackets, quotes, backslash and CR/LF that have no place in the query string.
+  // The server decodes the values again, so this is lossless for legitimate parameters (the
+  // executor/app/driver ids and the allowlisted logType).
+  return encodeURI(String(params)).replace(/'/g, "%27");
+}
+
 function initLogPage(params, logLen, start, end, totLogLen, defaultLen) {
-  baseParams = params;
+  baseParams = encodeLogParams(params);
   curLogLength = logLen;
   startByte = start;
   endByte = end;

--- a/core/src/main/scala/org/apache/spark/deploy/history/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/LogPage.scala
@@ -20,7 +20,6 @@ package org.apache.spark.deploy.history
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
-import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.Utils.{getLog, DEFAULT_BYTES}
@@ -57,12 +56,9 @@ private[history] class LogPage(conf: SparkConf) extends WebUIPage("logPage") wit
         End of Log
       </div>
 
-    val logParams = "?self&logType=%s".format(logType)
-    // The query string carries request-supplied values into an inline script literal, so encode
-    // it for a JavaScript string context before embedding it via Unparsed below.
-    val jsOnload = "window.onload = " +
-      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
-      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+    val logParams = "?self&logType=%s".format(UIUtils.encodeLogParam(logType))
+    val jsOnload = UIUtils.logPageOnloadScript(
+      logParams, curLogLength, startByte, endByte, logLength, byteLength)
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/deploy/history/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/LogPage.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy.history
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
+import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.Utils.{getLog, DEFAULT_BYTES}
@@ -57,8 +58,11 @@ private[history] class LogPage(conf: SparkConf) extends WebUIPage("logPage") wit
       </div>
 
     val logParams = "?self&logType=%s".format(logType)
+    // The query string carries request-supplied values into an inline script literal, so encode
+    // it for a JavaScript string context before embedding it via Unparsed below.
     val jsOnload = "window.onload = " +
-      s"initLogPage('$logParams', $curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
+      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/LogPage.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy.master.ui
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
+import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.deploy.Utils.{getLog, DEFAULT_BYTES}
 import org.apache.spark.internal.Logging
@@ -56,8 +57,11 @@ private[ui] class LogPage(parent: MasterWebUI) extends WebUIPage("logPage") with
       </div>
 
     val logParams = "?self&logType=%s".format(logType)
+    // The query string carries request-supplied values into an inline script literal, so encode
+    // it for a JavaScript string context before embedding it via Unparsed below.
     val jsOnload = "window.onload = " +
-      s"initLogPage('$logParams', $curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
+      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/LogPage.scala
@@ -20,7 +20,6 @@ package org.apache.spark.deploy.master.ui
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
-import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.deploy.Utils.{getLog, DEFAULT_BYTES}
 import org.apache.spark.internal.Logging
@@ -56,12 +55,9 @@ private[ui] class LogPage(parent: MasterWebUI) extends WebUIPage("logPage") with
         End of Log
       </div>
 
-    val logParams = "?self&logType=%s".format(logType)
-    // The query string carries request-supplied values into an inline script literal, so encode
-    // it for a JavaScript string context before embedding it via Unparsed below.
-    val jsOnload = "window.onload = " +
-      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
-      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+    val logParams = "?self&logType=%s".format(UIUtils.encodeLogParam(logType))
+    val jsOnload = UIUtils.logPageOnloadScript(
+      logParams, curLogLength, startByte, endByte, logLength, byteLength)
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -22,6 +22,7 @@ import java.io.File
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
+import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{LOG_TYPE, PATH}
@@ -106,8 +107,11 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
       </div>
 
     val logParams = "?%s&logType=%s".format(params, logType)
+    // The query string carries request-supplied values into an inline script literal, so encode
+    // it for a JavaScript string context before embedding it via Unparsed below.
     val jsOnload = "window.onload = " +
-      s"initLogPage('$logParams', $curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
+      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -22,7 +22,6 @@ import java.io.File
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
-import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{LOG_TYPE, PATH}
@@ -72,11 +71,16 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
     val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
       .getOrElse(defaultBytes)
 
+    // The identifiers below flow both into a filesystem path (logDir, kept raw and guarded by
+    // Utils.isInDirectory in getLog) and into the query string of the generated /log requests
+    // (params). URL-encode the query-string copy so request-supplied values cannot inject extra
+    // parameters or truncate the request.
     val (logDir, params, pageName) = (appId, executorId, driverId, self) match {
       case (Some(a), Some(e), None, None) =>
-        (s"${workDir.getPath}/$a/$e/", s"appId=$a&executorId=$e", s"$a/$e")
+        (s"${workDir.getPath}/$a/$e/",
+          s"appId=${UIUtils.encodeLogParam(a)}&executorId=${UIUtils.encodeLogParam(e)}", s"$a/$e")
       case (None, None, Some(d), None) =>
-        (s"${workDir.getPath}/$d/", s"driverId=$d", d)
+        (s"${workDir.getPath}/$d/", s"driverId=${UIUtils.encodeLogParam(d)}", d)
       case (None, None, None, Some(_)) =>
         (s"${sys.env.getOrElse("SPARK_LOG_DIR", workDir.getPath)}/", "self", "worker")
       case _ =>
@@ -106,12 +110,9 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
         End of Log
       </div>
 
-    val logParams = "?%s&logType=%s".format(params, logType)
-    // The query string carries request-supplied values into an inline script literal, so encode
-    // it for a JavaScript string context before embedding it via Unparsed below.
-    val jsOnload = "window.onload = " +
-      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
-      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+    val logParams = "?%s&logType=%s".format(params, UIUtils.encodeLogParam(logType))
+    val jsOnload = UIUtils.logPageOnloadScript(
+      logParams, curLogLength, startByte, endByte, logLength, byteLength)
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/ui/DriverLogPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/DriverLogPage.scala
@@ -19,7 +19,6 @@ package org.apache.spark.ui
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
-import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -71,12 +70,9 @@ private[ui] class DriverLogPage(
         End of Log
       </div>
 
-    val logParams = "/?logType=%s".format(logType)
-    // The query string carries request-supplied values into an inline script literal, so encode
-    // it for a JavaScript string context before embedding it via Unparsed below.
-    val jsOnload = "window.onload = " +
-      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
-      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+    val logParams = "/?logType=%s".format(UIUtils.encodeLogParam(logType))
+    val jsOnload = UIUtils.logPageOnloadScript(
+      logParams, curLogLength, startByte, endByte, logLength, byteLength)
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/ui/DriverLogPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/DriverLogPage.scala
@@ -19,6 +19,7 @@ package org.apache.spark.ui
 import scala.xml.{Node, Unparsed}
 
 import jakarta.servlet.http.HttpServletRequest
+import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -71,8 +72,11 @@ private[ui] class DriverLogPage(
       </div>
 
     val logParams = "/?logType=%s".format(logType)
+    // The query string carries request-supplied values into an inline script literal, so encode
+    // it for a JavaScript string context before embedding it via Unparsed below.
     val jsOnload = "window.onload = " +
-      s"initLogPage('$logParams', $curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
+      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
 
     val content =
       <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -659,7 +659,8 @@ private[spark] object UIUtils extends Logging {
    * This keeps characters such as '&', '=', '#' and whitespace from changing the structure of the
    * subsequent `/log` requests (parameter injection / query truncation).
    */
-  def encodeLogParam(value: String): String = URLEncoder.encode(String.valueOf(value), UTF_8)
+  def encodeLogParam(value: String): String =
+    URLEncoder.encode(Option(value).getOrElse("null"), UTF_8)
 
   /**
    * Build the inline `window.onload = initLogPage(...)` bootstrap script shared by the log pages

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ui
 
 import java.{util => ju}
 import java.lang.{Long => JLong}
-import java.net.URLDecoder
+import java.net.{URLDecoder, URLEncoder}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
@@ -32,6 +32,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.ws.rs.core.{MediaType, MultivaluedMap, Response}
+import org.apache.commons.text.StringEscapeUtils
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
 
 import org.apache.spark.internal.Logging
@@ -652,6 +653,32 @@ private[spark] object UIUtils extends Logging {
 
   def getTimeZoneOffset() : Int =
     TimeZone.getDefault().getOffset(System.currentTimeMillis()) / 1000 / 60
+
+  /**
+   * URL-encode a single request-supplied value before embedding it in a log page query string.
+   * This keeps characters such as '&', '=', '#' and whitespace from changing the structure of the
+   * subsequent `/log` requests (parameter injection / query truncation).
+   */
+  def encodeLogParam(value: String): String = URLEncoder.encode(String.valueOf(value), UTF_8)
+
+  /**
+   * Build the inline `window.onload = initLogPage(...)` bootstrap script shared by the log pages
+   * (history / master / worker / driver). Individual parameter values in `logParams` must already
+   * be URL-encoded via [[encodeLogParam]] so the query string is unambiguous; the assembled string
+   * is additionally escaped for the surrounding JavaScript string literal so request-supplied
+   * values cannot break out of the inline &lt;script&gt; block.
+   */
+  def logPageOnloadScript(
+      logParams: String,
+      curLogLength: Long,
+      startByte: Long,
+      endByte: Long,
+      logLength: Long,
+      byteLength: Long): String = {
+    "window.onload = " +
+      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
+      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+  }
 
   /**
   * Return the correct Href after checking if master is running in the

--- a/core/src/test/scala/org/apache/spark/deploy/history/LogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/LogPageSuite.scala
@@ -32,9 +32,11 @@ class LogPageSuite extends SparkFunSuite {
     when(request.getParameter("logType")).thenReturn("stdout');alert('xss')</script>")
     val html = page.render(request).mkString
 
-    // The value must be encoded for the JavaScript string context: quotes, backslashes and the
-    // slash in a closing tag are all escaped, so no raw breakout sequence reaches the browser.
-    assert(html.contains("""stdout\');alert(\'xss\')<\/script>"""))
-    assert(!html.contains("stdout');alert('xss')</script>"))
+    // The value is URL-encoded, so the quotes, angle brackets and slash that would break out of
+    // the inline <script> (or inject extra /log parameters) become inert percent escapes.
+    assert(html.contains("logType=stdout%27%29%3Balert%28%27xss%27%29%3C%2Fscript%3E"))
+    // The raw, structure-breaking form must never reach the generated query string. (The page
+    // title reflects logType too, but there the XML library HTML-escapes it, so it is safe.)
+    assert(!html.contains("logType=stdout');"))
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/LogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/LogPageSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.history
+
+import jakarta.servlet.http.HttpServletRequest
+import org.mockito.Mockito.{mock, when}
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+
+class LogPageSuite extends SparkFunSuite {
+
+  test("render encodes the logType parameter embedded in the inline script") {
+    val page = new LogPage(new SparkConf(false))
+    val request = mock(classOf[HttpServletRequest])
+    // A value that would break out of the single-quoted JavaScript string literal, close the
+    // script element, or start a new statement if it were emitted into the page verbatim.
+    when(request.getParameter("logType")).thenReturn("stdout');alert('xss')</script>")
+    val html = page.render(request).mkString
+
+    // The value must be encoded for the JavaScript string context: quotes, backslashes and the
+    // slash in a closing tag are all escaped, so no raw breakout sequence reaches the browser.
+    assert(html.contains("""stdout\');alert(\'xss\')<\/script>"""))
+    assert(!html.contains("stdout');alert('xss')</script>"))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
@@ -79,27 +79,28 @@ class LogPageSuite extends SparkFunSuite with PrivateMethodTester {
   test("render encodes request parameters embedded in the inline script") {
     val webui = mock(classOf[WorkerWebUI])
     val worker = mock(classOf[Worker])
-    val tmpDir = new File(sys.props("java.io.tmpdir"))
-    val workDir = new File(tmpDir, "work-dir")
-    workDir.mkdir()
-    when(webui.workDir).thenReturn(workDir)
-    when(webui.worker).thenReturn(worker)
-    when(worker.conf).thenReturn(new SparkConf())
-    when(worker.activeMasterWebUiUrl).thenReturn("http://master:8080")
-    val logPage = new LogPage(webui)
+    withTempDir { tmpDir =>
+      val workDir = new File(tmpDir, "work-dir")
+      workDir.mkdir()
+      when(webui.workDir).thenReturn(workDir)
+      when(webui.worker).thenReturn(worker)
+      when(worker.conf).thenReturn(new SparkConf())
+      when(worker.activeMasterWebUiUrl).thenReturn("http://master:8080")
+      val logPage = new LogPage(webui)
 
-    val request = mock(classOf[HttpServletRequest])
-    // appId is user-controlled; a '&' in it would inject an extra parameter into the /log
-    // requests, and the '</script>' would break out of the inline <script> block, if emitted raw.
-    when(request.getParameter("appId")).thenReturn("app&byteLength=0</script>")
-    when(request.getParameter("executorId")).thenReturn("0")
-    when(request.getParameter("logType")).thenReturn("stdout")
-    val html = logPage.render(request).mkString
+      val request = mock(classOf[HttpServletRequest])
+      // appId is user-controlled; a '&' in it would inject an extra parameter into the /log
+      // requests, and the '</script>' would break out of the inline <script> block, if emitted raw.
+      when(request.getParameter("appId")).thenReturn("app&byteLength=0</script>")
+      when(request.getParameter("executorId")).thenReturn("0")
+      when(request.getParameter("logType")).thenReturn("stdout")
+      val html = logPage.render(request).mkString
 
-    // The value is percent-encoded, so it stays a single opaque appId value and cannot inject a
-    // parameter or close the script element.
-    assert(html.contains("appId=app%26byteLength%3D0%3C%2Fscript%3E&executorId=0"))
-    assert(!html.contains("app&byteLength=0</script>"))
+      // The value is percent-encoded, so it stays a single opaque appId value and cannot inject a
+      // parameter or close the script element.
+      assert(html.contains("appId=app%26byteLength%3D0%3C%2Fscript%3E&executorId=0"))
+      assert(!html.contains("app&byteLength=0</script>"))
+    }
   }
 
   /** Write the specified string to the file. */

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.worker.ui
 
 import java.io.{File, FileWriter}
 
+import jakarta.servlet.http.HttpServletRequest
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.PrivateMethodTester
 
@@ -73,6 +74,32 @@ class LogPageSuite extends SparkFunSuite with PrivateMethodTester {
     assert(error2.startsWith("Error: Log type must be one of "))
     assert(error3.startsWith("Error: invalid log directory"))
     assert(error4.startsWith("Error: invalid log directory"))
+  }
+
+  test("render encodes request parameters embedded in the inline script") {
+    val webui = mock(classOf[WorkerWebUI])
+    val worker = mock(classOf[Worker])
+    val tmpDir = new File(sys.props("java.io.tmpdir"))
+    val workDir = new File(tmpDir, "work-dir")
+    workDir.mkdir()
+    when(webui.workDir).thenReturn(workDir)
+    when(webui.worker).thenReturn(worker)
+    when(worker.conf).thenReturn(new SparkConf())
+    when(worker.activeMasterWebUiUrl).thenReturn("http://master:8080")
+    val logPage = new LogPage(webui)
+
+    val request = mock(classOf[HttpServletRequest])
+    // appId is user-controlled; a '&' in it would inject an extra parameter into the /log
+    // requests, and the '</script>' would break out of the inline <script> block, if emitted raw.
+    when(request.getParameter("appId")).thenReturn("app&byteLength=0</script>")
+    when(request.getParameter("executorId")).thenReturn("0")
+    when(request.getParameter("logType")).thenReturn("stdout")
+    val html = logPage.render(request).mkString
+
+    // The value is percent-encoded, so it stays a single opaque appId value and cannot inject a
+    // parameter or close the script element.
+    assert(html.contains("appId=app%26byteLength%3D0%3C%2Fscript%3E&executorId=0"))
+    assert(!html.contains("app&byteLength=0</script>"))
   }
 
   /** Write the specified string to the file. */


### PR DESCRIPTION
### What changes were proposed in this pull request?

The log viewer pages assemble a query string from request parameters and embed it into an inline script literal. Encode that value for a JavaScript string context using the bundled commons-text StringEscapeUtils, matching the existing pattern in AllJobsPage, so the generated script stays well-formed regardless of the parameter contents. 

Backport to 4.1 of https://github.com/apache/spark/pull/57165

### Why are the changes needed?

Formatting can get funky with unescaped parameters.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

New test

### Was this patch authored or co-authored using generative AI tooling?

Primarily Claude 4.8