### PR TITLE
[SPARK-58228][SQL] Convert unreachable error condition _LEGACY_ERROR_TEMP_1058 to an internal error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -9604,11 +9604,6 @@
       "ADD COLUMN with v1 tables cannot specify NOT NULL."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1058" : {
-    "message" : [
-      "Cannot create table with both USING <provider> and <serDeInfo>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1059" : {
     "message" : [
       "STORED AS with file format '<serdeInfo>' is invalid."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1300,15 +1300,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "namespaceB" -> toSQLId(namespaceB)))
   }
 
-  def cannotCreateTableWithBothProviderAndSerdeError(
-      provider: Option[String], maybeSerdeInfo: Option[SerdeInfo]): Throwable = {
-    new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1058",
-      messageParameters = Map(
-        "provider" -> provider.toString,
-        "serDeInfo" -> maybeSerdeInfo.get.describe))
-  }
-
   def invalidFileFormatForStoredAsError(serdeInfo: SerdeInfo): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1059",

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -733,8 +733,9 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     if (provider.isDefined) {
       // The parser guarantees that USING and STORED AS/ROW FORMAT won't co-exist.
       if (maybeSerdeInfo.isDefined) {
-        throw QueryCompilationErrors.cannotCreateTableWithBothProviderAndSerdeError(
-          provider, maybeSerdeInfo)
+        throw SparkException.internalError(
+          s"Cannot create table with both USING ${provider.get} and " +
+            s"${maybeSerdeInfo.get.describe}")
       }
       (nonHiveStorageFormat, provider.get)
     } else if (maybeSerdeInfo.isDefined) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Convert `_LEGACY_ERROR_TEMP_1058` (raised in `ResolveSessionCatalog` when a table has both `USING` and a Hive SerDe) into a `SparkException.internalError`, and remove the condition from `error-conditions.json` plus its now-unused `QueryCompilationErrors` helper.

Part of [SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Why are the changes needed?

This branch is unreachable by users: the parser rejects `USING` + `STORED AS`/`ROW FORMAT` before analysis, and no DataFrame/Catalog API sets SerDe info. It can only fire if an invalid plan is built internally, so it is a bug guard, not a user error. Naming it as a user-facing condition would misclassify it; `internalError` is the correct classification.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No new test (the path is unreachable from SQL). Existing `DDLParserSuite` (parser rejection) and `SparkThrowableSuite` (error-catalog consistency) pass.

### Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Discovered-with: Claude Opus 4.8