### PR TITLE
[SPARK-58309][SS] Anchor now() and current_time() to the batch timestamp in streaming queries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -307,6 +307,9 @@ case class CurrentBatchTimestamp(
       case _: TimestampNTZType =>
         Literal(convertTz(timestampUs, ZoneOffset.UTC, zoneId), TimestampNTZType)
       case _: DateType => Literal(microsToDays(timestampUs, zoneId), DateType)
+      case t: TimeType =>
+        val nanosOfDay = instantToNanosOfDay(microsToInstant(timestampUs), zoneId)
+        Literal(truncateTimeToPrecision(nanosOfDay, t.precision), t)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4209,6 +4209,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val STREAMING_ANCHOR_NOW_AND_CURRENT_TIME =
+    buildConf("spark.sql.streaming.anchorNowAndCurrentTime")
+      .internal()
+      .doc("When true, now() and current_time() are anchored to the batch timestamp of a " +
+        "streaming query, so that a batch replayed after failure or restart reproduces the " +
+        "same value, as current_timestamp(), current_date() and localtimestamp() already do. " +
+        "When false, now() and current_time() are evaluated against the wall clock at plan " +
+        "optimization time and are not reproducible across batch replays.")
+      .version("4.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val STREAMING_POLLING_DELAY =
     buildConf("spark.sql.streaming.pollingDelay")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -31,7 +31,7 @@ import org.apache.spark.internal.LogKeys
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.catalyst.analysis.{ResolveDeduplicate, V2TableReference}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatchTimestamp, CurrentDate, CurrentTimestamp, FileSourceMetadataAttribute, LocalTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatchTimestamp, CurrentDate, CurrentTime, CurrentTimestampLike, FileSourceMetadataAttribute, LocalTimestamp}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Deduplicate, DeduplicateWithinWatermark, Distinct, FlatMapGroupsInPandasWithState, FlatMapGroupsWithState, GlobalLimit, Join, LeafNode, LocalRelation, LogicalPlan, Project, StreamSourceAwareLogicalPlan, TransformWithState, TransformWithStateInPySpark}
 import org.apache.spark.sql.catalyst.streaming.{StreamingRelationV2, Unassigned, WriteToStream}
 import org.apache.spark.sql.catalyst.trees.TreePattern.CURRENT_LIKE
@@ -1184,10 +1184,11 @@ class MicroBatchExecution(
     // Rewire the plan to use the new attributes that were returned by the source.
     val newAttributePlan = newBatchesPlan.transformAllExpressionsWithPruning(
       _.containsPattern(CURRENT_LIKE)) {
-      case ct: CurrentTimestamp =>
-        // CurrentTimestamp is not TimeZoneAwareExpression while CurrentBatchTimestamp is.
-        // Without TimeZoneId, CurrentBatchTimestamp is unresolved. Here, we use an explicit
-        // dummy string to prevent UnresolvedException and to prevent to be used in the future.
+      case ct: CurrentTimestampLike =>
+        // CurrentTimestampLike (current_timestamp(), now()) is not a TimeZoneAwareExpression
+        // while CurrentBatchTimestamp is. Without TimeZoneId, CurrentBatchTimestamp is unresolved.
+        // Here, we use an explicit dummy string to prevent UnresolvedException and to prevent to
+        // be used in the future.
         CurrentBatchTimestamp(execCtx.offsetSeqMetadata.batchTimestampMs,
           ct.dataType, Some("Dummy TimeZoneId"))
       case lt: LocalTimestamp =>
@@ -1196,6 +1197,9 @@ class MicroBatchExecution(
       case cd: CurrentDate =>
         CurrentBatchTimestamp(execCtx.offsetSeqMetadata.batchTimestampMs,
           cd.dataType, cd.timeZoneId)
+      case ct: CurrentTime =>
+        CurrentBatchTimestamp(execCtx.offsetSeqMetadata.batchTimestampMs,
+          ct.dataType, ct.timeZoneId)
     }
 
     val triggerLogicalPlan = sink match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -31,7 +31,7 @@ import org.apache.spark.internal.LogKeys
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.catalyst.analysis.{ResolveDeduplicate, V2TableReference}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatchTimestamp, CurrentDate, CurrentTime, CurrentTimestampLike, FileSourceMetadataAttribute, LocalTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatchTimestamp, CurrentDate, CurrentTime, CurrentTimestamp, CurrentTimestampLike, FileSourceMetadataAttribute, LocalTimestamp}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Deduplicate, DeduplicateWithinWatermark, Distinct, FlatMapGroupsInPandasWithState, FlatMapGroupsWithState, GlobalLimit, Join, LeafNode, LocalRelation, LogicalPlan, Project, StreamSourceAwareLogicalPlan, TransformWithState, TransformWithStateInPySpark}
 import org.apache.spark.sql.catalyst.streaming.{StreamingRelationV2, Unassigned, WriteToStream}
 import org.apache.spark.sql.catalyst.trees.TreePattern.CURRENT_LIKE
@@ -1182,13 +1182,17 @@ class MicroBatchExecution(
     }
     execCtx.newData = mutableNewData.toMap
     // Rewire the plan to use the new attributes that were returned by the source.
+    val anchorNowAndCurrentTime = sparkSession.sessionState.conf.getConf(
+      SQLConf.STREAMING_ANCHOR_NOW_AND_CURRENT_TIME)
     val newAttributePlan = newBatchesPlan.transformAllExpressionsWithPruning(
       _.containsPattern(CURRENT_LIKE)) {
-      case ct: CurrentTimestampLike =>
-        // CurrentTimestampLike (current_timestamp(), now()) is not a TimeZoneAwareExpression
-        // while CurrentBatchTimestamp is. Without TimeZoneId, CurrentBatchTimestamp is unresolved.
-        // Here, we use an explicit dummy string to prevent UnresolvedException and to prevent to
-        // be used in the future.
+      // CurrentTimestampLike (current_timestamp(), now()) is not a TimeZoneAwareExpression
+      // while CurrentBatchTimestamp is. Without TimeZoneId, CurrentBatchTimestamp is unresolved.
+      // Here, we use an explicit dummy string to prevent UnresolvedException and to prevent to
+      // be used in the future.
+      // current_timestamp() was anchored before SPARK-58309, so the conf does not apply to it.
+      case ct: CurrentTimestampLike
+          if anchorNowAndCurrentTime || ct.isInstanceOf[CurrentTimestamp] =>
         CurrentBatchTimestamp(execCtx.offsetSeqMetadata.batchTimestampMs,
           ct.dataType, Some("Dummy TimeZoneId"))
       case lt: LocalTimestamp =>
@@ -1197,7 +1201,7 @@ class MicroBatchExecution(
       case cd: CurrentDate =>
         CurrentBatchTimestamp(execCtx.offsetSeqMetadata.batchTimestampMs,
           cd.dataType, cd.timeZoneId)
-      case ct: CurrentTime =>
+      case ct: CurrentTime if anchorNowAndCurrentTime =>
         CurrentBatchTimestamp(execCtx.offsetSeqMetadata.batchTimestampMs,
           ct.dataType, ct.timeZoneId)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -32,7 +32,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkConf, SparkContext, TaskContext, TestUtils}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
-import org.apache.spark.sql.{AnalysisException, Encoders, Row, SQLContext, TestStrategy}
+import org.apache.spark.sql.{AnalysisException, Column, Encoders, Row, SQLContext, TestStrategy}
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.catalyst.streaming.{InternalOutputModes, StreamingRelationV2}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -1266,6 +1266,50 @@ class StreamSuite extends StreamTest {
         lastTimestamp = assertBatchOutputAndUpdateLastTimestamp(rows, lastTimestamp, currentDate, 2)
       }
     )
+  }
+
+  private def zone: ZoneId = ZoneId.of(spark.sessionState.conf.sessionLocalTimeZone)
+  Seq[(Column, Long => Any)](
+    (current_timestamp(), batchMs => new java.sql.Timestamp(batchMs)),
+    (now(), batchMs => new java.sql.Timestamp(batchMs)),
+    (current_date(),
+      batchMs => java.sql.Date.valueOf(java.time.Instant.ofEpochMilli(batchMs)
+        .atZone(zone).toLocalDate)),
+    (current_time(),
+      batchMs => java.time.Instant.ofEpochMilli(batchMs).atZone(zone).toLocalTime)
+  ).foreach { case (column, expected) =>
+    test(s"SPARK-58309 $column is anchored to the batch timestamp in streaming queries") {
+      val input = MemoryStream[Int]
+      val df = input.toDS().select(column)
+      val clock = new StreamManualClock
+
+      testStream(df)(
+        StartStream(Trigger.ProcessingTime("10 seconds"), triggerClock = clock),
+        AddData(input, 1),
+        AdvanceManualClock(10 * 1000),
+        CheckLastBatch { rows: Seq[Row] =>
+          assert(rows.map(_.get(0)) === Seq(expected(10 * 1000L)))
+        },
+        AddData(input, 2),
+        AdvanceManualClock(10 * 1000),
+        CheckLastBatch { rows: Seq[Row] =>
+          assert(rows.map(_.get(0)) === Seq(expected(20 * 1000L)))
+        },
+        // Purge batch 1's commit so restart reruns it. The rerun must reproduce the batch's
+        // persisted timestamp (20s), not the advanced wall clock (80s).
+        StopStream,
+        AssertOnQuery { q =>
+          q.sink.asInstanceOf[MemorySink].clear()
+          q.commitLog.purge(2)
+          clock.advance(60 * 1000L)
+          true
+        },
+        StartStream(Trigger.ProcessingTime("10 seconds"), triggerClock = clock),
+        CheckLastBatch { rows: Seq[Row] =>
+          assert(rows.map(_.get(0)) === Seq(expected(20 * 1000L)))
+        }
+      )
+    }
   }
 
   // ProcessingTime trigger generates MicroBatchExecution, and ContinuousTrigger starts a

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -33,6 +33,7 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark.{SparkConf, SparkContext, TaskContext, TestUtils}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, Column, Encoders, Row, SQLContext, TestStrategy}
+import org.apache.spark.sql.catalyst.expressions.CurrentBatchTimestamp
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.catalyst.streaming.{InternalOutputModes, StreamingRelationV2}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -1309,6 +1310,36 @@ class StreamSuite extends StreamTest {
           assert(rows.map(_.get(0)) === Seq(expected(20 * 1000L)))
         }
       )
+    }
+  }
+
+  // now() and current_time() are the two expressions SPARK-58309 started anchoring, so only
+  // they are affected by the conf. The rest were already anchored before it.
+  Seq(
+    ("now()", now(), true),
+    ("current_time()", current_time(), true),
+    ("current_timestamp()", current_timestamp(), false),
+    ("current_date()", current_date(), false),
+    ("localtimestamp()", localtimestamp(), false)
+  ).foreach { case (name, column, affectedByConf) =>
+    test(s"SPARK-58309 anchoring $name to the batch timestamp can be disabled by conf") {
+      withSQLConf(SQLConf.STREAMING_ANCHOR_NOW_AND_CURRENT_TIME.key -> "false") {
+        val input = MemoryStream[Int]
+        val df = input.toDS().select(column)
+
+        testStream(df)(
+          AddData(input, 1),
+          ProcessAllAvailable(),
+          AssertOnQuery { q =>
+            // With the conf off, now() and current_time() are left for the optimizer to fold
+            // against the wall clock, so no CurrentBatchTimestamp is planted for them.
+            val anchored = q.lastExecution.logical.exists(
+              _.expressions.exists(_.exists(_.isInstanceOf[CurrentBatchTimestamp])))
+            assert(anchored === !affectedByConf)
+            true
+          }
+        )
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `MicroBatchExecution`, the per-batch rewrite that replaces `CURRENT_LIKE` temporal expressions with `CurrentBatchTimestamp` only matched `CurrentTimestamp`, `CurrentDate` and `LocalTimestamp`. Two expressions carrying the `CURRENT_LIKE` tree pattern were missed:

- `Now` (`now()`) -- a sibling of `CurrentTimestamp` under the `CurrentTimestampLike` base class. The match on the leaf type `CurrentTimestamp` did not catch it.
- `CurrentTime` (`current_time()` / `localtime()`, the `TIME` value type).

This PR:
- Widens the `CurrentTimestamp` case to `CurrentTimestampLike`, covering both `current_timestamp()` and `now()`. Matching the base class rather than the leaf types keeps future `CurrentTimestampLike` subclasses covered.
- Adds a `CurrentTime` case, and a `TimeType` branch to `CurrentBatchTimestamp.toLiteral` that derives the time-of-day (nanoseconds since midnight, in the session time zone) from the batch timestamp, truncated to the type's precision. (Because the batch timestamp is millisecond-resolution, sub-millisecond digits of `current_time()` are zero in streaming.)
- Adds an internal config, `spark.sql.streaming.anchorNowAndCurrentTime` (default `true`), to gate the new anchoring. Setting it to `false` restores the previous behavior, where `now()` and `current_time()` are folded against the wall clock at plan-optimization time.

The config scope is exactly the two expressions this PR started anchoring. `current_timestamp()`, `current_date()` and `localtimestamp()` were already anchored before this PR and are rewritten regardless of the config.

### Why are the changes needed?

Expressions left unrewritten survive to the per-batch optimizer, where `ComputeCurrentTime` folds them using the wall clock at plan-optimization time. That value is not reproducible when a batch is replayed after failure or on restart from a checkpoint, breaking the determinism guarantee that `CurrentBatchTimestamp` (anchored to the batch timestamp persisted in the offset log) exists to provide. `now()` and `current_time()` were therefore non-deterministic across batch replays.

### Does this PR introduce _any_ user-facing change?

Yes. In a streaming query, `now()` and `current_time()` now return the batch timestamp (stable across replay/restart of the same batch), consistent with `current_timestamp()`, `current_date()` and `localtimestamp()`, instead of the wall clock at plan-optimization time. Setting `spark.sql.streaming.anchorNowAndCurrentTime` to `false` restores the previous behavior.

### How was this patch tested?

Added two parameterized tests in `StreamSuite`:

- Anchoring, covering `current_timestamp()`, `now()`, `current_date()` and `current_time()`. Using a manual clock it asserts the exact per-batch value, then purges the last batch's commit and restarts with the wall clock advanced far ahead, asserting the replayed batch reproduces its persisted timestamp rather than the advanced clock.
- Config, covering all five expressions. With the config off it asserts `now()` and `current_time()` are no longer rewritten to `CurrentBatchTimestamp`, while `current_timestamp()`, `current_date()` and `localtimestamp()` still are -- pinning the config's scope from both sides.

### Was this patch authored or co-authored using generative AI tooling?
No
