### PR TITLE
[SPARK-58193][SQL] Classify Databricks syntax errors by message

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
@@ -55,9 +55,10 @@ private case class DatabricksDialect() extends JdbcDialect with NoLegacyJDBCErro
     case _ => None
   }
 
-  // See https://docs.databricks.com/aws/en/error-messages/sqlstates
+  // The driver may report SYNTAX_ERROR only in the message.
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
-    Option(exception.getSQLState).exists(_.startsWith("42"))
+    Option(exception.getSQLState).exists(_.startsWith("42")) ||
+      Option(exception.getMessage).exists(_.contains("SYNTAX_ERROR"))
   }
 
   override def quoteIdentifier(colName: String): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DatabricksDialect.scala
@@ -55,10 +55,12 @@ private case class DatabricksDialect() extends JdbcDialect with NoLegacyJDBCErro
     case _ => None
   }
 
-  // The driver may report SYNTAX_ERROR only in the message.
+  // See https://docs.databricks.com/aws/en/error-messages/sqlstates.
+  // The driver may report syntax errors with a non-class-42 SQLState.
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
     Option(exception.getSQLState).exists(_.startsWith("42")) ||
-      Option(exception.getMessage).exists(_.contains("SYNTAX_ERROR"))
+      Option(exception.getMessage)
+        .exists(_.toUpperCase(Locale.ROOT).contains("SYNTAX_ERROR"))
   }
 
   override def quoteIdentifier(colName: String): String = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -230,7 +230,7 @@ class JDBCTableCatalogSuite extends SharedSparkSession {
   }
 
   test("DatabricksDialect recognizes syntax errors in messages") {
-    val exception = new SQLException("[PARSE_SYNTAX_ERROR] Syntax error at or near 'SQL'", "07000")
+    val exception = new SQLException("[parse_syntax_error] Syntax error at or near 'SQL'", "07000")
     val dialect = JdbcDialects.get("jdbc:databricks://account.cloud.databricks.com")
     assert(dialect.isSyntaxErrorBestEffort(exception))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
-import java.sql.{Connection, DriverManager}
+import java.sql.{Connection, DriverManager, SQLException}
 import java.util.Properties
 
 import scala.jdk.CollectionConverters._
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, TableSummary}
 import org.apache.spark.sql.errors.DataTypeErrors.{toSQLConf, toSQLStmt}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -226,6 +227,12 @@ class JDBCTableCatalogSuite extends SharedSparkSession {
       }
       checkErrorTableNotFound(e, expected)
     }
+  }
+
+  test("DatabricksDialect recognizes syntax errors in messages") {
+    val exception = new SQLException("[PARSE_SYNTAX_ERROR] Syntax error at or near 'SQL'", "07000")
+    val dialect = JdbcDialects.get("jdbc:databricks://account.cloud.databricks.com")
+    assert(dialect.isSyntaxErrorBestEffort(exception))
   }
 
   test("create a table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
-import java.sql.{Connection, DriverManager, SQLException}
+import java.sql.{Connection, DriverManager}
 import java.util.Properties
 
 import scala.jdk.CollectionConverters._
@@ -32,7 +32,6 @@ import org.apache.spark.sql.connector.catalog.{Identifier, TableSummary}
 import org.apache.spark.sql.errors.DataTypeErrors.{toSQLConf, toSQLStmt}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -227,12 +226,6 @@ class JDBCTableCatalogSuite extends SharedSparkSession {
       }
       checkErrorTableNotFound(e, expected)
     }
-  }
-
-  test("DatabricksDialect recognizes syntax errors in messages") {
-    val exception = new SQLException("[parse_syntax_error] Syntax error at or near 'SQL'", "07000")
-    val dialect = JdbcDialects.get("jdbc:databricks://account.cloud.databricks.com")
-    assert(dialect.isSyntaxErrorBestEffort(exception))
   }
 
   test("create a table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2608,7 +2608,7 @@ class JDBCSuite extends SharedSparkSession {
       .getJDBCType(BinaryType).map(_.databaseTypeDefinition).get == "BINARY")
   }
 
-  test("DatabricksDialect syntax error detection") {
+  test("SPARK-58193: DatabricksDialect syntax error detection") {
     val dialect = DatabricksDialect()
     assert(dialect.isSyntaxErrorBestEffort(
       new SQLException("[parse_syntax_error] Syntax error at or near 'SQL'", "07000")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.jdbc
 
 import java.math.BigDecimal
-import java.sql.{Connection, Date, DriverManager, ResultSet, Statement, Timestamp}
+import java.sql.{Connection, Date, DriverManager, ResultSet, SQLException, Statement, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime}
 import java.time.format.DateTimeFormatter
 import java.util.{Calendar, GregorianCalendar, Properties, TimeZone}
@@ -2606,6 +2606,13 @@ class JDBCSuite extends SharedSparkSession {
       .getJDBCType(StringType).map(_.databaseTypeDefinition).get == "STRING")
     assert(databricksDialect
       .getJDBCType(BinaryType).map(_.databaseTypeDefinition).get == "BINARY")
+  }
+
+  test("DatabricksDialect syntax error detection") {
+    val dialect = DatabricksDialect()
+    assert(dialect.isSyntaxErrorBestEffort(
+      new SQLException("[parse_syntax_error] Syntax error at or near 'SQL'", "07000")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("Connection reset", "08001")))
   }
 
   test("SPARK-45425: Mapped TINYINT to ShortType for MsSqlServerDialect") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Recognize remote Databricks parse errors when the JDBC driver reports the SYNTAX_ERROR condition only in its message.
Optimise `isSyntaxErrorBestEffort` for Databricks to catch syntax error even if SQLState is missing.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To improve the error classification.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Update the user-facing-change section from No: matching this driver error now produces Spark's JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR classification during schema resolution or query execution.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added a unit-test and checked a case on a Databricks workspace

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude 4.7