### PR TITLE
[SPARK-58267][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1059

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3938,6 +3938,12 @@
     ],
     "sqlState" : "42000"
   },
+  "INVALID_FILE_FORMAT_FOR_STORED_AS" : {
+    "message" : [
+      "STORED AS with file format '<serdeInfo>' is invalid."
+    ],
+    "sqlState" : "42601"
+  },
   "INVALID_FLOW_QUERY_TYPE" : {
     "message" : [
       "Flow <flowIdentifier> returns an invalid relation type."
@@ -9680,11 +9686,6 @@
   "_LEGACY_ERROR_TEMP_1058" : {
     "message" : [
       "Cannot create table with both USING <provider> and <serDeInfo>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1059" : {
-    "message" : [
-      "STORED AS with file format '<serdeInfo>' is invalid."
     ]
   },
   "_LEGACY_ERROR_TEMP_1060" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1315,7 +1315,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def invalidFileFormatForStoredAsError(serdeInfo: SerdeInfo): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1059",
+      errorClass = "INVALID_FILE_FORMAT_FOR_STORED_AS",
       messageParameters = Map("serdeInfo" -> serdeInfo.storedAs.get))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1109,6 +1109,17 @@ class QueryCompilationErrorsSuite
       )
     }
   }
+
+  test("INVALID_FILE_FORMAT_FOR_STORED_AS: CREATE TABLE STORED AS an unknown file format") {
+    withTable("t") {
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("CREATE TABLE t (c1 INT) STORED AS UNKNOWN_FORMAT")
+        },
+        condition = "INVALID_FILE_FORMAT_FOR_STORED_AS",
+        parameters = Map("serdeInfo" -> "UNKNOWN_FORMAT"))
+    }
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1059` to
`INVALID_FILE_FORMAT_FOR_STORED_AS`, with SQLSTATE `42601`.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks
existing ones to be resolved. This resolves one of them.

The error is raised by `ResolveSessionCatalog` when a CREATE TABLE uses `STORED AS
<fileFormat>` with a file format that does not map to a known Hive SerDe, e.g.
`CREATE TABLE t (c1 INT) STORED AS UNKNOWN_FORMAT`. It is an analysis-time
`AnalysisException`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a `checkError` test in `QueryCompilationErrorsSuite` that runs `CREATE TABLE ...
STORED AS <unknown format>` and asserts the `INVALID_FILE_FORMAT_FOR_STORED_AS`
condition. `build/sbt "core/testOnly org.apache.spark.SparkThrowableSuite"` passes.

### Was this patch authored or co-authored using generative AI tooling?
Co-Authored with: Claude Opus 4.8
