### PR TITLE
[SPARK-58114][PYTHON] Consolidate VALUE_NOT_ANY_OR_ALL into VALUE_NOT_ALLOWED

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1198,11 +1198,6 @@
       "Value for `<arg_name>` has to be amongst the following values: <allowed_values>."
     ]
   },
-  "VALUE_NOT_ANY_OR_ALL": {
-    "message": [
-      "Value for `<arg_name>` must be 'any' or 'all', got '<arg_value>'."
-    ]
-  },
   "VALUE_NOT_BETWEEN": {
     "message": [
       "Value for `<arg_name>` must be between <min> and <max>."

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1355,8 +1355,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         if how is not None and how not in ["any", "all"]:
             raise PySparkValueError(
-                errorClass="VALUE_NOT_ANY_OR_ALL",
-                messageParameters={"arg_name": "how", "arg_value": how},
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={"arg_name": "how", "allowed_values": "['any', 'all']"},
             )
 
         if subset is None:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1394,8 +1394,8 @@ class DataFrame(ParentDataFrame):
                 min_non_nulls = None
             else:
                 raise PySparkValueError(
-                    errorClass="VALUE_NOT_ANY_OR_ALL",
-                    messageParameters={"arg_name": "how", "arg_value": str(how)},
+                    errorClass="VALUE_NOT_ALLOWED",
+                    messageParameters={"arg_name": "how", "allowed_values": "['any', 'all']"},
                 )
 
         if thresh is not None:

--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -134,8 +134,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="VALUE_NOT_ANY_OR_ALL",
-            messageParameters={"arg_name": "how", "arg_value": "foo"},
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={"arg_name": "how", "allowed_values": "['any', 'all']"},
         )
 
     def test_fillna(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Consolidate the specialized PySpark `VALUE_NOT_ANY_OR_ALL` error condition into the existing
`VALUE_NOT_ALLOWED` condition. The classic and Spark Connect implementations of
`DataFrame.dropna` now report the allowed values through the generic condition, and the shared
test expectation is updated accordingly.

### Why are the changes needed?

`VALUE_NOT_ANY_OR_ALL` is used only for `DataFrame.dropna(how=...)` and duplicates the existing
generic condition for arguments restricted to a fixed set of values. Removing it reduces the
number of narrowly scoped error conditions and aligns this validation with other PySpark APIs.

### Does this PR introduce _any_ user-facing change?

Yes. Invalid values for `DataFrame.dropna(how=...)` now use the `VALUE_NOT_ALLOWED` error
condition and its generic message. Valid calls and exception types are unchanged.

### How was this patch tested?

The focused PySpark test was not run. The JSON error-condition file was parsed successfully,
`git diff --check` passed, and the existing shared error assertion was updated for both classic
and Spark Connect execution modes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
