### PR TITLE
[SPARK-58277][SQL] Stream DataType JSON serialization

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DataTypeJsonUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DataTypeJsonUtils.scala
@@ -17,25 +17,42 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
+import java.io.StringWriter
+
+import com.fasterxml.jackson.core.{JsonFactory, JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonSerializer, SerializerProvider}
 import org.json4s.JsonAST.JValue
-import org.json4s.jackson.{JValueDeserializer, JValueSerializer}
+import org.json4s.jackson.JValueDeserializer
 
 import org.apache.spark.sql.types.DataType
 
 object DataTypeJsonUtils {
+  private val jsonFactory = new JsonFactory()
+
+  def toJson(dataType: DataType): String = {
+    val writer = new StringWriter
+    val generator = jsonFactory.createGenerator(writer)
+    try {
+      writeDataType(dataType, generator)
+    } finally {
+      generator.close()
+    }
+    writer.toString
+  }
+
+  private[sql] def writeDataType(dataType: DataType, generator: JsonGenerator): Unit = {
+    dataType.writeJsonTo(generator)
+  }
 
   /**
-   * Jackson serializer for [[DataType]]. Internally this delegates to json4s based serialization.
+   * Jackson serializer for [[DataType]].
    */
   class DataTypeJsonSerializer extends JsonSerializer[DataType] {
-    private val delegate = new JValueSerializer
     override def serialize(
         value: DataType,
         gen: JsonGenerator,
         provider: SerializerProvider): Unit = {
-      delegate.serialize(value.jsonValue, gen, provider)
+      writeDataType(value, gen)
     }
   }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.types
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Stable
@@ -83,6 +85,15 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
     ("type" -> typeName) ~
       ("elementType" -> elementType.jsonValue) ~
       ("containsNull" -> containsNull)
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("type", typeName)
+    generator.writeFieldName("elementType")
+    elementType.writeJsonTo(generator)
+    generator.writeBooleanField("containsNull", containsNull)
+    generator.writeEndObject()
+  }
 
   /**
    * The default size of a value of the ArrayType is the default size of the element type. We

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.types
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Stable

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 
 import scala.util.control.NonFatal
 
+import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
 import org.json4s._
 import org.json4s.JsonAST.JValue
@@ -31,7 +32,7 @@ import org.apache.spark.{SparkClassNotFoundException, SparkIllegalArgumentExcept
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.analysis.SqlApiAnalysis
 import org.apache.spark.sql.catalyst.parser.DataTypeParser
-import org.apache.spark.sql.catalyst.util.{CollationFactory, StringConcat}
+import org.apache.spark.sql.catalyst.util.{CollationFactory, DataTypeJsonUtils, StringConcat}
 import org.apache.spark.sql.catalyst.util.DataTypeJsonUtils.{DataTypeJsonDeserializer, DataTypeJsonSerializer}
 import org.apache.spark.sql.errors.DataTypeErrors
 import org.apache.spark.sql.internal.SqlApiConf
@@ -66,8 +67,12 @@ abstract class DataType extends AbstractDataType {
 
   private[sql] def jsonValue: JValue = typeName
 
+  private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeString(typeName)
+  }
+
   /** The compact JSON representation of this data type. */
-  def json: String = compact(render(jsonValue))
+  def json: String = DataTypeJsonUtils.toJson(this)
 
   /** The pretty (i.e. indented) JSON representation of this data type. */
   def prettyJson: String = pretty(render(jsonValue))

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/GeographyType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/GeographyType.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.types
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.JsonAST.{JString, JValue}
 
 import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException}

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/GeographyType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/GeographyType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.types
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.JsonAST.{JString, JValue}
 
 import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException}
@@ -84,6 +86,10 @@ class GeographyType private (val crs: String, val algorithm: EdgeInterpolationAl
    * is also in accordance to storage formats.
    */
   override def jsonValue: JValue = JString(s"geography($crs, $algorithm)")
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeString(s"geography($crs, $algorithm)")
+  }
 
   private[spark] override def asNullable: GeographyType = this
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/GeometryType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/GeometryType.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.types
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.JsonAST.{JString, JValue}
 
 import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException}

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/GeometryType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/GeometryType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.types
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.JsonAST.{JString, JValue}
 
 import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException}
@@ -81,6 +83,10 @@ class GeometryType private (val crs: String) extends AtomicType with Serializabl
    * and only fixed SRID types can be stored. This is also in accordance to storage formats.
    */
   override def jsonValue: JValue = JString(s"geometry($crs)")
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeString(s"geometry($crs)")
+  }
 
   private[spark] override def asNullable: GeometryType = this
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.types
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.types
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
@@ -61,6 +63,17 @@ case class MapType(keyType: DataType, valueType: DataType, valueContainsNull: Bo
       ("keyType" -> keyType.jsonValue) ~
       ("valueType" -> valueType.jsonValue) ~
       ("valueContainsNull" -> valueContainsNull)
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("type", typeName)
+    generator.writeFieldName("keyType")
+    keyType.writeJsonTo(generator)
+    generator.writeFieldName("valueType")
+    valueType.writeJsonTo(generator)
+    generator.writeBooleanField("valueContainsNull", valueContainsNull)
+    generator.writeEndObject()
+  }
 
   /**
    * The default size of a value of the MapType is (the default size of the key type + the default

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.types
 import scala.collection.mutable
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.types
 
 import scala.collection.mutable
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
@@ -149,6 +151,28 @@ sealed class Metadata private[types] (private[types] val map: Map[String, Any])
   }
 
   private[sql] def jsonValue: JValue = Metadata.toJsonValue(this)
+
+  private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    writeJsonObjectTo(generator)
+  }
+
+  private[types] def writeJsonObjectTo(
+      generator: JsonGenerator,
+      extraFields: Seq[(String, Map[String, String])] = Nil): Unit = {
+    generator.writeStartObject()
+    map.toList.foreach { case (key, value) =>
+      generator.writeFieldName(key)
+      Metadata.writeJsonValue(value, generator)
+    }
+    extraFields.foreach { case (key, value) =>
+      generator.writeObjectFieldStart(key)
+      value.toList.foreach { case (nestedKey, nestedValue) =>
+        generator.writeStringField(nestedKey, nestedValue)
+      }
+      generator.writeEndObject()
+    }
+    generator.writeEndObject()
+  }
 }
 
 /**
@@ -236,6 +260,36 @@ object Metadata {
         JNull
       case x: Metadata =>
         toJsonValue(x.map)
+      case other =>
+        throw DataTypeErrors.unsupportedJavaTypeError(other.getClass)
+    }
+  }
+
+  private def writeJsonValue(obj: Any, generator: JsonGenerator): Unit = {
+    obj match {
+      case map: Map[_, _] =>
+        generator.writeStartObject()
+        map.toList.foreach { case (key, value) =>
+          generator.writeFieldName(key.toString)
+          writeJsonValue(value, generator)
+        }
+        generator.writeEndObject()
+      case arr: Array[_] =>
+        generator.writeStartArray()
+        arr.foreach(writeJsonValue(_, generator))
+        generator.writeEndArray()
+      case x: Long =>
+        generator.writeNumber(x)
+      case x: Double =>
+        generator.writeNumber(x)
+      case x: Boolean =>
+        generator.writeBoolean(x)
+      case x: String =>
+        generator.writeString(x)
+      case null =>
+        generator.writeNull()
+      case x: Metadata =>
+        x.writeJsonTo(generator)
       case other =>
         throw DataTypeErrors.unsupportedJavaTypeError(other.getClass)
     }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.types
 import scala.collection.mutable
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.{JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.types
 
 import scala.collection.mutable
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.{JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
@@ -104,6 +106,61 @@ case class StructField(
 
       case _ => metadataJsonValue
     }
+  }
+
+  private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("name", name)
+    generator.writeFieldName("type")
+    writeDataTypeJsonTo(generator)
+    generator.writeBooleanField("nullable", nullable)
+    generator.writeFieldName("metadata")
+    writeMetadataJsonTo(generator)
+    generator.writeEndObject()
+  }
+
+  private def writeDataTypeJsonTo(generator: JsonGenerator): Unit = {
+    if (collationMetadata.isEmpty) {
+      dataType.writeJsonTo(generator)
+    } else {
+      writeDataTypeWithoutCollations(dataType, generator)
+    }
+  }
+
+  private def writeDataTypeWithoutCollations(
+      dataType: DataType,
+      generator: JsonGenerator): Unit = dataType match {
+    // Only recurse into map and array types as any child struct type will have already been
+    // processed.
+    case ArrayType(elementType, containsNull) =>
+      generator.writeStartObject()
+      generator.writeStringField("type", dataType.typeName)
+      generator.writeFieldName("elementType")
+      writeDataTypeWithoutCollations(elementType, generator)
+      generator.writeBooleanField("containsNull", containsNull)
+      generator.writeEndObject()
+    case MapType(keyType, valueType, valueContainsNull) =>
+      generator.writeStartObject()
+      generator.writeStringField("type", dataType.typeName)
+      generator.writeFieldName("keyType")
+      writeDataTypeWithoutCollations(keyType, generator)
+      generator.writeFieldName("valueType")
+      writeDataTypeWithoutCollations(valueType, generator)
+      generator.writeBooleanField("valueContainsNull", valueContainsNull)
+      generator.writeEndObject()
+    case st: StringType =>
+      StringHelper.removeCollation(st).writeJsonTo(generator)
+    case other =>
+      other.writeJsonTo(generator)
+  }
+
+  private def writeMetadataJsonTo(generator: JsonGenerator): Unit = {
+    val extraFields = if (collationMetadata.isEmpty) {
+      Nil
+    } else {
+      Seq(DataType.COLLATIONS_METADATA_KEY -> collationMetadata)
+    }
+    metadata.writeJsonObjectTo(generator, extraFields)
   }
 
   /** Map of field path to collation name. */

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -126,32 +126,31 @@ case class StructField(
     }
   }
 
-  private def writeDataTypeWithoutCollations(
-      dataType: DataType,
-      generator: JsonGenerator): Unit = dataType match {
-    // Only recurse into map and array types as any child struct type will have already been
-    // processed.
-    case ArrayType(elementType, containsNull) =>
-      generator.writeStartObject()
-      generator.writeStringField("type", dataType.typeName)
-      generator.writeFieldName("elementType")
-      writeDataTypeWithoutCollations(elementType, generator)
-      generator.writeBooleanField("containsNull", containsNull)
-      generator.writeEndObject()
-    case MapType(keyType, valueType, valueContainsNull) =>
-      generator.writeStartObject()
-      generator.writeStringField("type", dataType.typeName)
-      generator.writeFieldName("keyType")
-      writeDataTypeWithoutCollations(keyType, generator)
-      generator.writeFieldName("valueType")
-      writeDataTypeWithoutCollations(valueType, generator)
-      generator.writeBooleanField("valueContainsNull", valueContainsNull)
-      generator.writeEndObject()
-    case st: StringType =>
-      StringHelper.removeCollation(st).writeJsonTo(generator)
-    case other =>
-      other.writeJsonTo(generator)
-  }
+  private def writeDataTypeWithoutCollations(dataType: DataType, generator: JsonGenerator): Unit =
+    dataType match {
+      // Only recurse into map and array types as any child struct type will have already been
+      // processed.
+      case ArrayType(elementType, containsNull) =>
+        generator.writeStartObject()
+        generator.writeStringField("type", dataType.typeName)
+        generator.writeFieldName("elementType")
+        writeDataTypeWithoutCollations(elementType, generator)
+        generator.writeBooleanField("containsNull", containsNull)
+        generator.writeEndObject()
+      case MapType(keyType, valueType, valueContainsNull) =>
+        generator.writeStartObject()
+        generator.writeStringField("type", dataType.typeName)
+        generator.writeFieldName("keyType")
+        writeDataTypeWithoutCollations(keyType, generator)
+        generator.writeFieldName("valueType")
+        writeDataTypeWithoutCollations(valueType, generator)
+        generator.writeBooleanField("valueContainsNull", valueContainsNull)
+        generator.writeEndObject()
+      case st: StringType =>
+        StringHelper.removeCollation(st).writeJsonTo(generator)
+      case other =>
+        other.writeJsonTo(generator)
+    }
 
   private def writeMetadataJsonTo(generator: JsonGenerator): Unit = {
     val extraFields = if (collationMetadata.isEmpty) {

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -24,7 +24,6 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.JsonDSL._
 
 import org.apache.spark.SparkIllegalArgumentException

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -23,6 +23,8 @@ import scala.collection.{immutable, mutable, Map}
 import scala.util.Try
 import scala.util.control.NonFatal
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.JsonDSL._
 
 import org.apache.spark.SparkIllegalArgumentException
@@ -406,6 +408,15 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
   override private[sql] def jsonValue =
     ("type" -> typeName) ~
       ("fields" -> map(_.jsonValue))
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("type", typeName)
+    generator.writeArrayFieldStart("fields")
+    fields.foreach(_.writeJsonTo(generator))
+    generator.writeEndArray()
+    generator.writeEndObject()
+  }
 
   override def apply(fieldIndex: Int): StructField = fields(fieldIndex)
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.types
 import java.util.Objects
 
 import com.fasterxml.jackson.core.JsonGenerator
-
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.types
 
 import java.util.Objects
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
@@ -62,6 +64,17 @@ abstract class UserDefinedType[UserType >: Null] extends DataType with Serializa
       ("class" -> this.getClass.getName) ~
       ("pyClass" -> pyUDT) ~
       ("sqlType" -> sqlType.jsonValue)
+  }
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("type", "udt")
+    generator.writeStringField("class", this.getClass.getName)
+    generator.writeFieldName("pyClass")
+    generator.writeString(pyUDT)
+    generator.writeFieldName("sqlType")
+    sqlType.writeJsonTo(generator)
+    generator.writeEndObject()
   }
 
   /**
@@ -146,6 +159,16 @@ private[sql] class PythonUserDefinedType(
       ("pyClass" -> pyUDT) ~
       ("serializedClass" -> serializedPyClass) ~
       ("sqlType" -> sqlType.jsonValue)
+  }
+
+  override private[sql] def writeJsonTo(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("type", "udt")
+    generator.writeStringField("pyClass", pyUDT)
+    generator.writeStringField("serializedClass", serializedPyClass)
+    generator.writeFieldName("sqlType")
+    sqlType.writeJsonTo(generator)
+    generator.writeEndObject()
   }
 
   override private[sql] def acceptsType(dataType: DataType): Boolean = dataType match {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -217,12 +217,29 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
     val metadata = new MetadataBuilder()
       .putString("comment", "field metadata")
       .putDouble("score", 1.5)
+      // Integral-valued double: the canonical spot where JSON number formatting can diverge
+      // between renderers (1.0 vs 1). Pins the byte-for-byte guarantee for this case.
+      .putDouble("whole", 1.0)
       .putBooleanArray("flags", Array(true, false))
       .putDoubleArray("weights", Array(2.5, 3.5))
       .putLongArray("ids", Array(1L, 2L))
       .putMetadata("nested", nestedMetadata)
       .putMetadataArray("children", Array(nestedMetadata))
       .build()
+    // Large schemas exercise the PR's core goal: streaming bounds peak memory for schemas whose
+    // node count is large. A wide struct (many fields), a deeply nested struct, and structs under
+    // array/map all stream field-by-field, so they must stay byte-identical to the json4s path.
+    val wideStruct = StructType((1 to 200).map { i =>
+      StructField(s"f$i", if (i % 2 == 0) LongType else StringType, nullable = i % 3 == 0)
+    })
+    val deepStruct = (1 to 50).foldLeft[DataType](LongType) { (inner, i) =>
+      StructType(Seq(StructField(s"level$i", inner, nullable = i % 2 == 0)))
+    }
+    val structUnderArrayAndMap = StructType(Seq(
+      StructField("arr", ArrayType(wideStruct, containsNull = false)),
+      StructField("map",
+        MapType(StringType(UTF8_LCASE_COLLATION_ID), wideStruct, valueContainsNull = false)),
+      StructField("deep", deepStruct)))
     val objectTypes = Seq(
       DecimalType(10, 2),
       CharType(5),
@@ -254,7 +271,10 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
           nullable = true),
         StructField("lookup",
           MapType(StringType(UTF8_LCASE_COLLATION_ID), StringType(UNICODE_COLLATION_ID)),
-          nullable = false))))
+          nullable = false))),
+      wideStruct,
+      deepStruct,
+      structUnderArrayAndMap)
     val mapper = new ObjectMapper()
     val dataTypes = (atomicTypes.toSeq ++ objectTypes).distinct
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -232,6 +232,19 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
       VarcharType(10, UTF8_LCASE_COLLATION_ID),
       ArrayType(MapType(StringType, LongType, valueContainsNull = false)),
       new ExampleBaseTypeUDT(),
+      // Python UDT: exercises PythonUserDefinedType.writeJsonTo, whose field layout differs
+      // from the Scala UDT path (it omits `class` and adds `serializedClass`). This case has
+      // a non-null pyClass and a non-null serializedClass.
+      new PythonUserDefinedType(
+        StructType(Seq(StructField("intfield", IntegerType, nullable = false))),
+        "pyspark.testing.ExamplePythonUDT",
+        "serialized-python-class-payload"),
+      // Python UDT with a null serializedClass: verifies the streaming path renders a null
+      // string field identically to json4s on this distinct code path.
+      new PythonUserDefinedType(
+        StructType(Seq(StructField("v", DoubleType))),
+        "pyspark.testing.NoSerializedClassUDT",
+        null),
       GeometryType(4326),
       GeographyType(4326),
       StructType(Seq(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.types
 import java.util.Locale
 
 import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.json4s.jackson.JsonMethods
 
 import org.apache.spark.{SparkClassNotFoundException, SparkException, SparkFunSuite}
@@ -28,9 +29,10 @@ import org.apache.spark.sql.catalyst.analysis.{caseInsensitiveResolution, caseSe
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.types.{DataTypeUtils, PhysicalDataType, UninitializedPhysicalType}
-import org.apache.spark.sql.catalyst.util.{CollationFactory, StringConcat}
+import org.apache.spark.sql.catalyst.util.{CollationFactory, DataTypeJsonUtils, StringConcat}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
+import org.apache.spark.sql.types.DataTypeTestUtils.{
+  atomicTypes, dayTimeIntervalTypes, yearMonthIntervalTypes}
 
 class DataTypeSuite extends SparkFunSuite with SQLHelper {
 
@@ -205,6 +207,49 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
     assert(DataType.fromJson("\"timestamp_ltz\"") == TimestampType)
     val expectedStructType = StructType(Seq(StructField("ts", TimestampType)))
     assert(DataType.fromDDL("ts timestamp_ltz") == expectedStructType)
+  }
+
+  test("SPARK-58277: streaming DataType JSON matches json4s output") {
+    val nestedMetadata = new MetadataBuilder()
+      .putString("note", "nested")
+      .putBoolean("valid", true)
+      .build()
+    val metadata = new MetadataBuilder()
+      .putString("comment", "field metadata")
+      .putDouble("score", 1.5)
+      .putBooleanArray("flags", Array(true, false))
+      .putDoubleArray("weights", Array(2.5, 3.5))
+      .putLongArray("ids", Array(1L, 2L))
+      .putMetadata("nested", nestedMetadata)
+      .putMetadataArray("children", Array(nestedMetadata))
+      .build()
+    val objectTypes = Seq(
+      DecimalType(10, 2),
+      CharType(5),
+      VarcharType(10),
+      StringType(UTF8_LCASE_COLLATION_ID),
+      CharType(5, UTF8_LCASE_COLLATION_ID),
+      VarcharType(10, UTF8_LCASE_COLLATION_ID),
+      ArrayType(MapType(StringType, LongType, valueContainsNull = false)),
+      new ExampleBaseTypeUDT(),
+      GeometryType(4326),
+      GeographyType(4326),
+      StructType(Seq(
+        StructField("id", LongType, nullable = false, metadata),
+        StructField("names",
+          ArrayType(StringType(UNICODE_COLLATION_ID), containsNull = false),
+          nullable = true),
+        StructField("lookup",
+          MapType(StringType(UTF8_LCASE_COLLATION_ID), StringType(UNICODE_COLLATION_ID)),
+          nullable = false))))
+    val mapper = new ObjectMapper()
+    val dataTypes = (atomicTypes.toSeq ++ objectTypes).distinct
+
+    dataTypes.foreach { dataType =>
+      val expected = JsonMethods.compact(JsonMethods.render(dataType.jsonValue))
+      assert(DataTypeJsonUtils.toJson(dataType) === expected)
+      assert(mapper.writeValueAsString(dataType) === expected)
+    }
   }
 
   test("loading a UDT class from a schema string is enabled by default") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes compact `DataType` JSON serialization to write directly with a Jackson
`JsonGenerator` instead of first building the full json4s AST and then rendering it.

It adds streaming writers for primitive data types, arrays, maps, structs, struct fields,
metadata, UDTs, geometry, and geography. The existing `jsonValue` and `prettyJson` paths are
kept unchanged for compatibility.

### Why are the changes needed?

`DataType.json` can be called on very wide or deeply nested schemas. The previous implementation
materialized a json4s AST for the whole schema before rendering the final string, which can make
peak driver memory much larger than the final JSON output.

Streaming directly to Jackson keeps serialization proportional to the output being written while
preserving the existing JSON format byte-for-byte.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a regression test that compares the streaming output byte-for-byte with the previous json4s
output through both `DataTypeJsonUtils.toJson` and Jackson `ObjectMapper` serialization.

Ran:

```
build/sbt 'catalyst/testOnly org.apache.spark.sql.types.DataTypeSuite -- -z "SPARK-58277"'
build/sbt 'catalyst/testOnly org.apache.spark.sql.types.DataTypeSuite'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex was used for code assistance.