### PR TITLE
[SPARK-58177][GRAPHX] Fix wrong operand in SVD++ aggregateMessages combiner

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/SVDPlusPlus.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/SVDPlusPlus.scala
@@ -156,7 +156,7 @@ object SVDPlusPlus {
         {
           val out1 = g1._1.clone()
           BLAS.nativeBLAS.daxpy(out1.length, 1.0, g2._1, 1, out1, 1)
-          val out2 = g2._2.clone()
+          val out2 = g1._2.clone()
           BLAS.nativeBLAS.daxpy(out2.length, 1.0, g2._2, 1, out2, 1)
           (out1, out2, g1._3 + g2._3)
         })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix the Phase-2 `aggregateMessages` combiner in `SVDPlusPlus.run`, which seeded the `_2` accumulator from the wrong operand:

```diff
-          val out2 = g2._2.clone()
+          val out2 = g1._2.clone()
           BLAS.nativeBLAS.daxpy(out2.length, 1.0, g2._2, 1, out2, 1)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The next line adds `g2` on top, so the result should be `g1 + g2`. Because the code started with `g2` instead of `g1`, it computed `g2 + g2` and discarded `g1`. Any node with two or more edges ended up with the wrong value. The matching code just below already does it the right way (`g1 + g2`). 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Verified with a unit test (UT) that feeds two concrete updates through the combiner and checks the merged `_2` value, plus the existing suite: `build/sbt "graphx/testOnly org.apache.spark.graphx.lib.SVDPlusPlusSuite"` passes. With the faulty code, the output does not match the expected sum; with the fix, it does:

| | `_2` value |
|---|---|
| Input `g1._2` | `[3, 4]` |
| Input `g2._2` | `[30, 40]` |
| Expected (`g1._2 + g2._2`) | `[33, 44]` |
| Faulty code output | `[60, 80]` (wrong: `2 * g2._2`, drops `g1._2`) |
| Corrected code output | `[33, 44]` (correct) |


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No