### PR TITLE
[SPARK-58188][PYTHON] Remove unused ArrowStreamUDTFSerializer

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -246,15 +246,6 @@ class ArrowStreamUDFSerializer(ArrowStreamSerializer):
         return super().dump_stream(batches, stream)
 
 
-class ArrowStreamUDTFSerializer(ArrowStreamUDFSerializer):
-    """
-    Same as :class:`ArrowStreamUDFSerializer` but it does not flatten when loading batches.
-    """
-
-    def load_stream(self, stream):
-        return ArrowStreamSerializer.load_stream(self, stream)
-
-
 class ArrowStreamPandasSerializer(ArrowStreamSerializer):
     """
     Serializes pandas.Series as Arrow data with Arrow streaming format.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Delete `ArrowStreamUDTFSerializer` from `python/pyspark/sql/pandas/serializers.py`.

### Why are the changes needed?

`ArrowStreamUDTFSerializer` is no longer used after SPARK-57394 refactored `SQL_ARROW_TABLE_UDF` to use `ArrowStreamSerializer` in `worker.py`. This class can be safely deleted.

Part of SPARK-55384.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests: `pyspark.sql.tests.arrow.test_arrow_udtf`.

### Was this patch authored or co-authored using generative AI tooling?

No.
