### PR TITLE
[SPARK-58251][ML][CONNECT] Add size estimates for OneHotEncoderModel, PCAModel, StringIndexerModel, and IDFModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
@@ -34,6 +34,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorVersion
 
 /**
@@ -125,6 +126,10 @@ class IDFModel private[ml] (
 
   // For ml connect only
   private[ml] def this() = this("", null)
+
+  private[spark] override def estimatedSize: Long = {
+    estimateMatadataSize + Option(idfModel).map(SizeEstimator.estimate).getOrElse(0L)
+  }
 
   /** @group setParam */
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/IDF.scala
@@ -128,7 +128,16 @@ class IDFModel private[ml] (
   private[ml] def this() = this("", null)
 
   private[spark] override def estimatedSize: Long = {
-    estimateMatadataSize + Option(idfModel).map(SizeEstimator.estimate).getOrElse(0L)
+    var size = estimateMatadataSize
+    if (idfModel != null) {
+      if (idfModel.idf != null) {
+        size += idfModel.idf.asML.getSizeInBytes
+      }
+      if (idfModel.docFreq != null) {
+        size += SizeEstimator.estimate(idfModel.docFreq)
+      }
+    }
+    size
   }
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{col, lit, udf}
 import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.SizeEstimator
 
 /** Private trait for params and common methods for OneHotEncoder and OneHotEncoderModel */
 private[ml] trait OneHotEncoderBase extends Params with HasHandleInvalid
@@ -238,6 +239,9 @@ class OneHotEncoderModel private[ml] (
 
   // For ml connect only
   private[ml] def this() = this("", Array.emptyIntArray)
+
+  private[spark] override def estimatedSize: Long =
+    estimateMatadataSize + SizeEstimator.estimate(categorySizes)
 
   // Returns the category size for each index with `dropLast` and `handleInvalid`
   // taken into account.

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -32,6 +32,7 @@ import org.apache.spark.mllib.linalg.{DenseMatrix => OldDenseMatrix, Vectors => 
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorVersion
 
 /**
@@ -131,6 +132,9 @@ class PCAModel private[ml] (
 
   // For ml connect only
   private[ml] def this() = this("", Matrices.empty, Vectors.empty)
+
+  private[spark] override def estimatedSize: Long =
+    estimateMatadataSize + SizeEstimator.estimate((pc, explainedVariance))
 
   /** @group setParam */
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -32,7 +32,6 @@ import org.apache.spark.mllib.linalg.{DenseMatrix => OldDenseMatrix, Vectors => 
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorVersion
 
 /**
@@ -133,8 +132,16 @@ class PCAModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Matrices.empty, Vectors.empty)
 
-  private[spark] override def estimatedSize: Long =
-    estimateMatadataSize + SizeEstimator.estimate((pc, explainedVariance))
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    if (pc != null) {
+      size += pc.getSizeInBytes
+    }
+    if (explainedVariance != null) {
+      size += explainedVariance.getSizeInBytes
+    }
+    size
+  }
 
   /** @group setParam */
   @Since("1.5.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Dataset}
 import org.apache.spark.sql.functions.{get => fget, printf => fprintf, _}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorMinorVersion
 import org.apache.spark.util.collection.OpenHashMap
 
@@ -326,6 +327,9 @@ class StringIndexerModel (
       map
     }
   }
+
+  private[spark] override def estimatedSize: Long =
+    estimateMatadataSize + SizeEstimator.estimate((labelsArray, labelsToIndexArray))
 
   /** @group setParam */
   @Since("1.6.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
@@ -59,7 +59,7 @@ class IDFSuite extends MLTest with DefaultReadWriteTest {
 
     val maxSize = 2 * 1024
     assert(model.estimatedSize < maxSize,
-      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("compute IDF with default parameter") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
@@ -57,7 +57,9 @@ class IDFSuite extends MLTest with DefaultReadWriteTest {
         Tuple1(Vectors.sparse(3, Array(0), Array(1.0))),
         Tuple1(Vectors.sparse(3, Array(1), Array(1.0)))).toDF("features"))
 
-    assert(model.estimatedSize < 2 * 1024)
+    val maxSize = 2 * 1024
+    assert(model.estimatedSize < maxSize,
+      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("compute IDF with default parameter") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/IDFSuite.scala
@@ -49,6 +49,17 @@ class IDFSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(model)
   }
 
+  test("IDFModel estimated size") {
+    val model = new IDF()
+      .setInputCol("features")
+      .setOutputCol("idf")
+      .fit(Seq(
+        Tuple1(Vectors.sparse(3, Array(0), Array(1.0))),
+        Tuple1(Vectors.sparse(3, Array(1), Array(1.0)))).toDF("features"))
+
+    assert(model.estimatedSize < 2 * 1024)
+  }
+
   test("compute IDF with default parameter") {
     val numOfFeatures = 4
     val data = Array(

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -35,6 +35,15 @@ class OneHotEncoderSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(new OneHotEncoder)
   }
 
+  test("OneHotEncoderModel estimated size") {
+    val model = new OneHotEncoder()
+      .setInputCol("input")
+      .setOutputCol("output")
+      .fit(Seq(0.0, 1.0).toDF("input"))
+
+    assert(model.estimatedSize < 2 * 1024)
+  }
+
   test("OneHotEncoder dropLast = false") {
     val data = Seq(
       Row(0.0, Vectors.sparse(3, Seq((0, 1.0)))),

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -43,7 +43,7 @@ class OneHotEncoderSuite extends MLTest with DefaultReadWriteTest {
 
     val maxSize = 4 * 1024
     assert(model.estimatedSize < maxSize,
-      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("OneHotEncoder dropLast = false") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -41,7 +41,9 @@ class OneHotEncoderSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("output")
       .fit(Seq(0.0, 1.0).toDF("input"))
 
-    assert(model.estimatedSize < 4 * 1024)
+    val maxSize = 4 * 1024
+    assert(model.estimatedSize < maxSize,
+      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("OneHotEncoder dropLast = false") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -41,7 +41,7 @@ class OneHotEncoderSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("output")
       .fit(Seq(0.0, 1.0).toDF("input"))
 
-    assert(model.estimatedSize < 2 * 1024)
+    assert(model.estimatedSize < 4 * 1024)
   }
 
   test("OneHotEncoder dropLast = false") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
@@ -47,7 +47,9 @@ class PCASuite extends MLTest with DefaultReadWriteTest {
         Tuple1(Vectors.dense(1.0, 0.0)),
         Tuple1(Vectors.dense(0.0, 1.0))).toDF("features"))
 
-    assert(model.estimatedSize < 2 * 1024)
+    val maxSize = 2 * 1024
+    assert(model.estimatedSize < maxSize,
+      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("pca") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
@@ -38,6 +38,18 @@ class PCASuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(model)
   }
 
+  test("PCAModel estimated size") {
+    val model = new PCA()
+      .setInputCol("features")
+      .setOutputCol("pca")
+      .setK(1)
+      .fit(Seq(
+        Tuple1(Vectors.dense(1.0, 0.0)),
+        Tuple1(Vectors.dense(0.0, 1.0))).toDF("features"))
+
+    assert(model.estimatedSize < 2 * 1024)
+  }
+
   test("pca") {
     val data = Array(
       Vectors.sparse(5, Seq((1, 1.0), (3, 7.0))),

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/PCASuite.scala
@@ -49,7 +49,7 @@ class PCASuite extends MLTest with DefaultReadWriteTest {
 
     val maxSize = 2 * 1024
     assert(model.estimatedSize < maxSize,
-      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("pca") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -43,7 +43,7 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("output")
       .fit(Seq("a", "b").toDF("input"))
 
-    assert(model.estimatedSize < 2 * 1024)
+    assert(model.estimatedSize < 4 * 1024)
   }
 
   test("params: input/output columns") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -43,7 +43,9 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("output")
       .fit(Seq("a", "b").toDF("input"))
 
-    assert(model.estimatedSize < 4 * 1024)
+    val maxSize = 4 * 1024
+    assert(model.estimatedSize < maxSize,
+      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("params: input/output columns") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -45,7 +45,7 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
 
     val maxSize = 4 * 1024
     assert(model.estimatedSize < maxSize,
-      s"model.estimatedSize (${model.estimatedSize}) should be less than $maxSize")
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("params: input/output columns") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -37,6 +37,15 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(modelWithoutUid)
   }
 
+  test("StringIndexerModel estimated size") {
+    val model = new StringIndexer()
+      .setInputCol("input")
+      .setOutputCol("output")
+      .fit(Seq("a", "b").toDF("input"))
+
+    assert(model.estimatedSize < 2 * 1024)
+  }
+
   test("params: input/output columns") {
     val stringIndexerSingleCol = new StringIndexer()
       .setInputCol("in").setOutputCol("out")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add explicit `estimatedSize` implementations for OneHotEncoderModel, PCAModel, StringIndexerModel, and IDFModel. Each directly accounts for model metadata and model-owned learned state; vectors and matrices use `getSizeInBytes`.

### Why are the changes needed?

SPARK-57521 already makes the default `Model.estimatedSize` estimate a parentless copy, avoiding parent-estimator and SparkSession traversal. These explicit implementations make size accounting cheaper and more precise for feature models, and align them with models that already provide specialized estimates.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added fitted-model size bounds to the corresponding feature algorithm suites.
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 build/sbt 'mllib/Test/compile'`\n- Targeted suites were not run.\n\n### Was this patch authored or co-authored using generative AI tooling?\n\nGenerated-by: OpenAI Codex (GPT-5)