### PR TITLE
[SPARK-58177][GRAPHX][TEST][FOLLOWUP] Add regression test for SVD++ aggregateMessages combiner

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/SVDPlusPlus.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/SVDPlusPlus.scala
@@ -38,6 +38,17 @@ object SVDPlusPlus {
       var gamma7: Double)
     extends Serializable
 
+  /** Sums two Phase 2 training messages component-wise: both vectors and the scalar. */
+  private[graphx] def combineTrainMessages(
+      g1: (Array[Double], Array[Double], Double),
+      g2: (Array[Double], Array[Double], Double)): (Array[Double], Array[Double], Double) = {
+    val out1 = g1._1.clone()
+    BLAS.nativeBLAS.daxpy(out1.length, 1.0, g2._1, 1, out1, 1)
+    val out2 = g1._2.clone()
+    BLAS.nativeBLAS.daxpy(out2.length, 1.0, g2._2, 1, out2, 1)
+    (out1, out2, g1._3 + g2._3)
+  }
+
   // scalastyle:off line.size.limit
   /**
    * Implement SVD++ based on "Factorization Meets the Neighborhood: a Multifaceted
@@ -152,14 +163,7 @@ object SVDPlusPlus {
       g.cache()
       val t2 = g.aggregateMessages(
         sendMsgTrainF(conf, u),
-        (g1: (Array[Double], Array[Double], Double), g2: (Array[Double], Array[Double], Double)) =>
-        {
-          val out1 = g1._1.clone()
-          BLAS.nativeBLAS.daxpy(out1.length, 1.0, g2._1, 1, out1, 1)
-          val out2 = g1._2.clone()
-          BLAS.nativeBLAS.daxpy(out2.length, 1.0, g2._2, 1, out2, 1)
-          (out1, out2, g1._3 + g2._3)
-        })
+        combineTrainMessages)
       val gJoinT2 = g.outerJoinVertices(t2) {
         (vid: VertexId,
          vd: (Array[Double], Array[Double], Double, Double),

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/SVDPlusPlusSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/SVDPlusPlusSuite.scala
@@ -49,4 +49,19 @@ class SVDPlusPlusSuite extends SparkFunSuite with LocalSparkContext {
       assert(graph.edges.count() == 0)
     }
   }
+
+  test("SPARK-58177: training-phase message combiner sums both vectors element-wise") {
+    val g1 = (Array(1.0, 2.0), Array(10.0, 20.0), 100.0)
+    val g2 = (Array(3.0, 4.0), Array(30.0, 40.0), 200.0)
+    val (out1, out2, out3) = SVDPlusPlus.combineTrainMessages(g1, g2)
+    // Each component is the element-wise sum of the two messages.
+    assert(out1.toSeq === Seq(4.0, 6.0))
+    assert(out2.toSeq === Seq(40.0, 60.0))
+    assert(out3 === 300.0)
+    // Inputs are cloned, not mutated.
+    assert(g1._1.toSeq === Seq(1.0, 2.0))
+    assert(g1._2.toSeq === Seq(10.0, 20.0))
+    assert(g2._1.toSeq === Seq(3.0, 4.0))
+    assert(g2._2.toSeq === Seq(30.0, 40.0))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to [SPARK-58177](https://issues.apache.org/jira/browse/SPARK-58177) / #57314, which fixed a wrong operand in the SVD++ Phase 2 `aggregateMessages` combiner but merged without a test. This adds the regression test:

- Extract the Phase 2 training-message merge logic into a package-private `SVDPlusPlus.combineTrainMessages`, and use it in place of the inline `aggregateMessages` combiner.
- Add a unit test in `SVDPlusPlusSuite` that asserts both vectors and the scalar are summed element-wise, and that the input messages are not mutated.

### Why are the changes needed?

The fixed bug (the second vector was based on `g2._2`, which dropped `g1._2` and doubled `g2._2`) only manifests when a vertex merges two or more differing messages, and the combiner was an inline lambda that could not be tested directly. Extracting it makes the merge logic unit-testable and guards against a future regression.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a unit test in `SVDPlusPlusSuite`; the full suite passes locally. The test was confirmed to fail when the pre-fix operand (`g2._2`) is restored and to pass with the fix in place.

### Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
