### PR TITLE
[SPARK-58166][SQL] Replace TypeTag on PhysicalDataType with ClassTag

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3366,7 +3366,7 @@ case class Sequence(
       val physicalDataType = PhysicalDataType(iType)
       type T = physicalDataType.InternalType
       val integral = PhysicalIntegralType.integral(iType)
-      val ct = ClassTag[T](physicalDataType.tag.mirror.runtimeClass(physicalDataType.tag.tpe))
+      val ct = physicalDataType.tag
       new IntegralSequenceImpl[T](iType)(ct, integral.asInstanceOf[Integral[T]])
 
     case TimestampType | TimestampNTZType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.catalyst.types
 
-import scala.reflect.runtime.universe.TypeTag
-import scala.reflect.runtime.universe.typeTag
+import scala.reflect.ClassTag
+import scala.reflect.classTag
 
 import org.apache.spark.sql.catalyst.expressions.{Ascending, BoundReference, InterpretedOrdering, SortOrder}
 import org.apache.spark.sql.catalyst.types.ops.TypeOps
@@ -31,7 +31,7 @@ import org.apache.spark.util.ArrayImplicits._
 sealed abstract class PhysicalDataType {
   private[sql] type InternalType
   private[sql] def ordering: Ordering[InternalType]
-  private[sql] val tag: TypeTag[InternalType]
+  private[sql] val tag: ClassTag[InternalType]
 }
 
 object PhysicalDataType {
@@ -133,7 +133,7 @@ class PhysicalBinaryType() extends PhysicalDataType {
     (x: Array[Byte], y: Array[Byte]) => ByteArray.compareBinary(x, y)
 
   private[sql] type InternalType = Array[Byte]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 case object PhysicalBinaryType extends PhysicalBinaryType
 
@@ -143,14 +143,14 @@ class PhysicalBooleanType extends PhysicalDataType with PhysicalPrimitiveType {
   // Defined with a private constructor so the companion object is the only possible instantiation.
   private[sql] type InternalType = Boolean
   private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 case object PhysicalBooleanType extends PhysicalBooleanType
 
 class PhysicalByteType() extends PhysicalIntegralType with PhysicalPrimitiveType {
   private[sql] type InternalType = Byte
   private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = implicitly[Numeric[Byte]]
   override private[sql] val exactNumeric = ByteExactNumeric
   private[sql] val integral = implicitly[Integral[Byte]]
@@ -162,7 +162,7 @@ class PhysicalCalendarIntervalType() extends PhysicalDataType {
     throw QueryExecutionErrors.orderedOperationUnsupportedByDataTypeError(
       "PhysicalCalendarIntervalType")
   override private[sql] type InternalType = Any
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 case object PhysicalCalendarIntervalType extends PhysicalCalendarIntervalType
 
@@ -180,7 +180,7 @@ case object PhysicalCalendarIntervalType extends PhysicalCalendarIntervalType
 class PhysicalTimestampNTZNanosType() extends PhysicalDataType {
   override private[sql] type InternalType = TimestampNanosVal
   override private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 case object PhysicalTimestampNTZNanosType extends PhysicalTimestampNTZNanosType
 
@@ -198,14 +198,14 @@ case object PhysicalTimestampNTZNanosType extends PhysicalTimestampNTZNanosType
 class PhysicalTimestampLTZNanosType() extends PhysicalDataType {
   override private[sql] type InternalType = TimestampNanosVal
   override private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 case object PhysicalTimestampLTZNanosType extends PhysicalTimestampLTZNanosType
 
 case class PhysicalDecimalType(precision: Int, scale: Int) extends PhysicalFractionalType {
   private[sql] type InternalType = Decimal
   private[sql] val ordering = Decimal.DecimalIsFractional
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = Decimal.DecimalIsFractional
   override private[sql] def exactNumeric = DecimalExactNumeric
   private[sql] val fractional = Decimal.DecimalIsFractional
@@ -225,7 +225,7 @@ class PhysicalDoubleType() extends PhysicalFractionalType with PhysicalPrimitive
   private[sql] type InternalType = Double
   private[sql] val ordering =
     (x: Double, y: Double) => SQLOrderingUtil.compareDoubles(x, y)
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = implicitly[Numeric[Double]]
   override private[sql] def exactNumeric = DoubleExactNumeric
   private[sql] val fractional = implicitly[Fractional[Double]]
@@ -240,7 +240,7 @@ class PhysicalFloatType() extends PhysicalFractionalType with PhysicalPrimitiveT
   private[sql] type InternalType = Float
   private[sql] val ordering =
     (x: Float, y: Float) => SQLOrderingUtil.compareFloats(x, y)
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = implicitly[Numeric[Float]]
   override private[sql] def exactNumeric = FloatExactNumeric
   private[sql] val fractional = implicitly[Fractional[Float]]
@@ -254,7 +254,7 @@ class PhysicalIntegerType() extends PhysicalIntegralType with PhysicalPrimitiveT
   // Defined with a private constructor so the companion object is the only possible instantiation.
   private[sql] type InternalType = Int
   private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = implicitly[Numeric[Int]]
   override private[sql] val exactNumeric = IntegerExactNumeric
   private[sql] val integral = implicitly[Integral[Int]]
@@ -267,7 +267,7 @@ class PhysicalLongType() extends PhysicalIntegralType with PhysicalPrimitiveType
   // Defined with a private constructor so the companion object is the only possible instantiation.
   private[sql] type InternalType = Long
   private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = implicitly[Numeric[Long]]
   override private[sql] val exactNumeric = LongExactNumeric
   private[sql] val integral = implicitly[Integral[Long]]
@@ -279,7 +279,7 @@ case class PhysicalMapType(keyType: DataType, valueType: DataType, valueContains
   // maps are not orderable, we use `ordering` just to support group by queries
   override private[sql] def ordering = interpretedOrdering
   override private[sql] type InternalType = MapData
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 
   @transient
   private[sql] lazy val interpretedOrdering: Ordering[MapData] = new Ordering[MapData] {
@@ -348,14 +348,14 @@ class PhysicalNullType() extends PhysicalDataType with PhysicalPrimitiveType {
   override private[sql] def ordering =
     implicitly[Ordering[Unit]].asInstanceOf[Ordering[Any]]
   override private[sql] type InternalType = Any
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 case object PhysicalNullType extends PhysicalNullType
 
 class PhysicalShortType() extends PhysicalIntegralType with PhysicalPrimitiveType {
   private[sql] type InternalType = Short
   private[sql] val ordering = implicitly[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
   private[sql] val numeric = implicitly[Numeric[Short]]
   override private[sql] val exactNumeric = ShortExactNumeric
   private[sql] val integral = implicitly[Integral[Short]]
@@ -368,7 +368,7 @@ case class PhysicalStringType(collationId: Int) extends PhysicalDataType {
   // Defined with a private constructor so the companion object is the only possible instantiation.
   private[sql] type InternalType = UTF8String
   private[sql] val ordering = CollationFactory.fetchCollation(collationId).comparator.compare(_, _)
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 object PhysicalStringType {
   def apply(collationId: Int): PhysicalStringType = new PhysicalStringType(collationId)
@@ -378,7 +378,7 @@ case class PhysicalArrayType(
     elementType: DataType, containsNull: Boolean) extends PhysicalDataType {
   override private[sql] type InternalType = ArrayData
   override private[sql] def ordering = interpretedOrdering
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 
   @transient
   private[sql] lazy val interpretedOrdering: Ordering[ArrayData] = new Ordering[ArrayData] {
@@ -425,7 +425,7 @@ case class PhysicalStructType(fields: Array[StructField]) extends PhysicalDataTy
   override private[sql] type InternalType = Any
   override private[sql] def ordering =
     forSchema(this.fields.map(_.dataType).toImmutableArraySeq).asInstanceOf[Ordering[InternalType]]
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 
   private[sql] def forSchema(dataTypes: Seq[DataType]): InterpretedOrdering = {
     new InterpretedOrdering(dataTypes.zipWithIndex.map {
@@ -436,7 +436,7 @@ case class PhysicalStructType(fields: Array[StructField]) extends PhysicalDataTy
 
 class PhysicalVariantType extends PhysicalDataType {
   private[sql] type InternalType = VariantVal
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 
   // TODO(SPARK-45891): Support comparison for the Variant type.
   override private[sql] def ordering =
@@ -451,7 +451,7 @@ object UninitializedPhysicalType extends PhysicalDataType {
     throw QueryExecutionErrors.orderedOperationUnsupportedByDataTypeError(
       "UninitializedPhysicalType")
   override private[sql] type InternalType = Any
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 
 // Physical type for opaque, variable-length byte payloads that are addressed as a zero-copy
@@ -466,7 +466,7 @@ object UninitializedPhysicalType extends PhysicalDataType {
 class PhysicalBinaryViewType extends PhysicalDataType {
   private[sql] val ordering = (x: BinaryView, y: BinaryView) => x.compareTo(y)
   private[sql] type InternalType = BinaryView
-  @transient private[sql] lazy val tag = typeTag[InternalType]
+  @transient private[sql] lazy val tag = classTag[InternalType]
 }
 
 case object PhysicalBinaryViewType extends PhysicalBinaryViewType


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Replace the TypeTag in PhysicalDataType with a ClassTag.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Because of this issue https://github.com/scala/scala3/issues/25896 the change top make it possible to use Spark from Scala 3.8.0 or later.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No. 

<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing tests ensure no regressions. That it makes the code more compatible with Scala 3.8 was done by running a local build against the tests in https://github.com/unum-io/tyda (a Scala 3 library that can use Spark as a backend).
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
