### PR TITLE
[SPARK-58230][PS] Batch pandas-on-Spark column projections

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9484,6 +9484,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise ValueError("Data overlaps.")
 
         data_fields = self._internal.data_fields.copy()
+        updated_columns: Dict[str, PySparkColumn] = {}
         for column_labels in update_columns:
             column_name = self._internal.spark_column_name_for(column_labels)
             old_col = scol_for(update_sdf, column_name)
@@ -9507,8 +9508,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     else F.when(old_col.isNull(), new_col).otherwise(old_col)
                 )
 
-            update_sdf = update_sdf.withColumn(column_name, updated_col)
+            updated_columns[column_name] = updated_col
             data_fields[self._internal.column_labels.index(column_labels)] = None
+        if updated_columns:
+            update_sdf = update_sdf.withColumns(updated_columns)
         sdf = update_sdf.select(
             *[scol_for(update_sdf, col) for col in self._internal.spark_column_names],
             *HIDDEN_COLUMNS,

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9484,7 +9484,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise ValueError("Data overlaps.")
 
         data_fields = self._internal.data_fields.copy()
-        updated_columns: Dict[str, PySparkColumn] = {}
         for column_labels in update_columns:
             column_name = self._internal.spark_column_name_for(column_labels)
             old_col = scol_for(update_sdf, column_name)
@@ -9508,10 +9507,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     else F.when(old_col.isNull(), new_col).otherwise(old_col)
                 )
 
-            updated_columns[column_name] = updated_col
+            update_sdf = update_sdf.withColumn(column_name, updated_col)
             data_fields[self._internal.column_labels.index(column_labels)] = None
-        if updated_columns:
-            update_sdf = update_sdf.withColumns(updated_columns)
         sdf = update_sdf.select(
             *[scol_for(update_sdf, col) for col in self._internal.spark_column_names],
             *HIDDEN_COLUMNS,

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -4067,12 +4067,14 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         # Split "quartiles" columns into first, second, and third quartiles.
         for label in agg_column_labels:
             quartiles_col = name_like_string(tuple(list(label) + ["quartiles"]))
-            percentile_columns = {}
-            for i, percentile in enumerate(formatted_percentiles):
-                percentile_columns[name_like_string(tuple(list(label) + [percentile]))] = scol_for(
-                    sdf, quartiles_col
-                )[i]
-            sdf = sdf.withColumns(percentile_columns).drop(quartiles_col)
+            sdf = sdf.withColumns(
+                {
+                    name_like_string(tuple(list(label) + [percentile])): scol_for(
+                        sdf, quartiles_col
+                    )[i]
+                    for i, percentile in enumerate(formatted_percentiles)
+                }
+            ).drop(quartiles_col)
 
         # Reorder columns lexicographically by agg column followed by stats.
         stats = ["count", "mean", "std", "min"] + formatted_percentiles + ["max"]

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2459,8 +2459,10 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
 
         sdf = self._psdf._internal.spark_frame
-        for s, name in zip(self._groupkeys, groupkey_names):
-            sdf = sdf.withColumn(name, s.spark.column)
+        if groupkey_names:
+            sdf = sdf.withColumns(
+                {name: s.spark.column for s, name in zip(self._groupkeys, groupkey_names)}
+            )
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
@@ -2554,8 +2556,10 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
 
         sdf = self._psdf._internal.spark_frame
-        for s, name in zip(self._groupkeys, groupkey_names):
-            sdf = sdf.withColumn(name, s.spark.column)
+        if groupkey_names:
+            sdf = sdf.withColumns(
+                {name: s.spark.column for s, name in zip(self._groupkeys, groupkey_names)}
+            )
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2459,8 +2459,10 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
 
         sdf = self._psdf._internal.spark_frame
-        for s, name in zip(self._groupkeys, groupkey_names):
-            sdf = sdf.withColumn(name, s.spark.column)
+        if groupkey_names:
+            sdf = sdf.withColumns(
+                {name: s.spark.column for s, name in zip(self._groupkeys, groupkey_names)}
+            )
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
@@ -2554,8 +2556,10 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
 
         sdf = self._psdf._internal.spark_frame
-        for s, name in zip(self._groupkeys, groupkey_names):
-            sdf = sdf.withColumn(name, s.spark.column)
+        if groupkey_names:
+            sdf = sdf.withColumns(
+                {name: s.spark.column for s, name in zip(self._groupkeys, groupkey_names)}
+            )
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
@@ -4065,14 +4069,17 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         formatted_percentiles = ["25%", "50%", "75%"]
 
         # Split "quartiles" columns into first, second, and third quartiles.
+        percentile_columns: Dict[str, Column] = {}
+        quartile_columns: List[str] = []
         for label in agg_column_labels:
             quartiles_col = name_like_string(tuple(list(label) + ["quartiles"]))
             for i, percentile in enumerate(formatted_percentiles):
-                sdf = sdf.withColumn(
-                    name_like_string(tuple(list(label) + [percentile])),
-                    scol_for(sdf, quartiles_col)[i],
-                )
-            sdf = sdf.drop(quartiles_col)
+                percentile_columns[name_like_string(tuple(list(label) + [percentile]))] = scol_for(
+                    sdf, quartiles_col
+                )[i]
+            quartile_columns.append(quartiles_col)
+        if percentile_columns:
+            sdf = sdf.withColumns(percentile_columns).drop(*quartile_columns)
 
         # Reorder columns lexicographically by agg column followed by stats.
         stats = ["count", "mean", "std", "min"] + formatted_percentiles + ["max"]

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2459,10 +2459,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
 
         sdf = self._psdf._internal.spark_frame
-        if groupkey_names:
-            sdf = sdf.withColumns(
-                {name: s.spark.column for s, name in zip(self._groupkeys, groupkey_names)}
-            )
+        for s, name in zip(self._groupkeys, groupkey_names):
+            sdf = sdf.withColumn(name, s.spark.column)
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
@@ -2556,10 +2554,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
 
         sdf = self._psdf._internal.spark_frame
-        if groupkey_names:
-            sdf = sdf.withColumns(
-                {name: s.spark.column for s, name in zip(self._groupkeys, groupkey_names)}
-            )
+        for s, name in zip(self._groupkeys, groupkey_names):
+            sdf = sdf.withColumn(name, s.spark.column)
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
@@ -4069,17 +4065,14 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         formatted_percentiles = ["25%", "50%", "75%"]
 
         # Split "quartiles" columns into first, second, and third quartiles.
-        percentile_columns: Dict[str, Column] = {}
-        quartile_columns: List[str] = []
         for label in agg_column_labels:
             quartiles_col = name_like_string(tuple(list(label) + ["quartiles"]))
+            percentile_columns = {}
             for i, percentile in enumerate(formatted_percentiles):
                 percentile_columns[name_like_string(tuple(list(label) + [percentile]))] = scol_for(
                     sdf, quartiles_col
                 )[i]
-            quartile_columns.append(quartiles_col)
-        if percentile_columns:
-            sdf = sdf.withColumns(percentile_columns).drop(*quartile_columns)
+            sdf = sdf.withColumns(percentile_columns).drop(quartiles_col)
 
         # Reorder columns lexicographically by agg column followed by stats.
         stats = ["count", "mean", "std", "min"] + formatted_percentiles + ["max"]

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2732,9 +2732,10 @@ def concat(
 
                 # TODO: NaN and None difference for missing values. pandas seems to be filling NaN.
                 sdf = psdf._internal.resolved_copy.spark_frame
-                sdf = sdf.withColumns(
-                    {name_like_string(label): F.lit(None) for label in columns_to_add}
-                )
+                if columns_to_add:
+                    sdf = sdf.withColumns(
+                        {name_like_string(label): F.lit(None) for label in columns_to_add}
+                    )
 
                 data_columns = psdf._internal.data_spark_column_names + [
                     name_like_string(label) for label in columns_to_add

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2732,8 +2732,9 @@ def concat(
 
                 # TODO: NaN and None difference for missing values. pandas seems to be filling NaN.
                 sdf = psdf._internal.resolved_copy.spark_frame
-                for label in columns_to_add:
-                    sdf = sdf.withColumn(name_like_string(label), F.lit(None))
+                sdf = sdf.withColumns(
+                    {name_like_string(label): F.lit(None) for label in columns_to_add}
+                )
 
                 data_columns = psdf._internal.data_spark_column_names + [
                     name_like_string(label) for label in columns_to_add


### PR DESCRIPTION
### What changes were proposed in this pull request?

Batch independent pandas-on-Spark column projections with `withColumns`:

- Add all missing columns together in outer `concat`, while skipping the call when no columns are missing.
- Add the three percentile columns together for each aggregate column in `DataFrameGroupBy.describe`.
- Add group-key aliases together in `GroupBy.idxmax` and `GroupBy.idxmin`.

### Why are the changes needed?

In classic mode, the previous loops made one Py4J call and one projection per missing, percentile, or group-key column. Batching the independent expressions reduces driver overhead and logical-plan construction and analysis work.

In Spark Connect mode, each batch produces one protobuf transformation instead of one transformation per column, reducing serialized-plan and transformation/analyze overhead. Results are unchanged.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)