### PR TITLE
[SPARK-58260][SQL] Add config to render Hive DDL in SHOW CREATE TABLE for Hive tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2079,6 +2079,16 @@ object SQLConf {
       .intConf
       .createOptional
 
+  val HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE =
+    buildConf("spark.sql.hive.showCreateTableAsSerde")
+      .doc("Whether to render the SHOW CREATE TABLE (without `AS SERDE`) statement of Hive table " +
+        "in the Hive DDL format. This is only for display purpose and does not affect how Spark " +
+        "reads or writes Hive tables.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(false)
+
   val OPTIMIZER_METADATA_ONLY = buildConf("spark.sql.optimizer.metadataOnly")
     .internal()
     .doc("When true, enable the metadata-only query optimization that use the table's metadata " +
@@ -8482,6 +8492,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
     getConf(HIVE_CASE_SENSITIVE_INFERENCE)
 
   def gatherFastStats: Boolean = getConf(GATHER_FASTSTAT)
+
+  def hiveTableShowCreateTableAsSerde: Boolean =
+    getConf(HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE)
 
   def optimizerMetadataOnly: Boolean = getConf(OPTIMIZER_METADATA_ONLY)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -455,9 +455,12 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         isOverwrite,
         partition)
 
-    case ShowCreateTable(ResolvedV1TableOrViewIdentifier(ident), asSerde, output) if asSerde ||
-         (conf.hiveTableShowCreateTableAsSerde &&
-           DDLUtils.isHiveTable(catalogManager.v1SessionCatalog.getTableRawMetadata(ident))) =>
+    case ShowCreateTable(ResolvedTable(catalog, _, t: V1Table, _), asSerde, output)
+        if supportsV1Command(catalog) && (asSerde ||
+          (conf.hiveTableShowCreateTableAsSerde && DDLUtils.isHiveTable(t.catalogTable))) =>
+      ShowCreateTableAsSerdeCommand(t.catalogTable.identifier, output)
+
+    case ShowCreateTable(ResolvedViewIdentifier(ident), asSerde, output) if asSerde =>
       ShowCreateTableAsSerdeCommand(ident, output)
 
     // If target is view, force use v1 command

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -455,7 +455,9 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         isOverwrite,
         partition)
 
-    case ShowCreateTable(ResolvedV1TableOrViewIdentifier(ident), asSerde, output) if asSerde =>
+    case ShowCreateTable(ResolvedV1TableOrViewIdentifier(ident), asSerde, output) if asSerde ||
+         (conf.hiveTableShowCreateTableAsSerde &&
+           DDLUtils.isHiveTable(catalogManager.v1SessionCatalog.getTableRawMetadata(ident))) =>
       ShowCreateTableAsSerdeCommand(ident, output)
 
     // If target is view, force use v1 command

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowCreateTableSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
 import org.apache.spark.sql.catalyst.util.escapeSingleQuotedString
 import org.apache.spark.sql.execution.command.v1
-import org.apache.spark.sql.internal.HiveSerDe
+import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
 
 /**
  * The class contains tests for the `SHOW CREATE TABLE` command to check V1 Hive external
@@ -442,6 +442,97 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
         sqlState = "0A000",
         parameters = Map("tableName" -> "`spark_catalog`.`default`.`t1`")
       )
+    }
+  }
+
+  test("plain SHOW CREATE TABLE returns Hive DDL for hive table when the config is on") {
+    withNamespaceAndTable(ns, table) { t =>
+      sql(
+        s"""CREATE TABLE $t (
+           |  c1 INT COMMENT 'bla',
+           |  c2 STRING
+           |) STORED AS PARQUET
+         """.stripMargin
+      )
+      val hiveDDL = getShowCreateDDL(t, true)
+      // By default, plain SHOW CREATE TABLE converts the Hive table to Spark DDL.
+      assert(getShowCreateDDL(t) !== hiveDDL)
+
+      withSQLConf(SQLConf.HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE.key -> "true") {
+        assert(getShowCreateDDL(t) === hiveDDL)
+        assert(hiveDDL.mkString(" ").contains(
+          "ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'"))
+      }
+    }
+  }
+
+  test("plain SHOW CREATE TABLE still returns Spark DDL for data source table with config on") {
+    withSQLConf(SQLConf.HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE.key -> "true") {
+      withNamespaceAndTable(ns, table) { t =>
+        sql(
+          s"""CREATE TABLE $t (
+             |  c1 STRING COMMENT 'bla',
+             |  c2 STRING
+             |) USING orc
+           """.stripMargin
+        )
+        // Should not fail with UNSUPPORTED_SHOW_CREATE_TABLE.ON_DATA_SOURCE_TABLE_WITH_AS_SERDE.
+        assert(getShowCreateDDL(t).contains("USING orc"))
+      }
+    }
+  }
+
+  test("plain SHOW CREATE TABLE still returns Spark DDL for view when the config is on") {
+    withSQLConf(SQLConf.HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE.key -> "true") {
+      withView("v1") {
+        sql("CREATE VIEW v1 AS SELECT 1 AS c1")
+        assert(sql("SHOW CREATE TABLE v1").head().getString(0).startsWith("CREATE VIEW"))
+      }
+    }
+  }
+
+  test("plain SHOW CREATE TABLE returns Hive DDL for unsupported serde when the config is on") {
+    withSQLConf(SQLConf.HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE.key -> "true") {
+      withTable("t1") {
+        sql(
+          s"""
+             |CREATE TABLE t1 (
+             |  c1 INT COMMENT 'bla',
+             |  c2 STRING
+             |) STORED AS RCFILE
+           """.stripMargin
+        )
+        // Without the config, this fails with
+        // UNSUPPORTED_SHOW_CREATE_TABLE.WITH_UNSUPPORTED_SERDE_CONFIGURATION because RCFILE
+        // cannot be mapped to a Spark data source.
+        val hiveDDL = getShowCreateDDL("t1", true)
+        assert(getShowCreateDDL("t1") === hiveDDL)
+        assert(hiveDDL.mkString(" ").contains(
+          "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.RCFileInputFormat'"))
+      }
+    }
+  }
+
+  test("plain SHOW CREATE TABLE returns Hive DDL for transactional hive table with config on") {
+    withSQLConf(SQLConf.HIVE_TABLE_SHOW_CREATE_TABLE_AS_SERDE.key -> "true") {
+      withTable("t1") {
+        sql(
+          s"""
+             |CREATE TABLE t1 (
+             |  c1 STRING COMMENT 'bla',
+             |  c2 STRING
+             |)
+             |TBLPROPERTIES ('transactional' = 'true')
+             |CLUSTERED BY (c1) INTO 10 BUCKETS
+             |STORED AS ORC
+           """.stripMargin
+        )
+        // Without the config, this fails with
+        // UNSUPPORTED_SHOW_CREATE_TABLE.ON_TRANSACTIONAL_HIVE_TABLE.
+        val showDDL = getShowCreateDDL("t1").mkString(" ")
+        assert(showDDL.contains("ROW FORMAT SERDE"))
+        assert(showDDL.contains("'transactional' = 'true'"))
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new config `spark.sql.hive.showCreateTableAsSerde` (default `false`). When enabled,
plain `SHOW CREATE TABLE` on a Hive serde table routes to the existing
`ShowCreateTableAsSerdeCommand` and renders Hive DDL, instead of converting to Spark DDL.

### Why are the changes needed?

We get some reports from customers: they are confused that `CREATE TABLE ... STORED AS Parquet` but `SHOW CREATE TABLE ...` displays `CREATE TABLE ... USING Parquet`.

Background: SPARK-27946 (#24938) deliberately changed plain `SHOW CREATE TABLE` to always emit Spark DDL, to push and simplify migration from Hive to Spark. `AS SERDE` was introduced in the same PR as the intended escape hatch for users who still need Hive DDL, and the failure modes were intentional: transactional Hive tables error out by design, and tables whose serde has no Spark data source mapping (e.g. RCFILE) are meant to be served by `SHOW CREATE TABLE AS SERDE`.

This PR keeps that direction intact: the default behavior is unchanged, and `AS SERDE` remains the per-query escape hatch. It only adds a session-level toggle that turns "append `AS SERDE` every time" into a config, which helps users and integrations (e.g. BI tools, metastore sync jobs) that cannot easily rewrite the SQL they issue.

### Does this PR introduce _any_ user-facing change?

Yes. New config `spark.sql.hive.showCreateTableAsSerde`, default `false` (no behavior
change). When `true`, `SHOW CREATE TABLE` on Hive serde tables returns Hive DDL; data
source tables and views are unaffected.

### How was this patch tested?

Added tests to `o.a.s.sql.hive.execution.command.ShowCreateTableSuite` covering: Hive
table (matches `AS SERDE` output), data source table and view (unaffected), RCFILE and
transactional Hive tables (Hive DDL rendered instead of erroring).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: KIMI K3