### PR TITLE
[SPARK-58258][PYTHON][SQL] Gate the columnar Arrow Python UDF passthrough on the vector shape matching the declared schema

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
@@ -18,7 +18,7 @@
 import datetime
 import unittest
 
-from pyspark.sql.functions import col, pandas_udf, udf
+from pyspark.sql.functions import col, udf
 from pyspark.sql import Row
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.testing.utils import (
@@ -72,12 +72,34 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
         finally:
             super().tearDownClass()
 
+    def _assert_columnar_arrow_eval(self, df, expected_nodes):
+        # Assert the executed plan contains exactly `expected_nodes` ArrowEvalPythonExec
+        # operators and every one of them takes the columnar input path -- otherwise the
+        # test silently stops exercising the code this suite exists to pin.
+        nodes = []
+        stack = [df._jdf.queryExecution().executedPlan()]
+        while stack:
+            node = stack.pop()
+            name = node.getClass().getSimpleName()
+            if name == "AdaptiveSparkPlanExec":
+                stack.append(node.executedPlan())
+                continue
+            if name == "ArrowEvalPythonExec":
+                nodes.append(node)
+            children = node.children()
+            for i in range(children.size()):
+                stack.append(children.apply(i))
+        self.assertEqual(len(nodes), expected_nodes, "unexpected number of ArrowEvalPythonExec")
+        for node in nodes:
+            self.assertTrue(node.supportsColumnar(), "expected the columnar input path")
+
     def _assert_udf_on_cached_strings(self):
         df = self.spark.createDataFrame(
             [("hello",), (None,), ("world",)], schema="v string"
         ).cache()
         try:
             result = df.select(udf(lambda x: x.upper() if x is not None else None)(col("v")))
+            self._assert_columnar_arrow_eval(result, expected_nodes=1)
             assertDataFrameEqual(result, [Row("HELLO"), Row(None), Row("WORLD")])
         finally:
             df.unpersist()
@@ -103,23 +125,33 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
         df = self.spark.createDataFrame([(1, "a"), (2, "b")], schema="i long, s string").cache()
         try:
             result = df.select(col("s"), udf(lambda x: x + 1, "long")(col("i")))
+            self._assert_columnar_arrow_eval(result, expected_nodes=1)
             assertDataFrameEqual(result, [Row("a", 2), Row("b", 3)])
         finally:
             df.unpersist()
 
-    def test_chained_udfs_on_timestamps_with_non_utc_session(self):
-        # A pandas UDF's timestamp output comes back from the worker labeled UTC, while the
-        # following Arrow-optimized Python UDF runs as a separate exec node whose stream
-        # declares the session time zone. The labels differ but the physical layout is
-        # identical (int64 epoch microseconds), so the congruence gate must not reject the
-        # pass-through for this normal mixed-UDF pipeline -- and the values must round-trip
-        # regardless of which path is taken.
+    def test_udf_on_timestamps_cached_under_different_time_zone(self):
+        # Pins the timestamp pass-through end to end: the plan takes the columnar path and
+        # the stored epoch round-trips unchanged across a session-timezone change between
+        # cache materialization and the UDF query. Note the cache rebuilds its Arrow schema
+        # at read time with the query's session timezone, so the actual and declared timezone
+        # labels the gate compares are equal by construction here; the layout-equal
+        # label-mismatch case (e.g. an external DSv2 Arrow source labeling UTC while the
+        # stream schema declares the session timezone) has no in-tree columnar producer and
+        # is pinned by the ArrowUtilsSuite congruence tests instead.
         ts = datetime.datetime(2025, 1, 6, 12, 30, 45)
-        with self.sql_conf({"spark.sql.session.timeZone": "America/Los_Angeles"}):
-            df = self.spark.createDataFrame([(ts,)], schema="ts timestamp")
-            identity = pandas_udf(lambda s: s, "timestamp")
-            result = df.select(udf(lambda t: t, "timestamp")(identity(col("ts"))))
-            assertDataFrameEqual(result, [Row(ts)])
+        with self.sql_conf({"spark.sql.session.timeZone": "UTC"}):
+            df = self.spark.createDataFrame([(ts,)], schema="ts timestamp").cache()
+            df.count()  # materialize: the cached vectors are labeled with the UTC session tz
+        try:
+            with self.sql_conf({"spark.sql.session.timeZone": "America/Los_Angeles"}):
+                result = df.select(udf(lambda t: t, "timestamp")(col("ts")))
+                self._assert_columnar_arrow_eval(result, expected_nodes=1)
+                # The stored epoch round-trips; naive-datetime wall time is preserved because
+                # createDataFrame and collect both convert against the machine-local timezone.
+                assertDataFrameEqual(result, [Row(ts)])
+        finally:
+            df.unpersist()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
@@ -41,7 +41,9 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
     Python runner (ColumnarArrowPythonWithNamedArgumentRunner) end to end -- the path an
     Arrow-backed DSv2 source would also take. This pins the init-message protocol between that
     runner and the worker: a mismatched section there desyncs the worker's init parse and hangs
-    the task (SPARK-58241).
+    the task (SPARK-58241). It also pins the columnar fast path's shape gate: the cached vectors
+    are forwarded verbatim only when their physical shape matches what the stream's schema
+    declares, and fall back to row-based re-encoding otherwise.
 
     This suite runs in its own module because spark.sql.cache.serializer is a static conf latched
     into a JVM-wide singleton on first cache materialization.
@@ -69,7 +71,7 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
         finally:
             super().tearDownClass()
 
-    def test_udf_on_cached_strings(self):
+    def _assert_udf_on_cached_strings(self):
         df = self.spark.createDataFrame(
             [("hello",), (None,), ("world",)], schema="v string"
         ).cache()
@@ -78,6 +80,20 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
             assertDataFrameEqual(result, [Row("HELLO"), Row(None), Row("WORLD")])
         finally:
             df.unpersist()
+
+    def test_udf_on_cached_strings(self):
+        # Cache-scan vectors use standard 32-bit var-width offsets, matching the default
+        # interchange schema: the columnar fast path forwards them verbatim.
+        self._assert_udf_on_cached_strings()
+
+    def test_udf_on_cached_strings_with_large_var_types(self):
+        # With useLargeVarTypes=true the UDF stream schema declares LargeUtf8 (64-bit offsets)
+        # but the cache always stores standard Utf8, so forwarding the cache-scan vector
+        # verbatim would produce a stream whose header and body disagree. The shape gate must
+        # route this through the row-based re-encoding fallback and still produce correct
+        # results.
+        with self.sql_conf({"spark.sql.execution.arrow.useLargeVarTypes": "true"}):
+            self._assert_udf_on_cached_strings()
 
     def test_udf_on_cached_numeric_column_alongside_unselected_string(self):
         # Only the UDF's input columns are serialized to the worker; the column that is not a

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 #
 
+import datetime
 import unittest
 
-from pyspark.sql.functions import col, udf
+from pyspark.sql.functions import col, pandas_udf, udf
 from pyspark.sql import Row
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.testing.utils import (
@@ -105,6 +106,21 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
             assertDataFrameEqual(result, [Row("a", 2), Row("b", 3)])
         finally:
             df.unpersist()
+
+
+    def test_chained_udfs_on_timestamps_with_non_utc_session(self):
+        # A pandas UDF's timestamp output comes back from the worker labeled UTC, while the
+        # following Arrow-optimized Python UDF runs as a separate exec node whose stream
+        # declares the session time zone. The labels differ but the physical layout is
+        # identical (int64 epoch microseconds), so the congruence gate must not reject the
+        # pass-through for this normal mixed-UDF pipeline -- and the values must round-trip
+        # regardless of which path is taken.
+        ts = datetime.datetime(2025, 1, 6, 12, 30, 45)
+        with self.sql_conf({"spark.sql.session.timeZone": "America/Los_Angeles"}):
+            df = self.spark.createDataFrame([(ts,)], schema="ts timestamp")
+            identity = pandas_udf(lambda s: s, "timestamp")
+            result = df.select(udf(lambda t: t, "timestamp")(identity(col("ts"))))
+            assertDataFrameEqual(result, [Row(ts)])
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
@@ -130,6 +130,21 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
         finally:
             df.unpersist()
 
+    def test_udf_on_cached_map_column(self):
+        # Canonical map vectors from the cache pass the gate (their entry-struct children carry
+        # the canonical "key"/"value" names in order) and ride the columnar path verbatim. The
+        # rejection of a source whose entry children are swapped is pinned at the unit level
+        # (ArrowUtilsSuite), since no in-tree producer can build such a vector.
+        df = self.spark.createDataFrame(
+            [({"a": 1},), ({"b": 2, "c": 3},)], schema="m map<string,long>"
+        ).cache()
+        try:
+            result = df.select(udf(lambda m: len(m), "long")(col("m")))
+            self._assert_columnar_arrow_eval(result, expected_nodes=1)
+            assertDataFrameEqual(result, [Row(1), Row(2)])
+        finally:
+            df.unpersist()
+
     def test_udf_on_timestamps_cached_under_different_time_zone(self):
         # Pins the timestamp pass-through end to end: the plan takes the columnar path and
         # the stored epoch round-trips unchanged across a session-timezone change between

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf_cached.py
@@ -107,7 +107,6 @@ class ArrowPythonUDFCachedInputTests(ReusedSQLTestCase):
         finally:
             df.unpersist()
 
-
     def test_chained_udfs_on_timestamps_with_non_utc_session(self):
         # A pandas UDF's timestamp output comes back from the worker labeled UTC, while the
         # following Arrow-optimized Python UDF runs as a separate exec node whose stream

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -556,6 +556,35 @@ private[sql] object ArrowUtils {
     }
   }
 
+  /**
+   * Whether an Arrow field tree (from an upstream vector) has exactly the physical shape the
+   * standard interchange encoding declares for its Spark type, so its buffers can be serialized
+   * verbatim under a schema built by `toArrowSchema(..., largeVarTypes)` with the default
+   * (non-lossless) encodings. An IPC consumer decodes a RecordBatch body strictly by the shape
+   * the stream's Schema message declared, so forwarding a vector whose shape differs -- the
+   * lossless internal struct encodings of nanosecond timestamps and CalendarInterval, a var-width
+   * vector whose offset width disagrees with `largeVarTypes`, or the Arrow view types (which
+   * Spark schemas never declare) -- produces a stream whose header and body disagree: depending
+   * on the column mix that surfaces as a decode error or, worse, silently mis-bound buffers.
+   * Callers that forward vectors verbatim (e.g. the columnar Arrow Python UDF input) must reject
+   * such vectors and re-encode them through ArrowWriter instead, which also reinstates the
+   * value-domain guards (DATETIME_OVERFLOW) for values the interchange encoding cannot represent.
+   */
+  def isInterchangeShapedField(field: Field, largeVarTypes: Boolean): Boolean = {
+    field.getType match {
+      case ArrowType.Utf8.INSTANCE | ArrowType.Binary.INSTANCE => !largeVarTypes
+      case ArrowType.LargeUtf8.INSTANCE | ArrowType.LargeBinary.INSTANCE => largeVarTypes
+      case ArrowType.Utf8View.INSTANCE | ArrowType.BinaryView.INSTANCE |
+          ArrowType.ListView.INSTANCE =>
+        false
+      case _: ArrowType.Struct
+          if isTimestampNanosStructField(field) || isCalendarIntervalStructField(field) =>
+        false
+      case _ =>
+        field.getChildren.asScala.forall(child => isInterchangeShapedField(child, largeVarTypes))
+    }
+  }
+
   def fromArrowField(field: Field): DataType = {
     field.getType match {
       case _: ArrowType.Map =>

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -578,12 +578,27 @@ private[sql] object ArrowUtils {
    */
   def isCompatibleWithDeclaredField(actual: Field, declared: Field): Boolean = {
     actual.getDictionary == null &&
-    actual.getType == declared.getType &&
+    sameLayoutArrowType(actual.getType, declared.getType) &&
     actual.getChildren.size == declared.getChildren.size &&
     actual.getChildren.asScala.zip(declared.getChildren.asScala).forall { case (a, d) =>
       isCompatibleWithDeclaredField(a, d)
     }
   }
+
+  // Physical-layout type comparison, mirroring ArrowFileReadWrite.checkLayoutMatch: the
+  // timestamp timezone label does not affect the layout (values are int64 epoch numbers either
+  // way) and differs across Spark's own paths (a worker's output comes back labeled UTC while
+  // the next stream declares the session time zone), so comparing it would only cause false
+  // rejects. Presence-vs-absence must still match: it distinguishes TimestampType from
+  // TimestampNTZType, whose identical-looking values are interpreted differently. Map equality
+  // includes the keysSorted flag, which has no layout impact.
+  private def sameLayoutArrowType(actual: ArrowType, declared: ArrowType): Boolean =
+    (actual, declared) match {
+      case (a: ArrowType.Timestamp, d: ArrowType.Timestamp) =>
+        a.getUnit == d.getUnit && (a.getTimezone == null) == (d.getTimezone == null)
+      case (_: ArrowType.Map, _: ArrowType.Map) => true
+      case (a, d) => a == d
+    }
 
   def fromArrowField(field: Field): DataType = {
     field.getType match {

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -557,60 +557,33 @@ private[sql] object ArrowUtils {
   }
 
   /**
-   * Whether an Arrow field tree (from an upstream vector) has exactly the physical shape the
-   * standard interchange encoding declares for its Spark type, so its buffers can be serialized
-   * verbatim under a schema built by `toArrowSchema(..., largeVarTypes)` with the default
-   * (non-lossless) encodings. An IPC consumer decodes a RecordBatch body strictly by the shape
-   * the stream's Schema message declared, so forwarding a vector whose shape differs -- the
-   * lossless internal struct encodings of nanosecond timestamps and CalendarInterval, a var-width
-   * vector whose offset width disagrees with `largeVarTypes`, or any Arrow type Spark schemas
-   * never declare (view types, LargeList, unions, ...) -- produces a stream whose header and body
-   * disagree: depending on the column mix that surfaces as a decode error or, worse, silently
-   * mis-bound buffers. Callers that forward vectors verbatim (e.g. the columnar Arrow Python UDF
-   * input) must reject such vectors and re-encode them through ArrowWriter instead, which also
-   * reinstates the value-domain guards (DATETIME_OVERFLOW) for values the interchange encoding
-   * cannot represent.
+   * Whether an Arrow field tree (from an upstream vector) is physically congruent with the
+   * declared field of the stream it would be forwarded into: same Arrow type, same child count,
+   * congruent children, and no dictionary encoding. An IPC consumer decodes a RecordBatch body
+   * strictly by the declared schema, walking a flattened sequence of field nodes and buffers, so
+   * ANY structural divergence silently shifts the node/buffer assignment of every following
+   * column or mis-binds buffers within one: the lossless internal struct encodings where the
+   * declared schema has the interchange types, a var-width vector whose offset width disagrees
+   * with the declared one, a tagged Variant/Geometry/Geography struct carrying an extra child
+   * that the recognizers tolerate but the declared canonical field does not include, or
+   * dictionary-encoded data whose values live in dictionary batches the stream never writes.
    *
-   * This is an allowlist of the shapes `toArrowField` can produce, not a blocklist of known-bad
-   * shapes: an unrecognized Arrow type must fail the check, because the two failure directions
-   * are not symmetric -- a shape wrongly rejected merely takes the row-based re-encoding fallback
-   * (slower, still correct), while a shape wrongly forwarded corrupts the stream. The same
-   * applies to dictionary-encoded fields: their record batches carry indices whose values live in
-   * separate dictionary batches this stream never writes, so they must take the fallback even
-   * though their type alone would pass.
+   * This compares against the declared field rather than allowlisting "declarable" shapes: the
+   * declared schema is the exact header the consumer will decode with, so congruence with it is
+   * the complete correctness condition, not an approximation of it. Field names, nullability, and
+   * metadata are ignored -- they do not affect the buffer layout. The two failure directions stay
+   * asymmetric: a false reject merely takes the row-based re-encoding fallback (slower, still
+   * correct, and with the value-domain guards such as DATETIME_OVERFLOW reinstated), while a
+   * false accept corrupts the stream -- so anything not provably congruent must be rejected.
    */
-  def isInterchangeShapedField(field: Field, largeVarTypes: Boolean): Boolean = {
-    val shapeOk = field.getType match {
-      case ArrowType.Utf8.INSTANCE | ArrowType.Binary.INSTANCE => !largeVarTypes
-      case ArrowType.LargeUtf8.INSTANCE | ArrowType.LargeBinary.INSTANCE => largeVarTypes
-      case _: ArrowType.Struct =>
-        // The lossless internal encodings are structs, but not ones the interchange schema
-        // declares; plain structs are fine (their children are checked below).
-        !(isTimestampNanosStructField(field) || isCalendarIntervalStructField(field))
-      case ArrowType.Bool.INSTANCE | ArrowType.Null.INSTANCE | ArrowType.List.INSTANCE => true
-      case i: ArrowType.Int => i.getIsSigned && interchangeIntBitWidths.contains(i.getBitWidth)
-      case f: ArrowType.FloatingPoint =>
-        f.getPrecision == FloatingPointPrecision.SINGLE ||
-        f.getPrecision == FloatingPointPrecision.DOUBLE
-      case d: ArrowType.Decimal => d.getBitWidth == 8 * 16
-      case d: ArrowType.Date => d.getUnit == DateUnit.DAY
-      case ts: ArrowType.Timestamp =>
-        ts.getUnit == TimeUnit.MICROSECOND || ts.getUnit == TimeUnit.NANOSECOND
-      case t: ArrowType.Time => t.getUnit == TimeUnit.NANOSECOND && t.getBitWidth == 8 * 8
-      case iv: ArrowType.Interval =>
-        iv.getUnit == IntervalUnit.YEAR_MONTH || iv.getUnit == IntervalUnit.MONTH_DAY_NANO
-      case d: ArrowType.Duration => d.getUnit == TimeUnit.MICROSECOND
-      case _: ArrowType.Map => true
-      case _ => false
+  def isCompatibleWithDeclaredField(actual: Field, declared: Field): Boolean = {
+    actual.getDictionary == null &&
+    actual.getType == declared.getType &&
+    actual.getChildren.size == declared.getChildren.size &&
+    actual.getChildren.asScala.zip(declared.getChildren.asScala).forall { case (a, d) =>
+      isCompatibleWithDeclaredField(a, d)
     }
-    shapeOk &&
-    field.getDictionary == null &&
-    field.getChildren.asScala.forall(child => isInterchangeShapedField(child, largeVarTypes))
   }
-
-  // Hoisted out of isInterchangeShapedField: it runs per field tree on every batch of the
-  // columnar Python UDF input path, and a literal Set would be re-allocated on each call.
-  private val interchangeIntBitWidths = Set(8, 16, 32, 64)
 
   def fromArrowField(field: Field): DataType = {
     field.getType match {

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -563,26 +563,45 @@ private[sql] object ArrowUtils {
    * (non-lossless) encodings. An IPC consumer decodes a RecordBatch body strictly by the shape
    * the stream's Schema message declared, so forwarding a vector whose shape differs -- the
    * lossless internal struct encodings of nanosecond timestamps and CalendarInterval, a var-width
-   * vector whose offset width disagrees with `largeVarTypes`, or the Arrow view types (which
-   * Spark schemas never declare) -- produces a stream whose header and body disagree: depending
-   * on the column mix that surfaces as a decode error or, worse, silently mis-bound buffers.
-   * Callers that forward vectors verbatim (e.g. the columnar Arrow Python UDF input) must reject
-   * such vectors and re-encode them through ArrowWriter instead, which also reinstates the
-   * value-domain guards (DATETIME_OVERFLOW) for values the interchange encoding cannot represent.
+   * vector whose offset width disagrees with `largeVarTypes`, or any Arrow type Spark schemas
+   * never declare (view types, LargeList, unions, ...) -- produces a stream whose header and body
+   * disagree: depending on the column mix that surfaces as a decode error or, worse, silently
+   * mis-bound buffers. Callers that forward vectors verbatim (e.g. the columnar Arrow Python UDF
+   * input) must reject such vectors and re-encode them through ArrowWriter instead, which also
+   * reinstates the value-domain guards (DATETIME_OVERFLOW) for values the interchange encoding
+   * cannot represent.
+   *
+   * This is an allowlist of the shapes `toArrowField` can produce, not a blocklist of known-bad
+   * shapes: an unrecognized Arrow type must fail the check, because the two failure directions
+   * are not symmetric -- a shape wrongly rejected merely takes the row-based re-encoding fallback
+   * (slower, still correct), while a shape wrongly forwarded corrupts the stream.
    */
   def isInterchangeShapedField(field: Field, largeVarTypes: Boolean): Boolean = {
-    field.getType match {
+    val shapeOk = field.getType match {
       case ArrowType.Utf8.INSTANCE | ArrowType.Binary.INSTANCE => !largeVarTypes
       case ArrowType.LargeUtf8.INSTANCE | ArrowType.LargeBinary.INSTANCE => largeVarTypes
-      case ArrowType.Utf8View.INSTANCE | ArrowType.BinaryView.INSTANCE |
-          ArrowType.ListView.INSTANCE =>
-        false
-      case _: ArrowType.Struct
-          if isTimestampNanosStructField(field) || isCalendarIntervalStructField(field) =>
-        false
-      case _ =>
-        field.getChildren.asScala.forall(child => isInterchangeShapedField(child, largeVarTypes))
+      case _: ArrowType.Struct =>
+        // The lossless internal encodings are structs, but not ones the interchange schema
+        // declares; plain structs are fine (their children are checked below).
+        !(isTimestampNanosStructField(field) || isCalendarIntervalStructField(field))
+      case ArrowType.Bool.INSTANCE | ArrowType.Null.INSTANCE | ArrowType.List.INSTANCE => true
+      case i: ArrowType.Int => i.getIsSigned && Set(8, 16, 32, 64).contains(i.getBitWidth)
+      case f: ArrowType.FloatingPoint =>
+        f.getPrecision == FloatingPointPrecision.SINGLE ||
+        f.getPrecision == FloatingPointPrecision.DOUBLE
+      case d: ArrowType.Decimal => d.getBitWidth == 8 * 16
+      case d: ArrowType.Date => d.getUnit == DateUnit.DAY
+      case ts: ArrowType.Timestamp =>
+        ts.getUnit == TimeUnit.MICROSECOND || ts.getUnit == TimeUnit.NANOSECOND
+      case t: ArrowType.Time => t.getUnit == TimeUnit.NANOSECOND && t.getBitWidth == 8 * 8
+      case iv: ArrowType.Interval =>
+        iv.getUnit == IntervalUnit.YEAR_MONTH || iv.getUnit == IntervalUnit.MONTH_DAY_NANO
+      case d: ArrowType.Duration => d.getUnit == TimeUnit.MICROSECOND
+      case _: ArrowType.Map => true
+      case _ => false
     }
+    shapeOk &&
+    field.getChildren.asScala.forall(child => isInterchangeShapedField(child, largeVarTypes))
   }
 
   def fromArrowField(field: Field): DataType = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -574,7 +574,10 @@ private[sql] object ArrowUtils {
    * This is an allowlist of the shapes `toArrowField` can produce, not a blocklist of known-bad
    * shapes: an unrecognized Arrow type must fail the check, because the two failure directions
    * are not symmetric -- a shape wrongly rejected merely takes the row-based re-encoding fallback
-   * (slower, still correct), while a shape wrongly forwarded corrupts the stream.
+   * (slower, still correct), while a shape wrongly forwarded corrupts the stream. The same
+   * applies to dictionary-encoded fields: their record batches carry indices whose values live in
+   * separate dictionary batches this stream never writes, so they must take the fallback even
+   * though their type alone would pass.
    */
   def isInterchangeShapedField(field: Field, largeVarTypes: Boolean): Boolean = {
     val shapeOk = field.getType match {
@@ -585,7 +588,7 @@ private[sql] object ArrowUtils {
         // declares; plain structs are fine (their children are checked below).
         !(isTimestampNanosStructField(field) || isCalendarIntervalStructField(field))
       case ArrowType.Bool.INSTANCE | ArrowType.Null.INSTANCE | ArrowType.List.INSTANCE => true
-      case i: ArrowType.Int => i.getIsSigned && Set(8, 16, 32, 64).contains(i.getBitWidth)
+      case i: ArrowType.Int => i.getIsSigned && interchangeIntBitWidths.contains(i.getBitWidth)
       case f: ArrowType.FloatingPoint =>
         f.getPrecision == FloatingPointPrecision.SINGLE ||
         f.getPrecision == FloatingPointPrecision.DOUBLE
@@ -601,8 +604,13 @@ private[sql] object ArrowUtils {
       case _ => false
     }
     shapeOk &&
+    field.getDictionary == null &&
     field.getChildren.asScala.forall(child => isInterchangeShapedField(child, largeVarTypes))
   }
+
+  // Hoisted out of isInterchangeShapedField: it runs per field tree on every batch of the
+  // columnar Python UDF input path, and a literal Set would be re-allocated on each call.
+  private val interchangeIntBitWidths = Set(8, 16, 32, 64)
 
   def fromArrowField(field: Field): DataType = {
     field.getType match {

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -571,19 +571,38 @@ private[sql] object ArrowUtils {
    * This compares against the declared field rather than allowlisting "declarable" shapes: the
    * declared schema is the exact header the consumer will decode with, so congruence with it is
    * the complete correctness condition, not an approximation of it. Field names, nullability, and
-   * metadata are ignored -- they do not affect the buffer layout. The two failure directions stay
-   * asymmetric: a false reject merely takes the row-based re-encoding fallback (slower, still
-   * correct, and with the value-domain guards such as DATETIME_OVERFLOW reinstated), while a
-   * false accept corrupts the stream -- so anything not provably congruent must be rejected.
+   * metadata are ignored -- they do not affect the buffer layout -- except for Map entry
+   * children, whose names carry the key/value semantics (see mapEntryNamesMatchDeclared). The two
+   * failure directions stay asymmetric: a false reject merely takes the row-based re-encoding
+   * fallback (slower, still correct, and with the value-domain guards such as DATETIME_OVERFLOW
+   * reinstated), while a false accept corrupts the stream -- so anything not provably congruent
+   * must be rejected.
    */
   def isCompatibleWithDeclaredField(actual: Field, declared: Field): Boolean = {
     actual.getDictionary == null &&
     sameLayoutArrowType(actual.getType, declared.getType) &&
     actual.getChildren.size == declared.getChildren.size &&
+    mapEntryNamesMatchDeclared(actual, declared) &&
     actual.getChildren.asScala.zip(declared.getChildren.asScala).forall { case (a, d) =>
       isCompatibleWithDeclaredField(a, d)
     }
   }
+
+  // An Arrow Map binds its key/value semantics to the entry-struct children by name (the spec
+  // puts the key first and MapVector addresses the children as "key"/"value"), yet Arrow
+  // tolerates vectors whose entry children sit in the opposite order. Such a vector is
+  // positionally indistinguishable from the canonical one when the key and value types agree,
+  // and forwarding its buffers verbatim under the declared header silently swaps keys and
+  // values -- so at Map nodes the entry children must also match the declared names. Field
+  // names remain ignored everywhere else: Spark's semantics are positional there and names
+  // carry no meaning.
+  private def mapEntryNamesMatchDeclared(actual: Field, declared: Field): Boolean =
+    !declared.getType.isInstanceOf[ArrowType.Map] || {
+      val actualNames = actual.getChildren.asScala.flatMap(_.getChildren.asScala).map(_.getName)
+      val declaredNames =
+        declared.getChildren.asScala.flatMap(_.getChildren.asScala).map(_.getName)
+      actualNames == declaredNames
+    }
 
   // Physical-layout type comparison, mirroring ArrowFileReadWrite.checkLayoutMatch: the
   // timestamp timezone label does not affect the layout (values are int64 epoch numbers either

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -463,6 +463,35 @@ class ArrowUtilsSuite extends SparkFunSuite {
       assert(!compat(listLike, declaredList), arrowType.toString)
     }
 
+    // The timestamp timezone LABEL does not affect the physical layout and differs across
+    // Spark's own paths (a worker's output comes back labeled UTC while the next stream
+    // declares the session time zone), so it must not cause a reject. Presence-vs-absence must
+    // still match: it distinguishes TimestampType from TimestampNTZType, whose values are
+    // interpreted differently. The unit must also match: both units are int64, but forwarding
+    // one under the other reinterprets every value by a factor of 1000.
+    def tsField(tz: String): Field = new Field(
+      "value",
+      new FieldType(true, new ArrowType.Timestamp(TimeUnit.MICROSECOND, tz), null, null),
+      java.util.Collections.emptyList[Field]())
+    assert(compat(tsField("UTC"), tsField("America/Los_Angeles")))
+    assert(compat(tsField("America/Los_Angeles"), tsField("UTC")))
+    assert(!compat(tsField(null), tsField("UTC")))
+    assert(!compat(tsField("UTC"), tsField(null)))
+    val tsNanoField = new Field(
+      "value",
+      new FieldType(true, new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC"), null, null),
+      java.util.Collections.emptyList[Field]())
+    assert(!compat(tsNanoField, tsField("UTC")))
+
+    // Map equality includes keysSorted, which has no layout impact and must not cause a reject.
+    val mapSchema = new StructType().add("value", MapType(IntegerType, StringType))
+    val declaredMap = declared(mapSchema)
+    val sortedMap = new Field(
+      declaredMap.getName,
+      new FieldType(declaredMap.isNullable, new ArrowType.Map(true), null, null),
+      declaredMap.getChildren)
+    assert(compat(sortedMap, declaredMap))
+
     // A view-typed field is incongruent with the declared Utf8.
     val stringSchema = new StructType().add("value", StringType)
     val viewField = new Field(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -433,6 +433,28 @@ class ArrowUtilsSuite extends SparkFunSuite {
       java.util.Collections.emptyList[Field]())
     assert(!ArrowUtils.isInterchangeShapedField(viewField, largeVarTypes = false))
     assert(!ArrowUtils.isInterchangeShapedField(viewField, largeVarTypes = true))
+
+    // The check is an allowlist of shapes toArrowField can produce, so list-like types Spark
+    // never declares are rejected even though their children would individually pass -- an
+    // unrecognized shape must take the fallback, never the verbatim forward.
+    val intChild = new Field(
+      "element",
+      new FieldType(true, new ArrowType.Int(32, true), null, null),
+      java.util.Collections.emptyList[Field]())
+    Seq[ArrowType](
+      ArrowType.LargeList.INSTANCE,
+      ArrowType.ListView.INSTANCE,
+      ArrowType.LargeListView.INSTANCE,
+      new ArrowType.FixedSizeList(4)).foreach { arrowType =>
+      val listLike = new Field(
+        "value",
+        new FieldType(true, arrowType, null, null),
+        java.util.Collections.singletonList(intChild))
+      assert(!ArrowUtils.isInterchangeShapedField(listLike, largeVarTypes = false),
+        arrowType.toString)
+      assert(!ArrowUtils.isInterchangeShapedField(listLike, largeVarTypes = true),
+        arrowType.toString)
+    }
   }
 
   test("time") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -369,6 +369,72 @@ class ArrowUtilsSuite extends SparkFunSuite {
       defaultType.asInstanceOf[ArrowType.Interval].getUnit === IntervalUnit.MONTH_DAY_NANO)
   }
 
+  test("isInterchangeShapedField rejects shapes the interchange schema cannot declare") {
+    def field(schema: StructType, lossless: Boolean, largeVarTypes: Boolean = false): Field = {
+      ArrowUtils
+        .toArrowSchema(schema, "UTC", true, largeVarTypes, losslessInternalTypes = lossless)
+        .findField("value")
+    }
+
+    // Interchange-encoded fields of every kind pass, including the standard nanos/interval
+    // encodings and nested complex types.
+    Seq[DataType](
+      IntegerType,
+      TimestampNTZNanosType(9),
+      TimestampLTZNanosType(7),
+      CalendarIntervalType,
+      ArrayType(TimestampNTZNanosType(9)),
+      new StructType().add("i", CalendarIntervalType),
+      MapType(IntegerType, StringType)).foreach { dt =>
+      val f = field(new StructType().add("value", dt), lossless = false)
+      assert(ArrowUtils.isInterchangeShapedField(f, largeVarTypes = false), dt.toString)
+    }
+
+    // The lossless internal struct encodings are rejected, top-level and nested.
+    Seq[DataType](
+      TimestampNTZNanosType(9),
+      TimestampLTZNanosType(7),
+      CalendarIntervalType,
+      ArrayType(TimestampNTZNanosType(9)),
+      new StructType().add("i", CalendarIntervalType),
+      MapType(IntegerType, TimestampLTZNanosType(9))).foreach { dt =>
+      val f = field(new StructType().add("value", dt), lossless = true)
+      assert(!ArrowUtils.isInterchangeShapedField(f, largeVarTypes = false), dt.toString)
+    }
+
+    // A plain struct with the same child names but no tag is not a lossless encoding: it is
+    // declarable by the interchange schema and passes.
+    val untagged = field(
+      new StructType().add(
+        "value",
+        new StructType()
+          .add("months", IntegerType, nullable = false)
+          .add("days", IntegerType, nullable = false)
+          .add("microseconds", LongType, nullable = false)),
+      lossless = false)
+    assert(ArrowUtils.isInterchangeShapedField(untagged, largeVarTypes = false))
+
+    // Var-width offset width must agree with the largeVarTypes flag, in both directions and
+    // nested.
+    Seq[DataType](StringType, BinaryType, ArrayType(StringType)).foreach { dt =>
+      val standard = field(new StructType().add("value", dt), lossless = false)
+      assert(ArrowUtils.isInterchangeShapedField(standard, largeVarTypes = false), dt.toString)
+      assert(!ArrowUtils.isInterchangeShapedField(standard, largeVarTypes = true), dt.toString)
+      val large =
+        field(new StructType().add("value", dt), lossless = false, largeVarTypes = true)
+      assert(ArrowUtils.isInterchangeShapedField(large, largeVarTypes = true), dt.toString)
+      assert(!ArrowUtils.isInterchangeShapedField(large, largeVarTypes = false), dt.toString)
+    }
+
+    // The Arrow view types are never declared by a Spark interchange schema.
+    val viewField = new Field(
+      "value",
+      new FieldType(true, ArrowType.Utf8View.INSTANCE, null, null),
+      java.util.Collections.emptyList[Field]())
+    assert(!ArrowUtils.isInterchangeShapedField(viewField, largeVarTypes = false))
+    assert(!ArrowUtils.isInterchangeShapedField(viewField, largeVarTypes = true))
+  }
+
   test("time") {
     // Arrow's Time type has no precision field, so TIME(p) precision is preserved via field
     // metadata; the Arrow type itself stays Time(NANOSECOND, 64).

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -369,74 +369,84 @@ class ArrowUtilsSuite extends SparkFunSuite {
       defaultType.asInstanceOf[ArrowType.Interval].getUnit === IntervalUnit.MONTH_DAY_NANO)
   }
 
-  test("isInterchangeShapedField rejects shapes the interchange schema cannot declare") {
-    def field(schema: StructType, lossless: Boolean, largeVarTypes: Boolean = false): Field = {
+  test("isCompatibleWithDeclaredField requires congruence with the declared field tree") {
+    def declared(schema: StructType, largeVarTypes: Boolean = false): Field = {
+      ArrowUtils.toArrowSchema(schema, "UTC", true, largeVarTypes).findField("value")
+    }
+    def actual(
+        schema: StructType,
+        lossless: Boolean = false,
+        largeVarTypes: Boolean = false): Field = {
       ArrowUtils
         .toArrowSchema(schema, "UTC", true, largeVarTypes, losslessInternalTypes = lossless)
         .findField("value")
     }
+    def compat(a: Field, d: Field): Boolean = ArrowUtils.isCompatibleWithDeclaredField(a, d)
 
-    // Interchange-encoded fields of every kind pass, including the standard nanos/interval
-    // encodings and nested complex types.
+    // Identical construction is congruent, for every kind of type the schema can declare,
+    // including the standard nanos/interval encodings, tagged struct types, and nested trees.
     Seq[DataType](
       IntegerType,
+      StringType,
       TimestampNTZNanosType(9),
-      TimestampLTZNanosType(7),
       CalendarIntervalType,
+      GeometryType(4326),
+      VariantType,
       ArrayType(TimestampNTZNanosType(9)),
       new StructType().add("i", CalendarIntervalType),
       MapType(IntegerType, StringType)).foreach { dt =>
-      val f = field(new StructType().add("value", dt), lossless = false)
-      assert(ArrowUtils.isInterchangeShapedField(f, largeVarTypes = false), dt.toString)
+      val s = new StructType().add("value", dt)
+      assert(compat(actual(s), declared(s)), dt.toString)
     }
 
-    // The lossless internal struct encodings are rejected, top-level and nested.
+    // The lossless internal encodings are structs where the declared schema has the
+    // interchange types: incongruent in both directions.
     Seq[DataType](
       TimestampNTZNanosType(9),
-      TimestampLTZNanosType(7),
       CalendarIntervalType,
-      ArrayType(TimestampNTZNanosType(9)),
-      new StructType().add("i", CalendarIntervalType),
-      MapType(IntegerType, TimestampLTZNanosType(9))).foreach { dt =>
-      val f = field(new StructType().add("value", dt), lossless = true)
-      assert(!ArrowUtils.isInterchangeShapedField(f, largeVarTypes = false), dt.toString)
+      ArrayType(TimestampLTZNanosType(7))).foreach { dt =>
+      val s = new StructType().add("value", dt)
+      assert(!compat(actual(s, lossless = true), declared(s)), dt.toString)
     }
 
-    // A plain struct with the same child names but no tag is not a lossless encoding: it is
-    // declarable by the interchange schema and passes.
-    val untagged = field(
-      new StructType().add(
-        "value",
-        new StructType()
-          .add("months", IntegerType, nullable = false)
-          .add("days", IntegerType, nullable = false)
-          .add("microseconds", LongType, nullable = false)),
-      lossless = false)
-    assert(ArrowUtils.isInterchangeShapedField(untagged, largeVarTypes = false))
-
-    // Var-width offset width must agree with the largeVarTypes flag, in both directions and
-    // nested.
+    // Var-width offset width must agree with the declared field, in both directions and nested.
     Seq[DataType](StringType, BinaryType, ArrayType(StringType)).foreach { dt =>
-      val standard = field(new StructType().add("value", dt), lossless = false)
-      assert(ArrowUtils.isInterchangeShapedField(standard, largeVarTypes = false), dt.toString)
-      assert(!ArrowUtils.isInterchangeShapedField(standard, largeVarTypes = true), dt.toString)
-      val large =
-        field(new StructType().add("value", dt), lossless = false, largeVarTypes = true)
-      assert(ArrowUtils.isInterchangeShapedField(large, largeVarTypes = true), dt.toString)
-      assert(!ArrowUtils.isInterchangeShapedField(large, largeVarTypes = false), dt.toString)
+      val s = new StructType().add("value", dt)
+      assert(compat(actual(s), declared(s)), dt.toString)
+      assert(!compat(actual(s), declared(s, largeVarTypes = true)), dt.toString)
+      assert(!compat(actual(s, largeVarTypes = true), declared(s)), dt.toString)
+      assert(
+        compat(actual(s, largeVarTypes = true), declared(s, largeVarTypes = true)),
+        dt.toString)
     }
 
-    // The Arrow view types are never declared by a Spark interchange schema.
-    val viewField = new Field(
-      "value",
-      new FieldType(true, ArrowType.Utf8View.INSTANCE, null, null),
+    // A tagged Geometry struct with an extra child is read back as GeometryType by the
+    // recognizers (which tolerate extra children), but the declared canonical field has exactly
+    // two children -- forwarding the three-child body verbatim would shift every following
+    // column's buffers (the extra child's buffers would be consumed as the next argument's
+    // data), so it must be incongruent.
+    val geometrySchema = new StructType().add("value", GeometryType(4326))
+    val canonicalGeometry = declared(geometrySchema)
+    val extraChild = new Field(
+      "extra",
+      new FieldType(true, new ArrowType.Int(32, true), null, null),
       java.util.Collections.emptyList[Field]())
-    assert(!ArrowUtils.isInterchangeShapedField(viewField, largeVarTypes = false))
-    assert(!ArrowUtils.isInterchangeShapedField(viewField, largeVarTypes = true))
+    val paddedChildren = new java.util.ArrayList[Field](canonicalGeometry.getChildren)
+    paddedChildren.add(extraChild)
+    val paddedGeometry = new Field(
+      canonicalGeometry.getName,
+      new FieldType(
+        canonicalGeometry.isNullable,
+        canonicalGeometry.getType,
+        null,
+        canonicalGeometry.getMetadata),
+      paddedChildren)
+    assert(ArrowUtils.fromArrowField(paddedGeometry) === GeometryType(4326))
+    assert(!compat(paddedGeometry, canonicalGeometry))
 
-    // The check is an allowlist of shapes toArrowField can produce, so list-like types Spark
-    // never declares are rejected even though their children would individually pass -- an
-    // unrecognized shape must take the fallback, never the verbatim forward.
+    // List-like types Spark never declares are incongruent with the declared List.
+    val arraySchema = new StructType().add("value", ArrayType(IntegerType))
+    val declaredList = declared(arraySchema)
     val intChild = new Field(
       "element",
       new FieldType(true, new ArrowType.Int(32, true), null, null),
@@ -450,15 +460,20 @@ class ArrowUtilsSuite extends SparkFunSuite {
         "value",
         new FieldType(true, arrowType, null, null),
         java.util.Collections.singletonList(intChild))
-      assert(!ArrowUtils.isInterchangeShapedField(listLike, largeVarTypes = false),
-        arrowType.toString)
-      assert(!ArrowUtils.isInterchangeShapedField(listLike, largeVarTypes = true),
-        arrowType.toString)
+      assert(!compat(listLike, declaredList), arrowType.toString)
     }
 
-    // A dictionary-encoded field is rejected even though its type alone would pass: its record
-    // batches carry indices whose values live in separate dictionary batches the UDF stream
-    // never writes.
+    // A view-typed field is incongruent with the declared Utf8.
+    val stringSchema = new StructType().add("value", StringType)
+    val viewField = new Field(
+      "value",
+      new FieldType(true, ArrowType.Utf8View.INSTANCE, null, null),
+      java.util.Collections.emptyList[Field]())
+    assert(!compat(viewField, declared(stringSchema)))
+
+    // A dictionary-encoded field is incongruent even though its value type matches the declared
+    // field: its record batches carry indices whose values live in separate dictionary batches
+    // the UDF stream never writes.
     val dictField = new Field(
       "value",
       new FieldType(
@@ -467,13 +482,14 @@ class ArrowUtilsSuite extends SparkFunSuite {
         new DictionaryEncoding(1L, false, new ArrowType.Int(32, true)),
         null),
       java.util.Collections.emptyList[Field]())
-    assert(!ArrowUtils.isInterchangeShapedField(dictField, largeVarTypes = false))
-    // The same field without the dictionary passes, isolating the dictionary as the reason.
+    assert(!compat(dictField, declared(stringSchema)))
+    // The same field without the dictionary is congruent, isolating the dictionary as the
+    // reason. Names and metadata are ignored: only the physical layout matters.
     val plainField = new Field(
-      "value",
+      "renamed",
       new FieldType(true, ArrowType.Utf8.INSTANCE, null, null),
       java.util.Collections.emptyList[Field]())
-    assert(ArrowUtils.isInterchangeShapedField(plainField, largeVarTypes = false))
+    assert(compat(plainField, declared(stringSchema)))
   }
 
   test("time") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -492,6 +492,47 @@ class ArrowUtilsSuite extends SparkFunSuite {
       declaredMap.getChildren)
     assert(compat(sortedMap, declaredMap))
 
+    // An Arrow Map binds key/value semantics to the entry-struct children by name (the key
+    // comes first and MapVector addresses the children as "key"/"value"), yet Arrow tolerates
+    // vectors whose entry children sit in the opposite order. With int keys and int values the
+    // swapped tree is positionally identical to the canonical one, so only the names reveal the
+    // swap -- forwarding the buffers verbatim under the canonical header would silently decode
+    // {k: v} as {v: k}. Map entry names must therefore match the declared ones, at every
+    // nesting level.
+    def swapEntries(mapField: Field): Field = {
+      val entries = mapField.getChildren.get(0)
+      val swapped = new Field(
+        entries.getName,
+        new FieldType(entries.isNullable, entries.getType, null, entries.getMetadata),
+        entries.getChildren.asScala.reverse.asJava)
+      new Field(
+        mapField.getName,
+        new FieldType(mapField.isNullable, mapField.getType, null, mapField.getMetadata),
+        java.util.Collections.singletonList(swapped))
+    }
+    val intMapSchema = new StructType().add("value", MapType(IntegerType, IntegerType, false))
+    val declaredIntMap = declared(intMapSchema)
+    assert(compat(declaredIntMap, declaredIntMap))
+    assert(!compat(swapEntries(declaredIntMap), declaredIntMap))
+    val nestedMapSchema = new StructType()
+      .add("value", MapType(IntegerType, MapType(IntegerType, IntegerType, false), false))
+    val declaredNestedMap = declared(nestedMapSchema)
+    val nestedEntries = declaredNestedMap.getChildren.get(0)
+    val innerSwappedEntries = new Field(
+      nestedEntries.getName,
+      new FieldType(nestedEntries.isNullable, nestedEntries.getType, null,
+        nestedEntries.getMetadata),
+      java.util.Arrays.asList(
+        nestedEntries.getChildren.get(0),
+        swapEntries(nestedEntries.getChildren.get(1))))
+    val innerSwappedMap = new Field(
+      declaredNestedMap.getName,
+      new FieldType(declaredNestedMap.isNullable, declaredNestedMap.getType, null,
+        declaredNestedMap.getMetadata),
+      java.util.Collections.singletonList(innerSwappedEntries))
+    assert(compat(declaredNestedMap, declaredNestedMap))
+    assert(!compat(innerSwappedMap, declaredNestedMap))
+
     // A view-typed field is incongruent with the declared Utf8.
     val stringSchema = new StructType().add("value", StringType)
     val viewField = new Field(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -22,7 +22,7 @@ import java.time.ZoneId
 import scala.jdk.CollectionConverters._
 
 import org.apache.arrow.vector.types.{IntervalUnit, TimeUnit}
-import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType}
+import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding, Field, FieldType}
 
 import org.apache.spark.{SparkException, SparkFunSuite, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.LA
@@ -455,6 +455,25 @@ class ArrowUtilsSuite extends SparkFunSuite {
       assert(!ArrowUtils.isInterchangeShapedField(listLike, largeVarTypes = true),
         arrowType.toString)
     }
+
+    // A dictionary-encoded field is rejected even though its type alone would pass: its record
+    // batches carry indices whose values live in separate dictionary batches the UDF stream
+    // never writes.
+    val dictField = new Field(
+      "value",
+      new FieldType(
+        true,
+        ArrowType.Utf8.INSTANCE,
+        new DictionaryEncoding(1L, false, new ArrowType.Int(32, true)),
+        null),
+      java.util.Collections.emptyList[Field]())
+    assert(!ArrowUtils.isInterchangeShapedField(dictField, largeVarTypes = false))
+    // The same field without the dictionary passes, isolating the dictionary as the reason.
+    val plainField = new Field(
+      "value",
+      new FieldType(true, ArrowType.Utf8.INSTANCE, null, null),
+      java.util.Collections.emptyList[Field]())
+    assert(ArrowUtils.isInterchangeShapedField(plainField, largeVarTypes = false))
   }
 
   test("time") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonInput.scala
@@ -28,6 +28,7 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer
 
 import org.apache.spark.api.python.BasePythonRunner
 import org.apache.spark.sql.execution.arrow.ArrowWriter
+import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 /**
@@ -81,10 +82,25 @@ private[python] trait ColumnarArrowPythonInput
   }
 
   /**
-   * Check whether all selected columns in the batch are Arrow-backed.
+   * Check whether all selected columns in the batch are Arrow-backed AND physically match the
+   * shape the stream's Schema message declares. The Schema message was written once from the
+   * declared UDF input schema with the standard interchange encoding, while writeArrowDirect
+   * serializes the upstream vectors' buffers verbatim -- so a vector in a different physical
+   * shape (the lossless internal struct encodings of nanosecond timestamps or CalendarInterval
+   * from an Arrow-cache scan, a var-width vector whose offset width disagrees with
+   * largeVarTypes, or an Arrow view type) would produce a stream whose header and body disagree,
+   * which the worker decodes as garbage or rejects. Such batches take writeRowByRow instead,
+   * which re-encodes through ArrowWriter under the declared schema -- including its
+   * DATETIME_OVERFLOW guards for values the interchange encoding cannot represent at all.
    */
   private def isArrowBacked(batch: ColumnarBatch): Boolean = {
-    inputColumnIndices.forall(i => batch.column(i).isInstanceOf[ArrowColumnVector])
+    inputColumnIndices.forall { i =>
+      batch.column(i) match {
+        case acv: ArrowColumnVector =>
+          ArrowUtils.isInterchangeShapedField(acv.getValueVector.getField, largeVarTypes)
+        case _ => false
+      }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonInput.scala
@@ -82,22 +82,25 @@ private[python] trait ColumnarArrowPythonInput
   }
 
   /**
-   * Check whether all selected columns in the batch are Arrow-backed AND physically match the
-   * shape the stream's Schema message declares. The Schema message was written once from the
-   * declared UDF input schema with the standard interchange encoding, while writeArrowDirect
-   * serializes the upstream vectors' buffers verbatim -- so a vector in a different physical
-   * shape (the lossless internal struct encodings of nanosecond timestamps or CalendarInterval
-   * from an Arrow-cache scan, a var-width vector whose offset width disagrees with
-   * largeVarTypes, or an Arrow view type) would produce a stream whose header and body disagree,
-   * which the worker decodes as garbage or rejects. Such batches take writeRowByRow instead,
+   * Check whether all selected columns in the batch are Arrow-backed AND physically congruent
+   * with the stream's Schema message. The Schema message was written once from `root` (built
+   * from the declared UDF input schema), while writeArrowDirect serializes the upstream
+   * vectors' buffers verbatim -- so each selected vector's field tree is compared against the
+   * corresponding declared field of that exact header. Any divergence (the lossless internal
+   * struct encodings from an Arrow-cache scan, a var-width offset width disagreeing with the
+   * declared one, a tagged struct carrying extra children the declared canonical field lacks,
+   * dictionary-encoded data, ...) would make the header and body disagree, which the worker
+   * decodes as silently shifted buffers or rejects. Such batches take writeRowByRow instead,
    * which re-encodes through ArrowWriter under the declared schema -- including its
    * DATETIME_OVERFLOW guards for values the interchange encoding cannot represent at all.
    */
   private def isArrowBacked(batch: ColumnarBatch): Boolean = {
-    inputColumnIndices.forall { i =>
-      batch.column(i) match {
+    val declaredFields = root.getSchema.getFields
+    inputColumnIndices.indices.forall { i =>
+      batch.column(inputColumnIndices(i)) match {
         case acv: ArrowColumnVector =>
-          ArrowUtils.isInterchangeShapedField(acv.getValueVector.getField, largeVarTypes)
+          ArrowUtils.isCompatibleWithDeclaredField(
+            acv.getValueVector.getField, declaredFields.get(i))
         case _ => false
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The columnar Arrow Python UDF input fast path (`ColumnarArrowPythonInput.writeArrowDirect`) forwards upstream vectors' buffers verbatim into the worker's IPC stream, whose Schema message was written once from the declared UDF input schema using the standard interchange encoding. Its eligibility check (`isArrowBacked`) only verified `isInstanceOf[ArrowColumnVector]` -- not that each selected vector's physical shape matches what that schema declares. This PR adds `ArrowUtils.isInterchangeShapedField`, a recursive check for shapes a Spark interchange schema cannot declare:

- the lossless internal struct encodings of nanosecond timestamps and `CalendarInterval` (SPARK-57975 / SPARK-58005, produced by the Arrow-cached scan),
- var-width vectors whose offset width disagrees with `spark.sql.execution.arrow.useLargeVarTypes`,
- the Arrow view types (readable through `ArrowColumnVector` but never declared by Spark schemas),

and requires it in the passthrough eligibility check. Mismatched batches take the existing `writeRowByRow` fallback, which re-encodes through `ArrowWriter` under the declared schema -- including its `DATETIME_OVERFLOW` guards for values the interchange encoding cannot represent at all.

### Why are the changes needed?

An IPC consumer decodes a RecordBatch body strictly by the shape the stream's Schema message declared, so forwarding a mismatched vector produces a stream whose header and body disagree: depending on the column mix that surfaces as a worker-side decode error or, worse, silently mis-bound buffers handed to the UDF. This is reachable today: the Arrow cache (SPARK-57268) always stores standard 32-bit var-width offsets, so caching a string column and running an Arrow-optimized Python UDF over it with `useLargeVarTypes=true` corrupts the stream -- the new test fails with a worker-side error without this gate and passes with it. The lossless struct encodings are the same hazard one step ahead: they become reachable the moment the Python side supports nanosecond timestamps or `CalendarInterval` as UDF inputs, and the gate closes that door now.

The safety argument for the passthrough is compositional: every interchange-shaped vector was produced under the guarded write boundary (its values already fit the encoding), so the forwarding point only needs to verify shape -- which this PR makes explicit instead of implicit.

### Does this PR introduce _any_ user-facing change?

No. Shape-matching batches keep the zero-copy fast path; mismatched ones fall back to the row-based re-encoding, which is the correct-by-construction slow path.

### How was this patch tested?

- `ArrowUtilsSuite` "isInterchangeShapedField rejects shapes the interchange schema cannot declare": interchange-encoded fields of every kind pass (including standard nanos/interval encodings and nested complex types); the lossless struct encodings are rejected top-level and nested; an untagged struct with the same child names passes; var-width offset width is checked against `largeVarTypes` in both directions and nested; view types are rejected.
- `pyspark.sql.tests.arrow.test_arrow_python_udf_cached` gains `test_udf_on_cached_strings_with_large_var_types`: an Arrow-optimized Python UDF over an Arrow-cached string column with `useLargeVarTypes=true`. Verified it fails with a worker-side error without the gate and passes with it; the existing default-config tests confirm shape-matching batches still take the fast path and produce correct results.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

This pull request and its description were written by Claude Code.