### PR TITLE
[MINOR][DOC] Fix to use Hive 4.1 on Hadoop 3.5 in PySpark installation guide

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -62,7 +62,7 @@ For PySpark with/without a specific Hadoop version, you can install it by using 
 
     PYSPARK_HADOOP_VERSION=3 pip install pyspark
 
-The default distribution uses Hadoop 3.5 and Hive 2.3. If users specify different versions of Hadoop, the pip installation automatically
+The default distribution uses Hadoop 3.5 and Hive 4.1. If users specify different versions of Hadoop, the pip installation automatically
 downloads a different version and uses it in PySpark. Downloading it can take a while depending on
 the network and the mirror chosen. ``PYSPARK_RELEASE_MIRROR`` can be set to manually choose the mirror for faster downloading.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the outdated Hive version references from `3.2` to `4.1` in the PySpark installation guide

### Why are the changes needed?

Referencing a commit bf5ccb4 [SPARK-58038]. Apache Hadoop 3.5 supports a minimum of Java 17, whereas Apache Hive supports Java 17 only in versions 4.1.x
- #57124

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.