### PR TITLE
[SPARK-57583][SQL] Support lazy dictionary decoding for TIME in the vectorized Parquet reader

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
@@ -17,15 +17,39 @@
 
 package org.apache.spark.sql.execution.datasources.parquet;
 
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.execution.vectorized.Dictionary;
 
 public final class ParquetDictionary implements Dictionary {
   private org.apache.parquet.column.Dictionary dictionary;
   private boolean needTransform = false;
 
+  // TIME-specific lazy dictionary decode fields: micros->nanos + truncation.
+  private boolean isTimeTransform = false;
+  private boolean fileStoresNanos = false;
+  private int timePrecision = 0;
+
   public ParquetDictionary(org.apache.parquet.column.Dictionary dictionary, boolean needTransform) {
     this.dictionary = dictionary;
     this.needTransform = needTransform;
+  }
+
+  /**
+   * Constructs a ParquetDictionary with TIME transform support. When {@code isTimeTransform} is
+   * true, {@link #decodeToLong(int)} converts the raw dictionary value from the on-disk unit
+   * (micros or nanos) to internal nanos and truncates to the requested precision - the same
+   * transform the eager path ({@code TimeVectorUpdater.toTruncatedNanos}) applies per value.
+   */
+  public ParquetDictionary(
+      org.apache.parquet.column.Dictionary dictionary,
+      boolean needTransform,
+      boolean isTimeTransform,
+      boolean fileStoresNanos,
+      int timePrecision) {
+    this(dictionary, needTransform);
+    this.isTimeTransform = isTimeTransform;
+    this.fileStoresNanos = fileStoresNanos;
+    this.timePrecision = timePrecision;
   }
 
   @Override
@@ -39,7 +63,11 @@ public final class ParquetDictionary implements Dictionary {
 
   @Override
   public long decodeToLong(int id) {
-    if (needTransform) {
+    if (isTimeTransform) {
+      long raw = dictionary.decodeToLong(id);
+      long nanos = fileStoresNanos ? raw : DateTimeUtils.microsToNanos(raw);
+      return DateTimeUtils.truncateTimeToPrecision(nanos, timePrecision);
+    } else if (needTransform) {
       // For unsigned int32, it stores as dictionary encoded signed int32 in Parquet
       // whenever dictionary is available.
       // Here we lazily decode it to the original signed int value then convert to long(unit32).

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -46,6 +46,7 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.GeographyType;
+import org.apache.spark.sql.types.TimeType;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
@@ -284,7 +285,21 @@ public class VectorizedColumnReader {
           boolean isUnsignedInt64 = updaterFactory.isUnsignedIntTypeMatched(64);
 
           boolean needTransform = castLongToInt || isUnsignedInt32 || isUnsignedInt64;
-          column.setDictionary(new ParquetDictionary(dictionary, needTransform));
+
+          // Detect TIME type: lazy decoding must apply micros->nanos + precision truncation.
+          DataType dt = column.dataType();
+          boolean isTimeTransform = dt instanceof TimeType;
+          boolean fileStoresNanos = false;
+          int timePrecision = 0;
+          if (isTimeTransform) {
+            timePrecision = ((TimeType) dt).precision();
+            fileStoresNanos =
+              typeAnnotation instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation t
+                && t.getUnit() == TimeUnit.NANOS;
+          }
+
+          column.setDictionary(new ParquetDictionary(
+              dictionary, needTransform, isTimeTransform, fileStoresNanos, timePrecision));
         } else {
           updater.decodeDictionaryIds(readState.valueOffset - startOffset, startOffset, column,
             dictionaryIds, dictionary);

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/types/ops/TimeTypeParquetOps.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/types/ops/TimeTypeParquetOps.scala
@@ -127,11 +127,9 @@ case class TimeTypeParquetOps(t: TimeType) extends ParquetTypeOps {
   }
 
   // TIME decoding converts micros->nanos (for TIME(MICROS)) and truncates to the requested
-  // precision per value in the updater; lazy dictionary decoding would attach the raw dictionary
-  // and skip that processing, so it must be disabled. This matches the fail-safe trait default,
-  // but is stated explicitly because TimeType opts into vectorized reads (isBatchReadSupported =
-  // true) and the per-value work is exactly why lazy decoding is unsafe here.
-  override def supportsLazyDictionaryDecoding(descriptor: ColumnDescriptor): Boolean = false
+  // precision per value. This transform is now handled inside ParquetDictionary.decodeToLong when
+  // the TIME-aware constructor is used, so lazy dictionary decoding is safe.
+  override def supportsLazyDictionaryDecoding(descriptor: ColumnDescriptor): Boolean = true
 }
 
 private[ops] object TimeTypeParquetOps {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -2009,6 +2009,185 @@ class ParquetIOSuite extends ParquetTest with SharedSparkSession {
     }
   }
 
+  test("SPARK-57583: lazy dictionary decode for TIME(NANOS) with precision truncation") {
+    // Dictionary-encoded TIME(NANOS) file read at a lower precision via the lazy dictionary
+    // decode path. The vectorized reader's lazy path (ParquetDictionary.decodeToLong) must apply
+    // the same nanos->truncated-nanos transform as the eager updater path.
+    val schema = MessageTypeParser.parseMessageType(
+      """message root {
+        |  required int64 t(TIME(NANOS,false));
+        |}""".stripMargin)
+
+    // Test at multiple precisions including full precision (no truncation).
+    val testCases = Seq(
+      (7, LocalTime.of(12, 30, 45, 123456700)),  // truncate to 100ns
+      (6, LocalTime.of(12, 30, 45, 123456000)),  // truncate to micros
+      (3, LocalTime.of(12, 30, 45, 123000000)),  // truncate to millis
+      (0, LocalTime.of(12, 30, 45, 0)),          // truncate to seconds
+      (9, LocalTime.of(12, 30, 45, 123456789))   // full precision (no truncation)
+    )
+
+    for ((precision, expected) <- testCases) {
+      val readSchema = new StructType().add("t", TimeType(precision))
+      withTempDir { dir =>
+        val tablePath = new Path(s"${dir.getCanonicalPath}/time_nanos_dict.parquet")
+        val numRecords = 100
+        val writer = createParquetWriter(schema, tablePath, dictionaryEnabled = true)
+        (0 until numRecords).foreach { _ =>
+          val record = new SimpleGroup(schema)
+          record.add(0, localTime(12, 30, 45, 123456, 789))
+          writer.write(record)
+        }
+        writer.close
+
+        // Vectorized reader with dictionary encoding -> lazy dictionary decode path.
+        withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+          val df = spark.read.schema(readSchema).parquet(tablePath.toString)
+          checkAnswer(df, (0 until numRecords).map(_ => Row(expected)))
+        }
+      }
+    }
+  }
+
+  test("SPARK-57583: lazy dictionary decode for TIME(MICROS) with precision truncation") {
+    // Dictionary-encoded TIME(MICROS) file read at various precisions. The lazy path must
+    // convert micros->nanos and then truncate, matching the eager updater path.
+    val schema = MessageTypeParser.parseMessageType(
+      """message root {
+        |  required int64 t(TIME(MICROS,false));
+        |}""".stripMargin)
+
+    val testCases = Seq(
+      (6, LocalTime.of(12, 30, 45, 123456000)),  // full micro precision (no truncation)
+      (3, LocalTime.of(12, 30, 45, 123000000)),  // truncate to millis
+      (0, LocalTime.of(12, 30, 45, 0))           // truncate to seconds
+    )
+
+    for ((precision, expected) <- testCases) {
+      val readSchema = new StructType().add("t", TimeType(precision))
+      withTempDir { dir =>
+        val tablePath = new Path(s"${dir.getCanonicalPath}/time_micros_dict.parquet")
+        val numRecords = 100
+        val writer = createParquetWriter(schema, tablePath, dictionaryEnabled = true)
+        (0 until numRecords).foreach { _ =>
+          val record = new SimpleGroup(schema)
+          record.add(0, localTime(12, 30, 45, 123456) / DateTimeConstants.NANOS_PER_MICROS)
+          writer.write(record)
+        }
+        writer.close
+
+        withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+          val df = spark.read.schema(readSchema).parquet(tablePath.toString)
+          checkAnswer(df, (0 until numRecords).map(_ => Row(expected)))
+        }
+      }
+    }
+  }
+
+  test("SPARK-57583: lazy vs eager dictionary decode parity for TIME") {
+    // Verifies that the lazy dictionary decode path (vectorized + dict) produces identical
+    // results to the eager path (vectorized + plain encoding which always uses the updater).
+    // This ensures the ParquetDictionary TIME transform matches TimeVectorUpdater exactly.
+    val nanosSchema = MessageTypeParser.parseMessageType(
+      """message root {
+        |  required int64 t(TIME(NANOS,false));
+        |}""".stripMargin)
+    val microsSchema = MessageTypeParser.parseMessageType(
+      """message root {
+        |  required int64 t(TIME(MICROS,false));
+        |}""".stripMargin)
+
+    val cases = Seq(
+      (nanosSchema, localTime(23, 59, 59, 999999, 999), 7),
+      (nanosSchema, localTime(0, 0, 0, 0, 1), 9),
+      (microsSchema, localTime(23, 59, 59, 999999) / DateTimeConstants.NANOS_PER_MICROS, 3)
+    )
+
+    for ((schema, rawValue, precision) <- cases) {
+      val readSchema = new StructType().add("t", TimeType(precision))
+      withTempDir { dir =>
+        val dictPath = new Path(s"${dir.getCanonicalPath}/dict.parquet")
+        val plainPath = new Path(s"${dir.getCanonicalPath}/plain.parquet")
+        val numRecords = 50
+
+        // Write dict-encoded file (lazy decode path).
+        val dictWriter = createParquetWriter(schema, dictPath, dictionaryEnabled = true)
+        (0 until numRecords).foreach { _ =>
+          val record = new SimpleGroup(schema)
+          record.add(0, rawValue)
+          dictWriter.write(record)
+        }
+        dictWriter.close
+
+        // Write plain-encoded file (eager updater path).
+        val plainWriter = createParquetWriter(schema, plainPath, dictionaryEnabled = false)
+        (0 until numRecords).foreach { _ =>
+          val record = new SimpleGroup(schema)
+          record.add(0, rawValue)
+          plainWriter.write(record)
+        }
+        plainWriter.close
+
+        withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+          val dictDf = spark.read.schema(readSchema).parquet(dictPath.toString)
+          val plainDf = spark.read.schema(readSchema).parquet(plainPath.toString)
+          checkAnswer(dictDf, plainDf.collect())
+        }
+      }
+    }
+  }
+
+  test("SPARK-57583: lazy dictionary decode for nullable TIME with multiple distinct values") {
+    // Nullable dict-encoded TIME column with multiple distinct values exercises the lazy path
+    // on each distinct dictionary entry independently.
+    val schema = MessageTypeParser.parseMessageType(
+      """message root {
+        |  optional int64 t(TIME(NANOS,false));
+        |}""".stripMargin)
+    val readSchema = new StructType().add("t", TimeType(6))
+
+    withTempDir { dir =>
+      val tablePath = new Path(s"${dir.getCanonicalPath}/nullable_dict.parquet")
+      val writer = createParquetWriter(schema, tablePath, dictionaryEnabled = true)
+      // Write distinct values + nulls.
+      val values: Seq[Option[Long]] = Seq(
+        Some(localTime(1, 2, 3, 100000, 500)),   // 1:02:03.100000500 -> truncate to .100000
+        Some(localTime(23, 59, 59, 999999, 999)), // 23:59:59.999999999 -> .999999
+        None,
+        Some(localTime(0, 0, 0, 0, 1)),           // 0:00:00.000000001 -> .000000
+        None
+      )
+      // Repeat the pattern multiple times to ensure dictionary stays active.
+      (0 until 20).foreach { _ =>
+        values.foreach {
+          case Some(nanos) =>
+            val record = new SimpleGroup(schema)
+            record.add(0, nanos)
+            writer.write(record)
+          case None =>
+            val record = new SimpleGroup(schema)
+            writer.write(record) // null: no value added for optional field
+        }
+      }
+      writer.close
+
+      val expected = (0 until 20).flatMap { _ =>
+        Seq(
+          Row(LocalTime.of(1, 2, 3, 100000000)),
+          Row(LocalTime.of(23, 59, 59, 999999000)),
+          Row(null),
+          Row(LocalTime.of(0, 0, 0, 0)),
+          Row(null)
+        )
+      }
+
+      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+        val df = spark.read.schema(readSchema).parquet(tablePath.toString)
+        checkAnswer(df, expected)
+      }
+    }
+  }
+
   test("SPARK-55444: vectorized read rejects an incompatible encoding requested as TimeType") {
     // TimeTypeParquetOps.getVectorUpdater returns None for any encoding other than INT64
     // TIME(MICROS/NANOS), so the vectorized factory falls through to a clean

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/types/ops/TimeTypeParquetOpsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/types/ops/TimeTypeParquetOpsSuite.scala
@@ -175,17 +175,17 @@ class TimeTypeParquetOpsSuite extends SparkFunSuite {
     assert(ParquetTypeOps.getVectorUpdaterOrNull(IntegerType, null) == null)
   }
 
-  test("supportsLazyDictionaryDecoding is false for TimeType (updater does per-value work)") {
-    // TIME decoding does per-value micros->nanos + truncation in the updater, so lazy dictionary
-    // decoding (which would bypass the updater) must stay disabled on the vectorized path.
-    assert(!TimeTypeParquetOps(timeMicros)
+  test("supportsLazyDictionaryDecoding is true for TimeType (transform in ParquetDictionary)") {
+    // TIME decoding (micros->nanos + truncation) is applied inside ParquetDictionary.decodeToLong
+    // when the TIME-aware constructor is used, so lazy dictionary decoding is safe.
+    assert(TimeTypeParquetOps(timeMicros)
       .supportsLazyDictionaryDecoding(timeColumn(TimeUnit.MICROS)))
-    assert(!TimeTypeParquetOps(timeNanos)
+    assert(TimeTypeParquetOps(timeNanos)
       .supportsLazyDictionaryDecoding(timeColumn(TimeUnit.NANOS)))
-    // Java-friendly companion entry point used by VectorizedColumnReader: FALSE for TimeType,
+    // Java-friendly companion entry point used by VectorizedColumnReader: TRUE for TimeType,
     // null for a non-framework type (so the reader keeps its built-in lazy-decoding decision).
     assert(ParquetTypeOps.supportsLazyDictionaryDecodingOrNull(
-      timeMicros, timeColumn(TimeUnit.MICROS)) === java.lang.Boolean.FALSE)
+      timeMicros, timeColumn(TimeUnit.MICROS)) === java.lang.Boolean.TRUE)
     assert(ParquetTypeOps.supportsLazyDictionaryDecodingOrNull(IntegerType, null) == null)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is the "option B" follow-up to [SPARK-57551](https://issues.apache.org/jira/browse/SPARK-57551), under the TIME data type epic (SPARK-57550). It re-enables **lazy dictionary decoding for TIME columns** in the vectorized Parquet reader by making the lazy path precision/unit-aware, rather than disabling it.

- `ParquetDictionary.decodeToLong` now applies the TIME transform on the lazy path: `micros -> nanos` (when the column is stored as micros) followed by `DateTimeUtils.truncateTimeToPrecision`, producing values byte-for-byte identical to the eager `TimeVectorUpdater`.
- `ParquetDictionary` carries the on-disk unit and the requested precision (set at construction in `VectorizedColumnReader` when the column is a `TimeType`).
- `TimeTypeParquetOps.supportsLazyDictionaryDecoding` now returns `true`, so TIME columns use the lazy optimization again through the types framework's dispatch.

The change is scoped to TIME: non-TIME dictionary reinterpretations and the other INT64 transforms (`TIMESTAMP_MILLIS` upcast, timestamp rebase) remain eager, as before.

### Why are the changes needed?

SPARK-57551 added read-time precision truncation for TIME columns and, to guarantee truncation applies, disabled lazy dictionary decoding for `TIME(NANOS)` (option A) so dictionary-encoded TIME columns eager-decoded through the truncating updater. This PR restores the lazy dictionary-decoding optimization (option B) without losing that correctness, by teaching the lazy path the same unit conversion and precision truncation.

### Does this PR introduce _any_ user-facing change?

No result change. It is a performance improvement: dictionary-encoded TIME columns can again be read via the lazy dictionary path.

### How was this patch tested?

New `ParquetIOSuite` tests exercising the lazy path (dictionary-encoded + vectorized reader + lazy decoding enabled): `TIME(NANOS)` and `TIME(MICROS)` columns read at a lower precision produce truncated values identical to the eager path; a lazy-vs-eager parity test; a nullable multi-value case; and a full-precision (no-truncation) case. `TimeTypeParquetOpsSuite` updated for the re-enabled lazy support. checkstyle + scalastyle clean.

### Was this patch authored or co-authored using generative AI tooling?

Authored with assistance by Claude Opus 4.8.
