### PR TITLE
[SPARK-58217][SQL] CAST(DECIMAL AS TIMESTAMP) silently produces garbage timestamps on overflow

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -40,6 +40,7 @@ license: |
 - Since Spark 4.3, `hash()` and `xxhash64()` include the `days` field of `CalendarInterval` when computing the hash, so their output for interval values differs from earlier releases. Previously the codegen path dropped `days`, disagreeing with interpreted evaluation.
 - Since Spark 4.3, when a `SELECT` or `INSERT` statement references the same table more than once with different `WITH (...)` options (for example a self-join, or `INSERT INTO t WITH (...) SELECT * FROM t WITH (...)`), each reference now uses its own options instead of the second reference silently inheriting the first reference's options via the analyzer's relation cache.
 - Since Spark 4.3, `HAVING` is evaluated before window functions when the `SELECT` list also contains generator functions such as `explode`. Previously, window functions could include groups removed by `HAVING` and produce incorrect results.
+- Since Spark 4.3, when casting a decimal value to timestamp overflows Long after scaling, Spark returns null (non-ANSI mode) or raises `CAST_OVERFLOW` error (ANSI mode) instead of a wrapping value.
 
 ## Upgrading from Spark SQL 4.1 to 4.2
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -89,6 +89,10 @@ object Cast extends QueryErrorsBase {
    *   - Numeric <=> Boolean
    *   - String <=> Binary
    */
+  private val MICROS_PER_SECOND_BD = java.math.BigDecimal.valueOf(MICROS_PER_SECOND)
+  private val LONG_MAX_BD = java.math.BigDecimal.valueOf(Long.MaxValue)
+  private val LONG_MIN_BD = java.math.BigDecimal.valueOf(Long.MinValue)
+
   def canAnsiCast(from: DataType, to: DataType): Boolean = (from, to) match {
     case (fromType, toType) if fromType == toType => true
 
@@ -557,6 +561,7 @@ object Cast extends QueryErrorsBase {
     case (TimestampType, ByteType | ShortType | IntegerType) => true
     case (_: TimeType, ByteType | ShortType) => true
     case (FloatType | DoubleType, TimestampType) => true
+    case (_: DecimalType, TimestampType) => true
     case (TimestampType, DateType) => false
     case (_: TimestampLTZNanosType, DateType) => false
     case (_: TimestampNTZNanosType, DateType) => false
@@ -1014,9 +1019,15 @@ case class Cast(
         DateTimeUtils.makeTimestampNTZNanos(currentDate(zoneId), nanos, precision))
   }
 
-  private[this] def decimalToTimestamp(d: Decimal): Long = {
-    (d.toBigDecimal * MICROS_PER_SECOND).longValue
+  private[this] def decimalToTimestamp(d: Decimal): Any = {
+    val result = d.toJavaBigDecimal.multiply(MICROS_PER_SECOND_BD)
+    if (result.compareTo(LONG_MAX_BD) > 0 || result.compareTo(LONG_MIN_BD) < 0) {
+      errorOrNull(d, DecimalType(d.precision, d.scale), TimestampType)
+    } else {
+      result.longValue()
+    }
   }
+
   private[this] def doubleToTimestamp(d: Double): Any = {
     if (d.isNaN || d.isInfinite) null else (d * MICROS_PER_SECOND).toLong
   }
@@ -2008,7 +2019,31 @@ case class Cast(
       (c, evPrim, evNull) =>
         code"$evPrim = $dateTimeUtilsCls.convertTz($c.epochMicros, $zid, java.time.ZoneOffset.UTC);"
     case DecimalType() =>
-      (c, evPrim, evNull) => code"$evPrim = ${decimalToTimestampCode(c)};"
+      val fromDt = ctx.addReferenceObj("from", from, from.getClass.getName)
+      val toDt = ctx.addReferenceObj("to", TimestampType, TimestampType.getClass.getName)
+      val microsBD = ctx.addReferenceObj("microsBD",
+        MICROS_PER_SECOND_BD, classOf[java.math.BigDecimal].getName)
+      val maxBD = ctx.addReferenceObj("maxBD",
+        LONG_MAX_BD, classOf[java.math.BigDecimal].getName)
+      val minBD = ctx.addReferenceObj("minBD",
+        LONG_MIN_BD, classOf[java.math.BigDecimal].getName)
+      (c, evPrim, evNull) =>
+        val result = ctx.freshName("decResult")
+        val overflow = if (ansiEnabled) {
+          code"""throw QueryExecutionErrors.castingCauseOverflowError($c, $fromDt, $toDt);"""
+        } else {
+          code"$evNull = true;"
+        }
+        code"""
+          java.math.BigDecimal $result = $c.toJavaBigDecimal()
+              .multiply($microsBD);
+          if ($result.compareTo($maxBD) > 0 ||
+              $result.compareTo($minBD) < 0) {
+            $overflow
+          } else {
+            $evPrim = $result.longValue();
+          }
+        """
     case DoubleType =>
       (c, evPrim, evNull) =>
         if (ansiEnabled) {
@@ -2272,10 +2307,6 @@ case class Cast(
         """
   }
 
-  private[this] def decimalToTimestampCode(d: ExprValue): Block = {
-    val block = inline"new java.math.BigDecimal($MICROS_PER_SECOND)"
-    code"($d.toBigDecimal().bigDecimal().multiply($block)).longValue()"
-  }
   private[this] def longToTimeStampCode(l: ExprValue): Block =
     code"java.util.concurrent.TimeUnit.SECONDS.toMicros($l)"
   private[this] def timestampToLongCode(ts: ExprValue): Block =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -89,10 +89,6 @@ object Cast extends QueryErrorsBase {
    *   - Numeric <=> Boolean
    *   - String <=> Binary
    */
-  private val MICROS_PER_SECOND_BD = java.math.BigDecimal.valueOf(MICROS_PER_SECOND)
-  private val LONG_MAX_BD = java.math.BigDecimal.valueOf(Long.MaxValue)
-  private val LONG_MIN_BD = java.math.BigDecimal.valueOf(Long.MinValue)
-
   def canAnsiCast(from: DataType, to: DataType): Boolean = (from, to) match {
     case (fromType, toType) if fromType == toType => true
 
@@ -689,6 +685,11 @@ case class Cast(
   with ToStringBase
   with SupportQueryContext
   with QueryErrorsBase {
+
+  private val MICROS_PER_SECOND_BD = java.math.BigDecimal.valueOf(MICROS_PER_SECOND)
+  private val LONG_MAX_BD = java.math.BigDecimal.valueOf(Long.MaxValue)
+  private val LONG_MIN_BD = java.math.BigDecimal.valueOf(Long.MinValue)
+
   override def nullIntolerant: Boolean = true
 
   def this(child: Expression, dataType: DataType, timeZoneId: Option[String]) =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -942,4 +942,48 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     checkEvaluation(cast(largeTime1, ShortType), null)
     checkEvaluation(cast(largeTime1, ByteType), null)
   }
+
+  test("SPARK-58217: cast large decimal to timestamp with overflow with ansi off") {
+    // Create a Decimal large enough that multiplying by MICROS_PER_SECOND overflows Long
+    val largeDecimal = Literal(Decimal(
+      new java.math.BigDecimal("99999999999999999999"), 38, 0))
+    checkEvaluation(
+      cast(largeDecimal, TimestampType, UTC_OPT), null)
+
+    // Negative overflow should also return null
+    val negativeDecimal = Literal(Decimal(
+      new java.math.BigDecimal("-99999999999999999999"), 38, 0))
+    checkEvaluation(
+      cast(negativeDecimal, TimestampType, UTC_OPT), null)
+
+    // Decimal with non-zero scale whose integer part overflows Long when scaled
+    val scaledDecimal = Literal(Decimal(
+      new java.math.BigDecimal("99999999999999999999.999999"), 38, 6))
+    checkEvaluation(
+      cast(scaledDecimal, TimestampType, UTC_OPT), null)
+
+    // A normal Decimal value should still work (1 second after epoch)
+    val normalDecimal = Literal(Decimal(1L, 10, 0))
+    checkEvaluation(
+      cast(normalDecimal, TimestampType, UTC_OPT), MICROS_PER_SECOND)
+
+    // Zero value should return epoch
+    val zeroDecimal = Literal(Decimal(0L, 10, 0))
+    checkEvaluation(
+      cast(zeroDecimal, TimestampType, UTC_OPT), 0L)
+
+    // Boundary: Long.MAX_VALUE / MICROS_PER_SECOND = 9223372036854
+    // 9223372036854 * 1000000 = 9223372036854000000 < Long.MAX_VALUE -> should pass
+    val justUnder = Literal(Decimal(
+      new java.math.BigDecimal("9223372036854"), 20, 0))
+    checkEvaluation(
+      cast(justUnder, TimestampType, UTC_OPT),
+      new java.math.BigDecimal("9223372036854").longValue * MICROS_PER_SECOND)
+
+    // 9223372036855 * 1000000 = 9223372036855000000 > Long.MAX_VALUE -> should overflow
+    val justOver = Literal(Decimal(
+      new java.math.BigDecimal("9223372036855"), 20, 0))
+    checkEvaluation(
+      cast(justOver, TimestampType, UTC_OPT), null)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -927,4 +927,31 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
       )
     }
   }
+
+  test("SPARK-58217: cast large decimal to timestamp overflow with ansi on") {
+    val largeDecimal = Literal(Decimal(
+      new java.math.BigDecimal("99999999999999999999"), 38, 0))
+    checkErrorInExpression[SparkArithmeticException](
+      cast(largeDecimal, TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> "99999999999999999999BD",
+        "sourceType" -> "\"DECIMAL(38,0)\"",
+        "targetType" -> "\"TIMESTAMP\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+
+    // Negative overflow should also throw
+    val negativeDecimal = Literal(Decimal(
+      new java.math.BigDecimal("-99999999999999999999"), 38, 0))
+    checkErrorInExpression[SparkArithmeticException](
+      cast(negativeDecimal, TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> "-99999999999999999999BD",
+        "sourceType" -> "\"DECIMAL(38,0)\"",
+        "targetType" -> "\"TIMESTAMP\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Long range validation for the Decimal-to-Timestamp cast path in both interpreted and codegen execution.

When a Decimal value multiplied by `MICROS_PER_SECOND` (1,000,000) exceeds `Long` range, `BigDecimal.longValue()` silently truncates the low 64 bits per the Java specification. The fix detects this overflow and either throws `CAST_OVERFLOW` (ANSI mode) or returns `NULL` (non-ANSI mode).

The cast implementation now validates the multiplication result against Long range before calling `longValue()`. `DecimalType → TimestampType` is also registered in `forceNullable` since the cast can now return null.

### Why are the changes needed?

`CAST(DECIMAL(38,0) AS TIMESTAMP)` silently produces garbage timestamps when the Decimal value overflows Long after scaling. This affects both ANSI and non-ANSI modes.

```sql
SET spark.sql.ansi.enabled=false;
SELECT CAST(CAST(9999999999999 AS DECIMAL(20,0)) AS TIMESTAMP);
-- Returns: -265697-05-04 09:44:49.448384 (garbage)
-- Expected: NULL

SET spark.sql.ansi.enabled=true;
SELECT CAST(CAST(9999999999999 AS DECIMAL(20,0)) AS TIMESTAMP);
-- Returns: -265697-05-04 09:44:49.448384 (garbage)
-- Expected: CAST_OVERFLOW error
```

Root cause: `BigDecimal.longValue()` silently returns the low 64 bits when the value exceeds Long range. The cast implementation had no range checking.

This is consistent with existing overflow protection:
- The double-to-timestamp path guards against `NaN`/`Infinite` by returning null
- `SecondsToTimestamp` uses `DATETIME_OVERFLOW` for similar overflow protection
- SPARK-45816 fixed the same class of bug for timestamp-to-integer overflow

### Does this PR introduce _any_ user-facing change?

Yes. Previously, `CAST(large_decimal AS TIMESTAMP)` returned a nonsensical timestamp value when the Decimal overflows Long after scaling. Now:
- Non-ANSI mode: returns `NULL` (consistent with other overflow casts)
- ANSI mode: throws `CAST_OVERFLOW` error

This is a behavior change for an edge case that previously produced silently wrong results.

### How was this patch tested?

Added unit tests in `CastWithAnsiOffSuite` and `CastWithAnsiOnSuite`:

Non-ANSI mode (`CastWithAnsiOffSuite`):
- Positive overflow: `Decimal(99999999999999999999, 38, 0)` → null
- Negative overflow: `Decimal(-99999999999999999999, 38, 0)` → null
- Scaled overflow: `Decimal(99999999999999999999.999999, 38, 6)` → null
- Normal value: `Decimal(1, 10, 0)` → `MICROS_PER_SECOND`
- Zero value: `Decimal(0, 10, 0)` → `0L`
- Boundary just under: `Decimal(9223372036854, 20, 0)` → passes through
- Boundary just over: `Decimal(9223372036855, 20, 0)` → null

ANSI mode (`CastWithAnsiOnSuite`):
- Positive overflow: throws `CAST_OVERFLOW` with correct error parameters
- Negative overflow: throws `CAST_OVERFLOW` with correct error parameters

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code with Claude Opus 4.8
