### PR TITLE
[SPARK-58172][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_0031

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4940,6 +4940,11 @@
           "The function <prettyName> does not support <syntax>."
         ]
       },
+      "INVALID_BUCKET_NUMBER" : {
+        "message" : [
+          "Invalid number of buckets: <describe>."
+        ]
+      },
       "INVALID_COLUMN_REFERENCE" : {
         "message" : [
           "Expected a column reference for transform <transform>: <expr>."
@@ -9425,11 +9430,6 @@
   "_LEGACY_ERROR_TEMP_0029" : {
     "message" : [
       "Cannot mix year-month and day-time fields: <literal>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0031" : {
-    "message" : [
-      "Invalid number of buckets: <describe>."
     ]
   },
   "_LEGACY_ERROR_TEMP_0032" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -524,7 +524,7 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
 
   def invalidBucketsNumberError(describe: String, ctx: ApplyTransformContext): Throwable = {
     new ParseException(
-      errorClass = "_LEGACY_ERROR_TEMP_0031",
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_BUCKET_NUMBER",
       messageParameters = Map("describe" -> describe),
       ctx)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -515,6 +515,20 @@ class QueryParsingErrorsSuite extends SharedSparkSession {
         stop = 83))
   }
 
+  test("INVALID_SQL_SYNTAX.INVALID_BUCKET_NUMBER: " +
+    "the number of buckets is not an integer literal") {
+    checkError(
+      exception = parseException("CREATE TABLE my_tab(a INT, b STRING) " +
+        "USING parquet PARTITIONED BY (bucket('12', b))"),
+      condition = "INVALID_SQL_SYNTAX.INVALID_BUCKET_NUMBER",
+      sqlState = "42000",
+      parameters = Map("describe" -> "'12'"),
+      context = ExpectedContext(
+        fragment = "bucket('12', b)",
+        start = 67,
+        stop = 81))
+  }
+
   test("UNSUPPORTED_FEATURE: DESC TABLE COLUMN for a specific partition") {
     val sqlText = "DESCRIBE TABLE EXTENDED customer PARTITION (grade = 'A') customer.age"
     checkError(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Convert the legacy error condition `_LEGACY_ERROR_TEMP_0031` ("Invalid number of buckets: <describe>.") into the `INVALID_SQL_SYNTAX.INVALID_BUCKET_NUMBER` subclass (SQLSTATE `42000`, inherited from the `INVALID_SQL_SYNTAX` umbrella).

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one of them.

The error is raised by `AstBuilder` when the first argument of a `bucket` partition transform is not an integer literal, e.g. `CREATE TABLE ... PARTITIONED BY (bucket('12', b))`. The sibling errors reported from the same transform-argument path -- `INVALID_SQL_SYNTAX.INVALID_COLUMN_REFERENCE` and `INVALID_SQL_SYNTAX.TRANSFORM_WRONG_NUM_ARGS` -- already live under the `INVALID_SQL_SYNTAX` umbrella, so folding this into `INVALID_SQL_SYNTAX.INVALID_BUCKET_NUMBER` keeps the parser syntax errors consistent instead of introducing a new top-level name.

### Does this PR introduce _any_ user-facing change?

No. Only the error condition name is assigned; the message text is unchanged. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API.

### How was this patch tested?

Added a `checkError` test in `QueryParsingErrorsSuite` that parses `CREATE TABLE my_tab(a INT, b STRING) USING parquet PARTITIONED BY (bucket('12', b))` and asserts the `INVALID_SQL_SYNTAX.INVALID_BUCKET_NUMBER` condition. `build/sbt "sql/testOnly *QueryParsingErrorsSuite" "core/testOnly org.apache.spark.SparkThrowableSuite"` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
