### PR TITLE
[SPARK-58069][SQL][FOLLOWUP] Handle empty approx_top_k combine buffers

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxTopKAggregates.scala
@@ -723,9 +723,20 @@ class CombineInternal[T](
    * boundaries (SPARK-58069).
    */
   def serialize(): Array[Byte] = {
-    val sketchWithNullCountBytes = sketchWithNullCount.serialize(
-      ApproxTopK.genSketchSerDe(itemDataType).asInstanceOf[ArrayOfItemsSerDe[T]])
-    val typeBytes: Array[Byte] = itemDataType.json.getBytes(StandardCharsets.UTF_8)
+    // An empty partition has a placeholder buffer whose itemDataType has not been initialized.
+    // It can still be serialized between aggregation stages, so use a default serde for its empty
+    // sketch and encode the missing type as a zero-length section.
+    val serDe: ArrayOfItemsSerDe[T] = if (itemDataType == null) {
+      new ArrayOfStringsSerDe().asInstanceOf[ArrayOfItemsSerDe[T]]
+    } else {
+      ApproxTopK.genSketchSerDe(itemDataType).asInstanceOf[ArrayOfItemsSerDe[T]]
+    }
+    val sketchWithNullCountBytes = sketchWithNullCount.serialize(serDe)
+    val typeBytes: Array[Byte] = if (itemDataType == null) {
+      Array.emptyByteArray
+    } else {
+      itemDataType.json.getBytes(StandardCharsets.UTF_8)
+    }
     val byteArray = new Array[Byte](
       sketchWithNullCountBytes.length + Integer.BYTES + Integer.BYTES + typeBytes.length)
 
@@ -755,12 +766,20 @@ object CombineInternal {
     val typeLength = byteBuffer.getInt
     val typeBytes = new Array[Byte](typeLength)
     byteBuffer.get(typeBytes)
-    val itemDataType = DataType.fromJson(new String(typeBytes, StandardCharsets.UTF_8))
+    val itemDataType = if (typeLength == 0) {
+      null
+    } else {
+      DataType.fromJson(new String(typeBytes, StandardCharsets.UTF_8))
+    }
     // read sketchBytes
     val sketchBytes = new Array[Byte](buffer.length - Integer.BYTES - Integer.BYTES - typeLength)
     byteBuffer.get(sketchBytes)
-    val sketchWithNullCount = ApproxTopKAggregateBuffer.deserialize(
-      sketchBytes, ApproxTopK.genSketchSerDe(itemDataType))
+    val serDe = if (itemDataType == null) {
+      new ArrayOfStringsSerDe().asInstanceOf[ArrayOfItemsSerDe[Any]]
+    } else {
+      ApproxTopK.genSketchSerDe(itemDataType)
+    }
+    val sketchWithNullCount = ApproxTopKAggregateBuffer.deserialize(sketchBytes, serDe)
     new CombineInternal[Any](sketchWithNullCount, itemDataType, maxItemsTracked)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -612,7 +612,7 @@ class ApproxTopKSuite extends SharedSparkSession {
     val combined = sketches.selectExpr("approx_top_k_combine(sketch) AS sketch")
 
     checkAnswer(
-      combined.selectExpr("inline(approx_top_k_estimate(sketch))"),
+      combined.selectExpr("inline(approx_top_k_estimate(sketch, 10))"),
       (0L until 10L).map(Row(_, 1L)))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -595,6 +595,16 @@ class ApproxTopKSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-58069: merge an empty approx_top_k_combine buffer") {
+    val initializedBuffer = new CombineInternal[Any](
+      new ApproxTopKAggregateBuffer[Any](new ItemsSketch[Any](128), 0L),
+      StringType,
+      100)
+    initializedBuffer.updateMaxItemsTracked(
+      combineSizeSpecified = false, ApproxTopK.VOID_MAX_ITEMS_TRACKED)
+    assert(initializedBuffer.getMaxItemsTracked == 100)
+  }
+
   test("SPARK-58069: combine sketches with empty shuffle partitions") {
     val sketches = sql(
       "SELECT approx_top_k_accumulate(id) AS sketch FROM range(10) GROUP BY id")

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -20,8 +20,11 @@ package org.apache.spark.sql
 import java.sql.{Date, Timestamp}
 import java.time.{LocalDateTime, LocalTime}
 
+import org.apache.datasketches.frequencies.ItemsSketch
+
 import org.apache.spark.{SparkArithmeticException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
+import org.apache.spark.sql.catalyst.expressions.aggregate.{ApproxTopKAggregateBuffer, CombineInternal}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampNTZType, TimestampType, TimeType}
@@ -574,6 +577,20 @@ class ApproxTopKSuite extends SharedSparkSession {
       Seq("CAST('12:00:00.123' AS TIME(3))", "CAST('12:00:00.123' AS TIME(3))",
         "CAST('13:00:00.123' AS TIME(3))"))
   )
+
+  test("SPARK-58069: serialize an empty approx_top_k_combine buffer") {
+    val maxItemsTracked = 100
+    val buffer = new CombineInternal[Any](
+      new ApproxTopKAggregateBuffer[Any](new ItemsSketch[Any](128), 0L),
+      null,
+      maxItemsTracked)
+
+    val restored = CombineInternal.deserialize(buffer.serialize())
+
+    assert(restored.getItemDataType == null)
+    assert(restored.getMaxItemsTracked == maxItemsTracked)
+    assert(restored.getSketchWithNullCount.sketch.isEmpty)
+  }
 
   // positive tests for approx_top_k_combine on every types
   gridTest("SPARK-52798: same type, same size, specified combine size - success")(itemsWithTopK) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -24,7 +24,8 @@ import org.apache.datasketches.frequencies.ItemsSketch
 
 import org.apache.spark.{SparkArithmeticException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
-import org.apache.spark.sql.catalyst.expressions.aggregate.{ApproxTopKAggregateBuffer, CombineInternal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{ApproxTopK, ApproxTopKAggregateBuffer,
+  CombineInternal}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampNTZType, TimestampType, TimeType}
@@ -579,17 +580,30 @@ class ApproxTopKSuite extends SharedSparkSession {
   )
 
   test("SPARK-58069: serialize an empty approx_top_k_combine buffer") {
-    val maxItemsTracked = 100
-    val buffer = new CombineInternal[Any](
-      new ApproxTopKAggregateBuffer[Any](new ItemsSketch[Any](128), 0L),
-      null,
-      maxItemsTracked)
+    Seq(100, ApproxTopK.VOID_MAX_ITEMS_TRACKED).foreach { maxItemsTracked =>
+      val buffer = new CombineInternal[Any](
+        new ApproxTopKAggregateBuffer[Any](new ItemsSketch[Any](128), 0L),
+        null,
+        maxItemsTracked)
 
-    val restored = CombineInternal.deserialize(buffer.serialize())
+      val restored = CombineInternal.deserialize(buffer.serialize())
 
-    assert(restored.getItemDataType == null)
-    assert(restored.getMaxItemsTracked == maxItemsTracked)
-    assert(restored.getSketchWithNullCount.sketch.isEmpty)
+      assert(restored.getItemDataType == null)
+      assert(restored.getMaxItemsTracked == maxItemsTracked)
+      assert(restored.getSketchWithNullCount.sketch.isEmpty)
+      assert(restored.getSketchWithNullCount.nullCount == 0L)
+    }
+  }
+
+  test("SPARK-58069: combine sketches with empty shuffle partitions") {
+    val sketches = sql(
+      "SELECT approx_top_k_accumulate(id) AS sketch FROM range(10) GROUP BY id")
+      .repartition(20)
+    val combined = sketches.selectExpr("approx_top_k_combine(sketch) AS sketch")
+
+    checkAnswer(
+      combined.selectExpr("inline(approx_top_k_estimate(sketch))"),
+      (0L until 10L).map(Row(_, 1L)))
   }
 
   // positive tests for approx_top_k_combine on every types

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -591,7 +591,7 @@ class ApproxTopKSuite extends SharedSparkSession {
       assert(restored.getItemDataType == null)
       assert(restored.getMaxItemsTracked == maxItemsTracked)
       assert(restored.getSketchWithNullCount.sketch.isEmpty)
-      assert(restored.getSketchWithNullCount.nullCount == 0L)
+      assert(restored.getSketchWithNullCount.eval(1, StringType).numElements() == 0)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -591,7 +591,7 @@ class ApproxTopKSuite extends SharedSparkSession {
       assert(restored.getItemDataType == null)
       assert(restored.getMaxItemsTracked == maxItemsTracked)
       assert(restored.getSketchWithNullCount.sketch.isEmpty)
-      assert(restored.getSketchWithNullCount.eval(1, StringType).numElements() == 0)
+      assert(restored.getSketchWithNullCount.eval(1, StringType, StringType).numElements() == 0)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -591,7 +591,7 @@ class ApproxTopKSuite extends SharedSparkSession {
       assert(restored.getItemDataType == null)
       assert(restored.getMaxItemsTracked == maxItemsTracked)
       assert(restored.getSketchWithNullCount.sketch.isEmpty)
-      assert(restored.getSketchWithNullCount.eval(1, StringType, StringType).numElements() == 0)
+      assert(restored.getSketchWithNullCount.eval(1, StringType).numElements() == 0)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -591,7 +591,7 @@ class ApproxTopKSuite extends SharedSparkSession {
       assert(restored.getItemDataType == null)
       assert(restored.getMaxItemsTracked == maxItemsTracked)
       assert(restored.getSketchWithNullCount.sketch.isEmpty)
-      assert(restored.getSketchWithNullCount.eval(1, StringType).numElements() == 0)
+      assert(restored.serialize().sameElements(buffer.serialize()))
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Followup to https://github.com/apache/spark/pull/57177.

This change makes `CombineInternal` serialize and deserialize the placeholder buffer created for
an empty partition. It encodes a missing item type as a zero-length type section and uses a default
string serde for the necessarily empty sketch.

### Why are the changes needed?

An untouched `approx_top_k_combine` buffer has no item type. It can nevertheless be serialized
between aggregation stages, where selecting a type-specific serde or serializing the type currently
throws. Preserving the empty placeholder allows the later merge to initialize it from real input.

### Does this PR introduce _any_ user-facing change?

Yes. `approx_top_k_combine` no longer fails when an empty partition contributes an untouched
placeholder buffer between aggregation stages.

### How was this patch tested?

Added a regression test to `ApproxTopKSuite` that round-trips an empty combine buffer and verifies
that its missing item type, sketch, and configured size are preserved. The staged workflow will run
the required fail-before and pass-after suite cycle before opening the pull request.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)

