### PR TITLE
[SPARK-58269][SQL] Infer generated column partition filters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -671,6 +671,9 @@ private[sql] object CatalogV2Util {
     Option(col.id()).foreach { id =>
       f = f.withId(id)
     }
+    // TODO: this only carries the SQL string form. We could also convert the connector
+    //  Expression form (GenerationExpression) via V2ExpressionUtils.toCatalyst and store it
+    //  with putExpression.
     Option(col.generationExpression()).foreach { genExpr =>
       f = f.copy(metadata = new MetadataBuilder()
         .withMetadata(f.metadata)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
@@ -39,4 +39,12 @@ trait SupportsPushDownCatalystFilters extends ScanBuilder {
    * {@link #pushFilters(Seq[Expression])}.
    */
   def pushedFilters: Array[Predicate]
+
+  /**
+   * Whether Spark should derive additional partition filters from filters on the base columns of
+   * generated partition columns and push them through {@link #pushFilters(Seq[Expression])}. Each
+   * derived filter is implied by an original filter, so enabling this never changes query results;
+   * it only lets the data source prune more easily prune data via explicit partition pruning.
+   */
+  def inferGeneratedColumnPartitionFilters: Boolean = false
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
@@ -44,7 +44,7 @@ trait SupportsPushDownCatalystFilters extends ScanBuilder {
    * Whether Spark should derive additional partition filters from filters on the base columns of
    * generated partition columns and push them through {@link #pushFilters(Seq[Expression])}. Each
    * derived filter is implied by an original filter, so enabling this never changes query results;
-   * it only lets the data source prune more easily prune data via explicit partition pruning.
+   * it only lets the data source prune data more easily via explicit partition pruning.
    */
   def inferGeneratedColumnPartitionFilters: Boolean = false
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithCatalystFilterCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithCatalystFilterCatalog.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog
+
+import java.util
+
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression, Predicate => CatalystPredicate}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.internal.connector.SupportsPushDownCatalystFilters
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * In-memory table whose scan builder implements [[SupportsPushDownCatalystFilters]], so pushed
+ * filters (including partition filters derived from generated partition columns) arrive as raw
+ * Catalyst expressions. Filters that reference only partition columns are used to prune partitions;
+ * the remaining data filters are returned for post-scan evaluation.
+ */
+class InMemoryTableWithCatalystFilter(
+    name: String,
+    columns: Array[Column],
+    partitioning: Array[Transform],
+    properties: util.Map[String, String])
+  extends InMemoryTable(name, columns, partitioning, properties) {
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new InMemoryCatalystFilterScanBuilder(schema())
+  }
+
+  class InMemoryCatalystFilterScanBuilder(tableSchema: StructType)
+    extends ScanBuilder
+    with SupportsPushDownCatalystFilters
+    with SupportsPushDownRequiredColumns {
+
+    private var readSchema: StructType = tableSchema
+    private var pushedPartitionFilters: Seq[Expression] = Nil
+
+    override def inferGeneratedColumnPartitionFilters: Boolean =
+      properties.getOrDefault(
+        InMemoryTableWithCatalystFilter.INFER_GENERATED_COLUMN_PARTITION_FILTERS, "true").toBoolean
+
+    private val partitionColumnNames: Set[String] =
+      partCols.map(_.mkString(".")).toSet
+
+    private def referencesOnlyPartitionColumns(e: Expression): Boolean =
+      e.references.nonEmpty && e.references.forall(a => partitionColumnNames.contains(a.name))
+
+    override def pushFilters(filters: Seq[Expression]): Seq[Expression] = {
+      val (partitionFilters, dataFilters) = filters.partition(referencesOnlyPartitionColumns)
+      pushedPartitionFilters = partitionFilters
+      // Data filters are evaluated after the scan; partition filters are consumed for pruning.
+      dataFilters
+    }
+
+    override def pushedFilters: Array[Predicate] = Array.empty
+
+    override def pruneColumns(requiredSchema: StructType): Unit = {
+      readSchema = requiredSchema
+    }
+
+    override def build(): Scan = {
+      val prunedPartitions = prunePartitions(pushedPartitionFilters)
+      InMemoryCatalystFilterBatchScan(
+        prunedPartitions.map(_.asInstanceOf[InputPartition]),
+        readSchema,
+        tableSchema,
+        pushedPartitionFilters)
+    }
+
+    private def prunePartitions(filters: Seq[Expression]): Seq[BufferedRows] = {
+      val allPartitions = data.toSeq
+      if (filters.isEmpty) {
+        return allPartitions
+      }
+      val nameToOrdinal = partCols.map(_.mkString(".")).zipWithIndex.toMap
+      val predicates = filters.flatMap { filter =>
+        val bound = filter.transformUp {
+          case a: AttributeReference if nameToOrdinal.contains(a.name) =>
+            BoundReference(nameToOrdinal(a.name), a.dataType, a.nullable)
+        }
+        // Only evaluate filters we could fully bind against the partition key.
+        if (bound.references.isEmpty) Some(CatalystPredicate.createInterpreted(bound)) else None
+      }
+      allPartitions.filter(part => predicates.forall(_.eval(part.partitionKey())))
+    }
+  }
+
+  /** Batch scan that records the Catalyst partition filters pushed to it. */
+  case class InMemoryCatalystFilterBatchScan(
+      var _data: Seq[InputPartition],
+      readSchema: StructType,
+      tableSchema: StructType,
+      pushedPartitionFilters: Seq[Expression])
+    extends BatchScanBaseClass(_data, readSchema, tableSchema)
+}
+
+object InMemoryTableWithCatalystFilter {
+  /**
+   * Table property controlling whether the scan builder opts in to deriving generated column
+   * partition filters via `inferGeneratedColumnPartitionFilters`. Defaults to `true`.
+   */
+  val INFER_GENERATED_COLUMN_PARTITION_FILTERS = "infer.generated.column.partition.filters"
+}
+
+class InMemoryTableWithCatalystFilterCatalog extends InMemoryTableCatalog {
+  import CatalogV2Implicits._
+
+  override def createTable(ident: Identifier, tableInfo: TableInfo): Table = {
+    if (tables.containsKey(ident)) {
+      throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
+    }
+    InMemoryTableCatalog.maybeSimulateFailedTableCreation(tableInfo.properties)
+    val tableName = s"$name.${ident.quoted}"
+    val table = new InMemoryTableWithCatalystFilter(
+      tableName, tableInfo.columns(), tableInfo.partitions(), tableInfo.properties)
+    tables.put(ident, table)
+    namespaces.putIfAbsent(ident.namespace.toList, Map())
+    table
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GeneratedColumnPartitionFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GeneratedColumnPartitionFilters.scala
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import java.util.Locale
+
+import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Cast, DateFormatClass, DayOfMonth, EqualTo, Expression, GetStructField, GreaterThan, GreaterThanOrEqual, Hour, IntegerLiteral, IsNull, LessThan, LessThanOrEqual, Literal, Month, StringLiteral, Substring, TruncDate, TruncTimestamp, Year}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Project}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils.{fromAttributes, toAttributes}
+import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, CaseInsensitiveMap, GeneratedColumn}
+import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.connector.expressions.IdentityTransform
+import org.apache.spark.sql.types.{DataType, DateType, StringType, StructField, StructType, TimestampType}
+
+/**
+ * Derives partition filters from data filters when a DataSource V2 table is partitioned by a
+ * generated column. For example, if a table has a partition column
+ * `date GENERATED ALWAYS AS (CAST(eventTime AS DATE))`, a data filter `eventTime < '2021-01-01'`
+ * can be used to derive the partition filter `date <= DATE '2021-01-01'`, which lets the connector
+ * prune partitions without scanning all of them.
+ *
+ * Used by [[V2ScanRelationPushDown]]. The derived filters are only used to help the data source
+ * prune data; because each derived filter is implied by the original data filter it is derived
+ * from, applying it never removes valid rows.
+ */
+object GeneratedColumnPartitionFilters extends Logging {
+
+  private val DATE_FORMAT_YEAR_MONTH = "yyyy-MM"
+  private val DATE_FORMAT_YEAR_MONTH_DAY = "yyyy-MM-dd"
+  private val DATE_FORMAT_YEAR_MONTH_DAY_HOUR = "yyyy-MM-dd-HH"
+
+  /**
+   * Extracts the base (source) column referenced by a data filter. Handles both top level columns
+   * and nested fields, returning the field path and the column data type.
+   */
+  private object ExtractBaseColumn {
+    def unapply(e: Expression): Option[(Seq[String], DataType)] = e match {
+      case a: AttributeReference =>
+        Some((Seq(a.name), a.dataType))
+      case g: GetStructField => g.child match {
+        case ExtractBaseColumn(nameParts, _) =>
+          Some((nameParts :+ g.extractFieldName, g.dataType))
+        case _ => None
+      }
+      case _ => None
+    }
+  }
+
+  private def createFieldPath(nameParts: Seq[String]): String = {
+    nameParts.map(quoteIfNeeded).mkString(".")
+  }
+
+  /**
+   * Returns the schema of the table's top level, identity-partitioned columns, preserving field
+   * metadata (which carries the generation expression). Only such columns can be generated
+   * partition columns for this optimization; the schema is empty if the table has none.
+   */
+  private[v2] def identityPartitionSchema(relation: DataSourceV2Relation): StructType = {
+    val partitionColumnNames = relation.table.partitioning().collect {
+      case t: IdentityTransform if t.ref.fieldNames().length == 1 => t.ref.fieldNames().head
+    }.toSet
+    StructType(relation.output.collect {
+      case a if partitionColumnNames.contains(a.name) =>
+        StructField(a.name, a.dataType, a.nullable, a.metadata)
+    })
+  }
+
+  /**
+   * The main entry point used by [[V2ScanRelationPushDown]]. Given a relation and its data filters,
+   * returns additional partition filters derived from the relation's generated partition columns.
+   * The returned filters are analyzed (resolved and type coerced) against the relation output and
+   * reference only the partition columns, so they are safe to add to the list of filters that are
+   * pushed down to the data source.
+   */
+  def generatePartitionFilters(
+      spark: SparkSession,
+      relation: DataSourceV2Relation,
+      dataFilters: Seq[Expression]): Seq[Expression] = {
+    if (dataFilters.isEmpty) {
+      return Nil
+    }
+
+    val output = relation.output
+    val partitionSchema = identityPartitionSchema(relation)
+    if (partitionSchema.isEmpty) {
+      return Nil
+    }
+    // Cheap guard: skip the (more expensive) analysis unless a partition column is generated.
+    if (!partitionSchema.exists(GeneratedColumn.isGeneratedColumn)) {
+      return Nil
+    }
+
+    val fullSchema = fromAttributes(output)
+
+    val rawExpressions = getOptimizablePartitionExpressions(spark, fullSchema, partitionSchema)
+    if (rawExpressions.isEmpty) {
+      return Nil
+    }
+    val optimizablePartitionExpressions =
+      if (spark.sessionState.conf.caseSensitiveAnalysis) {
+        rawExpressions
+      } else {
+        CaseInsensitiveMap(rawExpressions)
+      }
+
+    // Put the column on the left and the literal on the right.
+    def preprocess(filter: Expression): Expression = filter match {
+      case LessThan(lit: Literal, e: Expression) => GreaterThan(e, lit)
+      case LessThanOrEqual(lit: Literal, e: Expression) => GreaterThanOrEqual(e, lit)
+      case EqualTo(lit: Literal, e: Expression) => EqualTo(e, lit)
+      case GreaterThan(lit: Literal, e: Expression) => LessThan(e, lit)
+      case GreaterThanOrEqual(lit: Literal, e: Expression) => LessThanOrEqual(e, lit)
+      case e => e
+    }
+
+    def toPartitionFilter(
+        nameParts: Seq[String],
+        func: OptimizablePartitionExpression => Option[Expression]): Seq[Expression] = {
+      optimizablePartitionExpressions.get(createFieldPath(nameParts)).toSeq.flatMap { exprs =>
+        exprs.flatMap(expr => func(expr))
+      }
+    }
+
+    val partitionFilters = dataFilters.flatMap { filter =>
+      preprocess(filter) match {
+        case LessThan(ExtractBaseColumn(nameParts, _), lit: Literal) =>
+          toPartitionFilter(nameParts, _.lessThan(lit))
+        case LessThanOrEqual(ExtractBaseColumn(nameParts, _), lit: Literal) =>
+          toPartitionFilter(nameParts, _.lessThanOrEqual(lit))
+        case EqualTo(ExtractBaseColumn(nameParts, _), lit: Literal) =>
+          toPartitionFilter(nameParts, _.equalTo(lit))
+        case GreaterThan(ExtractBaseColumn(nameParts, _), lit: Literal) =>
+          toPartitionFilter(nameParts, _.greaterThan(lit))
+        case GreaterThanOrEqual(ExtractBaseColumn(nameParts, _), lit: Literal) =>
+          toPartitionFilter(nameParts, _.greaterThanOrEqual(lit))
+        case IsNull(ExtractBaseColumn(nameParts, _)) =>
+          toPartitionFilter(nameParts, _.isNull())
+        case _ => Nil
+      }
+    }
+
+    resolveAndCoerce(spark, partitionFilters, output)
+  }
+
+  /**
+   * Analyzes the derived partition filters against the relation output so that partition column
+   * references are resolved and the expressions are type coerced. The derived filters reference
+   * only partition columns that exist in `output`, so they are always expected to resolve; a
+   * failure indicates a bug and is surfaced as an internal error.
+   */
+  private def resolveAndCoerce(
+      spark: SparkSession,
+      filters: Seq[Expression],
+      output: Seq[AttributeReference]): Seq[Expression] = {
+    if (filters.isEmpty) {
+      return Nil
+    }
+    val plan = Project(filters.map(f => Alias(f, "gcpf")()), LocalRelation(output))
+    spark.sessionState.analyzer.execute(plan) match {
+      case Project(projectList, _) =>
+        projectList.map {
+          case Alias(child, _) if child.resolved => child
+          case other =>
+            throw SparkException.internalError(
+              s"Failed to resolve derived generated column partition filter: $other")
+        }
+      case other =>
+        throw SparkException.internalError(
+          s"Expected a Project when resolving derived partition filters but got $other")
+    }
+  }
+
+  /**
+   * Builds a map from a base column path to the [[OptimizablePartitionExpression]]s of the
+   * partition columns generated from that base column. The generation expressions are parsed and
+   * analyzed against `schema` to normalize their shape (e.g. inserting casts) before matching.
+   */
+  private[v2] def getOptimizablePartitionExpressions(
+      spark: SparkSession,
+      schema: StructType,
+      partitionSchema: StructType): Map[String, Seq[OptimizablePartitionExpression]] = {
+    val partitionGenerationExprs = partitionSchema.flatMap { col =>
+      GeneratedColumn.getGenerationExpression(col).map { exprStr =>
+        Alias(spark.sessionState.sqlParser.parseExpression(exprStr), col.name)()
+      }
+    }
+    if (partitionGenerationExprs.isEmpty) {
+      return Map.empty
+    }
+
+    val resolver = spark.sessionState.analyzer.resolver
+    val nameNormalizer: String => String =
+      if (spark.sessionState.conf.caseSensitiveAnalysis) identity else _.toLowerCase(Locale.ROOT)
+
+    def createExpr(nameParts: Seq[String])(func: => OptimizablePartitionExpression):
+        Option[(String, OptimizablePartitionExpression)] = {
+      if (schema.findNestedField(nameParts, resolver = resolver).isDefined) {
+        Some(nameNormalizer(createFieldPath(nameParts)) -> func)
+      } else {
+        None
+      }
+    }
+
+    // Analyze the parsed generation expressions against the table schema so that column references
+    // are resolved and implicit casts / type coercion are applied. This normalizes each expression
+    // into the canonical, coerced shape that the pattern match below relies on.
+    val analyzed = spark.sessionState.analyzer.execute(
+      Project(partitionGenerationExprs, LocalRelation(toAttributes(schema))))
+
+    val extractedPartitionExprs = analyzed match {
+      case Project(exprs, _) =>
+        exprs.flatMap {
+          case Alias(expr, partColName) =>
+            expr match {
+              case Cast(ExtractBaseColumn(name, TimestampType), DateType, _, _) =>
+                createExpr(name)(DatePartitionExpr(partColName))
+              case Cast(ExtractBaseColumn(name, DateType), DateType, _, _) =>
+                createExpr(name)(DatePartitionExpr(partColName))
+              case Year(ExtractBaseColumn(name, DateType)) =>
+                createExpr(name)(YearPartitionExpr(partColName))
+              case Year(Cast(ExtractBaseColumn(name, TimestampType), DateType, _, _)) =>
+                createExpr(name)(YearPartitionExpr(partColName))
+              case Year(Cast(ExtractBaseColumn(name, DateType), DateType, _, _)) =>
+                createExpr(name)(YearPartitionExpr(partColName))
+              case Month(Cast(ExtractBaseColumn(name, TimestampType), DateType, _, _)) =>
+                createExpr(name)(MonthPartitionExpr(partColName))
+              case DateFormatClass(
+                  Cast(ExtractBaseColumn(name, DateType), TimestampType, _, _),
+                  StringLiteral(format), _) =>
+                format match {
+                  case DATE_FORMAT_YEAR_MONTH =>
+                    createExpr(name)(DateFormatPartitionExpr(partColName, DATE_FORMAT_YEAR_MONTH))
+                  case _ => None
+                }
+              case DateFormatClass(
+                  ExtractBaseColumn(name, TimestampType), StringLiteral(format), _) =>
+                format match {
+                  case DATE_FORMAT_YEAR_MONTH =>
+                    createExpr(name)(DateFormatPartitionExpr(partColName, DATE_FORMAT_YEAR_MONTH))
+                  case DATE_FORMAT_YEAR_MONTH_DAY =>
+                    createExpr(name)(
+                      DateFormatPartitionExpr(partColName, DATE_FORMAT_YEAR_MONTH_DAY))
+                  case DATE_FORMAT_YEAR_MONTH_DAY_HOUR =>
+                    createExpr(name)(
+                      DateFormatPartitionExpr(partColName, DATE_FORMAT_YEAR_MONTH_DAY_HOUR))
+                  case _ => None
+                }
+              case DayOfMonth(Cast(ExtractBaseColumn(name, TimestampType), DateType, _, _)) =>
+                createExpr(name)(DayPartitionExpr(partColName))
+              case Hour(ExtractBaseColumn(name, TimestampType), _) =>
+                createExpr(name)(HourPartitionExpr(partColName))
+              case Substring(
+                  ExtractBaseColumn(name, StringType), IntegerLiteral(pos), IntegerLiteral(len)) =>
+                createExpr(name)(SubstringPartitionExpr(partColName, pos, len))
+              case TruncTimestamp(
+                  StringLiteral(format), ExtractBaseColumn(name, TimestampType), _) =>
+                createExpr(name)(TimestampTruncPartitionExpr(format, partColName))
+              case TruncTimestamp(
+                  StringLiteral(format),
+                  Cast(ExtractBaseColumn(name, DateType), TimestampType, _, _), _) =>
+                createExpr(name)(TimestampTruncPartitionExpr(format, partColName))
+              case ExtractBaseColumn(name, _) =>
+                createExpr(name)(IdentityPartitionExpr(partColName))
+              case TruncDate(ExtractBaseColumn(name, DateType), StringLiteral(format)) =>
+                createExpr(name)(TruncDatePartitionExpr(partColName, format))
+              case TruncDate(
+                  Cast(ExtractBaseColumn(name, TimestampType | StringType), DateType, _, _),
+                  StringLiteral(format)) =>
+                createExpr(name)(TruncDatePartitionExpr(partColName, format))
+              case _ => None
+            }
+          case other =>
+            // Should not happen since we wrap every generation expression in an Alias above.
+            throw SparkException.internalError(
+              s"Expected an Alias when analyzing generation expressions but got $other")
+        }
+      case other =>
+        // Should not happen since analyzing a Project always returns a Project.
+        throw SparkException.internalError(
+          s"Expected a Project when analyzing generation expressions but got $other")
+    }
+
+    extractedPartitionExprs.groupBy(_._1).map { case (name, group) =>
+      val mergedExprs = mergePartitionExpressionsIfPossible(group.map(_._2))
+      if (log.isDebugEnabled) {
+        logDebug(s"Optimizable partition expressions for column $name:")
+        mergedExprs.foreach(expr => logDebug(expr.toString))
+      }
+      name -> mergedExprs
+    }
+  }
+
+  /**
+   * Merges separate YEAR/MONTH/DAY/HOUR partition expressions on the same base column into a single
+   * composite expression, which allows deriving more selective partition filters.
+   */
+  private def mergePartitionExpressionsIfPossible(
+      exprs: Seq[OptimizablePartitionExpression]): Seq[OptimizablePartitionExpression] = {
+    def isRedundantPartitionExpr(f: OptimizablePartitionExpression): Boolean = {
+      f.isInstanceOf[YearPartitionExpr] ||
+        f.isInstanceOf[MonthPartitionExpr] ||
+        f.isInstanceOf[DayPartitionExpr] ||
+        f.isInstanceOf[HourPartitionExpr]
+    }
+
+    val year = exprs.collect { case y: YearPartitionExpr => y }.headOption
+    val month = exprs.collect { case m: MonthPartitionExpr => m }.headOption
+    val day = exprs.collect { case d: DayPartitionExpr => d }.headOption
+    val hour = exprs.collect { case h: HourPartitionExpr => h }.headOption
+    (year ++ month ++ day ++ hour).toSeq match {
+      case Seq(y: YearPartitionExpr, m: MonthPartitionExpr, d: DayPartitionExpr,
+          h: HourPartitionExpr) =>
+        exprs.filterNot(isRedundantPartitionExpr) :+
+          YearMonthDayHourPartitionExpr(y.yearPart, m.monthPart, d.dayPart, h.hourPart)
+      case Seq(y: YearPartitionExpr, m: MonthPartitionExpr, d: DayPartitionExpr) =>
+        exprs.filterNot(isRedundantPartitionExpr) :+
+          YearMonthDayPartitionExpr(y.yearPart, m.monthPart, d.dayPart)
+      case Seq(y: YearPartitionExpr, m: MonthPartitionExpr) =>
+        exprs.filterNot(isRedundantPartitionExpr) :+
+          YearMonthPartitionExpr(y.yearPart, m.monthPart)
+      case _ =>
+        exprs
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizablePartitionExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizablePartitionExpression.scala
@@ -472,10 +472,11 @@ case class SubstringPartitionExpr(
 case class DateFormatPartitionExpr(
     partitionColumn: String, format: String) extends OptimizablePartitionExpression {
 
-  private val partitionColumnUnixTimestamp = UnixTimestamp(partitionColumn.toPartCol, format)
+  private val partitionColumnUnixTimestamp =
+    UnixTimestamp(partitionColumn.toPartCol, format, failOnError = false)
 
   private def litUnixTimestamp(lit: Literal): UnixTimestamp =
-    UnixTimestamp(DateFormatClass(lit, format), format)
+    UnixTimestamp(DateFormatClass(lit, format), format, failOnError = false)
 
   override def lessThan(lit: Literal): Option[Expression] = {
     // As the partition column has truncated information, we need to turn "<" to "<=".
@@ -626,7 +627,7 @@ case class TruncDatePartitionExpr(partitionColumn: String, format: String)
 
   override def lessThanOrEqual(lit: Literal): Option[Expression] = {
     val expr = lit.dataType match {
-      case TimestampType | DateType | StringType =>
+      case TimestampType | DateType =>
         Some(partitionColumn.toPartCol <= TruncDate(lit, Literal(format)))
       case _ => None
     }
@@ -648,7 +649,7 @@ case class TruncDatePartitionExpr(partitionColumn: String, format: String)
 
   override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
     val expr = lit.dataType match {
-      case TimestampType | DateType | StringType =>
+      case TimestampType | DateType =>
         Some(partitionColumn.toPartCol >= TruncDate(lit, Literal(format)))
       case _ => None
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizablePartitionExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizablePartitionExpression.scala
@@ -1,0 +1,659 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{Cast, DateFormatClass, DayOfMonth, Expression, Hour, IsNull, Literal, Month, Or, Substring, TruncDate, TruncTimestamp, UnixTimestamp, Year}
+import org.apache.spark.sql.types.{DateType, StringType, TimestampType}
+
+/**
+ * Defines rules to convert a data filter to a partition filter for a special generation expression
+ * of a partition column.
+ *
+ * Note:
+ * - This may be shared across multiple `SparkSession`s, so implementations should not store any
+ *   state (such as expressions) referring to a specific `SparkSession`.
+ * - Partition columns may have different behaviors than data columns. For example, writing an empty
+ *   string to a partition column would become `null` (SPARK-24438). We need to pay attention to
+ *   these slight behavior differences and make sure applying the auto generated partition filters
+ *   would still return the same result as if they were not applied.
+ */
+sealed trait OptimizablePartitionExpression {
+  /**
+   * Assume we have a partition column `part`, and a data column `col`. Return a partition filter
+   * based on `part` for a data filter `col < lit`.
+   */
+  def lessThan(lit: Literal): Option[Expression] = None
+
+  /**
+   * Assume we have a partition column `part`, and a data column `col`. Return a partition filter
+   * based on `part` for a data filter `col <= lit`.
+   */
+  def lessThanOrEqual(lit: Literal): Option[Expression] = None
+
+  /**
+   * Assume we have a partition column `part`, and a data column `col`. Return a partition filter
+   * based on `part` for a data filter `col = lit`.
+   */
+  def equalTo(lit: Literal): Option[Expression] = None
+
+  /**
+   * Assume we have a partition column `part`, and a data column `col`. Return a partition filter
+   * based on `part` for a data filter `col > lit`.
+   */
+  def greaterThan(lit: Literal): Option[Expression] = None
+
+  /**
+   * Assume we have a partition column `part`, and a data column `col`. Return a partition filter
+   * based on `part` for a data filter `col >= lit`.
+   */
+  def greaterThanOrEqual(lit: Literal): Option[Expression] = None
+
+  /**
+   * Assume we have a partition column `part`, and a data column `col`. Return a partition filter
+   * based on `part` for a data filter `col IS NULL`.
+   */
+  def isNull(): Option[Expression] = None
+}
+
+object OptimizablePartitionExpression {
+  /** Provide a convenient method to convert a string to a column expression. */
+  implicit class ColumnExpression(val colName: String) extends AnyVal {
+    // This will always be a top level column so it is safe to reference it by name directly.
+    def toPartCol: Expression = UnresolvedAttribute(Seq(colName))
+  }
+}
+
+import org.apache.spark.sql.execution.datasources.v2.OptimizablePartitionExpression._
+
+/** The rules for the generation expression `CAST(col AS DATE)`. */
+case class DatePartitionExpr(partitionColumn: String) extends OptimizablePartitionExpression {
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol <= Cast(lit, DateType))
+      case DateType => Some(partitionColumn.toPartCol <= lit)
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol === Cast(lit, DateType))
+      case DateType => Some(partitionColumn.toPartCol === lit)
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol >= Cast(lit, DateType))
+      case DateType => Some(partitionColumn.toPartCol >= lit)
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
+}
+
+/**
+ * The rules for the generation expression `YEAR(col)`.
+ *
+ * @param yearPart the year partition column name.
+ */
+case class YearPartitionExpr(yearPart: String) extends OptimizablePartitionExpression {
+
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType => Some(yearPart.toPartCol <= Year(lit))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType => Some(yearPart.toPartCol === Year(lit))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType => Some(yearPart.toPartCol >= Year(lit))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def isNull(): Option[Expression] = Some(yearPart.toPartCol.isNull)
+}
+
+/**
+ * This is a placeholder to catch `month(col)` so that we can merge [[YearPartitionExpr]] and
+ * [[MonthPartitionExpr]] to [[YearMonthDayPartitionExpr]].
+ *
+ * @param monthPart the month partition column name.
+ */
+case class MonthPartitionExpr(monthPart: String) extends OptimizablePartitionExpression
+
+/**
+ * This is a placeholder to catch `day(col)` so that we can merge [[YearPartitionExpr]],
+ * [[MonthPartitionExpr]] and [[DayPartitionExpr]] to [[YearMonthDayPartitionExpr]].
+ *
+ * @param dayPart the day partition column name.
+ */
+case class DayPartitionExpr(dayPart: String) extends OptimizablePartitionExpression
+
+/**
+ * This is a placeholder to catch `hour(col)` so that we can merge [[YearPartitionExpr]],
+ * [[MonthPartitionExpr]], [[DayPartitionExpr]] and [[HourPartitionExpr]] to
+ * [[YearMonthDayHourPartitionExpr]].
+ *
+ * @param hourPart the hour partition column name.
+ */
+case class HourPartitionExpr(hourPart: String) extends OptimizablePartitionExpression
+
+/**
+ * Optimize the case that two partition columns use YEAR and MONTH on the same column, such
+ * as `YEAR(eventTime)` and `MONTH(eventTime)`.
+ *
+ * @param yearPart the year partition column name
+ * @param monthPart the month partition column name
+ */
+case class YearMonthPartitionExpr(
+    yearPart: String,
+    monthPart: String) extends OptimizablePartitionExpression {
+
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          (yearPart.toPartCol < Year(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol <= Month(lit)))
+      case _ => None
+    }
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit))
+      case _ => None
+    }
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          (yearPart.toPartCol > Year(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol >= Month(lit)))
+      case _ => None
+    }
+  }
+
+  override def isNull(): Option[Expression] = {
+    // `yearPart` and `monthPart` are derived columns, so they must be `null` when the input column
+    // is `null`.
+    Some(yearPart.toPartCol.isNull && monthPart.toPartCol.isNull)
+  }
+}
+
+/**
+ * Optimize the case that three partition columns use YEAR, MONTH and DAY on the same column,
+ * such as `YEAR(eventTime)`, `MONTH(eventTime)` and `DAY(eventTime)`.
+ *
+ * @param yearPart the year partition column name
+ * @param monthPart the month partition column name
+ * @param dayPart the day partition column name
+ */
+case class YearMonthDayPartitionExpr(
+    yearPart: String,
+    monthPart: String,
+    dayPart: String) extends OptimizablePartitionExpression {
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          (yearPart.toPartCol < Year(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol < Month(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+              dayPart.toPartCol <= DayOfMonth(lit)))
+      case _ => None
+    }
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+            dayPart.toPartCol === DayOfMonth(lit))
+      case _ => None
+    }
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          (yearPart.toPartCol > Year(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol > Month(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+              dayPart.toPartCol >= DayOfMonth(lit)))
+      case _ => None
+    }
+  }
+
+  override def isNull(): Option[Expression] = {
+    // `yearPart`, `monthPart` and `dayPart` are derived columns, so they must be `null` when the
+    // input column is `null`.
+    Some(yearPart.toPartCol.isNull && monthPart.toPartCol.isNull && dayPart.toPartCol.isNull)
+  }
+}
+
+/**
+ * Optimize the case that four partition columns use YEAR, MONTH, DAY and HOUR on the same
+ * column, such as `YEAR(eventTime)`, `MONTH(eventTime)`, `DAY(eventTime)`, `HOUR(eventTime)`.
+ *
+ * @param yearPart the year partition column name
+ * @param monthPart the month partition column name
+ * @param dayPart the day partition column name
+ * @param hourPart the hour partition column name
+ */
+case class YearMonthDayHourPartitionExpr(
+    yearPart: String,
+    monthPart: String,
+    dayPart: String,
+    hourPart: String) extends OptimizablePartitionExpression {
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          (yearPart.toPartCol < Year(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol < Month(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+              dayPart.toPartCol < DayOfMonth(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+              dayPart.toPartCol === DayOfMonth(lit) && hourPart.toPartCol <= Hour(lit)))
+      case _ => None
+    }
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+            dayPart.toPartCol === DayOfMonth(lit) && hourPart.toPartCol === Hour(lit))
+      case _ => None
+    }
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case TimestampType =>
+        Some(
+          (yearPart.toPartCol > Year(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol > Month(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+              dayPart.toPartCol > DayOfMonth(lit)) ||
+            (yearPart.toPartCol === Year(lit) && monthPart.toPartCol === Month(lit) &&
+              dayPart.toPartCol === DayOfMonth(lit) && hourPart.toPartCol >= Hour(lit)))
+      case _ => None
+    }
+  }
+
+  override def isNull(): Option[Expression] = {
+    // `yearPart`, `monthPart`, `dayPart` and `hourPart` are derived columns, so they must be `null`
+    // when the input column is `null`.
+    Some(yearPart.toPartCol.isNull && monthPart.toPartCol.isNull &&
+      dayPart.toPartCol.isNull && hourPart.toPartCol.isNull)
+  }
+}
+
+/**
+ * The rules for the generation expression `SUBSTRING(col, pos, len)`. Note:
+ * - Writing an empty string to a partition column would become `null` (SPARK-24438) so generated
+ *   partition filters always pick up the `null` partition for safety.
+ * - When `pos` is 0 or 1, we also support optimizations for comparison operators. Otherwise, we
+ *   only support optimizations for EqualTo.
+ *
+ * @param partitionColumn the partition column name using SUBSTRING in its generation expression.
+ * @param substringPos the `pos` parameter of SUBSTRING in the generation expression.
+ * @param substringLen the `len` parameter of SUBSTRING in the generation expression.
+ */
+case class SubstringPartitionExpr(
+    partitionColumn: String,
+    substringPos: Int,
+    substringLen: Int) extends OptimizablePartitionExpression {
+
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    // Both `pos == 0` and `pos == 1` start from the first char. See UTF8String.substringSQL.
+    if (substringPos == 0 || substringPos == 1) {
+      lit.dataType match {
+        case StringType =>
+          Some(
+            partitionColumn.toPartCol.isNull ||
+              partitionColumn.toPartCol <= Substring(lit, substringPos, substringLen))
+        case _ => None
+      }
+    } else {
+      None
+    }
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    lit.dataType match {
+      case StringType =>
+        Some(
+          partitionColumn.toPartCol.isNull ||
+            partitionColumn.toPartCol === Substring(lit, substringPos, substringLen))
+      case _ => None
+    }
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    // Both `pos == 0` and `pos == 1` start from the first char. See UTF8String.substringSQL.
+    if (substringPos == 0 || substringPos == 1) {
+      lit.dataType match {
+        case StringType =>
+          Some(
+            partitionColumn.toPartCol.isNull ||
+              partitionColumn.toPartCol >= Substring(lit, substringPos, substringLen))
+        case _ => None
+      }
+    } else {
+      None
+    }
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
+}
+
+/**
+ * The rules for the generation expression `DATE_FORMAT(col, format)`, such as
+ * `DATE_FORMAT(timestamp, 'yyyy-MM')` and `DATE_FORMAT(timestamp, 'yyyy-MM-dd-HH')`.
+ *
+ * @param partitionColumn the partition column name using DATE_FORMAT in its generation expression.
+ * @param format the `format` parameter of DATE_FORMAT in the generation expression.
+ *
+ *            unix_timestamp('12345-12', 'yyyy-MM') | unix_timestamp('+12345-12', 'yyyy-MM')
+ * EXCEPTION               fail                     |           327432240000
+ * CORRECTED               null                     |           327432240000
+ * LEGACY               327432240000                |               null
+ */
+case class DateFormatPartitionExpr(
+    partitionColumn: String, format: String) extends OptimizablePartitionExpression {
+
+  private val partitionColumnUnixTimestamp = UnixTimestamp(partitionColumn.toPartCol, format)
+
+  private def litUnixTimestamp(lit: Literal): UnixTimestamp =
+    UnixTimestamp(DateFormatClass(lit, format), format)
+
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    // timestamp + date are truncated to yyyy-MM
+    // timestamp are truncated to yyyy-MM-dd-HH
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType =>
+        Some(partitionColumnUnixTimestamp <= litUnixTimestamp(lit))
+      case _ => None
+    }
+    // when write and read timeParserPolicy-s are different, UnixTimestamp will yield null
+    // thus e would be null if either of two operands is null, we should not drop the data
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType =>
+        Some(partitionColumnUnixTimestamp === litUnixTimestamp(lit))
+      case _ => None
+    }
+    // when write and read timeParserPolicy-s are different, UnixTimestamp will yield null
+    // thus e would be null if either of two operands is null, we should not drop the data
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    // timestamp + date are truncated to yyyy-MM
+    // timestamp are truncated to yyyy-MM-dd-HH
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType =>
+        Some(partitionColumnUnixTimestamp >= litUnixTimestamp(lit))
+      case _ => None
+    }
+    // when write and read timeParserPolicy-s are different, UnixTimestamp will yield null
+    // thus e would be null if either of two operands is null, we should not drop the data
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
+}
+
+/** The rules for the generation expression `date_trunc(field, col)`. */
+case class TimestampTruncPartitionExpr(format: String, partitionColumn: String)
+  extends OptimizablePartitionExpression {
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol <= TruncTimestamp(format, lit))
+      case DateType =>
+        Some(partitionColumn.toPartCol <= TruncTimestamp(format, Cast(lit, TimestampType)))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol === TruncTimestamp(format, lit))
+      case DateType =>
+        Some(partitionColumn.toPartCol === TruncTimestamp(format, Cast(lit, TimestampType)))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol >= TruncTimestamp(format, lit))
+      case DateType =>
+        Some(partitionColumn.toPartCol >= TruncTimestamp(format, Cast(lit, TimestampType)))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
+}
+
+/**
+ * The rules for the identity generation expression, used for partitioning on a nested column.
+ * Note:
+ * - Writing an empty string to a partition column would become `null` (SPARK-24438) so generated
+ *   partition filters always pick up the `null` partition for safety.
+ *
+ * @param partitionColumn the partition column name used in the generation expression.
+ */
+case class IdentityPartitionExpr(partitionColumn: String)
+    extends OptimizablePartitionExpression {
+
+  override def lessThan(lit: Literal): Option[Expression] = {
+    Some(partitionColumn.toPartCol.isNull || partitionColumn.toPartCol < lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    Some(partitionColumn.toPartCol.isNull || partitionColumn.toPartCol <= lit)
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    Some(partitionColumn.toPartCol.isNull || partitionColumn.toPartCol === lit)
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    Some(partitionColumn.toPartCol.isNull || partitionColumn.toPartCol > lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    Some(partitionColumn.toPartCol.isNull || partitionColumn.toPartCol >= lit)
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
+}
+
+/**
+ * The rules for generation expressions that use the function `trunc(col, format)` such as
+ * `trunc(timestamp, 'year')`, `trunc(date, 'week')` and `trunc(timestampStr, 'hour')`.
+ *
+ * @param partitionColumn partition column using trunc function in the generation expression
+ * @param format the format that specifies the unit of truncation applied to the partitionColumn
+ */
+case class TruncDatePartitionExpr(partitionColumn: String, format: String)
+  extends OptimizablePartitionExpression {
+
+  override def lessThan(lit: Literal): Option[Expression] = {
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType | StringType =>
+        Some(partitionColumn.toPartCol <= TruncDate(lit, Literal(format)))
+      case _ => None
+    }
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType | StringType =>
+        Some(partitionColumn.toPartCol === TruncDate(lit, Literal(format)))
+      case _ => None
+    }
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType | DateType | StringType =>
+        Some(partitionColumn.toPartCol >= TruncDate(lit, Literal(format)))
+      case _ => None
+    }
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizablePartitionExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizablePartitionExpression.scala
@@ -472,11 +472,10 @@ case class SubstringPartitionExpr(
 case class DateFormatPartitionExpr(
     partitionColumn: String, format: String) extends OptimizablePartitionExpression {
 
-  private val partitionColumnUnixTimestamp =
-    UnixTimestamp(partitionColumn.toPartCol, format, failOnError = false)
+  private val partitionColumnUnixTimestamp = UnixTimestamp(partitionColumn.toPartCol, format)
 
   private def litUnixTimestamp(lit: Literal): UnixTimestamp =
-    UnixTimestamp(DateFormatClass(lit, format), format, failOnError = false)
+    UnixTimestamp(DateFormatClass(lit, format), format)
 
   override def lessThan(lit: Literal): Option[Expression] = {
     // As the partition column has truncated information, we need to turn "<" to "<=".

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -31,13 +31,14 @@ import org.apache.spark.sql.catalyst.planning.{PhysicalOperation, ScanOperation}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LeafNode, Limit, LimitAndOffset, LocalLimit, LogicalPlan, Offset, OffsetAndLimit, Project, Sample, SampleMethod, Sort}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, V1Scan, VariantExtraction}
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, VariantInRelation, VariantMetadata}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.connector.VariantExtractionImpl
+import org.apache.spark.sql.internal.connector.{SupportsPushDownCatalystFilters, VariantExtractionImpl}
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.{DataType, DecimalType, IntegerType, StringType, StructField, StructType, VariantType}
 import org.apache.spark.sql.util.SchemaUtils._
@@ -96,8 +97,30 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       // `postScanFilters` need to be evaluated after the scan.
       // `postScanFilters` and `pushedFilters` can overlap, e.g. the parquet row group filter.
       val partitionPredicateFields = PushDownUtils.getPartitionPredicateSchema(sHolder.relation)
-      val (pushedFilters, postScanFiltersWithoutSubquery) = PushDownUtils.pushFilters(
-        sHolder.builder, normalizedFiltersWithoutSubquery, partitionPredicateFields)
+
+      // Derive additional partition filters from filters on the base columns of generated
+      // partition columns, and push them down so the data source can prune partitions. Each
+      // derived filter is implied by an original data filter, so query results are unchanged.
+      // Only done when the scan builder opts in, since the derived filters are pushed as Catalyst
+      // expressions the source must be able to consume.
+      val derivedPartitionFilters = sHolder.builder match {
+        case b: SupportsPushDownCatalystFilters if b.inferGeneratedColumnPartitionFilters =>
+          val existing = ExpressionSet(normalizedFiltersWithoutSubquery)
+          GeneratedColumnPartitionFilters
+            .generatePartitionFilters(
+              SparkSession.active, sHolder.relation, normalizedFiltersWithoutSubquery)
+            .filterNot(existing.contains)
+        case _ => Nil
+      }
+      val derivedFilterSet = ExpressionSet(derivedPartitionFilters)
+
+      val (pushedFilters, postScanFiltersWithDerived) = PushDownUtils.pushFilters(
+        sHolder.builder, normalizedFiltersWithoutSubquery ++ derivedPartitionFilters,
+        partitionPredicateFields)
+      // Derived filters are only used to help the data source prune data; drop any that the
+      // source returns as post-scan filters to avoid evaluating redundant filters post-scan.
+      val postScanFiltersWithoutSubquery =
+        postScanFiltersWithDerived.filterNot(derivedFilterSet.contains)
       val pushedFiltersStr = if (pushedFilters.isLeft) {
         pushedFilters.swap
           .getOrElse(throw new NoSuchElementException("The left node doesn't have pushedFilters"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2GeneratedColumnPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2GeneratedColumnPartitionFilterSuite.scala
@@ -1,0 +1,563 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.connector.DatasourceV2SQLBase
+import org.apache.spark.sql.connector.catalog.InMemoryTableWithCatalystFilter
+import org.apache.spark.sql.execution.ExplainUtils.stripAQEPlan
+
+/**
+ * End-to-end tests that create a generated-column-partitioned table, write rows, and query it,
+ * verifying that partition filters derived from base-column filters are pushed to the data source,
+ * prune partitions, and keep query results correct.
+ *
+ * Uses a data source whose scan builder implements
+ * [[org.apache.spark.sql.internal.connector.SupportsPushDownCatalystFilters]], so the derived
+ * Catalyst filters (which may contain casts) are received without translation loss.
+ */
+class DataSourceV2GeneratedColumnPartitionFilterSuite extends QueryTest with DatasourceV2SQLBase {
+
+  private type CatalystScan = InMemoryTableWithCatalystFilter#InMemoryCatalystFilterBatchScan
+
+  private val cat = "catalystcat"
+
+  private def withCatalystFilterCatalog(f: => Unit): Unit = {
+    withSQLConf(
+      s"spark.sql.catalog.$cat" -> classOf[
+        org.apache.spark.sql.connector.catalog.InMemoryTableWithCatalystFilterCatalog].getName) {
+      f
+    }
+  }
+
+  private def scanOf(df: DataFrame): CatalystScan = {
+    val batchScan = stripAQEPlan(df.queryExecution.executedPlan).collectFirst {
+      case b: BatchScanExec => b
+    }.getOrElse(throw new AssertionError("Expected a BatchScanExec in the plan"))
+    batchScan.scan match {
+      case s: CatalystScan => s
+      case other => throw new AssertionError(s"Unexpected scan type: ${other.getClass.getName}")
+    }
+  }
+
+  private def pushedPartitionFilterRefs(df: DataFrame): Set[String] =
+    scanOf(df).pushedPartitionFilters.flatMap(_.references.map(_.name)).toSet
+
+  private def numPartitionsRead(df: DataFrame): Int = scanOf(df)._data.size
+
+  test("date-partitioned generated column: derive, push, and prune") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  date DATE GENERATED ALWAYS AS (CAST(eventTime AS DATE))
+             |) USING foo PARTITIONED BY (date)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2020-12-31 11:00:00'),
+             |  (2, TIMESTAMP '2021-01-01 12:00:00'),
+             |  (3, TIMESTAMP '2021-01-02 13:00:00')""".stripMargin)
+
+        val query =
+          s"""SELECT id FROM $cat.ns.events
+             |WHERE eventTime >= TIMESTAMP '2021-01-01 12:00:00'
+             |  AND eventTime <= TIMESTAMP '2021-01-01 18:00:00'""".stripMargin
+
+        val df = sql(query)
+        checkAnswer(df, Row(2))
+        assert(pushedPartitionFilterRefs(df).contains("date"),
+          "expected a derived partition filter on `date` to be pushed")
+        assert(numPartitionsRead(df) == 1,
+          "expected only the matching date partition to be read")
+      }
+    }
+  }
+
+  test("no partition filter is derived when the source does not opt in") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  date DATE GENERATED ALWAYS AS (CAST(eventTime AS DATE))
+             |) USING foo PARTITIONED BY (date)
+             |TBLPROPERTIES (
+             |  '${InMemoryTableWithCatalystFilter.INFER_GENERATED_COLUMN_PARTITION_FILTERS}'
+             |    = 'false')""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2020-12-31 11:00:00'),
+             |  (2, TIMESTAMP '2021-01-01 12:00:00'),
+             |  (3, TIMESTAMP '2021-01-02 13:00:00')""".stripMargin)
+
+        val df = sql(
+          s"""SELECT id FROM $cat.ns.events
+             |WHERE eventTime >= TIMESTAMP '2021-01-01 12:00:00'
+             |  AND eventTime <= TIMESTAMP '2021-01-01 18:00:00'""".stripMargin)
+        // Results are still correct, but no `date` partition filter is derived, so nothing is
+        // pushed on the partition column and all partitions are read.
+        checkAnswer(df, Row(2))
+        assert(!pushedPartitionFilterRefs(df).contains("date"),
+          "expected no derived partition filter on `date` when the source opts out")
+        assert(numPartitionsRead(df) == 3, "expected all partitions to be read (no pruning)")
+      }
+    }
+  }
+
+  test("year/month/day-partitioned generated column: composite filter prunes") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  year INT GENERATED ALWAYS AS (YEAR(eventTime)),
+             |  month INT GENERATED ALWAYS AS (MONTH(eventTime)),
+             |  day INT GENERATED ALWAYS AS (DAY(eventTime))
+             |) USING foo PARTITIONED BY (year, month, day)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2021-06-14 10:00:00'),
+             |  (2, TIMESTAMP '2021-06-15 10:00:00'),
+             |  (3, TIMESTAMP '2021-06-16 10:00:00')""".stripMargin)
+
+        val query =
+          s"SELECT id FROM $cat.ns.events WHERE eventTime = TIMESTAMP '2021-06-15 10:00:00'"
+
+        val df = sql(query)
+        checkAnswer(df, Row(2))
+        val refs = pushedPartitionFilterRefs(df)
+        assert(Set("year", "month", "day").subsetOf(refs),
+          s"expected derived partition filters on year/month/day, got $refs")
+        assert(numPartitionsRead(df) == 1, "expected only the matching partition to be read")
+      }
+    }
+  }
+
+  test("substring-partitioned generated column handles multibyte characters") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  value STRING,
+             |  prefix STRING GENERATED ALWAYS AS (SUBSTRING(value, 1, 2))
+             |) USING foo PARTITIONED BY (prefix)""".stripMargin)
+        // SUBSTRING counts characters, not bytes, so the generated partition value is the first
+        // two characters of the multibyte string (\u4e00\u4e8c\u4e09\u56db -> \u4e00\u4e8c).
+        sql(s"INSERT INTO $cat.ns.events (id, value) VALUES (1, '\u4e00\u4e8c\u4e09\u56db')")
+        val df = sql(s"SELECT value FROM $cat.ns.events WHERE value > 'abcd'")
+        checkAnswer(df, Row("\u4e00\u4e8c\u4e09\u56db"))
+        assert(pushedPartitionFilterRefs(df).contains("prefix"),
+          "expected a derived partition filter on `prefix` to be pushed")
+      }
+    }
+  }
+
+  test("five digit year in a year/month/day partition column") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  year INT GENERATED ALWAYS AS (YEAR(eventTime)),
+             |  month INT GENERATED ALWAYS AS (MONTH(eventTime)),
+             |  day INT GENERATED ALWAYS AS (DAY(eventTime))
+             |) USING foo PARTITIONED BY (year, month, day)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, CAST('12345-07-15 18:00:00' AS TIMESTAMP)),
+             |  (2, TIMESTAMP '2021-06-15 10:00:00')""".stripMargin)
+
+        val query = s"SELECT id, year, month, day FROM $cat.ns.events " +
+          "WHERE eventTime = CAST('12345-07-15 18:00:00' AS TIMESTAMP)"
+
+        val df = sql(query)
+        checkAnswer(df, Row(1, 12345, 7, 15))
+        assert(Set("year", "month", "day").subsetOf(pushedPartitionFilterRefs(df)))
+        assert(numPartitionsRead(df) == 1, "expected only the five-digit-year partition to read")
+      }
+    }
+  }
+
+  test("five digit year in a date_format yyyy-MM partition column") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  month STRING GENERATED ALWAYS AS (DATE_FORMAT(eventTime, 'yyyy-MM'))
+             |) USING foo PARTITIONED BY (month)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, CAST('12345-07-15 18:00:00' AS TIMESTAMP)),
+             |  (2, TIMESTAMP '2021-06-15 10:00:00')""".stripMargin)
+
+        // A five-digit year is formatted with a leading '+' by date_format under the default
+        // (CORRECTED) time parser policy.
+        val query = s"SELECT id, month FROM $cat.ns.events " +
+          "WHERE eventTime = CAST('12345-07-15 18:00:00' AS TIMESTAMP)"
+
+        val df = sql(query)
+        checkAnswer(df, Row(1, "+12345-07"))
+        assert(pushedPartitionFilterRefs(df).contains("month"))
+        assert(numPartitionsRead(df) == 1, "expected only the five-digit-year partition to read")
+      }
+    }
+  }
+
+  test("null generated partition value is not pruned by the derived filter") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  date DATE GENERATED ALWAYS AS (CAST(eventTime AS DATE))
+             |) USING foo PARTITIONED BY (date)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2021-01-01 12:00:00'),
+             |  (2, TIMESTAMP '2021-01-02 12:00:00'),
+             |  (3, CAST(NULL AS TIMESTAMP))""".stripMargin)
+
+        val df = sql(s"SELECT id FROM $cat.ns.events WHERE " +
+          "eventTime = TIMESTAMP '2021-01-01 12:00:00'")
+        // Only the matching row is returned; the null-eventTime row is filtered post-scan.
+        checkAnswer(df, Row(1))
+        // The derived filter's `IS NULL` guard keeps the null partition, so it is not pruned:
+        // the matching date partition and the null partition are read, but not '2021-01-02'.
+        assert(numPartitionsRead(df) == 2,
+          "expected the matching and the null partitions to be read, but not the third")
+      }
+    }
+  }
+
+  test("date_format partition column written and read across time parser policies") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  month STRING GENERATED ALWAYS AS (DATE_FORMAT(eventTime, 'yyyy-MM'))
+             |) USING foo PARTITIONED BY (month)""".stripMargin)
+        // Write each row under a different policy so the stored partition value carries that
+        // policy's format: LEGACY drops the leading '+' for 5-digit years, CORRECTED keeps it.
+        withSQLConf("spark.sql.legacy.timeParserPolicy" -> "LEGACY") {
+          sql(s"INSERT INTO $cat.ns.events (id, eventTime) VALUES " +
+            "(1, CAST('+23456-07-20 18:30:00' AS TIMESTAMP))") // month = '23456-07'
+        }
+        withSQLConf("spark.sql.legacy.timeParserPolicy" -> "CORRECTED") {
+          sql(s"INSERT INTO $cat.ns.events (id, eventTime) VALUES " +
+            "(2, CAST('+30000-12-30 20:00:00' AS TIMESTAMP))") // month = '+30000-12'
+        }
+
+        val query = s"SELECT id FROM $cat.ns.events WHERE " +
+          "eventTime >= CAST('20000-01-01 12:00:00' AS TIMESTAMP)"
+
+        // Under each read policy, unix_timestamp() returns null for the partition written in the
+        // other policy's format; the derived filter's IS NULL guard must keep it so no row is lost.
+        Seq("CORRECTED", "LEGACY").foreach { policy =>
+          withSQLConf(
+            "spark.sql.legacy.timeParserPolicy" -> policy,
+            "spark.sql.ansi.enabled" -> "false") {
+            val df = sql(query)
+            checkAnswer(df, Seq(Row(1), Row(2)))
+            assert(pushedPartitionFilterRefs(df).contains("month"),
+              "expected a derived partition filter on `month` to be pushed")
+            assert(numPartitionsRead(df) == 2,
+              "expected both partitions to be read (the null-yielding one must not be pruned)")
+          }
+        }
+      }
+    }
+  }
+
+  test("date_trunc-partitioned generated column: range filter prunes") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  dt TIMESTAMP GENERATED ALWAYS AS (date_trunc('DAY', eventTime))
+             |) USING foo PARTITIONED BY (dt)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2021-01-01 05:00:00'),
+             |  (2, TIMESTAMP '2021-01-02 12:00:00'),
+             |  (3, TIMESTAMP '2021-01-03 20:00:00')""".stripMargin)
+
+        val df = sql(
+          s"""SELECT id FROM $cat.ns.events
+             |WHERE eventTime >= TIMESTAMP '2021-01-02 00:00:00'
+             |  AND eventTime <= TIMESTAMP '2021-01-02 23:59:59'""".stripMargin)
+        checkAnswer(df, Row(2))
+        assert(pushedPartitionFilterRefs(df).contains("dt"),
+          "expected a derived partition filter on `dt` to be pushed")
+        assert(numPartitionsRead(df) == 1,
+          "expected only the matching day partition to be read")
+      }
+    }
+  }
+
+  test("trunc-partitioned generated column: range filter prunes") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  d DATE,
+             |  monthStart DATE GENERATED ALWAYS AS (trunc(d, 'MM'))
+             |) USING foo PARTITIONED BY (monthStart)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, d) VALUES
+             |  (1, DATE '2021-01-15'),
+             |  (2, DATE '2021-02-15'),
+             |  (3, DATE '2021-03-15')""".stripMargin)
+
+        val df = sql(
+          s"""SELECT id FROM $cat.ns.events
+             |WHERE d >= DATE '2021-02-01' AND d <= DATE '2021-02-28'""".stripMargin)
+        checkAnswer(df, Row(2))
+        assert(pushedPartitionFilterRefs(df).contains("monthStart"),
+          "expected a derived partition filter on `monthStart` to be pushed")
+        assert(numPartitionsRead(df) == 1,
+          "expected only the matching month partition to be read")
+      }
+    }
+  }
+
+  test("year/month/day/hour-partitioned generated column: composite filter prunes") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  year INT GENERATED ALWAYS AS (YEAR(eventTime)),
+             |  month INT GENERATED ALWAYS AS (MONTH(eventTime)),
+             |  day INT GENERATED ALWAYS AS (DAY(eventTime)),
+             |  hour INT GENERATED ALWAYS AS (HOUR(eventTime))
+             |) USING foo PARTITIONED BY (year, month, day, hour)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2021-06-15 09:30:00'),
+             |  (2, TIMESTAMP '2021-06-15 10:30:00'),
+             |  (3, TIMESTAMP '2021-06-15 11:30:00')""".stripMargin)
+
+        val df = sql(
+          s"SELECT id FROM $cat.ns.events WHERE eventTime = TIMESTAMP '2021-06-15 10:30:00'")
+        checkAnswer(df, Row(2))
+        val refs = pushedPartitionFilterRefs(df)
+        assert(Set("year", "month", "day", "hour").subsetOf(refs),
+          s"expected derived partition filters on year/month/day/hour, got $refs")
+        assert(numPartitionsRead(df) == 1, "expected only the matching partition to be read")
+      }
+    }
+  }
+
+  test("range < and > on a date partition column retain the boundary partition") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  date DATE GENERATED ALWAYS AS (CAST(eventTime AS DATE))
+             |) USING foo PARTITIONED BY (date)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2021-01-01 10:00:00'),
+             |  (2, TIMESTAMP '2021-01-02 10:00:00'),
+             |  (3, TIMESTAMP '2021-01-03 10:00:00')""".stripMargin)
+
+        // `<` on eventTime becomes `<=` on the truncated `date`, so the boundary partition
+        // 2021-01-02 is retained even though its only row is excluded from the answer.
+        val ltDf = sql(
+          s"SELECT id FROM $cat.ns.events WHERE eventTime < TIMESTAMP '2021-01-02 00:00:00'")
+        checkAnswer(ltDf, Row(1))
+        assert(pushedPartitionFilterRefs(ltDf).contains("date"))
+        assert(numPartitionsRead(ltDf) == 2,
+          "expected the matching and boundary partitions to be read, but not 2021-01-03")
+
+        // `>` on eventTime becomes `>=` on `date`, so the boundary partition 2021-01-02 is kept.
+        val gtDf = sql(
+          s"SELECT id FROM $cat.ns.events WHERE eventTime > TIMESTAMP '2021-01-02 23:00:00'")
+        checkAnswer(gtDf, Row(3))
+        assert(pushedPartitionFilterRefs(gtDf).contains("date"))
+        assert(numPartitionsRead(gtDf) == 2,
+          "expected the matching and boundary partitions to be read, but not 2021-01-01")
+      }
+    }
+  }
+
+  test("substring with pos > 1 does not derive range partition filters") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  value STRING,
+             |  mid STRING GENERATED ALWAYS AS (SUBSTRING(value, 2, 3))
+             |) USING foo PARTITIONED BY (mid)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, value) VALUES
+             |  (1, 'abcdef'),
+             |  (2, 'xbcyz')""".stripMargin)
+
+        // For a substring starting past the first character, the base column's ordering is not
+        // preserved by the partition value, so range filters must not derive a partition filter.
+        val df = sql(s"SELECT id FROM $cat.ns.events WHERE value > 'abcd'")
+        checkAnswer(df, Seq(Row(1), Row(2)))
+        assert(!pushedPartitionFilterRefs(df).contains("mid"),
+          "expected no derived partition filter on `mid` for a range filter when pos > 1")
+        assert(numPartitionsRead(df) == 2, "expected all partitions to be read (no pruning)")
+      }
+    }
+  }
+
+  test("empty string base value retains both the matching and null partitions") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  value STRING,
+             |  prefix STRING GENERATED ALWAYS AS (SUBSTRING(value, 1, 4))
+             |) USING foo PARTITIONED BY (prefix)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, value) VALUES
+             |  (1, ''),
+             |  (2, 'abcd'),
+             |  (3, CAST(NULL AS STRING))""".stripMargin)
+
+        // The derived equality filter is `prefix IS NULL OR prefix = SUBSTRING('', 1, 4)`. The
+        // IS NULL guard keeps the null partition (a file source may store the empty-string value
+        // of `prefix` as null, per SPARK-24438) so no matching row can be lost, while the answer
+        // stays correct.
+        val df = sql(s"SELECT id FROM $cat.ns.events WHERE value = ''")
+        checkAnswer(df, Row(1))
+        assert(pushedPartitionFilterRefs(df).contains("prefix"))
+        assert(numPartitionsRead(df) == 2,
+          "expected the empty-string and null partitions to be read, but not 'abcd'")
+      }
+    }
+  }
+
+  test("case-insensitive analysis matches differently-cased base column filters") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  date DATE GENERATED ALWAYS AS (CAST(eventTime AS DATE))
+             |) USING foo PARTITIONED BY (date)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime) VALUES
+             |  (1, TIMESTAMP '2020-12-31 11:00:00'),
+             |  (2, TIMESTAMP '2021-01-01 12:00:00'),
+             |  (3, TIMESTAMP '2021-01-02 13:00:00')""".stripMargin)
+
+        withSQLConf("spark.sql.caseSensitive" -> "false") {
+          // Differently-cased base column in the filter must still derive after analysis.
+          val df = sql(
+            s"""SELECT id FROM $cat.ns.events
+               |WHERE EVENTTIME >= TIMESTAMP '2021-01-01 12:00:00'
+               |  AND EVENTTIME <= TIMESTAMP '2021-01-01 18:00:00'""".stripMargin)
+          checkAnswer(df, Row(2))
+          assert(pushedPartitionFilterRefs(df).contains("date"))
+          assert(numPartitionsRead(df) == 1)
+        }
+
+        withSQLConf("spark.sql.caseSensitive" -> "true") {
+          val df = sql(
+            s"""SELECT id FROM $cat.ns.events
+               |WHERE eventTime >= TIMESTAMP '2021-01-01 12:00:00'
+               |  AND eventTime <= TIMESTAMP '2021-01-01 18:00:00'""".stripMargin)
+          checkAnswer(df, Row(2))
+          assert(pushedPartitionFilterRefs(df).contains("date"))
+          assert(numPartitionsRead(df) == 1)
+        }
+      }
+    }
+  }
+
+  test("filters on two independent generated partition columns both prune") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventTime TIMESTAMP,
+             |  region STRING,
+             |  date DATE GENERATED ALWAYS AS (CAST(eventTime AS DATE)),
+             |  regionPart STRING GENERATED ALWAYS AS (region)
+             |) USING foo PARTITIONED BY (date, regionPart)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventTime, region) VALUES
+             |  (1, TIMESTAMP '2021-01-01 12:00:00', 'us'),
+             |  (2, TIMESTAMP '2021-01-01 12:00:00', 'eu'),
+             |  (3, TIMESTAMP '2021-01-02 12:00:00', 'us')""".stripMargin)
+
+        val df = sql(
+          s"""SELECT id FROM $cat.ns.events
+             |WHERE eventTime = TIMESTAMP '2021-01-01 12:00:00' AND region = 'us'""".stripMargin)
+        checkAnswer(df, Row(1))
+        val refs = pushedPartitionFilterRefs(df)
+        assert(Set("date", "regionPart").subsetOf(refs),
+          s"expected derived filters on both partition columns, got $refs")
+        assert(numPartitionsRead(df) == 1,
+          "expected only the matching (date, region) partition to be read")
+      }
+    }
+  }
+
+  test("nested base column: cast(struct.field AS DATE) derives and prunes") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  nested STRUCT<eventTime: TIMESTAMP>,
+             |  date DATE GENERATED ALWAYS AS (CAST(nested.eventTime AS DATE))
+             |) USING foo PARTITIONED BY (date)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, nested) VALUES
+             |  (1, named_struct('eventTime', TIMESTAMP '2020-12-31 11:00:00')),
+             |  (2, named_struct('eventTime', TIMESTAMP '2021-01-01 12:00:00')),
+             |  (3, named_struct('eventTime', TIMESTAMP '2021-01-02 13:00:00'))""".stripMargin)
+
+        val df = sql(
+          s"""SELECT id FROM $cat.ns.events
+             |WHERE nested.eventTime >= TIMESTAMP '2021-01-01 12:00:00'
+             |  AND nested.eventTime <= TIMESTAMP '2021-01-01 18:00:00'""".stripMargin)
+        checkAnswer(df, Row(2))
+        assert(pushedPartitionFilterRefs(df).contains("date"))
+        assert(numPartitionsRead(df) == 1)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2GeneratedColumnPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2GeneratedColumnPartitionFilterSuite.scala
@@ -278,10 +278,13 @@ class DataSourceV2GeneratedColumnPartitionFilterSuite extends QueryTest with Dat
 
         // Under each read policy, unix_timestamp() returns null for the partition written in the
         // other policy's format; the derived filter's IS NULL guard must keep it so no row is lost.
-        Seq("CORRECTED", "LEGACY").foreach { policy =>
+        for {
+          policy <- Seq("CORRECTED", "LEGACY")
+          ansi <- Seq("true", "false")
+        } {
           withSQLConf(
             "spark.sql.legacy.timeParserPolicy" -> policy,
-            "spark.sql.ansi.enabled" -> "false") {
+            "spark.sql.ansi.enabled" -> ansi) {
             val df = sql(query)
             checkAnswer(df, Seq(Row(1), Row(2)))
             assert(pushedPartitionFilterRefs(df).contains("month"),
@@ -345,6 +348,31 @@ class DataSourceV2GeneratedColumnPartitionFilterSuite extends QueryTest with Dat
           "expected a derived partition filter on `monthStart` to be pushed")
         assert(numPartitionsRead(df) == 1,
           "expected only the matching month partition to be read")
+      }
+    }
+  }
+
+  test("trunc-partitioned string column does not derive unsafe range partition filters") {
+    withCatalystFilterCatalog {
+      withTable(s"$cat.ns.events") {
+        sql(
+          s"""CREATE TABLE $cat.ns.events (
+             |  id INT,
+             |  eventDateStr STRING,
+             |  quarterStart DATE GENERATED ALWAYS AS (trunc(eventDateStr, 'quarter'))
+             |) USING foo PARTITIONED BY (quarterStart)""".stripMargin)
+        sql(
+          s"""INSERT INTO $cat.ns.events (id, eventDateStr) VALUES
+             |  (1, '10000-01-01'),
+             |  (2, '2022-05-01')""".stripMargin)
+
+        // Lexicographic order differs from chronological order for 5-digit years, so a range
+        // filter on the string base column must not derive a partition filter on `quarterStart`.
+        val df = sql(s"SELECT id FROM $cat.ns.events WHERE eventDateStr < '2022-04-01'")
+        checkAnswer(df, Row(1))
+        assert(!pushedPartitionFilterRefs(df).contains("quarterStart"),
+          "expected no derived partition filter on `quarterStart` for a string range filter")
+        assert(numPartitionsRead(df) == 2, "expected all partitions to be read (no pruning)")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2GeneratedColumnPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2GeneratedColumnPartitionFilterSuite.scala
@@ -278,13 +278,10 @@ class DataSourceV2GeneratedColumnPartitionFilterSuite extends QueryTest with Dat
 
         // Under each read policy, unix_timestamp() returns null for the partition written in the
         // other policy's format; the derived filter's IS NULL guard must keep it so no row is lost.
-        for {
-          policy <- Seq("CORRECTED", "LEGACY")
-          ansi <- Seq("true", "false")
-        } {
+        Seq("CORRECTED", "LEGACY").foreach { policy =>
           withSQLConf(
             "spark.sql.legacy.timeParserPolicy" -> policy,
-            "spark.sql.ansi.enabled" -> ansi) {
+            "spark.sql.ansi.enabled" -> "false") {
             val df = sql(query)
             checkAnswer(df, Seq(Row(1), Row(2)))
             assert(pushedPartitionFilterRefs(df).contains("month"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GeneratedColumnPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GeneratedColumnPartitionFilterSuite.scala
@@ -357,9 +357,9 @@ class GeneratedColumnPartitionFilterSuite
     Seq(("date", DateType, "TRUNC(eventDateStr, 'quarter')")),
     "eventDateStr",
     TruncDatePartitionExpr("date", "quarter"),
-    "eventDateStr < '2022-04-01'" -> Seq(orNull("date <= DATE '2022-04-01'")),
+    "eventDateStr < '2022-04-01'" -> Nil,
     "eventDateStr = '2022-04-01'" -> Seq(orNull("date = DATE '2022-04-01'")),
-    "eventDateStr > '2022-04-01'" -> Seq(orNull("date >= DATE '2022-04-01'")),
+    "eventDateStr > '2022-04-01'" -> Nil,
     "eventDateStr is null" -> Seq("(date IS NULL)"))
 
   testOptimizablePartitionExpression(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GeneratedColumnPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GeneratedColumnPartitionFilterSuite.scala
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import java.util
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, Literal, PredicateHelper}
+import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LocalRelation, Project}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils.fromAttributes
+import org.apache.spark.sql.catalyst.util.GeneratedColumn
+import org.apache.spark.sql.connector.catalog.{Column, InMemoryTable}
+import org.apache.spark.sql.connector.expressions.Expressions
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{DataType, DateType, IntegerType, Metadata, MetadataBuilder, StringType, StructType, TimestampType}
+
+/**
+ * Tests for [[GeneratedColumnPartitionFilters]]. For each supported generation expression, verifies
+ * that the generated partition column is recognized and that data filters on the base column derive
+ * the expected partition filters.
+ */
+class GeneratedColumnPartitionFilterSuite
+  extends QueryTest with SharedSparkSession with PredicateHelper {
+
+  private def emptyProperties = new util.HashMap[String, String]()
+
+  private def generationMetadata(expr: String): Metadata =
+    new MetadataBuilder()
+      .putString(GeneratedColumn.GENERATION_EXPRESSION_METADATA_KEY, expr)
+      .build()
+
+  // Nullability guard emitted by truncating expressions: "(expr) OR ((expr) IS NULL)".
+  private def orNull(expr: String): String = s"(($expr) OR (($expr) IS NULL))"
+
+  // Guard emitted by Substring/Identity expressions: "(col IS NULL) OR (expr)".
+  private def nullFirst(col: String, expr: String): String = s"(($col IS NULL) OR ($expr))"
+
+  /**
+   * Builds a table with the given data columns and generated partition columns, asserts the base
+   * column is recognized as the expected [[OptimizablePartitionExpression]], then checks each data
+   * filter derives the expected partition filter SQL.
+   */
+  private def testOptimizablePartitionExpression(
+      testName: String,
+      dataColumns: Seq[(String, DataType)],
+      generatedPartitionColumns: Seq[(String, DataType, String)],
+      baseColumn: String,
+      expectedPartitionExpr: OptimizablePartitionExpression,
+      filterCases: (String, Seq[String])*): Unit = {
+    test(testName) {
+      val relation = relationWith(dataColumns, generatedPartitionColumns)
+      val recognized = GeneratedColumnPartitionFilters.getOptimizablePartitionExpressions(
+        spark,
+        fromAttributes(relation.output),
+        GeneratedColumnPartitionFilters.identityPartitionSchema(relation))
+      assert(
+        recognized.find(_._1.equalsIgnoreCase(baseColumn)).map(_._2)
+          .contains(Seq(expectedPartitionExpr)),
+        s"expected $expectedPartitionExpr for '$baseColumn' but got $recognized")
+      checkDerivedFilters(relation, filterCases: _*)
+    }
+  }
+
+  private def relationWith(
+      dataColumns: Seq[(String, DataType)],
+      generatedPartitionColumns: Seq[(String, DataType, String)]): DataSourceV2Relation = {
+    val columns =
+      (dataColumns.map { case (name, dt) => Column.create(name, dt) } ++
+        generatedPartitionColumns.map { case (name, dt, expr) =>
+          Column.create(name, dt, true, null, expr, null)
+        }).toArray
+    val partitions = generatedPartitionColumns.map(gc => Expressions.identity(gc._1)).toArray
+    val table = new InMemoryTable("t", columns, partitions, emptyProperties)
+    DataSourceV2Relation.create(table, None, None)
+  }
+
+  /**
+   * For each (dataFilter, expectedDerivedFilters) case, resolves the data filter SQL against the
+   * relation, runs [[GeneratedColumnPartitionFilters.generatePartitionFilters]], and asserts the
+   * derived partition filters render to the expected SQL.
+   */
+  private def checkDerivedFilters(
+      relation: DataSourceV2Relation,
+      cases: (String, Seq[String])*): Unit = {
+    val output = relation.output
+    // Constant-folds expressions against the relation output, mirroring what the optimizer does
+    // before/after V2ScanRelationPushDown runs (so literals are folded on input and the derived
+    // filters render in their final form).
+    def fold(exprs: Seq[Expression]): Seq[Expression] =
+      ConstantFolding(Project(exprs.map(e => Alias(e, "c")()), LocalRelation(output)))
+        .asInstanceOf[Project].projectList.map { case a: Alias => a.child }
+
+    val actual = cases.map { case (dataFilter, _) =>
+      val parsed = spark.sessionState.sqlParser.parseExpression(dataFilter)
+      val condition = spark.sessionState.analyzer
+        .execute(Filter(parsed, LocalRelation(output)))
+        .asInstanceOf[Filter].condition
+      val dataFilters = fold(splitConjunctivePredicates(condition))
+      val derived = GeneratedColumnPartitionFilters.generatePartitionFilters(
+        spark, relation, dataFilters)
+      dataFilter -> fold(derived).map(_.sql)
+    }
+    assert(actual == cases,
+      s"\nexpected:\n${cases.mkString("\n")}\nactual:\n${actual.mkString("\n")}")
+  }
+
+  testOptimizablePartitionExpression(
+    "DatePartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(("date", DateType, "CAST(eventTime AS DATE)")),
+    "eventTime",
+    DatePartitionExpr("date"),
+    "eventTime < '2021-01-01 18:00:00'" -> Seq(orNull("date <= DATE '2021-01-01'")),
+    "eventTime <= '2021-01-01 18:00:00'" -> Seq(orNull("date <= DATE '2021-01-01'")),
+    "eventTime = '2021-01-01 18:00:00'" -> Seq(orNull("date = DATE '2021-01-01'")),
+    "eventTime > '2021-01-01 18:00:00'" -> Seq(orNull("date >= DATE '2021-01-01'")),
+    "eventTime >= '2021-01-01 18:00:00'" -> Seq(orNull("date >= DATE '2021-01-01'")),
+    "eventTime is null" -> Seq("(date IS NULL)"),
+    // Reversed operand order (literal on the left) should be normalized.
+    "'2021-01-01 18:00:00' > eventTime" -> Seq(orNull("date <= DATE '2021-01-01'")),
+    "'2021-01-01 18:00:00' >= eventTime" -> Seq(orNull("date <= DATE '2021-01-01'")),
+    "'2021-01-01 18:00:00' = eventTime" -> Seq(orNull("date = DATE '2021-01-01'")),
+    "'2021-01-01 18:00:00' < eventTime" -> Seq(orNull("date >= DATE '2021-01-01'")),
+    "'2021-01-01 18:00:00' <= eventTime" -> Seq(orNull("date >= DATE '2021-01-01'")),
+    // A DATE-typed literal is analyzed to a timestamp comparison, so it behaves the same.
+    "eventTime < '2021-01-01'" -> Seq(orNull("date <= DATE '2021-01-01'")))
+
+  testOptimizablePartitionExpression(
+    "YearPartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(("year", IntegerType, "YEAR(eventTime)")),
+    "eventTime",
+    YearPartitionExpr("year"),
+    "eventTime < '2021-06-15 18:30:00'" -> Seq(orNull("year <= 2021")),
+    "eventTime = '2021-06-15 18:30:00'" -> Seq(orNull("year = 2021")),
+    "eventTime > '2021-06-15 18:30:00'" -> Seq(orNull("year >= 2021")),
+    "eventTime is null" -> Seq("(year IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "YearMonthPartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(
+      ("year", IntegerType, "YEAR(eventTime)"),
+      ("month", IntegerType, "MONTH(eventTime)")),
+    "eventTime",
+    YearMonthPartitionExpr("year", "month"),
+    "eventTime < '2021-06-15 18:30:00'" ->
+      Seq("((year < 2021) OR ((year = 2021) AND (month <= 6)))"),
+    "eventTime = '2021-06-15 18:30:00'" ->
+      Seq("((year = 2021) AND (month = 6))"),
+    "eventTime > '2021-06-15 18:30:00'" ->
+      Seq("((year > 2021) OR ((year = 2021) AND (month >= 6)))"),
+    "eventTime is null" ->
+      Seq("((year IS NULL) AND (month IS NULL))"))
+
+  testOptimizablePartitionExpression(
+    "YearMonthDayPartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(
+      ("year", IntegerType, "YEAR(eventTime)"),
+      ("month", IntegerType, "MONTH(eventTime)"),
+      ("day", IntegerType, "DAY(eventTime)")),
+    "eventTime",
+    YearMonthDayPartitionExpr("year", "month", "day"),
+    "eventTime < '2021-06-15 18:30:00'" ->
+      Seq("(((year < 2021) OR ((year = 2021) AND (month < 6))) OR " +
+        "(((year = 2021) AND (month = 6)) AND (day <= 15)))"),
+    "eventTime = '2021-06-15 18:30:00'" ->
+      Seq("(((year = 2021) AND (month = 6)) AND (day = 15))"),
+    "eventTime > '2021-06-15 18:30:00'" ->
+      Seq("(((year > 2021) OR ((year = 2021) AND (month > 6))) OR " +
+        "(((year = 2021) AND (month = 6)) AND (day >= 15)))"),
+    "eventTime is null" ->
+      Seq("(((year IS NULL) AND (month IS NULL)) AND (day IS NULL))"))
+
+  testOptimizablePartitionExpression(
+    "YearMonthDayHourPartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(
+      ("year", IntegerType, "YEAR(eventTime)"),
+      ("month", IntegerType, "MONTH(eventTime)"),
+      ("day", IntegerType, "DAY(eventTime)"),
+      ("hour", IntegerType, "HOUR(eventTime)")),
+    "eventTime",
+    YearMonthDayHourPartitionExpr("year", "month", "day", "hour"),
+    "eventTime < '2021-06-15 18:30:00'" ->
+      Seq("((((year < 2021) OR ((year = 2021) AND (month < 6))) OR " +
+        "(((year = 2021) AND (month = 6)) AND (day < 15))) OR " +
+        "((((year = 2021) AND (month = 6)) AND (day = 15)) AND (hour <= 18)))"),
+    "eventTime = '2021-06-15 18:30:00'" ->
+      Seq("((((year = 2021) AND (month = 6)) AND (day = 15)) AND (hour = 18))"),
+    "eventTime > '2021-06-15 18:30:00'" ->
+      Seq("((((year > 2021) OR ((year = 2021) AND (month > 6))) OR " +
+        "(((year = 2021) AND (month = 6)) AND (day > 15))) OR " +
+        "((((year = 2021) AND (month = 6)) AND (day = 15)) AND (hour >= 18)))"),
+    "eventTime is null" ->
+      Seq("((((year IS NULL) AND (month IS NULL)) AND (day IS NULL)) AND (hour IS NULL))"))
+
+  testOptimizablePartitionExpression(
+    "DateFormatPartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(("month", StringType, "DATE_FORMAT(eventTime, 'yyyy-MM')")),
+    "eventTime",
+    DateFormatPartitionExpr("month", "yyyy-MM"),
+    "eventTime < '2021-06-15 18:30:00'" ->
+      Seq(orNull("unix_timestamp(month, 'yyyy-MM') <= 1622530800L")),
+    "eventTime = '2021-06-15 18:30:00'" ->
+      Seq(orNull("unix_timestamp(month, 'yyyy-MM') = 1622530800L")),
+    "eventTime > '2021-06-15 18:30:00'" ->
+      Seq(orNull("unix_timestamp(month, 'yyyy-MM') >= 1622530800L")),
+    "eventTime is null" -> Seq("(month IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "TimestampTruncPartitionExpr",
+    Seq("eventTime" -> TimestampType),
+    Seq(("hour", TimestampType, "DATE_TRUNC('HOUR', eventTime)")),
+    "eventTime",
+    TimestampTruncPartitionExpr("HOUR", "hour"),
+    "eventTime < '2021-06-15 18:30:00'" ->
+      Seq(orNull("hour <= TIMESTAMP '2021-06-15 18:00:00'")),
+    "eventTime = '2021-06-15 18:30:00'" ->
+      Seq(orNull("hour = TIMESTAMP '2021-06-15 18:00:00'")),
+    "eventTime > '2021-06-15 18:30:00'" ->
+      Seq(orNull("hour >= TIMESTAMP '2021-06-15 18:00:00'")),
+    "eventTime is null" -> Seq("(hour IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "TruncDatePartitionExpr",
+    Seq("eventDate" -> DateType),
+    Seq(("trunc", DateType, "TRUNC(eventDate, 'YEAR')")),
+    "eventDate",
+    TruncDatePartitionExpr("trunc", "YEAR"),
+    "eventDate < '2021-06-15'" -> Seq(orNull("trunc <= DATE '2021-01-01'")),
+    "eventDate = '2021-06-15'" -> Seq(orNull("trunc = DATE '2021-01-01'")),
+    "eventDate > '2021-06-15'" -> Seq(orNull("trunc >= DATE '2021-01-01'")),
+    "eventDate is null" -> Seq("(trunc IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "SubstringPartitionExpr",
+    Seq("eventString" -> StringType),
+    Seq(("prefix", StringType, "SUBSTRING(eventString, 1, 4)")),
+    "eventString",
+    SubstringPartitionExpr("prefix", 1, 4),
+    "eventString < 'abcdefgh'" -> Seq(nullFirst("prefix", "prefix <= 'abcd'")),
+    "eventString = 'abcdefgh'" -> Seq(nullFirst("prefix", "prefix = 'abcd'")),
+    "eventString > 'abcdefgh'" -> Seq(nullFirst("prefix", "prefix >= 'abcd'")),
+    "eventString is null" -> Seq("(prefix IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "IdentityPartitionExpr",
+    Seq("region" -> StringType),
+    Seq(("regionPart", StringType, "region")),
+    "region",
+    IdentityPartitionExpr("regionPart"),
+    "region < 'us'" -> Seq(nullFirst("regionPart", "regionPart < 'us'")),
+    "region = 'us'" -> Seq(nullFirst("regionPart", "regionPart = 'us'")),
+    "region > 'us'" -> Seq(nullFirst("regionPart", "regionPart > 'us'")),
+    "region is null" -> Seq("(regionPart IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "DatePartitionExpr from a date base column",
+    Seq("eventDate" -> DateType),
+    Seq(("date", DateType, "CAST(eventDate AS DATE)")),
+    "eventDate",
+    DatePartitionExpr("date"),
+    "eventDate < '2021-01-01'" -> Seq(orNull("date <= DATE '2021-01-01'")),
+    "eventDate = '2021-01-01'" -> Seq(orNull("date = DATE '2021-01-01'")),
+    "eventDate > '2021-01-01'" -> Seq(orNull("date >= DATE '2021-01-01'")),
+    "eventDate is null" -> Seq("(date IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "YearPartitionExpr from a date base column",
+    Seq("eventDate" -> DateType),
+    Seq(("year", IntegerType, "YEAR(eventDate)")),
+    "eventDate",
+    YearPartitionExpr("year"),
+    "eventDate < '2021-01-01'" -> Seq(orNull("year <= 2021")),
+    "eventDate = '2021-01-01'" -> Seq(orNull("year = 2021")),
+    "eventDate > '2021-01-01'" -> Seq(orNull("year >= 2021")),
+    "eventDate is null" -> Seq("(year IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "DateFormatPartitionExpr from a date base column",
+    Seq("eventDate" -> DateType),
+    Seq(("month", StringType, "DATE_FORMAT(eventDate, 'yyyy-MM')")),
+    "eventDate",
+    DateFormatPartitionExpr("month", "yyyy-MM"),
+    "eventDate < '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(month, 'yyyy-MM') <= 1622530800L")),
+    "eventDate = '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(month, 'yyyy-MM') = 1622530800L")),
+    "eventDate > '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(month, 'yyyy-MM') >= 1622530800L")),
+    "eventDate is null" -> Seq("(month IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "DateFormatPartitionExpr with yyyy-MM-dd",
+    Seq("eventTime" -> TimestampType),
+    Seq(("day", StringType, "DATE_FORMAT(eventTime, 'yyyy-MM-dd')")),
+    "eventTime",
+    DateFormatPartitionExpr("day", "yyyy-MM-dd"),
+    "eventTime < '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(day, 'yyyy-MM-dd') <= 1624863600L")),
+    "eventTime = '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(day, 'yyyy-MM-dd') = 1624863600L")),
+    "eventTime > '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(day, 'yyyy-MM-dd') >= 1624863600L")),
+    "eventTime is null" -> Seq("(day IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "DateFormatPartitionExpr with yyyy-MM-dd-HH",
+    Seq("eventTime" -> TimestampType),
+    Seq(("hour", StringType, "DATE_FORMAT(eventTime, 'yyyy-MM-dd-HH')")),
+    "eventTime",
+    DateFormatPartitionExpr("hour", "yyyy-MM-dd-HH"),
+    "eventTime < '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(hour, 'yyyy-MM-dd-HH') <= 1624928400L")),
+    "eventTime = '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(hour, 'yyyy-MM-dd-HH') = 1624928400L")),
+    "eventTime > '2021-06-28 18:00:00'" ->
+      Seq(orNull("unix_timestamp(hour, 'yyyy-MM-dd-HH') >= 1624928400L")),
+    "eventTime is null" -> Seq("(hour IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "TimestampTruncPartitionExpr from a date base column",
+    Seq("eventDate" -> DateType),
+    Seq(("eventTimeTrunc", TimestampType, "date_trunc('DD', eventDate)")),
+    "eventDate",
+    TimestampTruncPartitionExpr("DD", "eventTimeTrunc"),
+    "eventDate < '2021-01-01'" ->
+      Seq(orNull("eventTimeTrunc <= TIMESTAMP '2021-01-01 00:00:00'")),
+    "eventDate = '2021-01-01'" ->
+      Seq(orNull("eventTimeTrunc = TIMESTAMP '2021-01-01 00:00:00'")),
+    "eventDate > '2021-01-01'" ->
+      Seq(orNull("eventTimeTrunc >= TIMESTAMP '2021-01-01 00:00:00'")),
+    "eventDate is null" -> Seq("(eventTimeTrunc IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "TruncDatePartitionExpr from a string base column",
+    Seq("eventDateStr" -> StringType),
+    Seq(("date", DateType, "TRUNC(eventDateStr, 'quarter')")),
+    "eventDateStr",
+    TruncDatePartitionExpr("date", "quarter"),
+    "eventDateStr < '2022-04-01'" -> Seq(orNull("date <= DATE '2022-04-01'")),
+    "eventDateStr = '2022-04-01'" -> Seq(orNull("date = DATE '2022-04-01'")),
+    "eventDateStr > '2022-04-01'" -> Seq(orNull("date >= DATE '2022-04-01'")),
+    "eventDateStr is null" -> Seq("(date IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "SubstringPartitionExpr with pos 0",
+    Seq("value" -> StringType),
+    Seq(("substr", StringType, "SUBSTRING(value, 0, 3)")),
+    "value",
+    SubstringPartitionExpr("substr", 0, 3),
+    "value < 'foo'" -> Seq(nullFirst("substr", "substr <= 'foo'")),
+    "value = 'foo'" -> Seq(nullFirst("substr", "substr = 'foo'")),
+    "value > 'foo'" -> Seq(nullFirst("substr", "substr >= 'foo'")),
+    "value is null" -> Seq("(substr IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "SubstringPartitionExpr with pos 2 supports only equality",
+    Seq("value" -> StringType),
+    Seq(("substr", StringType, "SUBSTRING(value, 2, 3)")),
+    "value",
+    SubstringPartitionExpr("substr", 2, 3),
+    "value < 'foo'" -> Nil,
+    "value = 'foo'" -> Seq(nullFirst("substr", "substr = 'oo'")),
+    "value > 'foo'" -> Nil,
+    "value is null" -> Seq("(substr IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "SubstringPartitionExpr on a deeply nested base column",
+    Seq("outer" -> new StructType()
+      .add("inner", new StructType()
+        .add("nested", new StructType().add("value", StringType)))),
+    Seq(("substr", StringType, "SUBSTRING(outer.inner.nested.value, 1, 3)")),
+    "outer.inner.nested.value",
+    SubstringPartitionExpr("substr", 1, 3),
+    "outer.inner.nested.value < 'foo'" -> Seq(nullFirst("substr", "substr <= 'foo'")),
+    "outer.inner.nested.value = 'foo'" -> Seq(nullFirst("substr", "substr = 'foo'")),
+    "outer.inner.nested.value > 'foo'" -> Seq(nullFirst("substr", "substr >= 'foo'")),
+    "outer.inner.nested.value is null" -> Seq("(substr IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "DatePartitionExpr on a nested timestamp base column",
+    Seq("nested" -> new StructType().add("eventTime", TimestampType)),
+    Seq(("date", DateType, "CAST(nested.eventTime AS DATE)")),
+    "nested.eventTime",
+    DatePartitionExpr("date"),
+    "nested.eventTime < '2021-01-01 18:00:00'" -> Seq(orNull("date <= DATE '2021-01-01'")),
+    "nested.eventTime = '2021-01-01 18:00:00'" -> Seq(orNull("date = DATE '2021-01-01'")),
+    "nested.eventTime > '2021-01-01 18:00:00'" -> Seq(orNull("date >= DATE '2021-01-01'")),
+    "nested.eventTime is null" -> Seq("(date IS NULL)"))
+
+  testOptimizablePartitionExpression(
+    "YearMonthPartitionExpr with differently-cased generation expressions",
+    Seq("eventTime" -> TimestampType),
+    // Generation expressions may spell the base column with a different case; recognition must
+    // still merge YEAR/MONTH into a composite expression under case-insensitive analysis.
+    Seq(
+      ("year", IntegerType, "YEAR(EVENTTIME)"),
+      ("month", IntegerType, "MONTH(eventTime)")),
+    "eventTime",
+    YearMonthPartitionExpr("year", "month"),
+    "eventTime = '2021-06-15 18:30:00'" ->
+      Seq("((year = 2021) AND (month = 6))"),
+    "eventTime is null" ->
+      Seq("((year IS NULL) AND (month IS NULL))"))
+
+  testOptimizablePartitionExpression(
+    "TruncDatePartitionExpr from a timestamp base column",
+    Seq("eventTime" -> TimestampType),
+    Seq(("trunc", DateType, "TRUNC(eventTime, 'YEAR')")),
+    "eventTime",
+    TruncDatePartitionExpr("trunc", "YEAR"),
+    "eventTime < '2021-06-15 18:30:00'" -> Seq(orNull("trunc <= DATE '2021-01-01'")),
+    "eventTime = '2021-06-15 18:30:00'" -> Seq(orNull("trunc = DATE '2021-01-01'")),
+    "eventTime > '2021-06-15 18:30:00'" -> Seq(orNull("trunc >= DATE '2021-01-01'")),
+    "eventTime is null" -> Seq("(trunc IS NULL)"))
+
+  test("month-only and incomplete year/day partitions do not derive filters") {
+    // MonthPartitionExpr / DayPartitionExpr / HourPartitionExpr are placeholders used only for
+    // merging with Year. Alone, or without the contiguous year->month->day->hour chain, they
+    // must not produce partition filters.
+    val monthOnly = relationWith(
+      Seq("eventTime" -> TimestampType),
+      Seq(("month", IntegerType, "MONTH(eventTime)")))
+    checkDerivedFilters(
+      monthOnly,
+      "eventTime = '2021-06-15 18:30:00'" -> Nil,
+      "eventTime < '2021-06-15 18:30:00'" -> Nil)
+
+    val yearAndDay = relationWith(
+      Seq("eventTime" -> TimestampType),
+      Seq(
+        ("year", IntegerType, "YEAR(eventTime)"),
+        ("day", IntegerType, "DAY(eventTime)")))
+    // YEAR alone is still optimizable; DAY alone is not merged without MONTH.
+    val recognized = GeneratedColumnPartitionFilters.getOptimizablePartitionExpressions(
+      spark,
+      fromAttributes(yearAndDay.output),
+      GeneratedColumnPartitionFilters.identityPartitionSchema(yearAndDay))
+    assert(
+      recognized.find(_._1.equalsIgnoreCase("eventTime")).map(_._2)
+        .contains(Seq(YearPartitionExpr("year"), DayPartitionExpr("day"))),
+      s"expected unmerged year+day expressions, got $recognized")
+    checkDerivedFilters(
+      yearAndDay,
+      // Only YEAR contributes a derived filter; DAY remains a no-op placeholder.
+      "eventTime = '2021-06-15 18:30:00'" -> Seq(orNull("year = 2021")),
+      "eventTime is null" -> Seq("(year IS NULL)"))
+  }
+
+  test("a partition column whose name contains a dot is quoted in the derived filter") {
+    val schema = new StructType()
+      .add("value", StringType)
+      .add("my.substr", StringType, nullable = true, generationMetadata("SUBSTRING(value, 1, 3)"))
+    val partitionSchema = new StructType().add(schema("my.substr"))
+    val result = GeneratedColumnPartitionFilters.getOptimizablePartitionExpressions(
+      spark, schema, partitionSchema)
+    assert(result.get("value").contains(Seq(SubstringPartitionExpr("my.substr", 1, 3))),
+      s"got $result")
+    // The dotted partition column name must be back-tick quoted when rendered in a derived filter.
+    val derived = SubstringPartitionExpr("my.substr", 1, 3).equalTo(Literal("foo")).get
+    assert(derived.sql.contains("`my.substr`"), s"got ${derived.sql}")
+  }
+
+  test("a dotted column name and a nested field resolve to distinct base columns") {
+    // The schema has both a top level column literally named `nested.value` and a struct `nested`
+    // with a field `value`; escaping must keep the two base column paths distinct.
+    val schema = new StructType()
+      .add("nested.value", StringType)
+      .add("nested", new StructType().add("value", StringType))
+      .add("part1", StringType, nullable = true, generationMetadata("`nested.value`"))
+      .add("part2", StringType, nullable = true, generationMetadata("nested.value"))
+    val partitionSchema = new StructType().add(schema("part1")).add(schema("part2"))
+    val result = GeneratedColumnPartitionFilters.getOptimizablePartitionExpressions(
+      spark, schema, partitionSchema)
+    assert(result.get("`nested.value`").contains(Seq(IdentityPartitionExpr("part1"))),
+      s"got $result")
+    assert(result.get("nested.value").contains(Seq(IdentityPartitionExpr("part2"))),
+      s"got $result")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR allows DataSource V2 connectors that consume Catalyst filters to opt in to partition-filter inference for identity-partitioned generated columns. When a query filters a generated column's base column, Spark derives a conservative filter on the generated partition column and includes it in filter pushdown.

The supported generation expressions include casts to date, date/time extraction and truncation, `date_format`, `substring`, identity expressions, and composite year/month/day/hour partitions. Derived filters preserve null and truncation boundaries so they cannot remove matching rows.

The PR also adds an in-memory test connector that evaluates Catalyst partition filters, unit coverage for expression recognition and derivation, and end-to-end coverage for pushdown and partition pruning.

### Why are the changes needed?

Filters on a base column do not directly reference its generated partition column. Without inference, V2 data sources cannot use those filters for partition pruning and may scan every partition even when the generation expression makes a safe, selective partition predicate available.

### Does this PR introduce _any_ user-facing change?

Yes. DataSource V2 implementations that explicitly opt in can receive additional generated-column partition filters and prune partitions more effectively. Query results are unchanged because every derived filter is implied by the original data filter and is used only for pushdown.

### How was this patch tested?

Added `GeneratedColumnPartitionFilterSuite` for expression-level derivation and negative cases, and `DataSourceV2GeneratedColumnPartitionFilterSuite` for end-to-end pushdown, pruning, opt-out, null, parser-policy, case-sensitivity, nested-column, and multi-column behavior.

Targeted test command (running at PR creation time):

```bash
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
MAVEN_MIRROR_URL=https://maven-proxy.cloud.databricks.com \
build/sbt 'sql/testOnly org.apache.spark.sql.execution.datasources.v2.GeneratedColumnPartitionFilterSuite org.apache.spark.sql.execution.datasources.v2.DataSourceV2GeneratedColumnPartitionFilterSuite'
```

Also verified `git diff --check`, non-ASCII content, changed-file line lengths, and IDE diagnostics.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (GPT-5.6 Sol)