### PR TITLE
[SPARK-58212][SQL] Replace _LEGACY_ERROR_TEMP_1052 with UNSUPPORTED_FEATURE.TABLE_OPERATION

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -9599,11 +9599,6 @@
       "Can only star expand struct data types. Attribute: `<attributes>`."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1052" : {
-    "message" : [
-      "ADD COLUMN with v1 tables cannot specify NOT NULL."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1058" : {
     "message" : [
       "Cannot create table with both USING <provider> and <serDeInfo>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1175,12 +1175,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "columns" -> columns))
   }
 
-  def addColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {
-    new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1052",
-      messageParameters = Map.empty)
-  }
-
   def unsupportedTableOperationError(
       catalog: CatalogPlugin,
       ident: Identifier,

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -61,7 +61,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
             ident, "ADD COLUMN with qualified column")
         }
         if (!c.nullable) {
-          throw QueryCompilationErrors.addColumnWithV1TableCannotSpecifyNotNullError()
+          throw QueryCompilationErrors.unsupportedTableOperationError(
+            ident, "ADD COLUMN with NOT NULL")
         }
       }
       // For V1 ALTER TABLE ADD COLUMNS command, the default value expression is hidden in the

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1099,6 +1099,21 @@ class QueryCompilationErrorsSuite
       )
     }
   }
+
+  test("UNSUPPORTED_FEATURE.TABLE_OPERATION: v1 table ADD COLUMN with NOT NULL") {
+    withTable("t") {
+      sql("CREATE TABLE t(i INT) USING parquet")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("ALTER TABLE t ADD COLUMN c INT NOT NULL")
+        },
+        condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+        parameters = Map(
+          "tableName" -> "`spark_catalog`.`default`.`t`",
+          "operation" -> "ADD COLUMN with NOT NULL")
+      )
+    }
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR assigns a name to the legacy error condition `_LEGACY_ERROR_TEMP_1052`, raised when a `NOT NULL` column is added to a v1 (session-catalog) table via `ALTER TABLE ... ADD COLUMN`. Rather than introducing a brand-new condition, it reuses the existing `UNSUPPORTED_FEATURE.TABLE_OPERATION`, matching the sibling "ADD COLUMN with qualified column" rejection immediately above the same call site in `ResolveSessionCatalog`. Concretely: removed `_LEGACY_ERROR_TEMP_1052` from `error-conditions.json`; removed the now-unused `addColumnWithV1TableCannotSpecifyNotNullError()` helper from `QueryCompilationErrors`; and changed the call site to throw `unsupportedTableOperationError(ident, "ADD COLUMN with NOT NULL")`.

### Why are the changes needed?

This is part of the ongoing effort under [SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935) to migrate `_LEGACY_ERROR_TEMP_*` conditions onto proper, named error classes. Reusing `UNSUPPORTED_FEATURE.TABLE_OPERATION` keeps the two `ADD COLUMN` rejections at this call site consistent and yields a clearer, table-qualified message.

### Does this PR introduce _any_ user-facing change?

Yes. The error condition name and message change; the behavior (the conditions under which the error is raised) is unchanged.

Before (condition `_LEGACY_ERROR_TEMP_1052`):

```
ADD COLUMN with v1 tables cannot specify NOT NULL.
```

After (condition `UNSUPPORTED_FEATURE.TABLE_OPERATION`):

```
Table `spark_catalog`.`default`.`t` does not support ADD COLUMN with NOT NULL. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by "spark.sql.catalog".
```

### How was this patch tested?

Added a new `checkError` test in `QueryCompilationErrorsSuite` that runs `ALTER TABLE t ADD COLUMN c INT NOT NULL` on a v1 parquet table and asserts the `UNSUPPORTED_FEATURE.TABLE_OPERATION` condition and its parameters. No test previously covered this path.

### Was this patch authored or co-authored using generative AI tooling?

No