### PR TITLE
[SPARK-58205][SQL] Mark JSON/CSV/XML expressions stateful to prevent shared-evaluator data races

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -102,6 +102,7 @@ case class CsvToStructs(
   @transient
   private lazy val evaluator: CsvToStructsEvaluator = CsvToStructsEvaluator(
     options, nullableSchema, nameOfCorruptRecord, timeZoneId, requiredSchema)
+  override def stateful: Boolean = true
 
   override def nullSafeEval(input: Any): Any = {
     evaluator.evaluate(input.asInstanceOf[UTF8String])
@@ -275,6 +276,7 @@ case class StructsToCsv(
   lazy val converter: Any => UTF8String = {
     (row: Any) => UTF8String.fromString(gen.writeToString(row.asInstanceOf[InternalRow]))
   }
+  override def stateful: Boolean = true
 
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -188,6 +188,8 @@ case class SchemaOfCsv(
   override protected def withNewChildInternal(newChild: Expression): SchemaOfCsv =
     copy(child = newChild)
 
+  override def stateful: Boolean = true
+
   @transient
   private lazy val evaluator: SchemaOfCsvEvaluator = SchemaOfCsvEvaluator(options)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -188,8 +188,6 @@ case class SchemaOfCsv(
   override protected def withNewChildInternal(newChild: Expression): SchemaOfCsv =
     copy(child = newChild)
 
-  override def stateful: Boolean = true
-
   @transient
   private lazy val evaluator: SchemaOfCsvEvaluator = SchemaOfCsvEvaluator(options)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -75,6 +75,7 @@ case class GetJsonObject(json: Expression, path: Expression)
   } else {
     new GetJsonObjectEvaluator()
   }
+  override def stateful: Boolean = true
 
   override def eval(input: InternalRow): Any = {
     evaluator.setJson(json.eval(input).asInstanceOf[UTF8String])
@@ -293,6 +294,7 @@ case class JsonTuple(children: Seq[Expression])
 
   @transient
   private lazy val evaluator: JsonTupleEvaluator = JsonTupleEvaluator(foldableFieldNames)
+  override def stateful: Boolean = true
 
   override def eval(input: InternalRow): IterableOnce[InternalRow] = {
     val json = jsonExpr.eval(input).asInstanceOf[UTF8String]
@@ -420,6 +422,7 @@ case class JsonToStructs(
   @transient
   private lazy val evaluator = new JsonToStructsEvaluator(
     options, nullableSchema, nameOfCorruptRecord, timeZoneId, variantAllowDuplicateKeys)
+  override def stateful: Boolean = true
 
   override def nullSafeEval(json: Any): Any = evaluator.evaluate(json.asInstanceOf[UTF8String])
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -521,6 +521,8 @@ case class StructsToJson(
   override protected def withNewChildInternal(newChild: Expression): StructsToJson =
     copy(child = newChild)
 
+  override def stateful: Boolean = true
+
   @transient
   private lazy val evaluator = StructsToJsonEvaluator(options, inputSchema, timeZoneId)
 
@@ -587,6 +589,8 @@ case class SchemaOfJson(
       super.checkInputDataTypes()
     }
   }
+
+  override def stateful: Boolean = true
 
   @transient
   private lazy val evaluator: SchemaOfJsonEvaluator = SchemaOfJsonEvaluator(options)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -207,6 +207,8 @@ case class MultiGetJsonObject(
     }
   }
 
+  override def stateful: Boolean = true
+
   @transient
   private lazy val evaluator = MultiGetJsonObjectEvaluator(
     fallbackPaths.map(UTF8String.fromString),
@@ -521,8 +523,6 @@ case class StructsToJson(
   override protected def withNewChildInternal(newChild: Expression): StructsToJson =
     copy(child = newChild)
 
-  override def stateful: Boolean = true
-
   @transient
   private lazy val evaluator = StructsToJsonEvaluator(options, inputSchema, timeZoneId)
 
@@ -589,8 +589,6 @@ case class SchemaOfJson(
       super.checkInputDataTypes()
     }
   }
-
-  override def stateful: Boolean = true
 
   @transient
   private lazy val evaluator: SchemaOfJsonEvaluator = SchemaOfJsonEvaluator(options)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -96,6 +96,7 @@ case class XmlToStructs(
   @transient
   private lazy val evaluator: XmlToStructsEvaluator =
     XmlToStructsEvaluator(options, nullableSchema, nameOfCorruptRecord, timeZoneId, child)
+  override def stateful: Boolean = true
 
   private val nameOfCorruptRecord = SQLConf.get.getConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD)
 
@@ -278,6 +279,7 @@ case class StructsToXml(
 
   @transient
   private lazy val evaluator = StructsToXmlEvaluator(options, child.dataType, timeZoneId)
+  override def stateful: Boolean = true
 
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
@@ -25,6 +25,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{PST, UTC_OPT}
 import org.apache.spark.sql.types._
@@ -326,5 +327,20 @@ class CsvExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val structsToCsv = StructsToCsv(Map.empty, struct, UTC_OPT)
     assert(structsToCsv.stateful)
     assert(structsToCsv.freshCopyIfContainsStatefulExpression() ne structsToCsv)
+  }
+
+  test("SchemaOfCsv is stateful and produces fresh copies with independent evaluators") {
+    val schemaOfCsv = new SchemaOfCsv(Literal.create("1,abc"))
+    assert(schemaOfCsv.stateful)
+    val copy1 = schemaOfCsv.freshCopyIfContainsStatefulExpression()
+    assert(copy1 ne schemaOfCsv)
+    val copy2 = schemaOfCsv.freshCopyIfContainsStatefulExpression()
+    assert(copy2 ne schemaOfCsv)
+    // Each copy owns an independent evaluator - mutable state must not be shared.
+    val eval1 = copy1.asInstanceOf[SchemaOfCsv].replacement
+      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
+    val eval2 = copy2.asInstanceOf[SchemaOfCsv].replacement
+      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
+    assert(eval1 ne eval2)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
@@ -314,4 +314,17 @@ class CsvExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       CsvToStructs(schema, Map.empty, Literal.create(null, StringType), UTC_OPT),
       null)
   }
+
+  test("CsvToStructs and StructsToCsv are stateful and produce fresh copies") {
+    val schema = StructType(StructField("a", IntegerType) :: Nil)
+
+    val csvToStructs = CsvToStructs(schema, Map.empty, Literal("1"), UTC_OPT)
+    assert(csvToStructs.stateful)
+    assert(csvToStructs.freshCopyIfContainsStatefulExpression() ne csvToStructs)
+
+    val struct = Literal.create(create_row(1), schema)
+    val structsToCsv = StructsToCsv(Map.empty, struct, UTC_OPT)
+    assert(structsToCsv.stateful)
+    assert(structsToCsv.freshCopyIfContainsStatefulExpression() ne structsToCsv)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
@@ -25,7 +25,6 @@ import org.scalatest.exceptions.TestFailedException
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{PST, UTC_OPT}
 import org.apache.spark.sql.types._
@@ -329,18 +328,4 @@ class CsvExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(structsToCsv.freshCopyIfContainsStatefulExpression() ne structsToCsv)
   }
 
-  test("SchemaOfCsv is stateful and produces fresh copies with independent evaluators") {
-    val schemaOfCsv = new SchemaOfCsv(Literal.create("1,abc"))
-    assert(schemaOfCsv.stateful)
-    val copy1 = schemaOfCsv.freshCopyIfContainsStatefulExpression()
-    assert(copy1 ne schemaOfCsv)
-    val copy2 = schemaOfCsv.freshCopyIfContainsStatefulExpression()
-    assert(copy2 ne schemaOfCsv)
-    // Each copy owns an independent evaluator - mutable state must not be shared.
-    val eval1 = copy1.asInstanceOf[SchemaOfCsv].replacement
-      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
-    val eval2 = copy2.asInstanceOf[SchemaOfCsv].replacement
-      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
-    assert(eval1 ne eval2)
-  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
-import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{PST, UTC, UTC_OPT}
 import org.apache.spark.sql.internal.SQLConf
@@ -1042,7 +1041,8 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       input)
   }
 
-  test("JsonToStructs, GetJsonObject, JsonTuple are stateful and produce fresh copies") {
+  test("JsonToStructs, GetJsonObject, JsonTuple, MultiGetJsonObject are stateful " +
+      "and produce fresh copies") {
     val schema = StructType(StructField("a", IntegerType) :: Nil)
     val jsonToStructs = JsonToStructs(schema, Map.empty, Literal("{}"), UTC_OPT)
     assert(jsonToStructs.stateful)
@@ -1055,29 +1055,10 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val jsonTuple = JsonTuple(Literal("{}") :: Literal("a") :: Nil)
     assert(jsonTuple.stateful)
     assert(jsonTuple.freshCopyIfContainsStatefulExpression() ne jsonTuple)
-  }
 
-  test("StructsToJson and SchemaOfJson are stateful and produce fresh copies with " +
-      "independent evaluators") {
-    val schema = StructType(StructField("a", IntegerType) :: Nil)
-    val struct = Literal.create(create_row(1), schema)
-
-    val structsToJson = StructsToJson(Map.empty, struct, UTC_OPT)
-    assert(structsToJson.stateful)
-    val copy1 = structsToJson.freshCopyIfContainsStatefulExpression()
-    assert(copy1 ne structsToJson)
-    val copy2 = structsToJson.freshCopyIfContainsStatefulExpression()
-    assert(copy2 ne structsToJson)
-    // Each copy owns an independent evaluator - mutable state must not be shared.
-    val eval1 = copy1.asInstanceOf[StructsToJson].replacement
-      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
-    val eval2 = copy2.asInstanceOf[StructsToJson].replacement
-      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
-    assert(eval1 ne eval2)
-
-    val schemaOfJson = SchemaOfJson(Literal("""{"a":1}"""), Map.empty)
-    assert(schemaOfJson.stateful)
-    assert(schemaOfJson.freshCopyIfContainsStatefulExpression() ne schemaOfJson)
+    val multiGetJsonObject = MultiGetJsonObject(Literal("{}"), Seq("$.a", "$.b"))
+    assert(multiGetJsonObject.stateful)
+    assert(multiGetJsonObject.freshCopyIfContainsStatefulExpression() ne multiGetJsonObject)
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{PST, UTC, UTC_OPT}
 import org.apache.spark.sql.internal.SQLConf
@@ -1054,6 +1055,29 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val jsonTuple = JsonTuple(Literal("{}") :: Literal("a") :: Nil)
     assert(jsonTuple.stateful)
     assert(jsonTuple.freshCopyIfContainsStatefulExpression() ne jsonTuple)
+  }
+
+  test("StructsToJson and SchemaOfJson are stateful and produce fresh copies with " +
+      "independent evaluators") {
+    val schema = StructType(StructField("a", IntegerType) :: Nil)
+    val struct = Literal.create(create_row(1), schema)
+
+    val structsToJson = StructsToJson(Map.empty, struct, UTC_OPT)
+    assert(structsToJson.stateful)
+    val copy1 = structsToJson.freshCopyIfContainsStatefulExpression()
+    assert(copy1 ne structsToJson)
+    val copy2 = structsToJson.freshCopyIfContainsStatefulExpression()
+    assert(copy2 ne structsToJson)
+    // Each copy owns an independent evaluator - mutable state must not be shared.
+    val eval1 = copy1.asInstanceOf[StructsToJson].replacement
+      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
+    val eval2 = copy2.asInstanceOf[StructsToJson].replacement
+      .asInstanceOf[Invoke].targetObject.asInstanceOf[Literal].value.asInstanceOf[AnyRef]
+    assert(eval1 ne eval2)
+
+    val schemaOfJson = SchemaOfJson(Literal("""{"a":1}"""), Map.empty)
+    assert(schemaOfJson.stateful)
+    assert(schemaOfJson.freshCopyIfContainsStatefulExpression() ne schemaOfJson)
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -1041,4 +1041,19 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       input)
   }
 
+  test("JsonToStructs, GetJsonObject, JsonTuple are stateful and produce fresh copies") {
+    val schema = StructType(StructField("a", IntegerType) :: Nil)
+    val jsonToStructs = JsonToStructs(schema, Map.empty, Literal("{}"), UTC_OPT)
+    assert(jsonToStructs.stateful)
+    assert(jsonToStructs.freshCopyIfContainsStatefulExpression() ne jsonToStructs)
+
+    val getJsonObject = GetJsonObject(Literal("{}"), Literal("$.a"))
+    assert(getJsonObject.stateful)
+    assert(getJsonObject.freshCopyIfContainsStatefulExpression() ne getJsonObject)
+
+    val jsonTuple = JsonTuple(Literal("{}") :: Literal("a") :: Nil)
+    assert(jsonTuple.stateful)
+    assert(jsonTuple.freshCopyIfContainsStatefulExpression() ne jsonTuple)
+  }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/XmlExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/XmlExpressionsSuite.scala
@@ -522,4 +522,17 @@ class XmlExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
   }
 
+  test("XmlToStructs and StructsToXml are stateful and produce fresh copies") {
+    val schema = StructType(StructField("a", IntegerType) :: Nil)
+
+    val xmlToStructs = XmlToStructs(schema, Map.empty, Literal("<a>1</a>"), UTC_OPT)
+    assert(xmlToStructs.stateful)
+    assert(xmlToStructs.freshCopyIfContainsStatefulExpression() ne xmlToStructs)
+
+    val struct = Literal.create(InternalRow(1), schema)
+    val structsToXml = StructsToXml(Map.empty, struct, UTC_OPT)
+    assert(structsToXml.stateful)
+    assert(structsToXml.freshCopyIfContainsStatefulExpression() ne structsToXml)
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds `override def stateful: Boolean = true` to eight JSON/CSV/XML expressions that own their own `eval`/`nullSafeEval` and hold mutable state in `@transient lazy val evaluator` fields:
`GetJsonObject`, `MultiGetJsonObject`, `JsonTuple`, `JsonToStructs`, `CsvToStructs`, `StructsToCsv`, `XmlToStructs`, and `StructsToXml`.

`StructsToJson`, `SchemaOfJson`, and `SchemaOfCsv` are excluded:
- `SchemaOfJson` and `SchemaOfCsv` are `RuntimeReplaceable` with foldable-only children and config-only lazy-vals — constant-folded, so no race is possible.
- `StructsToJson` is also `RuntimeReplaceable`; `ReplaceExpressions` rewrites it to `Invoke(Literal(evaluator), ...)` before any `freshCopyIfContainsStatefulExpression` runs, making the override dead at execution. The sharing via `Literal(evaluator)` will be addressed by SPARK-58208's deep-copy in `QueryExecution.optimizedPlan`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These expressions hold mutable state in `@transient lazy val evaluator` fields but did not override `stateful` (which defaults to `false`). As a result, `freshCopyIfContainsStatefulExpression()` never made fresh copies of them. When the same expression node appears more than once in a query plan — e.g. `df.select(from_json(col, schema), from_json(col, schema))` — both references share the same underlying evaluator instance. In interpreted execution this causes data-race corruption and silently incorrect results.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. Queries that were previously correct continue to produce the same results. Queries that previously silently produced incorrect results due to evaluator sharing now produce correct results.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added one unit test per suite (`JsonExpressionsSuite`, `CsvExpressionsSuite`,`XmlExpressionsSuite`) 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No