### PR TITLE
[SPARK-58209][SQL] Mark stateful expressions to prevent data races

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -71,6 +71,8 @@ case class CallMethodViaReflection(
   // This could be pretty much anything.
   override def expensive: Boolean = true
 
+  override def stateful: Boolean = true
+
   def this(children: Seq[Expression]) =
     this(children, true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -105,6 +105,8 @@ case class UserDefinedGenerator(
     children: Seq[Expression])
   extends Generator with CodegenFallback {
 
+  override def stateful: Boolean = true
+
   @transient private[this] var inputRow: InterpretedProjection = _
   @transient private[this] var convertToScala: (InternalRow) => Row = _
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/xpath.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/xpath.scala
@@ -39,6 +39,8 @@ abstract class XPathExtract
   /** XPath expressions are always nullable, e.g. if the xml string is empty. */
   override def nullable: Boolean = true
 
+  override def stateful: Boolean = true
+
   override def inputTypes: Seq[AbstractDataType] =
     Seq(
       StringTypeWithCollation(supportsTrimCollation = true),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflectionSuite.scala
@@ -64,6 +64,17 @@ class CallMethodViaReflectionSuite extends SparkFunSuite with ExpressionEvalHelp
     SQLConf.withExistingConf(conf)(f)
   }
 
+  test("SPARK-58209: reflect expressions are copied before evaluation") {
+    val expression = createExpr(staticClassName, "method1")
+
+    assert(expression.stateful)
+    val freshCopy = expression.freshCopyIfContainsStatefulExpression()
+      .asInstanceOf[CallMethodViaReflection]
+    assert(freshCopy ne expression)
+    assert(freshCopy.children == expression.children)
+    assert(freshCopy.failOnError == expression.failOnError)
+  }
+
   test("findMethod via reflection for static methods") {
     assert(findMethod(staticClassName, "method1", Seq.empty).exists(_.getName == "method1"))
     assert(findMethod(staticClassName, "method2", Seq(IntegerType)).isDefined)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratorExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratorExpressionSuite.scala
@@ -18,12 +18,28 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.{SPARK_DOC_ROOT, SparkFunSuite}
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.types._
 
 class GeneratorExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
+  test("SPARK-58209: user-defined generators are copied before evaluation") {
+    val function = (_: Row) => Nil
+    val expression = UserDefinedGenerator(
+      StructType(Seq(StructField("value", IntegerType))),
+      function,
+      Seq(Literal(1)))
+
+    assert(expression.stateful)
+    val freshCopy = expression.freshCopyIfContainsStatefulExpression()
+      .asInstanceOf[UserDefinedGenerator]
+    assert(freshCopy ne expression)
+    assert(freshCopy.elementSchema == expression.elementSchema)
+    assert(freshCopy.function eq expression.function)
+    assert(freshCopy.children == expression.children)
+  }
+
   private def checkTuple(actual: Expression, expected: Seq[InternalRow]): Unit = {
     assert(actual.eval(null).asInstanceOf[IterableOnce[InternalRow]].iterator.to(Seq) === expected)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/xml/XPathExpressionSuite.scala
@@ -27,6 +27,17 @@ import org.apache.spark.sql.types.StringType
  */
 class XPathExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
+  test("SPARK-58209: XPath expressions are copied before evaluation") {
+    val expression = XPathString(Literal("<a/>"), Literal("a"))
+
+    assert(expression.stateful)
+    val freshCopy = expression.freshCopyIfContainsStatefulExpression()
+      .asInstanceOf[XPathString]
+    assert(freshCopy ne expression)
+    assert(freshCopy.xml == expression.xml)
+    assert(freshCopy.path == expression.path)
+  }
+
   /** A helper function that tests null and error behaviors for xpath expressions. */
   private def testNullAndErrorBehavior[T <: AnyRef](testExpr: (String, String, T) => Unit): Unit = {
     // null input should lead to null output


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR marks `XPathExtract`, `CallMethodViaReflection`, and
`UserDefinedGenerator` as stateful Catalyst expressions.

It also adds focused regression tests verifying that
`freshCopyIfContainsStatefulExpression()` returns a distinct expression instance while preserving
the expression's children and configuration.

### Why are the changes needed?

These expressions retain mutable runtime state, including an XPath evaluator, a reusable
reflection argument buffer, and generator projections/converters. They currently inherit
`stateful = false`, so independent query executions can reuse the same expression instance.
Concurrent executor tasks may then race on the shared state and silently produce incorrect
results.

Declaring the expressions stateful makes Catalyst create a fresh, uninitialized expression for
each execution path using its existing fresh-copy mechanism.

### Does this PR introduce _any_ user-facing change?

Yes. Concurrent query executions no longer risk incorrect results caused by shared mutable state
in these expressions. There is no SQL API or syntax change.

### How was this patch tested?

Added fresh-copy regression coverage to `XPathExpressionSuite`,
`CallMethodViaReflectionSuite`, and `GeneratorExpressionSuite`.

```bash
./build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.expressions.xml.XPathExpressionSuite org.apache.spark.sql.catalyst.expressions.CallMethodViaReflectionSuite org.apache.spark.sql.catalyst.expressions.GeneratorExpressionSuite"
./build/sbt "catalyst/scalastyle"
```

The three suites passed 27 tests, and Catalyst Scalastyle processed 705 files with no findings.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
