### PR TITLE
[SPARK-57724][SQL][FOLLOWUP] Use consistent operation name "CREATE METRIC VIEW" in MISSING_CLAUSES_FOR_OPERATION

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -897,12 +897,12 @@ class SparkSqlAstBuilder extends AstBuilder {
 
     if (ctx.METRICS(0) == null) {
       throw QueryParsingErrors.missingClausesForOperation(
-        ctx, "WITH METRICS", "METRIC VIEW CREATION")
+        ctx, "WITH METRICS", "CREATE METRIC VIEW")
     }
 
     if (ctx.routineLanguage(0) == null) {
       throw QueryParsingErrors.missingClausesForOperation(
-        ctx, "LANGUAGE", "METRIC VIEW CREATION")
+        ctx, "LANGUAGE", "CREATE METRIC VIEW")
     }
 
     val languageCtx = ctx.routineLanguage(0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -804,7 +804,7 @@ class QueryParsingErrorsSuite extends SharedSparkSession {
       sqlState = "42601",
       parameters = Map(
         "clauses" -> "WITH METRICS",
-        "operation" -> "METRIC VIEW CREATION"),
+        "operation" -> "CREATE METRIC VIEW"),
       context = ExpectedContext(
         fragment = query,
         start = 0,
@@ -826,7 +826,7 @@ class QueryParsingErrorsSuite extends SharedSparkSession {
       sqlState = "42601",
       parameters = Map(
         "clauses" -> "LANGUAGE",
-        "operation" -> "METRIC VIEW CREATION"),
+        "operation" -> "CREATE METRIC VIEW"),
       context = ExpectedContext(
         fragment = query,
         start = 0,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup to https://github.com/apache/spark/pull/56827.

That PR registered the `MISSING_CLAUSES_FOR_OPERATION` error class, which is thrown by the metric view parser (`SparkSqlAstBuilder.visitCreateMetricView`) with the `operation` value `"METRIC VIEW CREATION"`. This PR changes the two metric-view call sites (missing `WITH METRICS` and missing `LANGUAGE`) to use `"CREATE METRIC VIEW"` instead, and updates the two corresponding test assertions in `QueryParsingErrorsSuite`.

### Why are the changes needed?

The `operation` argument of `MISSING_CLAUSES_FOR_OPERATION` (and the sibling `UNSUPPORTED_CLAUSES_FOR_OPERATION`) is, everywhere else, the imperative DDL statement form that matches the SQL the user actually wrote, e.g. `CREATE PROCEDURE`, `CREATE TABLE`. The metric-view value `"METRIC VIEW CREATION"` is a nominalized phrasing that is inconsistent with the rest of the error class. Standardizing on `"CREATE METRIC VIEW"` makes the operation name consistent and matches the statement the user typed (`CREATE VIEW ... WITH METRICS`).

### Does this PR introduce _any_ user-facing change?

Yes. The `operation` value in the `MISSING_CLAUSES_FOR_OPERATION` error message for a metric view with a missing clause changes from `METRIC VIEW CREATION` to `CREATE METRIC VIEW`. This error class is unreleased (added in the same development line as the referenced PR).

### How was this patch tested?

Updated the two existing unit tests in `QueryParsingErrorsSuite` that assert the `operation` parameter; they parse a `CREATE VIEW ... WITH METRICS` statement missing a required clause and verify the emitted operation name.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
