### PR TITLE
[SPARK-58296][SQL] Fix to_time return type with null format

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -98,7 +98,7 @@ case class ToTime(str: Expression, format: Option[Expression])
     case Some(expr) if expr.foldable =>
       Option(expr.eval())
         .map(f => invokeParser(Some(f.toString), Seq(str)))
-        .getOrElse(Literal(null, expr.dataType))
+        .getOrElse(Literal.create(null, TimeType()))
     case _ => invokeParser()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -586,6 +586,17 @@ abstract class TimeFunctionsSuiteBase extends SharedSparkSession {
     )
   }
 
+  test("SPARK-58296: to_time with a foldable null format returns TIME") {
+    val results = Seq(
+      spark.range(1).selectExpr("to_time('00:00:00', NULL)"),
+      spark.range(1).select(to_time(lit("00:00:00"), lit(null))))
+
+    results.foreach { result =>
+      assert(result.schema.fields.head.dataType == TimeType())
+      checkAnswer(result, Row(null))
+    }
+  }
+
   test("SPARK-53929: try_make_timestamp function") {
     // Input data for the function.
     val schema = StructType(Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `ToTime` to return a null literal typed as `TimeType` when its
foldable format argument evaluates to null.

It also adds regression coverage for SQL and Column API calls. The shared test
runs with both ANSI mode enabled and disabled.

### Why are the changes needed?

When a foldable null format was provided, `ToTime` created its null result using
the format expression's data type. Since the format argument is a string
expression, the result was incorrectly typed as `STRING` instead of `TIME`.

`to_time` must preserve its declared `TIME` result type even when the format
argument causes the result value to be null.

### Does this PR introduce _any_ user-facing change?

Yes. For expressions such as `to_time('00:00:00', NULL)`, the result value
remains null, but its schema is now correctly reported as `TIME` instead of
`STRING`.

### How was this patch tested?

Added a regression test and ran it in both ANSI configurations:

```bash
build/sbt \
  'sql/testOnly org.apache.spark.sql.TimeFunctionsAnsiOnSuite -- -z "SPARK-58296"' \
  'sql/testOnly org.apache.spark.sql.TimeFunctionsAnsiOffSuite -- -z "SPARK-58296"'
```

Both tests passed.