### PR TITLE
[SPARK-58179][PYTHON] Simplify namespace list construction in PySpark Catalog

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -365,10 +365,7 @@ class Catalog:
         while iter.hasNext():
             jtable = iter.next()
             jnamespace = jtable.namespace()
-            if jnamespace is not None:
-                namespace = [jnamespace[i] for i in range(0, len(jnamespace))]
-            else:
-                namespace = None
+            namespace = list(jnamespace) if jnamespace is not None else None
             views.append(
                 Table(
                     name=jtable.name(),
@@ -694,10 +691,7 @@ class Catalog:
             jtable = iter.next()
 
             jnamespace = jtable.namespace()
-            if jnamespace is not None:
-                namespace = [jnamespace[i] for i in range(0, len(jnamespace))]
-            else:
-                namespace = None
+            namespace = list(jnamespace) if jnamespace is not None else None
 
             tables.append(
                 Table(
@@ -754,10 +748,7 @@ class Catalog:
         """
         jtable = self._jcatalog.getTable(tableName)
         jnamespace = jtable.namespace()
-        if jnamespace is not None:
-            namespace = [jnamespace[i] for i in range(0, len(jnamespace))]
-        else:
-            namespace = None
+        namespace = list(jnamespace) if jnamespace is not None else None
         return Table(
             name=jtable.name(),
             catalog=jtable.catalog(),
@@ -815,10 +806,7 @@ class Catalog:
         while iter.hasNext():
             jfunction = iter.next()
             jnamespace = jfunction.namespace()
-            if jnamespace is not None:
-                namespace = [jnamespace[i] for i in range(0, len(jnamespace))]
-            else:
-                namespace = None
+            namespace = list(jnamespace) if jnamespace is not None else None
 
             functions.append(
                 Function(
@@ -920,10 +908,7 @@ class Catalog:
         """
         jfunction = self._jcatalog.getFunction(functionName)
         jnamespace = jfunction.namespace()
-        if jnamespace is not None:
-            namespace = [jnamespace[i] for i in range(0, len(jnamespace))]
-        else:
-            namespace = None
+        namespace = list(jnamespace) if jnamespace is not None else None
         return Function(
             name=jfunction.name(),
             catalog=jfunction.catalog(),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Replace the manual index-range comprehension used to turn a py4j `JavaArray` into a Python list with a plain `list()` call, in `python/pyspark/sql/catalog.py` (5 identical sites in `listViews`, `listTables`, `getTable`, `listFunctions`, `getFunction`): [SPARK-58179](https://issues.apache.org/jira/browse/SPARK-58179)

```diff
# before
- if jnamespace is not None:
-     namespace = [jnamespace[i] for i in range(0, len(jnamespace))]
- else:
-     namespace = None

# after
+ namespace = list(jnamespace) if jnamespace is not None else None
```



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Readability and de-duplication: five copies of a 4-line block collapse to one idiomatic line each (5 insertions, 20 deletions). `list(jnamespace)` is the standard way to materialize a sized, indexable py4j `JavaArray`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing catalog tests (`pyspark.sql.tests.test_catalog`). No behavior change, so no new tests added.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No