### PR TITLE
[MINOR][CONNECT][PYTHON][TEST] Fix mock session leakage in test_clinet.py

### DIFF
--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -425,20 +425,24 @@ class SparkConnectClientTestCase(unittest.TestCase):
         session = (
             RemoteSparkSession.builder.remote("sc://foo")._registerHook(TestHook).getOrCreate()
         )
-        self.assertEqual(inits, 1)
-        self.assertEqual(calls, 0)
-        session.client._stub = MockService(session.client._session_id)
-        session.client.disable_reattachable_execute()
+        try:
+            self.assertEqual(inits, 1)
+            self.assertEqual(calls, 0)
+            session.client._stub = MockService(session.client._session_id)
+            session.client.disable_reattachable_execute()
 
-        # Called from _execute_and_fetch_as_iterator
-        session.range(1).collect()
-        self.assertEqual(inits, 1)
-        self.assertEqual(calls, 1)
+            # Called from _execute_and_fetch_as_iterator
+            session.range(1).collect()
+            self.assertEqual(inits, 1)
+            self.assertEqual(calls, 1)
 
-        # Called from _execute
-        session.udf.register("test_func", lambda x: x + 1)
-        self.assertEqual(inits, 1)
-        self.assertEqual(calls, 2)
+            # Called from _execute
+            session.udf.register("test_func", lambda x: x + 1)
+            self.assertEqual(inits, 1)
+            self.assertEqual(calls, 2)
+        finally:
+            # Close the session to avoid leaking dummy session inter-test
+            session.stop()
 
     def test_session_hook_preserved_after_new_session(self):
         calls = 0
@@ -473,6 +477,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
             # against the unreachable endpoint at interpreter shutdown.
             new_session.client.close()
             session.client.close()
+            session.stop()
 
     def test_new_session_preserves_custom_channel_builder(self):
         class CustomChannelBuilder(DefaultChannelBuilder):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Close mock sessions at the end of test_session_hook and its variant

### Why are the changes needed?

`test_client.py` creates mock `SparkSession` instances that are not stopped, leaving `SparkSession._default_session` set globally. On shared test workers (e.g., under `pytest-xdist`), subsequent tests calling `SparkSession.builder.getOrCreate()` reuse this leftover mock session, causing downstream test failures such as `KeyError: 'spark.sql.session.timeZone'`.

### Does this PR introduce any user-facing change?

No. Test-only change.

### How was this patch tested?

Verified by running `test_client.py` followed by parity tests on a single worker process:
```bash
python -m pytest -v -n 1 --dist loadscope python/pyspark/sql/tests/connect/client/test_client.py python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_basic.py
```
against a sparkconnect server


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by:  Gemini