### PR TITLE
[SPARK-58107][FOLLOWUP][CORE] Fix stale identifier in local-checkpoint self-check comment

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1158,8 +1158,9 @@ private[spark] class BlockManager(
         // For a sealed block whose local copy does not match the sealed checksum, skip the local
         // copy and fall through to a remote (authoritative) location: it is a stale replica the
         // seal is evicting, but that eviction is async and may not have landed. This self-check
-        // makes correctness independent of the eviction landing. Only `verifySealed` blocks are
-        // checked; an unsealed block, or one checksummed only for observation, is served as-is.
+        // makes correctness independent of the eviction landing. Only `verifySealedChecksum`
+        // blocks are checked; an unsealed block, or one checksummed only for observation, is
+        // served as-is.
         // This is only used with localCheckpoint, whose lineage is cut once sealed, so a lost block
         // is never recomputed: there is no later, differently-checksummed re-materialization to
         // reconcile here - a skipped local copy means the block is genuinely gone, not superseded.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to [SPARK-58107](https://issues.apache.org/jira/browse/SPARK-58107). In
`BlockManager.getLocalValues`, the read-side self-check comment referred to `verifySealed`; the
`BlockInfo` field it checks is `verifySealedChecksum`. Corrected the comment.

Comment-only change.

### Why are the changes needed?

The comment names a field that does not exist (`verifySealed`), which is misleading when reading the
self-check logic. The actual field is `verifySealedChecksum`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests needed - source comment only, no behavioral effect.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)