### PR TITLE
[SPARK-58174][BUILD] Fetch maven plugins from mirror if MAVEN_MIRROR_URL is set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3553,6 +3553,12 @@
           <url>${env.MAVEN_MIRROR_URL}</url>
         </repository>
       </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>maven-mirror</id>
+          <url>${env.MAVEN_MIRROR_URL}</url>
+        </pluginRepository>
+      </pluginRepositories>
     </profile>
 
     <!--


### PR DESCRIPTION
### What changes were proposed in this pull request?

If `MAVEN_MIRROR_URL` use it not only to fetch build dependencies but also to fetch maven plugins.

### Why are the changes needed?

Maven cannot build spark if it cannot fetch plugins, which is currently the case if public maven repos are not available.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I manually built spark with `MAVEN_MIRROR_URL` set.

### Was this patch authored or co-authored using generative AI tooling?

No