### PR TITLE
[SPARK-58215][ML][CONNECT] Include parameter metadata in tree regressor size estimates

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -190,7 +190,7 @@ class DecisionTreeRegressionModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Node.dummyNode, -1)
 
-  private[spark] override def estimatedSize: Long = getEstimatedSize()
+  private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {
     rootNode.predictImpl(features).prediction

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -245,7 +245,7 @@ class GBTRegressionModel private[ml](
   // For ml connect only
   private[ml] def this() = this("", Array(new DecisionTreeRegressionModel), Array(Double.NaN), -1)
 
-  private[spark] override def estimatedSize: Long = getEstimatedSize()
+  private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   @Since("1.4.0")
   override def trees: Array[DecisionTreeRegressionModel] = _trees

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -215,7 +215,7 @@ class RandomForestRegressionModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Array(new DecisionTreeRegressionModel), -1)
 
-  private[spark] override def estimatedSize: Long = getEstimatedSize()
+  private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   @Since("1.4.0")
   override def trees: Array[DecisionTreeRegressionModel] = _trees

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLSuite.scala
@@ -358,7 +358,7 @@ class MLSuite extends MLHelper {
       .set(Connect.CONNECT_SESSION_CONNECT_ML_CACHE_MEMORY_CONTROL_ENABLED.key, "true")
 
     for (estimator <- Seq(getDecisionTreeClassifier, getRandomForestClassifier)) {
-      for (maxModelSize <- Seq(20000, 50000)) {
+      for (maxModelSize <- Seq(25000, 50000)) {
         sessionHolder.session.conf.set(
           Connect.CONNECT_SESSION_CONNECT_ML_CACHE_MEMORY_CONTROL_MAX_MODEL_SIZE.key,
           maxModelSize.toString)
@@ -375,7 +375,7 @@ class MLSuite extends MLHelper {
     sessionHolder.session.conf
       .set(Connect.CONNECT_SESSION_CONNECT_ML_CACHE_MEMORY_CONTROL_ENABLED.key, "true")
 
-    for (maxModelSize <- Seq(20000, 50000, 130000)) {
+    for (maxModelSize <- Seq(25000, 50000, 130000)) {
       sessionHolder.session.conf.set(
         Connect.CONNECT_SESSION_CONNECT_ML_CACHE_MEMORY_CONTROL_MAX_MODEL_SIZE.key,
         maxModelSize.toString)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch extends the parameter-metadata accounting from #57322 to `DecisionTreeRegressionModel`, `RandomForestRegressionModel`, and `GBTRegressionModel`. Their custom `estimatedSize` implementations now include the existing parameter/default maps and UID in addition to learned tree state.

The existing Spark Connect early-stop test limits are raised to reflect the classifier metadata accounting introduced by #57322.

### Why are the changes needed?

Spark Connect uses a model's estimated size for ML cache accounting and tree-training early stopping. The tree regression models override the general estimate but previously omitted their parameter metadata, undercounting the memory charged to cached models. This keeps the regression models consistent with the classifier counterparts.

### Does this PR introduce _any_ user-facing change?

Yes. Spark Connect reports a larger estimated size for tree regression models, so ML cache accounting and model-size-based early stopping include model parameter metadata.

### How was this patch tested?

Updated the existing Connect tree-model early-stop limits to account for metadata. `git diff --check` passed. The relevant test suite was not run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)