### PR TITLE
[SPARK-58274][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1068

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -854,6 +854,12 @@
     ],
     "sqlState" : "42000"
   },
+  "CANNOT_USE_PRESERVED_DATABASE_AS_CURRENT" : {
+    "message" : [
+      "<database> is a system preserved database, you cannot use it as current database. To access global temporary views, you should use qualified name with the GLOBAL_TEMP_DATABASE, e.g. SELECT * FROM <database>.viewName."
+    ],
+    "sqlState" : "42000"
+  },
   "CANNOT_WRITE_STATE_STORE" : {
     "message" : [
       "Error writing state store files for provider <providerClass>."
@@ -9695,11 +9701,6 @@
   "_LEGACY_ERROR_TEMP_1066" : {
     "message" : [
       "<database> is a system preserved database, you cannot create a database with this name."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1068" : {
-    "message" : [
-      "<database> is a system preserved database, you cannot use it as current database. To access global temporary views, you should use qualified name with the GLOBAL_TEMP_DATABASE, e.g. SELECT * FROM <database>.viewName."
     ]
   },
   "_LEGACY_ERROR_TEMP_1071" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1361,7 +1361,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def cannotUsePreservedDatabaseAsCurrentDatabaseError(database: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1068",
+      errorClass = "CANNOT_USE_PRESERVED_DATABASE_AS_CURRENT",
       messageParameters = Map("database" -> database))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1109,6 +1109,15 @@ class QueryCompilationErrorsSuite
       )
     }
   }
+
+  test("CANNOT_USE_PRESERVED_DATABASE_AS_CURRENT: set the global temp database as current") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.catalog.setCurrentDatabase("global_temp")
+      },
+      condition = "CANNOT_USE_PRESERVED_DATABASE_AS_CURRENT",
+      parameters = Map("database" -> "global_temp"))
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1068` to
`CANNOT_USE_PRESERVED_DATABASE_AS_CURRENT` (SQLSTATE `42000`). Message text is unchanged.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks
existing ones to be resolved. This resolves one.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a `checkError` test in `QueryCompilationErrorsSuite`. `SparkThrowableSuite` passes.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8
