### PR TITLE
[SPARK-58234][PS] Use native functions for NumPy inverse hyperbolic ufuncs

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -27,11 +27,11 @@ unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
     "arccos": F.acos,
-    "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore[call-overload]
+    "arccosh": F.acosh,
     "arcsin": F.asin,
-    "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore[call-overload]
+    "arcsinh": F.asinh,
     "arctan": F.atan,
-    "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore[call-overload]
+    "arctanh": F.atanh,
     "bitwise_not": F.bitwiseNOT,
     "cbrt": F.cbrt,
     "ceil": F.ceil,

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -85,6 +85,19 @@ class NumPyCompatTestsMixin:
         with self.assertRaisesRegex(ValueError, "cannot join with no overlapping index names"):
             np.left_shift(psdf1, psdf2)
 
+    def test_np_inverse_hyperbolic_series_uses_native_functions(self):
+        for np_func, values in (
+            (np.arccosh, [1.0, 2.0, 4.0]),
+            (np.arcsinh, [-2.0, 0.0, 2.0]),
+            (np.arctanh, [-0.5, 0.0, 0.5]),
+        ):
+            with self.subTest(name=np_func.__name__):
+                pdf = pd.DataFrame({"a": values})
+                psdf = ps.from_pandas(pdf)
+                result = np_func(psdf.a)
+
+                self.assert_eq(result, np_func(pdf.a), almost=True)
+
     def test_np_spark_compat_series(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the scalar pandas UDF mappings for NumPy `arccosh`, `arcsinh`, and `arctanh` on pandas-on-Spark objects with the native Spark SQL functions `acosh`, `asinh`, and `atanh`.

Add end-to-end pandas-on-Spark coverage that compares each NumPy ufunc result with pandas.

### Why are the changes needed?

These mappings originated in Koalas when it supported PySpark 2.4, before the native inverse-hyperbolic Spark SQL functions were available. Current Spark provides the native functions, including Spark Connect support, so this removes the Python worker boundary while preserving NumPy-compatible results.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added end-to-end pandas-on-Spark coverage for `arccosh`, `arcsinh`, and `arctanh`.
- Ran `git diff --check`.
- Runtime tests were not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)