### PR TITLE
[SPARK-58227][CONNECT] Support Spark Connect in the spark-sql CLI (spark-sql --remote)

### DIFF
--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -18,6 +18,13 @@
 #
 export SPARK_CONNECT_MODE=0
 
+# Marker read by SparkSubmitCommandBuilder: when combined with a remote session
+# (--remote / spark.remote / spark.api.mode=connect), the CLI main class is swapped to
+# org.apache.spark.sql.application.SparkConnectSQLCLIDriver, mirroring how SPARK_SCALA_SHELL
+# selects the Connect REPL for spark-shell. Without a remote session this has no effect and
+# the classic local SparkSQLCLIDriver is used.
+export SPARK_SQL_SHELL=1
+
 if [ -z "${SPARK_HOME}" ]; then
   source "$(dirname "$0")"/find-spark-home
 fi

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -84,6 +84,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
   static {
     specialClasses.put("org.apache.spark.repl.Main", "spark-shell");
     specialClasses.put("org.apache.spark.sql.application.ConnectRepl", "connect-shell");
+    specialClasses.put("org.apache.spark.sql.application.SparkConnectSQLCLIDriver",
+      "connect-shell");
     specialClasses.put("org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver",
       SparkLauncher.NO_RESOURCE);
     specialClasses.put("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2",
@@ -289,6 +291,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       args.add(parser.CLASS);
       if (isRemote && "1".equals(getenv("SPARK_SCALA_SHELL"))) {
         args.add("org.apache.spark.sql.application.ConnectRepl");
+      } else if (isRemote && "1".equals(getenv("SPARK_SQL_SHELL"))) {
+        args.add("org.apache.spark.sql.application.SparkConnectSQLCLIDriver");
       } else {
         args.add(mainClass);
       }
@@ -297,7 +301,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     args.addAll(parsedArgs);
 
     if (appResource != null) {
-      if (isRemote && "1".equals(getenv("SPARK_SCALA_SHELL"))) {
+      if (isRemote && ("1".equals(getenv("SPARK_SCALA_SHELL"))
+          || "1".equals(getenv("SPARK_SQL_SHELL")))) {
         args.add("connect-shell");
       } else {
         args.add(appResource);

--- a/sql/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/SparkConnectSQLCLIDriver.scala
+++ b/sql/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/SparkConnectSQLCLIDriver.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.application
+
+import java.io.{BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.connect.SparkSession
+import org.apache.spark.sql.connect.SparkSession.withLocalConnectServer
+import org.apache.spark.sql.connect.client.{SparkConnectClient, SparkConnectClientParser}
+
+/**
+ * A minimal `spark-sql` CLI that runs against a Spark Connect server (`spark-sql --remote
+ * sc://...`). It mirrors [[ConnectRepl]] (SPARK-48936) for the SQL command shell rather than the
+ * Scala REPL: it builds a remote [[SparkSession]] from the Connect client, executes statements
+ * via `spark.sql(...)`, and prints tab-separated output collected on the client side.
+ *
+ * This is an intentionally minimal MVP. It supports `-e` / `-f` and an interactive loop. Full
+ * `hiveResultString` output parity (types, complex/nested values, timestamps, aligned columns),
+ * the remaining CLI flags (`--database`, `--help`, init files, ...), and prompt / `USE db`
+ * semantics are deferred to follow-ups. The existing local
+ * [[org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver]] is untouched and remains the
+ * default; there is no dependency on `sql/hive-thriftserver` here.
+ */
+@DeveloperApi
+object SparkConnectSQLCLIDriver {
+  // scalastyle:off println
+  // This is a console CLI whose purpose is to print query results and diagnostics to
+  // stdout/stderr, mirroring ConnectRepl. println is intentional here.
+  private val name = "Spark Connect SQL CLI"
+
+  /**
+   * Driver options (`-e` statements and `-f` files) split from the remaining Connect client
+   * arguments (e.g. `--remote`), which are forwarded verbatim to [[SparkConnectClientParser]].
+   */
+  private[application] case class CliArgs(
+      statements: Seq[String],
+      files: Seq[String],
+      clientArgs: Array[String])
+
+  def main(args: Array[String]): Unit = doMain(args)
+
+  private[application] def doMain(
+      args: Array[String],
+      inputStream: InputStream = System.in,
+      outputStream: OutputStream = System.out,
+      errorStream: OutputStream = System.err): Unit = withLocalConnectServer {
+    val out = new PrintStream(outputStream, true, StandardCharsets.UTF_8.name())
+    val err = new PrintStream(errorStream, true, StandardCharsets.UTF_8.name())
+    val cli = parseArgs(args)
+
+    // Build the Connect client from the Connect arguments only. The client parser rejects
+    // unknown flags, so the CLI options (-e / -f) must already have been stripped out.
+    val client =
+      try {
+        SparkConnectClient
+          .builder()
+          .loadFromEnvironment()
+          .userAgent(name)
+          .parse(cli.clientArgs)
+          .build()
+      } catch {
+        case NonFatal(e) =>
+          err.println(s"$name\n${e.getMessage}\n${SparkConnectClientParser.usage()}")
+          sys.exit(1)
+      }
+
+    val spark = SparkSession.builder().client(client).getOrCreate()
+    try {
+      val batch = cli.statements.flatMap(splitStatements) ++
+        cli.files.flatMap(file => splitStatements(readFile(file)))
+      if (batch.nonEmpty) {
+        // Non-interactive mode (-e / -f): exit non-zero on the first failure (Hive semantics).
+        batch.foreach { statement =>
+          try {
+            run(spark, statement, out)
+          } catch {
+            case NonFatal(e) =>
+              err.println(s"Error in statement: $statement\n${e.getMessage}")
+              sys.exit(1)
+          }
+        }
+      } else {
+        interactiveLoop(spark, inputStream, out, err)
+      }
+    } finally {
+      spark.close()
+    }
+  }
+
+  /** Execute a single statement and print its result as tab-separated rows. */
+  private def run(spark: SparkSession, statement: String, out: PrintStream): Unit = {
+    spark.sql(statement).collect().foreach(row => out.println(formatRow(row)))
+  }
+
+  /** Format a [[Row]] as tab-separated values, rendering nulls as "NULL". */
+  private[application] def formatRow(row: Row): String = {
+    val fields = new Array[String](row.length)
+    var i = 0
+    while (i < row.length) {
+      val value = row.get(i)
+      fields(i) = if (value == null) "NULL" else value.toString
+      i += 1
+    }
+    fields.mkString("\t")
+  }
+
+  private def isExit(statement: String): Boolean =
+    statement.equalsIgnoreCase("quit") || statement.equalsIgnoreCase("exit")
+
+  private def interactiveLoop(
+      spark: SparkSession,
+      inputStream: InputStream,
+      out: PrintStream,
+      err: PrintStream): Unit = {
+    val reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+    val prompt = "spark-sql (connect)> "
+    val buffer = new StringBuilder
+    var running = true
+    out.print(prompt)
+    var line = reader.readLine()
+    while (running && line != null) {
+      buffer.append(line).append('\n')
+      if (line.contains(";")) {
+        val statements = splitStatements(buffer.toString)
+        buffer.clear()
+        val iter = statements.iterator
+        while (running && iter.hasNext) {
+          val statement = iter.next()
+          if (isExit(statement)) {
+            running = false
+          } else {
+            try {
+              run(spark, statement, out)
+            } catch {
+              case NonFatal(e) => err.println(e.getMessage)
+            }
+          }
+        }
+      }
+      if (running) {
+        out.print(prompt)
+        line = reader.readLine()
+      }
+    }
+  }
+
+  /**
+   * Split a block of text into individual statements on ';'.
+   *
+   * This MVP uses a naive split and does not handle ';' inside string literals or comments. A
+   * robust quote/comment-aware splitter exists (`StringUtils.splitSemiColon`) but only in the
+   * catalyst module, which this Connect client must not depend on. A follow-up could relocate
+   * that helper to a shared low-level module (e.g. sql-api) for reuse here, or give the client
+   * its own. Guidance on the preferred layering is welcome.
+   */
+  private[application] def splitStatements(text: String): Seq[String] = {
+    text.split(';').map(_.trim).filter(_.nonEmpty).toSeq
+  }
+
+  private def readFile(path: String): String = {
+    new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8)
+  }
+
+  /**
+   * Split raw CLI arguments into driver options (`-e` / `-f`) and the remaining Connect client
+   * arguments, which are forwarded verbatim to [[SparkConnectClientParser]].
+   */
+  private[application] def parseArgs(args: Array[String]): CliArgs = {
+    val statements = Seq.newBuilder[String]
+    val files = Seq.newBuilder[String]
+    val clientArgs = Array.newBuilder[String]
+    var i = 0
+    while (i < args.length) {
+      args(i) match {
+        case "-e" if i + 1 < args.length =>
+          statements += args(i + 1)
+          i += 2
+        case "-f" if i + 1 < args.length =>
+          files += args(i + 1)
+          i += 2
+        case other =>
+          clientArgs += other
+          i += 1
+      }
+    }
+    CliArgs(statements.result(), files.result(), clientArgs.result())
+  }
+  // scalastyle:on println
+}

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/SparkConnectSQLCLIDriverE2ESuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/SparkConnectSQLCLIDriverE2ESuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.application
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.apache.spark.sql.connect.test.{ConnectFunSuite, RemoteSparkSession}
+
+/**
+ * End-to-end tests for [[SparkConnectSQLCLIDriver]] against a live local Spark Connect server
+ * booted by [[RemoteSparkSession]]. These exercise the real remote path: build the Connect
+ * client, open a remote [[org.apache.spark.sql.connect.SparkSession]], run statements via
+ * `spark.sql(...)`, and render tab-separated output on the client side.
+ */
+class SparkConnectSQLCLIDriverE2ESuite extends ConnectFunSuite with RemoteSparkSession {
+
+  /** Run the CLI against the local server with the given driver args; return captured stdout. */
+  private def runCli(args: String*): String = {
+    val out = new ByteArrayOutputStream()
+    val err = new ByteArrayOutputStream()
+    SparkConnectSQLCLIDriver.doMain(
+      args = Array("--port", serverPort.toString) ++ args,
+      inputStream = new ByteArrayInputStream(Array.emptyByteArray),
+      outputStream = out,
+      errorStream = err)
+    out.toString(StandardCharsets.UTF_8.name())
+  }
+
+  test("SPARK-58227: spark-sql --remote runs -e and prints tab-separated output") {
+    val output = runCli("-e", "select 1 as a, 'x' as b, cast(null as int) as c")
+    assert(output.contains("1\tx\tNULL"))
+  }
+
+  test("SPARK-58227: spark-sql --remote runs multiple ';'-separated statements from -e") {
+    val output = runCli("-e", "select 1; select 2")
+    val lines = output.split("\n").map(_.trim).filter(_.nonEmpty).toSeq
+    assert(lines.contains("1"))
+    assert(lines.contains("2"))
+  }
+
+  test("SPARK-58227: spark-sql --remote runs an -f script file") {
+    val file = File.createTempFile("spark-connect-sql-cli", ".sql")
+    try {
+      Files.write(file.toPath, "select 42 as answer;\n".getBytes(StandardCharsets.UTF_8))
+      val output = runCli("-f", file.getAbsolutePath)
+      assert(output.contains("42"))
+    } finally {
+      file.delete()
+    }
+  }
+}

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/SparkConnectSQLCLIDriverSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/SparkConnectSQLCLIDriverSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.application
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.connect.test.ConnectFunSuite
+
+/**
+ * Unit tests for the pure argument/statement/output helpers of [[SparkConnectSQLCLIDriver]].
+ * These do not require a live Spark Connect server.
+ */
+class SparkConnectSQLCLIDriverSuite extends ConnectFunSuite {
+
+  test("SPARK-58227: parseArgs separates -e statements from Connect client args") {
+    val cli = SparkConnectSQLCLIDriver.parseArgs(
+      Array("--remote", "sc://localhost:15002", "-e", "SELECT 1"))
+    assert(cli.statements == Seq("SELECT 1"))
+    assert(cli.files.isEmpty)
+    assert(cli.clientArgs.toSeq == Seq("--remote", "sc://localhost:15002"))
+  }
+
+  test("SPARK-58227: parseArgs collects multiple -e and -f in order") {
+    val cli =
+      SparkConnectSQLCLIDriver.parseArgs(Array("-e", "SELECT 1", "-f", "a.sql", "-e", "SELECT 2"))
+    assert(cli.statements == Seq("SELECT 1", "SELECT 2"))
+    assert(cli.files == Seq("a.sql"))
+    assert(cli.clientArgs.isEmpty)
+  }
+
+  test("SPARK-58227: parseArgs forwards non-CLI flags to the Connect client parser") {
+    val cli = SparkConnectSQLCLIDriver.parseArgs(Array("--host", "h", "--port", "15002"))
+    assert(cli.clientArgs.toSeq == Seq("--host", "h", "--port", "15002"))
+    assert(cli.statements.isEmpty)
+    assert(cli.files.isEmpty)
+  }
+
+  test("SPARK-58227: splitStatements splits on ';' and drops blanks") {
+    assert(
+      SparkConnectSQLCLIDriver.splitStatements(" SELECT 1 ;\n SELECT 2 ;; ") ==
+        Seq("SELECT 1", "SELECT 2"))
+    assert(SparkConnectSQLCLIDriver.splitStatements("   ").isEmpty)
+  }
+
+  test("SPARK-58227: formatRow renders tab-separated values with NULL for nulls") {
+    assert(SparkConnectSQLCLIDriver.formatRow(Row(1, "abc", null)) == "1\tabc\tNULL")
+    assert(SparkConnectSQLCLIDriver.formatRow(Row()) == "")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds Spark Connect support to the `spark-sql` CLI: `spark-sql --remote sc://...`
starts a SQL shell backed by a remote Spark Connect session, mirroring the existing
`spark-shell --remote` (SPARK-48936).

A new `SparkConnectSQLCLIDriver` is added in `sql/connect/client/jvm`, selected when
`--remote` / `spark.api.mode=connect` is set (the same dispatch `spark-shell` uses). It
builds a remote `SparkSession` against the `sc://` URL (as `ConnectRepl` does), executes
statements via `spark.sql(...)`, prints tab-separated output client-side, and supports
`-e` / `-f` and an interactive loop.

The existing `SparkSQLCLIDriver` (Catalyst / hive-thriftserver-coupled) is unchanged and
remains the default; there is no `sql/hive-thriftserver` dependency and no change to
existing public API. This completes the `--remote` entry-point set under the SPARK-49194
umbrella (`spark-shell` / `spark-submit` / `pyspark` already have it); `spark-sql` was the
last interactive entry point without it.

Scope: an initial, focused implementation. Follow-ups (to be tracked as separate JIRAs):
full `hiveResultString` output parity (types / nulls / complex / timestamps), remaining
CLI flags (`--database`, init files, ...), prompt / `USE db` semantics, and a
quote/comment-aware statement splitter (a robust one exists as `StringUtils.splitSemiColon`
in catalyst but isn't on the Connect client's classpath -- relocating it to `sql-api` for
shared reuse is a candidate; guidance welcome).

Design doc: https://docs.google.com/document/d/14iOZAZFt5BN9whbbjCzZX1mVuhaKq2LEkfP6Ts4prHo/edit
dev@ discussion: https://lists.apache.org/thread/cw897hvjqlmrtdo7byr10b86wtls819l

### Why are the changes needed?

`spark-sql` is the last interactive entry point without Spark Connect support, and the only
one still requiring a local Catalyst driver and the Hive Thrift Server module. This lets the
SQL CLI run against remote, service-hosted compute, consistent with the other entry points.

### Does this PR introduce _any_ user-facing change?

Yes -- a new `spark-sql --remote sc://...` mode. No change to existing `spark-sql` behavior;
the classic local driver remains the default.

### How was this patch tested?

- Unit (server-free, `ConnectFunSuite`): `SparkConnectSQLCLIDriverSuite` -- covers the
  `-e`/`-f` split from the Connect client args, statement splitting, and row formatting.
- Integration / E2E (`SparkConnectSQLCLIDriverE2ESuite`, on `RemoteSparkSession`): boots a
  local Spark Connect server and drives the real remote path -- `spark-sql --remote -e`,
  multiple `;`-separated statements, and an `-f` script -- asserting rendered output.
- CI green: compile, unit, and the E2E integration test on JDK 17/21; scalastyle / scalafmt /
  license / checkstyle all pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8 (Claude Code)
