### PR TITLE
[SPARK-58255][BUILD] Upgrade PostgreSQL JDBC driver to 42.7.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
     </extraJavaTestArgs>
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
     <mysql.connector.version>9.6.0</mysql.connector.version>
-    <postgresql.version>42.7.11</postgresql.version>
+    <postgresql.version>42.7.13</postgresql.version>
     <db2.jcc.version>12.1.4.0</db2.jcc.version>
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.26.1.0.0</ojdbc17.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the test dependency `PostgreSQL` JDBC driver to `42.7.13` which was released on 2026-07-06. The one-week dependency-update grace-period passed.

- https://github.com/apache/spark/security/dependabot/206

### Why are the changes needed?

To maintain `PostgreSQL` JDBC driver test coverage up-to-date. This upgrade brings two releases:

- https://github.com/pgjdbc/pgjdbc/releases/tag/REL42.7.12 (2026-06-29)
  - Security: Fix silent channel-binding authentication downgrade (CVE-2026-54291). `channelBinding=require` connections could be silently downgraded from SCRAM-SHA-256-PLUS to plain SCRAM-SHA-256, losing MITM protection. Affects 42.7.4 through 42.7.11.
- https://github.com/pgjdbc/pgjdbc/releases/tag/REL42.7.13 (2026-07-06)
  - Security: Fail closed on channel-binding downgrade (hardening on top of the 42.7.12 fix).
  - Feature: Invalidate prepared statement cache via `search_path` GUC_REPORT (PG 18+), `flushCacheOnDdl` for transparent re-prepare after DDL, cap `reWriteBatchedInserts` by the protocol limit.
  - Fixes: honor scale in `ResultSet.getBigDecimal(int, int)`, `BlobInputStream` mark/reset position, detect native `CALL` preceded by a comment, auto-detect SSL key format, close socket when connection setup fails after connect, support `java.time` values in updatable ResultSet, and more.

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5