### PR TITLE
[SPARK-58283][SQL] Assign names to the error conditions _LEGACY_ERROR_TEMP_1138-1141

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -350,6 +350,12 @@
     ],
     "sqlState" : "22004"
   },
+  "AVRO_DATA_SOURCE_NOT_ENABLED" : {
+    "message" : [
+      "Failed to find data source: <provider>. Avro is built-in but external data source module since Spark 2.4. Please deploy the application as per the deployment section of Apache Avro Data Source Guide."
+    ],
+    "sqlState" : "42K02"
+  },
   "AVRO_INCOMPATIBLE_READ_TYPE" : {
     "message" : [
       "Cannot convert Avro <avroPath> to SQL <sqlPath> because the original encoded data type is <avroType>, however you're trying to read the field as <sqlType>, which would lead to an incorrect answer.",
@@ -5393,6 +5399,12 @@
     ],
     "sqlState" : "42K0E"
   },
+  "KAFKA_DATA_SOURCE_NOT_ENABLED" : {
+    "message" : [
+      "Failed to find data source: <provider>. Please deploy the application as per the deployment section of Structured Streaming + Kafka Integration Guide."
+    ],
+    "sqlState" : "42K02"
+  },
   "KLL_INVALID_INPUT_SKETCH_BUFFER" : {
     "message" : [
       "Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)."
@@ -5684,6 +5696,12 @@
       "Flow with multipart name '<flowName>' is not supported."
     ],
     "sqlState" : "0A000"
+  },
+  "MULTIPLE_DATA_SOURCES" : {
+    "message" : [
+      "Multiple sources found for <provider> (<sourceNames>), please specify the fully qualified class name."
+    ],
+    "sqlState" : "42710"
   },
   "MULTIPLE_EVENT_TIME_COLUMNS" : {
     "message" : [
@@ -6156,6 +6174,12 @@
       "The value of <paramName> cannot be more than one character, but got <actualValue>."
     ],
     "sqlState" : "22023"
+  },
+  "ORC_DATA_SOURCE_REQUIRES_HIVE_SUPPORT" : {
+    "message" : [
+      "Hive built-in ORC data source must be used with Hive support enabled. Please use the native ORC data source by setting 'spark.sql.orc.impl' to 'native'."
+    ],
+    "sqlState" : "0A000"
   },
   "ORDER_BY_POS_OUT_OF_RANGE" : {
     "message" : [
@@ -9805,26 +9829,6 @@
   "_LEGACY_ERROR_TEMP_1137" : {
     "message" : [
       "Unable to resolve <name> given [<outputStr>]."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1138" : {
-    "message" : [
-      "Hive built-in ORC data source must be used with Hive support enabled. Please use the native ORC data source by setting 'spark.sql.orc.impl' to 'native'."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1139" : {
-    "message" : [
-      "Failed to find data source: <provider>. Avro is built-in but external data source module since Spark 2.4. Please deploy the application as per the deployment section of Apache Avro Data Source Guide."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1140" : {
-    "message" : [
-      "Failed to find data source: <provider>. Please deploy the application as per the deployment section of Structured Streaming + Kafka Integration Guide."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1141" : {
-    "message" : [
-      "Multiple sources found for <provider> (<sourceNames>), please specify the fully qualified class name."
     ]
   },
   "_LEGACY_ERROR_TEMP_1143" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1966,19 +1966,19 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def orcNotUsedWithHiveEnabledError(): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1138",
+      errorClass = "ORC_DATA_SOURCE_REQUIRES_HIVE_SUPPORT",
       messageParameters = Map.empty)
   }
 
   def failedToFindAvroDataSourceError(provider: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1139",
+      errorClass = "AVRO_DATA_SOURCE_NOT_ENABLED",
       messageParameters = Map("provider" -> provider))
   }
 
   def failedToFindKafkaDataSourceError(provider: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1140",
+      errorClass = "KAFKA_DATA_SOURCE_NOT_ENABLED",
       messageParameters = Map("provider" -> provider))
   }
 
@@ -1992,7 +1992,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def findMultipleDataSourceError(provider: String, sourceNames: Seq[String]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1141",
+      errorClass = "MULTIPLE_DATA_SOURCES",
       messageParameters = Map(
         "provider" -> provider,
         "sourceNames" -> sourceNames.mkString(", ")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1676,7 +1676,7 @@ class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
       exception = intercept[AnalysisException] {
         sql(s"select id from `org.apache.spark.sql.hive.orc`.`file_path`")
       },
-      condition = "_LEGACY_ERROR_TEMP_1138"
+      condition = "ORC_DATA_SOURCE_REQUIRES_HIVE_SUPPORT"
     )
 
     e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -196,7 +196,7 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
         exception = intercept[AnalysisException] {
           sql("CREATE TABLE t LIKE s USING org.apache.spark.sql.hive.orc")
         },
-        condition = "_LEGACY_ERROR_TEMP_1138",
+        condition = "ORC_DATA_SOURCE_REQUIRES_HIVE_SUPPORT",
         parameters = Map.empty
       )
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLSourceLoadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLSourceLoadSuite.scala
@@ -30,7 +30,7 @@ class DDLSourceLoadSuite extends DataSourceTest with SharedSparkSession {
       exception = intercept[AnalysisException] {
         spark.read.format("Fluet da Bomb").load()
       },
-      condition = "_LEGACY_ERROR_TEMP_1141",
+      condition = "MULTIPLE_DATA_SOURCES",
       parameters = Map(
         "provider" -> "Fluet da Bomb",
         "sourceNames" -> ("org.apache.spark.sql.sources.FakeSourceOne, " +
@@ -49,7 +49,7 @@ class DDLSourceLoadSuite extends DataSourceTest with SharedSparkSession {
       exception = intercept[AnalysisException] {
         spark.read.format("Fake external source").load()
       },
-      condition = "_LEGACY_ERROR_TEMP_1141",
+      condition = "MULTIPLE_DATA_SOURCES",
       parameters = Map(
         "provider" -> "Fake external source",
         "sourceNames" -> ("org.apache.fakesource.FakeExternalSourceOne, " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
@@ -84,7 +84,7 @@ class ResolvedDataSourceSuite extends SharedSparkSession {
         exception = intercept[AnalysisException] {
           getProvidingClass(provider)
         },
-        condition = "_LEGACY_ERROR_TEMP_1139",
+        condition = "AVRO_DATA_SOURCE_NOT_ENABLED",
         parameters = Map("provider" -> provider)
       )
     }
@@ -95,7 +95,7 @@ class ResolvedDataSourceSuite extends SharedSparkSession {
       exception = intercept[AnalysisException] {
         getProvidingClass("kafka")
       },
-      condition = "_LEGACY_ERROR_TEMP_1140",
+      condition = "KAFKA_DATA_SOURCE_NOT_ENABLED",
       parameters = Map("provider" -> "kafka")
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Resolve four legacy error conditions raised while resolving a data source provider in `DataSource.lookupDataSource`, converting them to proper top-level names in `error-conditions.json`:

- `_LEGACY_ERROR_TEMP_1138` → `ORC_DATA_SOURCE_REQUIRES_HIVE_SUPPORT` (`0A000`)
- `_LEGACY_ERROR_TEMP_1139` → `AVRO_DATA_SOURCE_NOT_ENABLED` (`42K02`)
- `_LEGACY_ERROR_TEMP_1140` → `KAFKA_DATA_SOURCE_NOT_ENABLED` (`42K02`)
- `_LEGACY_ERROR_TEMP_1141` → `MULTIPLE_DATA_SOURCES` (`42710`)

The message text is preserved verbatim from the legacy entries.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves four of them.

They are kept as top-level names rather than folded into the existing `DATA_SOURCE_NOT_FOUND` / `MULTIPLE_XML_DATA_SOURCE`: the Avro/Kafka errors are `AnalysisException`s (not the `SparkClassNotFoundException` of `DATA_SOURCE_NOT_FOUND`) and carry module-specific deployment guidance, and the multiple-sources error mirrors the existing XML-specific `MULTIPLE_XML_DATA_SOURCE` but for the generic provider path.

### Does this PR introduce _any_ user-facing change?

No. Only the error condition names are assigned; the message text is unchanged. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API.

### How was this patch tested?

Updated the existing `checkError` assertions to the new condition names in `SQLQuerySuite`, `DDLSuite`, `ResolvedDataSourceSuite`, and `DDLSourceLoadSuite`. `build/sbt "sql/testOnly *ResolvedDataSourceSuite *DDLSourceLoadSuite *SQLQuerySuite *InMemoryCatalogedDDLSuite" "core/testOnly org.apache.spark.SparkThrowableSuite"` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
