### PR TITLE
[MINOR][CONNECT] Remove redundant user_context.user_id assignment in execute_command methods

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1413,8 +1413,6 @@ class SparkConnectClient(object):
             # when not at debug log level.
             logger.debug(f"Execute command for command {self._proto_to_string(command, True)}")
         req = self._execute_plan_request_with_metadata()
-        if self._user_id:
-            req.user_context.user_id = self._user_id
         self._set_command_in_plan(req.plan, command)
         data, _, metrics, observed_metrics, properties = self._execute_and_fetch(
             req, observations or {}
@@ -1439,8 +1437,6 @@ class SparkConnectClient(object):
                 f"Execute command as iterator for command {self._proto_to_string(command, True)}"
             )
         req = self._execute_plan_request_with_metadata()
-        if self._user_id:
-            req.user_context.user_id = self._user_id
         self._set_command_in_plan(req.plan, command)
         for response in self._execute_and_fetch_as_iterator(req, observations or {}):
             if isinstance(response, dict):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove two redundant assignments of `req.user_context.user_id = self._user_id` from `SparkConnectClient.execute_command` and `SparkConnectClient.execute_command_as_iterator`.

Both methods call `_execute_plan_request_with_metadata()` to build the request, and that helper already sets `req.user_context.user_id` under the identical `if self._user_id:` guard. The subsequent reassignments in the two callers are dead code.

```python
# _execute_plan_request_with_metadata() already does this:
if self._user_id:
    req.user_context.user_id = self._user_id

# These lines in execute_command / execute_command_as_iterator were redundant:
- if self._user_id:
-     req.user_context.user_id = self._user_id
```

Relates to GitHub issue #56408.

### Why are the changes needed?

Dead code removal / readability improvement. Setting the same protobuf field to the same value twice in sequence is misleading — it implies the first assignment might not be sufficient when it is.

### Does this PR introduce _any_ user-facing change?

No. The resulting `req.user_context.user_id` value is identical before and after this change.

### How was this patch tested?

No behavior change; existing Spark Connect unit tests cover `execute_command` / `execute_command_as_iterator` request construction.

> This PR was created with the assistance of Claude (AI). Disclosed per Apache Spark contribution guidelines.