### PR TITLE
[BACKPORT][MINOR][UI] Encode query parameters when generating log page scripts

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -18,9 +18,13 @@
 package org.apache.spark.deploy.worker.ui
 
 import java.io.File
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 import javax.servlet.http.HttpServletRequest
 
 import scala.xml.{Node, Unparsed}
+
+import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.ui.{UIUtils, WebUIPage}
@@ -32,6 +36,12 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
   private val workDir = new File(parent.workDir.toURI.normalize().getPath)
   private val supportedLogTypes = Set("stderr", "stdout")
   private val defaultBytes = 100 * 1024
+
+  // URL-encode a single request-supplied value before embedding it in a log page query string, so
+  // characters such as '&', '=', '#' and whitespace cannot change the structure of the subsequent
+  // /log requests (parameter injection / query truncation).
+  private def encodeParam(value: String): String =
+    URLEncoder.encode(String.valueOf(value), UTF_8.name())
 
   def renderLog(request: HttpServletRequest): String = {
     val appId = Option(request.getParameter("appId"))
@@ -65,11 +75,16 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
     val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
       .getOrElse(defaultBytes)
 
+    // The identifiers below flow both into a filesystem path (logDir, kept raw and guarded by
+    // Utils.isInDirectory in getLog) and into the query string of the generated /log requests
+    // (params). URL-encode the query-string copy so request-supplied values cannot inject extra
+    // parameters or truncate the request.
     val (logDir, params, pageName) = (appId, executorId, driverId) match {
       case (Some(a), Some(e), None) =>
-        (s"${workDir.getPath}/$a/$e/", s"appId=$a&executorId=$e", s"$a/$e")
+        (s"${workDir.getPath}/$a/$e/",
+          s"appId=${encodeParam(a)}&executorId=${encodeParam(e)}", s"$a/$e")
       case (None, None, Some(d)) =>
-        (s"${workDir.getPath}/$d/", s"driverId=$d", d)
+        (s"${workDir.getPath}/$d/", s"driverId=${encodeParam(d)}", d)
       case _ =>
         throw new Exception("Request must specify either application or driver identifiers")
     }
@@ -97,9 +112,13 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
         End of Log
       </div>
 
-    val logParams = "?%s&logType=%s".format(params, logType)
+    val logParams = "?%s&logType=%s".format(params, encodeParam(logType))
+    // logParams carries request-supplied values into an inline script literal, so escape it for a
+    // JavaScript string context before embedding it via Unparsed below (defense in depth on top of
+    // the URL-encoding above).
     val jsOnload = "window.onload = " +
-      s"initLogPage('$logParams', $curLogLength, $startByte, $endByte, $logLength, $byteLength);"
+      s"initLogPage('${StringEscapeUtils.escapeEcmaScript(logParams)}', " +
+      s"$curLogLength, $startByte, $endByte, $logLength, $byteLength);"
 
     val content =
       <script src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -41,7 +41,7 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
   // characters such as '&', '=', '#' and whitespace cannot change the structure of the subsequent
   // /log requests (parameter injection / query truncation).
   private def encodeParam(value: String): String =
-    URLEncoder.encode(String.valueOf(value), UTF_8.name())
+    URLEncoder.encode(Option(value).getOrElse("null"), UTF_8.name())
 
   def renderLog(request: HttpServletRequest): String = {
     val appId = Option(request.getParameter("appId"))

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
@@ -79,27 +79,28 @@ class LogPageSuite extends SparkFunSuite with PrivateMethodTester {
   test("render encodes request parameters embedded in the inline script") {
     val webui = mock(classOf[WorkerWebUI])
     val worker = mock(classOf[Worker])
-    val tmpDir = new File(sys.props("java.io.tmpdir"))
-    val workDir = new File(tmpDir, "work-dir")
-    workDir.mkdir()
-    when(webui.workDir).thenReturn(workDir)
-    when(webui.worker).thenReturn(worker)
-    when(worker.conf).thenReturn(new SparkConf())
-    when(worker.activeMasterWebUiUrl).thenReturn("http://master:8080")
-    val logPage = new LogPage(webui)
+    withTempDir { tmpDir =>
+      val workDir = new File(tmpDir, "work-dir")
+      workDir.mkdir()
+      when(webui.workDir).thenReturn(workDir)
+      when(webui.worker).thenReturn(worker)
+      when(worker.conf).thenReturn(new SparkConf())
+      when(worker.activeMasterWebUiUrl).thenReturn("http://master:8080")
+      val logPage = new LogPage(webui)
 
-    val request = mock(classOf[HttpServletRequest])
-    // appId is user-controlled; a '&' in it would inject an extra parameter into the /log
-    // requests, and the '</script>' would break out of the inline <script> block, if emitted raw.
-    when(request.getParameter("appId")).thenReturn("app&byteLength=0</script>")
-    when(request.getParameter("executorId")).thenReturn("0")
-    when(request.getParameter("logType")).thenReturn("stdout")
-    val html = logPage.render(request).mkString
+      val request = mock(classOf[HttpServletRequest])
+      // appId is user-controlled; a '&' in it would inject an extra parameter into the /log
+      // requests, and the '</script>' would break out of the inline <script> block, if emitted raw.
+      when(request.getParameter("appId")).thenReturn("app&byteLength=0</script>")
+      when(request.getParameter("executorId")).thenReturn("0")
+      when(request.getParameter("logType")).thenReturn("stdout")
+      val html = logPage.render(request).mkString
 
-    // The value is percent-encoded, so it stays a single opaque appId value and cannot inject a
-    // parameter or close the script element.
-    assert(html.contains("appId=app%26byteLength%3D0%3C%2Fscript%3E&executorId=0"))
-    assert(!html.contains("app&byteLength=0</script>"))
+      // The value is percent-encoded, so it stays a single opaque appId value and cannot inject a
+      // parameter or close the script element.
+      assert(html.contains("appId=app%26byteLength%3D0%3C%2Fscript%3E&executorId=0"))
+      assert(!html.contains("app&byteLength=0</script>"))
+    }
   }
 
   /** Write the specified string to the file. */

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ui/LogPageSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy.worker.ui
 
 import java.io.{File, FileWriter}
+import javax.servlet.http.HttpServletRequest
 
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.PrivateMethodTester
@@ -73,6 +74,32 @@ class LogPageSuite extends SparkFunSuite with PrivateMethodTester {
     assert(error2.startsWith("Error: Log type must be one of "))
     assert(error3.startsWith("Error: invalid log directory"))
     assert(error4.startsWith("Error: invalid log directory"))
+  }
+
+  test("render encodes request parameters embedded in the inline script") {
+    val webui = mock(classOf[WorkerWebUI])
+    val worker = mock(classOf[Worker])
+    val tmpDir = new File(sys.props("java.io.tmpdir"))
+    val workDir = new File(tmpDir, "work-dir")
+    workDir.mkdir()
+    when(webui.workDir).thenReturn(workDir)
+    when(webui.worker).thenReturn(worker)
+    when(worker.conf).thenReturn(new SparkConf())
+    when(worker.activeMasterWebUiUrl).thenReturn("http://master:8080")
+    val logPage = new LogPage(webui)
+
+    val request = mock(classOf[HttpServletRequest])
+    // appId is user-controlled; a '&' in it would inject an extra parameter into the /log
+    // requests, and the '</script>' would break out of the inline <script> block, if emitted raw.
+    when(request.getParameter("appId")).thenReturn("app&byteLength=0</script>")
+    when(request.getParameter("executorId")).thenReturn("0")
+    when(request.getParameter("logType")).thenReturn("stdout")
+    val html = logPage.render(request).mkString
+
+    // The value is percent-encoded, so it stays a single opaque appId value and cannot inject a
+    // parameter or close the script element.
+    assert(html.contains("appId=app%26byteLength%3D0%3C%2Fscript%3E&executorId=0"))
+    assert(!html.contains("app&byteLength=0</script>"))
   }
 
   /** Write the specified string to the file. */


### PR DESCRIPTION
### What changes were proposed in this pull request?

The log viewer pages assemble a query string from request parameters and embed it into an inline script literal. Encode that value for a JavaScript string context using the bundled commons-text StringEscapeUtils, matching the existing pattern in AllJobsPage, so the generated script stays well-formed regardless of the parameter contents. 

Backport to 3.5 of https://github.com/apache/spark/pull/57165

### Why are the changes needed?

Formatting can get funky with unescaped parameters.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

New test

### Was this patch authored or co-authored using generative AI tooling?

Primarily Claude 4.8