### PR TITLE
[SPARK-58137][CORE] Optimize hasAttemptOnHost from O(m) linear scan to O(1) HashSet lookup

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -131,6 +131,7 @@ private[spark] class TaskSetManager(
   private val killedByOtherAttempt = new HashSet[Long]
 
   val taskAttempts = Array.fill[List[TaskInfo]](numTasks)(Nil)
+  val taskAttemptHosts = Array.ofDim[HashSet[String]](numTasks)
   private[scheduler] var tasksSuccessful = 0
 
   val weight = 1
@@ -354,7 +355,8 @@ private[spark] class TaskSetManager(
 
   /** Check whether a task once ran an attempt on a given host */
   private def hasAttemptOnHost(taskIndex: Int, host: String): Boolean = {
-    taskAttempts(taskIndex).exists(_.host == host)
+    val hosts = taskAttemptHosts(taskIndex)
+    hosts != null && hosts.contains(host)
   }
 
   private def isTaskExcludededOnExecOrNode(index: Int, execId: String, host: String): Boolean = {
@@ -545,6 +547,10 @@ private[spark] class TaskSetManager(
     taskInfos(taskId) = info
     executorIdToTaskIds.getOrElseUpdate(execId, new OpenHashSet[Long]).add(taskId)
     taskAttempts(index) = info :: taskAttempts(index)
+    if (taskAttemptHosts(index) == null) {
+      taskAttemptHosts(index) = new HashSet[String]
+    }
+    taskAttemptHosts(index) += host
     // Serialize and return the task
     val serializedTask: ByteBuffer = try {
       ser.serialize(task)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2996,6 +2996,41 @@ class TaskSetManagerSuite
       s"Expected staleMapIndexes to contain mapIndex 0, got $staleMapIndexes")
   }
 
+  test("SPARK-58137: hasAttemptOnHost uses taskAttemptHosts for O(1) host lookup") {
+    sc = new SparkContext("local", "test")
+    sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
+    sc.conf.set(config.SPECULATION_ENABLED, true)
+    sc.conf.set(config.SPECULATION_QUANTILE, 0.5)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"),
+      ("exec3", "host3"))
+    val taskSet = FakeTask.createTaskSet(1, Seq(TaskLocation("host1", "exec1")))
+    val clock = new ManualClock()
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+
+    // Launch the single task on host1 (exec1)
+    val task1 = manager.resourceOffer("exec1", "host1", TaskLocality.PROCESS_LOCAL)._1.get
+    assert(task1.index === 0)
+    assert(manager.runningTasks === 1)
+
+    // Mark the task as speculatable and add to pending speculative list
+    manager.speculatableTasks += 0
+    manager.addPendingTask(0, speculatable = true)
+
+    // Speculative task should NOT be scheduled on host1 which already has an attempt
+    assert(manager.resourceOffer("exec1", "host1", TaskLocality.ANY)._1.isEmpty)
+
+    // Speculative task SHOULD be scheduled on host2 which has no attempt for task 0
+    val task2 = manager.resourceOffer("exec2", "host2", TaskLocality.ANY)._1
+    assert(task2.isDefined)
+    assert(task2.get.index === 0)
+    assert(task2.get.attemptNumber === 1)
+
+    // Now task 0 has attempts on both host1 and host2.
+    // Offering host1 or host2 should not schedule another speculative copy.
+    assert(manager.resourceOffer("exec1", "host1", TaskLocality.ANY)._1.isEmpty)
+    assert(manager.resourceOffer("exec2", "host2", TaskLocality.ANY)._1.isEmpty)
+  }
+
   private def createMapStatusTaskResult(
       mapStatus: MapStatus,
       accumUpdates: Seq[AccumulatorV2[_, _]],


### PR DESCRIPTION
### What changes were proposed in this pull request?

When speculation is enabled, `dequeueTaskFromList` iterates through the entire pending speculative task list and calls `hasAttemptOnHost` for each entry — all while holding the `TaskSchedulerImpl` monitor. As noted in `TaskSchedulerImpl.scala:122`:

> TaskSetManagers are not thread safe, so any access to one should be synchronized on this class. Protected by `this`

The current implementation does an O(m) linear scan:

```scala
taskAttempts(taskIndex).exists(_.host == host)
```

This PR adds a lazily-allocated `HashSet[String]` per task index (`taskAttemptHosts`) to track which hosts have attempted each task, enabling O(1) lookup instead of O(m) linear scan.

### Why are the changes needed?

`hasAttemptOnHost` runs inside `TaskSchedulerImpl.resourceOffers`, which is `synchronized` on the `TaskSchedulerImpl` instance (`TaskSchedulerImpl.scala:514`). The call chain is:

```
resourceOffers (synchronized on this)
  -> resourceOfferSingleTaskSet
    -> TaskSetManager.resourceOffer
      -> dequeueTask -> dequeueTaskHelper -> dequeueTaskFromList -> hasAttemptOnHost
```

That same monitor guards every other `TaskSchedulerImpl` operation — `statusUpdate`, `executorLost`, `handleSuccessfulTask`/`handleFailedTask`, `checkSpeculatableTasks`, etc. With 100K+ speculatable tasks and many attempts per task (due to failures or prior speculation), the O(n*m) scan in `resourceOffers` holds the monitor for an extended period, blocking those operations behind it.

Note that `makeOffers` itself is single-threaded on the driver — `DriverEndpoint` is an `IsolatedThreadSafeRpcEndpoint` with `threadCount() = 1` (`RpcEndpoint.scala:175`), processed by the `dispatcher-CoarseGrainedScheduler` thread — so the contention is not between parallel make-offer threads, but between `resourceOffers` and the other scheduler operations that share the `TaskSchedulerImpl` monitor.

## Benchmark results

(100K tasks, 1000 offers, while holding lock) of [HasAttemptOnHostBenchmark.scala](https://github.com/user-attachments/files/30037162/HasAttemptOnHostBenchmark.scala.txt)

| Attempts/Task | Linear Scan (ms/offer) | HashSet (ms/offer) | Speedup |
|---|---|---|---|
| 1 | 352 | 466 | 0.8X |
| 10 | 2,655 | 2,246 | 1.2X |
| 50 | 17,114 | 3,455 | 5.0X |
| 100 | 30,640 | 3,758 | 8.2X |

At 100 attempts/task, monitor hold time drops from ~30.6s to ~3.8s.

### Does this PR introduce a user-facing change?

No.

### How was this patch tested?

Added one unit test in `TaskSetManagerSuite`:
- `hasAttemptOnHost uses taskAttemptHosts for O(1) host lookup` — verifies speculation is blocked on hosts with prior attempts

### Was this patch authored or co-authored using generative AI tooling?

Authored with assistance by GLM 5.2.
