### PR TITLE
[SPARK-58305][PYTHON] Clarify jinja2 usage

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -57,7 +57,7 @@ RUN python3.11 -m pip install --ignore-installed 'blinker>=1.6.2' && \
 # Sphinx and documentation packages
 # See 'ipython_genutils' in SPARK-38517, 'docutils' in SPARK-39421
 RUN python3.11 -m pip install 'sphinx==8.2.3' mkdocs 'pydata_sphinx_theme>=0.13' \
-    sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
+    sphinx-copybutton nbsphinx numpydoc markupsafe 'pyzmq<24.0.0' \
     ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.23.2' pyarrow pandas \
     'plotly>=4.8' 'docutils' 'mypy==1.19.1' 'pytest==7.1.3' \
     'pytest-mypy-plugins==1.9.3' 'ruff==0.14.8' 'pandas-stubs==1.2.0.53' \

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -91,7 +91,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # See 'ipython_genutils' in SPARK-38517
 # See 'docutils<0.18.0' in SPARK-39421
-RUN python3.12 -m pip install 'sphinx==8.2.3' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe \
+RUN python3.12 -m pip install 'sphinx==8.2.3' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc markupsafe \
   ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.23.2' 'pyarrow>=23.0.0' 'pandas==2.3.3' 'plotly>=4.8' 'docutils' \
   'mypy==1.19.1' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'ruff==0.14.8' \
   'pandas-stubs==1.2.0.53' 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.5' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -90,7 +90,6 @@ RUN python3.12 -m pip install \
     'zstandard==0.25.0' \
     'ipython' \
     'ipython_genutils' \
-    'jinja2' \
     'matplotlib' \
     'mypy==1.19.1' \
     'numpy==2.4.1' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ pandas_on_spark_extra = [
     "plotly<6.0.0",
     "matplotlib",
     "mlflow>=2.3.1",
+    "jinja2",
 ]
 
 ml = [
@@ -179,7 +180,6 @@ _docs = [
     "ipython",
     "nbsphinx",
     "numpydoc",
-    "jinja2",
     "mkdocs",
 ]
 

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -280,6 +280,7 @@ Additional libraries that enhance functionality but are not included in the inst
 - **mlflow**: Required for ``pyspark.pandas.mlflow``.
 - **plotly**: Provide plotting for visualization. It is recommended using **plotly** over **matplotlib**.
 - **matplotlib**: Provide plotting for visualization. The default is **plotly**.
+- **jinja2**: Required for ``pyspark.pandas.to_latex``.
 
 
 MLlib DataFrame-based API


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Moved `jinja2` to `pandas_on_spark_extra` in dependency groups. Removed if from all the lint/doc docker images. Added documentation about it as the other optional requirements for pandas on spark.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`jinja2` was not well documented and it was misused in our CIs. It is a [requirement](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_latex.html) to use `to_latex`, not doc related. That's also the only usage we have in pyspark code.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI needs to pass - if docs/lint CI fails because `jinja2` is removed, I need to investigate again. Otherwise it proves that this package is not used for docs/lint.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.