### PR TITLE
[SPARK-58098][SQL] Convert _LEGACY_ERROR_TEMP_0033 to an internal error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7270,13 +7270,6 @@
     ],
     "sqlState" : "42K09"
   },
-  "STORED_AS_AND_STORED_BY_BOTH_SPECIFIED" : {
-    "message" : [
-      "Internal error: both STORED AS and STORED BY were specified.",
-      "This should have been blocked at the grammar level. Report this as a bug."
-    ],
-    "sqlState" : "XX000"
-  },
   "STREAMING_CHECKPOINT_MISSING_METADATA_FILE" : {
     "message" : [
       "Checkpoint location <checkpointLocation> is in an inconsistent state: the metadata file is missing but offset and/or commit logs contain data. Please restore the metadata file or create a new checkpoint directory."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7270,6 +7270,13 @@
     ],
     "sqlState" : "42K09"
   },
+  "STORED_AS_AND_STORED_BY_BOTH_SPECIFIED" : {
+    "message" : [
+      "Internal error: both STORED AS and STORED BY were specified.",
+      "This should have been blocked at the grammar level. Report this as a bug."
+    ],
+    "sqlState" : "XX000"
+  },
   "STREAMING_CHECKPOINT_MISSING_METADATA_FILE" : {
     "message" : [
       "Checkpoint location <checkpointLocation> is in an inconsistent state: the metadata file is missing but offset and/or commit logs contain data. Please restore the metadata file or create a new checkpoint directory."
@@ -9376,11 +9383,6 @@
   "_LEGACY_ERROR_TEMP_0032" : {
     "message" : [
       "Duplicated table paths found: '<pathOne>' and '<pathTwo>'. LOCATION and the case insensitive key 'path' in OPTIONS are all used to indicate the custom table path, you can only specify one of them."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0033" : {
-    "message" : [
-      "Expected either STORED AS or STORED BY, not both."
     ]
   },
   "_LEGACY_ERROR_TEMP_0034" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -550,8 +550,13 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
+  /**
+   * Throws an internal error when both STORED AS and STORED BY are specified. This should be
+   * unreachable in normal operation because the grammar rule `createFileFormat` accepts either
+   * STORED AS or STORED BY, but not both.
+   */
   def storedAsAndStoredByBothSpecifiedError(ctx: CreateFileFormatContext): Throwable = {
-    new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0033", ctx)
+    new ParseException(errorClass = "STORED_AS_AND_STORED_BY_BOTH_SPECIFIED", ctx)
   }
 
   def operationInHiveStyleCommandUnsupportedError(

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -550,13 +550,8 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
-  /**
-   * Throws an internal error when both STORED AS and STORED BY are specified. This should be
-   * unreachable in normal operation because the grammar rule `createFileFormat` accepts either
-   * STORED AS or STORED BY, but not both.
-   */
-  def storedAsAndStoredByBothSpecifiedError(ctx: CreateFileFormatContext): Throwable = {
-    new ParseException(errorClass = "STORED_AS_AND_STORED_BY_BOTH_SPECIFIED", ctx)
+  def storedAsAndStoredByBothSpecifiedError(): Throwable = {
+    SparkException.internalError("Expected either STORED AS or STORED BY, not both.")
   }
 
   def operationInHiveStyleCommandUnsupportedError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5608,7 +5608,7 @@ class AstBuilder extends DataTypeAstBuilder
       case (null, storageHandler) =>
         invalidStatement("STORED BY", ctx)
       case _ =>
-        throw QueryParsingErrors.storedAsAndStoredByBothSpecifiedError(ctx)
+        throw QueryParsingErrors.storedAsAndStoredByBothSpecifiedError()
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Convert the legacy error condition `_LEGACY_ERROR_TEMP_0033` to a `SparkException.internalError` and remove it from `error-conditions.json`.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one of them.

The condition is raised in `AstBuilder.visitCreateFileFormat`, in the branch where both `STORED AS` and `STORED BY` are present. That branch is not reachable from normal parsing:

- The grammar rule `createFileFormat` is `STORED AS fileFormat | STORED BY storageHandler`, so one clause carries only one of the two.
- Two clauses (`STORED AS ... STORED BY ...`) are rejected earlier by `checkDuplicateClauses` as `DUPLICATE_CLAUSES`.

As it only signals an internal inconsistency, it does not need a user-facing error condition and is converted to an internal error, following precedents such as SPARK-42839.

One trade-off: `SparkException.internalError` has no overload that carries the parser context, so the `ParseException` position information (offending fragment, line/column) is no longer attached. This is acceptable here because the branch is unreachable from user queries.

### Does this PR introduce _any_ user-facing change?

No. The code path is unreachable from user queries, so the change is not observable in practice.

### How was this patch tested?

`build/sbt "core/testOnly org.apache.spark.SparkThrowableSuite"` passes, covering the JSON validation gates (alphabetical ordering, mandatory SQLSTATE, round-trip). No test is added because the path is unreachable.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
