### PR TITLE
[MINOR][PYTHON][ML][DOC] Fix parameter name in BisectingKMeansModel.computeCost docstring

### DIFF
--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -135,7 +135,7 @@ class BisectingKMeansModel(JavaModelWrapper):
 
         Parameters
         ----------
-        point : :py:class:`pyspark.mllib.linalg.Vector` or :py:class:`pyspark.RDD`
+        x : :py:class:`pyspark.mllib.linalg.Vector` or :py:class:`pyspark.RDD`
             A data point (or RDD of points) to compute the cost(s).
             :py:class:`pyspark.mllib.linalg.Vector` can be replaced with equivalent
             objects (list, tuple, numpy.ndarray).


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `Parameters` section of `BisectingKMeansModel.computeCost` (in `python/pyspark/mllib/clustering.py`) documented the argument as `point`, but the method signature names it `x`:

```python
def computeCost(self, x: Union["VectorLike", RDD["VectorLike"]]) -> float:
    ...
    Parameters
    ----------
    point : :py:class:`pyspark.mllib.linalg.Vector` or :py:class:`pyspark.RDD`
```

This renames the docstring entry from `point` to `x` so the documented parameter matches the actual signature.

### Why are the changes needed?

The documented parameter name did not exist in the signature. NumPyDoc-style `Parameters` entries are expected to name the actual arguments; the mismatch is misleading in the rendered API docs. For contrast, the sibling `GaussianMixtureModel.computeCost` in the same file already documents its `rdd` argument correctly.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only wording fix in a docstring.

### How was this patch tested?

No behavior change. Verified the file with `python -m py_compile` and `ruff check` (both pass). The rendered docstring now names the same parameter as the signature.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
