### PR TITLE
[SPARK-58266][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1058

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1647,6 +1647,12 @@
     ],
     "sqlState" : "42710"
   },
+  "CREATE_TABLE_WITH_BOTH_PROVIDER_AND_SERDE" : {
+    "message" : [
+      "Cannot create table with both USING <provider> and <serDeInfo>."
+    ],
+    "sqlState" : "42908"
+  },
   "CREATE_VIEW_COLUMN_ARITY_MISMATCH" : {
     "message" : [
       "Cannot create view <viewName>, the reason is"
@@ -9675,11 +9681,6 @@
   "_LEGACY_ERROR_TEMP_1052" : {
     "message" : [
       "ADD COLUMN with v1 tables cannot specify NOT NULL."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1058" : {
-    "message" : [
-      "Cannot create table with both USING <provider> and <serDeInfo>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1059" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1307,7 +1307,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def cannotCreateTableWithBothProviderAndSerdeError(
       provider: Option[String], maybeSerdeInfo: Option[SerdeInfo]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1058",
+      errorClass = "CREATE_TABLE_WITH_BOTH_PROVIDER_AND_SERDE",
       messageParameters = Map(
         "provider" -> provider.toString,
         "serDeInfo" -> maybeSerdeInfo.get.describe))

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.api.java.{UDF1, UDF2, UDF23Test}
 import org.apache.spark.sql.catalyst.expressions.{Coalesce, Literal, UnsafeRow}
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.logical.SerdeInfo
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand
 import org.apache.spark.sql.execution.datasources.parquet.SparkToParquetSchemaConverter
 import org.apache.spark.sql.expressions.SparkUserDefinedFunction
@@ -1108,6 +1109,20 @@ class QueryCompilationErrorsSuite
         parameters = Map("format" -> "JSON")
       )
     }
+  }
+
+  test("CREATE_TABLE_WITH_BOTH_PROVIDER_AND_SERDE: USING and a serde clause together") {
+    // Not reachable via SQL (the parser rejects USING with a serde clause); throw directly.
+    val serdeInfo = SerdeInfo(storedAs = Some("PARQUET"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        throw QueryCompilationErrors.cannotCreateTableWithBothProviderAndSerdeError(
+          Some("parquet"), Some(serdeInfo))
+      },
+      condition = "CREATE_TABLE_WITH_BOTH_PROVIDER_AND_SERDE",
+      parameters = Map(
+        "provider" -> "Some(parquet)",
+        "serDeInfo" -> serdeInfo.describe))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1058` to
`CREATE_TABLE_WITH_BOTH_PROVIDER_AND_SERDE`, with SQLSTATE `42908`.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks
existing ones to be resolved. This resolves one of them.

The error is raised by `ResolveSessionCatalog` when a CREATE TABLE plan carries both a
`USING <provider>` and a serde clause. It is an analysis-time `AnalysisException`. Note
the parser (`AstBuilder.visitCreateTable`) already rejects `CREATE TABLE ... USING ...
ROW FORMAT/STORED AS ...` up front, so this is a defensive check that is not reachable
through SQL.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a `checkError` test in `QueryCompilationErrorsSuite` that invokes the error
factory directly (the SQL path is guarded by the parser) and asserts the
`CREATE_TABLE_WITH_BOTH_PROVIDER_AND_SERDE` condition. `build/sbt "core/testOnly
org.apache.spark.SparkThrowableSuite"` passes.

### Was this patch authored or co-authored using generative AI tooling?
Co-Authored with: Claude Opus 4.8
