### PR TITLE
[SPARK-58114][PYTHON] Consolidate VALUE_NOT_ANY_OR_ALL into VALUE_NOT_ALLOWED

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1198,11 +1198,6 @@
       "Value for `<arg_name>` has to be amongst the following values: <allowed_values>."
     ]
   },
-  "VALUE_NOT_ANY_OR_ALL": {
-    "message": [
-      "Value for `<arg_name>` must be 'any' or 'all', got '<arg_value>'."
-    ]
-  },
   "VALUE_NOT_BETWEEN": {
     "message": [
       "Value for `<arg_name>` must be between <min> and <max>."

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1355,8 +1355,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         if how is not None and how not in ["any", "all"]:
             raise PySparkValueError(
-                errorClass="VALUE_NOT_ANY_OR_ALL",
-                messageParameters={"arg_name": "how", "arg_value": how},
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
+                    "arg_name": "how",
+                    "allowed_values": str(["any", "all"]),
+                },
             )
 
         if subset is None:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1394,8 +1394,11 @@ class DataFrame(ParentDataFrame):
                 min_non_nulls = None
             else:
                 raise PySparkValueError(
-                    errorClass="VALUE_NOT_ANY_OR_ALL",
-                    messageParameters={"arg_name": "how", "arg_value": str(how)},
+                    errorClass="VALUE_NOT_ALLOWED",
+                    messageParameters={
+                        "arg_name": "how",
+                        "allowed_values": str(["any", "all"]),
+                    },
                 )
 
         if thresh is not None:

--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -134,8 +134,11 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="VALUE_NOT_ANY_OR_ALL",
-            messageParameters={"arg_name": "how", "arg_value": "foo"},
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
+                "arg_name": "how",
+                "allowed_values": str(["any", "all"]),
+            },
         )
 
     def test_fillna(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the specialized `VALUE_NOT_ANY_OR_ALL` PySpark error condition and replace its single use site (`DataFrame.dropna`'s `how` validation, in both classic and Spark Connect) with the more general `VALUE_NOT_ALLOWED` condition, which already exists and expresses the same thing via an `allowed_values` parameter.

Before:
```
VALUE_NOT_ANY_OR_ALL: "Value for `<arg_name>` must be 'any' or 'all', got '<arg_value>'."
```
After (reusing the existing general condition):
```
VALUE_NOT_ALLOWED: "Value for `<arg_name>` has to be amongst the following values: <allowed_values>."
```

### Why are the changes needed?

`VALUE_NOT_ANY_OR_ALL` is a narrow, single-purpose error condition that duplicates what `VALUE_NOT_ALLOWED` already provides generically. Consolidating reduces the number of error conditions to maintain and keeps `dropna`'s error consistent with other "value must be one of a fixed set" validations across PySpark (e.g. `between`, profiler options).

### Does this PR introduce _any_ user-facing change?

Yes, a minor change to the error message for `df.dropna(how=<invalid>)`. Previously: "Value for `how` must be 'any' or 'all', got 'foo'." Now: "Value for `how` has to be amongst the following values: ['any', 'all']." The raised exception type (`PySparkValueError`) is unchanged.

### How was this patch tested?

Updated the existing regression test in `test_stat.py` to assert the `VALUE_NOT_ALLOWED` condition and its parameters. Test passes:
`python/run-tests --testnames "pyspark.sql.tests.test_stat DataFrameStatTests.test_dropna"`

### Was this patch authored or co-authored using generative AI tooling?

Generative AI tooling (Claude Code) was used as an assistive tool for implementation guidance.