### PR TITLE
[SPARK-58195][BUILD] Upgrade ORC to 2.3.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -234,10 +234,10 @@ opentelemetry-context/1.49.0//opentelemetry-context-1.49.0.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/2.3.0/shaded-protobuf/orc-core-2.3.0-shaded-protobuf.jar
+orc-core/2.3.1/shaded-protobuf/orc-core-2.3.1-shaded-protobuf.jar
 orc-format/1.1.1/shaded-protobuf/orc-format-1.1.1-shaded-protobuf.jar
-orc-mapreduce/2.3.0/shaded-protobuf/orc-mapreduce-2.3.0-shaded-protobuf.jar
-orc-shims/2.3.0//orc-shims-2.3.0.jar
+orc-mapreduce/2.3.1/shaded-protobuf/orc-mapreduce-2.3.1-shaded-protobuf.jar
+orc-shims/2.3.1//orc-shims-2.3.1.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8.3//paranamer-2.8.3.jar
@@ -268,7 +268,7 @@ spire-util_2.13/0.18.0//spire-util_2.13-0.18.0.jar
 spire_2.13/0.18.0//spire_2.13-0.18.0.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
-threeten-extra/1.8.0//threeten-extra-1.8.0.jar
+threeten-extra/1.9.0//threeten-extra-1.9.0.jar
 tink/1.23.0//tink-1.23.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
     <derby.version>10.16.1.1</derby.version>
     <parquet.version>1.17.1</parquet.version>
-    <orc.version>2.3.0</orc.version>
+    <orc.version>2.3.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>12.1.11</jetty.version>
     <jakartaservlet.version>6.0.0</jakartaservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 2.3.1.

### Why are the changes needed?

To bring the latest bug fixes from the ORC 2.3.1 maintenance release:
- https://orc.apache.org/news/2026/07/16/ORC-2.3.1/
- https://github.com/apache/orc/releases/tag/v2.3.1

Notable Java-side changes include:
- ORC-2131: Set default of `orc.stripe.size.check.ratio` and `orc.dictionary.max.size.bytes` to 0
- ORC-2149: Supports merging multiple ORC files with the same schema into multiple ORC files
- ORC-2177: Fix array conversion with empty first batch
- ORC-2180: Upgrade `threeten-extra` to 1.9.0
- Many robustness improvements

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5