### PR TITLE
[SPARK-58155][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1066

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6511,6 +6511,12 @@
     ],
     "sqlState" : "42K05"
   },
+  "RESERVED_DATABASE_NAME" : {
+    "message" : [
+      "Cannot create the database <database> because the name is reserved for system use."
+    ],
+    "sqlState" : "42939"
+  },
   "ROUTINE_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create the <newRoutineType> <routineName> because a <existingRoutineType> of that name already exists.",
@@ -9588,11 +9594,6 @@
   "_LEGACY_ERROR_TEMP_1060" : {
     "message" : [
       "<command> does not support nested column: <column>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1066" : {
-    "message" : [
-      "<database> is a system preserved database, you cannot create a database with this name."
     ]
   },
   "_LEGACY_ERROR_TEMP_1068" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1345,8 +1345,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def cannotCreateDatabaseWithSameNameAsPreservedDatabaseError(database: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1066",
-      messageParameters = Map("database" -> database))
+      errorClass = "RESERVED_DATABASE_NAME",
+      messageParameters = Map("database" -> toSQLId(database)))
   }
 
   def cannotDropDefaultDatabaseError(nameParts: Seq[String]): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand
 import org.apache.spark.sql.execution.datasources.parquet.SparkToParquetSchemaConverter
 import org.apache.spark.sql.expressions.SparkUserDefinedFunction
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
@@ -1098,6 +1098,17 @@ class QueryCompilationErrorsSuite
         parameters = Map("format" -> "JSON")
       )
     }
+  }
+
+  test("RESERVED_DATABASE_NAME: cannot create a database with a system-preserved name") {
+    val globalTempDB = spark.conf.get(StaticSQLConf.GLOBAL_TEMP_DATABASE)
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(s"CREATE DATABASE $globalTempDB")
+      },
+      condition = "RESERVED_DATABASE_NAME",
+      parameters = Map("database" -> s"`$globalTempDB`")
+    )
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -93,8 +93,10 @@ class GlobalTempViewSuite extends SharedSparkSession {
   }
 
   test("global temp view database should be preserved") {
-    val e = intercept[AnalysisException](sql(s"CREATE DATABASE $globalTempDB"))
-    assert(e.message.contains("system preserved database"))
+    checkError(
+      exception = intercept[AnalysisException](sql(s"CREATE DATABASE $globalTempDB")),
+      condition = "RESERVED_DATABASE_NAME",
+      parameters = Map("database" -> s"`$globalTempDB`"))
 
     val e2 = intercept[AnalysisException](sql(s"USE $globalTempDB"))
     assert(e2.message.contains("system preserved database"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Assign the name `RESERVED_DATABASE_NAME` to the legacy error condition `_LEGACY_ERROR_TEMP_1066`. This error is raised when a user attempts to create a database with the system-reserved name (`global_temp`). The new condition is given SQLSTATE `42939` ("the name cannot be used, because the specified identifier is reserved for system use").

### Why are the changes needed?

The error conditions [README](https://github.com/apache/spark/blob/master/common/utils/src/main/resources/error/README.md) disallow new `_LEGACY_ERROR_TEMP_*` entries and ask existing ones to be assigned proper names. This resolves one of them, under the umbrella [SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Does this PR introduce _any_ user-facing change?

No. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API. The rendered message becomes "Cannot create the database `global_temp` because the name is reserved for system use." (previously "global_temp is a system-preserved database, you cannot create a database with this name.").

### How was this patch tested?

Added a `checkError` test in `QueryCompilationErrorsSuite` that runs `CREATE DATABASE global_temp` and asserts the `RESERVED_DATABASE_NAME` condition. `build/sbt "core/testOnly *SparkThrowableSuite"` and the new test in `QueryCompilationErrorsSuite` pass.

### Was this patch authored or co-authored using generative AI tooling?

Co-Authored with: Claude Opus 4.8