### PR TITLE
[MINOR][DOCS] Allow JIRA-free draft and minor PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,9 +200,9 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 ## Pull Request Workflow
 
-PR title format is `[SPARK-xxxx][COMPONENT] Title`. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
+PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-Infer the PR title from the changes. If no ticket ID is given, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
+Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 
     python3 dev/create_spark_jira.py "<title>" -c <component> { -t <type> | -p <parent-jira-id> }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updates `AGENTS.md` so draft, WIP, MINOR, and TRIVIAL PRs may omit a JIRA ID, and only other PRs require ticket creation when no ID is provided.

### Why are the changes needed?

I often create draft PRs for testing. Requiring me to manually tell the AI to skip JIRA creation for each one is repetitive, so the workflow guidance now records this exception directly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation-only change. Ran `git diff --check` on the staged patch.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)