### PR TITLE
[SPARK-58135][PYTHON] Consolidate VALUE_NOT_TRUE into VALUE_NOT_ALLOWED

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1223,11 +1223,6 @@
       "Value for `<arg_name>` must be positive, got '<arg_value>'."
     ]
   },
-  "VALUE_NOT_TRUE": {
-    "message": [
-      "Value for `<arg_name>` must be True, got '<arg_value>'."
-    ]
-  },
   "VALUE_OUT_OF_BOUNDS": {
     "message": [
       "Value for `<arg_name>` must be between <lower_bound> and <upper_bound> (inclusive), got <actual>"

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -600,8 +600,8 @@ class DataStreamWriter:
         elif once is not None:
             if once is not True:
                 raise PySparkValueError(
-                    errorClass="VALUE_NOT_TRUE",
-                    messageParameters={"arg_name": "once", "arg_value": str(once)},
+                    errorClass="VALUE_NOT_ALLOWED",
+                    messageParameters={"arg_name": "once", "allowed_values": "[True]"},
                 )
             self._write_proto.once = True
 
@@ -624,8 +624,8 @@ class DataStreamWriter:
         else:
             if availableNow is not True:
                 raise PySparkValueError(
-                    errorClass="VALUE_NOT_TRUE",
-                    messageParameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
+                    errorClass="VALUE_NOT_ALLOWED",
+                    messageParameters={"arg_name": "availableNow", "allowed_values": "[True]"},
                 )
             self._write_proto.available_now = True
 

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -1448,8 +1448,8 @@ class DataStreamWriter:
         elif once is not None:
             if once is not True:
                 raise PySparkValueError(
-                    errorClass="VALUE_NOT_TRUE",
-                    messageParameters={"arg_name": "once", "arg_value": str(once)},
+                    errorClass="VALUE_NOT_ALLOWED",
+                    messageParameters={"arg_name": "once", "allowed_values": "[True]"},
                 )
 
             jTrigger = getattr(
@@ -1479,8 +1479,8 @@ class DataStreamWriter:
         else:
             if availableNow is not True:
                 raise PySparkValueError(
-                    errorClass="VALUE_NOT_TRUE",
-                    messageParameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
+                    errorClass="VALUE_NOT_ALLOWED",
+                    messageParameters={"arg_name": "availableNow", "allowed_values": "[True]"},
                 )
             jTrigger = getattr(
                 self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger"

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -147,6 +147,15 @@ class StreamingTestsMixin:
         except TypeError:
             pass
 
+        for arg_name in ("once", "availableNow"):
+            with self.assertRaises(PySparkValueError) as pe:
+                df.writeStream.trigger(**{arg_name: False})
+            self.check_error(
+                exception=pe.exception,
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={"arg_name": arg_name, "allowed_values": "[True]"},
+            )
+
     def test_stream_real_time_trigger(self):
         df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
         tmpPath = tempfile.mkdtemp()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Consolidate the specialized PySpark `VALUE_NOT_TRUE` error condition into `VALUE_NOT_ALLOWED`. Classic and Spark Connect streaming `DataStreamWriter.trigger` now report the generic condition when `once` or `availableNow` is not `True`. The shared streaming tests assert the new condition in both modes.

### Why are the changes needed?

`VALUE_NOT_TRUE` only represents a single allowed argument value and duplicates the generic allowed-values condition. Removing it reduces narrowly scoped error conditions and aligns the validation with other PySpark APIs.

### Does this PR introduce _any_ user-facing change?

Yes. Invalid `trigger(once=...)` and `trigger(availableNow=...)` calls now use `VALUE_NOT_ALLOWED` and its generic message. The exception type remains `PySparkValueError`.

### How was this patch tested?

Added shared classic and Spark Connect test assertions. The focused PySpark test suite was not run. The JSON error-condition file was parsed successfully and no `VALUE_NOT_TRUE` references remain.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)