### PR TITLE
[SPARK-58150][BUILD] Upgrade Jetty to 12.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <parquet.version>1.17.1</parquet.version>
     <orc.version>2.3.0</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>12.1.10</jetty.version>
+    <jetty.version>12.1.11</jetty.version>
     <jakartaservlet.version>6.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades Jetty to `12.1.11`.

### Why are the changes needed?

To bring in the latest upstream bug fixes and improvements from the Jetty 12.1.x patch release line.

- https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.11 (2026-07-08)
  - https://github.com/jetty/jetty.project/issues/15228
  - https://github.com/jetty/jetty.project/issues/15226
  - https://github.com/jetty/jetty.project/issues/15156

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5