### PR TITLE
[SPARK-58248][SQL] Reuse single-line inference path for JSON/XML archive inference

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -68,17 +68,19 @@ abstract class CSVDataSource extends Serializable with Logging with SupportsArch
   final def inferSchema(
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
-      parsedOptions: CSVOptions): Option[StructType] = {
+      parsedOptions: CSVOptions,
+      supportsArchiveScan: Boolean): Option[StructType] = {
     parsedOptions.singleVariantColumn match {
       case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
       case None =>
         val hasArchive = parsedOptions.archiveFormatEnabled &&
           inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
-        if (hasArchive) {
-          // Archives (and any loose files alongside them) are inferred in a single CSVInferSchema
-          // pass over all inputs -- archive entries are streamed, never unpacked -- so the result
-          // matches what the scan returns for the same files.
+        if (hasArchive && supportsArchiveScan) {
           Some(inferWithArchives(sparkSession, inputPaths, parsedOptions))
+        } else if (hasArchive) {
+          // The caller's scan cannot read archives (e.g. DSv2), so refuse rather than let it
+          // mis-read raw archive bytes as CSV.
+          None
         } else if (inputPaths.nonEmpty) {
           Some(infer(sparkSession, inputPaths, parsedOptions))
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -68,23 +68,17 @@ abstract class CSVDataSource extends Serializable with Logging with SupportsArch
   final def inferSchema(
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
-      parsedOptions: CSVOptions,
-      supportsArchiveScan: Boolean): Option[StructType] = {
+      parsedOptions: CSVOptions): Option[StructType] = {
     parsedOptions.singleVariantColumn match {
       case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
       case None =>
         val hasArchive = parsedOptions.archiveFormatEnabled &&
           inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
-        if (hasArchive && supportsArchiveScan) {
+        if (hasArchive) {
           // Archives (and any loose files alongside them) are inferred in a single CSVInferSchema
           // pass over all inputs -- archive entries are streamed, never unpacked -- so the result
           // matches what the scan returns for the same files.
           Some(inferWithArchives(sparkSession, inputPaths, parsedOptions))
-        } else if (hasArchive) {
-          // The caller's scan path cannot read archives (e.g. the DSv2 reader), so refuse to infer
-          // a schema when any input is an archive: returning None raises UNABLE_TO_INFER_SCHEMA,
-          // which fails loudly instead of letting the scan parse raw archive bytes as CSV.
-          None
         } else if (inputPaths.nonEmpty) {
           Some(infer(sparkSession, inputPaths, parsedOptions))
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -57,10 +57,7 @@ case class CSVFileFormat() extends TextBasedFileFormat with DataSourceRegister {
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     val parsedOptions = getCsvOptions(sparkSession, options)
-    // The v1 file format routes archives to `readArchive` (see `buildReader`), so archive schema
-    // inference is supported here.
-    CSVDataSource(parsedOptions)
-      .inferSchema(sparkSession, files, parsedOptions, supportsArchiveScan = true)
+    CSVDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
   }
 
   override def prepareWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -57,7 +57,8 @@ case class CSVFileFormat() extends TextBasedFileFormat with DataSourceRegister {
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     val parsedOptions = getCsvOptions(sparkSession, options)
-    CSVDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
+    CSVDataSource(parsedOptions)
+      .inferSchema(sparkSession, files, parsedOptions, supportsArchiveScan = true)
   }
 
   override def prepareWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.json
 
 import java.io.{ByteArrayInputStream, FileNotFoundException, InputStream, IOException}
 
-import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
@@ -98,24 +97,11 @@ abstract class JsonDataSource extends Serializable with Logging with SupportsArc
   final def inferSchema(
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
-      parsedOptions: JSONOptions,
-      supportsArchiveScan: Boolean): Option[StructType] = {
+      parsedOptions: JSONOptions): Option[StructType] = {
     parsedOptions.singleVariantColumn.orElse(parsedOptions.explodeEmbeddedArray) match {
       case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
       case None =>
-        val hasArchive = parsedOptions.archiveFormatEnabled &&
-          inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
-        if (hasArchive && supportsArchiveScan) {
-          // Archives (and any loose files alongside them) are inferred in a single JsonInferSchema
-          // pass over all inputs -- archive entries are streamed, never unpacked -- so the result
-          // matches what the scan returns for the same files.
-          Some(inferWithArchives(sparkSession, inputPaths, parsedOptions))
-        } else if (hasArchive) {
-          // The caller's scan path cannot read archives (e.g. the DSv2 reader), so refuse to infer
-          // a schema when any input is an archive: returning None raises UNABLE_TO_INFER_SCHEMA,
-          // which fails loudly instead of letting the scan parse raw archive bytes as JSON.
-          None
-        } else if (inputPaths.nonEmpty) {
+        if (inputPaths.nonEmpty) {
           Some(infer(sparkSession, inputPaths, parsedOptions))
         } else {
           None
@@ -127,92 +113,6 @@ abstract class JsonDataSource extends Serializable with Logging with SupportsArc
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
       parsedOptions: JSONOptions): StructType
-
-  /**
-   * Infers a JSON schema when at least one input is a tar archive. Every archive entry (streamed
-   * via `SupportsArchiveFormat`, never unpacked to disk) and every loose file is read as JSON
-   * records -- each line is a record, or the whole input is one document in multi-line mode -- and
-   * all of them feed a single [[JsonInferSchema]] pass, exactly as a directory of the same files
-   * would infer.
-   * Because [[JsonInferSchema]] already merges every record's type by field name across all inputs,
-   * one pass is itself the union: a field empty in one input but typed in another widens to the
-   * real type, and a `NullType` field survives to the single final canonicalization rather than
-   * being collapsed per-input. A corrupt/missing input is skipped as a unit (a whole archive or a
-   * whole file) when `ignoreCorruptFiles`/`ignoreMissingFiles` are set.
-   */
-  private def inferWithArchives(
-      sparkSession: SparkSession,
-      inputPaths: Seq[FileStatus],
-      parsedOptions: JSONOptions): StructType = {
-    val baseRdd = JsonDataSource.createBaseRdd(sparkSession, inputPaths, parsedOptions)
-    val multiLine = parsedOptions.multiLine
-    val lineSeparator = parsedOptions.lineSeparatorInRead
-    val encoding = parsedOptions.encoding
-    val ignoreCorruptFiles = parsedOptions.ignoreCorruptFiles
-    val ignoreMissingFiles = parsedOptions.ignoreMissingFiles
-
-    // Applies `perEntry` to each input -- once per archive entry, once for a loose file -- skipping
-    // a whole input when it is corrupt/missing and the ignore flags are set. The entry/file stream
-    // is consumed lazily by `perEntry`, never buffered whole; mirrors CSV's `inferWithArchives`.
-    //
-    // An archive entry's stream is a `CloseShieldInputStream` view over the one shared
-    // `TarArchiveInputStream` cursor, valid only until `readEntries` advances to the next entry
-    // (`getNextEntry` skips the prior entry's unread bytes). A consumer that emits the raw stream
-    // (the multiLine path below) must therefore fully consume each element before the iterator
-    // advances; `JsonInferSchema.infer` does, parsing each record before pulling the next.
-    // Buffering, look-ahead, or parallelizing the per-partition consumption would read from an
-    // advanced cursor and infer a wrong schema. The line-delimited path sidesteps this by
-    // materializing each record (`copyBytes()`).
-    def perInput[T: ClassTag](perEntry: InputStream => Iterator[T]): RDD[T] = baseRdd.flatMap {
-      stream =>
-        val path = new Path(stream.getPath())
-        try {
-          if (SupportsArchiveFormat.isArchivePath(path)) {
-            SupportsArchiveFormat.readArchiveEntries(path, stream.getConfiguration) { (_, in) =>
-              perEntry(in)
-            }
-          } else {
-            perEntry(
-              CodecStreams.createInputStreamWithCloseResource(stream.getConfiguration, path))
-          }
-        } catch {
-          case e: FileNotFoundException if ignoreMissingFiles =>
-            logWarning(log"Skipped missing input: ${MDC(PATH, stream.getPath())}", e)
-            Iterator.empty
-          case e: FileNotFoundException => throw e
-          case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
-            logWarning(log"Skipped the corrupted input: ${MDC(PATH, stream.getPath())}", e)
-            Iterator.empty
-          case NonFatal(e) =>
-            throw QueryExecutionErrors.cannotReadFilesError(
-              e, SparkPath.fromPathString(stream.getPath()).urlEncoded)
-        }
-    }
-
-    SQLExecution.withSQLConfPropagated(sparkSession) {
-      val inferSchema = new JsonInferSchema(parsedOptions)
-      if (multiLine) {
-        // Each input/entry is one JSON document: hand its stream straight to the parser
-        // (`CreateJacksonParser.inputStream`, matching MultiLineJsonDataSource and its charset
-        // auto-detect) so the document is parsed incrementally rather than buffered.
-        val docs = perInput(in => Iterator.single(in))
-        val docParser: (JsonFactory, InputStream) => JsonParser = encoding
-          .map(enc => CreateJacksonParser.inputStream(enc, _: JsonFactory, _: InputStream))
-          .getOrElse(CreateJacksonParser.inputStream(_: JsonFactory, _: InputStream))
-        inferSchema.infer[InputStream](
-          JsonUtils.sample(docs, parsedOptions), docParser, isReadFile = true)
-      } else {
-        // Line-delimited: each line is a record, copied off the reused line buffer and parsed from
-        // its bytes (`CreateJacksonParser.bytes`, matching TextInputJsonDataSource).
-        val lines = perInput(in => lineIterator(in, lineSeparator).map(_.copyBytes()))
-        val lineParser: (JsonFactory, Array[Byte]) => JsonParser = encoding
-          .map(enc => CreateJacksonParser.bytes(enc, _: JsonFactory, _: Array[Byte]))
-          .getOrElse(CreateJacksonParser.bytes(_: JsonFactory, _: Array[Byte]))
-        inferSchema.infer[Array[Byte]](
-          JsonUtils.sample(lines, parsedOptions), lineParser, isReadFile = false)
-      }
-    }
-  }
 }
 
 object JsonDataSource {
@@ -344,6 +244,12 @@ object MultiLineJsonDataSource extends JsonDataSource {
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
       parsedOptions: JSONOptions): StructType = {
+    val hasArchive = parsedOptions.archiveFormatEnabled &&
+      inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
+    if (hasArchive) {
+      return inferWithArchives(sparkSession, inputPaths, parsedOptions)
+    }
+
     val json: RDD[PortableDataStream] =
       JsonDataSource.createBaseRdd(sparkSession, inputPaths, parsedOptions)
     val sampled: RDD[PortableDataStream] = JsonUtils.sample(json, parsedOptions)
@@ -354,6 +260,63 @@ object MultiLineJsonDataSource extends JsonDataSource {
     SQLExecution.withSQLConfPropagated(sparkSession) {
       new JsonInferSchema(parsedOptions)
         .infer[PortableDataStream](sampled, parser, isReadFile = true)
+    }
+  }
+
+  /**
+   * Infers a multi-line JSON schema when at least one input is an archive. Each archive entry
+   * (streamed via `SupportsArchiveFormat`, never unpacked to disk) and each loose file is one whole
+   * JSON document, and all feed a single [[JsonInferSchema]] pass -- exactly as a directory of the
+   * same files would infer. Single-line archive inference does not come here: the Text data source
+   * reads archives directly, so it flows through [[TextInputJsonDataSource.infer]] like any
+   * directory read. A corrupt/missing input is skipped as a unit when the ignore flags are set.
+   */
+  private def inferWithArchives(
+      sparkSession: SparkSession,
+      inputPaths: Seq[FileStatus],
+      parsedOptions: JSONOptions): StructType = {
+    val baseRdd = JsonDataSource.createBaseRdd(sparkSession, inputPaths, parsedOptions)
+    val encoding = parsedOptions.encoding
+    val ignoreCorruptFiles = parsedOptions.ignoreCorruptFiles
+    val ignoreMissingFiles = parsedOptions.ignoreMissingFiles
+
+    // Each archive entry and each loose file is one JSON document: stream it straight through (an
+    // archive entry by entry -- streamed, never unpacked -- a loose file directly), skipping a
+    // whole input when it is corrupt/missing and the ignore flags are set. An archive entry's
+    // stream is a `CloseShieldInputStream` view over the one shared archive cursor, valid only
+    // until `readArchiveEntries` advances; `JsonInferSchema.infer` fully consumes each document
+    // before pulling the next, so the cursor is never read after it advances.
+    val docs: RDD[InputStream] = baseRdd.flatMap { stream =>
+      val path = new Path(stream.getPath())
+      try {
+        if (SupportsArchiveFormat.isArchivePath(path)) {
+          SupportsArchiveFormat.readArchiveEntries(path, stream.getConfiguration) { (_, in) =>
+            Iterator.single(in)
+          }
+        } else {
+          Iterator.single(
+            CodecStreams.createInputStreamWithCloseResource(stream.getConfiguration, path))
+        }
+      } catch {
+        case e: FileNotFoundException if ignoreMissingFiles =>
+          logWarning(log"Skipped missing input: ${MDC(PATH, stream.getPath())}", e)
+          Iterator.empty
+        case e: FileNotFoundException => throw e
+        case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+          logWarning(log"Skipped the corrupted input: ${MDC(PATH, stream.getPath())}", e)
+          Iterator.empty
+        case NonFatal(e) =>
+          throw QueryExecutionErrors.cannotReadFilesError(
+            e, SparkPath.fromPathString(stream.getPath()).urlEncoded)
+      }
+    }
+
+    SQLExecution.withSQLConfPropagated(sparkSession) {
+      val docParser: (JsonFactory, InputStream) => JsonParser = encoding
+        .map(enc => CreateJacksonParser.inputStream(enc, _: JsonFactory, _: InputStream))
+        .getOrElse(CreateJacksonParser.inputStream(_: JsonFactory, _: InputStream))
+      new JsonInferSchema(parsedOptions).infer[InputStream](
+        JsonUtils.sample(docs, parsedOptions), docParser, isReadFile = true)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -348,8 +348,8 @@ object MultiLineJsonDataSource extends JsonDataSource {
         try delegate.hasNext
         catch {
           case NonFatal(e) =>
-            // The failed iterator owns the archive stream and releases it only on exhaustion or an
-            // explicit close, neither of which a mid-advance throw reaches.
+            // A mid-advance throw reaches neither exhaustion nor close, so close the failed
+            // iterator here to release its archive stream promptly rather than at task completion.
             delegate match {
               case c: Closeable => try c.close() catch { case NonFatal(_) => }
               case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -276,8 +276,7 @@ object MultiLineJsonDataSource extends JsonDataSource {
    * JSON document, and all feed a single [[JsonInferSchema]] pass -- exactly as a directory of the
    * same files would infer. Single-line archive inference does not come here: the Text data source
    * reads archives directly, so it flows through [[TextInputJsonDataSource.infer]] like any
-   * directory read. A corrupt/missing input is skipped as a unit when the ignore flags are set --
-   * across the whole input, since `readArchiveEntries` advances to later entries lazily (see
+   * directory read. Corrupt/missing inputs are skipped when the ignore flags are set (see
    * [[skipInputOnError]]).
    */
   private def inferWithArchives(
@@ -315,12 +314,11 @@ object MultiLineJsonDataSource extends JsonDataSource {
   }
 
   /**
-   * Builds one input's document iterator, skipping the whole input when the ignore flags are set
-   * and it is missing/corrupt. `readArchiveEntries` opens only the first entry eagerly and advances
-   * to later entries lazily, so a corrupt later entry throws while the returned iterator is
-   * consumed, not while it is built -- guarding only construction would let that escape. The
-   * returned iterator therefore catches on both construction and advancement (`hasNext`), ending
-   * the input on a skipped error rather than propagating it.
+   * Builds one input's document iterator, catching a missing/corrupt error when the ignore flags
+   * are set. `readArchiveEntries` advances to later entries lazily, so a corrupt later entry throws
+   * on `hasNext`, not at construction; the returned iterator catches both. A construction failure
+   * skips the whole input; a mid-advance failure keeps the entries already yielded and skips only
+   * the remainder of the archive.
    */
   private def skipInputOnError(
       inputPath: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -97,11 +97,18 @@ abstract class JsonDataSource extends Serializable with Logging with SupportsArc
   final def inferSchema(
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
-      parsedOptions: JSONOptions): Option[StructType] = {
+      parsedOptions: JSONOptions,
+      supportsArchiveScan: Boolean): Option[StructType] = {
     parsedOptions.singleVariantColumn.orElse(parsedOptions.explodeEmbeddedArray) match {
       case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
       case None =>
-        if (inputPaths.nonEmpty) {
+        val hasArchive = parsedOptions.archiveFormatEnabled &&
+          inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
+        if (hasArchive && !supportsArchiveScan) {
+          // The caller's scan cannot read archives (e.g. DSv2), so refuse rather than let it
+          // mis-read raw archive bytes as JSON.
+          None
+        } else if (inputPaths.nonEmpty) {
           Some(infer(sparkSession, inputPaths, parsedOptions))
         } else {
           None
@@ -269,7 +276,9 @@ object MultiLineJsonDataSource extends JsonDataSource {
    * JSON document, and all feed a single [[JsonInferSchema]] pass -- exactly as a directory of the
    * same files would infer. Single-line archive inference does not come here: the Text data source
    * reads archives directly, so it flows through [[TextInputJsonDataSource.infer]] like any
-   * directory read. A corrupt/missing input is skipped as a unit when the ignore flags are set.
+   * directory read. A corrupt/missing input is skipped as a unit when the ignore flags are set --
+   * across the whole input, since `readArchiveEntries` advances to later entries lazily (see
+   * [[skipInputOnError]]).
    */
   private def inferWithArchives(
       sparkSession: SparkSession,
@@ -280,15 +289,11 @@ object MultiLineJsonDataSource extends JsonDataSource {
     val ignoreCorruptFiles = parsedOptions.ignoreCorruptFiles
     val ignoreMissingFiles = parsedOptions.ignoreMissingFiles
 
-    // Each archive entry and each loose file is one JSON document: stream it straight through (an
-    // archive entry by entry -- streamed, never unpacked -- a loose file directly), skipping a
-    // whole input when it is corrupt/missing and the ignore flags are set. An archive entry's
-    // stream is a `CloseShieldInputStream` view over the one shared archive cursor, valid only
-    // until `readArchiveEntries` advances; `JsonInferSchema.infer` fully consumes each document
-    // before pulling the next, so the cursor is never read after it advances.
+    // An archive entry's stream is only valid until the shared cursor advances, so each document
+    // must be consumed before the next is pulled; `JsonInferSchema.infer` does.
     val docs: RDD[InputStream] = baseRdd.flatMap { stream =>
       val path = new Path(stream.getPath())
-      try {
+      skipInputOnError(stream.getPath(), ignoreMissingFiles, ignoreCorruptFiles) {
         if (SupportsArchiveFormat.isArchivePath(path)) {
           SupportsArchiveFormat.readArchiveEntries(path, stream.getConfiguration) { (_, in) =>
             Iterator.single(in)
@@ -297,17 +302,6 @@ object MultiLineJsonDataSource extends JsonDataSource {
           Iterator.single(
             CodecStreams.createInputStreamWithCloseResource(stream.getConfiguration, path))
         }
-      } catch {
-        case e: FileNotFoundException if ignoreMissingFiles =>
-          logWarning(log"Skipped missing input: ${MDC(PATH, stream.getPath())}", e)
-          Iterator.empty
-        case e: FileNotFoundException => throw e
-        case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
-          logWarning(log"Skipped the corrupted input: ${MDC(PATH, stream.getPath())}", e)
-          Iterator.empty
-        case NonFatal(e) =>
-          throw QueryExecutionErrors.cannotReadFilesError(
-            e, SparkPath.fromPathString(stream.getPath()).urlEncoded)
       }
     }
 
@@ -317,6 +311,49 @@ object MultiLineJsonDataSource extends JsonDataSource {
         .getOrElse(CreateJacksonParser.inputStream(_: JsonFactory, _: InputStream))
       new JsonInferSchema(parsedOptions).infer[InputStream](
         JsonUtils.sample(docs, parsedOptions), docParser, isReadFile = true)
+    }
+  }
+
+  /**
+   * Builds one input's document iterator, skipping the whole input when the ignore flags are set
+   * and it is missing/corrupt. `readArchiveEntries` opens only the first entry eagerly and advances
+   * to later entries lazily, so a corrupt later entry throws while the returned iterator is
+   * consumed, not while it is built -- guarding only construction would let that escape. The
+   * returned iterator therefore catches on both construction and advancement (`hasNext`), ending
+   * the input on a skipped error rather than propagating it.
+   */
+  private def skipInputOnError(
+      inputPath: String,
+      ignoreMissingFiles: Boolean,
+      ignoreCorruptFiles: Boolean)(
+      build: => Iterator[InputStream]): Iterator[InputStream] = {
+    def handle(e: Throwable): Iterator[InputStream] = e match {
+      case e: FileNotFoundException if ignoreMissingFiles =>
+        logWarning(log"Skipped missing input: ${MDC(PATH, inputPath)}", e)
+        Iterator.empty
+      case e: FileNotFoundException => throw e
+      case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+        logWarning(log"Skipped the corrupted input: ${MDC(PATH, inputPath)}", e)
+        Iterator.empty
+      case NonFatal(e) =>
+        throw QueryExecutionErrors.cannotReadFilesError(
+          e, SparkPath.fromPathString(inputPath).urlEncoded)
+    }
+
+    val underlying =
+      try build
+      catch { case NonFatal(e) => return handle(e) }
+
+    new Iterator[InputStream] {
+      private var delegate = underlying
+      override def hasNext: Boolean =
+        try delegate.hasNext
+        catch {
+          case NonFatal(e) =>
+            delegate = handle(e)
+            delegate.hasNext
+        }
+      override def next(): InputStream = delegate.next()
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.json
 
-import java.io.{ByteArrayInputStream, FileNotFoundException, InputStream, IOException}
+import java.io.{ByteArrayInputStream, Closeable, FileNotFoundException, InputStream, IOException}
 
 import scala.util.control.NonFatal
 
@@ -348,6 +348,12 @@ object MultiLineJsonDataSource extends JsonDataSource {
         try delegate.hasNext
         catch {
           case NonFatal(e) =>
+            // The failed iterator owns the archive stream and releases it only on exhaustion or an
+            // explicit close, neither of which a mid-advance throw reaches.
+            delegate match {
+              case c: Closeable => try c.close() catch { case NonFatal(_) => }
+              case _ =>
+            }
             delegate = handle(e)
             delegate.hasNext
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -52,7 +52,8 @@ case class JsonFileFormat() extends TextBasedFileFormat with DataSourceRegister 
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     val parsedOptions = getJsonOptions(sparkSession, options)
-    JsonDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
+    JsonDataSource(parsedOptions)
+      .inferSchema(sparkSession, files, parsedOptions, supportsArchiveScan = true)
   }
 
   override def prepareWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -52,8 +52,7 @@ case class JsonFileFormat() extends TextBasedFileFormat with DataSourceRegister 
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     val parsedOptions = getJsonOptions(sparkSession, options)
-    JsonDataSource(parsedOptions)
-      .inferSchema(sparkSession, files, parsedOptions, supportsArchiveScan = true)
+    JsonDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
   }
 
   override def prepareWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVTable.scala
@@ -46,11 +46,7 @@ case class CSVTable(
       columnPruning = sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
 
-    // The DSv2 reader does not route archives to `readArchive` (it calls `readFile` directly), so
-    // archive scans aren't supported here; pass supportsArchiveScan = false so an archive input
-    // keeps failing with UNABLE_TO_INFER_SCHEMA rather than having its raw bytes parsed as CSV.
-    CSVDataSource(parsedOptions)
-      .inferSchema(sparkSession, files, parsedOptions, supportsArchiveScan = false)
+    CSVDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVTable.scala
@@ -46,7 +46,9 @@ case class CSVTable(
       columnPruning = sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
 
-    CSVDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
+    // The DSv2 scan cannot read archives, so refuse archive inference here.
+    CSVDataSource(parsedOptions)
+      .inferSchema(sparkSession, files, parsedOptions, supportsArchiveScan = false)
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonTable.scala
@@ -45,7 +45,8 @@ case class JsonTable(
       options.asScala.toMap,
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
-    JsonDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
+    JsonDataSource(parsedOptions).inferSchema(
+      sparkSession, files, parsedOptions, supportsArchiveScan = false)
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonTable.scala
@@ -45,10 +45,7 @@ case class JsonTable(
       options.asScala.toMap,
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
-    // The DSv2 reader calls `readFile` directly and cannot read archives, so refuse to infer a
-    // schema for archive inputs (supportsArchiveScan = false) rather than mis-reading raw bytes.
-    JsonDataSource(parsedOptions).inferSchema(
-      sparkSession, files, parsedOptions, supportsArchiveScan = false)
+    JsonDataSource(parsedOptions).inferSchema(sparkSession, files, parsedOptions)
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
@@ -101,15 +101,7 @@ abstract class XmlDataSource extends Serializable with Logging with SupportsArch
     parsedOptions.singleVariantColumn match {
       case Some(columnName) => Some(StructType(Array(StructField(columnName, VariantType))))
       case None =>
-        // When any input is a tar archive, infer over all inputs in a single pass -- archive
-        // entries are streamed (never unpacked to disk) and tokenized as XML records alongside any
-        // loose files -- so the result matches a directory read of the same files. XML has no DSv2
-        // reader, so this archive scan is always V1.
-        val hasArchive = parsedOptions.archiveFormatEnabled &&
-          inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
-        if (hasArchive) {
-          Some(inferWithArchives(sparkSession, inputPaths, parsedOptions))
-        } else if (inputPaths.nonEmpty) {
+        if (inputPaths.nonEmpty) {
           Some(infer(sparkSession, inputPaths, parsedOptions))
         } else {
           None
@@ -121,69 +113,6 @@ abstract class XmlDataSource extends Serializable with Logging with SupportsArch
       sparkSession: SparkSession,
       inputPaths: Seq[FileStatus],
       parsedOptions: XmlOptions): StructType
-
-  /**
-   * Infers an XML schema when at least one input is a tar archive (`.tar`/`.tar.gz`/`.tgz`). Every
-   * archive entry (streamed through `SupportsArchiveFormat`, never unpacked to disk) and every
-   * loose file is tokenized into records and fed to a single [[XmlInferSchema]] pass, exactly as a
-   * directory of the same files would infer. Tokenization is per-mode so it matches the scan:
-   * multi-line splits the whole stream into `rowTag`-delimited records, single-line treats each
-   * line as a record (mirroring [[readFile]] and JSON's `inferWithArchives`).
-   */
-  private def inferWithArchives(
-      sparkSession: SparkSession,
-      inputPaths: Seq[FileStatus],
-      parsedOptions: XmlOptions): StructType = {
-    val baseRdd = createBaseRdd(sparkSession, inputPaths, parsedOptions)
-    val ignoreCorruptFiles = parsedOptions.ignoreCorruptFiles
-    val ignoreMissingFiles = parsedOptions.ignoreMissingFiles
-
-    // Applies `perEntry` to each input -- an archive entry by entry (streamed, so only one entry's
-    // bytes are in flight at a time), a loose file directly -- skipping a whole input when it is
-    // corrupt/missing and the ignore flags are set.
-    def perInput(perEntry: InputStream => Iterator[String]): RDD[String] = baseRdd.flatMap {
-      stream =>
-        val path = new Path(stream.getPath())
-        try {
-          if (SupportsArchiveFormat.isArchivePath(path)) {
-            SupportsArchiveFormat.readArchiveEntries(path, stream.getConfiguration) { (_, in) =>
-              perEntry(in)
-            }
-          } else {
-            perEntry(
-              CodecStreams.createInputStreamWithCloseResource(stream.getConfiguration, path))
-          }
-        } catch {
-          case e: FileNotFoundException if ignoreMissingFiles =>
-            logWarning("Skipped missing file", e)
-            Iterator.empty[String]
-          case NonFatal(e) =>
-            Utils.getRootCause(e) match {
-              case root @ (_: AccessControlException | _: BlockMissingException) => throw root
-              case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
-                logWarning("Skipped the rest of the content in the corrupted file", e)
-                Iterator.empty[String]
-              case other => throw other
-            }
-        }
-    }
-
-    // Tokenize each input the way this mode's scan reads records, so the inferred schema matches a
-    // directory read: multi-line splits the whole stream into rowTag-delimited records, single-line
-    // treats each line as a record (mirroring TextInputXmlDataSource.readFile).
-    val tokenRDD: RDD[String] = if (parsedOptions.multiLine) {
-      perInput(in => StaxXmlParser.tokenizeStream(in, parsedOptions))
-    } else {
-      val charset = parsedOptions.charset
-      perInput(in => lineIterator(in, None).map { line =>
-        new String(line.getBytes, 0, line.getLength, charset)
-      })
-    }
-    SQLExecution.withSQLConfPropagated(sparkSession) {
-      new XmlInferSchema(parsedOptions, sparkSession.sessionState.conf.caseSensitiveAnalysis)
-        .infer(tokenRDD)
-    }
-  }
 
   protected def createBaseRdd(
       sparkSession: SparkSession,
@@ -358,6 +287,12 @@ object MultiLineXmlDataSource extends XmlDataSource {
       inputPaths: Seq[FileStatus],
       parsedOptions: XmlOptions): StructType = {
 
+    val hasArchive = parsedOptions.archiveFormatEnabled &&
+      inputPaths.exists(f => SupportsArchiveFormat.isArchivePath(f.getPath))
+    if (hasArchive) {
+      return inferWithArchives(sparkSession, inputPaths, parsedOptions)
+    }
+
     if (!parsedOptions.useLegacyXMLParser) {
       return inferOptimized(sparkSession, inputPaths, parsedOptions)
     }
@@ -416,6 +351,56 @@ object MultiLineXmlDataSource extends XmlDataSource {
         new XmlInferSchema(parsedOptions, sparkSession.sessionState.conf.caseSensitiveAnalysis)
           .inferFromReaders(xmlParserRdd)
       schema
+    }
+  }
+
+  /**
+   * Infers a multi-line XML schema when at least one input is an archive. Every archive entry
+   * (streamed through `SupportsArchiveFormat`, never unpacked to disk) and every loose file is
+   * tokenized into `rowTag`-delimited records and fed to a single [[XmlInferSchema]] pass, exactly
+   * as a directory of the same files would infer. Single-line archive inference does not come here:
+   * the Text data source reads archives directly, so it flows through
+   * [[TextInputXmlDataSource.infer]] like any directory read. A corrupt/missing input is skipped as
+   * a unit when the ignore flags are set. Uses the legacy tokenizer because the optimized parser
+   * re-opens its input, which a single-use archive entry stream does not support.
+   */
+  private def inferWithArchives(
+      sparkSession: SparkSession,
+      inputPaths: Seq[FileStatus],
+      parsedOptions: XmlOptions): StructType = {
+    val baseRdd = createBaseRdd(sparkSession, inputPaths, parsedOptions)
+    val ignoreCorruptFiles = parsedOptions.ignoreCorruptFiles
+    val ignoreMissingFiles = parsedOptions.ignoreMissingFiles
+
+    val tokenRDD: RDD[String] = baseRdd.flatMap { stream =>
+      val path = new Path(stream.getPath())
+      try {
+        if (SupportsArchiveFormat.isArchivePath(path)) {
+          SupportsArchiveFormat.readArchiveEntries(path, stream.getConfiguration) { (_, in) =>
+            StaxXmlParser.tokenizeStream(in, parsedOptions)
+          }
+        } else {
+          StaxXmlParser.tokenizeStream(
+            CodecStreams.createInputStreamWithCloseResource(stream.getConfiguration, path),
+            parsedOptions)
+        }
+      } catch {
+        case e: FileNotFoundException if ignoreMissingFiles =>
+          logWarning("Skipped missing file", e)
+          Iterator.empty[String]
+        case NonFatal(e) =>
+          Utils.getRootCause(e) match {
+            case root @ (_: AccessControlException | _: BlockMissingException) => throw root
+            case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
+              logWarning("Skipped the rest of the content in the corrupted file", e)
+              Iterator.empty[String]
+            case other => throw other
+          }
+      }
+    }
+    SQLExecution.withSQLConfPropagated(sparkSession) {
+      new XmlInferSchema(parsedOptions, sparkSession.sessionState.conf.caseSensitiveAnalysis)
+        .infer(tokenRDD)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.xml
 
-import java.io.{ByteArrayInputStream, FileNotFoundException, InputStream, IOException}
+import java.io.{ByteArrayInputStream, Closeable, FileNotFoundException, InputStream, IOException}
 import java.nio.charset.{Charset, StandardCharsets}
 
 import scala.util.control.NonFatal
@@ -428,6 +428,12 @@ object MultiLineXmlDataSource extends XmlDataSource {
         try delegate.hasNext
         catch {
           case NonFatal(e) =>
+            // The failed iterator owns the archive stream and releases it only on exhaustion or an
+            // explicit close, neither of which a mid-advance throw reaches.
+            delegate match {
+              case c: Closeable => try c.close() catch { case NonFatal(_) => }
+              case _ =>
+            }
             delegate = handle(e)
             delegate.hasNext
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
@@ -360,11 +360,9 @@ object MultiLineXmlDataSource extends XmlDataSource {
    * tokenized into `rowTag`-delimited records and fed to a single [[XmlInferSchema]] pass, exactly
    * as a directory of the same files would infer. Single-line archive inference does not come here:
    * the Text data source reads archives directly, so it flows through
-   * [[TextInputXmlDataSource.infer]] like any directory read. A corrupt/missing input is skipped as
-   * a unit when the ignore flags are set -- across the whole input, since `readArchiveEntries`
-   * advances to later entries lazily (see [[skipInputOnError]]). Uses the legacy tokenizer because
-   * the optimized parser re-opens its input, which a single-use archive entry stream does not
-   * support.
+   * [[TextInputXmlDataSource.infer]] like any directory read. Corrupt/missing inputs are skipped
+   * when the ignore flags are set (see [[skipInputOnError]]). Uses the legacy tokenizer because the
+   * optimized parser re-opens its input, which a single-use archive entry stream does not support.
    */
   private def inferWithArchives(
       sparkSession: SparkSession,
@@ -395,12 +393,12 @@ object MultiLineXmlDataSource extends XmlDataSource {
   }
 
   /**
-   * Builds one input's token iterator, skipping the whole input when the ignore flags are set and
-   * it is missing/corrupt. `readArchiveEntries` opens only the first entry eagerly and advances to
-   * later entries lazily, so a corrupt later entry throws while the returned iterator is consumed,
-   * not while it is built -- guarding only construction would let that escape. The returned
-   * iterator therefore catches on both construction and advancement (`hasNext`). Access/block
-   * errors are always rethrown (unwrapped), matching the non-archive read path.
+   * Builds one input's token iterator, catching a missing/corrupt error when the ignore flags are
+   * set. `readArchiveEntries` advances to later entries lazily, so a corrupt later entry throws on
+   * `hasNext`, not at construction; the returned iterator catches both. A construction failure
+   * skips the whole input; a mid-advance failure keeps the records already yielded and skips only
+   * the remainder of the archive. Access/block errors are always rethrown (unwrapped), matching the
+   * non-archive read path.
    */
   private def skipInputOnError(
       ignoreMissingFiles: Boolean,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
@@ -361,8 +361,10 @@ object MultiLineXmlDataSource extends XmlDataSource {
    * as a directory of the same files would infer. Single-line archive inference does not come here:
    * the Text data source reads archives directly, so it flows through
    * [[TextInputXmlDataSource.infer]] like any directory read. A corrupt/missing input is skipped as
-   * a unit when the ignore flags are set. Uses the legacy tokenizer because the optimized parser
-   * re-opens its input, which a single-use archive entry stream does not support.
+   * a unit when the ignore flags are set -- across the whole input, since `readArchiveEntries`
+   * advances to later entries lazily (see [[skipInputOnError]]). Uses the legacy tokenizer because
+   * the optimized parser re-opens its input, which a single-use archive entry stream does not
+   * support.
    */
   private def inferWithArchives(
       sparkSession: SparkSession,
@@ -374,7 +376,7 @@ object MultiLineXmlDataSource extends XmlDataSource {
 
     val tokenRDD: RDD[String] = baseRdd.flatMap { stream =>
       val path = new Path(stream.getPath())
-      try {
+      skipInputOnError(ignoreMissingFiles, ignoreCorruptFiles) {
         if (SupportsArchiveFormat.isArchivePath(path)) {
           SupportsArchiveFormat.readArchiveEntries(path, stream.getConfiguration) { (_, in) =>
             StaxXmlParser.tokenizeStream(in, parsedOptions)
@@ -384,23 +386,54 @@ object MultiLineXmlDataSource extends XmlDataSource {
             CodecStreams.createInputStreamWithCloseResource(stream.getConfiguration, path),
             parsedOptions)
         }
-      } catch {
-        case e: FileNotFoundException if ignoreMissingFiles =>
-          logWarning("Skipped missing file", e)
-          Iterator.empty[String]
-        case NonFatal(e) =>
-          Utils.getRootCause(e) match {
-            case root @ (_: AccessControlException | _: BlockMissingException) => throw root
-            case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
-              logWarning("Skipped the rest of the content in the corrupted file", e)
-              Iterator.empty[String]
-            case other => throw other
-          }
       }
     }
     SQLExecution.withSQLConfPropagated(sparkSession) {
       new XmlInferSchema(parsedOptions, sparkSession.sessionState.conf.caseSensitiveAnalysis)
         .infer(tokenRDD)
+    }
+  }
+
+  /**
+   * Builds one input's token iterator, skipping the whole input when the ignore flags are set and
+   * it is missing/corrupt. `readArchiveEntries` opens only the first entry eagerly and advances to
+   * later entries lazily, so a corrupt later entry throws while the returned iterator is consumed,
+   * not while it is built -- guarding only construction would let that escape. The returned
+   * iterator therefore catches on both construction and advancement (`hasNext`). Access/block
+   * errors are always rethrown (unwrapped), matching the non-archive read path.
+   */
+  private def skipInputOnError(
+      ignoreMissingFiles: Boolean,
+      ignoreCorruptFiles: Boolean)(
+      build: => Iterator[String]): Iterator[String] = {
+    def handle(e: Throwable): Iterator[String] = e match {
+      case e: FileNotFoundException if ignoreMissingFiles =>
+        logWarning("Skipped missing file", e)
+        Iterator.empty[String]
+      case NonFatal(e) =>
+        Utils.getRootCause(e) match {
+          case root @ (_: AccessControlException | _: BlockMissingException) => throw root
+          case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
+            logWarning("Skipped the rest of the content in the corrupted file", e)
+            Iterator.empty[String]
+          case other => throw other
+        }
+    }
+
+    val underlying =
+      try build
+      catch { case NonFatal(e) => return handle(e) }
+
+    new Iterator[String] {
+      private var delegate = underlying
+      override def hasNext: Boolean =
+        try delegate.hasNext
+        catch {
+          case NonFatal(e) =>
+            delegate = handle(e)
+            delegate.hasNext
+        }
+      override def next(): String = delegate.next()
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
@@ -428,8 +428,8 @@ object MultiLineXmlDataSource extends XmlDataSource {
         try delegate.hasNext
         catch {
           case NonFatal(e) =>
-            // The failed iterator owns the archive stream and releases it only on exhaustion or an
-            // explicit close, neither of which a mid-advance throw reaches.
+            // A mid-advance throw reaches neither exhaustion nor close, so close the failed
+            // iterator here to release its archive stream promptly rather than at task completion.
             delegate match {
               case c: Closeable => try c.close() catch { case NonFatal(_) => }
               case _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
@@ -105,6 +105,22 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
   protected def corruptEntryBytes: Array[Byte] =
     s"This is not a valid $format file".getBytes("UTF-8")
 
+  /**
+   * Whether this container can produce an archive that reads a first entry cleanly and then throws
+   * while advancing to a later entry (see [[writeArchiveFailingAfterFirstEntry]]). A seek-indexed
+   * container (7z) validates its whole index at open, so it cannot fail mid-advance; sequential
+   * containers can. Gates the mid-advance corrupt-skip regression test. From the container trait.
+   */
+  protected def supportsMidAdvanceFailure: Boolean
+
+  /**
+   * Writes an archive at `dest` whose first entry (`firstEntry`) reads cleanly but which then
+   * throws while advancing to a later entry -- a valid entry followed by a truncated one. Applies
+   * only where [[supportsMidAdvanceFailure]] is true. From the container trait.
+   */
+  protected def writeArchiveFailingAfterFirstEntry(
+      dest: File, firstEntry: (String, Array[Byte])): Unit
+
   /** An archive extension whose reader fails on corrupt bytes (used by the corrupt-file tests). */
   protected def corruptArchiveExtension: String
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
@@ -106,17 +106,14 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
     s"This is not a valid $format file".getBytes("UTF-8")
 
   /**
-   * Whether this container can produce an archive that reads a first entry cleanly and then throws
-   * while advancing to a later entry (see [[writeArchiveFailingAfterFirstEntry]]). A seek-indexed
-   * container (7z) validates its whole index at open, so it cannot fail mid-advance; sequential
-   * containers can. Gates the mid-advance corrupt-skip regression test. From the container trait.
+   * Whether [[writeArchiveFailingAfterFirstEntry]] is supported, gating the mid-advance
+   * corrupt-skip regression test. From the container trait.
    */
   protected def supportsMidAdvanceFailure: Boolean
 
   /**
-   * Writes an archive at `dest` whose first entry (`firstEntry`) reads cleanly but which then
-   * throws while advancing to a later entry -- a valid entry followed by a truncated one. Applies
-   * only where [[supportsMidAdvanceFailure]] is true. From the container trait.
+   * Writes an archive at `dest` whose first entry (`firstEntry`) reads cleanly but which then fails
+   * while advancing to a later entry. From the container trait.
    */
   protected def writeArchiveFailingAfterFirstEntry(
       dest: File, firstEntry: (String, Array[Byte])): Unit

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CSVArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CSVArchiveReadBase.scala
@@ -21,6 +21,8 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
 
 /**
@@ -124,6 +126,23 @@ trait CSVArchiveReadBase extends ArchiveReadSuiteBase {
         assert(archiveSchema == dirSchema,
           s"multiLine archive inference diverged from the multiLine read; " +
             s"archive=$archiveSchema dir=$dirSchema")
+      }
+    }
+  }
+
+  test("CSV: the DSv2 path refuses to infer a schema for an archive (UNABLE_TO_INFER_SCHEMA)") {
+    // Forcing csv off the V1 source list routes the archive read through the DSv2 CSVTable, which
+    // cannot read archives and must fail with UNABLE_TO_INFER_SCHEMA, not parse raw bytes.
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+        val e = intercept[AnalysisException] {
+          spark.read.options(readOptions).option("inferSchema", "true")
+            .format(format).load(archive.getCanonicalPath)
+        }
+        assert(e.getCondition == "UNABLE_TO_INFER_SCHEMA",
+          s"expected UNABLE_TO_INFER_SCHEMA on the DSv2 path, " +
+            s"got ${e.getCondition}: ${e.getMessage}")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CSVArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CSVArchiveReadBase.scala
@@ -21,8 +21,6 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
 
 /**
@@ -126,26 +124,6 @@ trait CSVArchiveReadBase extends ArchiveReadSuiteBase {
         assert(archiveSchema == dirSchema,
           s"multiLine archive inference diverged from the multiLine read; " +
             s"archive=$archiveSchema dir=$dirSchema")
-      }
-    }
-  }
-
-  test("CSV: the DSv2 path refuses to infer a schema for an archive (UNABLE_TO_INFER_SCHEMA)") {
-    // Archive scanning is wired into the V1 file source only, so the DSv2 reader cannot read
-    // archives. On the V2 path inference must keep returning None for an archive input -- raising
-    // UNABLE_TO_INFER_SCHEMA -- rather than inferring a schema and letting the V2 scan parse the
-    // raw archive bytes as CSV. Forcing csv off the V1 source list routes the read through
-    // CSVTable.
-    withArchiveFile() { archive =>
-      writeArchive(archive, Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
-      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
-        val e = intercept[AnalysisException] {
-          spark.read.options(readOptions).option("inferSchema", "true")
-            .format(format).load(archive.getCanonicalPath)
-        }
-        assert(e.getCondition == "UNABLE_TO_INFER_SCHEMA",
-          s"expected UNABLE_TO_INFER_SCHEMA on the DSv2 path, " +
-            s"got ${e.getCondition}: ${e.getMessage}")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
@@ -21,6 +21,8 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{NullType, StringType}
 
 /**
@@ -180,6 +182,22 @@ trait JSONArchiveReadBase extends ArchiveReadSuiteBase {
       Seq("a.json" -> jsonBytes("{ not valid json")),
       extraOptions = Map("multiLine" -> "true"),
       schema = corruptSchema)
+  }
+
+  test("JSON: the DSv2 path refuses to infer a schema for an archive (UNABLE_TO_INFER_SCHEMA)") {
+    // Forcing json off the v1 source list routes the archive read through the DSv2 JsonTable, which
+    // cannot read archives and must fail with UNABLE_TO_INFER_SCHEMA, not parse raw bytes.
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+        val e = intercept[AnalysisException] {
+          spark.read.options(readOptions).format(format).load(archive.getCanonicalPath)
+        }
+        assert(e.getCondition == "UNABLE_TO_INFER_SCHEMA",
+          s"expected UNABLE_TO_INFER_SCHEMA on the DSv2 path, got " +
+            s"${e.getCondition}: ${e.getMessage}")
+      }
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
@@ -21,8 +21,6 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{NullType, StringType}
 
 /**
@@ -182,24 +180,6 @@ trait JSONArchiveReadBase extends ArchiveReadSuiteBase {
       Seq("a.json" -> jsonBytes("{ not valid json")),
       extraOptions = Map("multiLine" -> "true"),
       schema = corruptSchema)
-  }
-
-  test("JSON: the DSv2 path refuses to infer a schema for an archive (UNABLE_TO_INFER_SCHEMA)") {
-    // Archive scanning is wired into the v1 file source only, so the DSv2 reader cannot read
-    // archives. On the v2 path inference must keep returning None for an archive input -- raising
-    // UNABLE_TO_INFER_SCHEMA -- rather than inferring a schema the v2 scan would then mis-read as
-    // raw archive bytes. Forcing json off the v1 source list routes the read through JsonTable.
-    withArchiveFile() { archive =>
-      writeArchive(archive, Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
-      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
-        val e = intercept[AnalysisException] {
-          spark.read.options(readOptions).format(format).load(archive.getCanonicalPath)
-        }
-        assert(e.getCondition == "UNABLE_TO_INFER_SCHEMA",
-          s"expected UNABLE_TO_INFER_SCHEMA on the DSv2 path, got " +
-            s"${e.getCondition}: ${e.getMessage}")
-      }
-    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
@@ -187,16 +187,19 @@ trait JSONArchiveReadBase extends ArchiveReadSuiteBase {
   if (supportsMidAdvanceFailure) {
     test("JSON: multiLine inference keeps entries read before a mid-advance failure " +
         "(ignoreCorruptFiles)") {
-      // Entry 0 is read, then advancing to a later entry throws (not at open). The `extra` field
-      // from entry 0 must survive the skip; a whole-archive drop would lose it.
+      // Entry 0 is read, then advancing to a later entry throws (not at open). A whole-archive drop
+      // would lose entry 0's `extra`; aborting the traversal would lose the sibling file's `later`.
       val opts = Map("multiLine" -> "true")
       withArchiveFile() { archive =>
         writeArchiveFailingAfterFirstEntry(archive,
           entryName(0) -> jsonBytes("{\n  \"id\": 1,\n  \"name\": \"Alice\",\n  \"extra\": 9\n}"))
+        Files.write(new File(archive.getParentFile, s"later.$fileExtension").toPath,
+          jsonBytes("{\n  \"id\": 2,\n  \"name\": \"Bob\",\n  \"later\": 7\n}"))
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-          val schema = inferredSchema(Seq(archive.getCanonicalPath), opts)
-          assert(schema.fieldNames.toSet == Set("id", "name", "extra"),
-            s"expected the first entry (with `extra`) to survive the mid-advance skip, got $schema")
+          val schema = inferredSchema(Seq(archive.getParentFile.getCanonicalPath), opts)
+          assert(schema.fieldNames.toSet == Set("id", "name", "extra", "later"),
+            "expected `extra` (pre-failure entry) and `later` (sibling file) in the inferred " +
+              s"schema after the mid-advance skip, got $schema")
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
@@ -184,6 +184,28 @@ trait JSONArchiveReadBase extends ArchiveReadSuiteBase {
       schema = corruptSchema)
   }
 
+  if (supportsMidAdvanceFailure) {
+    test("JSON: multiLine inference skips a corrupt entry reached while advancing " +
+        "(ignoreCorruptFiles)") {
+      // The first entry is valid; advancing to a later entry throws (not at open). With
+      // ignoreCorruptFiles the whole archive is skipped via the hasNext recovery in
+      // inferWithArchives, so a good sibling archive still infers -- proving the skip covers a
+      // mid-advance failure, not only the first entry.
+      val opts = Map("multiLine" -> "true")
+      withTempDir { dir =>
+        writeArchiveFailingAfterFirstEntry(new File(dir, s"bad.${archiveExtensions.head}"),
+          entryName(0) -> jsonBytes("{\n  \"id\": 1,\n  \"name\": \"Alice\"\n}"))
+        writeArchive(new File(dir, s"good.${archiveExtensions.head}"),
+          Seq(entryName(0) -> jsonBytes("{\n  \"id\": 2,\n  \"name\": \"Bob\"\n}")))
+        withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
+          val schema = inferredSchema(Seq(dir.getCanonicalPath), opts)
+          assert(schema.fieldNames.toSet == Set("id", "name"),
+            s"expected the good archive's schema after skipping the corrupt one, got $schema")
+        }
+      }
+    }
+  }
+
   test("JSON: the DSv2 path refuses to infer a schema for an archive (UNABLE_TO_INFER_SCHEMA)") {
     // Forcing json off the v1 source list routes the archive read through the DSv2 JsonTable, which
     // cannot read archives and must fail with UNABLE_TO_INFER_SCHEMA, not parse raw bytes.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/JSONArchiveReadBase.scala
@@ -185,22 +185,18 @@ trait JSONArchiveReadBase extends ArchiveReadSuiteBase {
   }
 
   if (supportsMidAdvanceFailure) {
-    test("JSON: multiLine inference skips a corrupt entry reached while advancing " +
+    test("JSON: multiLine inference keeps entries read before a mid-advance failure " +
         "(ignoreCorruptFiles)") {
-      // The first entry is valid; advancing to a later entry throws (not at open). With
-      // ignoreCorruptFiles the whole archive is skipped via the hasNext recovery in
-      // inferWithArchives, so a good sibling archive still infers -- proving the skip covers a
-      // mid-advance failure, not only the first entry.
+      // Entry 0 is read, then advancing to a later entry throws (not at open). The `extra` field
+      // from entry 0 must survive the skip; a whole-archive drop would lose it.
       val opts = Map("multiLine" -> "true")
-      withTempDir { dir =>
-        writeArchiveFailingAfterFirstEntry(new File(dir, s"bad.${archiveExtensions.head}"),
-          entryName(0) -> jsonBytes("{\n  \"id\": 1,\n  \"name\": \"Alice\"\n}"))
-        writeArchive(new File(dir, s"good.${archiveExtensions.head}"),
-          Seq(entryName(0) -> jsonBytes("{\n  \"id\": 2,\n  \"name\": \"Bob\"\n}")))
+      withArchiveFile() { archive =>
+        writeArchiveFailingAfterFirstEntry(archive,
+          entryName(0) -> jsonBytes("{\n  \"id\": 1,\n  \"name\": \"Alice\",\n  \"extra\": 9\n}"))
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-          val schema = inferredSchema(Seq(dir.getCanonicalPath), opts)
-          assert(schema.fieldNames.toSet == Set("id", "name"),
-            s"expected the good archive's schema after skipping the corrupt one, got $schema")
+          val schema = inferredSchema(Seq(archive.getCanonicalPath), opts)
+          assert(schema.fieldNames.toSet == Set("id", "name", "extra"),
+            s"expected the first entry (with `extra`) to survive the mid-advance skip, got $schema")
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
@@ -68,8 +68,8 @@ trait SevenZArchiveTestUtils {
   protected def writeCorruptArchive(dest: File): Unit =
     Files.write(dest.toPath, "this is not a valid 7z archive, just some random bytes"
       .getBytes(StandardCharsets.UTF_8))
-
-  // 7z validates its whole index when the archive is opened, so it can only fail at open, never
+  // 7z validates its whole index when the archive is opened, so this helper cannot construct a
+  // failure that occurs only while advancing to another entry.
   // mid-advance.
   protected def supportsMidAdvanceFailure: Boolean = false
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
@@ -69,9 +69,8 @@ trait SevenZArchiveTestUtils {
     Files.write(dest.toPath, "this is not a valid 7z archive, just some random bytes"
       .getBytes(StandardCharsets.UTF_8))
 
-  // 7z stores its entry index at the end of the file and validates it when the archive is opened,
-  // so it cannot read a first entry and then fail while advancing to a later one -- the open-time
-  // corrupt case is covered by the shared corrupt-archive tests instead.
+  // 7z validates its whole index when the archive is opened, so it can only fail at open, never
+  // mid-advance.
   protected def supportsMidAdvanceFailure: Boolean = false
 
   protected def writeArchiveFailingAfterFirstEntry(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
@@ -68,9 +68,9 @@ trait SevenZArchiveTestUtils {
   protected def writeCorruptArchive(dest: File): Unit =
     Files.write(dest.toPath, "this is not a valid 7z archive, just some random bytes"
       .getBytes(StandardCharsets.UTF_8))
+
   // 7z validates its whole index when the archive is opened, so this helper cannot construct a
   // failure that occurs only while advancing to another entry.
-  // mid-advance.
   protected def supportsMidAdvanceFailure: Boolean = false
 
   protected def writeArchiveFailingAfterFirstEntry(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SevenZArchiveReadBase.scala
@@ -68,4 +68,13 @@ trait SevenZArchiveTestUtils {
   protected def writeCorruptArchive(dest: File): Unit =
     Files.write(dest.toPath, "this is not a valid 7z archive, just some random bytes"
       .getBytes(StandardCharsets.UTF_8))
+
+  // 7z stores its entry index at the end of the file and validates it when the archive is opened,
+  // so it cannot read a first entry and then fail while advancing to a later one -- the open-time
+  // corrupt case is covered by the shared corrupt-archive tests instead.
+  protected def supportsMidAdvanceFailure: Boolean = false
+
+  protected def writeArchiveFailingAfterFirstEntry(
+      dest: File, firstEntry: (String, Array[Byte])): Unit =
+    throw new UnsupportedOperationException("7z cannot fail while advancing to a later entry")
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TarArchiveTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TarArchiveTestUtils.scala
@@ -72,6 +72,9 @@ trait TarArchiveTestUtils {
    */
   protected def writeArchiveFailingAfterFirstEntry(
       dest: File, firstEntry: (String, Array[Byte])): Unit = {
+    require(firstEntry._1.getBytes(StandardCharsets.UTF_8).length <= 100,
+      "the first entry's name must fit the 100-byte ustar name field so its header is a single " +
+        s"512-byte block, otherwise the truncation offset below shifts; got '${firstEntry._1}'")
     val buf = new ByteArrayOutputStream()
     val out = new TarArchiveOutputStream(buf)
     Seq(firstEntry, ("part-later.bin", ("x" * 4096).getBytes(StandardCharsets.UTF_8))).foreach {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TarArchiveTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TarArchiveTestUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.io.{File, FileOutputStream, OutputStream}
+import java.io.{ByteArrayOutputStream, File, FileOutputStream, OutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Locale
@@ -62,4 +62,33 @@ trait TarArchiveTestUtils {
   protected def writeCorruptArchive(dest: File): Unit =
     Files.write(dest.toPath, "this is not a valid gzip-compressed tar archive"
       .getBytes(StandardCharsets.UTF_8))
+
+  protected def supportsMidAdvanceFailure: Boolean = true
+
+  /**
+   * Writes a plain `.tar` with `firstEntry` intact followed by a second entry that is then
+   * truncated partway through its header, so a reader parses the first entry cleanly and throws
+   * from `getNextEntry` while advancing to the second. Plain (uncompressed) tar keeps the first
+   * entry readable after truncation; gzipping corrupts the whole stream, so the ext is `.tar`.
+   */
+  protected def writeArchiveFailingAfterFirstEntry(
+      dest: File, firstEntry: (String, Array[Byte])): Unit = {
+    val buf = new ByteArrayOutputStream()
+    val out = new TarArchiveOutputStream(buf)
+    Seq(firstEntry, ("part-later.bin", ("x" * 4096).getBytes(StandardCharsets.UTF_8))).foreach {
+      case (entryName, bytes) =>
+        val entry = new TarArchiveEntry(entryName)
+        entry.setSize(bytes.length.toLong)
+        out.putArchiveEntry(entry)
+        out.write(bytes)
+        out.closeArchiveEntry()
+    }
+    out.finish()
+    out.close()
+    // Keep the first entry's 512-byte header and block-aligned body, then only part of the second
+    // entry's 512-byte header, so reading the first entry succeeds and `getNextEntry` throws on the
+    // partial header while advancing.
+    val firstBlocks = 512 + ((firstEntry._2.length + 511) / 512) * 512
+    Files.write(dest.toPath, buf.toByteArray.take(firstBlocks + 256))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TarArchiveTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TarArchiveTestUtils.scala
@@ -66,10 +66,9 @@ trait TarArchiveTestUtils {
   protected def supportsMidAdvanceFailure: Boolean = true
 
   /**
-   * Writes a plain `.tar` with `firstEntry` intact followed by a second entry that is then
-   * truncated partway through its header, so a reader parses the first entry cleanly and throws
-   * from `getNextEntry` while advancing to the second. Plain (uncompressed) tar keeps the first
-   * entry readable after truncation; gzipping corrupts the whole stream, so the ext is `.tar`.
+   * Writes a plain `.tar` (uncompressed, so the first entry survives truncation) with `firstEntry`
+   * intact followed by a second entry whose header is cut short, so `getNextEntry` throws while
+   * advancing to it.
    */
   protected def writeArchiveFailingAfterFirstEntry(
       dest: File, firstEntry: (String, Array[Byte])): Unit = {
@@ -85,9 +84,8 @@ trait TarArchiveTestUtils {
     }
     out.finish()
     out.close()
-    // Keep the first entry's 512-byte header and block-aligned body, then only part of the second
-    // entry's 512-byte header, so reading the first entry succeeds and `getNextEntry` throws on the
-    // partial header while advancing.
+    // Keep the first entry (512-byte header + block-aligned body) plus half of the second entry's
+    // 512-byte header, so `getNextEntry` hits a partial header while advancing.
     val firstBlocks = 512 + ((firstEntry._2.length + 511) / 512) * 512
     Files.write(dest.toPath, buf.toByteArray.take(firstBlocks + 256))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/XMLArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/XMLArchiveReadBase.scala
@@ -137,16 +137,19 @@ trait XMLArchiveReadBase extends ArchiveReadSuiteBase {
   if (supportsMidAdvanceFailure) {
     test("XML: multiLine inference keeps records read before a mid-advance failure " +
         "(ignoreCorruptFiles)") {
-      // Entry 0 is read, then advancing to a later entry throws (not at open). The `extra` field
-      // from entry 0 must survive the skip; a whole-archive drop would lose it.
+      // Entry 0 is read, then advancing to a later entry throws (not at open). A whole-archive drop
+      // would lose entry 0's `extra`; aborting the traversal would lose the sibling file's `later`.
       val opts = Map("multiLine" -> "true")
       withArchiveFile() { archive =>
         writeArchiveFailingAfterFirstEntry(archive, entryName(0) ->
           xmlBytes("<rows><row><id>1</id><name>Alice</name><extra>9</extra></row></rows>"))
+        Files.write(new File(archive.getParentFile, s"later.$fileExtension").toPath,
+          xmlBytes("<rows><row><id>2</id><name>Bob</name><later>7</later></row></rows>"))
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-          val schema = inferredSchema(Seq(archive.getCanonicalPath), opts)
-          assert(schema.fieldNames.toSet == Set("id", "name", "extra"),
-            s"expected the first entry (with `extra`) to survive the mid-advance skip, got $schema")
+          val schema = inferredSchema(Seq(archive.getParentFile.getCanonicalPath), opts)
+          assert(schema.fieldNames.toSet == Set("id", "name", "extra", "later"),
+            "expected `extra` (pre-failure entry) and `later` (sibling file) in the inferred " +
+              s"schema after the mid-advance skip, got $schema")
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/XMLArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/XMLArchiveReadBase.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
 
 /**
@@ -131,6 +132,28 @@ trait XMLArchiveReadBase extends ArchiveReadSuiteBase {
       Seq(entryName(0) -> xmlBytes("<row><id>1</id><name>Alice</name>")),
       extraOptions = Map("multiLine" -> "true"),
       schema = corruptSchema)
+  }
+
+  if (supportsMidAdvanceFailure) {
+    test("XML: multiLine inference skips a corrupt entry reached while advancing " +
+        "(ignoreCorruptFiles)") {
+      // The first entry is valid; advancing to a later entry throws (not at open). With
+      // ignoreCorruptFiles the whole archive is skipped via the hasNext recovery in
+      // inferWithArchives, so a good sibling archive still infers -- proving the skip covers a
+      // mid-advance failure, not only the first entry.
+      val opts = Map("multiLine" -> "true")
+      withTempDir { dir =>
+        writeArchiveFailingAfterFirstEntry(new File(dir, s"bad.${archiveExtensions.head}"),
+          entryName(0) -> xmlBytes("<rows><row><id>1</id><name>Alice</name></row></rows>"))
+        writeArchive(new File(dir, s"good.${archiveExtensions.head}"),
+          Seq(entryName(0) -> xmlBytes("<rows><row><id>2</id><name>Bob</name></row></rows>")))
+        withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
+          val schema = inferredSchema(Seq(dir.getCanonicalPath), opts)
+          assert(schema.fieldNames.toSet == Set("id", "name"),
+            s"expected the good archive's schema after skipping the corrupt one, got $schema")
+        }
+      }
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/XMLArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/XMLArchiveReadBase.scala
@@ -135,22 +135,18 @@ trait XMLArchiveReadBase extends ArchiveReadSuiteBase {
   }
 
   if (supportsMidAdvanceFailure) {
-    test("XML: multiLine inference skips a corrupt entry reached while advancing " +
+    test("XML: multiLine inference keeps records read before a mid-advance failure " +
         "(ignoreCorruptFiles)") {
-      // The first entry is valid; advancing to a later entry throws (not at open). With
-      // ignoreCorruptFiles the whole archive is skipped via the hasNext recovery in
-      // inferWithArchives, so a good sibling archive still infers -- proving the skip covers a
-      // mid-advance failure, not only the first entry.
+      // Entry 0 is read, then advancing to a later entry throws (not at open). The `extra` field
+      // from entry 0 must survive the skip; a whole-archive drop would lose it.
       val opts = Map("multiLine" -> "true")
-      withTempDir { dir =>
-        writeArchiveFailingAfterFirstEntry(new File(dir, s"bad.${archiveExtensions.head}"),
-          entryName(0) -> xmlBytes("<rows><row><id>1</id><name>Alice</name></row></rows>"))
-        writeArchive(new File(dir, s"good.${archiveExtensions.head}"),
-          Seq(entryName(0) -> xmlBytes("<rows><row><id>2</id><name>Bob</name></row></rows>")))
+      withArchiveFile() { archive =>
+        writeArchiveFailingAfterFirstEntry(archive, entryName(0) ->
+          xmlBytes("<rows><row><id>1</id><name>Alice</name><extra>9</extra></row></rows>"))
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-          val schema = inferredSchema(Seq(dir.getCanonicalPath), opts)
-          assert(schema.fieldNames.toSet == Set("id", "name"),
-            s"expected the good archive's schema after skipping the corrupt one, got $schema")
+          val schema = inferredSchema(Seq(archive.getCanonicalPath), opts)
+          assert(schema.fieldNames.toSet == Set("id", "name", "extra"),
+            s"expected the first entry (with `extra`) to survive the mid-advance skip, got $schema")
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ZipArchiveTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ZipArchiveTestUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.io.{ByteArrayOutputStream, File, FileOutputStream}
+import java.io.{File, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
@@ -58,35 +58,12 @@ trait ZipArchiveTestUtils {
     Files.write(dest.toPath, "this is not a valid zip archive, just some random bytes"
       .getBytes(StandardCharsets.UTF_8))
 
-  protected def supportsMidAdvanceFailure: Boolean = true
+  // Zip can't throw while *advancing*: a cut header reads as clean EOF, and a cut body only throws
+  // when the entry's bytes are read -- which a lazy reader (JSON) defers downstream. Tar is used
+  // for the mid-advance regression test instead.
+  protected def supportsMidAdvanceFailure: Boolean = false
 
-  /**
-   * Writes a zip with `firstEntry` intact followed by a second STORED entry that is then truncated
-   * partway through its body, so `ZipArchiveInputStream` reads the first entry cleanly and throws
-   * while streaming the second. The second entry is STORED (uncompressed) and large so the
-   * truncated bytes are unambiguously short of its declared size.
-   */
   protected def writeArchiveFailingAfterFirstEntry(
-      dest: File, firstEntry: (String, Array[Byte])): Unit = {
-    val buf = new ByteArrayOutputStream()
-    val out = new ZipArchiveOutputStream(buf)
-    val secondBytes = ("x" * 8192).getBytes(StandardCharsets.UTF_8)
-    Seq(firstEntry, ("part-later.bin", secondBytes)).foreach { case (entryName, bytes) =>
-      val entry = new ZipArchiveEntry(entryName)
-      entry.setMethod(java.util.zip.ZipEntry.STORED)
-      entry.setSize(bytes.length.toLong)
-      entry.setCompressedSize(bytes.length.toLong)
-      val crc = new java.util.zip.CRC32()
-      crc.update(bytes)
-      entry.setCrc(crc.getValue)
-      out.putArchiveEntry(entry)
-      out.write(bytes)
-      out.closeArchiveEntry()
-    }
-    out.finish()
-    out.close()
-    // Cut within the second STORED entry's body so the first entry still reads and streaming the
-    // second hits a truncated, shorter-than-declared payload.
-    Files.write(dest.toPath, buf.toByteArray.dropRight(secondBytes.length / 2))
-  }
+      dest: File, firstEntry: (String, Array[Byte])): Unit =
+    throw new UnsupportedOperationException("zip cannot force a throw while advancing to an entry")
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ZipArchiveTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ZipArchiveTestUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.io.{File, FileOutputStream}
+import java.io.{ByteArrayOutputStream, File, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
@@ -57,4 +57,36 @@ trait ZipArchiveTestUtils {
   protected def writeCorruptArchive(dest: File): Unit =
     Files.write(dest.toPath, "this is not a valid zip archive, just some random bytes"
       .getBytes(StandardCharsets.UTF_8))
+
+  protected def supportsMidAdvanceFailure: Boolean = true
+
+  /**
+   * Writes a zip with `firstEntry` intact followed by a second STORED entry that is then truncated
+   * partway through its body, so `ZipArchiveInputStream` reads the first entry cleanly and throws
+   * while streaming the second. The second entry is STORED (uncompressed) and large so the
+   * truncated bytes are unambiguously short of its declared size.
+   */
+  protected def writeArchiveFailingAfterFirstEntry(
+      dest: File, firstEntry: (String, Array[Byte])): Unit = {
+    val buf = new ByteArrayOutputStream()
+    val out = new ZipArchiveOutputStream(buf)
+    val secondBytes = ("x" * 8192).getBytes(StandardCharsets.UTF_8)
+    Seq(firstEntry, ("part-later.bin", secondBytes)).foreach { case (entryName, bytes) =>
+      val entry = new ZipArchiveEntry(entryName)
+      entry.setMethod(java.util.zip.ZipEntry.STORED)
+      entry.setSize(bytes.length.toLong)
+      entry.setCompressedSize(bytes.length.toLong)
+      val crc = new java.util.zip.CRC32()
+      crc.update(bytes)
+      entry.setCrc(crc.getValue)
+      out.putArchiveEntry(entry)
+      out.write(bytes)
+      out.closeArchiveEntry()
+    }
+    out.finish()
+    out.close()
+    // Cut within the second STORED entry's body so the first entry still reads and streaming the
+    // second hits a truncated, shorter-than-declared payload.
+    Files.write(dest.toPath, buf.toByteArray.dropRight(secondBytes.length / 2))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JsonDataSource` and `XmlDataSource` each carried a custom per-entry, line-delimited
archive-schema-inference branch in `inferWithArchives` (added alongside JSON/XML archive support):
for single-line mode they streamed every archive entry and loose file, split the bytes into lines,
and fed them through a bespoke `JsonInferSchema` / `XmlInferSchema` pass. This duplicated the
format's existing single-line inference path (`TextInput{Json,Xml}DataSource.infer` via
`createBaseDataset` / `inferFromDataset`), which already tokenizes line-delimited records by
delegating to the Text data source.

That duplication was only necessary because the Text data source could not read archives. Since
SPARK-57705 added archive support to `TextFileFormat`, that is no longer the case, so this PR
removes the custom single-line branch in both `inferWithArchives` methods. Single-line archive
schema inference now falls through the dispatch in `inferSchema` to the normal `infer` path — the
exact same path a directory or loose-file read takes — so it is identical to a directory read by
construction. `inferWithArchives` moves into the multi-line data source and is multi-line-only
(it reads whole streams / `rowTag`-tokenizes, which has no line model to reuse).

The DSv2 archive-inference refuse guard is kept: DSv2 archive reads are unsupported (the v2 scan
reads raw file bytes and never routes archives through `readArchive`), so the `supportsArchiveScan`
parameter on `inferSchema` still makes the DSv2 callers (`{CSV,Json}Table`) return `None`
(`UNABLE_TO_INFER_SCHEMA`) for an archive input, failing loudly instead of letting the v2 scan
mis-read raw archive bytes. Only the v1 callers (`{Csv,Json}FileFormat`) pass
`supportsArchiveScan = true`. This is unchanged behavior; the refactor above is orthogonal to it.

### Why are the changes needed?

The custom single-line inference branch was a workaround for the Text data source's lack of archive
support; that support now exists, so the workaround is dead code that can diverge from the real
single-line read path. Removing it makes single-line archive inference identical to a directory read
by construction rather than by a parallel implementation.

### Does this PR introduce _any_ user-facing change?

No. This is a behavior-preserving refactor; single-line archive inference produces the same schema
(now via the shared path), multi-line inference is unchanged, and the DSv2 path still does not read
archives.

### How was this patch tested?

Existing archive test suites already assert that single-line archive inference equals the directory
read (`inferredSchema(archive) == inferredSchema(dir)`), cross-entry type widening, corrupt-entry
skip, and null-across-entries widening — these are unchanged and remain the safety net
(`JSON{Tar,Zip}ArchiveReadSuite`, `XML{Tar,Zip}ArchiveReadSuite`), as are the two DSv2-refuse tests
(`CSV/JSON: the DSv2 path refuses to infer a schema for an archive`). The corrupt-entry skip now
also covers a corrupt entry reached while advancing through a multi-entry archive during inference,
not only the first entry.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)


