### PR TITLE
[MINOR][BUILD] Remove unused Parquet test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2455,7 +2455,7 @@
         <artifactId>parquet-column</artifactId>
         <version>${parquet.version}</version>
         <scope>${parquet.test.deps.scope}</scope>
-        <classifier>tests</classifier>
+        <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2438,20 +2438,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet-encoding</artifactId>
-        <version>${parquet.version}</version>
-        <scope>${parquet.test.deps.scope}</scope>
-        <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet-common</artifactId>
-        <version>${parquet.version}</version>
-        <scope>${parquet.test.deps.scope}</scope>
-        <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-column</artifactId>
         <version>${parquet.version}</version>
         <scope>${parquet.test.deps.scope}</scope>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -145,7 +145,7 @@
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <scope>test</scope>
-      <classifier>tests</classifier>
+      <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -143,18 +143,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-encoding</artifactId>
-      <scope>test</scope>
-      <classifier>tests</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-common</artifactId>
-      <scope>test</scope>
-      <classifier>tests</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <scope>test</scope>
       <classifier>tests</classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `parquet-common` and `parquet-encoding` test-JAR dependencies from
`sql/core/pom.xml` and their unused managed declarations from the root `pom.xml`. Retain the
`parquet-column` test JAR using `<type>test-jar</type>`, and update its root
dependency-management entry to match.

Spark SQL uses helper classes from the `parquet-column` test JAR, but does not reference classes
from the `parquet-common` or `parquet-encoding` test JARs. Removing those unused artifacts narrows
the test classpath and makes the module's actual dependency explicit.

CI exposed a Maven/SBT interoperability detail: Spark's POM reader treats
`<classifier>tests</classifier>` as a transitive test-configuration dependency. This revision uses
Maven's `<type>test-jar</type>` representation for the retained `parquet-column` dependency, which
the POM reader intentionally maps intransitively while Maven continues to resolve the same
published test JAR.

### Why are the changes needed?

The removed JARs provide no classes referenced by Spark SQL tests. Bytecode inspection also
confirmed that the retained `MemPageStore` and `Utils` helpers depend only on Parquet production
classes and other classes in the `parquet-column` test JAR.

Using the intransitive `test-jar` representation also prevents SBT from resolving the complete
Parquet column test configuration, which includes unrelated common and encoding test artifacts.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
