### PR TITLE
[SPARK-58107][CORE][FOLLOWUP] Fix BlockManagerSuite compilation error

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -2547,7 +2547,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
       rpcEnv.setupEndpoint("blockmanager-ess",
         new BlockManagerMasterEndpoint(rpcEnv, isLocal = true, conf, liveListenerBus,
           Some(mock(classOf[ExternalBlockStoreClient])), essBlockManagerInfo, mapOutputTracker,
-          shuffleManager, isDriver = true)),
+          isDriver = true)),
       rpcEnv.setupEndpoint("blockmanagerHeartbeat-ess",
         new BlockManagerMasterHeartbeatEndpoint(rpcEnv, true, essBlockManagerInfo)),
       conf, true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove a stale `shuffleManager` argument from a `BlockManagerMasterEndpoint` constructor call in `BlockManagerSuite`.

### Why are the changes needed?
[SPARK-58185](https://issues.apache.org/jira/browse/SPARK-58185) removed the `_shuffleManager` parameter from `BlockManagerMasterEndpoint`, but the test added by the [SPARK-58107](https://issues.apache.org/jira/browse/SPARK-58107) follow-up still passed it. The two commits merged without a textual conflict, so `core` test sources fail to compile on current master.

### Does this PR introduce _any_ user-facing change?
No. Test-only change.

### How was this patch tested?
`build/sbt core/Test/compile` passes. Ran the affected `verifyRddChecksumSeal` tests in `BlockManagerSuite` -- both pass.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.8
