### PR TITLE
[SPARK-58121][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_0012

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2187,6 +2187,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "DISTRIBUTE_BY_UNSUPPORTED" : {
+    "message" : [
+      "DISTRIBUTE BY is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "DIVIDE_BY_ZERO" : {
     "message" : [
       "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error."
@@ -9321,11 +9327,6 @@
   "_LEGACY_ERROR_TEMP_0004" : {
     "message" : [
       "Empty source for merge: you should specify a source table/subquery in merge."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0012" : {
-    "message" : [
-      "DISTRIBUTE BY is not supported."
     ]
   },
   "_LEGACY_ERROR_TEMP_0014" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2187,12 +2187,6 @@
     ],
     "sqlState" : "0A000"
   },
-  "DISTRIBUTE_BY_UNSUPPORTED" : {
-    "message" : [
-      "DISTRIBUTE BY is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
   "DIVIDE_BY_ZERO" : {
     "message" : [
       "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error."
@@ -8310,6 +8304,11 @@
       "DESC_TABLE_COLUMN_PARTITION" : {
         "message" : [
           "DESC TABLE COLUMN for a specific partition."
+        ]
+      },
+      "DISTRIBUTE_BY" : {
+        "message" : [
+          "DISTRIBUTE BY clause."
         ]
       },
       "DROP_DATABASE" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -161,7 +161,7 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
   }
 
   def distributeByUnsupportedError(ctx: QueryOrganizationContext): Throwable = {
-    new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0012", ctx)
+    new ParseException(errorClass = "DISTRIBUTE_BY_UNSUPPORTED", ctx)
   }
 
   def transformNotSupportQuantifierError(ctx: ParserRuleContext): Throwable = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -161,7 +161,7 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
   }
 
   def distributeByUnsupportedError(ctx: QueryOrganizationContext): Throwable = {
-    new ParseException(errorClass = "DISTRIBUTE_BY_UNSUPPORTED", ctx)
+    new ParseException(errorClass = "UNSUPPORTED_FEATURE.DISTRIBUTE_BY", ctx)
   }
 
   def transformNotSupportQuantifierError(ctx: ParserRuleContext): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -437,6 +437,18 @@ class PlanParserSuite extends AnalysisTest {
         stop = 41))
   }
 
+  test("DISTRIBUTE BY is not supported in the Catalyst parser") {
+    val sql = "select * from t distribute by a"
+    checkError(
+      exception = parseException(sql),
+      condition = "DISTRIBUTE_BY_UNSUPPORTED",
+      parameters = Map.empty,
+      context = ExpectedContext(
+        fragment = "distribute by a",
+        start = 16,
+        stop = 30))
+  }
+
   test("insert into") {
     import org.apache.spark.sql.catalyst.dsl.expressions._
     import org.apache.spark.sql.catalyst.dsl.plans._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -441,7 +441,7 @@ class PlanParserSuite extends AnalysisTest {
     val sql = "select * from t distribute by a"
     checkError(
       exception = parseException(sql),
-      condition = "DISTRIBUTE_BY_UNSUPPORTED",
+      condition = "UNSUPPORTED_FEATURE.DISTRIBUTE_BY",
       parameters = Map.empty,
       context = ExpectedContext(
         fragment = "distribute by a",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Convert the legacy error condition `_LEGACY_ERROR_TEMP_0012` ("DISTRIBUTE BY is not supported.") into the `UNSUPPORTED_FEATURE.DISTRIBUTE_BY` subclass (SQLSTATE `0A000`, inherited from the `UNSUPPORTED_FEATURE` umbrella).

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one of them.

The error is raised by the base `AstBuilder`, which does not support `DISTRIBUTE BY`; `SparkSqlAstBuilder` overrides `withRepartitionByExpression` to support it, so only parsers built on the base `AstBuilder` (via `CatalystSqlParser`) reject the clause. This is the same `withQueryResultClauses` code path whose combination case already reports `UNSUPPORTED_FEATURE.COMBINATION_QUERY_RESULT_CLAUSES`, so a `DISTRIBUTE_BY` subclass under the same umbrella keeps the parser feature-not-supported errors consistent instead of introducing a new top-level name.

### Does this PR introduce _any_ user-facing change?

No. Only the error condition name is assigned; the `_LEGACY_ERROR_TEMP_*` names are not part of the public API. The rendered message becomes "The feature is not supported: DISTRIBUTE BY clause."

### How was this patch tested?

Added a `checkError` test in `PlanParserSuite` (which uses `CatalystSqlParser`) that parses `select * from t distribute by a` and asserts the `UNSUPPORTED_FEATURE.DISTRIBUTE_BY` condition. `build/sbt "catalyst/testOnly *PlanParserSuite" "core/testOnly org.apache.spark.SparkThrowableSuite"` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
