### PR TITLE
[MINOR][PYTHON][DOCS] Add example to Column.outer docstring

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1578,6 +1578,24 @@ class Column(TableValuedFunctionArgument):
         --------
         pyspark.sql.DataFrame.scalar
         pyspark.sql.DataFrame.exists
+
+        Examples
+        --------
+        >>> from pyspark.sql import functions as sf
+        >>> employees = spark.createDataFrame(
+        ...     [(1, "Alice", 5000, 101), (2, "Bob", 6000, 101), (3, "Charlie", 4500, 102)],
+        ...     ["id", "name", "salary", "department_id"],
+        ... )
+        >>> employees.alias("e1").where(
+        ...     sf.col("salary") > employees.alias("e2").where(
+        ...         sf.col("e2.department_id") == sf.col("e1.department_id").outer()
+        ...     ).select(sf.avg("salary")).scalar()
+        ... ).select("name", "salary", "department_id").orderBy("name").show()
+        +----+------+-------------+
+        |name|salary|department_id|
+        +----+------+-------------+
+        | Bob|  6000|          101|
+        +----+------+-------------+
         """
         ...
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1583,7 +1583,10 @@ class Column(TableValuedFunctionArgument):
         --------
         >>> from pyspark.sql import functions as sf
         >>> employees = spark.createDataFrame(
-        ...     [(1, "Alice", 5000, 101), (2, "Bob", 6000, 101), (3, "Charlie", 4500, 102)],
+        ...     [
+        ...         (1, "Alice", 45000, 101), (2, "Bob", 54000, 101), (3, "Charlie", 29000, 102),
+        ...         (4, "David", 61000, 102), (5, "Eve", 48000, 101),
+        ...     ],
         ...     ["id", "name", "salary", "department_id"],
         ... )
         >>> employees.alias("e1").where(
@@ -1591,11 +1594,12 @@ class Column(TableValuedFunctionArgument):
         ...         sf.col("e2.department_id") == sf.col("e1.department_id").outer()
         ...     ).select(sf.avg("salary")).scalar()
         ... ).select("name", "salary", "department_id").orderBy("name").show()
-        +----+------+-------------+
-        |name|salary|department_id|
-        +----+------+-------------+
-        | Bob|  6000|          101|
-        +----+------+-------------+
+        +-----+------+-------------+
+        | name|salary|department_id|
+        +-----+------+-------------+
+        |  Bob| 54000|          101|
+        |David| 61000|          102|
+        +-----+------+-------------+
         """
         ...
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds an `Examples` section to `Column.outer()`'s docstring in `python/pyspark/sql/column.py`. Every other `Column` method in this file has a worked example; `outer()` was the one exception.

The example builds a small `employees` DataFrame and uses `.outer()` inside a correlated scalar subquery to filter employees earning above their department's average salary.

### Why are the changes needed?

`outer()` is easy to misunderstand from the description alone, since its effect (marking a column so it resolves against an outer query) only makes sense in the context of a correlated subquery. A concrete example makes that immediately clear, consistent with the rest of the file.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change (a docstring example).

### How was this patch tested?

Built Spark locally (`build/sbt -Phive package`) and ran the `Column.outer` doctest directly against the built jars to confirm the example's output matches exactly.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored. The code example and documentation text were authored by me, but I used Claude as a peer-review to validate the clarity of the example and check for edge cases before submission.