### PR TITLE
[SPARK-58187][CORE] Increase task CPUs on OOM retry to reduce concurrency and grow per-task memory

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -767,6 +767,7 @@ package object config {
         "that does, rather than falling back to the default. Set to 0 (the default) to disable " +
         "this feature and retry OOM tasks with the same resources as the original attempt. " +
         "This feature does not apply to barrier stages.")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .decimalConf
       .checkValue(v => v >= 0 && v <= CpuAmount.MAX_AMOUNT,
         "OOM retry cpus increment must be non-negative (0 disables) and at most " +
@@ -787,6 +788,7 @@ package object config {
         "its memory limit is killed with the container exit codes -103 (virtual memory) and " +
         "-104 (physical memory), consider setting this to `52,-103,-104`. Has no effect when " +
         "spark.task.oomRetryCpusIncrement is 0.")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .intConf
       .toSequence
       .createWithDefault(Seq(SparkExitCode.OOM))

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -757,18 +757,18 @@ package object config {
       .doc("Number of additional CPUs to allocate when retrying a task that failed due to " +
         "out-of-memory. When a task fails with a SparkOutOfMemoryError (unable to acquire " +
         "execution memory) or the executor exits with an OOM exit code, each subsequent retry " +
-        "of that task is allocated `spark.task.cpus + spark.task.oomRetryCpusIncrement * N` " +
-        "CPUs, where N is the number of OOM failures the task has experienced. The additional " +
-        "CPUs reduce the number of concurrent tasks on the executor, which increases the share " +
-        "of the execution memory pool available to the retrying task, improving the chance of " +
-        "success. The total CPUs per task is capped at the executor's total core count " +
-        "(spark.executor.cores or the ResourceProfile equivalent). If that core count is not " +
-        "known (e.g. Standalone / local-cluster without spark.executor.cores), the retry keeps " +
-        "the original CPUs rather than risk requesting more than the executor has. If the " +
-        "executor does not currently have enough free CPUs to satisfy the request, the retry " +
-        "waits for an offer that does, rather than falling back to the default. Set to 0 (the " +
-        "default) to disable this feature and retry OOM tasks with the same resources as the " +
-        "original attempt. This feature does not apply to barrier stages.")
+        "of that task is allocated `T + spark.task.oomRetryCpusIncrement * N` CPUs, where T is " +
+        "the task's CPU request (the ResourceProfile's task cpus, or spark.task.cpus when the " +
+        "profile supplies no override) and N is the number of OOM failures the task has " +
+        "experienced. The additional CPUs reduce the number of concurrent tasks on the executor, " +
+        "which increases the share of the execution memory pool available to the retrying task, " +
+        "improving the chance of success. The total CPUs per task is capped at the executor's " +
+        "actual total core count. If that core count is not known, the retry keeps the original " +
+        "CPUs rather than risk requesting more than the executor has. If the executor does not " +
+        "currently have enough free CPUs to satisfy the request, the retry waits for an offer " +
+        "that does, rather than falling back to the default. Set to 0 (the default) to disable " +
+        "this feature and retry OOM tasks with the same resources as the original attempt. This " +
+        "feature does not apply to barrier stages.")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .decimalConf
       .checkValue(v => v >= 0 && v <= CpuAmount.MAX_AMOUNT,

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -33,7 +33,7 @@ import org.apache.spark.scheduler.{EventLoggingListener, SchedulingMode}
 import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO
 import org.apache.spark.storage.{DefaultTopologyMapper, RandomBlockReplicationPolicy}
 import org.apache.spark.unsafe.array.ByteArrayMethods
-import org.apache.spark.util.{MavenUtils, Utils}
+import org.apache.spark.util.{MavenUtils, SparkExitCode, Utils}
 import org.apache.spark.util.collection.unsafe.sort.UnsafeSorterSpillReader.MAX_BUFFER_SIZE_BYTES
 
 package object config {
@@ -750,6 +750,46 @@ package object config {
       // normalize to the fixed CPU accounting scale so every read is a uniform, compact BigDecimal
       .transform(CpuAmount.normalize)
       .createWithDefault(BigDecimal(1))
+
+  private[spark] val OOM_RETRY_CPUS_INCREMENT =
+    ConfigBuilder("spark.task.oomRetryCpusIncrement")
+      .version("4.3.0")
+      .doc("Number of additional CPUs to allocate when retrying a task that failed due to " +
+        "out-of-memory. When a task fails with a SparkOutOfMemoryError (unable to acquire " +
+        "execution memory) or the executor exits with an OOM exit code, each subsequent retry " +
+        "of that task is allocated `spark.task.cpus + spark.task.oomRetryCpusIncrement * N` " +
+        "CPUs, where N is the number of OOM failures the task has experienced. The additional " +
+        "CPUs reduce the number of concurrent tasks on the executor, which increases the share " +
+        "of the execution memory pool available to the retrying task, improving the chance of " +
+        "success. The total CPUs per task is capped at the executor's total core count " +
+        "(spark.executor.cores or the ResourceProfile equivalent). If the executor does not " +
+        "currently have enough free CPUs to satisfy the request, the retry waits for an offer " +
+        "that does, rather than falling back to the default. Set to 0 (the default) to disable " +
+        "this feature and retry OOM tasks with the same resources as the original attempt. " +
+        "This feature does not apply to barrier stages.")
+      .decimalConf
+      .checkValue(v => v >= 0 && v <= CpuAmount.MAX_AMOUNT,
+        "OOM retry cpus increment must be non-negative (0 disables) and at most " +
+          s"${CpuAmount.MAX_AMOUNT}.")
+      .checkValue(CpuAmount.stripTrailingZeros(_).scale <= CpuAmount.SCALE,
+        s"OOM retry cpus increment supports at most ${CpuAmount.SCALE} decimal places.")
+      .transform(CpuAmount.normalize)
+      .createWithDefault(BigDecimal(0))
+
+  private[spark] val OOM_RETRY_EXECUTOR_EXIT_CODES =
+    ConfigBuilder("spark.task.oomRetryExecutorExitCodes")
+      .version("4.3.0")
+      .doc("Comma-separated list of executor exit codes that are treated as out-of-memory for " +
+        "the purpose of spark.task.oomRetryCpusIncrement. When an executor exits with one of " +
+        "these codes, the tasks that were running on it have their OOM retry count incremented " +
+        "(so their retries request more CPUs). The default is 52, the exit code Spark uses when " +
+        "an executor JVM dies of an OutOfMemoryError. On YARN, where a container that exceeds " +
+        "its memory limit is killed with the container exit codes -103 (virtual memory) and " +
+        "-104 (physical memory), consider setting this to `52,-103,-104`. Has no effect when " +
+        "spark.task.oomRetryCpusIncrement is 0.")
+      .intConf
+      .toSequence
+      .createWithDefault(Seq(SparkExitCode.OOM))
 
   private[spark] val DYN_ALLOCATION_ENABLED =
     ConfigBuilder("spark.dynamicAllocation.enabled")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -762,11 +762,13 @@ package object config {
         "CPUs reduce the number of concurrent tasks on the executor, which increases the share " +
         "of the execution memory pool available to the retrying task, improving the chance of " +
         "success. The total CPUs per task is capped at the executor's total core count " +
-        "(spark.executor.cores or the ResourceProfile equivalent). If the executor does not " +
-        "currently have enough free CPUs to satisfy the request, the retry waits for an offer " +
-        "that does, rather than falling back to the default. Set to 0 (the default) to disable " +
-        "this feature and retry OOM tasks with the same resources as the original attempt. " +
-        "This feature does not apply to barrier stages.")
+        "(spark.executor.cores or the ResourceProfile equivalent). If that core count is not " +
+        "known (e.g. Standalone / local-cluster without spark.executor.cores), the retry keeps " +
+        "the original CPUs rather than risk requesting more than the executor has. If the " +
+        "executor does not currently have enough free CPUs to satisfy the request, the retry " +
+        "waits for an offer that does, rather than falling back to the default. Set to 0 (the " +
+        "default) to disable this feature and retry OOM tasks with the same resources as the " +
+        "original attempt. This feature does not apply to barrier stages.")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .decimalConf
       .checkValue(v => v >= 0 && v <= CpuAmount.MAX_AMOUNT,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -430,9 +430,13 @@ private[spark] class TaskSchedulerImpl(
           availableCpus(i), availableResources(i))
         taskResAssignmentsOpt.foreach { taskResAssignments =>
           try {
+            // The offer's actual registered total cores (if provided) caps the OOM retry cpus at
+            // what the executor can physically run (see spark.task.oomRetryCpusIncrement).
+            val offerTotalCores =
+              Some(shuffledOffers(i).totalCores).filter(_ >= 0)
             val (taskDescOption, didReject, index) =
               taskSet.resourceOffer(execId, host, maxLocality, taskCpus, taskResAssignments,
-                availableCpus(i))
+                availableCpus(i), offerTotalCores)
             noDelayScheduleRejects &= !didReject
             for (task <- taskDescOption) {
               // The CPUs actually used may exceed the ResourceProfile's taskCpus when the task is

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -431,23 +431,27 @@ private[spark] class TaskSchedulerImpl(
         taskResAssignmentsOpt.foreach { taskResAssignments =>
           try {
             val (taskDescOption, didReject, index) =
-              taskSet.resourceOffer(execId, host, maxLocality, taskCpus, taskResAssignments)
+              taskSet.resourceOffer(execId, host, maxLocality, taskCpus, taskResAssignments,
+                availableCpus(i))
             noDelayScheduleRejects &= !didReject
             for (task <- taskDescOption) {
-              val (locality, resources) = if (task != null) {
+              // The CPUs actually used may exceed the ResourceProfile's taskCpus when the task is
+              // an OOM retry (see spark.task.oomRetryCpusIncrement); read it from the
+              // TaskDescription so the availableCpus bookkeeping matches what was launched.
+              val (locality, resources, cpusUsed) = if (task != null) {
                 tasks(i) += task
                 addRunningTask(task.taskId, execId, taskSet)
-                (taskSet.taskInfos(task.taskId).taskLocality, task.resources)
+                (taskSet.taskInfos(task.taskId).taskLocality, task.resources, task.cpus)
               } else {
                 assert(taskSet.isBarrier, "TaskDescription can only be null for barrier task")
                 val barrierTask = taskSet.barrierPendingLaunchTasks(index)
                 barrierTask.assignedOfferIndex = i
                 barrierTask.assignedCores = taskCpus
-                (barrierTask.taskLocality, barrierTask.assignedResources)
+                (barrierTask.taskLocality, barrierTask.assignedResources, taskCpus)
               }
 
               minLaunchedLocality = minTaskLocality(minLaunchedLocality, Some(locality))
-              availableCpus(i) = availableCpus(i) - taskCpus
+              availableCpus(i) = availableCpus(i) - cpusUsed
               assert(availableCpus(i).signum >= 0)
               availableResources(i).acquire(resources)
             }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -33,6 +33,7 @@ import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.{config, Logging, LogKeys}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.config._
+import org.apache.spark.memory.SparkOutOfMemoryError
 import org.apache.spark.resource.CpuAmount
 import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.util.{AccumulatorV2, Clock, LongAccumulator, SystemClock, Utils}
@@ -125,6 +126,30 @@ private[spark] class TaskSetManager(
   // be re-run because the missing map data needs to be regenerated first.
   val successful = new Array[Boolean](numTasks)
   private val numFailures = new Array[Int](numTasks)
+
+  // For each task, tracks the number of times it has failed due to out-of-memory. Used to grow
+  // the number of CPUs allocated to a retry (see spark.task.oomRetryCpusIncrement), which lowers
+  // the executor's concurrent task count and thus increases the retry's execution-memory share.
+  // Reset to 0 when the task succeeds, mirroring numFailures.
+  private[scheduler] val numOomRetries = new Array[Int](numTasks)
+  private val oomRetryCpusIncrement = conf.get(config.OOM_RETRY_CPUS_INCREMENT)
+  // Executor exit codes treated as OOM (see spark.task.oomRetryExecutorExitCodes); when an
+  // executor exits with one of these, the tasks it was running have their OOM retry count bumped.
+  private val oomRetryExecutorExitCodes = conf.get(config.OOM_RETRY_EXECUTOR_EXIT_CODES).toSet
+  // The executor total cores of this TaskSet's ResourceProfile. A TaskSetManager is tied to a
+  // single ResourceProfile, so this is constant for its lifetime and caps the OOM retry cpus.
+  private val executorCoresLimit: Int = {
+    val rp = sched.sc.resourceProfileManager.resourceProfileFromId(taskSet.resourceProfileId)
+    rp.getExecutorCores.getOrElse(conf.get(EXECUTOR_CORES))
+  }
+
+  // The number of CPUs a retry of the given task should request, given the ResourceProfile's
+  // base taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per
+  // OOM failure, capped at the executor total cores.
+  private def effectiveCpusFor(index: Int, baseCpus: BigDecimal): BigDecimal = {
+    val requested = baseCpus + oomRetryCpusIncrement * numOomRetries(index)
+    CpuAmount.normalize(requested.min(BigDecimal(executorCoresLimit)))
+  }
 
   // Add the tid of task into this HashSet when the task is killed by other attempt tasks.
   // This happened while we set the `spark.speculation` to true. The task killed by others
@@ -330,13 +355,19 @@ private[spark] class TaskSetManager(
       execId: String,
       host: String,
       list: ArrayBuffer[Int],
-      speculative: Boolean = false): Option[Int] = {
+      speculative: Boolean = false,
+      taskCpus: BigDecimal = sched.CPUS_PER_TASK,
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT): Option[Int] = {
     var indexOffset = list.size
     while (indexOffset > 0) {
       indexOffset -= 1
       val index = list(indexOffset)
+      // Strict wait for OOM retries: if a task that previously failed with OOM needs more CPUs
+      // than this offer currently has free, leave it in the queue and look for another task,
+      // rather than launching it with the same resources that already caused the OOM.
       if (!isTaskExcludededOnExecOrNode(index, execId, host) &&
-          !(speculative && hasAttemptOnHost(index, host))) {
+          !(speculative && hasAttemptOnHost(index, host)) &&
+          !oomRetryNeedsMoreCpus(index, taskCpus, availCpus)) {
         // This should almost always be list.trimEnd(1) to remove tail
         list.remove(indexOffset)
         // Speculatable task should only be launched when at most one copy of the
@@ -351,6 +382,15 @@ private[spark] class TaskSetManager(
       }
     }
     None
+  }
+
+  // Whether the given task is an OOM retry that requires more CPUs than the offer has free, in
+  // which case dequeue should skip it and wait for an offer with enough CPUs (see
+  // spark.task.oomRetryCpusIncrement). Barrier tasks never use the increment.
+  private def oomRetryNeedsMoreCpus(index: Int, taskCpus: BigDecimal, availCpus: BigDecimal)
+      : Boolean = {
+    oomRetryCpusIncrement.signum > 0 && !isBarrier && numOomRetries(index) > 0 &&
+      effectiveCpusFor(index, taskCpus) > availCpus
   }
 
   /** Check whether a task once ran an attempt on a given host */
@@ -374,24 +414,29 @@ private[spark] class TaskSetManager(
   private def dequeueTask(
       execId: String,
       host: String,
-      maxLocality: TaskLocality.Value): Option[(Int, TaskLocality.Value, Boolean)] = {
+      maxLocality: TaskLocality.Value,
+      taskCpus: BigDecimal = sched.CPUS_PER_TASK,
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT): Option[(Int, TaskLocality.Value, Boolean)] = {
     // Tries to schedule a regular task first; if it returns None, then schedules
     // a speculative task
-    dequeueTaskHelper(execId, host, maxLocality, false).orElse(
-      dequeueTaskHelper(execId, host, maxLocality, true))
+    dequeueTaskHelper(execId, host, maxLocality, false, taskCpus, availCpus).orElse(
+      dequeueTaskHelper(execId, host, maxLocality, true, taskCpus, availCpus))
   }
 
   protected def dequeueTaskHelper(
       execId: String,
       host: String,
       maxLocality: TaskLocality.Value,
-      speculative: Boolean): Option[(Int, TaskLocality.Value, Boolean)] = {
+      speculative: Boolean,
+      taskCpus: BigDecimal = sched.CPUS_PER_TASK,
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT)
+      : Option[(Int, TaskLocality.Value, Boolean)] = {
     if (speculative && speculatableTasks.isEmpty) {
       return None
     }
     val pendingTaskSetToUse = if (speculative) pendingSpeculatableTasks else pendingTasks
     def dequeue(list: ArrayBuffer[Int]): Option[Int] = {
-      val task = dequeueTaskFromList(execId, host, list, speculative)
+      val task = dequeueTaskFromList(execId, host, list, speculative, taskCpus, availCpus)
       if (speculative && task.isDefined) {
         speculatableTasks -= task.get
       }
@@ -452,6 +497,8 @@ private[spark] class TaskSetManager(
    * @param maxLocality the maximum locality we want to schedule the tasks at
    * @param taskCpus the number of CPUs for the task
    * @param taskResourceAssignments the resource assignments for the task
+   * @param availCpus the number of CPUs currently free on the offered executor, used to enforce
+   *                  the strict-wait policy for OOM retries (see spark.task.oomRetryCpusIncrement)
    *
    * @return Triple containing:
    *         (TaskDescription of launched task if any,
@@ -464,7 +511,8 @@ private[spark] class TaskSetManager(
       host: String,
       maxLocality: TaskLocality.TaskLocality,
       taskCpus: BigDecimal = sched.CPUS_PER_TASK,
-      taskResourceAssignments: Map[String, Map[String, Long]] = Map.empty)
+      taskResourceAssignments: Map[String, Map[String, Long]] = Map.empty,
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT)
     : (Option[TaskDescription], Boolean, Int) =
   {
     val offerExcluded = taskSetExcludelistHelperOpt.exists { excludeList =>
@@ -486,7 +534,7 @@ private[spark] class TaskSetManager(
 
       var dequeuedTaskIndex: Option[Int] = None
       val taskDescription =
-        dequeueTask(execId, host, allowedLocality)
+        dequeueTask(execId, host, allowedLocality, taskCpus, availCpus)
           .map { case (index, taskLocality, speculative) =>
             dequeuedTaskIndex = Some(index)
             if (legacyLocalityWaitReset && maxLocality != TaskLocality.NO_PREF) {
@@ -503,13 +551,21 @@ private[spark] class TaskSetManager(
               // return null since the TaskDescription for the barrier task is not ready yet
               null
             } else {
+              // For an OOM retry, allocate extra CPUs (capped at the executor cores). dequeueTask
+              // guarantees effectiveCpus <= availCpus, so the scheduler's cpu bookkeeping is safe.
+              // Barrier tasks are excluded above and keep the ResourceProfile's taskCpus.
+              val effectiveCpus = if (oomRetryCpusIncrement.signum > 0) {
+                effectiveCpusFor(index, taskCpus)
+              } else {
+                taskCpus
+              }
               prepareLaunchingTask(
                 execId,
                 host,
                 index,
                 taskLocality,
                 speculative,
-                taskCpus,
+                effectiveCpus,
                 taskResourceAssignments,
                 curTime)
             }
@@ -875,6 +931,7 @@ private[spark] class TaskSetManager(
       // Mark successful and stop if all the tasks have succeeded.
       successful(index) = true
       numFailures(index) = 0
+      numOomRetries(index) = 0
       if (tasksSuccessful == numTasks) {
         isZombie = true
       }
@@ -967,6 +1024,7 @@ private[spark] class TaskSetManager(
         tasksSuccessful += 1
         successful(index) = true
         numFailures(index) = 0
+        numOomRetries(index) = 0
         if (tasksSuccessful == numTasks) {
           isZombie = true
         }
@@ -1046,6 +1104,13 @@ private[spark] class TaskSetManager(
           abort("Task %s in stage %s (TID %d) can not write to output file: %s".format(
             info.id, taskSet.id, tid, ef.description))
           return
+        }
+        // Grow the CPUs allocated to the retry of a task that failed with a (non-fatal)
+        // SparkOutOfMemoryError, so it runs with fewer concurrent tasks and a larger
+        // execution-memory share. Barrier tasks are excluded (uniform, gang-scheduled resources).
+        if (oomRetryCpusIncrement.signum > 0 && !isBarrier &&
+            ef.className == classOf[SparkOutOfMemoryError].getName) {
+          numOomRetries(index) += 1
         }
         val key = ef.description
         val now = clock.getTimeMillis()
@@ -1241,6 +1306,14 @@ private[spark] class TaskSetManager(
       }
     }
     val iter2 = taskIdsOnExec.iterator
+    // Whether the executor exited with an exit code treated as OOM
+    // (spark.task.oomRetryExecutorExitCodes). The exit code is only available here on the
+    // ExecutorLossReason; it is dropped by the ExecutorLostFailure passed to handleFailedTask
+    // below, so an OOM exit must be recognized (and pre-marked) at this point.
+    val isOomExit = reason match {
+      case ExecutorExited(exitCode, _, _) => oomRetryExecutorExitCodes.contains(exitCode)
+      case _ => false
+    }
     while (iter2.hasNext) {
       val tid = iter2.next()
       val info = taskInfos(tid)
@@ -1253,6 +1326,11 @@ private[spark] class TaskSetManager(
           // but Executor has not sent StatusUpdate(TaskState.RUNNING) to Driver. Hence, we assume
           // that the task is not running, and it is NetworkFailure rather than TaskFailure.
           case _ => !info.launching
+        }
+        // Grow the CPUs of the retry when a running task's executor died of a JVM heap OOM. See
+        // the SparkOutOfMemoryError branch in handleFailedTask for the non-fatal counterpart.
+        if (oomRetryCpusIncrement.signum > 0 && !isBarrier && isOomExit && exitCausedByApp) {
+          numOomRetries(info.index) += 1
         }
         handleFailedTask(tid, TaskState.FAILED, ExecutorLostFailure(info.executorId,
           exitCausedByApp, Some(reason.toString)))

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -136,19 +136,36 @@ private[spark] class TaskSetManager(
   // Executor exit codes treated as OOM (see spark.task.oomRetryExecutorExitCodes); when an
   // executor exits with one of these, the tasks it was running have their OOM retry count bumped.
   private val oomRetryExecutorExitCodes = conf.get(config.OOM_RETRY_EXECUTOR_EXIT_CODES).toSet
-  // The executor total cores of this TaskSet's ResourceProfile. A TaskSetManager is tied to a
-  // single ResourceProfile, so this is constant for its lifetime and caps the OOM retry cpus.
-  private val executorCoresLimit: Int = {
-    val rp = sched.sc.resourceProfileManager.resourceProfileFromId(taskSet.resourceProfileId)
-    rp.getExecutorCores.getOrElse(conf.get(EXECUTOR_CORES))
-  }
+  // The executor total cores that caps the OOM retry cpus, if known. A TaskSetManager is tied to
+  // a single ResourceProfile, so this is constant for its lifetime. It is taken from the
+  // ResourceProfile's executor cores, falling back to an explicitly configured
+  // spark.executor.cores (e.g. for a TaskResourceProfile whose tasks run on default-profile
+  // executors). It is None only when neither is set (e.g. Standalone / local-cluster without
+  // spark.executor.cores, where an executor uses the worker's available cores); in that case the
+  // OOM retry cpus are not capped here and the executor's actual free cpus at offer time still
+  // bound them (see oomRetryNeedsMoreCpus).
+  private val executorCoresLimit: Option[Int] =
+    sched.sc.resourceProfileManager
+      .resourceProfileFromId(taskSet.resourceProfileId)
+      .getExecutorCores
+      .orElse(conf.getOption(EXECUTOR_CORES.key).map(_.toInt))
 
   // The number of CPUs a retry of the given task should request, given the ResourceProfile's
   // base taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per
-  // OOM failure, capped at the executor total cores.
+  // The number of CPUs a retry of the given task should request, given the ResourceProfile's
+  // base taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per
+  // OOM failure, capped at the executor total cores when that is known. When the cap is unknown
+  // the request stays at baseCpus (no growth), so it can never exceed the executor's real capacity
+  // and become permanently unschedulable. BigDecimal arithmetic is exact; the result is floored at
+  // baseCpus and normalized, and is always in [baseCpus, cap].
   private def effectiveCpusFor(index: Int, baseCpus: BigDecimal): BigDecimal = {
     val requested = baseCpus + oomRetryCpusIncrement * numOomRetries(index)
-    CpuAmount.normalize(requested.min(BigDecimal(executorCoresLimit)))
+    val capped = executorCoresLimit match {
+      case Some(cap) => requested.min(BigDecimal(cap))
+      case None => baseCpus
+    }
+    CpuAmount.normalize(capped.max(baseCpus))
+  }
   }
 
   // Add the tid of task into this HashSet when the task is killed by other attempt tasks.
@@ -1105,11 +1122,14 @@ private[spark] class TaskSetManager(
             info.id, taskSet.id, tid, ef.description))
           return
         }
-        // Grow the CPUs allocated to the retry of a task that failed with a (non-fatal)
-        // SparkOutOfMemoryError, so it runs with fewer concurrent tasks and a larger
-        // execution-memory share. Barrier tasks are excluded (uniform, gang-scheduled resources).
-        if (oomRetryCpusIncrement.signum > 0 && !isBarrier &&
-            ef.className == classOf[SparkOutOfMemoryError].getName) {
+        // Grow the CPUs allocated to the retry of a task that failed out-of-memory: either a
+        // non-fatal SparkOutOfMemoryError (unable to acquire execution memory) or a fatal JVM
+        // heap OutOfMemoryError. A fatal heap OOM also kills the executor (exit code 52) whose
+        // ExecutorExited is handled in executorLost; the Executor sends this ExceptionFailure
+        // before it exits, so either event may reach the driver first. Whichever arrives first
+        // does the increment; the info.finished guard at the top of handleFailedTask makes the
+        // second a no-op, so there is no double counting.
+        if (oomRetryCpusIncrement.signum > 0 && !isBarrier && TaskSetManager.isOom(ef)) {
           numOomRetries(index) += 1
         }
         val key = ef.description
@@ -1583,6 +1603,17 @@ private[spark] object TaskSetManager {
   // Shared empty set used as default value for executorIdToTaskIds lookups
   // to avoid allocating a new empty set on each executorLost call.
   private val EMPTY_LONG_SET = new OpenHashSet[Long](0)
+
+  // Whether an ExceptionFailure represents an OutOfMemoryError: either a fatal JVM heap
+  // OutOfMemoryError or the non-fatal SparkOutOfMemoryError (which subclasses OutOfMemoryError).
+  // Prefers the preserved Throwable and falls back to the serialized class name, since the
+  // exception may not have been preserved (see ExceptionFailure preserveCause) and its class may
+  // not be loadable in the driver. Used by the spark.task.oomRetryCpusIncrement feature.
+  private def isOom(ef: ExceptionFailure): Boolean = {
+    ef.exception.exists(_.isInstanceOf[OutOfMemoryError]) ||
+      ef.className == classOf[OutOfMemoryError].getName ||
+      ef.className == classOf[SparkOutOfMemoryError].getName
+  }
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -152,8 +152,6 @@ private[spark] class TaskSetManager(
 
   // The number of CPUs a retry of the given task should request, given the ResourceProfile's
   // base taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per
-  // The number of CPUs a retry of the given task should request, given the ResourceProfile's
-  // base taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per
   // OOM failure, capped at the executor total cores when that is known. When the cap is unknown
   // the request stays at baseCpus (no growth), so it can never exceed the executor's real capacity
   // and become permanently unschedulable. BigDecimal arithmetic is exact; the result is floored at
@@ -165,7 +163,6 @@ private[spark] class TaskSetManager(
       case None => baseCpus
     }
     CpuAmount.normalize(capped.max(baseCpus))
-  }
   }
 
   // Add the tid of task into this HashSet when the task is killed by other attempt tasks.
@@ -568,9 +565,10 @@ private[spark] class TaskSetManager(
               // return null since the TaskDescription for the barrier task is not ready yet
               null
             } else {
-              // For an OOM retry, allocate extra CPUs (capped at the executor cores). dequeueTask
-              // guarantees effectiveCpus <= availCpus, so the scheduler's cpu bookkeeping is safe.
-              // Barrier tasks are excluded above and keep the ResourceProfile's taskCpus.
+              // For an OOM retry (numOomRetries > 0), allocate extra CPUs (capped at the executor
+              // cores). Such a retry is dequeued only when effectiveCpus <= availCpus (see
+              // oomRetryNeedsMoreCpus), so the scheduler's cpu bookkeeping is safe; a first attempt
+              // is never gated and keeps the base taskCpus. Barrier tasks are excluded above.
               val effectiveCpus = if (oomRetryCpusIncrement.signum > 0) {
                 effectiveCpusFor(index, taskCpus)
               } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -136,39 +136,40 @@ private[spark] class TaskSetManager(
   // Executor exit codes treated as OOM (see spark.task.oomRetryExecutorExitCodes); when an
   // executor exits with one of these, the tasks it was running have their OOM retry count bumped.
   private val oomRetryExecutorExitCodes = conf.get(config.OOM_RETRY_EXECUTOR_EXIT_CODES).toSet
-  // Max depth of the exception cause chain to search for an OutOfMemoryError when deciding whether
-  // a task failure is OOM (see TaskSetManager.isOom). Reuses spark.executor.killOnFatalError.depth,
-  // the same bound Executor.isFatalError uses to find a fatal error in a wrapped exception.
-  private val oomRetryCauseDepth = conf.get(config.KILL_ON_FATAL_ERROR_DEPTH)
-  // The executor total cores that caps the OOM retry cpus, if known. A TaskSetManager is tied to
-  // a single ResourceProfile, so this is constant for its lifetime. It is taken from the
-  // ResourceProfile's executor cores, falling back to an explicitly configured
-  // spark.executor.cores. It is None only when neither is set (e.g. Standalone / local-cluster
-  // without spark.executor.cores, or the generic default that does not reflect the real worker
-  // capacity). When the cap is unknown, the OOM retry does NOT grow its cpus (see
-  // effectiveCpusFor): growing without a real capacity bound risks requesting more cpus than the
-  // executor physically has, which oomRetryNeedsMoreCpus would then reject on every offer forever,
-  // starving the task so it never launches nor reaches maxTaskFailures.
-  private val executorCoresLimit: Option[Int] =
+  // The executor total cores from the TaskSet's ResourceProfile (or an explicitly configured
+  // spark.executor.cores), if known. This is a static upper bound, but it can exceed an
+  // executor's actual registered cores (e.g. Kubernetes OOM recovery registers spark.task.cpus
+  // cores, or local[N] differs from spark.executor.cores), so effectiveCpusFor also caps against
+  // the offer's actual total cores. None means neither is set.
+  private val profileCoresLimit: Option[Int] =
     sched.sc.resourceProfileManager
       .resourceProfileFromId(taskSet.resourceProfileId)
       .getExecutorCores
       .orElse(conf.getOption(EXECUTOR_CORES.key).map(_.toInt))
 
-  // The number of CPUs a retry of the given task should request, given the ResourceProfile's
-  // base taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per
-  // OOM failure, capped at the executor total cores when that is known. When the cap is unknown
-  // the request stays at baseCpus (no growth), so it can never exceed the executor's real capacity
-  // and become permanently unschedulable. BigDecimal arithmetic is exact; the result is floored at
-  // baseCpus and normalized, and is always in [baseCpus, cap].
-  private def effectiveCpusFor(index: Int, baseCpus: BigDecimal): BigDecimal = {
-    val requested = baseCpus + oomRetryCpusIncrement * numOomRetries(index)
-    val capped = executorCoresLimit match {
-      case Some(cap) => requested.min(BigDecimal(cap))
-      case None => baseCpus
+  // The number of CPUs a retry of the given task should request, given the ResourceProfile's base
+  // taskCpus. For a task that has failed with OOM, this grows by oomRetryCpusIncrement per OOM
+  // failure, capped at the executor's total cores. The cap is the min of the offer's actual
+  // registered total cores (offerTotalCores, or None when the offer does not supply it) and the
+  // ResourceProfile/configured cores (profileCoresLimit); capping against the actual registered
+  // total is what prevents a request larger than the executor can physically run, which
+  // oomRetryNeedsMoreCpus would otherwise reject on every offer forever, stranding the task so it
+  // never launches nor reaches maxTaskFailures. When no cap is known the request stays at baseCpus
+  // (no growth). BigDecimal arithmetic is exact; the result is floored at baseCpus and normalized,
+  // and is always in [baseCpus, cap].
+  private def effectiveCpusFor(
+      index: Int, baseCpus: BigDecimal, offerTotalCores: Option[Int]): BigDecimal = {
+    val cap = (offerTotalCores.toSeq ++ profileCoresLimit.toSeq) match {
+      case Seq() => None
+      case caps => Some(caps.min)
+    }
+    val capped = cap match {
+      case Some(c) => (baseCpus + oomRetryCpusIncrement * numOomRetries(index)).min(BigDecimal(c))
+      case None =>
+        // Unknown executor capacity: do not grow, to avoid an unschedulable over-request.
+        baseCpus
     }
     CpuAmount.normalize(capped.max(baseCpus))
-  }
   }
 
   // Add the tid of task into this HashSet when the task is killed by other attempt tasks.
@@ -377,7 +378,8 @@ private[spark] class TaskSetManager(
       list: ArrayBuffer[Int],
       speculative: Boolean = false,
       taskCpus: BigDecimal = sched.CPUS_PER_TASK,
-      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT): Option[Int] = {
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT,
+      offerTotalCores: Option[Int] = None): Option[Int] = {
     var indexOffset = list.size
     while (indexOffset > 0) {
       indexOffset -= 1
@@ -387,7 +389,7 @@ private[spark] class TaskSetManager(
       // rather than launching it with the same resources that already caused the OOM.
       if (!isTaskExcludededOnExecOrNode(index, execId, host) &&
           !(speculative && hasAttemptOnHost(index, host)) &&
-          !oomRetryNeedsMoreCpus(index, taskCpus, availCpus)) {
+          !oomRetryNeedsMoreCpus(index, taskCpus, availCpus, offerTotalCores)) {
         // This should almost always be list.trimEnd(1) to remove tail
         list.remove(indexOffset)
         // Speculatable task should only be launched when at most one copy of the
@@ -407,10 +409,11 @@ private[spark] class TaskSetManager(
   // Whether the given task is an OOM retry that requires more CPUs than the offer has free, in
   // which case dequeue should skip it and wait for an offer with enough CPUs (see
   // spark.task.oomRetryCpusIncrement). Barrier tasks never use the increment.
-  private def oomRetryNeedsMoreCpus(index: Int, taskCpus: BigDecimal, availCpus: BigDecimal)
-      : Boolean = {
+  private def oomRetryNeedsMoreCpus(
+      index: Int, taskCpus: BigDecimal, availCpus: BigDecimal,
+      offerTotalCores: Option[Int]): Boolean = {
     oomRetryCpusIncrement.signum > 0 && !isBarrier && numOomRetries(index) > 0 &&
-      effectiveCpusFor(index, taskCpus) > availCpus
+      effectiveCpusFor(index, taskCpus, offerTotalCores) > availCpus
   }
 
   /** Check whether a task once ran an attempt on a given host */
@@ -436,11 +439,13 @@ private[spark] class TaskSetManager(
       host: String,
       maxLocality: TaskLocality.Value,
       taskCpus: BigDecimal = sched.CPUS_PER_TASK,
-      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT): Option[(Int, TaskLocality.Value, Boolean)] = {
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT,
+      offerTotalCores: Option[Int] = None): Option[(Int, TaskLocality.Value, Boolean)] = {
     // Tries to schedule a regular task first; if it returns None, then schedules
     // a speculative task
-    dequeueTaskHelper(execId, host, maxLocality, false, taskCpus, availCpus).orElse(
-      dequeueTaskHelper(execId, host, maxLocality, true, taskCpus, availCpus))
+    dequeueTaskHelper(execId, host, maxLocality, false, taskCpus, availCpus, offerTotalCores)
+      .orElse(
+        dequeueTaskHelper(execId, host, maxLocality, true, taskCpus, availCpus, offerTotalCores))
   }
 
   protected def dequeueTaskHelper(
@@ -449,14 +454,15 @@ private[spark] class TaskSetManager(
       maxLocality: TaskLocality.Value,
       speculative: Boolean,
       taskCpus: BigDecimal = sched.CPUS_PER_TASK,
-      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT)
-      : Option[(Int, TaskLocality.Value, Boolean)] = {
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT,
+      offerTotalCores: Option[Int] = None): Option[(Int, TaskLocality.Value, Boolean)] = {
     if (speculative && speculatableTasks.isEmpty) {
       return None
     }
     val pendingTaskSetToUse = if (speculative) pendingSpeculatableTasks else pendingTasks
     def dequeue(list: ArrayBuffer[Int]): Option[Int] = {
-      val task = dequeueTaskFromList(execId, host, list, speculative, taskCpus, availCpus)
+      val task = dequeueTaskFromList(
+        execId, host, list, speculative, taskCpus, availCpus, offerTotalCores)
       if (speculative && task.isDefined) {
         speculatableTasks -= task.get
       }
@@ -519,6 +525,9 @@ private[spark] class TaskSetManager(
    * @param taskResourceAssignments the resource assignments for the task
    * @param availCpus the number of CPUs currently free on the offered executor, used to enforce
    *                  the strict-wait policy for OOM retries (see spark.task.oomRetryCpusIncrement)
+   * @param offerTotalCores the offered executor's actual registered total cores, used to cap the
+   *                        OOM retry cpus at what the executor can physically run; None when the
+   *                        offer does not supply it
    *
    * @return Triple containing:
    *         (TaskDescription of launched task if any,
@@ -532,7 +541,8 @@ private[spark] class TaskSetManager(
       maxLocality: TaskLocality.TaskLocality,
       taskCpus: BigDecimal = sched.CPUS_PER_TASK,
       taskResourceAssignments: Map[String, Map[String, Long]] = Map.empty,
-      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT)
+      availCpus: BigDecimal = CpuAmount.MAX_AMOUNT,
+      offerTotalCores: Option[Int] = None)
     : (Option[TaskDescription], Boolean, Int) =
   {
     val offerExcluded = taskSetExcludelistHelperOpt.exists { excludeList =>
@@ -554,7 +564,7 @@ private[spark] class TaskSetManager(
 
       var dequeuedTaskIndex: Option[Int] = None
       val taskDescription =
-        dequeueTask(execId, host, allowedLocality, taskCpus, availCpus)
+        dequeueTask(execId, host, allowedLocality, taskCpus, availCpus, offerTotalCores)
           .map { case (index, taskLocality, speculative) =>
             dequeuedTaskIndex = Some(index)
             if (legacyLocalityWaitReset && maxLocality != TaskLocality.NO_PREF) {
@@ -576,7 +586,7 @@ private[spark] class TaskSetManager(
               // oomRetryNeedsMoreCpus), so the scheduler's cpu bookkeeping is safe; a first attempt
               // is never gated and keeps the base taskCpus. Barrier tasks are excluded above.
               val effectiveCpus = if (oomRetryCpusIncrement.signum > 0) {
-                effectiveCpusFor(index, taskCpus)
+                effectiveCpusFor(index, taskCpus, offerTotalCores)
               } else {
                 taskCpus
               }
@@ -1134,8 +1144,7 @@ private[spark] class TaskSetManager(
         // Executor sends this ExceptionFailure before it exits, so either event may reach the
         // driver first. Whichever arrives first does the increment; the info.finished guard at the
         // top of handleFailedTask makes the second a no-op, so there is no double counting.
-        if (oomRetryCpusIncrement.signum > 0 && !isBarrier &&
-            TaskSetManager.isOom(ef, oomRetryCauseDepth)) {
+        if (oomRetryCpusIncrement.signum > 0 && !isBarrier && TaskSetManager.isOom(ef)) {
           numOomRetries(index) += 1
         }
         val key = ef.description
@@ -1610,22 +1619,26 @@ private[spark] object TaskSetManager {
   // to avoid allocating a new empty set on each executorLost call.
   private val EMPTY_LONG_SET = new OpenHashSet[Long](0)
 
+  // Max depth of the exception cause chain searched for a wrapped OutOfMemoryError in isOom. This
+  // is independent of spark.executor.killOnFatalError.depth (which the executor uses to decide
+  // whether to kill the JVM, and which may be set to 0 to disable that search): a top-level OOM is
+  // always classified regardless of this depth, and this only bounds how far a wrapped OOM (e.g.
+  // the SparkException from FileFormatDataWriter.enrichWriteError) is unwrapped, also guarding
+  // against a cause cycle.
+  private val OOM_CAUSE_SEARCH_DEPTH = 5
+
   // Whether an ExceptionFailure represents an OutOfMemoryError: either a fatal JVM heap
   // OutOfMemoryError or the non-fatal SparkOutOfMemoryError (which subclasses OutOfMemoryError),
   // possibly wrapped in another exception (e.g. FileFormatDataWriter.enrichWriteError wraps the
-  // cause in a SparkException). When the throwable is preserved, walk a bounded cause chain the
-  // way Executor.isFatalError does (depthToCheck bounds the walk and guards against a cause
-  // cycle). Otherwise fall back to the top-level serialized class name, which is always present
-  // even when the throwable could not be preserved or is not loadable in the driver; a wrapped
-  // OOM whose throwable was dropped cannot be recognized from the class name alone, which is an
-  // accepted limitation of the fallback.
-  private def isOom(ef: ExceptionFailure, depthToCheck: Int): Boolean = {
-    ef.exception match {
-      case Some(t) => causedByOom(t, depthToCheck)
-      case None =>
-        ef.className == classOf[OutOfMemoryError].getName ||
-          ef.className == classOf[SparkOutOfMemoryError].getName
-    }
+  // cause in a SparkException). A top-level OOM is recognized unconditionally, from the preserved
+  // throwable or, when it was not preserved, from the serialized class name. A wrapped OOM is
+  // recognized only when the throwable is preserved, by walking a bounded cause chain; a wrapped
+  // OOM whose throwable was dropped cannot be recognized from the top-level class name alone,
+  // which is an accepted limitation of the fallback.
+  private def isOom(ef: ExceptionFailure): Boolean = {
+    ef.className == classOf[OutOfMemoryError].getName ||
+      ef.className == classOf[SparkOutOfMemoryError].getName ||
+      ef.exception.exists(causedByOom(_, OOM_CAUSE_SEARCH_DEPTH))
   }
 
   @scala.annotation.tailrec

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -136,14 +136,19 @@ private[spark] class TaskSetManager(
   // Executor exit codes treated as OOM (see spark.task.oomRetryExecutorExitCodes); when an
   // executor exits with one of these, the tasks it was running have their OOM retry count bumped.
   private val oomRetryExecutorExitCodes = conf.get(config.OOM_RETRY_EXECUTOR_EXIT_CODES).toSet
+  // Max depth of the exception cause chain to search for an OutOfMemoryError when deciding whether
+  // a task failure is OOM (see TaskSetManager.isOom). Reuses spark.executor.killOnFatalError.depth,
+  // the same bound Executor.isFatalError uses to find a fatal error in a wrapped exception.
+  private val oomRetryCauseDepth = conf.get(config.KILL_ON_FATAL_ERROR_DEPTH)
   // The executor total cores that caps the OOM retry cpus, if known. A TaskSetManager is tied to
   // a single ResourceProfile, so this is constant for its lifetime. It is taken from the
   // ResourceProfile's executor cores, falling back to an explicitly configured
-  // spark.executor.cores (e.g. for a TaskResourceProfile whose tasks run on default-profile
-  // executors). It is None only when neither is set (e.g. Standalone / local-cluster without
-  // spark.executor.cores, where an executor uses the worker's available cores); in that case the
-  // OOM retry cpus are not capped here and the executor's actual free cpus at offer time still
-  // bound them (see oomRetryNeedsMoreCpus).
+  // spark.executor.cores. It is None only when neither is set (e.g. Standalone / local-cluster
+  // without spark.executor.cores, or the generic default that does not reflect the real worker
+  // capacity). When the cap is unknown, the OOM retry does NOT grow its cpus (see
+  // effectiveCpusFor): growing without a real capacity bound risks requesting more cpus than the
+  // executor physically has, which oomRetryNeedsMoreCpus would then reject on every offer forever,
+  // starving the task so it never launches nor reaches maxTaskFailures.
   private val executorCoresLimit: Option[Int] =
     sched.sc.resourceProfileManager
       .resourceProfileFromId(taskSet.resourceProfileId)
@@ -163,6 +168,7 @@ private[spark] class TaskSetManager(
       case None => baseCpus
     }
     CpuAmount.normalize(capped.max(baseCpus))
+  }
   }
 
   // Add the tid of task into this HashSet when the task is killed by other attempt tasks.
@@ -1122,12 +1128,14 @@ private[spark] class TaskSetManager(
         }
         // Grow the CPUs allocated to the retry of a task that failed out-of-memory: either a
         // non-fatal SparkOutOfMemoryError (unable to acquire execution memory) or a fatal JVM
-        // heap OutOfMemoryError. A fatal heap OOM also kills the executor (exit code 52) whose
-        // ExecutorExited is handled in executorLost; the Executor sends this ExceptionFailure
-        // before it exits, so either event may reach the driver first. Whichever arrives first
-        // does the increment; the info.finished guard at the top of handleFailedTask makes the
-        // second a no-op, so there is no double counting.
-        if (oomRetryCpusIncrement.signum > 0 && !isBarrier && TaskSetManager.isOom(ef)) {
+        // heap OutOfMemoryError, including when either is wrapped in another exception (e.g. the
+        // SparkException from FileFormatDataWriter.enrichWriteError). A fatal heap OOM also kills
+        // the executor (exit code 52) whose ExecutorExited is handled in executorLost; the
+        // Executor sends this ExceptionFailure before it exits, so either event may reach the
+        // driver first. Whichever arrives first does the increment; the info.finished guard at the
+        // top of handleFailedTask makes the second a no-op, so there is no double counting.
+        if (oomRetryCpusIncrement.signum > 0 && !isBarrier &&
+            TaskSetManager.isOom(ef, oomRetryCauseDepth)) {
           numOomRetries(index) += 1
         }
         val key = ef.description
@@ -1603,14 +1611,34 @@ private[spark] object TaskSetManager {
   private val EMPTY_LONG_SET = new OpenHashSet[Long](0)
 
   // Whether an ExceptionFailure represents an OutOfMemoryError: either a fatal JVM heap
-  // OutOfMemoryError or the non-fatal SparkOutOfMemoryError (which subclasses OutOfMemoryError).
-  // Prefers the preserved Throwable and falls back to the serialized class name, since the
-  // exception may not have been preserved (see ExceptionFailure preserveCause) and its class may
-  // not be loadable in the driver. Used by the spark.task.oomRetryCpusIncrement feature.
-  private def isOom(ef: ExceptionFailure): Boolean = {
-    ef.exception.exists(_.isInstanceOf[OutOfMemoryError]) ||
-      ef.className == classOf[OutOfMemoryError].getName ||
-      ef.className == classOf[SparkOutOfMemoryError].getName
+  // OutOfMemoryError or the non-fatal SparkOutOfMemoryError (which subclasses OutOfMemoryError),
+  // possibly wrapped in another exception (e.g. FileFormatDataWriter.enrichWriteError wraps the
+  // cause in a SparkException). When the throwable is preserved, walk a bounded cause chain the
+  // way Executor.isFatalError does (depthToCheck bounds the walk and guards against a cause
+  // cycle). Otherwise fall back to the top-level serialized class name, which is always present
+  // even when the throwable could not be preserved or is not loadable in the driver; a wrapped
+  // OOM whose throwable was dropped cannot be recognized from the class name alone, which is an
+  // accepted limitation of the fallback.
+  private def isOom(ef: ExceptionFailure, depthToCheck: Int): Boolean = {
+    ef.exception match {
+      case Some(t) => causedByOom(t, depthToCheck)
+      case None =>
+        ef.className == classOf[OutOfMemoryError].getName ||
+          ef.className == classOf[SparkOutOfMemoryError].getName
+    }
+  }
+
+  @scala.annotation.tailrec
+  private def causedByOom(t: Throwable, depthToCheck: Int): Boolean = {
+    if (depthToCheck <= 0) {
+      false
+    } else {
+      t match {
+        case _: OutOfMemoryError => true
+        case e if e.getCause != null => causedByOom(e.getCause, depthToCheck - 1)
+        case _ => false
+      }
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/WorkerOffer.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/WorkerOffer.scala
@@ -31,4 +31,13 @@ case class WorkerOffer(
     // when multiple executors are launched on the same host.
     address: Option[String] = None,
     resources: ExecutorResourcesAmounts = ExecutorResourcesAmounts.empty,
-    resourceProfileId: Int = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
+    resourceProfileId: Int = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID,
+    // The executor's actual registered total cores (the `--cores` it registered with), which can
+    // be smaller than the cores declared by the ResourceProfile or spark.executor.cores. For
+    // example, Kubernetes OOM recovery deliberately registers a recovered executor with only
+    // spark.task.cpus cores so it runs a single task at a time, and local[N] may use a different N
+    // than spark.executor.cores. Used to cap the OOM retry cpus at what the executor can actually
+    // run, so a retry can never request more cores than exist and become permanently unschedulable
+    // (see spark.task.oomRetryCpusIncrement). Defaults to -1 (unset), which the scheduler treats
+    // as "no known total" (no cap from this field).
+    totalCores: Int = -1)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -392,7 +392,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         executorData.freeCores,
         Some(executorData.executorAddress.hostPort),
         resources,
-        executorData.resourceProfileId)
+        executorData.resourceProfileId,
+        executorData.totalCores)
     }
 
     override def onDisconnected(remoteAddress: RpcAddress): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -105,7 +105,7 @@ private[spark] class LocalEndpoint(
   def reviveOffers(): Unit = {
     // local mode doesn't support extra resources like GPUs right now
     val offers = IndexedSeq(new WorkerOffer(localExecutorId, localExecutorHostname, freeCores,
-      Some(rpcEnv.address.hostPort)))
+      Some(rpcEnv.address.hostPort), totalCores = totalCores))
     for (task <- scheduler.resourceOffers(offers, true).flatten) {
       freeCores -= task.cpus
       runningTaskCpus(task.taskId) = task.cpus

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -21,6 +21,8 @@ import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
 
+import scala.collection.mutable
+
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv, TaskState}
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -59,6 +61,12 @@ private[spark] class LocalEndpoint(
 
   private var freeCores: BigDecimal = CpuAmount.normalize(BigDecimal(totalCores))
 
+  // The actual number of cpus charged for each launched task, so that completion refunds exactly
+  // what launch charged. An OOM retry (see spark.task.oomRetryCpusIncrement) can use more than
+  // CPUS_PER_TASK, and the StatusUpdate message carries only the task id, so a fixed refund of
+  // CPUS_PER_TASK would leak or double-count cores and let the local executor be oversubscribed.
+  private val runningTaskCpus = new mutable.HashMap[Long, BigDecimal]()
+
   val localExecutorId = SparkContext.DRIVER_IDENTIFIER
   val localExecutorHostname = Utils.localCanonicalHostName()
 
@@ -74,7 +82,7 @@ private[spark] class LocalEndpoint(
     case StatusUpdate(taskId, state, serializedData) =>
       scheduler.statusUpdate(taskId, state, serializedData)
       if (TaskState.isFinished(state)) {
-        freeCores += scheduler.CPUS_PER_TASK
+        freeCores += runningTaskCpus.remove(taskId).getOrElse(scheduler.CPUS_PER_TASK)
         reviveOffers()
       }
 
@@ -99,7 +107,8 @@ private[spark] class LocalEndpoint(
     val offers = IndexedSeq(new WorkerOffer(localExecutorId, localExecutorHostname, freeCores,
       Some(rpcEnv.address.hostPort)))
     for (task <- scheduler.resourceOffers(offers, true).flatten) {
-      freeCores -= scheduler.CPUS_PER_TASK
+      freeCores -= task.cpus
+      runningTaskCpus(task.taskId) = task.cpus
       executor.launchTask(executorBackend, task)
     }
   }

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -19,8 +19,9 @@ package org.apache.spark
 
 import java.io.{IOException, NotSerializableException, ObjectInputStream}
 
+import org.apache.spark.internal.config
 import org.apache.spark.internal.config.UNSAFE_EXCEPTION_ON_MEMORY_LEAK
-import org.apache.spark.memory.TestMemoryConsumer
+import org.apache.spark.memory.{SparkOutOfMemoryError, TestMemoryConsumer}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.NonSerializable
 
@@ -262,6 +263,36 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
         throw new LinkageError()
         // scalastyle:on throwerror
       }
+    }
+  }
+
+  test("SPARK-58187: local backend accounts for the increased cpus of an OOM retry") {
+    // With the OOM cpus increment enabled, a retry uses more cpus than spark.task.cpus. The local
+    // backend must charge and refund the task's actual cpus (not the fixed CPUS_PER_TASK), or it
+    // would advertise phantom cores / oversubscribe and the job could deadlock or run extra tasks.
+    // Exercise the real LocalSchedulerBackend end to end: the first attempt of each task OOMs, the
+    // retry needs 2 cpus, and the whole job must still complete.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local[4,2]", "test", conf)
+    FailureSuiteState.clear()
+    val results = sc.makeRDD(1 to 4, 4).map { x =>
+      val failFirstAttempt = FailureSuiteState.synchronized {
+        FailureSuiteState.tasksRun += 1
+        TaskContext.get().attemptNumber() == 0
+      }
+      if (failFirstAttempt) {
+        throw new SparkOutOfMemoryError(
+          "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String])
+      }
+      x * x
+    }.collect()
+    assert(results.toSet === Set(1, 4, 9, 16))
+    // 4 first attempts (all OOM) + 4 successful retries.
+    FailureSuiteState.synchronized {
+      assert(FailureSuiteState.tasksRun === 8)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -292,7 +292,11 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
       x * x
     }.collect()
     assert(results.toSet === Set(1, 4, 9, 16))
-    // 4 first attempts (all OOM) + 4 successful retries.
+    // Each task runs exactly twice regardless of scheduling order: attempt 0 always OOMs and
+    // attempt 1 always succeeds (maxFailures = 2 caps it there). So the total is a deterministic
+    // 4 * 2 = 8. The exact count is the assertion that matters here: fewer would mean a retry was
+    // lost or deadlocked on a phantom core, more would mean the executor was oversubscribed and
+    // ran a duplicate attempt.
     FailureSuiteState.synchronized {
       assert(FailureSuiteState.tasksRun === 8)
     }

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -284,8 +284,10 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
         TaskContext.get().attemptNumber() == 0
       }
       if (failFirstAttempt) {
+        // scalastyle:off throwerror
         throw new SparkOutOfMemoryError(
           "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String])
+        // scalastyle:on throwerror
       }
       x * x
     }.collect()

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -302,6 +302,37 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  test("SPARK-58187: OOM retry is capped at the actual registered cores, not configured cores") {
+    // spark.executor.cores (4) exceeds the local backend's actual total cores (local[2,...] = 2).
+    // With increment 2, base+increment = 3 would exceed the real capacity of 2 and, if capped only
+    // at the configured 4, the retry would be rejected on every offer forever (never launching nor
+    // reaching maxFailures). Capping at the offer's actual registered total (2) lets it complete.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local[2,2]", "test", conf)
+    FailureSuiteState.clear()
+    val results = sc.makeRDD(1 to 2, 2).map { x =>
+      val failFirstAttempt = FailureSuiteState.synchronized {
+        FailureSuiteState.tasksRun += 1
+        TaskContext.get().attemptNumber() == 0
+      }
+      if (failFirstAttempt) {
+        // scalastyle:off throwerror
+        throw new SparkOutOfMemoryError(
+          "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String])
+        // scalastyle:on throwerror
+      }
+      x * x
+    }.collect()
+    assert(results.toSet === Set(1, 4))
+    // 2 tasks * 2 attempts = 4; a strand would hang the job (and time out) rather than reach here.
+    FailureSuiteState.synchronized {
+      assert(FailureSuiteState.tasksRun === 4)
+    }
+  }
+
   // TODO: Need to add tests with shuffle fetch failures.
 }
 

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -273,8 +273,8 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
     // Exercise the real LocalSchedulerBackend end to end: the first attempt of each task OOMs, the
     // retry needs 2 cpus, and the whole job must still complete.
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local[4,2]", "test", conf)
     FailureSuiteState.clear()
@@ -308,8 +308,8 @@ class FailureSuite extends SparkFunSuite with LocalSparkContext {
     // at the configured 4, the retry would be rejected on every offer forever (never launching nor
     // reaching maxFailures). Capping at the offer's actual registered total (2) lets it complete.
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(2))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local[2,2]", "test", conf)
     FailureSuiteState.clear()

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -115,9 +115,11 @@ class OutputCommitCoordinatorSuite extends SparkFunSuite with BeforeAndAfter {
             locality: TaskLocality.Value,
             speculative: Boolean,
             taskCpus: BigDecimal,
-            availCpus: BigDecimal): Option[(Int, TaskLocality.Value, Boolean)] = {
+            availCpus: BigDecimal,
+            offerTotalCores: Option[Int]): Option[(Int, TaskLocality.Value, Boolean)] = {
           if (!speculative) {
-            super.dequeueTaskHelper(execId, host, locality, speculative, taskCpus, availCpus)
+            super.dequeueTaskHelper(
+              execId, host, locality, speculative, taskCpus, availCpus, offerTotalCores)
           } else if (hasDequeuedSpeculatedTask) {
             None
           } else {

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -113,9 +113,11 @@ class OutputCommitCoordinatorSuite extends SparkFunSuite with BeforeAndAfter {
             execId: String,
             host: String,
             locality: TaskLocality.Value,
-            speculative: Boolean): Option[(Int, TaskLocality.Value, Boolean)] = {
+            speculative: Boolean,
+            taskCpus: BigDecimal,
+            availCpus: BigDecimal): Option[(Int, TaskLocality.Value, Boolean)] = {
           if (!speculative) {
-            super.dequeueTaskHelper(execId, host, locality, speculative)
+            super.dequeueTaskHelper(execId, host, locality, speculative, taskCpus, availCpus)
           } else if (hasDequeuedSpeculatedTask) {
             None
           } else {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -35,6 +35,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark._
 import org.apache.spark.internal.config
+import org.apache.spark.memory.SparkOutOfMemoryError
 import org.apache.spark.resource.{CpuAmount, ExecutorResourceRequests, ResourceAmountUtils, ResourceProfile, TaskResourceProfile, TaskResourceRequests}
 import org.apache.spark.resource.ResourceAmountUtils.ONE_ENTIRE_RESOURCE
 import org.apache.spark.resource.ResourceUtils._
@@ -2286,6 +2287,42 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
 
   private implicit def toInternalResource(resources: Map[String, Double]): Map[String, Long] =
     resources.map { case (k, v) => k -> ResourceAmountUtils.toInternalResource(v) }
+
+  test("SPARK-58187: availableCpus accounts for the increased cpus of an OOM retry") {
+    val taskScheduler = setupSchedulerWithMaster(
+      "local[4]",
+      config.OOM_RETRY_CPUS_INCREMENT.key -> "1",
+      config.CPUS_PER_TASK.key -> "1",
+      config.EXECUTOR_CORES.key -> "4")
+
+    val taskSet = FakeTask.createTaskSet(2)
+    taskScheduler.submitTasks(taskSet)
+    val tsm = taskScheduler.taskSetManagerForAttempt(taskSet.stageId, taskSet.stageAttemptId).get
+
+    // Launch both tasks on a 4-core executor.
+    val first = taskScheduler.resourceOffers(
+      IndexedSeq(new WorkerOffer("executor0", "host0", 4))).flatten
+    assert(first.length === 2)
+    assert(first.forall(_.cpus === 1))
+
+    // OOM-fail task 0 so its retry needs 2 cpus.
+    val oom = new ExceptionFailure(
+      new SparkOutOfMemoryError(
+        "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String]),
+      Seq.empty[AccumulableInfo])
+    val task0 = first.minBy(_.index)
+    failTask(task0.taskId, TaskState.FAILED, oom, tsm)
+
+    // Re-offer a 4-core executor. The retry launches with 2 cpus, and the scheduler decrements
+    // availableCpus by 2 (assert(availableCpus >= 0) must hold), verifying the bookkeeping uses
+    // the TaskDescription's actual cpus rather than the ResourceProfile default.
+    val retryDescs = taskScheduler.resourceOffers(
+      IndexedSeq(new WorkerOffer("executor0", "host0", 4))).flatten
+    assert(retryDescs.length === 1)
+    assert(retryDescs.head.index === 0)
+    assert(retryDescs.head.cpus === 2)
+    assert(!failedTaskSet)
+  }
 
   // 1 executor with 4 GPUS
   Seq(true, false).foreach { barrierMode =>

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config.Tests.{SKIP_VALIDATE_CORES_TESTING, TEST_DYNAMIC_ALLOCATION_SCHEDULE_ENABLED}
+import org.apache.spark.memory.SparkOutOfMemoryError
 import org.apache.spark.resource.ResourceAmountUtils.ONE_ENTIRE_RESOURCE
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.resource.ResourceUtils._
@@ -45,7 +46,7 @@ import org.apache.spark.resource.TestResourceIDs._
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.{AccumulatorV2, Clock, ManualClock, SystemClock}
+import org.apache.spark.util.{AccumulatorV2, Clock, ManualClock, SparkExitCode, SystemClock}
 import org.apache.spark.util.ArrayImplicits._
 
 class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
@@ -2377,6 +2378,300 @@ class TaskSetManagerSuite
       Seq.empty[AccumulableInfo])
     manager.handleFailedTask(offerResult.get.taskId, TaskState.FAILED, reason)
     assert(sched.taskSetsFailed.contains(taskSet.id))
+  }
+
+  private def numOomRetriesOf(manager: TaskSetManager): Array[Int] = {
+    val field = classOf[TaskSetManager].getDeclaredField("numOomRetries")
+    field.setAccessible(true)
+    field.get(manager).asInstanceOf[Array[Int]]
+  }
+
+  private def oomExceptionFailure: ExceptionFailure = {
+    new ExceptionFailure(
+      new SparkOutOfMemoryError(
+        "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String]),
+      Seq.empty[AccumulableInfo])
+  }
+
+  test("SPARK-58187: OOM retry cpus increment disabled by default (zero regression)") {
+    sc = new SparkContext("local", "test")
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // Fail the task with OOM a couple of times; with the feature disabled numOomRetries stays 0
+    // and each retry keeps the default cpus.
+    (0 until 2).foreach { _ =>
+      val taskOption = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+      assert(taskOption.isDefined)
+      assert(taskOption.get.cpus === sched.CPUS_PER_TASK)
+      manager.handleFailedTask(taskOption.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    }
+    assert(numOomRetriesOf(manager)(0) === 0)
+  }
+
+  test("SPARK-58187: disabled increment short-circuits the executor OOM exit-code path") {
+    // Feature disabled (default 0) but an OOM exit code is offered: numOomRetries must stay 0.
+    sc = new SparkContext("local", "test")
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    manager.executorLost(
+      "exec1", "host1", ExecutorExited(SparkExitCode.OOM, exitCausedByApp = true))
+    assert(numOomRetriesOf(manager)(0) === 0)
+  }
+
+  test("SPARK-58187: repeated OOM failures still abort the task set at maxTaskFailures") {
+    // OOM failures count towards numFailures, so the existing maxTaskFailures cap still bounds
+    // the number of retries (and thus the growth of the requested cpus).
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    (0 until MAX_TASK_FAILURES).foreach { _ =>
+      val taskOption = manager.resourceOffer("exec1", "host1", ANY, availCpus = 8)._1
+      assert(taskOption.isDefined)
+      manager.handleFailedTask(taskOption.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    }
+    assert(sched.taskSetsFailed.contains(taskSet.id))
+  }
+
+  test("SPARK-58187: SparkOutOfMemoryError increments numOomRetries when enabled") {
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val first = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(first.isDefined)
+    manager.handleFailedTask(first.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 1)
+
+    val second = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(second.isDefined)
+    manager.handleFailedTask(second.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 2)
+  }
+
+  test("SPARK-58187: OOM retry task is allocated increasing cpus") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // First attempt: base cpus.
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined && a0.get.cpus === 1)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // First OOM retry: 1 + 1 * 1 = 2 cpus.
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a1.isDefined && a1.get.cpus === 2)
+    manager.handleFailedTask(a1.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // Second OOM retry: 1 + 1 * 2 = 3 cpus.
+    val a2 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a2.isDefined && a2.get.cpus === 3)
+  }
+
+  test("SPARK-58187: OOM retry waits when the offer has too few free cpus (strict)") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined && a0.get.cpus === 1)
+    // OOM once: the retry needs 1 + 2 * 1 = 3 cpus.
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // Only 2 free cpus: the retry must wait, so no task is launched.
+    assert(manager.resourceOffer("exec1", "host1", ANY, availCpus = 2)._1.isEmpty)
+    assert(numOomRetriesOf(manager)(0) === 1)
+
+    // 3 free cpus: the retry launches with 3 cpus.
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 3)._1
+    assert(a1.isDefined && a1.get.cpus === 3)
+  }
+
+  test("SPARK-58187: OOM retry does not starve a normal task on the same executor") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(2)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // Launch and OOM-fail task 0 so its retry needs 3 cpus.
+    val t0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(t0.isDefined && t0.get.index === 0)
+    manager.handleFailedTask(t0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // With only 2 free cpus, task 0's retry is skipped but the normal task 1 still launches.
+    val next = manager.resourceOffer("exec1", "host1", ANY, availCpus = 2)._1
+    assert(next.isDefined && next.get.index === 1 && next.get.cpus === 1)
+  }
+
+  test("SPARK-58187: OOM retry cpus are capped at executor cores") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 10)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    // OOM once: request is 1 + 10 = 11, but capped at executor cores = 4.
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // 3 free cpus is below the capped requirement (4): must wait.
+    assert(manager.resourceOffer("exec1", "host1", ANY, availCpus = 3)._1.isEmpty)
+    // 4 free cpus: launches with the capped 4 cpus.
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a1.isDefined && a1.get.cpus === 4)
+  }
+
+  test("SPARK-58187: numOomRetries is reset when the task succeeds") {
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 1)
+
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a1.isDefined)
+    manager.handleSuccessfulTask(a1.get.taskId, createTaskResult(0))
+    assert(numOomRetriesOf(manager)(0) === 0)
+  }
+
+  test("SPARK-58187: JVM heap OOM via ExecutorLostFailure increments numOomRetries") {
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    // Driver receives StatusUpdate(RUNNING), so the task is running (not just launching).
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    // The executor died of an OutOfMemoryError while the task was running.
+    manager.executorLost(
+      "exec1", "host1", ExecutorExited(SparkExitCode.OOM, exitCausedByApp = true))
+    assert(numOomRetriesOf(manager)(0) === 1)
+  }
+
+  test("SPARK-58187: non-OOM executor exit codes do not increment numOomRetries") {
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    // -104 is not in the default oomRetryExecutorExitCodes (only 52), so it must not be OOM.
+    manager.executorLost("exec1", "host1", ExecutorExited(-104, exitCausedByApp = true))
+    assert(numOomRetriesOf(manager)(0) === 0)
+  }
+
+  test("SPARK-58187: custom oomRetryExecutorExitCodes are honored (YARN memory-limit codes)") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+      .set(config.OOM_RETRY_EXECUTOR_EXIT_CODES, Seq(SparkExitCode.OOM, -103, -104))
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    // -104 (YARN physical memory exceeded) is now configured as an OOM exit code.
+    manager.executorLost("exec1", "host1", ExecutorExited(-104, exitCausedByApp = true))
+    assert(numOomRetriesOf(manager)(0) === 1)
+  }
+
+  test("SPARK-58187: barrier stage does not get the OOM cpus increment") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createBarrierTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // Barrier tasks return Some(null) from resourceOffer (the real launch is deferred to
+    // TaskSchedulerImpl). Materialize the launch the way TaskSchedulerImpl does, then OOM-fail it
+    // and verify numOomRetries is not incremented (the feature does not apply to barrier stages).
+    val (taskOption, _, index) = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)
+    assert(taskOption.isDefined && taskOption.get == null && index === 0)
+    val desc = manager.prepareLaunchingTask(
+      "exec1", "host1", index, TaskLocality.ANY, speculative = false,
+      taskCpus = sched.CPUS_PER_TASK, taskResourceAssignments = Map.empty,
+      launchTime = 0)
+    manager.handleFailedTask(desc.taskId, TaskState.FAILED, oomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 0)
+  }
+
+  test("SPARK-58187: speculative copy of an OOM-retried task uses the same increased cpus") {
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 8)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // OOM-fail index 0 twice so numOomRetries(0) == 2. The third attempt then requests
+    // 1 + 2 * 2 = 5 cpus.
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 8)._1
+    assert(a0.isDefined && a0.get.cpus === 1)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 8)._1
+    assert(a1.isDefined && a1.get.cpus === 3)
+    manager.handleFailedTask(a1.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // Launch the third (OOM-retry) attempt and keep it running.
+    val a2 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 8)._1
+    assert(a2.isDefined && a2.get.cpus === 5)
+    assert(numOomRetriesOf(manager)(0) === 2)
+
+    // Mark index 0 speculatable while its retry is still running, then dequeue the speculative
+    // copy on a different host. It must request the same 5 cpus as the running OOM retry.
+    manager.speculatableTasks += 0
+    manager.addPendingTask(0, speculatable = true)
+    val spec = manager.resourceOffer("exec2", "host2", ANY, availCpus = 8)._1
+    assert(spec.isDefined && spec.get.index === 0)
+    assert(spec.get.cpus === 5)
   }
 
   test("SPARK-30359: don't clean executorsPendingToRemove " +

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -41,7 +41,9 @@ import org.apache.spark.internal.config.Tests.{SKIP_VALIDATE_CORES_TESTING, TEST
 import org.apache.spark.memory.SparkOutOfMemoryError
 import org.apache.spark.resource.ResourceAmountUtils.ONE_ENTIRE_RESOURCE
 import org.apache.spark.resource.ResourceProfile
+import org.apache.spark.resource.ResourceProfileBuilder
 import org.apache.spark.resource.ResourceUtils._
+import org.apache.spark.resource.TaskResourceRequests
 import org.apache.spark.resource.TestResourceIDs._
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.serializer.SerializerInstance
@@ -2393,6 +2395,13 @@ class TaskSetManagerSuite
       Seq.empty[AccumulableInfo])
   }
 
+  // A fatal JVM heap OutOfMemoryError, as reported by the ExceptionFailure the Executor sends
+  // before it exits with the OOM exit code. Its className is java.lang.OutOfMemoryError, not
+  // SparkOutOfMemoryError.
+  private def jvmOomExceptionFailure: ExceptionFailure = {
+    new ExceptionFailure(new OutOfMemoryError("Java heap space"), Seq.empty[AccumulableInfo])
+  }
+
   test("SPARK-58187: OOM retry cpus increment disabled by default (zero regression)") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2672,6 +2681,104 @@ class TaskSetManagerSuite
     val spec = manager.resourceOffer("exec2", "host2", ANY, availCpus = 8)._1
     assert(spec.isDefined && spec.get.index === 0)
     assert(spec.get.cpus === 5)
+  }
+
+  test("SPARK-58187: OOM retry grows cpus when executor cores are unknown") {
+    // A ResourceProfile without an explicit executor-core count (e.g. Standalone / local-cluster
+    // without spark.executor.cores) reports getExecutorCores == None. Previously the cap fell back
+    // to the generic default spark.executor.cores of 1, which pinned every retry at 1 cpu so the
+    // increment never took effect. With the fix the cap is absent and the retry cpus grow, bounded
+    // only by the executor's actual free cpus at offer time.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+      .set(config.CPUS_PER_TASK, 1)
+    sc = new SparkContext("local[4]", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    // Build a TaskResourceProfile (only task resources, no executor cores).
+    val rp = new ResourceProfileBuilder()
+      .require(new TaskResourceRequests().cpus(1))
+      .build()
+    sc.resourceProfileManager.addResourceProfile(rp)
+    assert(rp.getExecutorCores.isEmpty)
+    val taskSet = FakeTask.createTaskSet(1, rpId = rp.id)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // First attempt uses the base 1 cpu.
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 1, availCpus = 8)._1
+    assert(a0.isDefined && a0.get.cpus === 1)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // First OOM retry with an unknown cap: 1 + 1 * 1 = 2 cpus (grows; the old code pinned it at 1).
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 1, availCpus = 8)._1
+    assert(a1.isDefined && a1.get.cpus === 2)
+  }
+
+  test("SPARK-58187: maximum increment never yields a non-positive cpu request") {
+    // The config accepts any non-negative Int. An extreme increment (Int.MaxValue) overflows the
+    // Int request arithmetic, but effectiveCpusFor floors the result at baseCpus, so the launch
+    // never sees a non-positive cpu count (which would trip the cpus > 0 assertion in
+    // TaskDescription after scheduler state was already mutated). It degrades gracefully to the
+    // base cpus rather than crashing.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, Int.MaxValue)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined && a0.get.cpus === 1)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // The overflowed request is floored at baseCpus, so the retry still launches with a positive
+    // cpu count (no crash, no cpus > 0 assertion failure).
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a1.isDefined && a1.get.cpus >= 1)
+  }
+
+  test("SPARK-58187: fatal JVM OutOfMemoryError FAILED before executor loss increments once") {
+    // The Executor sends the ExceptionFailure (java.lang.OutOfMemoryError) before it exits with
+    // the OOM exit code, so the driver may process FAILED first. That path must recognize the
+    // fatal OOM, and the later ExecutorExited(52) must not double-count.
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    // FAILED (fatal heap OOM) arrives first.
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, jvmOomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 1)
+    // The executor-loss event for the same, now-finished attempt must not increment again.
+    manager.executorLost(
+      "exec1", "host1", ExecutorExited(SparkExitCode.OOM, exitCausedByApp = true))
+    assert(numOomRetriesOf(manager)(0) === 1)
+  }
+
+  test("SPARK-58187: JVM OutOfMemoryError executor loss before FAILED increments once") {
+    // The reverse ordering: the ExecutorExited(52) is processed before the stale FAILED. The
+    // executor-loss path increments and marks the attempt finished, so the later FAILED is a
+    // no-op (info.finished guard).
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    manager.executorLost(
+      "exec1", "host1", ExecutorExited(SparkExitCode.OOM, exitCausedByApp = true))
+    assert(numOomRetriesOf(manager)(0) === 1)
+    // The stale FAILED for the same attempt must be ignored (already finished).
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, jvmOomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 1)
   }
 
   test("SPARK-30359: don't clean executorsPendingToRemove " +

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2402,6 +2402,13 @@ class TaskSetManagerSuite
     new ExceptionFailure(new OutOfMemoryError("Java heap space"), Seq.empty[AccumulableInfo])
   }
 
+  // An OOM wrapped in another exception, mirroring FileFormatDataWriter.enrichWriteError which
+  // wraps the cause in a SparkException. The top-level className is not an OOM; only the cause is.
+  private def wrappedOomExceptionFailure(cause: Throwable): ExceptionFailure = {
+    new ExceptionFailure(
+      new SparkException("Task failed while writing rows.", cause), Seq.empty[AccumulableInfo])
+  }
+
   test("SPARK-58187: OOM retry cpus increment disabled by default (zero regression)") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2683,18 +2690,20 @@ class TaskSetManagerSuite
     assert(spec.get.cpus === 5)
   }
 
-  test("SPARK-58187: OOM retry grows cpus when executor cores are unknown") {
+  test("SPARK-58187: OOM retry does not grow cpus when executor cores are unknown") {
     // A ResourceProfile without an explicit executor-core count (e.g. Standalone / local-cluster
-    // without spark.executor.cores) reports getExecutorCores == None. Previously the cap fell back
-    // to the generic default spark.executor.cores of 1, which pinned every retry at 1 cpu so the
-    // increment never took effect. With the fix the cap is absent and the retry cpus grow, bounded
-    // only by the executor's actual free cpus at offer time.
+    // without spark.executor.cores) reports getExecutorCores == None. Growing the retry cpus
+    // without a real capacity bound risks requesting more cpus than the executor physically has,
+    // which oomRetryNeedsMoreCpus would reject on every offer forever, starving the task. So when
+    // the cap is unknown the retry keeps the base cpus (no growth) and is always schedulable.
     val conf = new SparkConf()
       .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
       .set(config.CPUS_PER_TASK, 1)
     sc = new SparkContext("local[4]", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-    // Build a TaskResourceProfile (only task resources, no executor cores).
+    // Build a TaskResourceProfile (only task resources, no executor cores) and make sure no
+    // explicit spark.executor.cores is set, so the cap is genuinely unknown.
+    assert(sc.conf.getOption(config.EXECUTOR_CORES.key).isEmpty)
     val rp = new ResourceProfileBuilder()
       .require(new TaskResourceRequests().cpus(1))
       .build()
@@ -2707,18 +2716,18 @@ class TaskSetManagerSuite
     val a0 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 1, availCpus = 8)._1
     assert(a0.isDefined && a0.get.cpus === 1)
     manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 1)
 
-    // First OOM retry with an unknown cap: 1 + 1 * 1 = 2 cpus (grows; the old code pinned it at 1).
-    val a1 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 1, availCpus = 8)._1
-    assert(a1.isDefined && a1.get.cpus === 2)
+    // With an unknown cap the retry stays at the base 1 cpu (no growth), so it can never become
+    // unschedulable on an offer that already fits the base request.
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 1, availCpus = 1)._1
+    assert(a1.isDefined && a1.get.cpus === 1)
   }
 
-  test("SPARK-58187: maximum increment never yields a non-positive cpu request") {
-    // The config accepts any non-negative Int. An extreme increment (Int.MaxValue) overflows the
-    // Int request arithmetic, but effectiveCpusFor floors the result at baseCpus, so the launch
-    // never sees a non-positive cpu count (which would trip the cpus > 0 assertion in
-    // TaskDescription after scheduler state was already mutated). It degrades gracefully to the
-    // base cpus rather than crashing.
+  test("SPARK-58187: maximum increment is capped at executor cores without overflow") {
+    // The config accepts any non-negative Int. An extreme increment (Int.MaxValue) must not
+    // overflow the request arithmetic; the Long computation is clamped to the executor cores, so
+    // the very first OOM retry requests exactly the cap (4), never a wrapped negative value.
     val conf = new SparkConf()
       .set(config.OOM_RETRY_CPUS_INCREMENT, Int.MaxValue)
       .set(config.CPUS_PER_TASK, 1)
@@ -2732,10 +2741,12 @@ class TaskSetManagerSuite
     assert(a0.isDefined && a0.get.cpus === 1)
     manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
 
-    // The overflowed request is floored at baseCpus, so the retry still launches with a positive
-    // cpu count (no crash, no cpus > 0 assertion failure).
+    // Below the capped requirement (4): must wait rather than launch or crash.
+    assert(manager.resourceOffer("exec1", "host1", ANY, availCpus = 3)._1.isEmpty)
+    // The first retry requests exactly the capped 4 cpus (documented formula), not a negative
+    // overflowed value that only becomes positive after several wraps.
     val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
-    assert(a1.isDefined && a1.get.cpus >= 1)
+    assert(a1.isDefined && a1.get.cpus === 4)
   }
 
   test("SPARK-58187: fatal JVM OutOfMemoryError FAILED before executor loss increments once") {
@@ -2778,6 +2789,46 @@ class TaskSetManagerSuite
     assert(numOomRetriesOf(manager)(0) === 1)
     // The stale FAILED for the same attempt must be ignored (already finished).
     manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, jvmOomExceptionFailure)
+    assert(numOomRetriesOf(manager)(0) === 1)
+  }
+
+  test("SPARK-58187: wrapped SparkOutOfMemoryError increments numOomRetries") {
+    // FileFormatDataWriter.enrichWriteError wraps the cause in a SparkException, and a wrapped
+    // SparkOutOfMemoryError is non-fatal so there is no executor-loss fallback. The OOM must be
+    // recognized through the preserved cause chain, not just the top-level exception.
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    val cause = new SparkOutOfMemoryError(
+      "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String])
+    manager.handleFailedTask(
+      a0.get.taskId, TaskState.FAILED, wrappedOomExceptionFailure(cause))
+    assert(numOomRetriesOf(manager)(0) === 1)
+  }
+
+  test("SPARK-58187: wrapped JVM OutOfMemoryError FAILED before executor loss increments once") {
+    // A wrapped JVM OutOfMemoryError sent as FAILED before the executor exits must be recognized
+    // through the preserved cause chain, and the later OOM exit must not double-count.
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+    assert(a0.isDefined)
+    manager.taskInfos(a0.get.taskId).launchSucceeded()
+    val cause = new OutOfMemoryError("Java heap space")
+    manager.handleFailedTask(
+      a0.get.taskId, TaskState.FAILED, wrappedOomExceptionFailure(cause))
+    assert(numOomRetriesOf(manager)(0) === 1)
+    manager.executorLost(
+      "exec1", "host1", ExecutorExited(SparkExitCode.OOM, exitCausedByApp = true))
     assert(numOomRetriesOf(manager)(0) === 1)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2724,6 +2724,35 @@ class TaskSetManagerSuite
     assert(a1.isDefined && a1.get.cpus === 1)
   }
 
+  test("SPARK-58187: OOM retry cpus are capped at the offer's actual registered total cores") {
+    // The configured/profile cap can exceed an executor's actual registered total cores (e.g.
+    // Kubernetes OOM recovery registers spark.task.cpus cores, or local[N] differs from
+    // spark.executor.cores). Capping only at the configured cores would let the retry request
+    // more cpus than the executor can physically run, which oomRetryNeedsMoreCpus would then
+    // reject on every offer forever. The retry must be capped at the offer's registered total.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 4)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 8)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // The executor actually registered only 2 cores, even though spark.executor.cores is 8.
+    val a0 = manager.resourceOffer(
+      "exec1", "host1", ANY, availCpus = 2, offerTotalCores = Some(2))._1
+    assert(a0.isDefined && a0.get.cpus === 1)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // Base + increment would be 1 + 4 = 5, and the profile cap is 8, but the offer's registered
+    // total is 2, so the request is capped at 2 and launches (rather than needing 5 and being
+    // rejected forever).
+    val a1 = manager.resourceOffer(
+      "exec1", "host1", ANY, availCpus = 2, offerTotalCores = Some(2))._1
+    assert(a1.isDefined && a1.get.cpus === 2)
+  }
+
   test("SPARK-58187: maximum increment is capped at executor cores without overflow") {
     // The config accepts any non-negative Int. An extreme increment (Int.MaxValue) must not
     // overflow the request arithmetic; the Long computation is clamped to the executor cores, so
@@ -2747,6 +2776,29 @@ class TaskSetManagerSuite
     // overflowed value that only becomes positive after several wraps.
     val a1 = manager.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
     assert(a1.isDefined && a1.get.cpus === 4)
+  }
+
+  test("SPARK-58187: OOM retry grows from the task ResourceProfile's cpus, not spark.task.cpus") {
+    // TaskSchedulerImpl passes the profile's task cpus (getTaskCpusOrDefaultForProfile) as the
+    // base into resourceOffer, so with a stage profile requiring 4 task cpus and increment 1, the
+    // first OOM retry needs 4 + 1 = 5, not spark.task.cpus (1) + 1 = 2.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+      .set(config.CPUS_PER_TASK, 1)
+      .set(config.EXECUTOR_CORES, 8)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // Model the scheduler offering the profile's task cpus (4) as the base.
+    val a0 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 4, availCpus = 8)._1
+    assert(a0.isDefined && a0.get.cpus === 4)
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // First OOM retry: 4 (profile task cpus) + 1 * 1 = 5 cpus, not 2.
+    val a1 = manager.resourceOffer("exec1", "host1", ANY, taskCpus = 4, availCpus = 8)._1
+    assert(a1.isDefined && a1.get.cpus === 5)
   }
 
   test("SPARK-58187: fatal JVM OutOfMemoryError FAILED before executor loss increments once") {
@@ -2830,6 +2882,36 @@ class TaskSetManagerSuite
     manager.executorLost(
       "exec1", "host1", ExecutorExited(SparkExitCode.OOM, exitCausedByApp = true))
     assert(numOomRetriesOf(manager)(0) === 1)
+  }
+
+  Seq(0, 1).foreach { killDepth =>
+    test(s"SPARK-58187: OOM classification is independent of killOnFatalError.depth=$killDepth") {
+      // spark.executor.killOnFatalError.depth is the executor's fatal-kill search bound and may be
+      // 0 (do not inspect for a fatal error). OOM classification for the cpus increment must not
+      // reuse it: a direct SparkOutOfMemoryError must always count, and a SparkException-wrapped
+      // OOM must count regardless of this setting.
+      val conf = new SparkConf()
+        .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+        .set(config.KILL_ON_FATAL_ERROR_DEPTH, killDepth)
+      sc = new SparkContext("local", "test", conf)
+      sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+
+      // Direct SparkOutOfMemoryError: recognized even at depth 0.
+      val m1 = new TaskSetManager(sched, FakeTask.createTaskSet(1), MAX_TASK_FAILURES)
+      val a0 = m1.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+      assert(a0.isDefined)
+      m1.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+      assert(numOomRetriesOf(m1)(0) === 1)
+
+      // SparkException-wrapped OOM: recognized regardless of the fatal-kill depth.
+      val m2 = new TaskSetManager(sched, FakeTask.createTaskSet(1), MAX_TASK_FAILURES)
+      val b0 = m2.resourceOffer("exec1", "host1", ANY, availCpus = 4)._1
+      assert(b0.isDefined)
+      val cause = new SparkOutOfMemoryError(
+        "POINTER_ARRAY_OUT_OF_MEMORY", new java.util.HashMap[String, String])
+      m2.handleFailedTask(b0.get.taskId, TaskState.FAILED, wrappedOomExceptionFailure(cause))
+      assert(numOomRetriesOf(m2)(0) === 1)
+    }
   }
 
   test("SPARK-30359: don't clean executorsPendingToRemove " +

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2444,7 +2444,7 @@ class TaskSetManagerSuite
   test("SPARK-58187: repeated OOM failures still abort the task set at maxTaskFailures") {
     // OOM failures count towards numFailures, so the existing maxTaskFailures cap still bounds
     // the number of retries (and thus the growth of the requested cpus).
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2459,7 +2459,7 @@ class TaskSetManagerSuite
   }
 
   test("SPARK-58187: SparkOutOfMemoryError increments numOomRetries when enabled") {
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2478,8 +2478,8 @@ class TaskSetManagerSuite
 
   test("SPARK-58187: OOM retry task is allocated increasing cpus") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2501,10 +2501,41 @@ class TaskSetManagerSuite
     assert(a2.isDefined && a2.get.cpus === 3)
   }
 
+  test("SPARK-58187: OOM retry grows fractional cpus exactly (spark.task.cpus and increment)") {
+    // spark.task.cpus is fractional (0.5) and the increment is fractional (0.5); the exact
+    // BigDecimal accounting must grow the retry to 0.5 + 0.5 * N without rounding drift, capped
+    // at the executor cores.
+    val conf = new SparkConf()
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(0.5))
+      .set(config.CPUS_PER_TASK, BigDecimal(0.5))
+      .set(config.EXECUTOR_CORES, 4)
+    sc = new SparkContext("local", "test", conf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+
+    // First attempt: base 0.5 cpus.
+    val a0 = manager.resourceOffer(
+      "exec1", "host1", ANY, taskCpus = BigDecimal(0.5), availCpus = 4)._1
+    assert(a0.isDefined && a0.get.cpus === BigDecimal(0.5))
+    manager.handleFailedTask(a0.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // First OOM retry: 0.5 + 0.5 * 1 = 1.0 cpus (exact, no drift).
+    val a1 = manager.resourceOffer(
+      "exec1", "host1", ANY, taskCpus = BigDecimal(0.5), availCpus = 4)._1
+    assert(a1.isDefined && a1.get.cpus === BigDecimal(1))
+    manager.handleFailedTask(a1.get.taskId, TaskState.FAILED, oomExceptionFailure)
+
+    // Second OOM retry: 0.5 + 0.5 * 2 = 1.5 cpus.
+    val a2 = manager.resourceOffer(
+      "exec1", "host1", ANY, taskCpus = BigDecimal(0.5), availCpus = 4)._1
+    assert(a2.isDefined && a2.get.cpus === BigDecimal(1.5))
+  }
+
   test("SPARK-58187: OOM retry waits when the offer has too few free cpus (strict)") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(2))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2527,8 +2558,8 @@ class TaskSetManagerSuite
 
   test("SPARK-58187: OOM retry does not starve a normal task on the same executor") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(2))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2547,8 +2578,8 @@ class TaskSetManagerSuite
 
   test("SPARK-58187: OOM retry cpus are capped at executor cores") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 10)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(10))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2568,7 +2599,7 @@ class TaskSetManagerSuite
   }
 
   test("SPARK-58187: numOomRetries is reset when the task succeeds") {
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2586,7 +2617,7 @@ class TaskSetManagerSuite
   }
 
   test("SPARK-58187: JVM heap OOM via ExecutorLostFailure increments numOomRetries") {
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2603,7 +2634,7 @@ class TaskSetManagerSuite
   }
 
   test("SPARK-58187: non-OOM executor exit codes do not increment numOomRetries") {
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2619,7 +2650,7 @@ class TaskSetManagerSuite
 
   test("SPARK-58187: custom oomRetryExecutorExitCodes are honored (YARN memory-limit codes)") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
       .set(config.OOM_RETRY_EXECUTOR_EXIT_CODES, Seq(SparkExitCode.OOM, -103, -104))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
@@ -2636,8 +2667,8 @@ class TaskSetManagerSuite
 
   test("SPARK-58187: barrier stage does not get the OOM cpus increment") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(2))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2659,8 +2690,8 @@ class TaskSetManagerSuite
 
   test("SPARK-58187: speculative copy of an OOM-retried task uses the same increased cpus") {
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 2)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(2))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 8)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
@@ -2697,8 +2728,8 @@ class TaskSetManagerSuite
     // which oomRetryNeedsMoreCpus would reject on every offer forever, starving the task. So when
     // the cap is unknown the retry keeps the base cpus (no growth) and is always schedulable.
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
     sc = new SparkContext("local[4]", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
     // Build a TaskResourceProfile (only task resources, no executor cores) and make sure no
@@ -2731,8 +2762,8 @@ class TaskSetManagerSuite
     // more cpus than the executor can physically run, which oomRetryNeedsMoreCpus would then
     // reject on every offer forever. The retry must be capped at the offer's registered total.
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 4)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(4))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 8)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2758,8 +2789,8 @@ class TaskSetManagerSuite
     // overflow the request arithmetic; the Long computation is clamped to the executor cores, so
     // the very first OOM retry requests exactly the cap (4), never a wrapped negative value.
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, Int.MaxValue)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(Int.MaxValue))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 4)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2783,8 +2814,8 @@ class TaskSetManagerSuite
     // base into resourceOffer, so with a stage profile requiring 4 task cpus and increment 1, the
     // first OOM retry needs 4 + 1 = 5, not spark.task.cpus (1) + 1 = 2.
     val conf = new SparkConf()
-      .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
-      .set(config.CPUS_PER_TASK, 1)
+      .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
+      .set(config.CPUS_PER_TASK, BigDecimal(1))
       .set(config.EXECUTOR_CORES, 8)
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
@@ -2805,7 +2836,7 @@ class TaskSetManagerSuite
     // The Executor sends the ExceptionFailure (java.lang.OutOfMemoryError) before it exits with
     // the OOM exit code, so the driver may process FAILED first. That path must recognize the
     // fatal OOM, and the later ExecutorExited(52) must not double-count.
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2827,7 +2858,7 @@ class TaskSetManagerSuite
     // The reverse ordering: the ExecutorExited(52) is processed before the stale FAILED. The
     // executor-loss path increments and marks the attempt finished, so the later FAILED is a
     // no-op (info.finished guard).
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2848,7 +2879,7 @@ class TaskSetManagerSuite
     // FileFormatDataWriter.enrichWriteError wraps the cause in a SparkException, and a wrapped
     // SparkOutOfMemoryError is non-fatal so there is no executor-loss fallback. The OOM must be
     // recognized through the preserved cause chain, not just the top-level exception.
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2866,7 +2897,7 @@ class TaskSetManagerSuite
   test("SPARK-58187: wrapped JVM OutOfMemoryError FAILED before executor loss increments once") {
     // A wrapped JVM OutOfMemoryError sent as FAILED before the executor exits must be recognized
     // through the preserved cause chain, and the later OOM exit must not double-count.
-    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+    val conf = new SparkConf().set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
     sc = new SparkContext("local", "test", conf)
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
     val taskSet = FakeTask.createTaskSet(1)
@@ -2891,7 +2922,7 @@ class TaskSetManagerSuite
       // reuse it: a direct SparkOutOfMemoryError must always count, and a SparkException-wrapped
       // OOM must count regardless of this setting.
       val conf = new SparkConf()
-        .set(config.OOM_RETRY_CPUS_INCREMENT, 1)
+        .set(config.OOM_RETRY_CPUS_INCREMENT, BigDecimal(1))
         .set(config.KILL_ON_FATAL_ERROR_DEPTH, killDepth)
       sc = new SparkContext("local", "test", conf)
       sched = new FakeTaskScheduler(sc, ("exec1", "host1"))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3187,6 +3187,38 @@ Apart from these, the following properties are also available, and may be useful
   <td>0.5.0</td>
 </tr>
 <tr>
+  <td><code>spark.task.oomRetryCpusIncrement</code></td>
+  <td>0</td>
+  <td>
+    Number of additional CPUs to allocate for each retry of a task that failed due to
+    out-of-memory. Each OOM retry of a task gets
+    <code>spark.task.cpus + spark.task.oomRetryCpusIncrement * N</code> CPUs (N = number of
+    OOM failures of that task), capped at the executor's total core count. The extra CPUs
+    reduce concurrent tasks on the executor, increasing the retrying task's share of the
+    execution memory pool. If the executor lacks enough free CPUs, the retry waits for a
+    sufficient offer rather than falling back. Set to 0 to disable (retry with the same
+    resources). Does not apply to barrier stages. Note: for a true JVM heap OOM (executor
+    exited), the executor heap size is fixed, so this only indirectly helps; it most directly
+    helps SparkOutOfMemoryError (execution memory pool exhaustion).
+  </td>
+  <td>4.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.task.oomRetryExecutorExitCodes</code></td>
+  <td>52</td>
+  <td>
+    Comma-separated list of executor exit codes treated as out-of-memory for
+    <code>spark.task.oomRetryCpusIncrement</code>. When an executor exits with one of these
+    codes, the tasks that were running on it have their OOM retry count incremented, so their
+    retries request more CPUs. The default is 52, the exit code Spark uses when an executor JVM
+    dies of an <code>OutOfMemoryError</code>. On YARN, a container that exceeds its memory limit
+    is killed with container exit codes -103 (virtual memory) and -104 (physical memory), so on
+    YARN consider setting this to <code>52,-103,-104</code>. Has no effect when
+    <code>spark.task.oomRetryCpusIncrement</code> is 0.
+  </td>
+  <td>4.3.0</td>
+</tr>
+<tr>
   <td><code>spark.task.resource.{resourceName}.amount</code></td>
   <td>1</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3192,16 +3192,16 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     Number of additional CPUs to allocate for each retry of a task that failed due to
     out-of-memory. Each OOM retry of a task gets
-    <code>spark.task.cpus + spark.task.oomRetryCpusIncrement * N</code> CPUs (N = number of
-    OOM failures of that task), capped at the executor's total core count. If that core count
-    is not known (e.g. Standalone / local-cluster without <code>spark.executor.cores</code>),
-    the retry keeps the original CPUs rather than risk requesting more than the executor has.
-    The extra CPUs reduce concurrent tasks on the executor, increasing the retrying task's
-    share of the execution memory pool. If the executor lacks enough free CPUs, the retry waits
-    for a sufficient offer rather than falling back. Set to 0 to disable (retry with the same
-    resources). Does not apply to barrier stages. Note: for a true JVM heap OOM (executor
-    exited), the executor heap size is fixed, so this only indirectly helps; it most directly
-    helps SparkOutOfMemoryError (execution memory pool exhaustion).
+    <code>T + spark.task.oomRetryCpusIncrement * N</code> CPUs, where T is the task's CPU request
+    (the ResourceProfile's task cpus, or <code>spark.task.cpus</code> when the profile supplies no
+    override) and N = number of OOM failures of that task, capped at the executor's actual total
+    core count. If that core count is not known, the retry keeps the original CPUs rather than
+    risk requesting more than the executor has. The extra CPUs reduce concurrent tasks on the
+    executor, increasing the retrying task's share of the execution memory pool. If the executor
+    lacks enough free CPUs, the retry waits for a sufficient offer rather than falling back. Set
+    to 0 to disable (retry with the same resources). Does not apply to barrier stages. Note: for a
+    true JVM heap OOM (executor exited), the executor heap size is fixed, so this only indirectly
+    helps; it most directly helps SparkOutOfMemoryError (execution memory pool exhaustion).
   </td>
   <td>4.3.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3193,10 +3193,12 @@ Apart from these, the following properties are also available, and may be useful
     Number of additional CPUs to allocate for each retry of a task that failed due to
     out-of-memory. Each OOM retry of a task gets
     <code>spark.task.cpus + spark.task.oomRetryCpusIncrement * N</code> CPUs (N = number of
-    OOM failures of that task), capped at the executor's total core count. The extra CPUs
-    reduce concurrent tasks on the executor, increasing the retrying task's share of the
-    execution memory pool. If the executor lacks enough free CPUs, the retry waits for a
-    sufficient offer rather than falling back. Set to 0 to disable (retry with the same
+    OOM failures of that task), capped at the executor's total core count. If that core count
+    is not known (e.g. Standalone / local-cluster without <code>spark.executor.cores</code>),
+    the retry keeps the original CPUs rather than risk requesting more than the executor has.
+    The extra CPUs reduce concurrent tasks on the executor, increasing the retrying task's
+    share of the execution memory pool. If the executor lacks enough free CPUs, the retry waits
+    for a sufficient offer rather than falling back. Set to 0 to disable (retry with the same
     resources). Does not apply to barrier stages. Note: for a true JVM heap OOM (executor
     exited), the executor heap size is fixed, so this only indirectly helps; it most directly
     helps SparkOutOfMemoryError (execution memory pool exhaustion).


### PR DESCRIPTION
### What changes were proposed in this pull request?

When a task fails with out-of-memory, the retry can now request more CPUs than the ResourceProfile's `spark.task.cpus`, controlled by a new config `spark.task.oomRetryCpusIncrement` (default 0 = disabled). Each OOM retry of a task gets `spark.task.cpus + spark.task.oomRetryCpusIncrement * N` CPUs (N = the number of OOM failures of that task), capped at the executor's total core count.

Two OOM sources are recognized:
- `SparkOutOfMemoryError` (execution memory pool exhaustion), via the `ExceptionFailure` path in `handleFailedTask`.
- A JVM heap OutOfMemoryError that kills the executor, recognized by the executor exit code in `executorLost` (configurable via `spark.task.oomRetryExecutorExitCodes`, default 52).

The extra CPUs reduce the number of concurrent tasks on the executor, which increases the retrying task's share of the execution memory pool (the pool is split by the number of active tasks). If the offered executor does not have enough free CPUs, the retry waits for a sufficient offer rather than falling back. Barrier stages are excluded. Speculative copies reuse the same per-index retry count, so they request the same CPUs as the running OOM retry.

### Why are the changes needed?

Today an OOM-failed task is retried with identical resources, which is unlikely to succeed and wastes retry attempts. Giving the retry more CPUs (hence more memory) improves the chance of success.

### Does this PR introduce any user-facing change?

Yes, two new configs `spark.task.oomRetryCpusIncrement` and `spark.task.oomRetryExecutorExitCodes`, both documented in configuration.md. Disabled by default (increment 0), so behavior is unchanged unless opted in.

### How was this patch tested?

New unit tests in `TaskSetManagerSuite` and `TaskSchedulerImplSuite` covering the disabled default (zero regression), cpus increment, strict wait, no starvation of normal tasks, executor-cores cap, reset on success, both OOM recognition paths, configurable exit codes, barrier exclusion, speculative consistency, and the maxTaskFailures safety bound.
