### PR TITLE
[MINOR][SQL] Fix incorrect type wording in Row getter scaladoc

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -304,7 +304,7 @@ trait Row extends Serializable {
   def getDecimal(i: Int): java.math.BigDecimal = getAs[java.math.BigDecimal](i)
 
   /**
-   * Returns the value at position i of date type as org.apache.spark.sql.types.Geometry.
+   * Returns the value at position i of geometry type as org.apache.spark.sql.types.Geometry.
    *
    * @throws ClassCastException
    *   when data type does not match.
@@ -313,7 +313,7 @@ trait Row extends Serializable {
     getAs[org.apache.spark.sql.types.Geometry](i)
 
   /**
-   * Returns the value at position i of date type as org.apache.spark.sql.types.Geography.
+   * Returns the value at position i of geography type as org.apache.spark.sql.types.Geography.
    *
    * @throws ClassCastException
    *   when data type does not match.
@@ -338,7 +338,7 @@ trait Row extends Serializable {
   def getLocalDate(i: Int): java.time.LocalDate = getAs[java.time.LocalDate](i)
 
   /**
-   * Returns the value at position i of date type as java.sql.Timestamp.
+   * Returns the value at position i of timestamp type as java.sql.Timestamp.
    *
    * @throws ClassCastException
    *   when data type does not match.
@@ -346,7 +346,7 @@ trait Row extends Serializable {
   def getTimestamp(i: Int): java.sql.Timestamp = getAs[java.sql.Timestamp](i)
 
   /**
-   * Returns the value at position i of date type as java.time.Instant.
+   * Returns the value at position i of timestamp type as java.time.Instant.
    *
    * @throws ClassCastException
    *   when data type does not match.
@@ -389,7 +389,7 @@ trait Row extends Serializable {
   def getMap[K, V](i: Int): scala.collection.Map[K, V] = getAs[Map[K, V]](i)
 
   /**
-   * Returns the value at position i of array type as a `java.util.Map`.
+   * Returns the value at position i of map type as a `java.util.Map`.
    *
    * @throws ClassCastException
    *   when data type does not match.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes copy-pasted type wording in the scaladoc of several `Row` getters in the sql-api module. The phrase "value at position i of `<type>` type" had been copy-pasted from the date getters onto getters that return other types:

- `getGeometry`: "of date type" -> "of geometry type"
- `getGeography`: "of date type" -> "of geography type"
- `getTimestamp` / `getInstant`: "of date type" -> "of timestamp type"
- `getJavaMap`: "of array type" -> "of map type"

### Why are the changes needed?

The type wording on these getters was incorrect (copy-pasted from sibling getters), which is misleading in the generated API docs.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only; no behavior change.

### How was this patch tested?

No tests needed (documentation only).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code(Opus 4.8)
