### PR TITLE
[SPARK-58148][BUILD] Upgrade `tink` to 1.23.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -269,7 +269,7 @@ spire_2.13/0.18.0//spire_2.13-0.18.0.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.8.0//threeten-extra-1.8.0.jar
-tink/1.22.0//tink-1.22.0.jar
+tink/1.23.0//tink-1.23.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 vertx-auth-common/4.5.28//vertx-auth-common-4.5.28.jar

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.11.0</commons-cli.version>
     <bouncycastle.version>1.84</bouncycastle.version>
-    <tink.version>1.22.0</tink.version>
+    <tink.version>1.23.0</tink.version>
     <!--
       TODO: Once upgrade datasketches to a version that supports Java 25,
             SPARK-53327 workaround should be reverted.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `Tink` dependency to 1.23.0 for Apache Spark 5.0.0.

### Why are the changes needed?

To pick up the latest bug fixes and improvements:

- https://github.com/tink-crypto/tink-java/releases/tag/v1.23.0 (2026-07-08)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5