### PR TITLE
[SPARK-49442][SS] Cache Kafka partition metadata to reduce DescribeTopics RPCs per micro-batch

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -57,6 +57,13 @@ private[kafka010] class KafkaOffsetReaderAdmin(
   private[kafka010] val offsetFetchAttemptIntervalMs =
     readerOptions.getOrElse(KafkaSourceProvider.FETCH_OFFSET_RETRY_INTERVAL_MS, "1000").toLong
 
+  private val partitionMetadataCacheTtlMs: Long =
+    readerOptions.getOrElse(KafkaSourceProvider.PARTITION_METADATA_CACHE_TTL_MS, "-1").toLong
+
+  // Protected by this.synchronized (always accessed inside withRetries, which holds the lock).
+  private var cachedPartitions: Set[TopicPartition] = Set.empty
+  private var cacheTimestampMs: Long = 0L
+
   /**
    * An AdminClient used in the driver to query the latest Kafka offsets.
    * This only queries the offsets because AdminClient has no functionality to commit offsets like
@@ -127,7 +134,7 @@ private[kafka010] class KafkaOffsetReaderAdmin(
       logDebug(s"Assigned partitions: $partitions. Seeking to $partitionOffsets")
       partitionOffsets
     }
-    val partitions = withRetries { consumerStrategy.assignedTopicPartitions(admin) }
+    val partitions = withRetries { resolvePartitions() }
     // Obtain TopicPartition offsets with late binding support
     offsetRangeLimit match {
       case EarliestOffsetRangeLimit => partitions.map {
@@ -439,12 +446,30 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     }
   }
 
+  // Must be called inside withRetries (which holds this.synchronized).
+  private def resolvePartitions(): Set[TopicPartition] = {
+    if (partitionMetadataCacheTtlMs <= 0) {
+      return consumerStrategy.assignedTopicPartitions(admin)
+    }
+    val now = System.currentTimeMillis()
+    if (cacheTimestampMs > 0 && (now - cacheTimestampMs) < partitionMetadataCacheTtlMs) {
+      logDebug(s"Reusing cached partitions (age ${now - cacheTimestampMs}ms < " +
+        s"${partitionMetadataCacheTtlMs}ms TTL): $cachedPartitions")
+      cachedPartitions
+    } else {
+      val fresh = consumerStrategy.assignedTopicPartitions(admin)
+      cachedPartitions = fresh
+      cacheTimestampMs = now
+      fresh
+    }
+  }
+
   private def partitionsAssignedToAdmin(
       body: ju.Set[TopicPartition] => Map[TopicPartition, Long])
     : Map[TopicPartition, Long] = {
 
     withRetries {
-      val partitions = consumerStrategy.assignedTopicPartitions(admin).asJava
+      val partitions = resolvePartitions().asJava
       logDebug(s"Partitions assigned: $partitions.")
       body(partitions)
     }
@@ -493,5 +518,7 @@ private[kafka010] class KafkaOffsetReaderAdmin(
   private def resetAdmin(): Unit = synchronized {
     stopAdmin()
     _admin = null  // will automatically get reinitialized again
+    cachedPartitions = Set.empty
+    cacheTimestampMs = 0L
   }
 }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -274,6 +274,15 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
       if (p <= 0) throw new IllegalArgumentException("minPartitions must be positive")
     }
 
+    if (params.contains(PARTITION_METADATA_CACHE_TTL_MS)) {
+      val v = params(PARTITION_METADATA_CACHE_TTL_MS).toLong
+      if (v != -1 && v <= 0) {
+        throw new IllegalArgumentException(
+          "Option 'partition.metadata.cache.ttl.ms' must be a positive number of milliseconds, " +
+          "or -1 to disable caching")
+      }
+    }
+
     if (params.contains(MAX_RECORDS_PER_PARTITION_OPTION_KEY)) {
       val p = params(MAX_RECORDS_PER_PARTITION_OPTION_KEY).toLong
       if (p <= 0) {
@@ -577,6 +586,7 @@ private[kafka010] object KafkaSourceProvider extends Logging {
   private[kafka010] val DEFAULT_MAX_TRIGGER_DELAY = "15m"
   private[kafka010] val FETCH_OFFSET_NUM_RETRY = "fetchoffset.numretries"
   private[kafka010] val FETCH_OFFSET_RETRY_INTERVAL_MS = "fetchoffset.retryintervalms"
+  private[kafka010] val PARTITION_METADATA_CACHE_TTL_MS = "partition.metadata.cache.ttl.ms"
   private[kafka010] val CONSUMER_POLL_TIMEOUT = "kafkaconsumer.polltimeoutms"
   private[kafka010] val STARTING_OFFSETS_BY_TIMESTAMP_STRATEGY_KEY =
     "startingoffsetsbytimestampstrategy"

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderSuite.scala
@@ -369,7 +369,7 @@ class KafkaOffsetReaderSuite extends SharedSparkSession with KafkaTest {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 3)
 
-    val ttlMs = 200 // short TTL so the test doesn't need to sleep long
+    val ttlMs = 2000 // large enough to not expire during two sequential fetches
     val describeCount = new AtomicInteger(0)
     val countingStrategy = new SubscribeStrategy(Seq(topic)) {
       override def assignedTopicPartitions(admin: Admin): Set[TopicPartition] = {

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderSuite.scala
@@ -323,4 +323,90 @@ class KafkaOffsetReaderSuite extends SharedSparkSession with KafkaTest {
       reader.close()
     }
   }
+
+  // SPARK-49442: When partition.metadata.cache.ttl.ms is set, repeated fetchLatestOffsets
+  // calls within the TTL window must reuse the cached partition set and issue only one
+  // DescribeTopics RPC to the broker, regardless of how many micro-batches run.
+  test("SPARK-49442: partition.metadata.cache.ttl.ms suppresses redundant " +
+      "DescribeTopics RPCs within the TTL window") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 3)
+
+    val ttlMs = 300000 // 5 minutes
+    val describeCount = new AtomicInteger(0)
+    val countingStrategy = new SubscribeStrategy(Seq(topic)) {
+      override def assignedTopicPartitions(admin: Admin): Set[TopicPartition] = {
+        describeCount.incrementAndGet()
+        super.assignedTopicPartitions(admin)
+      }
+    }
+
+    val reader = new KafkaOffsetReaderAdmin(
+      countingStrategy,
+      KafkaSourceProvider.kafkaParamsForDriver(Map(
+        "bootstrap.servers" -> testUtils.brokerAddress
+      )),
+      CaseInsensitiveMap(Map(
+        KafkaSourceProvider.PARTITION_METADATA_CACHE_TTL_MS -> ttlMs.toString
+      )),
+      ""
+    )
+
+    try {
+      val numBatches = 5
+      for (_ <- 1 to numBatches) {
+        reader.fetchLatestOffsets(None)
+      }
+      // All 5 fetches fall within the TTL window, so the partition set is resolved only once.
+      assert(describeCount.get() === 1,
+        s"Expected 1 DescribeTopics call but got ${describeCount.get()}")
+    } finally {
+      reader.close()
+    }
+  }
+
+  test("SPARK-49442: partition.metadata.cache.ttl.ms refreshes after TTL expires") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 3)
+
+    val ttlMs = 200 // short TTL so the test doesn't need to sleep long
+    val describeCount = new AtomicInteger(0)
+    val countingStrategy = new SubscribeStrategy(Seq(topic)) {
+      override def assignedTopicPartitions(admin: Admin): Set[TopicPartition] = {
+        describeCount.incrementAndGet()
+        super.assignedTopicPartitions(admin)
+      }
+    }
+
+    val reader = new KafkaOffsetReaderAdmin(
+      countingStrategy,
+      KafkaSourceProvider.kafkaParamsForDriver(Map(
+        "bootstrap.servers" -> testUtils.brokerAddress
+      )),
+      CaseInsensitiveMap(Map(
+        KafkaSourceProvider.PARTITION_METADATA_CACHE_TTL_MS -> ttlMs.toString
+      )),
+      ""
+    )
+
+    try {
+      // First fetch populates the cache (1 RPC).
+      reader.fetchLatestOffsets(None)
+      assert(describeCount.get() === 1)
+
+      // Fetches within the TTL reuse the cache (still 1 RPC).
+      reader.fetchLatestOffsets(None)
+      assert(describeCount.get() === 1)
+
+      // Sleep past the TTL so the next fetch must refresh.
+      Thread.sleep(ttlMs + 50)
+
+      // Cache has expired: one more RPC expected.
+      reader.fetchLatestOffsets(None)
+      assert(describeCount.get() === 2,
+        s"Expected 2 DescribeTopics calls after TTL expiry but got ${describeCount.get()}")
+    } finally {
+      reader.close()
+    }
+  }
 }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -133,4 +133,25 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
     val provider = new KafkaSourceProvider()
     provider.getTable(options).newScanBuilder(options).build()
   }
+
+  test("SPARK-49442: partition.metadata.cache.ttl.ms validation") {
+    val sparkEnv = mock(classOf[SparkEnv])
+    when(sparkEnv.conf).thenReturn(new SparkConf())
+    SparkEnv.set(sparkEnv)
+
+    // -1 (disabled) and positive values are valid; validation fires inside toMicroBatchStream
+    Seq("-1", "1", "30000").foreach { v =>
+      val options = buildKafkaSourceCaseInsensitiveStringMap(
+        KafkaSourceProvider.PARTITION_METADATA_CACHE_TTL_MS -> v)
+      getKafkaDataSourceScan(options).toMicroBatchStream("dummy")
+    }
+    // 0 and other non-positive values (except -1) are invalid
+    Seq("0", "-2", "-100").foreach { v =>
+      val options = buildKafkaSourceCaseInsensitiveStringMap(
+        KafkaSourceProvider.PARTITION_METADATA_CACHE_TTL_MS -> v)
+      intercept[IllegalArgumentException] {
+        getKafkaDataSourceScan(options).toMicroBatchStream("dummy")
+      }
+    }
+  }
 }

--- a/docs/streaming/structured-streaming-kafka-integration.md
+++ b/docs/streaming/structured-streaming-kafka-integration.md
@@ -482,6 +482,19 @@ The following configurations are optional:
   <td>milliseconds to wait before retrying to fetch Kafka offsets</td>
 </tr>
 <tr>
+  <td>partition.metadata.cache.ttl.ms</td>
+  <td>long</td>
+  <td>-1</td>
+  <td>streaming and batch</td>
+  <td>How long (in milliseconds) to cache the set of assigned Kafka topic-partitions in the driver
+  before issuing a fresh <code>DescribeTopics</code> RPC to the broker. When set to a positive value,
+  repeated offset fetches within the TTL window reuse the cached partition set instead of querying
+  the broker each time, reducing metadata load on the broker and on the driver. This mirrors
+  the semantics of the Kafka client's own <code>metadata.max.age.ms</code> setting. Set to -1
+  (the default) to disable caching (existing behavior). Note: newly added partitions will not be
+  discovered until the cache expires.</td>
+</tr>
+<tr>
   <td>maxOffsetsPerTrigger</td>
   <td>long</td>
   <td>none</td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds a new source option `partition.metadata.cache.ttl.ms` to `KafkaOffsetReaderAdmin`. When set to a positive value, the driver caches the set of assigned `TopicPartition`s and reuses it for all offset fetch calls within the TTL window, skipping the `DescribeTopics` RPC to the broker. The cache is invalidated on admin reset (i.e., on retry). Default is `-1` (caching disabled, preserving existing behavior).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Every micro-batch unconditionally called `consumerStrategy.assignedTopicPartitions(admin)`, which issues a `DescribeTopics` RPC to the Kafka broker even though partition assignments are stable in most production deployments. For deployments with large partition counts and short trigger intervals, this generates unnecessary metadata traffic.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Adds a new source option `partition.metadata.cache.ttl.ms` (long, default `-1`). Valid values are `-1` (caching disabled) or any positive integer representing milliseconds. Documentation is updated accordingly. Existing behavior is unchanged when the option is not set.

> **Note:** when caching is enabled, newly added partitions will not be discovered until the cache expires.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added tests in `KafkaOffsetReaderSuite` `KafkaSourceProviderSuite`, `KafkaOffsetReaderSuite` and `KafkaSourceProviderSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, 'Generated-by:  Claude (Sonnet 4.6)