### PR TITLE
[SPARK-58152][K8S] Avoid logging credentials in Kubernetes client config debug log

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -19,7 +19,6 @@ package org.apache.spark.deploy.k8s
 import java.io.File
 import java.nio.file.Files
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.fabric8.kubernetes.client.{ConfigBuilder, KubernetesClient, KubernetesClientBuilder}
 import io.fabric8.kubernetes.client.Config.KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY
 import io.fabric8.kubernetes.client.Config.autoConfigure
@@ -107,8 +106,12 @@ object SparkKubernetesClientFactory extends Logging {
       }.withOption(namespace) {
         (ns, configBuilder) => configBuilder.withNamespace(ns)
       }.build()
-    logDebug("Kubernetes client config: " +
-      new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(config))
+    // Log only non-sensitive fields. Serializing the whole Config would leak credentials
+    // such as the OAuth token, client key, and certificate data.
+    logDebug(s"Kubernetes client config: masterUrl=${config.getMasterUrl}, " +
+      s"namespace=${config.getNamespace}, apiVersion=${config.getApiVersion}, " +
+      s"requestTimeout=${config.getRequestTimeout}, " +
+      s"connectionTimeout=${config.getConnectionTimeout}, trustCerts=${config.isTrustCerts}")
     new KubernetesClientBuilder().withConfig(config).build()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Log only non-sensitive fields (`masterUrl`, `namespace`, `apiVersion`, `requestTimeout`,
`connectionTimeout`, `trustCerts`) in the DEBUG log line of
`SparkKubernetesClientFactory.createKubernetesClient`, instead of serializing the entire fabric8
`Config` object with a plain `ObjectMapper`.

### Why are the changes needed?

`Config` holds the API server credentials, and a plain `ObjectMapper` applies no masking, so the
previous line logged `oauthToken`, `clientKeyData`, `caCertData`, `clientCertData`, the basic-auth
password, and the truststore password in cleartext. (`oauthToken` is annotated `@JsonIgnore`, but
`@JsonIgnoreProperties(allowGetters = true)` on the class re-enables it via its getter.)
`createKubernetesClient` runs on both the submission client and the driver, and driver logs are
commonly collected and archived.

### Does this PR introduce _any_ user-facing change?

No. DEBUG log content only.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5