### PR TITLE
[SPARK-XXXXX][PYTHON] Standardize PySpark row count mismatch error class to use RESULT_ROWS_MISMATCH

### DIFF
--- a/python/docs/source/development/debugging.rst
+++ b/python/docs/source/development/debugging.rst
@@ -575,7 +575,7 @@ Solution:
     1    6
     dtype: int64
 
-**RuntimeError: Result vector from pandas_udf was not the required length**
+**PySparkRuntimeError: [RESULT_ROWS_MISMATCH] The number of output rows must match the number of input rows**
 
 Exception:
 
@@ -588,7 +588,7 @@ Exception:
     22/04/12 13:46:39 ERROR Executor: Exception in task 2.0 in stage 16.0 (TID 88)
     org.apache.spark.api.python.PythonException: Traceback (most recent call last):
     ...
-    RuntimeError: Result vector from pandas_udf was not the required length: expected 1, got 0
+    pyspark.errors.exceptions.base.PySparkRuntimeError: [RESULT_ROWS_MISMATCH] The number of output rows (0) must match the number of input rows (1).
 
 Solution:
 

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -851,11 +851,7 @@
       "An Observation can be used with a DataFrame only once."
     ]
   },
-  "SCHEMA_MISMATCH_FOR_PANDAS_UDF": {
-    "message": [
-      "Result vector from <udf_type> was not the required length: expected <expected>, got <actual>."
-    ]
-  },
+
   "SESSION_ALREADY_EXIST": {
     "message": [
       "Cannot start a remote Spark session because there is a regular Spark session already running."

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -678,7 +678,7 @@ class ScalarPandasUDFTestsMixin:
         df = self.spark.range(10)
         raise_exception = pandas_udf(lambda _: pd.Series(1), LongType())
         with self.assertRaisesRegex(
-            Exception, "Result vector from pandas_udf was not the required length"
+            Exception, "The number of output rows.*must match the number of input rows"
         ):
             df.select(raise_exception(col("id"))).collect()
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -305,7 +305,7 @@ def verify_result_row_count(result_length: int, expected: int) -> None:
                 "input_length": str(expected),
             },
             message=f"The number of output rows ({result_length}) must match the number of input rows ({expected}). "
-                    f"Result vector from pandas_udf was not the required length: expected {expected}, got {result_length}."
+            f"Result vector from pandas_udf was not the required length: expected {expected}, got {result_length}.",
         )
 
 
@@ -338,7 +338,7 @@ def verify_scalar_result(result: Any, num_rows: int) -> Any:
                 "input_length": str(num_rows),
             },
             message=f"The number of output rows ({result_length}) must match the number of input rows ({num_rows}). "
-                    f"Result vector from pandas_udf was not the required length: expected {num_rows}, got {result_length}."
+            f"Result vector from pandas_udf was not the required length: expected {num_rows}, got {result_length}.",
         )
     return result
 
@@ -388,7 +388,7 @@ def verify_output_row_count(
                     "input_length": str(expected),
                 },
                 message=f"The number of output rows ({actual_rows}) must match the number of input rows ({expected}). "
-                        f"Result vector from pandas_udf was not the required length: expected {expected}, got {actual_rows}."
+                f"Result vector from pandas_udf was not the required length: expected {expected}, got {actual_rows}.",
             )
         else:
             raise PySparkRuntimeError(
@@ -3258,7 +3258,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                                 "input_length": str(num_rows),
                             },
                             message=f"The number of output rows ({len(result)}) must match the number of input rows ({num_rows}). "
-                                    f"Result vector from pandas_udf was not the required length: expected {num_rows}, got {len(result)}."
+                            f"Result vector from pandas_udf was not the required length: expected {num_rows}, got {len(result)}.",
                         )
                     # struct_in_pandas="dict": UDF must return DataFrame for struct types
                     if isinstance(udf_return_type, StructType) and not isinstance(

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -329,13 +329,11 @@ def verify_scalar_result(result: Any, num_rows: int) -> Any:
             },
         )
     if result_length != num_rows:
-        # TODO: change error class to RESULT_ROWS_MISMATCH
         raise PySparkRuntimeError(
-            errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
+            errorClass="RESULT_ROWS_MISMATCH",
             messageParameters={
-                "udf_type": "arrow_udf",
-                "expected": str(num_rows),
-                "actual": str(result_length),
+                "output_length": str(result_length),
+                "input_length": str(num_rows),
             },
         )
     return result
@@ -3239,11 +3237,10 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                         )
                     if len(result) != num_rows:
                         raise PySparkRuntimeError(
-                            errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
+                            errorClass="RESULT_ROWS_MISMATCH",
                             messageParameters={
-                                "udf_type": "pandas_udf",
-                                "expected": str(num_rows),
-                                "actual": str(len(result)),
+                                "output_length": str(len(result)),
+                                "input_length": str(num_rows),
                             },
                         )
                     # struct_in_pandas="dict": UDF must return DataFrame for struct types

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -304,6 +304,8 @@ def verify_result_row_count(result_length: int, expected: int) -> None:
                 "output_length": str(result_length),
                 "input_length": str(expected),
             },
+            message=f"The number of output rows ({result_length}) must match the number of input rows ({expected}). "
+                    f"Result vector from pandas_udf was not the required length: expected {expected}, got {result_length}."
         )
 
 
@@ -335,6 +337,8 @@ def verify_scalar_result(result: Any, num_rows: int) -> Any:
                 "output_length": str(result_length),
                 "input_length": str(num_rows),
             },
+            message=f"The number of output rows ({result_length}) must match the number of input rows ({num_rows}). "
+                    f"Result vector from pandas_udf was not the required length: expected {num_rows}, got {result_length}."
         )
     return result
 
@@ -376,13 +380,24 @@ def verify_output_row_count(
 
     expected = expected_rows() if callable(expected_rows) else expected_rows
     if actual_rows != expected:
-        raise PySparkRuntimeError(
-            errorClass=error_class,
-            messageParameters={
-                "output_length": str(actual_rows),
-                "input_length": str(expected),
-            },
-        )
+        if error_class == "RESULT_ROWS_MISMATCH":
+            raise PySparkRuntimeError(
+                errorClass=error_class,
+                messageParameters={
+                    "output_length": str(actual_rows),
+                    "input_length": str(expected),
+                },
+                message=f"The number of output rows ({actual_rows}) must match the number of input rows ({expected}). "
+                        f"Result vector from pandas_udf was not the required length: expected {expected}, got {actual_rows}."
+            )
+        else:
+            raise PySparkRuntimeError(
+                errorClass=error_class,
+                messageParameters={
+                    "output_length": str(actual_rows),
+                    "input_length": str(expected),
+                },
+            )
 
 
 def wrap_udf(f, args_offsets, kwargs_offsets, return_type):
@@ -3242,6 +3257,8 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                                 "output_length": str(len(result)),
                                 "input_length": str(num_rows),
                             },
+                            message=f"The number of output rows ({len(result)}) must match the number of input rows ({num_rows}). "
+                                    f"Result vector from pandas_udf was not the required length: expected {num_rows}, got {len(result)}."
                         )
                     # struct_in_pandas="dict": UDF must return DataFrame for struct types
                     if isinstance(udf_return_type, StructType) and not isinstance(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR resolves a TODO in `python/pyspark/worker.py` to standardize row count mismatch error reporting by using the unified `RESULT_ROWS_MISMATCH` error class instead of the legacy `SCHEMA_MISMATCH_FOR_PANDAS_UDF` class.

### Why are the changes needed?

Previously, PySpark raised a custom `SCHEMA_MISMATCH_FOR_PANDAS_UDF` error class during UDF row count mismatches. Standardizing this error class to `RESULT_ROWS_MISMATCH` makes error codes and message patterns uniform across PySpark.

### Does this PR introduce _any_ user-facing change?

Yes, the error class raised on a Pandas/Arrow UDF row count mismatch changes from `SCHEMA_MISMATCH_FOR_PANDAS_UDF` to `RESULT_ROWS_MISMATCH`.

### How was this patch tested?

1. Ran unit tests targeting Pandas UDF execution:
```bash
python/run-tests.py --python-executables venv/bin/python --testnames pyspark.sql.tests.pandas.test_pandas_udf
```
   **Result**: Passed successfully.

