### PR TITLE
[SPARK-58216][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1069

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1623,6 +1623,12 @@
     ],
     "sqlState" : "22023"
   },
+  "CREATE_EXTERNAL_TABLE_WITHOUT_LOCATION" : {
+    "message" : [
+      "CREATE EXTERNAL TABLE must be accompanied by LOCATION."
+    ],
+    "sqlState" : "42601"
+  },
   "CREATE_PERMANENT_VIEW_WITHOUT_ALIAS" : {
     "message" : [
       "Not allowed to create the permanent view <name> without explicitly assigning an alias for the expression <attr>."
@@ -9627,11 +9633,6 @@
   "_LEGACY_ERROR_TEMP_1068" : {
     "message" : [
       "<database> is a system preserved database, you cannot use it as current database. To access global temporary views, you should use qualified name with the GLOBAL_TEMP_DATABASE, e.g. SELECT * FROM <database>.viewName."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1069" : {
-    "message" : [
-      "CREATE EXTERNAL TABLE must be accompanied by LOCATION."
     ]
   },
   "_LEGACY_ERROR_TEMP_1071" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1363,7 +1363,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def createExternalTableWithoutLocationError(): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1069",
+      errorClass = "CREATE_EXTERNAL_TABLE_WITHOUT_LOCATION",
       messageParameters = Map.empty)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -454,6 +454,22 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     }
   }
 
+  test("create external table without location") {
+    withBasicCatalog { catalog =>
+      val externalTableWithoutLocation = CatalogTable(
+        identifier = TableIdentifier("tbl_ext", Some("db1")),
+        tableType = CatalogTableType.EXTERNAL,
+        storage = CatalogStorageFormat.empty,
+        schema = new StructType().add("col1", "int"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.createTable(externalTableWithoutLocation, ignoreIfExists = false)
+        },
+        condition = "CREATE_EXTERNAL_TABLE_WITHOUT_LOCATION",
+        parameters = Map.empty)
+    }
+  }
+
   test("create table when database does not exist") {
     withBasicCatalog { catalog =>
       // Creating table in non-existent database should always fail


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1069` to `CREATE_EXTERNAL_TABLE_WITHOUT_LOCATION`, with SQLSTATE `42601`.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one of them.

The error is raised by `SessionCatalog.createTable` when an EXTERNAL table has no location, e.g. `CREATE EXTERNAL TABLE t(i INT) STORED AS PARQUET` without a LOCATION clause. It is an analysis-time `AnalysisException`, consistent with sibling "missing required clause" errors such as `SORT_BY_WITHOUT_BUCKETING` and `CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE`, which are top-level names with SQLSTATE `42601`. A top-level name is therefore used here rather than an `INVALID_SQL_SYNTAX.*` subclass, which is reserved for parse-time `ParseException`s.

### Does this PR introduce _any_ user-facing change?

No. Only the error condition name is assigned; the message text is unchanged. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API.

### How was this patch tested?

Added a `checkError` test in `SessionCatalogSuite` that creates an EXTERNAL table with an empty storage location and asserts the `CREATE_EXTERNAL_TABLE_WITHOUT_LOCATION` condition. `build/sbt "catalyst/testOnly *InMemorySessionCatalogSuite" "core/testOnly org.apache.spark.SparkThrowableSuite"` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
