### PR TITLE
[SPARK-58158][CORE][UI][4.1][FOLLOWUP] Fix broken jQuery import path in executorspage.test.js

### DIFF
--- a/ui-test/tests/executorspage.test.js
+++ b/ui-test/tests/executorspage.test.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import '../../core/src/main/resources/org/apache/spark/ui/static/jquery.min.js';
+import '../../core/src/main/resources/org/apache/spark/ui/static/jquery-3.5.1.min.js';
 import '../../core/src/main/resources/org/apache/spark/ui/static/jquery.dataTables.min.js';
 import { formatLossReason } from '../../core/src/main/resources/org/apache/spark/ui/static/executorspage.js';
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the jQuery import path in `ui-test/tests/executorspage.test.js` on `branch-4.1`, changing `jquery.min.js` to `jquery-3.5.1.min.js`.

### Why are the changes needed?

The `executorspage.test.js` added by SPARK-58158 imports `jquery.min.js`. That file name only exists on `master`, where SPARK-54235 (a master-only jQuery 3.5.1 -> 3.7.1 upgrade) renamed `jquery-3.5.1.min.js` to the version-agnostic `jquery.min.js`. SPARK-54235 was not backported, so on `branch-4.1` the file is still `jquery-3.5.1.min.js` and the import fails:

```
FAIL tests/executorspage.test.js
  Cannot find module '.../ui/static/jquery.min.js' from 'tests/executorspage.test.js'
```

This breaks the daily "Run Spark UI tests" job on `branch-4.1` (e.g. https://github.com/apache/spark/actions/runs/29675755877/job/88162850620). The other three ui-test files on this branch already import `jquery-3.5.1.min.js`; this aligns `executorspage.test.js` with them. The `jquery.dataTables.min.js` import on the following line is unaffected (that file exists on the branch).

### Does this PR introduce _any_ user-facing change?

No. Test-only.

### How was this patch tested?

Ran the ui-test suite locally on `branch-4.1` with the fix:

```
cd ui-test
npm install --save-dev
node --experimental-vm-modules node_modules/.bin/jest

Test Suites: 5 passed, 5 total
Tests:       13 passed, 13 total
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)