### PR TITLE
[SPARK-52825][SQL] Register existing dialects for additional URL prefixes

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8169,6 +8169,12 @@
     },
     "sqlState" : "42000"
   },
+  "UNSUPPORTED_BUILT_IN_JDBC_DIALECT" : {
+    "message" : [
+      "`<name>` is not a supported built-in JDBC dialect. Supported dialects are: <supportedNames>."
+    ],
+    "sqlState" : "22023"
+  },
   "UNSUPPORTED_CALL" : {
     "message" : [
       "Cannot call the method \"<methodName>\" of the class \"<className>\"."

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -1002,6 +1002,11 @@ object JdbcDialects {
    * registered dialect handles the URL through [[JdbcDialect#canHandle]].
    *
    * The prefix must start with `jdbc:` and end with `:`. Matching is case-insensitive.
+   * For example, a MySQL-compatible wrapper can reuse [[MYSQL]]:
+   *
+   * {{{
+   * JdbcDialects.registerDialectForUrlPrefix("jdbc:aws-wrapper:mysql:", JdbcDialects.MYSQL)
+   * }}}
    *
    * @param urlPrefix The additional JDBC URL prefix.
    * @param dialect The existing dialect to use for URLs with the prefix.
@@ -1068,6 +1073,18 @@ object JdbcDialects {
     }
   }
   registerDialects()
+
+  /** The built-in MySQL dialect. */
+  @Since("4.3.0")
+  val MYSQL: JdbcDialect = dialects.collectFirst {
+    case dialect: MySQLDialect => dialect
+  }.get
+
+  /** The built-in PostgreSQL dialect. */
+  @Since("4.3.0")
+  val POSTGRESQL: JdbcDialect = dialects.collectFirst {
+    case dialect: PostgresDialect => dialect
+  }.get
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -999,7 +999,7 @@ object JdbcDialects {
    * Register an existing dialect for an additional JDBC URL prefix. The registration affects
    * dialect lookup only; Spark still passes the original URL to the JDBC driver. Registering the
    * same prefix again replaces its previous dialect. These registrations are used only when no
-   * registered dialect handles the URL through [[JdbcDialect.canHandle]].
+   * registered dialect handles the URL through [[JdbcDialect#canHandle]].
    *
    * The prefix must start with `jdbc:` and end with `:`. Matching is case-insensitive.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -993,50 +993,50 @@ private[sql] trait NoLegacyJDBCError extends JdbcDialect {
 @DeveloperApi
 object JdbcDialects {
 
-  private[this] var aliases = List[(String, String)]()
+  private[this] var dialectsByUrlPrefix = List[(String, JdbcDialect)]()
 
   /**
-   * Register an alias from a JDBC URL prefix to the canonical prefix understood by a dialect.
-   * The alias affects dialect lookup only; Spark still passes the original URL to the JDBC driver.
-   * Registering the same alias again replaces its previous canonical prefix.
-   * Aliases are used only when no registered dialect handles the original URL.
+   * Register an existing dialect for an additional JDBC URL prefix. The registration affects
+   * dialect lookup only; Spark still passes the original URL to the JDBC driver. Registering the
+   * same prefix again replaces its previous dialect. These registrations are used only when no
+   * registered dialect handles the URL through [[JdbcDialect.canHandle]].
    *
-   * Prefixes must start with `jdbc:` and end with `:`. Matching is case-insensitive.
+   * The prefix must start with `jdbc:` and end with `:`. Matching is case-insensitive.
    *
-   * @param aliasPrefix The JDBC URL prefix used by a wrapper driver.
-   * @param canonicalPrefix The corresponding prefix understood by the underlying dialect.
+   * @param urlPrefix The additional JDBC URL prefix.
+   * @param dialect The existing dialect to use for URLs with the prefix.
    */
   @Since("4.3.0")
-  def registerDialectAlias(aliasPrefix: String, canonicalPrefix: String): Unit = {
-    val alias = normalizePrefix(aliasPrefix)
-    val canonical = normalizePrefix(canonicalPrefix)
-    aliases = (alias, canonical) :: aliases.filterNot(_._1 == alias)
+  def registerDialectForUrlPrefix(urlPrefix: String, dialect: JdbcDialect): Unit = {
+    val prefix = normalizePrefix(urlPrefix)
+    dialectsByUrlPrefix = ((prefix, dialect) :: dialectsByUrlPrefix.filterNot(_._1 == prefix))
+      .sortBy { case (registeredPrefix, _) => -registeredPrefix.length }
   }
 
   /**
-   * Unregister a JDBC dialect alias. Does nothing if the alias is not registered.
+   * Unregister the dialect associated with an additional JDBC URL prefix. Does nothing if the
+   * prefix is not registered.
    *
-   * @param aliasPrefix The JDBC URL prefix used by a wrapper driver.
+   * @param urlPrefix The additional JDBC URL prefix.
    */
   @Since("4.3.0")
-  def unregisterDialectAlias(aliasPrefix: String): Unit = {
-    val alias = normalizePrefix(aliasPrefix)
-    aliases = aliases.filterNot(_._1 == alias)
+  def unregisterDialectForUrlPrefix(urlPrefix: String): Unit = {
+    val prefix = normalizePrefix(urlPrefix)
+    dialectsByUrlPrefix = dialectsByUrlPrefix.filterNot(_._1 == prefix)
   }
 
   private def normalizePrefix(prefix: String): String = {
     val normalized = prefix.toLowerCase(Locale.ROOT)
     require(normalized.startsWith("jdbc:") && normalized.endsWith(":"),
-      s"JDBC dialect alias prefixes must start with 'jdbc:' and end with ':': $prefix")
+      s"JDBC URL prefixes must start with 'jdbc:' and end with ':': $prefix")
     normalized
   }
 
-  private def resolveAlias(url: String): String = {
+  private def getDialectForUrlPrefix(url: String): Option[JdbcDialect] = {
     val normalizedUrl = url.toLowerCase(Locale.ROOT)
-    aliases.collectFirst {
-      case (alias, canonical) if normalizedUrl.startsWith(alias) =>
-        canonical + url.substring(alias.length)
-    }.getOrElse(url)
+    dialectsByUrlPrefix.collectFirst {
+      case (prefix, dialect) if normalizedUrl.startsWith(prefix) => dialect
+    }
   }
 
   /**
@@ -1068,15 +1068,13 @@ object JdbcDialects {
     }
   }
   registerDialects()
-  registerDialectAlias("jdbc:aws-wrapper:mysql:", "jdbc:mysql:")
-  registerDialectAlias("jdbc:aws-wrapper:postgresql:", "jdbc:postgresql:")
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.
    */
   def get(url: String): JdbcDialect = {
     val matchingDialects = dialects.filter(_.canHandle(url)) match {
-      case Nil => dialects.filter(_.canHandle(resolveAlias(url)))
+      case Nil => getDialectForUrlPrefix(url).toList
       case matches => matches
     }
     matchingDialects.length match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.jdbc
 import java.sql.{Connection, Date, Driver, ResultSetMetaData, SQLException, Statement, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime}
 import java.util
+import java.util.Locale
 import java.util.ServiceLoader
 import java.util.concurrent.TimeUnit
 
@@ -992,6 +993,52 @@ private[sql] trait NoLegacyJDBCError extends JdbcDialect {
 @DeveloperApi
 object JdbcDialects {
 
+  private[this] var aliases = List[(String, String)]()
+
+  /**
+   * Register an alias from a JDBC URL prefix to the canonical prefix understood by a dialect.
+   * The alias affects dialect lookup only; Spark still passes the original URL to the JDBC driver.
+   * Registering the same alias again replaces its previous canonical prefix.
+   * Aliases are used only when no registered dialect handles the original URL.
+   *
+   * Prefixes must start with `jdbc:` and end with `:`. Matching is case-insensitive.
+   *
+   * @param aliasPrefix The JDBC URL prefix used by a wrapper driver.
+   * @param canonicalPrefix The corresponding prefix understood by the underlying dialect.
+   */
+  @Since("4.3.0")
+  def registerDialectAlias(aliasPrefix: String, canonicalPrefix: String): Unit = {
+    val alias = normalizePrefix(aliasPrefix)
+    val canonical = normalizePrefix(canonicalPrefix)
+    aliases = (alias, canonical) :: aliases.filterNot(_._1 == alias)
+  }
+
+  /**
+   * Unregister a JDBC dialect alias. Does nothing if the alias is not registered.
+   *
+   * @param aliasPrefix The JDBC URL prefix used by a wrapper driver.
+   */
+  @Since("4.3.0")
+  def unregisterDialectAlias(aliasPrefix: String): Unit = {
+    val alias = normalizePrefix(aliasPrefix)
+    aliases = aliases.filterNot(_._1 == alias)
+  }
+
+  private def normalizePrefix(prefix: String): String = {
+    val normalized = prefix.toLowerCase(Locale.ROOT)
+    require(normalized.startsWith("jdbc:") && normalized.endsWith(":"),
+      s"JDBC dialect alias prefixes must start with 'jdbc:' and end with ':': $prefix")
+    normalized
+  }
+
+  private def resolveAlias(url: String): String = {
+    val normalizedUrl = url.toLowerCase(Locale.ROOT)
+    aliases.collectFirst {
+      case (alias, canonical) if normalizedUrl.startsWith(alias) =>
+        canonical + url.substring(alias.length)
+    }.getOrElse(url)
+  }
+
   /**
    * Register a dialect for use on all new matching jdbc `org.apache.spark.sql.DataFrame`.
    * Reading an existing dialect will cause a move-to-front.
@@ -1021,12 +1068,17 @@ object JdbcDialects {
     }
   }
   registerDialects()
+  registerDialectAlias("jdbc:aws-wrapper:mysql:", "jdbc:mysql:")
+  registerDialectAlias("jdbc:aws-wrapper:postgresql:", "jdbc:postgresql:")
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.
    */
   def get(url: String): JdbcDialect = {
-    val matchingDialects = dialects.filter(_.canHandle(url))
+    val matchingDialects = dialects.filter(_.canHandle(url)) match {
+      case Nil => dialects.filter(_.canHandle(resolveAlias(url)))
+      case matches => matches
+    }
     matchingDialects.length match {
       case 0 => NoopDialect
       case 1 => matchingDialects.head

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -27,7 +27,8 @@ import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuilder
 import scala.util.control.NonFatal
 
-import org.apache.spark.{SparkRuntimeException, SparkThrowable, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException, SparkThrowable,
+  SparkUnsupportedOperationException}
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
@@ -1002,10 +1003,12 @@ object JdbcDialects {
    * registered dialect handles the URL through [[JdbcDialect#canHandle]].
    *
    * The prefix must start with `jdbc:` and end with `:`. Matching is case-insensitive.
-   * For example, a MySQL-compatible wrapper can reuse [[MYSQL]]:
+   * For example, a MySQL-compatible wrapper can reuse the built-in MySQL dialect:
    *
    * {{{
-   * JdbcDialects.registerDialectForUrlPrefix("jdbc:aws-wrapper:mysql:", JdbcDialects.MYSQL)
+   * JdbcDialects.registerDialectForUrlPrefix(
+   *   "jdbc:aws-wrapper:mysql:",
+   *   JdbcDialects.getBuiltInDialect("mysql"))
    * }}}
    *
    * @param urlPrefix The additional JDBC URL prefix.
@@ -1074,17 +1077,36 @@ object JdbcDialects {
   }
   registerDialects()
 
-  /** The built-in MySQL dialect. */
-  @Since("4.3.0")
-  val MYSQL: JdbcDialect = dialects.collectFirst {
-    case dialect: MySQLDialect => dialect
-  }.get
+  private val builtInDialects: Map[String, JdbcDialect] = dialects.collect {
+    case dialect: MySQLDialect => "mysql" -> dialect
+    case dialect: PostgresDialect => "postgresql" -> dialect
+    case dialect: DB2Dialect => "db2" -> dialect
+    case dialect: MsSqlServerDialect => "sqlserver" -> dialect
+    case dialect: DerbyDialect => "derby" -> dialect
+    case dialect: OracleDialect => "oracle" -> dialect
+    case dialect: TeradataDialect => "teradata" -> dialect
+    case dialect: H2Dialect => "h2" -> dialect
+    case dialect: SnowflakeDialect => "snowflake" -> dialect
+    case dialect: DatabricksDialect => "databricks" -> dialect
+  }.toMap
 
-  /** The built-in PostgreSQL dialect. */
+  /**
+   * Return a built-in JDBC dialect by name. The lookup is case-insensitive. Supported names are
+   * `mysql`, `postgresql`, `db2`, `sqlserver`, `derby`, `oracle`, `teradata`, `h2`, `snowflake`,
+   * and `databricks`.
+   *
+   * @param name The name of the built-in JDBC dialect.
+   */
   @Since("4.3.0")
-  val POSTGRESQL: JdbcDialect = dialects.collectFirst {
-    case dialect: PostgresDialect => dialect
-  }.get
+  def getBuiltInDialect(name: String): JdbcDialect = {
+    Option(name).flatMap(name => builtInDialects.get(name.toLowerCase(Locale.ROOT))).getOrElse {
+      throw new SparkIllegalArgumentException(
+        errorClass = "UNSUPPORTED_BUILT_IN_JDBC_DIALECT",
+        messageParameters = Map(
+          "name" -> String.valueOf(name),
+          "supportedNames" -> builtInDialects.keys.toSeq.sorted.mkString(", ")))
+    }
+  }
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -994,7 +994,7 @@ private[sql] trait NoLegacyJDBCError extends JdbcDialect {
 @DeveloperApi
 object JdbcDialects {
 
-  private[this] var dialectsByUrlPrefix = List[(String, JdbcDialect)]()
+  @volatile private[this] var dialectsByUrlPrefix = List[(String, JdbcDialect)]()
 
   /**
    * Register an existing dialect for an additional JDBC URL prefix. The registration affects
@@ -1015,7 +1015,7 @@ object JdbcDialects {
    * @param dialect The existing dialect to use for URLs with the prefix.
    */
   @Since("4.3.0")
-  def registerDialectForUrlPrefix(urlPrefix: String, dialect: JdbcDialect): Unit = {
+  def registerDialectForUrlPrefix(urlPrefix: String, dialect: JdbcDialect): Unit = synchronized {
     val prefix = normalizePrefix(urlPrefix)
     dialectsByUrlPrefix = ((prefix, dialect) :: dialectsByUrlPrefix.filterNot(_._1 == prefix))
       .sortBy { case (registeredPrefix, _) => -registeredPrefix.length }
@@ -1028,7 +1028,7 @@ object JdbcDialects {
    * @param urlPrefix The additional JDBC URL prefix.
    */
   @Since("4.3.0")
-  def unregisterDialectForUrlPrefix(urlPrefix: String): Unit = {
+  def unregisterDialectForUrlPrefix(urlPrefix: String): Unit = synchronized {
     val prefix = normalizePrefix(urlPrefix)
     dialectsByUrlPrefix = dialectsByUrlPrefix.filterNot(_._1 == prefix)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -919,49 +919,70 @@ class JDBCSuite extends SharedSparkSession {
     assert(JdbcDialects.get("test.invalid") === NoopDialect)
   }
 
-  test("JDBC dialect aliases") {
-    assert(JdbcDialects.get("jdbc:aws-wrapper:mysql://127.0.0.1/db") === MySQLDialect())
-    assert(JdbcDialects.get("jdbc:aws-wrapper:postgresql://127.0.0.1/db") ===
-      PostgresDialect())
-
-    val alias = "jdbc:test-wrapper:mysql:"
+  test("Register existing JDBC dialects for additional URL prefixes") {
+    val mysqlPrefix = "jdbc:aws-wrapper:mysql:"
+    val postgresPrefix = "jdbc:aws-wrapper:postgresql:"
+    val mysqlUrl = "jdbc:aws-wrapper:mysql://127.0.0.1/db"
+    val postgresUrl = "jdbc:aws-wrapper:postgresql://127.0.0.1/db"
+    assert(JdbcDialects.get(mysqlUrl) === NoopDialect)
+    assert(JdbcDialects.get(postgresUrl) === NoopDialect)
     try {
-      JdbcDialects.registerDialectAlias(alias, "jdbc:mysql:")
-      assert(JdbcDialects.get("jdbc:test-wrapper:mysql://127.0.0.1/db") === MySQLDialect())
-      assert(JdbcDialects.get("JDBC:TEST-WRAPPER:MYSQL://127.0.0.1/db") === MySQLDialect())
+      JdbcDialects.registerDialectForUrlPrefix(
+        mysqlPrefix, JdbcDialects.get("jdbc:mysql:"))
+      JdbcDialects.registerDialectForUrlPrefix(
+        postgresPrefix, JdbcDialects.get("jdbc:postgresql:"))
+      assert(JdbcDialects.get(mysqlUrl) === MySQLDialect())
+      assert(JdbcDialects.get(postgresUrl) === PostgresDialect())
+      assert(JdbcDialects.get(mysqlUrl.toUpperCase(Locale.ROOT)) === MySQLDialect())
 
-      JdbcDialects.registerDialectAlias(alias, "jdbc:postgresql:")
-      assert(JdbcDialects.get("jdbc:test-wrapper:mysql://127.0.0.1/db") ===
-        PostgresDialect())
+      JdbcDialects.registerDialectForUrlPrefix(
+        mysqlPrefix, JdbcDialects.get("jdbc:postgresql:"))
+      assert(JdbcDialects.get(mysqlUrl) === PostgresDialect())
     } finally {
-      JdbcDialects.unregisterDialectAlias(alias)
+      JdbcDialects.unregisterDialectForUrlPrefix(mysqlPrefix)
+      JdbcDialects.unregisterDialectForUrlPrefix(postgresPrefix)
     }
-    assert(JdbcDialects.get("jdbc:test-wrapper:mysql://127.0.0.1/db") === NoopDialect)
+    assert(JdbcDialects.get(mysqlUrl) === NoopDialect)
+    assert(JdbcDialects.get(postgresUrl) === NoopDialect)
   }
 
-  test("A registered JDBC dialect takes precedence over an alias") {
+  test("A registered JDBC dialect takes precedence over an additional URL prefix") {
+    val prefix = "jdbc:aws-wrapper:mysql:"
     val dialect = new JdbcDialect {
       override def canHandle(url: String): Boolean =
-        url.toLowerCase(Locale.ROOT).startsWith("jdbc:aws-wrapper:mysql:")
+        url.toLowerCase(Locale.ROOT).startsWith(prefix)
     }
+    JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.get("jdbc:mysql:"))
     JdbcDialects.registerDialect(dialect)
     try {
       assert(JdbcDialects.get("jdbc:aws-wrapper:mysql://127.0.0.1/db") === dialect)
     } finally {
       JdbcDialects.unregisterDialect(dialect)
+      JdbcDialects.unregisterDialectForUrlPrefix(prefix)
     }
   }
 
-  test("JDBC dialect alias validation") {
-    Seq(
-      "mysql:" -> "jdbc:mysql:",
-      "jdbc:mysql" -> "jdbc:mysql:",
-      "jdbc:test-wrapper:" -> "mysql:",
-      "jdbc:test-wrapper:" -> "jdbc:mysql").foreach { case (alias, canonical) =>
+  test("The longest registered JDBC dialect URL prefix takes precedence") {
+    val shortPrefix = "jdbc:test:"
+    val longPrefix = "jdbc:test:mysql:"
+    try {
+      JdbcDialects.registerDialectForUrlPrefix(
+        longPrefix, JdbcDialects.get("jdbc:mysql:"))
+      JdbcDialects.registerDialectForUrlPrefix(
+        shortPrefix, JdbcDialects.get("jdbc:postgresql:"))
+      assert(JdbcDialects.get("jdbc:test:mysql://127.0.0.1/db") === MySQLDialect())
+    } finally {
+      JdbcDialects.unregisterDialectForUrlPrefix(shortPrefix)
+      JdbcDialects.unregisterDialectForUrlPrefix(longPrefix)
+    }
+  }
+
+  test("JDBC dialect URL prefix validation") {
+    Seq("mysql:", "jdbc:mysql").foreach { prefix =>
       val error = intercept[IllegalArgumentException] {
-        JdbcDialects.registerDialectAlias(alias, canonical)
+        JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.get("jdbc:mysql:"))
       }
-      assert(error.getMessage.contains("must start with 'jdbc:' and end with ':'"))
+      assert(error.getMessage.contains("URL prefixes must start with 'jdbc:' and end with ':'"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -22,6 +22,7 @@ import java.sql.{Connection, Date, DriverManager, ResultSet, SQLException, State
 import java.time.{Instant, LocalDate, LocalDateTime}
 import java.time.format.DateTimeFormatter
 import java.util.{Calendar, GregorianCalendar, Locale, Properties, TimeZone}
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
 
 import scala.jdk.CollectionConverters._
 import scala.util.Random
@@ -1004,6 +1005,33 @@ class JDBCSuite extends SharedSparkSession {
     } finally {
       JdbcDialects.unregisterDialectForUrlPrefix(shortPrefix)
       JdbcDialects.unregisterDialectForUrlPrefix(longPrefix)
+    }
+  }
+
+  test("Register JDBC dialect URL prefixes concurrently") {
+    val numPrefixes = 16
+    val prefixes = (0 until numPrefixes).map(i => s"jdbc:concurrent-$i:")
+    val pool = Executors.newFixedThreadPool(numPrefixes)
+    val startLatch = new CountDownLatch(1)
+    try {
+      val registrations = prefixes.map { prefix =>
+        pool.submit(new Runnable {
+          override def run(): Unit = {
+            startLatch.await()
+            JdbcDialects.registerDialectForUrlPrefix(
+              prefix, JdbcDialects.getBuiltInDialect("mysql"))
+          }
+        })
+      }
+      startLatch.countDown()
+      registrations.foreach(_.get(30, TimeUnit.SECONDS))
+
+      prefixes.foreach { prefix =>
+        assert(JdbcDialects.get(s"${prefix}//127.0.0.1/db") === MySQLDialect())
+      }
+    } finally {
+      prefixes.foreach(JdbcDialects.unregisterDialectForUrlPrefix)
+      pool.shutdownNow()
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -911,8 +911,8 @@ class JDBCSuite extends SharedSparkSession {
   }
 
   test("Default jdbc dialect registration") {
-    assert(JdbcDialects.get("jdbc:mysql://127.0.0.1/db") === MySQLDialect())
-    assert(JdbcDialects.get("jdbc:postgresql://127.0.0.1/db") === PostgresDialect())
+    assert(JdbcDialects.get("jdbc:mysql://127.0.0.1/db") eq JdbcDialects.MYSQL)
+    assert(JdbcDialects.get("jdbc:postgresql://127.0.0.1/db") eq JdbcDialects.POSTGRESQL)
     assert(JdbcDialects.get("jdbc:db2://127.0.0.1/db") === DB2Dialect())
     assert(JdbcDialects.get("jdbc:sqlserver://127.0.0.1/db") === MsSqlServerDialect())
     assert(JdbcDialects.get("jdbc:derby:db") === DerbyDialect())
@@ -927,16 +927,13 @@ class JDBCSuite extends SharedSparkSession {
     assert(JdbcDialects.get(mysqlUrl) === NoopDialect)
     assert(JdbcDialects.get(postgresUrl) === NoopDialect)
     try {
-      JdbcDialects.registerDialectForUrlPrefix(
-        mysqlPrefix, JdbcDialects.get("jdbc:mysql:"))
-      JdbcDialects.registerDialectForUrlPrefix(
-        postgresPrefix, JdbcDialects.get("jdbc:postgresql:"))
+      JdbcDialects.registerDialectForUrlPrefix(mysqlPrefix, JdbcDialects.MYSQL)
+      JdbcDialects.registerDialectForUrlPrefix(postgresPrefix, JdbcDialects.POSTGRESQL)
       assert(JdbcDialects.get(mysqlUrl) === MySQLDialect())
       assert(JdbcDialects.get(postgresUrl) === PostgresDialect())
       assert(JdbcDialects.get(mysqlUrl.toUpperCase(Locale.ROOT)) === MySQLDialect())
 
-      JdbcDialects.registerDialectForUrlPrefix(
-        mysqlPrefix, JdbcDialects.get("jdbc:postgresql:"))
+      JdbcDialects.registerDialectForUrlPrefix(mysqlPrefix, JdbcDialects.POSTGRESQL)
       assert(JdbcDialects.get(mysqlUrl) === PostgresDialect())
     } finally {
       JdbcDialects.unregisterDialectForUrlPrefix(mysqlPrefix)
@@ -952,7 +949,7 @@ class JDBCSuite extends SharedSparkSession {
       override def canHandle(url: String): Boolean =
         url.toLowerCase(Locale.ROOT).startsWith(prefix)
     }
-    JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.get("jdbc:mysql:"))
+    JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.MYSQL)
     JdbcDialects.registerDialect(dialect)
     try {
       assert(JdbcDialects.get("jdbc:aws-wrapper:mysql://127.0.0.1/db") === dialect)
@@ -966,10 +963,8 @@ class JDBCSuite extends SharedSparkSession {
     val shortPrefix = "jdbc:test:"
     val longPrefix = "jdbc:test:mysql:"
     try {
-      JdbcDialects.registerDialectForUrlPrefix(
-        longPrefix, JdbcDialects.get("jdbc:mysql:"))
-      JdbcDialects.registerDialectForUrlPrefix(
-        shortPrefix, JdbcDialects.get("jdbc:postgresql:"))
+      JdbcDialects.registerDialectForUrlPrefix(longPrefix, JdbcDialects.MYSQL)
+      JdbcDialects.registerDialectForUrlPrefix(shortPrefix, JdbcDialects.POSTGRESQL)
       assert(JdbcDialects.get("jdbc:test:mysql://127.0.0.1/db") === MySQLDialect())
     } finally {
       JdbcDialects.unregisterDialectForUrlPrefix(shortPrefix)
@@ -980,7 +975,7 @@ class JDBCSuite extends SharedSparkSession {
   test("JDBC dialect URL prefix validation") {
     Seq("mysql:", "jdbc:mysql").foreach { prefix =>
       val error = intercept[IllegalArgumentException] {
-        JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.get("jdbc:mysql:"))
+        JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.MYSQL)
       }
       assert(error.getMessage.contains("URL prefixes must start with 'jdbc:' and end with ':'"))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -21,7 +21,7 @@ import java.math.BigDecimal
 import java.sql.{Connection, Date, DriverManager, ResultSet, SQLException, Statement, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime}
 import java.time.format.DateTimeFormatter
-import java.util.{Calendar, GregorianCalendar, Properties, TimeZone}
+import java.util.{Calendar, GregorianCalendar, Locale, Properties, TimeZone}
 
 import scala.jdk.CollectionConverters._
 import scala.util.Random
@@ -917,6 +917,59 @@ class JDBCSuite extends SharedSparkSession {
     assert(JdbcDialects.get("jdbc:sqlserver://127.0.0.1/db") === MsSqlServerDialect())
     assert(JdbcDialects.get("jdbc:derby:db") === DerbyDialect())
     assert(JdbcDialects.get("test.invalid") === NoopDialect)
+  }
+
+  test("JDBC dialect aliases") {
+    assert(JdbcDialects.get("jdbc:aws-wrapper:mysql://127.0.0.1/db") === MySQLDialect())
+    assert(JdbcDialects.get("jdbc:aws-wrapper:postgresql://127.0.0.1/db") ===
+      PostgresDialect())
+
+    val alias = "jdbc:test-wrapper:mysql:"
+    try {
+      JdbcDialects.registerDialectAlias(alias, "jdbc:mysql:")
+      assert(JdbcDialects.get("jdbc:test-wrapper:mysql://127.0.0.1/db") === MySQLDialect())
+      assert(JdbcDialects.get("JDBC:TEST-WRAPPER:MYSQL://127.0.0.1/db") === MySQLDialect())
+
+      JdbcDialects.registerDialectAlias(alias, "jdbc:postgresql:")
+      assert(JdbcDialects.get("jdbc:test-wrapper:mysql://127.0.0.1/db") ===
+        PostgresDialect())
+    } finally {
+      JdbcDialects.unregisterDialectAlias(alias)
+    }
+    assert(JdbcDialects.get("jdbc:test-wrapper:mysql://127.0.0.1/db") === NoopDialect)
+  }
+
+  test("A registered JDBC dialect takes precedence over an alias") {
+    val dialect = new JdbcDialect {
+      override def canHandle(url: String): Boolean =
+        url.toLowerCase(Locale.ROOT).startsWith("jdbc:aws-wrapper:mysql:")
+    }
+    JdbcDialects.registerDialect(dialect)
+    try {
+      assert(JdbcDialects.get("jdbc:aws-wrapper:mysql://127.0.0.1/db") === dialect)
+    } finally {
+      JdbcDialects.unregisterDialect(dialect)
+    }
+  }
+
+  test("JDBC dialect alias validation") {
+    Seq(
+      "mysql:" -> "jdbc:mysql:",
+      "jdbc:mysql" -> "jdbc:mysql:",
+      "jdbc:test-wrapper:" -> "mysql:",
+      "jdbc:test-wrapper:" -> "jdbc:mysql").foreach { case (alias, canonical) =>
+      val error = intercept[IllegalArgumentException] {
+        JdbcDialects.registerDialectAlias(alias, canonical)
+      }
+      assert(error.getMessage.contains("must start with 'jdbc:' and end with ':'"))
+    }
+  }
+
+  test("JDBC dialect matching does not inspect the URL authority or path") {
+    assert(JdbcDialects.get("jdbc:unknown:mysql://127.0.0.1/db") === NoopDialect)
+    assert(JdbcDialects.get("jdbc:p6spy:mysql://127.0.0.1/db") === NoopDialect)
+    assert(JdbcDialects.get("jdbc:postgresql://host.mysql.com/db") === PostgresDialect())
+    assert(JdbcDialects.get("jdbc:mysql://host.postgresql.com/db") === MySQLDialect())
   }
 
   test("SPARK-57447: (H2|MySQL|Postgres)Dialect escape a single quote in indexExists") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -911,12 +911,41 @@ class JDBCSuite extends SharedSparkSession {
   }
 
   test("Default jdbc dialect registration") {
-    assert(JdbcDialects.get("jdbc:mysql://127.0.0.1/db") eq JdbcDialects.MYSQL)
-    assert(JdbcDialects.get("jdbc:postgresql://127.0.0.1/db") eq JdbcDialects.POSTGRESQL)
+    assert(JdbcDialects.get("jdbc:mysql://127.0.0.1/db") === MySQLDialect())
+    assert(JdbcDialects.get("jdbc:postgresql://127.0.0.1/db") === PostgresDialect())
     assert(JdbcDialects.get("jdbc:db2://127.0.0.1/db") === DB2Dialect())
     assert(JdbcDialects.get("jdbc:sqlserver://127.0.0.1/db") === MsSqlServerDialect())
     assert(JdbcDialects.get("jdbc:derby:db") === DerbyDialect())
     assert(JdbcDialects.get("test.invalid") === NoopDialect)
+  }
+
+  test("Get built-in JDBC dialects by name") {
+    Seq(
+      "mysql" -> "jdbc:mysql:",
+      "postgresql" -> "jdbc:postgresql:",
+      "db2" -> "jdbc:db2:",
+      "sqlserver" -> "jdbc:sqlserver:",
+      "derby" -> "jdbc:derby:",
+      "oracle" -> "jdbc:oracle:",
+      "teradata" -> "jdbc:teradata:",
+      "h2" -> "jdbc:h2:",
+      "snowflake" -> "jdbc:snowflake:",
+      "databricks" -> "jdbc:databricks:"
+    ).foreach { case (name, url) =>
+      val dialect = JdbcDialects.getBuiltInDialect(name)
+      assert(dialect eq JdbcDialects.get(url))
+      assert(dialect eq JdbcDialects.getBuiltInDialect(name.toUpperCase(Locale.ROOT)))
+    }
+
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        JdbcDialects.getBuiltInDialect("unknown")
+      },
+      condition = "UNSUPPORTED_BUILT_IN_JDBC_DIALECT",
+      parameters = Map(
+        "name" -> "unknown",
+        "supportedNames" ->
+          "databricks, db2, derby, h2, mysql, oracle, postgresql, snowflake, sqlserver, teradata"))
   }
 
   test("Register existing JDBC dialects for additional URL prefixes") {
@@ -927,13 +956,16 @@ class JDBCSuite extends SharedSparkSession {
     assert(JdbcDialects.get(mysqlUrl) === NoopDialect)
     assert(JdbcDialects.get(postgresUrl) === NoopDialect)
     try {
-      JdbcDialects.registerDialectForUrlPrefix(mysqlPrefix, JdbcDialects.MYSQL)
-      JdbcDialects.registerDialectForUrlPrefix(postgresPrefix, JdbcDialects.POSTGRESQL)
+      JdbcDialects.registerDialectForUrlPrefix(
+        mysqlPrefix, JdbcDialects.getBuiltInDialect("mysql"))
+      JdbcDialects.registerDialectForUrlPrefix(
+        postgresPrefix, JdbcDialects.getBuiltInDialect("postgresql"))
       assert(JdbcDialects.get(mysqlUrl) === MySQLDialect())
       assert(JdbcDialects.get(postgresUrl) === PostgresDialect())
       assert(JdbcDialects.get(mysqlUrl.toUpperCase(Locale.ROOT)) === MySQLDialect())
 
-      JdbcDialects.registerDialectForUrlPrefix(mysqlPrefix, JdbcDialects.POSTGRESQL)
+      JdbcDialects.registerDialectForUrlPrefix(
+        mysqlPrefix, JdbcDialects.getBuiltInDialect("postgresql"))
       assert(JdbcDialects.get(mysqlUrl) === PostgresDialect())
     } finally {
       JdbcDialects.unregisterDialectForUrlPrefix(mysqlPrefix)
@@ -949,7 +981,8 @@ class JDBCSuite extends SharedSparkSession {
       override def canHandle(url: String): Boolean =
         url.toLowerCase(Locale.ROOT).startsWith(prefix)
     }
-    JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.MYSQL)
+    JdbcDialects.registerDialectForUrlPrefix(
+      prefix, JdbcDialects.getBuiltInDialect("mysql"))
     JdbcDialects.registerDialect(dialect)
     try {
       assert(JdbcDialects.get("jdbc:aws-wrapper:mysql://127.0.0.1/db") === dialect)
@@ -963,8 +996,10 @@ class JDBCSuite extends SharedSparkSession {
     val shortPrefix = "jdbc:test:"
     val longPrefix = "jdbc:test:mysql:"
     try {
-      JdbcDialects.registerDialectForUrlPrefix(longPrefix, JdbcDialects.MYSQL)
-      JdbcDialects.registerDialectForUrlPrefix(shortPrefix, JdbcDialects.POSTGRESQL)
+      JdbcDialects.registerDialectForUrlPrefix(
+        longPrefix, JdbcDialects.getBuiltInDialect("mysql"))
+      JdbcDialects.registerDialectForUrlPrefix(
+        shortPrefix, JdbcDialects.getBuiltInDialect("postgresql"))
       assert(JdbcDialects.get("jdbc:test:mysql://127.0.0.1/db") === MySQLDialect())
     } finally {
       JdbcDialects.unregisterDialectForUrlPrefix(shortPrefix)
@@ -975,7 +1010,8 @@ class JDBCSuite extends SharedSparkSession {
   test("JDBC dialect URL prefix validation") {
     Seq("mysql:", "jdbc:mysql").foreach { prefix =>
       val error = intercept[IllegalArgumentException] {
-        JdbcDialects.registerDialectForUrlPrefix(prefix, JdbcDialects.MYSQL)
+        JdbcDialects.registerDialectForUrlPrefix(
+          prefix, JdbcDialects.getBuiltInDialect("mysql"))
       }
       assert(error.getMessage.contains("URL prefixes must start with 'jdbc:' and end with ':'"))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR lets users register an existing `JdbcDialect` for an additional JDBC URL prefix. The
registration affects dialect lookup only; Spark still passes the original URL to the JDBC driver.

It adds `JdbcDialects.registerDialectForUrlPrefix` and
`unregisterDialectForUrlPrefix`. It also adds `getBuiltInDialect`, a case-insensitive lookup for
the built-in `mysql`, `postgresql`, `db2`, `sqlserver`, `derby`, `oracle`, `teradata`, `h2`,
`snowflake`, and `databricks` dialects. For example, a user can reuse the built-in MySQL dialect
for a known-compatible wrapper:

```scala
JdbcDialects.registerDialectForUrlPrefix(
  "jdbc:aws-wrapper:mysql:",
  JdbcDialects.getBuiltInDialect("mysql"))
```

An unsupported built-in dialect name raises a `SparkIllegalArgumentException` with the
`UNSUPPORTED_BUILT_IN_JDBC_DIALECT` error condition.

Prefixes are case-insensitive, validated to start with `jdbc:` and end with `:`, and consulted only
when no registered dialect handles the original URL through `canHandle`. This preserves the
precedence of user-provided dialects. When prefixes overlap, the longest matching prefix wins.

### Why are the changes needed?

Wrapper JDBC drivers can use URLs such as `jdbc:aws-wrapper:mysql://...` while speaking the same
database dialect as the underlying MySQL or PostgreSQL driver.

Matching arbitrary nested protocols with a broad regular expression assumes that every URL of the
form `jdbc:<anything>:mysql` or `jdbc:<anything>:postgresql` is compatible with the corresponding
built-in dialect. It can also inspect unrelated portions of the URL. Registering a specific prefix
directly to an existing dialect makes that relationship deliberate and bounded without requiring
users to inherit from or copy a built-in dialect. The named lookup makes all built-in dialects
discoverable without exposing a public collection or requiring knowledge of canonical JDBC URLs.
Spark registers no additional prefixes by default, so compatibility remains an explicit user
decision.

This follows up on the discussion in #53902.

### Does this PR introduce _any_ user-facing change?

Yes. Users can look up a built-in dialect by its documented name, and register or unregister an
existing dialect for an additional JDBC URL prefix through `JdbcDialects`. Wrapper URLs remain
unmatched until a user explicitly registers a dialect for their prefix.

### How was this patch tested?

Added tests covering all ten built-in dialect names, case-insensitive named lookup, structured
errors for unsupported names, explicit prefix registration and replacement, case-insensitive
prefix matching, unregistration, prefix validation, longest-prefix matching, user-registered
dialect precedence, and negative cases where unregistered wrappers or database names in the URL
authority must not select a dialect.

The following commands were run:

```
build/sbt 'sql/testOnly *JDBCSuite -- -z "JDBC dialect"'
build/sbt sql/scalastyle sql/Test/scalastyle
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
