### PR TITLE
[SPARK-58106][DOCS][INFRA] Remove stale references to black

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -26,8 +26,6 @@ PYTEST_BUILD="pytest"
 
 PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE:-python3}"
 
-BLACK_BUILD="$PYTHON_EXECUTABLE -m black"
-
 function exit_with_usage {
   set +x
   echo "lint-python - linter for Python"
@@ -44,9 +42,6 @@ while (( "$#" )); do
   case $1 in
     --compile)
       COMPILE_TEST=true
-      ;;
-    --black)
-      BLACK_TEST=true
       ;;
     --custom-pyspark-error)
       PYSPARK_CUSTOM_ERRORS_CHECK_TEST=true
@@ -74,7 +69,7 @@ while (( "$#" )); do
   shift
 done
 
-if [[ -z "$COMPILE_TEST$BLACK_TEST$PYSPARK_CUSTOM_ERRORS_CHECK_TEST$FLAKE8_TEST$RUFF_TEST$MYPY_TEST$MYPY_EXAMPLES_TEST$MYPY_DATA_TEST" ]]; then
+if [[ -z "$COMPILE_TEST$PYSPARK_CUSTOM_ERRORS_CHECK_TEST$FLAKE8_TEST$RUFF_TEST$MYPY_TEST$MYPY_EXAMPLES_TEST$MYPY_DATA_TEST" ]]; then
   COMPILE_TEST=true
   PYSPARK_CUSTOM_ERRORS_CHECK_TEST=true
   RUFF_TEST=true
@@ -329,34 +324,6 @@ ruff checks failed."
 
 }
 
-function black_test {
-    local BLACK_REPORT=
-    local BLACK_STATUS=
-
-    # Skip check if black is not installed.
-    $PYTHON_EXECUTABLE -c 'import black' &> /dev/null
-    if [ $? -ne 0 ]; then
-        echo "The Python library providing 'black' module was not found. Skipping black checks for now."
-        echo
-        return
-    fi
-
-    echo "starting black test..."
-    BLACK_REPORT=$( ($BLACK_BUILD --check python/pyspark dev python/packaging python/benchmarks) 2>&1)
-    BLACK_STATUS=$?
-
-    if [ "$BLACK_STATUS" -ne 0 ]; then
-        echo "black checks failed:"
-        echo "$BLACK_REPORT"
-        echo "Please run 'dev/reformat-python' script."
-        echo "$BLACK_STATUS"
-        exit "$BLACK_STATUS"
-    else
-        echo "black checks passed."
-        echo
-    fi
-}
-
 function pyspark_custom_errors_check_test {
     local PYSPARK_CUSTOM_ERRORS_CHECK_REPORT=
     local PYSPARK_CUSTOM_ERRORS_CHECK_STATUS=
@@ -384,9 +351,6 @@ PYTHON_SOURCE="$(git ls-files '*.py')"
 
 if [[ "$COMPILE_TEST" == "true" ]]; then
     compile_python_test "$PYTHON_SOURCE"
-fi
-if [[ "$BLACK_TEST" == "true" ]]; then
-    black_test
 fi
 if [[ "$PYSPARK_CUSTOM_ERRORS_CHECK_TEST" == "true" ]]; then
     pyspark_custom_errors_check_test

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -55,9 +55,6 @@ markupsafe
 jira>=3.5.2
 PyGithub
 
-# pandas API on Spark Code formatter.
-black==26.3.1
-
 # Spark Connect (required)
 grpcio>=1.76.0
 grpcio-status>=1.76.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,15 +60,6 @@ ignore = [
     # Examples contain some unused variables.
     "examples/src/main/python/sql/datasource.py" = ["F841"]
 
-[tool.black]
-# When changing the version, we have to update
-# GitHub workflow version and dev/reformat-python
-required-version = "26.3.1"
-line-length = 100
-target-version = ['py39']
-include = '\.pyi?$'
-extend-exclude = 'cloudpickle|error_classes.py'
-
 [dependency-groups]
 _py4j = ["py4j>=0.10.9.9"]
 

--- a/sql/connect/README.md
+++ b/sql/connect/README.md
@@ -24,7 +24,7 @@ Python-specific development guidelines are located in [python/docs/source/develo
 To generate the Python client code from the proto files:
 
 First, make sure to have a Python environment with the installed dependencies.
-Specifically, install `black` and dependencies from the "Spark Connect python proto generation plugin (optional)" section.
+Specifically, install `ruff` and dependencies from the "Spark Connect python proto generation plugin (optional)" section.
 
 
 ```

--- a/sql/connect/common/src/main/protobuf/README.md
+++ b/sql/connect/common/src/main/protobuf/README.md
@@ -42,16 +42,16 @@ Install the required tools:
 - Python 3.12+
 
 Install the required Python packages. Check `pyproject.toml` for the latest
-pinned versions of `mypy`, `mypy-protobuf`, and `black`, then run:
+pinned versions of `mypy`, `mypy-protobuf`, and `ruff`, then run:
 
 ```bash
-pip install 'mypy==<version>' 'mypy-protobuf==<version>' 'black==<version>'
+pip install 'mypy==<version>' 'mypy-protobuf==<version>' 'ruff==<version>'
 ```
 
 For example, based on the current `pyproject.toml`:
 
 ```bash
-pip install 'mypy==1.19.1' 'mypy-protobuf==3.3.0' 'black==26.3.1'
+pip install 'mypy==1.19.1' 'mypy-protobuf==3.3.0' 'ruff==0.14.8'
 ```
 
 ### Generate


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Remove some stale references to `black`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We have been moved to `ruff` for a while. `branch-4.x` and `master` are using `ruff` exclusively for formatting, not `black`. We need to update our docs and some dependency files.

Notice that the `--black` command in `lint-python` is also removed. That was already deprecated for a while and was kind of hidden from users. Leaving it available does not gain us anything because it will conflict with `ruff`. Using `black` will mess up the format for `ruff` - it's better to just remove it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI - this should not have any impact on real code.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.