### PR TITLE
[SPARK-58134][BUILD] Upgrade janino to 3.1.12

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -44,7 +44,7 @@ chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.11.0//commons-cli-1.11.0.jar
 commons-codec/1.22.0//commons-codec-1.22.0.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar
-commons-compiler/3.1.9//commons-compiler-3.1.9.jar
+commons-compiler/3.1.12//commons-compiler-3.1.12.jar
 commons-compress/1.28.0//commons-compress-1.28.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
@@ -119,7 +119,7 @@ jakarta.servlet-api/6.0.0//jakarta.servlet-api-6.0.0.jar
 jakarta.validation-api/3.0.2//jakarta.validation-api-3.0.2.jar
 jakarta.ws.rs-api/3.1.0//jakarta.ws.rs-api-3.1.0.jar
 jakarta.xml.bind-api/4.0.5//jakarta.xml.bind-api-4.0.5.jar
-janino/3.1.9//janino-3.1.9.jar
+janino/3.1.12//janino-3.1.12.jar
 java-diff-utils/4.16//java-diff-utils-4.16.jar
 java-trace-api/0.2.11-beta//java-trace-api-0.2.11-beta.jar
 javassist/3.30.2-GA//javassist-3.30.2-GA.jar

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <guava.version>33.6.0-jre</guava.version>
     <guava.failureaccess.version>1.0.3</guava.failureaccess.version>
     <gson.version>2.14.0</gson.version>
-    <janino.version>3.1.9</janino.version>
+    <janino.version>3.1.12</janino.version>
     <jersey.version>3.1.11</jersey.version>
     <joda.version>2.14.3</joda.version>
     <jsr305.version>3.0.0</jsr305.version>


### PR DESCRIPTION

### What changes were proposed in this pull request?
This pr upgrade janino from 3.1.9 to 3.1.12.


### Why are the changes needed?
Janino 3.1.9 and earlier are affected by [CVE-2023-33546](https://nvd.nist.gov/vuln/detail/cve-2023-33546), a disputed DoS issue where deeply nested user-supplied input can trigger a `StackOverflowError` in Janino parser APIs such as `ExpressionEvaluator.guessParameterNames`. Although Spark SQL codegen uses Janino through `ClassBodyEvaluator` rather than that specific API, upgrading removes the vulnerable dependency version reported by dependency scanners and picks up Janino's parser/codegen robustness fixes.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.


### Was this patch authored or co-authored using generative AI tooling?
No.