### PR TITLE
[SPARK-58226][SQL] Honor persistentCatalogFirst for DDL on two-part name resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1323,13 +1323,11 @@ class Analyzer(
       relationResolution.sessionQualifiedCandidateOrder(identifier) match {
         case Some(order) =>
           order.iterator
-            .map[() => Option[LogicalPlan]] {
-              case RelationResolution.TempViewCandidate => () => tempViewCandidate
-              case RelationResolution.PersistentCandidate => () => persistentCandidate
+            .map {
+              case RelationResolution.TempViewCandidate => tempViewCandidate
+              case RelationResolution.PersistentCandidate => persistentCandidate
             }
-            .foldLeft(Option.empty[LogicalPlan]) {
-              (resolved, candidate) => resolved.orElse(candidate())
-            }
+            .collectFirst { case Some(plan) => plan }
         case None =>
           tempViewCandidate.orElse(persistentCandidate)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1319,19 +1319,19 @@ class Analyzer(
           case _ => None
         }
       }
-      // Three-part `system.session.<name>` denotes a local temp view `name` only; it must never
-      // consult the persistent schema `session`, regardless of `PERSISTENT_CATALOG_FIRST`.
-      if (CatalogManager.isFullyQualifiedSystemSessionViewName(identifier)) {
-        tempViewCandidate
-      } else if (identifier.length == 2 &&
-          identifier.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE) &&
-          !conf.prioritizeSystemCatalog) {
-        // Two-part `session.<name>`: the name can denote either a local temp view `name` or a
-        // persistent relation `name` in schema `session`. Order follows
-        // `SQLConf.prioritizeSystemCatalog`.
-        persistentCandidate.orElse(tempViewCandidate)
-      } else {
-        tempViewCandidate.orElse(persistentCandidate)
+      // Map the shared session-qualified candidate order to DDL plans.
+      relationResolution.sessionQualifiedCandidateOrder(identifier) match {
+        case Some(order) =>
+          order.iterator
+            .map[() => Option[LogicalPlan]] {
+              case RelationResolution.TempViewCandidate => () => tempViewCandidate
+              case RelationResolution.PersistentCandidate => () => persistentCandidate
+            }
+            .foldLeft(Option.empty[LogicalPlan]) {
+              (resolved, candidate) => resolved.orElse(candidate())
+            }
+        case None =>
+          tempViewCandidate.orElse(persistentCandidate)
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1255,9 +1255,11 @@ class Analyzer(
     private def lookupTableOrView(
         identifier: Seq[String],
         viewOnly: Boolean = false): Option[LogicalPlan] = {
-      relationResolution.lookupTempView(identifier).map { tempView =>
-        ResolvedTempView(identifier.asIdentifier, tempView.tableMeta)
-      }.orElse {
+      def tempViewCandidate: Option[LogicalPlan] =
+        relationResolution.lookupTempView(identifier).map { tempView =>
+          ResolvedTempView(identifier.asIdentifier, tempView.tableMeta)
+        }
+      def persistentCandidate: Option[LogicalPlan] = {
         relationResolution.expandIdentifier(identifier) match {
           case CatalogAndIdentifier(catalog, ident) =>
             if (viewOnly && !CatalogV2Util.isSessionCatalog(catalog) &&
@@ -1316,6 +1318,19 @@ class Analyzer(
             }
           case _ => None
         }
+      }
+      // Two-part `session.<name>`: the name can denote either a local temp view `name` or a
+      // persistent relation `name` in schema `session`. Order follows
+      // `SQLConf.prioritizeSystemCatalog` (the inverse of `PERSISTENT_CATALOG_FIRST`), matching
+      // the SELECT/DML path in `RelationResolution.resolveRelation`. Without this, DDL and misc
+      // commands (e.g. DESCRIBE TABLE, ALTER TABLE) would always resolve the temp view first and
+      // ignore `PERSISTENT_CATALOG_FIRST`, diverging from how the same name resolves in a query.
+      if (identifier.length == 2 &&
+          identifier.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE) &&
+          !conf.prioritizeSystemCatalog) {
+        persistentCandidate.orElse(tempViewCandidate)
+      } else {
+        tempViewCandidate.orElse(persistentCandidate)
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1319,15 +1319,16 @@ class Analyzer(
           case _ => None
         }
       }
-      // Two-part `session.<name>`: the name can denote either a local temp view `name` or a
-      // persistent relation `name` in schema `session`. Order follows
-      // `SQLConf.prioritizeSystemCatalog` (the inverse of `PERSISTENT_CATALOG_FIRST`), matching
-      // the SELECT/DML path in `RelationResolution.resolveRelation`. Without this, DDL and misc
-      // commands (e.g. DESCRIBE TABLE, ALTER TABLE) would always resolve the temp view first and
-      // ignore `PERSISTENT_CATALOG_FIRST`, diverging from how the same name resolves in a query.
-      if (identifier.length == 2 &&
+      // Three-part `system.session.<name>` denotes a local temp view `name` only; it must never
+      // consult the persistent schema `session`, regardless of `PERSISTENT_CATALOG_FIRST`.
+      if (CatalogManager.isFullyQualifiedSystemSessionViewName(identifier)) {
+        tempViewCandidate
+      } else if (identifier.length == 2 &&
           identifier.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE) &&
           !conf.prioritizeSystemCatalog) {
+        // Two-part `session.<name>`: the name can denote either a local temp view `name` or a
+        // persistent relation `name` in schema `session`. Order follows
+        // `SQLConf.prioritizeSystemCatalog`.
         persistentCandidate.orElse(tempViewCandidate)
       } else {
         tempViewCandidate.orElse(persistentCandidate)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -115,6 +115,27 @@ class RelationResolution(
   }
 
   /**
+   * Candidate order for session-qualified names. Three-part names are temp-only; two-part names
+   * follow [[SQLConf.prioritizeSystemCatalog]]. Returns `None` for other names.
+   */
+  def sessionQualifiedCandidateOrder(
+      identifier: Seq[String]): Option[Seq[RelationResolution.SessionCandidateKind]] = {
+    import RelationResolution._
+    if (CatalogManager.isFullyQualifiedSystemSessionViewName(identifier)) {
+      Some(Seq(TempViewCandidate))
+    } else if (identifier.length == 2 &&
+        identifier.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)) {
+      Some(if (conf.prioritizeSystemCatalog) {
+        Seq(TempViewCandidate, PersistentCandidate)
+      } else {
+        Seq(PersistentCandidate, TempViewCandidate)
+      })
+    } else {
+      None
+    }
+  }
+
+  /**
    * Scope in the relation resolution search path. Used to interpret
    * [[CatalogManager.sqlResolutionPathEntries]] when resolving unqualified table/view names.
    */
@@ -176,30 +197,17 @@ class RelationResolution(
     val finalTimeTravelSpec = timeTravelSpec.orElse(timeTravelSpecFromOptions)
     val identifier = u.multipartIdentifier
 
-    // system.session.v (3 parts): only local temp view by name; same as SessionCatalog matching.
-    if (CatalogManager.isFullyQualifiedSystemSessionViewName(identifier)) {
-      val normalized = normalizeSessionQualifiedViewIdentifier(identifier)
-      return resolveTempView(
-        normalized,
-        u.isStreaming,
-        finalTimeTravelSpec.isDefined
-      )
-    }
-
-    // Two-part session.v: local temp view `v`, or persistent relation `v` in schema `session`.
-    // Order follows [[SQLConf.prioritizeSystemCatalog]] (inverse of `PERSISTENT_CATALOG_FIRST`).
-    if (identifier.length == 2 &&
-        identifier.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)) {
+    // Map the shared session-qualified candidate order to SELECT/DML plans.
+    sessionQualifiedCandidateOrder(identifier).foreach { order =>
       val viewNameOnly = Seq(identifier.last)
-      val tempSession = () =>
-        resolveTempView(viewNameOnly, u.isStreaming, finalTimeTravelSpec.isDefined)
-      val persistentSessionDb = () =>
-        tryResolvePersistent(u, identifier, finalTimeTravelSpec)
-      return if (conf.prioritizeSystemCatalog) {
-        tempSession().orElse(persistentSessionDb())
-      } else {
-        persistentSessionDb().orElse(tempSession())
-      }
+      return order.iterator
+        .map[() => Option[LogicalPlan]] {
+          case RelationResolution.TempViewCandidate =>
+            () => resolveTempView(viewNameOnly, u.isStreaming, finalTimeTravelSpec.isDefined)
+          case RelationResolution.PersistentCandidate =>
+            () => tryResolvePersistent(u, identifier, finalTimeTravelSpec)
+        }
+        .foldLeft(Option.empty[LogicalPlan])((resolved, candidate) => resolved.orElse(candidate()))
     }
 
     // Multi-part (but not session-qualified): try temp view first (e.g. global_temp.tbl1), then
@@ -545,4 +553,11 @@ class RelationResolution(
         plan
     }
   }
+}
+
+object RelationResolution {
+  /** Candidate kind for session-qualified relation resolution. */
+  sealed trait SessionCandidateKind
+  case object TempViewCandidate extends SessionCandidateKind
+  case object PersistentCandidate extends SessionCandidateKind
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -201,13 +201,13 @@ class RelationResolution(
     sessionQualifiedCandidateOrder(identifier).foreach { order =>
       val viewNameOnly = Seq(identifier.last)
       return order.iterator
-        .map[() => Option[LogicalPlan]] {
+        .map {
           case RelationResolution.TempViewCandidate =>
-            () => resolveTempView(viewNameOnly, u.isStreaming, finalTimeTravelSpec.isDefined)
+            resolveTempView(viewNameOnly, u.isStreaming, finalTimeTravelSpec.isDefined)
           case RelationResolution.PersistentCandidate =>
-            () => tryResolvePersistent(u, identifier, finalTimeTravelSpec)
+            tryResolvePersistent(u, identifier, finalTimeTravelSpec)
         }
-        .foldLeft(Option.empty[LogicalPlan])((resolved, candidate) => resolved.orElse(candidate()))
+        .collectFirst { case Some(plan) => plan }
     }
 
     // Multi-part (but not session-qualified): try temp view first (e.g. global_temp.tbl1), then

--- a/sql/core/src/test/scala/org/apache/spark/sql/RelationQualificationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RelationQualificationSuite.scala
@@ -319,24 +319,42 @@ class RelationQualificationSuite extends SharedSparkSession {
     }
 
     // Three-part system.session.<name> is temp-only in both paths and must never consult the
-    // persistent schema `session`, regardless of persistentCatalogFirst (guards the length == 2
-    // condition in lookupTableOrView).
-    withDatabase("session") {
-      sql("CREATE DATABASE session")
-      sql(s"CREATE TABLE session.$tbl (persistent_col INT) USING parquet")
-      sql(s"CREATE TEMPORARY VIEW $tbl AS SELECT 1 AS temp_col")
-      try {
-        Seq(false, true).foreach { persistentCatalogFirst =>
+    // persistent schema `session`, regardless of persistentCatalogFirst. This guards the
+    // isFullyQualifiedSystemSessionViewName branch in lookupTableOrView. We cover both the
+    // temp-present case (resolves the temp view) and, critically, the temp-absent case (must NOT
+    // fall through to the persistent table).
+    for {
+      tempExists <- Seq(true, false)
+      persistentCatalogFirst <- Seq(false, true)
+    } {
+      withDatabase("session") {
+        sql("CREATE DATABASE session")
+        // A persistent `session.<name>` always exists here so a fall-through would resolve it.
+        sql(s"CREATE TABLE session.$tbl (persistent_col INT) USING parquet")
+        if (tempExists) {
+          sql(s"CREATE TEMPORARY VIEW $tbl AS SELECT 1 AS temp_col")
+        }
+        try {
           withSQLConf(SQLConf.PERSISTENT_CATALOG_FIRST.key -> persistentCatalogFirst.toString) {
-            withClue(s"3-part, persistentCatalogFirst=$persistentCatalogFirst: ") {
-              val cols = sql(s"DESCRIBE TABLE system.session.$tbl")
-                .collect().map(_.getString(0)).toSeq
-              assert(cols.contains("temp_col"))
+            withClue(s"3-part, tempExists=$tempExists, " +
+                s"persistentCatalogFirst=$persistentCatalogFirst: ") {
+              if (tempExists) {
+                val cols = sql(s"DESCRIBE TABLE system.session.$tbl")
+                  .collect().map(_.getString(0)).toSeq
+                assert(cols.contains("temp_col"))
+              } else {
+                // Temp view absent: the three-part name is temp-only, so it must NOT resolve the
+                // persistent `session.<name>`. Resolution fails with TABLE_OR_VIEW_NOT_FOUND.
+                val e = intercept[AnalysisException] {
+                  sql(s"DESCRIBE TABLE system.session.$tbl")
+                }
+                assert(e.getCondition == "TABLE_OR_VIEW_NOT_FOUND")
+              }
             }
           }
+        } finally {
+          sql(s"DROP VIEW IF EXISTS $tbl")
         }
-      } finally {
-        sql(s"DROP VIEW IF EXISTS $tbl")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RelationQualificationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RelationQualificationSuite.scala
@@ -254,4 +254,90 @@ class RelationQualificationSuite extends SharedSparkSession {
         "searchPath" -> "[`system`.`session`]"),
       context = ExpectedContext("system.session.no_such_view_xyz"))
   }
+
+  test("SECTION 15: Two-part session.name DDL - persistentCatalogFirst controls temp vs " +
+      "persistent") {
+    // Companion to SECTION 13, but for the DDL / misc-command path (lookupTableOrView).
+    val tbl = "ddl_probe_tbl"
+
+    // The columns DESCRIBE TABLE session.<name> reports (only the leading column-name rows).
+    def describedColumns(): Seq[String] =
+      sql(s"DESCRIBE TABLE session.$tbl").collect().map(_.getString(0)).toSeq
+
+    // Run ALTER TABLE session.<name> SET TBLPROPERTIES and report which object it resolved to by
+    // observing the outcome: it succeeds on the persistent table, but a temp view rejects
+    // ALTER TABLE with EXPECT_TABLE_NOT_VIEW.USE_ALTER_VIEW. Returns "persistent" or "temp".
+    def alterResolvesTo(): String = {
+      try {
+        sql(s"ALTER TABLE session.$tbl SET TBLPROPERTIES ('k' = 'v')")
+        "persistent"
+      } catch {
+        case e: AnalysisException if e.getCondition == "EXPECT_TABLE_NOT_VIEW.USE_ALTER_VIEW" =>
+          "temp"
+      }
+    }
+
+    // (tempExists, permExists); the neither-exists case is covered by SECTION 14 / errors.
+    val existenceCombinations = Seq((true, true), (true, false), (false, true))
+    for {
+      (tempExists, permExists) <- existenceCombinations
+      persistentCatalogFirst <- Seq(false, true)
+    } {
+      withDatabase("session") {
+        sql("CREATE DATABASE session")
+        if (permExists) {
+          sql(s"CREATE TABLE session.$tbl (persistent_col INT) USING parquet")
+        }
+        if (tempExists) {
+          sql(s"CREATE TEMPORARY VIEW $tbl AS SELECT 1 AS temp_col")
+        }
+        try {
+          // Resolves to the temp view unless a permanent table shadows it and
+          // persistentCatalogFirst prefers the permanent one.
+          val resolvesToTemp = tempExists && !(permExists && persistentCatalogFirst)
+          withSQLConf(SQLConf.PERSISTENT_CATALOG_FIRST.key -> persistentCatalogFirst.toString) {
+            withClue(s"tempExists=$tempExists, permExists=$permExists, " +
+                s"persistentCatalogFirst=$persistentCatalogFirst: ") {
+              if (resolvesToTemp) {
+                assert(describedColumns().contains("temp_col"))
+                assert(alterResolvesTo() == "temp")
+              } else {
+                assert(describedColumns().contains("persistent_col"))
+                assert(alterResolvesTo() == "persistent")
+                // The ALTER above targeted the persistent table; confirm the property landed on
+                // spark_catalog.session.<name> and not on any temp object.
+                val props = sql(s"SHOW TBLPROPERTIES spark_catalog.session.$tbl")
+                  .collect().map(r => r.getString(0) -> r.getString(1)).toMap
+                assert(props.get("k").contains("v"))
+              }
+            }
+          }
+        } finally {
+          sql(s"DROP VIEW IF EXISTS $tbl")
+        }
+      }
+    }
+
+    // Three-part system.session.<name> is temp-only in both paths and must never consult the
+    // persistent schema `session`, regardless of persistentCatalogFirst (guards the length == 2
+    // condition in lookupTableOrView).
+    withDatabase("session") {
+      sql("CREATE DATABASE session")
+      sql(s"CREATE TABLE session.$tbl (persistent_col INT) USING parquet")
+      sql(s"CREATE TEMPORARY VIEW $tbl AS SELECT 1 AS temp_col")
+      try {
+        Seq(false, true).foreach { persistentCatalogFirst =>
+          withSQLConf(SQLConf.PERSISTENT_CATALOG_FIRST.key -> persistentCatalogFirst.toString) {
+            withClue(s"3-part, persistentCatalogFirst=$persistentCatalogFirst: ") {
+              val cols = sql(s"DESCRIBE TABLE system.session.$tbl")
+                .collect().map(_.getString(0)).toSeq
+              assert(cols.contains("temp_col"))
+            }
+          }
+        }
+      } finally {
+        sql(s"DROP VIEW IF EXISTS $tbl")
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
The DDL resolution path (`Analyzer.lookupTableOrView`, used by DESCRIBE TABLE, ALTER TABLE, etc.) always resolved a local temp view before the persistent relation for a two-part `session.<name>` identifier, ignoring `spark.sql.legacy.persistentCatalogFirst`. Whereas, the SELECT/DML path (`RelationResolution.resolveRelation`) already honors that config for the same name shape from #53630, so the two paths diverged: the same `session.<name>` could resolve to different relations in a query vs. a DDL command.

In this PR, we fix this ordering. And we also consolidate the ordering logic for both RelationResolution and DDL resolution to share a common path to determine the resolution order for qualified name. 

### Why are the changes needed?
To resolve the resolution divergence and ambiguity between DDL and SELECT. 

### Does this PR introduce _any_ user-facing change?
Yes

#### Before this change
If both a perm table `t` exists under `session` schema and a temp view exists with name `t`, `session.t` will always resolve to the temp view regardless of the setting of persistentCatalogFirst. 

#### After this change
If the persistentCatalogFirst=true, `session.t` will resolve to the perm table. Otherwise, it will resolve to the temp view. 

### How was this patch tested?
Add test to check for DDL commands like `DESCRIBE TABLE` and `ALTER TABLE` resolve to the correct table entity. 

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude-Opus4.8
