### PR TITLE
[SPARK-58180][INFRA][4.2] Prepare branch-4.2 build workflows for decoupling

### DIFF
--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Java21 (master, Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build / Java21 (Scala 2.13, Hadoop 3, JDK 21)"
 
 on:
-  schedule:
-    - cron: '0 4 * * *'
   workflow_dispatch:
 
 jobs:
@@ -33,7 +31,6 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 21
-      branch: master
       hadoop: hadoop3
       envs: >-
         {

--- a/.github/workflows/build_java25.yml
+++ b/.github/workflows/build_java25.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Java25 (master, Scala 2.13, Hadoop 3, JDK 25)"
+name: "Build / Java25 (Scala 2.13, Hadoop 3, JDK 25)"
 
 on:
-  schedule:
-    - cron: '0 4 * * *'
   workflow_dispatch:
 
 jobs:
@@ -33,7 +31,6 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 25
-      branch: master
       hadoop: hadoop3
       envs: >-
         {

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 17)"
+name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 17)"
 
 on:
-  schedule:
-    - cron: '0 13 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_maven_java21.yml
+++ b/.github/workflows/build_maven_java21.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 21)"
 
 on:
-  schedule:
-    - cron: '0 14 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_non_ansi.yml
+++ b/.github/workflows/build_non_ansi.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Non-ANSI (master, Hadoop 3, JDK 17, Scala 2.13)"
+name: "Build / Non-ANSI (Hadoop 3, JDK 17, Scala 2.13)"
 
 on:
-  schedule:
-    - cron: '0 1 * * *'
   workflow_dispatch:
 
 jobs:
@@ -33,21 +31,19 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 17
-      branch: master
       hadoop: hadoop3
       envs: >-
         {
-          "PYSPARK_IMAGE_TO_TEST": "python-312",
-          "PYTHON_TO_TEST": "python3.12",
-          "SPARK_ANSI_SQL_MODE": "false",
-          "SPARK_TEST_SPARK_BLOOM_FILTER_SUITE_ENABLED": "true"
+          "PYSPARK_IMAGE_TO_TEST": "python-311",
+          "PYTHON_TO_TEST": "python3.11",
+          "SPARK_ANSI_SQL_MODE": "false"
         }
       jobs: >-
         {
           "build": "true",
+          "build-core-utils": "false",
           "docs": "true",
           "pyspark": "true",
-          "pyspark-pandas": "true",
           "sparkr": "true",
           "tpcds-1g": "true",
           "docker-integration-tests": "true",

--- a/.github/workflows/build_python_3.11.yml
+++ b/.github/workflows/build_python_3.11.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Python-only (master, Python 3.11)"
+name: "Build / Python-only (Python 3.11)"
 
 on:
-  schedule:
-    - cron: '0 19 * * *'
   workflow_dispatch:
 
 jobs:
@@ -33,7 +31,6 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 17
-      branch: master
       hadoop: hadoop3
       envs: >-
         {

--- a/.github/workflows/build_python_3.14.yml
+++ b/.github/workflows/build_python_3.14.yml
@@ -17,11 +17,9 @@
 # under the License.
 #
 
-name: "Build / Python-only (master, Python 3.14)"
+name: "Build / Python-only (Python 3.14)"
 
 on:
-  schedule:
-    - cron: '0 21 * * *'
   workflow_dispatch:
 
 jobs:
@@ -33,7 +31,6 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 17
-      branch: master
       hadoop: hadoop3
       envs: >-
         {

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -30,7 +30,7 @@ on:
         description: Branch to run the build against
         required: false
         type: string
-        default: master
+        default: branch-4.2
       hadoop:
         description: Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.
         required: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the remaining `branch-4.2` scheduled build workflow files self-contained, following the same approach as the `branch-4.1` work (SPARK-57267) and SPARK-57115 (which did this for `build_java17.yml`):

- Rewrites `build_java21.yml`, `build_java25.yml`, `build_maven.yml`, `build_maven_java21.yml`, `build_non_ansi.yml`, `build_python_3.11.yml`, and `build_python_3.14.yml` so they are triggered by `workflow_dispatch` only (the dormant `schedule:` triggers are removed; scheduled runs on a non-default branch never fire anyway), drop the inherited `branch: master` (so they build `branch-4.2`), and use generic, non-branch-tagged names.

The per-build configurations are relocated from the active `build_branch42_*.yml` files on `master` so the coverage matches what `branch-4.2` schedules today.

Notes:
- `build_and_test.yml` defaults `branch` to `branch-4.2`, so those callers omit `branch`. `maven_test.yml` defaulted `branch` to `master`, so this PR bumps that default to `branch-4.2` (matching `build_and_test.yml`); with the default fixed, `build_maven.yml` / `build_maven_java21.yml` no longer need an explicit `branch: branch-4.2`.
- `build_non_ansi.yml` picks up the `branch-4.2` config from `build_branch42_non_ansi.yml` (Python 3.11 image, no bloom-filter env, `build-core-utils: false`, no `pyspark-pandas`). A pre-existing invalid trailing comma in the non-ANSI `envs` JSON was fixed during relocation.
- `build_java17.yml` is already self-contained (SPARK-57115) and is left unchanged.

### Why are the changes needed?

This is the `branch-4.2` side of decoupling our scheduled CIs (cf. the `branch-4.1` and `branch-4.x` efforts). Scheduled workflows only fire from the default branch, so `branch-4.2` CI should consist of self-contained, dispatchable workflow files on `branch-4.2` that a single scheduler on `master` can trigger. This PR prepares those targets; a follow-up on `master` will add the scheduler and remove the `build_branch42_*.yml` files.

### Does this PR introduce _any_ user-facing change?

No. CI only.

### How was this patch tested?

These workflows can be triggered manually via `workflow_dispatch` once merged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
