### PR TITLE
[SPARK-58235][SQL] Fix Double/Float to Timestamp silent overflow clamping in non-ANSI mode

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -73,6 +73,7 @@ license: |
 - Since Spark 4.0, Spark removes `hive-llap-common` dependency. To restore the previous behavior, add `hive-llap-common` jar to the class path.
 - Since Spark 4.0, `spark.sql.parquet.compression.codec` drops the support of codec name `lz4raw`, please use `lz4_raw` instead.
 - Since Spark 4.0, when overflowing during casting timestamp to byte/short/int under non-ansi mode, Spark will return null instead a wrapping value.
+- Since Spark 4.0, when overflowing during casting numeric types (double, float) to timestamp under non-ansi mode, Spark will return null instead of an incorrect value caused by numeric overflow.
 - Since Spark 4.0, the `encode()` and `decode()` functions support only the following charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32'. To restore the previous behavior when the function accepts charsets of the current JDK used by Spark, set `spark.sql.legacy.javaCharsets` to `true`.
 - Since Spark 4.0, the `encode()` and `decode()` functions raise `MALFORMED_CHARACTER_CODING` error when handling unmappable characters, while in Spark 3.5 and earlier versions, these characters will be replaced with mojibakes. To restore the previous behavior, set `spark.sql.legacy.codingErrorAction` to `true`. For example, if you try to `decode` a string value `tést` / [116, -23, 115, 116] (encoded in latin1) with 'UTF-8', you get `t�st`.
 - Since Spark 4.0, the legacy datetime rebasing SQL configs with the prefix `spark.sql.legacy` are removed. To restore the previous behavior, use the following configs:

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -40,6 +40,7 @@ license: |
 - Since Spark 4.3, `hash()` and `xxhash64()` include the `days` field of `CalendarInterval` when computing the hash, so their output for interval values differs from earlier releases. Previously the codegen path dropped `days`, disagreeing with interpreted evaluation.
 - Since Spark 4.3, when a `SELECT` or `INSERT` statement references the same table more than once with different `WITH (...)` options (for example a self-join, or `INSERT INTO t WITH (...) SELECT * FROM t WITH (...)`), each reference now uses its own options instead of the second reference silently inheriting the first reference's options via the analyzer's relation cache.
 - Since Spark 4.3, `HAVING` is evaluated before window functions when the `SELECT` list also contains generator functions such as `explode`. Previously, window functions could include groups removed by `HAVING` and produce incorrect results.
+- Since Spark 4.3, when overflowing during casting numeric types (double, float) to timestamp under non-ansi mode, Spark will return null instead of an incorrect value caused by numeric overflow.
 
 ## Upgrading from Spark SQL 4.1 to 4.2
 
@@ -73,7 +74,6 @@ license: |
 - Since Spark 4.0, Spark removes `hive-llap-common` dependency. To restore the previous behavior, add `hive-llap-common` jar to the class path.
 - Since Spark 4.0, `spark.sql.parquet.compression.codec` drops the support of codec name `lz4raw`, please use `lz4_raw` instead.
 - Since Spark 4.0, when overflowing during casting timestamp to byte/short/int under non-ansi mode, Spark will return null instead a wrapping value.
-- Since Spark 4.0, when overflowing during casting numeric types (double, float) to timestamp under non-ansi mode, Spark will return null instead of an incorrect value caused by numeric overflow.
 - Since Spark 4.0, the `encode()` and `decode()` functions support only the following charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32'. To restore the previous behavior when the function accepts charsets of the current JDK used by Spark, set `spark.sql.legacy.javaCharsets` to `true`.
 - Since Spark 4.0, the `encode()` and `decode()` functions raise `MALFORMED_CHARACTER_CODING` error when handling unmappable characters, while in Spark 3.5 and earlier versions, these characters will be replaced with mojibakes. To restore the previous behavior, set `spark.sql.legacy.codingErrorAction` to `true`. For example, if you try to `decode` a string value `tést` / [116, -23, 115, 116] (encoded in latin1) with 'UTF-8', you get `t�st`.
 - Since Spark 4.0, the legacy datetime rebasing SQL configs with the prefix `spark.sql.legacy` are removed. To restore the previous behavior, use the following configs:

--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -129,7 +129,7 @@ In the table above, all the `CAST`s with new syntax are marked as red <span styl
 * CAST(Numeric AS Numeric): raise an overflow exception if the value is out of the target data type's range.
 * CAST(String AS (Numeric/Date/Timestamp/Timestamp_NTZ/Interval/Boolean)): raise a runtime exception if the value can't be parsed as the target data type.
 * CAST(Timestamp AS Numeric): raise an overflow exception if the number of seconds since epoch is out of the target data type's range.
-* CAST(Numeric AS Timestamp): raise an overflow exception if numeric value times 1000000(microseconds per second) is out of the range of Long type.
+* CAST(Numeric AS Timestamp): raise an overflow exception if numeric value times 1000000(microseconds per second) is out of the range of Long type. In non-ANSI mode, overflow returns NULL instead.
 * CAST(Array AS Array): raise an exception if there is any on the conversion of the elements.
 * CAST(Map AS Map): raise an exception if there is any on the conversion of the keys and the values.
 * CAST(Struct AS Struct): raise an exception if there is any on the conversion of the struct fields.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1018,7 +1018,24 @@ case class Cast(
     (d.toBigDecimal * MICROS_PER_SECOND).longValue
   }
   private[this] def doubleToTimestamp(d: Double): Any = {
-    if (d.isNaN || d.isInfinite) null else (d * MICROS_PER_SECOND).toLong
+    if (d.isNaN || d.isInfinite) {
+      null
+    } else {
+      val result = d * MICROS_PER_SECOND
+      // Detect overflow before casting to Long. Conditions 2 and 3 also catch
+      // finite d whose multiplication overflows to +-Infinity (then (long)result
+      // clamps to Long.MAX_VALUE or Long.MIN_VALUE). Note: condition 3 has a
+      // theoretical false positive when d = Long.MinValue / 1e6 (double rounding
+      // makes d * 1e6 == Long.MinValue), but the corresponding timestamp is
+      // ~292 million years BCE, so this is harmless in practice.
+      if (result > Long.MaxValue ||
+        (result.toLong == Long.MaxValue && d > 0) ||
+        (result.toLong == Long.MinValue && d < 0)) {
+        errorOrNull(d, DoubleType, TimestampType)
+      } else {
+        result.toLong
+      }
+    }
   }
 
   // converting seconds to us
@@ -2015,11 +2032,19 @@ case class Cast(
           val errorContext = getContextOrNullCode(ctx)
           code"$evPrim = $dateTimeUtilsCls.doubleToTimestampAnsi($c, $errorContext);"
         } else {
+          val result = ctx.freshName("dblResult")
           code"""
             if (Double.isNaN($c) || Double.isInfinite($c)) {
               $evNull = true;
             } else {
-              $evPrim = (long)($c * $MICROS_PER_SECOND);
+              double $result = $c * $MICROS_PER_SECOND;
+              if ($result > Long.MAX_VALUE ||
+                  ((long)$result == Long.MAX_VALUE && $c > 0) ||
+                  ((long)$result == Long.MIN_VALUE && $c < 0)) {
+                $evNull = true;
+              } else {
+                $evPrim = (long)$result;
+              }
             }
           """
         }
@@ -2029,11 +2054,19 @@ case class Cast(
           val errorContext = getContextOrNullCode(ctx)
           code"$evPrim = $dateTimeUtilsCls.doubleToTimestampAnsi((double)$c, $errorContext);"
         } else {
+          val result = ctx.freshName("fltResult")
           code"""
             if (Float.isNaN($c) || Float.isInfinite($c)) {
               $evNull = true;
             } else {
-              $evPrim = (long)((double)$c * $MICROS_PER_SECOND);
+              double $result = (double)$c * $MICROS_PER_SECOND;
+              if ($result > Long.MAX_VALUE ||
+                  ((long)$result == Long.MAX_VALUE && $c > 0) ||
+                  ((long)$result == Long.MIN_VALUE && $c < 0)) {
+                $evNull = true;
+              } else {
+                $evPrim = (long)$result;
+              }
             }
           """
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -942,4 +942,79 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     checkEvaluation(cast(largeTime1, ShortType), null)
     checkEvaluation(cast(largeTime1, ByteType), null)
   }
+
+  test("SPARK-58235: cast large double to timestamp overflow with ansi off") {
+    // Large positive double that overflows Long range when multiplied by MICROS_PER_SECOND
+    val largePosDouble = Literal(1E20.toDouble)
+    checkEvaluation(cast(largePosDouble, TimestampType, UTC_OPT), null)
+
+    // Large negative double overflow
+    val largeNegDouble = Literal(-1E20.toDouble)
+    checkEvaluation(cast(largeNegDouble, TimestampType, UTC_OPT), null)
+
+    // NaN should return null
+    checkEvaluation(cast(Literal(Double.NaN), TimestampType, UTC_OPT), null)
+
+    // Positive Infinity should return null
+    checkEvaluation(
+      cast(Literal(Double.PositiveInfinity), TimestampType, UTC_OPT), null)
+
+    // Negative Infinity should return null
+    checkEvaluation(
+      cast(Literal(Double.NegativeInfinity), TimestampType, UTC_OPT), null)
+
+    // Normal value should work: 1.5 seconds = 1,500,000 microseconds
+    checkEvaluation(
+      cast(Literal(1.5), TimestampType, UTC_OPT), 1500000L)
+
+    // Zero should return epoch
+    checkEvaluation(cast(Literal(0.0), TimestampType, UTC_OPT), 0L)
+
+    // Positive boundary: 9223372036854 * 1e6 = 9223372036853999616 (within Long range)
+    checkEvaluation(
+      cast(Literal(9223372036854.0), TimestampType, UTC_OPT),
+      (9223372036854.0 * 1000000.0).toLong)
+
+    // Positive overflow: 9223372036855 * 1e6 overflows Long range -> null
+    checkEvaluation(
+      cast(Literal(9223372036855.0), TimestampType, UTC_OPT), null)
+
+    // Negative boundary: -9223372036854 * 1e6 = -9223372036853999616 (within Long range)
+    checkEvaluation(
+      cast(Literal(-9223372036854.0), TimestampType, UTC_OPT),
+      (-9223372036854.0 * 1000000.0).toLong)
+
+    // Negative overflow: -9223372036855 * 1e6 overflows Long range -> null
+    checkEvaluation(
+      cast(Literal(-9223372036855.0), TimestampType, UTC_OPT), null)
+
+    // Finite double whose multiplication overflows to +-Infinity
+    checkEvaluation(cast(Literal(-Double.MaxValue), TimestampType, UTC_OPT), null)
+    checkEvaluation(cast(Literal(Double.MaxValue), TimestampType, UTC_OPT), null)
+  }
+
+  test("SPARK-58235: cast large float to timestamp overflow with ansi off") {
+    // Large positive float overflow
+    val largePosFloat = Literal(1E20f)
+    checkEvaluation(cast(largePosFloat, TimestampType, UTC_OPT), null)
+
+    // Large negative float overflow
+    val largeNegFloat = Literal(-1E20f)
+    checkEvaluation(cast(largeNegFloat, TimestampType, UTC_OPT), null)
+
+    // Float NaN should return null
+    checkEvaluation(cast(Literal(Float.NaN), TimestampType, UTC_OPT), null)
+
+    // Float Infinity should return null
+    checkEvaluation(
+      cast(Literal(Float.PositiveInfinity), TimestampType, UTC_OPT), null)
+
+    // Normal float value: 1.5f seconds = 1,500,000 microseconds
+    checkEvaluation(
+      cast(Literal(1.5f), TimestampType, UTC_OPT), 1500000L)
+
+    // Float boundary: 92233720000000.0f * 1e6 = 9.223372E19 overflows Long range
+    checkEvaluation(
+      cast(Literal(92233720000000.0f), TimestampType, UTC_OPT), null)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -927,4 +927,101 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
       )
     }
   }
+
+  test("SPARK-58235: cast large double to timestamp overflow with ansi on") {
+    // Large positive double overflow - error from DoubleExactNumeric.toLong
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(1E20.toDouble), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(1E20 * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+
+    // Large negative double overflow
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(-1E20.toDouble), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(-1E20 * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+
+    // Normal value should work: 1.5 seconds = 1,500,000 microseconds
+    checkEvaluation(cast(Literal(1.5), TimestampType), 1500000L)
+
+    // Positive boundary: 9223372036854 * 1e6 = 9223372036853999616 (within Long range)
+    checkEvaluation(
+      cast(Literal(9223372036854.0), TimestampType),
+      (9223372036854.0 * 1000000.0).toLong)
+
+    // Positive overflow: 9223372036855 * 1e6 > Long.MaxValue -> overflow
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(9223372036855.0), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(9223372036855.0 * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+
+    // Negative boundary: -9223372036854 * 1e6 within Long range
+    checkEvaluation(
+      cast(Literal(-9223372036854.0), TimestampType),
+      (-9223372036854.0 * 1000000.0).toLong)
+
+    // Negative overflow: -9223372036855 * 1e6 < Long.MinValue -> overflow
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(-9223372036855.0), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(-9223372036855.0 * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+  }
+
+  test("SPARK-58235: cast large float to timestamp overflow with ansi on") {
+    // Large positive float overflow - value is (double)float * MICROS_PER_SECOND
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(1E20f), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(1E20f.toDouble * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+
+    // Large negative float overflow
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(-1E20f), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(-1E20f.toDouble * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+
+    // Normal float value: 1.5f seconds = 1,500,000 microseconds
+    checkEvaluation(cast(Literal(1.5f), TimestampType), 1500000L)
+
+    // Float boundary: 92233720000000.0f * 1e6 = 9.223372E19 overflows Long range
+    checkErrorInExpression[SparkArithmeticException](
+      cast(Literal(92233720000000.0f), TimestampType),
+      "CAST_OVERFLOW",
+      Map(
+        "value" -> s"${(92233720000000.0f.toDouble * 1000000.0)}D",
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> "\"BIGINT\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+      ))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Long range validation for the Double/Float-to-Timestamp cast path in both interpreted and codegen execution.

When a Double or Float value multiplied by `MICROS_PER_SECOND` (1,000,000) exceeds `Long` range, the unchecked cast to `long` silently produces a clamped value (`Long.MAX_VALUE` or `Long.MIN_VALUE`). The fix detects this overflow and either returns `NULL` (non-ANSI mode) or throws `CAST_OVERFLOW` (ANSI mode).

The interpreted path (`Cast.doubleToTimestamp`) now checks the multiplication result against Long range before calling `.toLong`. The codegen path (`castToTimestampCode` Double/Float branches) applies the same range check before the `(long)` cast.

### Why are the changes needed?

`CAST(1e20 AS TIMESTAMP)` silently produces `+294247-01-10 04:00:54.775807` (clamped to `Long.MAX_VALUE`) instead of `NULL` in non-ANSI mode. This is inconsistent with other overflow behavior:

```sql
SET spark.sql.ansi.enabled=false;
SELECT CAST(1e20 AS TIMESTAMP);
-- Before fix: +294247-01-10 04:00:54.775807  (clamped to Long.MAX_VALUE)
-- After fix:  NULL

SELECT CAST(-1e20 AS TIMESTAMP);
-- Before fix: -290308-12-21 19:59:05.224192  (clamped to Long.MIN_VALUE)
-- After fix:  NULL
```

The ANSI mode path (`doubleToTimestampAnsi` → `DoubleExactNumeric.toLong`) already correctly throws `CAST_OVERFLOW`. This bug only affects non-ANSI mode.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, `CAST(large_double AS TIMESTAMP)` silently returned an incorrect value caused by numeric overflow. Now:
- Non-ANSI mode: returns `NULL` (consistent with other overflow casts)
- ANSI mode: throws `CAST_OVERFLOW` error (unchanged)

### How was this patch tested?

Added unit tests in `CastWithAnsiOffSuite` and `CastWithAnsiOnSuite`:

Non-ANSI mode (`CastWithAnsiOffSuite`):
- Positive overflow: `1E20` → null
- Negative overflow: `-1E20` → null
- Boundary just under: `9223372036854.0` → passes through
- Boundary just over: `9223372036855.0` → null
- Negative boundary: `-9223372036854.0` / `-9223372036855.0`
- Finite input overflowing to +-Infinity: `Double.MaxValue` / `-Double.MaxValue`
- NaN, Infinity, normal values, zero, Float overflow

ANSI mode (`CastWithAnsiOnSuite`):
- Positive overflow: throws `CAST_OVERFLOW` with correct error parameters
- Negative overflow: throws `CAST_OVERFLOW` with correct error parameters
- Boundary values, normal values, Float overflow

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
