### PR TITLE
[SPARK-58856][ML] Avoid per-leaf map for tree predictions

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -341,7 +341,7 @@ object DecisionTreeClassificationModel extends MLReadable[DecisionTreeClassifica
     require(oldModel.algo == OldAlgo.Classification,
       s"Cannot convert non-classification DecisionTreeModel (old API) to" +
         s" DecisionTreeClassificationModel (new API).  Algo is: ${oldModel.algo}")
-    val rootNode = Node.fromOld(oldModel.topNode, categoricalFeatures)
+    val rootNode = Node.withLeafIndices(Node.fromOld(oldModel.topNode, categoricalFeatures))
     val uid = if (parent != null) parent.uid else Identifiable.randomUID("dtc")
     // Can't infer number of features from old model, so default to -1
     new DecisionTreeClassificationModel(uid, rootNode, numFeatures, -1)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -343,7 +343,7 @@ object DecisionTreeRegressionModel extends MLReadable[DecisionTreeRegressionMode
     require(oldModel.algo == OldAlgo.Regression,
       s"Cannot convert non-regression DecisionTreeModel (old API) to" +
         s" DecisionTreeRegressionModel (new API).  Algo is: ${oldModel.algo}")
-    val rootNode = Node.fromOld(oldModel.topNode, categoricalFeatures)
+    val rootNode = Node.withLeafIndices(Node.fromOld(oldModel.topNode, categoricalFeatures))
     val uid = if (parent != null) parent.uid else Identifiable.randomUID("dtr")
     new DecisionTreeRegressionModel(uid, rootNode, numFeatures)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -107,6 +107,25 @@ private[ml] object Node {
   val dummyNode: Node = {
     new LeafNode(0.0, 0.0, ImpurityCalculator.getCalculator("gini", Array.empty, 0))
   }
+
+  /** Return a copy of the tree with left-to-right DFS indices assigned to leaves. */
+  private[ml] def withLeafIndices(rootNode: Node): Node = {
+    withLeafIndices(rootNode, 0)._1
+  }
+
+  private def withLeafIndices(node: Node, nextLeafIndex: Int): (Node, Int) = {
+    node match {
+      case n: LeafNode =>
+        (new LeafNode(n.prediction, n.impurity, n.impurityStats, nextLeafIndex),
+          nextLeafIndex + 1)
+      case n: InternalNode =>
+        val (leftChild, nextIndex) = withLeafIndices(n.leftChild, nextLeafIndex)
+        val (rightChild, endIndex) = withLeafIndices(n.rightChild, nextIndex)
+        val newNode = new InternalNode(n.prediction, n.impurity, n.gain, leftChild, rightChild,
+          n.split, n.impurityStats)
+        (newNode, endIndex)
+    }
+  }
 }
 
 /**
@@ -117,7 +136,8 @@ private[ml] object Node {
 class LeafNode private[ml] (
     override val prediction: Double,
     override val impurity: Double,
-    override private[ml] val impurityStats: ImpurityCalculator) extends Node {
+    override private[ml] val impurityStats: ImpurityCalculator,
+    private[tree] val leafIndex: Int = -1) extends Node {
 
   override def toString: String =
     s"LeafNode(prediction = $prediction, impurity = $impurity)"

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/RandomForest.scala
@@ -269,26 +269,31 @@ private[spark] object RandomForest extends Logging with Serializable {
           topNodes.map { rootNode =>
             new DecisionTreeClassificationModel(
               uid,
-              rootNode.toNode(strategy.pruneTree),
+              Node.withLeafIndices(rootNode.toNode(strategy.pruneTree)),
               numFeatures,
               strategy.getNumClasses())
           }
         } else {
           topNodes.map { rootNode =>
-            new DecisionTreeRegressionModel(uid, rootNode.toNode(strategy.pruneTree), numFeatures)
+            new DecisionTreeRegressionModel(
+              uid,
+              Node.withLeafIndices(rootNode.toNode(strategy.pruneTree)),
+              numFeatures)
           }
         }
       case None =>
         if (strategy.algo == OldAlgo.Classification) {
           topNodes.map { rootNode =>
             new DecisionTreeClassificationModel(
-              rootNode.toNode(strategy.pruneTree),
+              Node.withLeafIndices(rootNode.toNode(strategy.pruneTree)),
               numFeatures,
               strategy.getNumClasses())
           }
         } else {
           topNodes.map(rootNode =>
-            new DecisionTreeRegressionModel(rootNode.toNode(strategy.pruneTree), numFeatures))
+            new DecisionTreeRegressionModel(
+              Node.withLeafIndices(rootNode.toNode(strategy.pruneTree)),
+              numFeatures))
         }
     }
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -107,16 +107,14 @@ private[spark] trait DecisionTreeModel {
     leafAttr.withName(leafCol).toStructField()
   }
 
-  @transient private lazy val leafIndices: Map[LeafNode, Int] = {
-    leafIterator(rootNode).zipWithIndex.toMap
-  }
-
   /**
    * @return The index of the leaf corresponding to the feature vector.
    *         Leaves are indexed in pre-order from 0.
    */
   def predictLeaf(features: Vector): Double = {
-    leafIndices(rootNode.predictImpl(features)).toDouble
+    val leaf = rootNode.predictImpl(features)
+    assert(leaf.leafIndex >= 0, "Leaf indices are not assigned.")
+    leaf.leafIndex.toDouble
   }
 
   def getEstimatedSize(): Long = {
@@ -514,7 +512,7 @@ private[ml] object DecisionTreeModelReadWrite {
       finalNodes(n.id) = node
     }
     // Return the root node
-    finalNodes.head
+    Node.withLeafIndices(finalNodes.head)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -427,6 +427,8 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
       TreeTests.checkEqual(model, model2)
       assert(model.numFeatures === model2.numFeatures)
       assert(model.numClasses === model2.numClasses)
+      val features = Vectors.dense(0.0, 0.0)
+      assert(model.predictLeaf(features) === model2.predictLeaf(features))
     }
 
     val dt = new DecisionTreeClassifier()

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -222,6 +222,8 @@ class DecisionTreeRegressorSuite extends MLTest with DefaultReadWriteTest {
         model2: DecisionTreeRegressionModel): Unit = {
       TreeTests.checkEqual(model, model2)
       assert(model.numFeatures === model2.numFeatures)
+      val features = Vectors.dense(0.0, 0.0)
+      assert(model.predictLeaf(features) === model2.predictLeaf(features))
     }
 
     val dt = new DecisionTreeRegressor()

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -266,8 +266,9 @@ private[ml] object TreeTests extends SparkFunSuite {
     val leaf2 = new LeafNode(0.0, Double.NaN, null)
     val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, leaf1,
       new ContinuousSplit(0, 0.0), null)
-    new InternalNode(0.0, Double.NaN, Double.NaN, node1, leaf2,
-      new CategoricalSplit(1, Array(0.0, 2.0), 3), null)
+    Node.withLeafIndices(
+      new InternalNode(0.0, Double.NaN, Double.NaN, node1, leaf2,
+        new CategoricalSplit(1, Array(0.0, 2.0), 3), null))
   }
 
   /**
@@ -294,8 +295,9 @@ private[ml] object TreeTests extends SparkFunSuite {
     val leaf2 = new LeafNode(0.0, Double.NaN, null)
     val node1 = new InternalNode(0.0, Double.NaN, Double.NaN, leaf1, leaf2,
       new CategoricalSplit(1, Array(0.0, 1.0), 3), null)
-    new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, node1,
-      new ContinuousSplit(2, 1.0), null)
+    Node.withLeafIndices(
+      new InternalNode(0.0, Double.NaN, Double.NaN, leaf0, node1,
+        new ContinuousSplit(2, 1.0), null))
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the transient `Map[LeafNode, Int]` used by tree leaf prediction with a normal integer
field on each `LeafNode`. Tree-model construction assigns the same left-to-right DFS indices
after training and loading, so prediction only traverses the tree and reads the reached leaf's
stored ID. The existing `NodeData` format deliberately omits this field, while broadcast
serialization retains it. The previous `leafIndices` map was not counted in model size
estimation; after this PR, leaf-index storage is counted as the new `LeafNode` field.


### Why are the changes needed?

Large trees can have many leaves. When leaf prediction is used, the map creates a hash-table
entry and boxed value for every leaf in each executor's model copy. A single integer per leaf
keeps the lookup constant-time while substantially reducing the memory overhead and avoids
building an executor-side lookup cache. Since the leaf-index storage is now part of the tree
nodes, model size estimation also accounts for it more accurately.


### Does this PR introduce _any_ user-facing change?

No. Leaf IDs and their traversal order are unchanged.


### How was this patch tested?

Added persistence assertions that verify classifier and regressor leaf IDs are unchanged after
loading. Tests have not been run yet; the relevant ML suites will be run before this draft is
marked ready for review.


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
