### PR TITLE
[SPARK-58112][SQL] Skip pushdown for nondeterministic Catalyst filters

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -58,7 +58,6 @@ object PushDownUtils extends Logging {
       filters: Seq[Expression],
       partitionFields: Option[Seq[PartitionPredicateField]])
       : (Either[Seq[sources.Filter], Seq[Predicate]], Seq[Expression]) = {
-    val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
     scanBuilder match {
       case r: SupportsPushDownFilters =>
         // A map from translated data source leaf node filters to original catalyst filter
@@ -70,7 +69,7 @@ object PushDownUtils extends Logging {
         // Catalyst filter expression that can't be translated to data source filters.
         val untranslatableExprs = mutable.ArrayBuffer.empty[Expression]
 
-        for (filterExpr <- deterministicFilters) {
+        for (filterExpr <- filters) {
           val translated =
             DataSourceStrategy.translateFilterWithMapping(filterExpr, Some(translatedFilterToExpr),
               nestedPredicatePushdownEnabled = true)
@@ -90,9 +89,8 @@ object PushDownUtils extends Logging {
         // Normally translated filters (postScanFilters) are simple filters that can be evaluated
         // faster, while the untranslated filters are complicated filters that take more time to
         // evaluate, so we want to evaluate the postScanFilters filters first.
-        val finalPostScanFilters =
-          (postScanFilters ++ untranslatableExprs ++ nonDeterministicFilters).toImmutableArraySeq
-        (Left(r.pushedFilters().toImmutableArraySeq), finalPostScanFilters)
+        (Left(r.pushedFilters().toImmutableArraySeq),
+          (postScanFilters ++ untranslatableExprs).toImmutableArraySeq)
 
       case r: SupportsPushDownV2Filters =>
         // Divide the filters into those translatable and untranslatable to data source filters.
@@ -103,7 +101,7 @@ object PushDownUtils extends Logging {
         val translatedFilters = mutable.ArrayBuffer.empty[Predicate]
         val untranslatableExprs = mutable.ArrayBuffer.empty[Expression]
 
-        for (filterExpr <- deterministicFilters) {
+        for (filterExpr <- filters) {
           val translated =
             DataSourceV2Strategy.translateFilterV2WithMapping(
               filterExpr, Some(translatedFilterToExpr))
@@ -132,11 +130,11 @@ object PushDownUtils extends Logging {
               rebuildExpressions(pushedPostScanFilters, translatedFilterToExpr)
           }
 
-        val orderedPostScanFilters = prioritizeFilters(
-          finalPostScanFilters ++ nonDeterministicFilters,
-          ExpressionSet(untranslatableExprs ++ nonDeterministicFilters))
+        val orderedPostScanFilters = prioritizeFilters(finalPostScanFilters,
+          ExpressionSet(untranslatableExprs))
         (Right(r.pushedPredicates.toImmutableArraySeq), orderedPostScanFilters)
       case r: SupportsPushDownCatalystFilters =>
+        val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
         val postScanFilters = r.pushFilters(deterministicFilters) ++ nonDeterministicFilters
         (Right(r.pushedFilters.toImmutableArraySeq), postScanFilters)
       case _ => (Left(Nil), filters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -134,7 +134,8 @@ object PushDownUtils extends Logging {
           ExpressionSet(untranslatableExprs))
         (Right(r.pushedPredicates.toImmutableArraySeq), orderedPostScanFilters)
       case r: SupportsPushDownCatalystFilters =>
-        val postScanFilters = r.pushFilters(filters)
+        val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
+        val postScanFilters = r.pushFilters(deterministicFilters) ++ nonDeterministicFilters
         (Right(r.pushedFilters.toImmutableArraySeq), postScanFilters)
       case _ => (Left(Nil), filters)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -58,6 +58,7 @@ object PushDownUtils extends Logging {
       filters: Seq[Expression],
       partitionFields: Option[Seq[PartitionPredicateField]])
       : (Either[Seq[sources.Filter], Seq[Predicate]], Seq[Expression]) = {
+    val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
     scanBuilder match {
       case r: SupportsPushDownFilters =>
         // A map from translated data source leaf node filters to original catalyst filter
@@ -69,7 +70,7 @@ object PushDownUtils extends Logging {
         // Catalyst filter expression that can't be translated to data source filters.
         val untranslatableExprs = mutable.ArrayBuffer.empty[Expression]
 
-        for (filterExpr <- filters) {
+        for (filterExpr <- deterministicFilters) {
           val translated =
             DataSourceStrategy.translateFilterWithMapping(filterExpr, Some(translatedFilterToExpr),
               nestedPredicatePushdownEnabled = true)
@@ -89,8 +90,9 @@ object PushDownUtils extends Logging {
         // Normally translated filters (postScanFilters) are simple filters that can be evaluated
         // faster, while the untranslated filters are complicated filters that take more time to
         // evaluate, so we want to evaluate the postScanFilters filters first.
-        (Left(r.pushedFilters().toImmutableArraySeq),
-          (postScanFilters ++ untranslatableExprs).toImmutableArraySeq)
+        val finalPostScanFilters =
+          (postScanFilters ++ untranslatableExprs ++ nonDeterministicFilters).toImmutableArraySeq
+        (Left(r.pushedFilters().toImmutableArraySeq), finalPostScanFilters)
 
       case r: SupportsPushDownV2Filters =>
         // Divide the filters into those translatable and untranslatable to data source filters.
@@ -101,7 +103,7 @@ object PushDownUtils extends Logging {
         val translatedFilters = mutable.ArrayBuffer.empty[Predicate]
         val untranslatableExprs = mutable.ArrayBuffer.empty[Expression]
 
-        for (filterExpr <- filters) {
+        for (filterExpr <- deterministicFilters) {
           val translated =
             DataSourceV2Strategy.translateFilterV2WithMapping(
               filterExpr, Some(translatedFilterToExpr))
@@ -130,11 +132,11 @@ object PushDownUtils extends Logging {
               rebuildExpressions(pushedPostScanFilters, translatedFilterToExpr)
           }
 
-        val orderedPostScanFilters = prioritizeFilters(finalPostScanFilters,
-          ExpressionSet(untranslatableExprs))
+        val orderedPostScanFilters = prioritizeFilters(
+          finalPostScanFilters ++ nonDeterministicFilters,
+          ExpressionSet(untranslatableExprs ++ nonDeterministicFilters))
         (Right(r.pushedPredicates.toImmutableArraySeq), orderedPostScanFilters)
       case r: SupportsPushDownCatalystFilters =>
-        val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
         val postScanFilters = r.pushFilters(deterministicFilters) ++ nonDeterministicFilters
         (Right(r.pushedFilters.toImmutableArraySeq), postScanFilters)
       case _ => (Left(Nil), filters)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -28,7 +28,9 @@ import test.org.apache.spark.sql.connector._
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThan => CatalystGreaterThan, Literal => CatalystLiteral, ScalarSubquery}
+import org.apache.spark.sql.catalyst.expressions.{
+  AttributeReference, Expression => CatalystExpression, GreaterThan => CatalystGreaterThan,
+  Literal => CatalystLiteral, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
 import org.apache.spark.sql.connector.catalog.{PartitionInternalRow, SupportsRead, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability._
@@ -46,6 +48,7 @@ import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.connector.SupportsPushDownCatalystFilters
 import org.apache.spark.sql.sources.{Filter, GreaterThan}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -1351,6 +1354,20 @@ class DataSourceV2Suite extends SharedSparkSession with AdaptiveSparkPlanHelper 
       "pushedFilters should contain the pushed filter on column i")
   }
 
+  test("catalyst filter pushdown skips non-deterministic filters") {
+    val df = spark.read.format(classOf[CatalystFilterDataSourceV2].getName).load()
+    val q = df.filter($"i" > 3 && rand() > 0.5)
+
+    val scanRelation = getScanRelation(q)
+    assert(scanRelation.pushedFilters.nonEmpty,
+      "pushedFilters should contain the deterministic pushed filter")
+    assert(scanRelation.pushedFilters.forall(_.deterministic),
+      "pushedFilters should not contain non-deterministic filters")
+    val referencedCols = scanRelation.pushedFilters.flatMap(_.references.map(_.name)).toSet
+    assert(referencedCols.contains("i"),
+      "pushedFilters should contain the pushed filter on column i")
+  }
+
   test("pushedFilters drops filters referencing pruned columns") {
     // Disable constraint propagation so IsNotNull(i) is not added (it would keep
     // column i in the scan output). This simulates a connector that pushes IsNotNull.
@@ -1500,6 +1517,33 @@ class AdvancedDataSourceV2 extends TestingV2Source {
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       new AdvancedScanBuilder()
     }
+  }
+}
+
+class CatalystFilterDataSourceV2 extends TestingV2Source {
+
+  override def getTable(options: CaseInsensitiveStringMap): Table = new SimpleBatchTable {
+    override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+      new CatalystFilterScanBuilder()
+    }
+  }
+}
+
+class CatalystFilterScanBuilder extends SimpleScanBuilder
+  with SupportsPushDownCatalystFilters {
+
+  override def pushFilters(filters: Seq[CatalystExpression]): Seq[CatalystExpression] = {
+    if (filters.exists(!_.deterministic)) {
+      throw new IllegalArgumentException(
+        s"Non-deterministic filters should not be pushed: ${filters.mkString(", ")}")
+    }
+    Nil
+  }
+
+  override def pushedFilters: Array[Predicate] = Array.empty
+
+  override def planInputPartitions(): Array[InputPartition] = {
+    throw new IllegalArgumentException("planInputPartitions must not be called")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{
   AttributeReference, Expression => CatalystExpression, GreaterThan => CatalystGreaterThan,
   Literal => CatalystLiteral, ScalarSubquery}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter => LogicalFilter, Project}
 import org.apache.spark.sql.connector.catalog.{PartitionInternalRow, SupportsRead, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, Literal, NamedReference, NullOrdering, SortDirection, SortOrder, Transform}
@@ -1366,6 +1366,14 @@ class DataSourceV2Suite extends SharedSparkSession with AdaptiveSparkPlanHelper 
     val referencedCols = scanRelation.pushedFilters.flatMap(_.references.map(_.name)).toSet
     assert(referencedCols.contains("i"),
       "pushedFilters should contain the pushed filter on column i")
+
+    // The non-deterministic filter is not pushed, so it must be retained as a post-scan
+    // Filter above the scan to still be evaluated.
+    val postScanConditions = q.queryExecution.optimizedPlan.collect {
+      case f: LogicalFilter => f.condition
+    }
+    assert(postScanConditions.exists(cond => cond.exists(!_.deterministic)),
+      "non-deterministic filter should be retained as a post-scan Filter")
   }
 
   test("pushedFilters drops filters referencing pruned columns") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates Catalyst filter pushdown for `SupportsPushDownCatalystFilters` so Spark only passes deterministic filters to the connector pushdown API. Nondeterministic filters are kept as post-scan filters and evaluated by Spark after the scan.

This also adds a regression test with a test data source implementing `SupportsPushDownCatalystFilters`; the source fails if a nondeterministic predicate reaches `pushFilters`.

### Why are the changes needed?

Pushing nondeterministic filters into a data source can change query semantics because the filter may be evaluated at a different point or a different number of times than Spark expects. The existing V2 file scan path already avoids pushing nondeterministic filters; this makes the Catalyst filter pushdown utility apply the same guard before invoking `SupportsPushDownCatalystFilters`.

### Does this PR introduce _any_ user-facing change?

Yes. Data sources using `SupportsPushDownCatalystFilters` will no longer receive nondeterministic filters for pushdown. Those filters remain in Spark as post-scan filters.

### How was this patch tested?

Added a regression test in `DataSourceV2Suite`: `catalyst filter pushdown skips non-deterministic filters`.

Local checks run:

```bash
git diff --check
grep -rn -P "[^\x00-\x7F]" sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 MAVEN_MIRROR_URL=https://maven-proxy.cloud.databricks.com build/sbt 'sql/testOnly *DataSourceV2Suite -- -z "catalyst filter pushdown skips non-deterministic filters"'\n```\n\nThe focused SBT test passed locally: 1 test run, 1 succeeded, 0 failed.\n\n### Was this patch authored or co-authored using generative AI tooling?\n\nGenerated-by: Codex (GPT-5)\n