### PR TITLE
[SPARK-58312][PYTHON] Remove unnecessary type: ignore comments in pyspark.sql.group

### DIFF
--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# mypy: disable-error-code="empty-body"
+
 import sys
 
 from typing import Callable, List, Optional, TYPE_CHECKING, overload, Dict, Union, cast, Tuple
@@ -189,7 +191,7 @@ class GroupedData(PandasGroupedOpsMixin):
         return DataFrame(jdf, self.session)
 
     @dfapi
-    def count(self) -> "DataFrame":  # type: ignore[empty-body]
+    def count(self) -> "DataFrame":
         """Counts the number of records for each group.
 
         .. versionadded:: 1.3.0
@@ -223,7 +225,7 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     @df_varargs_api
-    def mean(self, *cols: str) -> DataFrame:  # type: ignore[empty-body]
+    def mean(self, *cols: str) -> DataFrame:
         """Computes average values for each numeric columns for each group.
 
         :func:`mean` is an alias for :func:`avg`.
@@ -240,7 +242,7 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     @df_varargs_api
-    def avg(self, *cols: str) -> "DataFrame":  # type: ignore[empty-body]
+    def avg(self, *cols: str) -> "DataFrame":
         """Computes average values for each numeric columns for each group.
 
         :func:`mean` is an alias for :func:`avg`.
@@ -291,7 +293,7 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     @df_varargs_api
-    def max(self, *cols: str) -> "DataFrame":  # type: ignore[empty-body]
+    def max(self, *cols: str) -> "DataFrame":
         """Computes the max value for each numeric columns for each group.
 
         .. versionadded:: 1.3.0
@@ -335,7 +337,7 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     @df_varargs_api
-    def min(self, *cols: str) -> "DataFrame":  # type: ignore[empty-body]
+    def min(self, *cols: str) -> "DataFrame":
         """Computes the min value for each numeric column for each group.
 
         .. versionadded:: 1.3.0
@@ -384,7 +386,7 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     @df_varargs_api
-    def sum(self, *cols: str) -> DataFrame:  # type: ignore[empty-body]
+    def sum(self, *cols: str) -> DataFrame:
         """Computes the sum for each numeric columns for each group.
 
         .. versionadded:: 1.3.0

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -707,22 +707,21 @@ class UDFRegistration:
                         "SQL_GROUPED_AGG_PANDAS_ITER_UDF or SQL_GROUPED_AGG_ARROW_ITER_UDF"
                     },
                 )
-            source_udf = _create_udf(
+            register_udf = UserDefinedFunction(
                 f.func,
                 returnType=f.returnType,
                 name=name,
                 evalType=f.evalType,
                 deterministic=f.deterministic,
             )
-            register_udf = source_udf._unwrapped  # type: ignore[attr-defined]
-            return_udf = register_udf
+            return_udf: "UserDefinedFunctionLike" = register_udf
         else:
             if returnType is None:
                 returnType = StringType()
-            return_udf = _create_udf(
+            register_udf = UserDefinedFunction(
                 f, returnType=returnType, evalType=PythonEvalType.SQL_BATCHED_UDF, name=name
             )
-            register_udf = return_udf._unwrapped  # type: ignore[attr-defined]
+            return_udf = register_udf._wrapped()
         self.sparkSession._jsparkSession.udf().registerPython(name, register_udf._judf)
         return return_udf
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -707,21 +707,22 @@ class UDFRegistration:
                         "SQL_GROUPED_AGG_PANDAS_ITER_UDF or SQL_GROUPED_AGG_ARROW_ITER_UDF"
                     },
                 )
-            register_udf = UserDefinedFunction(
+            source_udf = _create_udf(
                 f.func,
                 returnType=f.returnType,
                 name=name,
                 evalType=f.evalType,
                 deterministic=f.deterministic,
             )
-            return_udf: "UserDefinedFunctionLike" = register_udf
+            register_udf = source_udf._unwrapped  # type: ignore[attr-defined]
+            return_udf = register_udf
         else:
             if returnType is None:
                 returnType = StringType()
-            register_udf = UserDefinedFunction(
+            return_udf = _create_udf(
                 f, returnType=returnType, evalType=PythonEvalType.SQL_BATCHED_UDF, name=name
             )
-            return_udf = register_udf._wrapped()
+            register_udf = return_udf._unwrapped  # type: ignore[attr-defined]
         self.sparkSession._jsparkSession.udf().registerPython(name, register_udf._judf)
         return return_udf
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `python/pyspark/sql/group.py`, the `@dfapi`/`@df_varargs_api` decorated methods (`count`, `mean`, `avg`, `max`, `min`, `sum`) intentionally have docstring-only bodies, which trigger 6 `# type: ignore[empty-body]` comments. These per-method ignores are replaced by a single file-level `# mypy: disable-error-code="empty-body"` directive, matching the style already used in `dataframe.py`, `column.py`, `window.py`, and `table_arg.py`.

Note: an earlier revision of this PR also touched `python/pyspark/sql/udf.py`. That part has been reverted per review feedback. This PR now only changes `group.py`.


### Why are the changes needed?
To reduce type-checker noise and improve readability, and to make `group.py` consistent with the sibling files that already suppress `empty-body` at the file level.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests. `mypy --namespace-packages --config-file python/mypy.ini python/pyspark` passes at full scope.


### Was this patch authored or co-authored using generative AI tooling?
No