### PR TITLE
[SPARK-57109][SQL] Fix exchange reuse failure when a VIEW is referenced in both UNION ALL branches via a CTE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -709,6 +709,26 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     var id = -1
     val allAttributesSeq = this.allAttributes
     mapExpressions {
+      // A no-op rename alias - i.e. `Alias(attr, attr.name)` with metadata that matches the
+      // child attribute's metadata - is exactly the shape that `RemoveRedundantAliases` strips
+      // whenever the underlying attribute is not on its exclude list. Such an alias can still
+      // survive to this point even though it is semantically redundant, e.g. because it sits on
+      // the first child of a `Union` (SPARK-39887 protects the first child's attributes for
+      // correctness) while the exact same alias was stripped from a sibling branch that
+      // references the same underlying attribute (e.g. via a de-duplicated CTE/self-join).
+      // That leaves two semantically-identical branches with different shapes: one still
+      // wrapped in the alias, the other already a bare `AttributeReference`. Left alone, this
+      // asymmetry makes their canonical forms differ, which defeats exchange/subquery reuse.
+      // Canonicalize the no-op alias exactly like the bare attribute it is equivalent to, so
+      // both shapes converge on the same canonical form.
+      case a @ Alias(attr: Attribute, name) if name == attr.name && a.metadata == attr.metadata =>
+        if (allAttributesSeq.indexOf(attr.exprId) == -1) {
+          id += 1
+          attr.withExprId(ExprId(id)).canonicalized
+        } else {
+          QueryPlan.normalizeExpressions(attr, allAttributesSeq)
+        }
+
       case a: Alias =>
         id += 1
         // As the root of the expression, Alias will always take an arbitrary exprId, we need to

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
@@ -200,4 +200,23 @@ class QueryPlanSuite extends SparkFunSuite {
     assert(normalizedExpressions.map(_.dataType) == Seq(IntegerType, StringType),
       "normalizeExpressions preserves original expression order")
   }
+
+  test("SPARK-57109: no-op rename Alias canonicalizes the same as a bare attribute") {
+    val relation = LocalRelation(AttributeReference("a", IntegerType)(ExprId(0)))
+    val a = relation.output.head
+
+    // Branch 1: the attribute is still wrapped in a no-op rename alias, e.g. because it is
+    // protected from RemoveRedundantAliases (the Union first-child case in SPARK-39887, or a
+    // self-join dedup alias).
+    val aliasedBranch = Project(Seq(Alias(a, a.name)(ExprId(1))), relation)
+
+    // Branch 2: the exact same underlying attribute, but the no-op alias has already been
+    // stripped down to a bare AttributeReference (e.g. because RemoveRedundantAliases was free
+    // to remove it here).
+    val bareBranch = Project(Seq(a), relation)
+
+    assert(aliasedBranch.sameResult(bareBranch),
+      "a no-op rename alias and the bare attribute it wraps must canonicalize identically, " +
+      "or ReuseExchange/subquery reuse cannot match semantically equivalent Union branches")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.sql.execution
 
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ReuseExchangeAndSubquerySuite extends SharedSparkSession {
+class ReuseExchangeAndSubquerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
   val tableFormat: String = "parquet"
 
@@ -109,6 +110,31 @@ class ReuseExchangeAndSubquerySuite extends SharedSparkSession {
 
         assert(reusedExchangeIds.forall(exchangeIds.contains(_)),
           "ReusedExchangeExec should reuse an existing exchange")
+      }
+    }
+  }
+
+  test("SPARK-57109: Exchange reused when a VIEW is referenced via a CTE in both UNION branches") {
+    withTable("t1", "t2") {
+      withView("v") {
+        sql(s"CREATE TABLE t1 (a BIGINT, b INT, c INT) USING $tableFormat")
+        sql(s"CREATE TABLE t2 (a BIGINT, d BIGINT) USING $tableFormat")
+        sql("INSERT INTO t1 VALUES (1, 2, 3), (4, 5, 6)")
+        sql("INSERT INTO t2 VALUES (1, 7), (4, 8)")
+        sql("CREATE OR REPLACE VIEW v AS SELECT a, b FROM t1 WHERE c <> 6")
+
+        val df = sql(
+          """
+            |WITH cte AS (SELECT ta.d, tv.b FROM t2 ta JOIN v tv ON ta.a = tv.a)
+            |SELECT d, b, count(1) FROM cte GROUP BY 1, 2
+            |UNION ALL
+            |SELECT d, b, count(1) FROM cte GROUP BY 1, 2
+            |""".stripMargin)
+
+        val plan = df.queryExecution.executedPlan
+        val reusedExchanges = plan.collectWithSubqueries { case re: ReusedExchangeExec => re }
+        assert(reusedExchanges.nonEmpty,
+          "expected the t1 shuffle to be reused across both UNION branches")
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a performance regression where ReusedExchangeExec fails to match the shuffle of the underlying table when a persisted VIEW is referenced in both branches of a UNION ALL through a CTE, causing the table to be scanned and shuffled twice.

The fix is confined entirely to the canonicalization layer (QueryPlan.doCanonicalize()). Inside mapExpressions, a new case is added **before** the generic case a: Alias branch:

- Detect a *no-op rename alias* — Alias(attr: Attribute, name) where 
ame == attr.name AND .metadata == attr.metadata. This is precisely the condition RemoveRedundantAliases itself uses to decide an alias is truly redundant.
- When matched, canonicalize the wrapping alias away and normalize the bare ttr exactly as the existing bare-AttributeReference branches do:
  - If ttr.exprId is not in llAttributesSeq (the node's children's output), assign it the next sequential id (id += 1; attr.withExprId(ExprId(id)).canonicalized).
  - Otherwise normalize via QueryPlan.normalizeExpressions(attr, allAttributesSeq).

No changes are made to RemoveRedundantAliases, DeduplicateRelations, or InlineCTE.

### Why are the changes needed?

**Root cause chain (5 steps):**

1. **VIEW construction** (SPARK-34269) wraps each output column in a schema-compat Alias(UpCast(col, field.dataType), field.name)(explicitMetadata = Some(field.metadata)) — a genuine rename since #scan != #catalog.

2. **InlineCTE**: both UNION branches share identical ExprIds, making Union.duplicateResolved = false.

3. **DeduplicateRelations** resolves duplicates by wrapping the non-first branch in an outer Project(Alias(attr, attr.name)) and rewriting ExprIds via 
ewInstance()/ewriteAttrs, turning the view's inner schema-compat alias into a no-op Alias(a#X AS a#X).

4. **RemoveRedundantAliases** (SPARK-39887 Union first-child protection): protects branch 1's attribute set from alias removal, strips the no-op alias from branch 2. Result: branch 1 keeps the Alias node, branch 2 has a bare AttributeReference — structurally asymmetric though semantically identical. This protection is **required for correctness** and is not touched.

5. **Canonicalization asymmetry**: doCanonicalize() assigns a sequential id to the top-level Alias (branch 1) but uses ordinal-position normalization for the bare AttributeReference (branch 2). The two branches get different canonical forms, so ReuseExchangeAndSubquery (and AQE's stage cache) cannot match the upstream Exchange, and 	1 is shuffled twice.

### Does this PR introduce _any_ user-facing change?

Yes — this is a **performance fix**. Queries matching the pattern (a persisted VIEW referenced in both branches of a UNION ALL via a CTE) will now correctly reuse the shuffle/exchange across both branches, avoiding redundant table scans and shuffles.

### How was this patch tested?

Two tests were added:

1. **Unit test** in sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala:
   - SPARK-57109: no-op rename Alias canonicalizes the same as a bare attribute
   - Constructs two Project branches over the same LocalRelation: one wraps the attribute in a no-op rename Alias, the other uses the bare AttributeReference. Asserts liasedBranch.sameResult(bareBranch) is 	rue.

2. **End-to-end regression test** in sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala:
   - SPARK-57109: Exchange reused when a VIEW is referenced via a CTE in both UNION branches
   - Uses the exact repro SQL from the issue (creates 	1, 	2, view , runs the CTE + UNION ALL query).
   - Asserts that plan.collectWithSubqueries { case re: ReusedExchangeExec => re }.nonEmpty.

Closes #57109

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Google Antigravity (Gemini 2.5 Pro)