### PR TITLE
[SPARK-57891][CORE][DOCS][FOLLOWUP] Fix contradictory thread-safety docs in `CredentialProviderLoader`

### DIFF
--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -51,9 +51,10 @@ import org.apache.spark.annotation.Private;
  * multiple candidates produce an ambiguity error; no candidates produce {@code Optional.empty()}.
  * <p>
  * <b>Thread-safety:</b> This class uses synchronized access to the cached provider list and
- * initialization tracking. Callers may invoke {@link #providerFor(String, Map)} from multiple
- * threads. However, the returned {@link CredentialProvider} instances are not guaranteed to be
- * thread-safe; callers should synchronize on the provider or confine it to a single thread.
+ * initialization tracking, and callers may invoke {@link #providerFor(String, Map)} from
+ * multiple threads. A provider instance is cached and shared across callers; per the
+ * {@link CredentialProvider} contract, implementations must be thread-safe, so a returned
+ * instance may be used concurrently.
  *
  * @since 4.3.0
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to [SPARK-57891](https://issues.apache.org/jira/browse/SPARK-57891) (#57191). A review comment on the merged PR pointed out a contradiction in the thread-safety documentation:

- `CredentialProvider` says: *"Implementations must be thread-safe: `resolve()` may be called concurrently from multiple threads after `init()` completes."*
- `CredentialProviderLoader` said: *"the returned `CredentialProvider` instances are not guaranteed to be thread-safe; callers should synchronize on the provider or confine it to a single thread."*

These conflict. The intended contract is thread-safe-required: `CredentialProviderLoader` caches and shares a single provider instance across callers, and `resolve()` may be invoked concurrently (e.g., credential refresh), so implementations must be thread-safe. This corrects the `CredentialProviderLoader` Javadoc to state that a returned (shared) instance may be used concurrently per the `CredentialProvider` contract, while keeping the note that the loader itself synchronizes its cached-provider access.

### Why are the changes needed?

To remove the contradictory guidance so the SPI's thread-safety contract is unambiguous for provider implementers.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change; no behavior change.

### How was this patch tested?

Documentation-only. `core` compiles and `dev/lint-java` (checkstyle) passes.
Also double-checked other javadocs to make sure they're consistent with the changes in #57191

### Was this patch authored or co-authored using generative AI tooling?

No.
