### PR TITLE
[SPARK-38983][SQL][TESTS] Add grouping boolean error regression test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -234,6 +234,16 @@ class DataFrameAggregateSuite extends SharedSparkSession
     }
   }
 
+  test("SPARK-38983: grouping functions in boolean expressions report type mismatch") {
+    Seq(grouping("course"), grouping_id("course", "year")).foreach { groupingExpr =>
+      val error = intercept[AnalysisException] {
+        courseSales.cube("course", "year").agg(groupingExpr && lit(true)).collect()
+      }
+      assert(error.getCondition === "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES")
+      assert(!error.getMessage.contains("grouping()/grouping_id() can only be used"))
+    }
+  }
+
   test("grouping/grouping_id inside window function") {
     checkAnswer(
       courseSales.cube("course", "year")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -244,7 +244,7 @@ class DataFrameAggregateSuite extends SharedSparkSession
         Column("year"))
     ).foreach { groupedData =>
       Seq(
-        (grouping("course"), "\"INT\""),
+        (grouping("course"), "\"TINYINT\""),
         (grouping_id("course", "year"), "\"BIGINT\"")
       ).foreach { case (groupingExpr, leftType) =>
         checkError(
@@ -256,6 +256,9 @@ class DataFrameAggregateSuite extends SharedSparkSession
             "left" -> leftType,
             "right" -> "\"BOOLEAN\"",
             "sqlExpr" -> "\"\\(.+ AND true\\)\""),
+          context = ExpectedContext(
+            fragment = "amp$amp",
+            callSitePattern = getCurrentClassCallSitePattern),
           matchPVals = true)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -256,10 +256,10 @@ class DataFrameAggregateSuite extends SharedSparkSession
             "left" -> leftType,
             "right" -> "\"BOOLEAN\"",
             "sqlExpr" -> "\"\\(.+ AND true\\)\""),
-          context = ExpectedContext(
+          matchPVals = true,
+          queryContext = Array(ExpectedContext(
             fragment = "amp$amp",
-            callSitePattern = getCurrentClassCallSitePattern),
-          matchPVals = true)
+            callSitePattern = getCurrentClassCallSitePattern)))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -235,12 +235,29 @@ class DataFrameAggregateSuite extends SharedSparkSession
   }
 
   test("SPARK-38983: grouping functions in boolean expressions report type mismatch") {
-    Seq(grouping("course"), grouping_id("course", "year")).foreach { groupingExpr =>
-      val error = intercept[AnalysisException] {
-        courseSales.cube("course", "year").agg(groupingExpr && lit(true)).collect()
+    Seq(
+      courseSales.cube("course", "year"),
+      courseSales.rollup("course", "year"),
+      courseSales.groupingSets(
+        Seq(Seq(Column("course"), Column("year")), Seq()),
+        Column("course"),
+        Column("year"))
+    ).foreach { groupedData =>
+      Seq(
+        (grouping("course"), "\"INT\""),
+        (grouping_id("course", "year"), "\"BIGINT\"")
+      ).foreach { case (groupingExpr, leftType) =>
+        checkError(
+          exception = intercept[AnalysisException] {
+            groupedData.agg(groupingExpr && lit(true)).collect()
+          },
+          condition = "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
+          parameters = Map(
+            "left" -> leftType,
+            "right" -> "\"BOOLEAN\"",
+            "sqlExpr" -> "\"\\(.+ AND true\\)\""),
+          matchPVals = true)
       }
-      assert(error.getCondition === "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES")
-      assert(!error.getMessage.contains("grouping()/grouping_id() can only be used"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a regression test covering `grouping()` and `grouping_id()` when they are used in boolean expressions inside DataFrame aggregate expressions.

### Why are the changes needed?

SPARK-38983 reported that using grouping functions in boolean expressions could surface a misleading grouping analytics error. Current master reports a type mismatch instead; this test locks in that behavior and prevents the misleading error from coming back.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

- `git diff --check`
- Attempted `./build/sbt "sql/testOnly org.apache.spark.sql.DataFrameAggregateSuite -- -z SPARK-38983"`, but the local sbt run did not complete in a reasonable time and was interrupted.

### Was this patch authored or co-authored using generative AI tooling?

Yes, assisted by Codex.