### PR TITLE
⚡ perf(sql): Fold single-row anti joins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2615,6 +2615,20 @@ object ConvertToLocalRelation extends Rule[LogicalPlan] {
       val predicate = Predicate.create(condition, output)
       predicate.initialize(0)
       LocalRelation(output, data.filter(row => predicate.eval(row)), isStreaming, stream)
+
+    // A left anti join only keeps a row from the left side when the join condition does not
+    // evaluate to true for any row on the right side. When the right side is a single-row local
+    // relation, replace its attributes with literals and express that existence check as a filter.
+    case Join(left, LocalRelation(output, data, false, _), LeftAnti, Some(condition), JoinHint.NONE)
+        if data.length == 1 && !hasUnevaluableExpr(condition) =>
+      val row = data.head
+      val literalMap = AttributeMap(output.zipWithIndex.map { case (attr, index) =>
+        attr -> Literal.create(row.get(index, attr.dataType), attr.dataType)
+      })
+      val rewrittenCondition = condition.transform {
+        case attr: Attribute => literalMap.getOrElse(attr, attr)
+      }
+      Filter(Not(EqualNullSafe(rewrittenCondition, Literal.TrueLiteral)), left)
   }
 
   def hasUnevaluableExpr(expr: Expression): Boolean = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConvertToLocalRelationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConvertToLocalRelationSuite.scala
@@ -21,10 +21,12 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow, LessThan, Literal, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, EqualNullSafe, EqualTo, Expression,
+  GenericInternalRow, IsNull, LessThan, Literal, Not, Or, UnaryExpression}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.{LeftAnti, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, JoinHint, LeafNode, LocalRelation,
+  LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -87,7 +89,82 @@ class ConvertToLocalRelationSuite extends PlanTest {
 
     comparePlans(optimized, correctAnswer)
   }
+
+  test("left anti join with a single-row LocalRelation should be turned into a Filter") {
+    val left = NonLocalRelation(Seq($"a".int))
+    val right = LocalRelation(Seq($"b".int), Seq(InternalRow(2)))
+    val condition = EqualTo(left.output.head, right.output.head)
+
+    val optimized = Optimize.execute(
+      Join(left, right, LeftAnti, Some(condition), JoinHint.NONE))
+    val correctAnswer = Filter(
+      Not(EqualNullSafe(EqualTo(left.output.head, Literal(2)), Literal.TrueLiteral)),
+      left)
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("left anti join conversion should preserve null semantics") {
+    val left = LocalRelation(
+      Seq($"a".int),
+      Seq(InternalRow(1), InternalRow(2), InternalRow(null)))
+    val right = LocalRelation(Seq($"b".int), Seq(InternalRow(2)))
+    val condition = EqualTo(left.output.head, right.output.head)
+
+    val optimized = Optimize.execute(
+      Join(left, right, LeftAnti, Some(condition), JoinHint.NONE))
+    val correctAnswer = LocalRelation(
+      left.output,
+      Seq(InternalRow(1), InternalRow(null)))
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("left anti join conversion should preserve a null value on the right side") {
+    val left = LocalRelation(
+      Seq($"a".int),
+      Seq(InternalRow(1), InternalRow(null)))
+    val right = LocalRelation(Seq($"b".int), Seq(InternalRow(null)))
+    val condition = EqualTo(left.output.head, right.output.head)
+
+    val optimized = Optimize.execute(
+      Join(left, right, LeftAnti, Some(condition), JoinHint.NONE))
+
+    comparePlans(optimized, left)
+  }
+
+  test("left anti join conversion should preserve null-aware anti join semantics") {
+    val left = LocalRelation(
+      Seq($"a".int),
+      Seq(InternalRow(1), InternalRow(null)))
+    val right = LocalRelation(Seq($"b".int), Seq(InternalRow(null)))
+    val equality = EqualTo(left.output.head, right.output.head)
+    val nullAwareCondition = Or(equality, IsNull(equality))
+
+    val optimized = Optimize.execute(
+      Join(left, right, LeftAnti, Some(nullAwareCondition), JoinHint.NONE))
+    val correctAnswer = LocalRelation(left.output, Seq.empty)
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("left anti join with a multi-row LocalRelation should not be converted") {
+    val left = NonLocalRelation(Seq($"a".int))
+    val right = LocalRelation(
+      Seq($"b".int),
+      Seq(InternalRow(1), InternalRow(2)))
+    val join = Join(
+      left,
+      right,
+      LeftAnti,
+      Some(EqualTo(left.output.head, right.output.head)),
+      JoinHint.NONE)
+
+    comparePlans(Optimize.execute(join), join)
+  }
 }
+
+case class NonLocalRelation(output: Seq[Attribute]) extends LeafNode
 
 
 // Dummy expression used for testing. It reuses output row. Assumes child expr outputs an integer.


### PR DESCRIPTION
- Rewrite a one-row right LocalRelation as a null-safe filter.
- Preserve regular and null-aware anti join semantics.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
