### PR TITLE
[SPARK-56486][SQL] Add XSDToSchema.extendDecimalPrecision to prevent silent decimal truncation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -66,6 +66,39 @@ object XSDToSchema extends Logging{
     getStructType(xmlSchema)
   }
 
+  /**
+   * Widens every [[DecimalType]] in the given schema so that decimals inferred from an XSD's
+   * `totalDigits`/`fractionDigits` facets can hold their full integer range without silent
+   * truncation. `read` maps `totalDigits=t, fractionDigits=f` to `DecimalType(t, f)`, which is
+   * correct per the W3C XML Schema spec but leaves only `t - f` integer digits. Because Spark's
+   * decimal scale is fixed while the XSD `fractionDigits` facet is only a maximum, values that
+   * use fewer fractional digits and more integer digits overflow the precision and are silently
+   * read as null. This opt-in utility raises each `DecimalType(p, s)` to
+   * `DecimalType(min(maxPrecision, p + s), s)`, recursing into nested struct fields and array
+   * elements. It does not change `read`'s default inference, so existing callers are unaffected.
+   *
+   * @param schema the schema returned by `read`
+   * @param maxPrecision the maximum precision a widened decimal may reach; must not exceed
+   *                     [[DecimalType.MAX_PRECISION]]
+   * @return a copy of the schema with decimal precisions widened
+   */
+  def extendDecimalPrecision(
+      schema: StructType,
+      maxPrecision: Int = DecimalType.MAX_PRECISION): StructType = {
+    StructType(schema.map { field =>
+      field.copy(dataType = extendDecimalType(field.dataType, maxPrecision))
+    })
+  }
+
+  private def extendDecimalType(dataType: DataType, maxPrecision: Int): DataType = dataType match {
+    case DecimalType.Fixed(precision, scale) =>
+      DecimalType(math.min(maxPrecision, precision + scale), scale)
+    case struct: StructType =>
+      extendDecimalPrecision(struct, maxPrecision)
+    case ArrayType(elementType, containsNull) =>
+      ArrayType(extendDecimalType(elementType, maxPrecision), containsNull)
+    case other => other
+  }
 
   private def getStructField(xmlSchema: XmlSchema, schemaType: XmlSchemaType): StructField = {
     schemaType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -81,10 +81,13 @@ object XSDToSchema extends Logging{
    * @param maxPrecision the maximum precision a widened decimal may reach; must not exceed
    *                     [[DecimalType.MAX_PRECISION]]
    * @return a copy of the schema with decimal precisions widened
+   * @throws IllegalArgumentException if `maxPrecision` is not in [1, [[DecimalType.MAX_PRECISION]]]
    */
   def extendDecimalPrecision(
       schema: StructType,
       maxPrecision: Int = DecimalType.MAX_PRECISION): StructType = {
+    require(maxPrecision > 0 && maxPrecision <= DecimalType.MAX_PRECISION,
+      s"maxPrecision must be in [1, ${DecimalType.MAX_PRECISION}], got $maxPrecision")
     StructType(schema.map { field =>
       field.copy(dataType = extendDecimalType(field.dataType, maxPrecision))
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
@@ -130,6 +130,86 @@ class XSDToSchemaSuite extends SharedSparkSession {
     assert(parsedSchema === expectedSchema)
   }
 
+  test("SPARK-56486: extendDecimalPrecision widens decimals and caps at max precision") {
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "decimal-with-restriction.xsd")))
+    val widenedSchema = XSDToSchema.extendDecimalPrecision(parsedSchema)
+    // decimal_type_3 (12, 6) -> (18, 6); the other two are already at precision 38 (the cap)
+    // and so are left unchanged.
+    val expectedSchema = buildSchema(
+      field("decimal_type_3", DecimalType(18, 6), nullable = false),
+      field("decimal_type_1", DecimalType(38, 18), nullable = false),
+      field("decimal_type_2", DecimalType(38, 2), nullable = false)
+    )
+    assert(widenedSchema === expectedSchema)
+  }
+
+  test("SPARK-56486: extendDecimalPrecision recurses into nested struct and array decimals") {
+    val xsdString =
+      """<?xml version="1.0" encoding="UTF-8" ?>
+        |<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        |  <xs:element name="root">
+        |    <xs:complexType>
+        |      <xs:sequence>
+        |        <xs:element name="nested">
+        |          <xs:complexType>
+        |            <xs:sequence>
+        |              <xs:element name="amount">
+        |                <xs:simpleType>
+        |                  <xs:restriction base="xs:decimal">
+        |                    <xs:totalDigits value="20"/>
+        |                    <xs:fractionDigits value="5"/>
+        |                  </xs:restriction>
+        |                </xs:simpleType>
+        |              </xs:element>
+        |            </xs:sequence>
+        |          </xs:complexType>
+        |        </xs:element>
+        |        <xs:element name="prices" maxOccurs="unbounded">
+        |          <xs:simpleType>
+        |            <xs:restriction base="xs:decimal">
+        |              <xs:totalDigits value="10"/>
+        |              <xs:fractionDigits value="2"/>
+        |            </xs:restriction>
+        |          </xs:simpleType>
+        |        </xs:element>
+        |      </xs:sequence>
+        |    </xs:complexType>
+        |  </xs:element>
+        |</xs:schema>
+        |""".stripMargin
+    val widenedSchema = XSDToSchema.extendDecimalPrecision(XSDToSchema.read(xsdString))
+    val expectedSchema = StructType(StructField("root",
+      StructType(
+        StructField("nested",
+          StructType(StructField("amount", DecimalType(25, 5), false) :: Nil), false) ::
+        StructField("prices", ArrayType(DecimalType(12, 2)), false) :: Nil),
+      false) :: Nil)
+    assert(widenedSchema === expectedSchema)
+  }
+
+  test("SPARK-56486: extendDecimalPrecision respects an explicit maxPrecision") {
+    val xsdString =
+      """<?xml version="1.0" encoding="UTF-8" ?>
+        |<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        |  <xs:element name="amount">
+        |    <xs:simpleType>
+        |      <xs:restriction base="xs:decimal">
+        |        <xs:totalDigits value="20"/>
+        |        <xs:fractionDigits value="5"/>
+        |      </xs:restriction>
+        |    </xs:simpleType>
+        |  </xs:element>
+        |</xs:schema>
+        |""".stripMargin
+    val parsedSchema = XSDToSchema.read(xsdString)
+    // read() leaves only 20 - 5 = 15 integer digits, which is where the silent truncation occurs.
+    assert(parsedSchema === buildSchema(field("amount", DecimalType(20, 5), nullable = false)))
+    val widenedSchema = XSDToSchema.extendDecimalPrecision(parsedSchema, maxPrecision = 22)
+    // p + s = 25, but the explicit cap of 22 wins.
+    val expectedSchema = buildSchema(field("amount", DecimalType(22, 5), nullable = false))
+    assert(widenedSchema === expectedSchema)
+  }
+
   test("Test ref attribute / Issue 617") {
     val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "ref-attribute.xsd")))
     val expectedSchema = buildSchema(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
@@ -210,6 +210,22 @@ class XSDToSchemaSuite extends SharedSparkSession {
     assert(widenedSchema === expectedSchema)
   }
 
+  test("SPARK-56486: extendDecimalPrecision rejects an out-of-range maxPrecision") {
+    val schema = XSDToSchema.read(
+      """<?xml version="1.0" encoding="UTF-8" ?>
+        |<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        |  <xs:element name="amount" type="xs:decimal"/>
+        |</xs:schema>
+        |""".stripMargin)
+    Seq(0, DecimalType.MAX_PRECISION + 1).foreach { invalid =>
+      val e = intercept[IllegalArgumentException] {
+        XSDToSchema.extendDecimalPrecision(schema, maxPrecision = invalid)
+      }
+      assert(e.getMessage.contains(
+        s"maxPrecision must be in [1, ${DecimalType.MAX_PRECISION}], got $invalid"))
+    }
+  }
+
   test("Test ref attribute / Issue 617") {
     val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "ref-attribute.xsd")))
     val expectedSchema = buildSchema(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new opt-in utility method `XSDToSchema.extendDecimalPrecision(schema: StructType, maxPrecision: Int = 38): StructType` that widens `DecimalType` precision to accommodate full integer-digit capacity.

For each `DecimalType(p, s)` in the schema, the method raises precision to `min(maxPrecision, p + s)` while keeping scale unchanged. It recurses into nested `StructType` fields and `ArrayType` elements.

The default inference behavior of `XSDToSchema.read()` is intentionally unchanged: it still maps XSD `totalDigits`/`fractionDigits` to `DecimalType(totalDigits, fractionDigits)` per the W3C spec. Users opt in by calling `extendDecimalPrecision` on the returned schema.

### Why are the changes needed?

`XSDToSchema.read()` maps an XSD decimal restriction with `totalDigits=t` and `fractionDigits=f` to `DecimalType(t, f)`. This is spec-correct, but Spark's `DecimalType` scale is fixed, whereas the XSD `fractionDigits` facet is only a maximum. A value that uses fewer fractional digits and more integer digits overflows precision. For example, `totalDigits=20, fractionDigits=5` produces `DecimalType(20, 5)` which allows only 15 integer digits. Values exceeding that are silently read as `null` in non-ANSI mode, causing data loss with no warning.

This matches the fix proposed by the JIRA reporter: an opt-in utility rather than changing default behavior.

JIRA: https://issues.apache.org/jira/browse/SPARK-56486

### Does this PR introduce _any_ user-facing change?

Yes. A new public utility method `XSDToSchema.extendDecimalPrecision` is added. Existing behavior of `XSDToSchema.read()` is unchanged.

### How was this patch tested?

Three new unit tests in `XSDToSchemaSuite`:
- Verifies decimal widening and capping at max precision (e.g. `(12,6)` -> `(18,6)`, `(38,18)` unchanged)
- Verifies recursion into nested struct fields and array elements
- Verifies an explicit `maxPrecision` parameter is respected

Ran the suite locally (all pass). Full lint/test matrix via GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated using Kiro (Claude Opus 4.8)