### PR TITLE
[SPARK-56942][SPARK-58815][SQL] Support nested row IDs and collision-safe attribute binding

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
@@ -72,7 +72,7 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
 
     // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readPlan = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
 
     // construct a plan that contains unmatched rows in matched groups that must be carried over
     // such rows do not match the condition but have to be copied over as the source can replace
@@ -81,7 +81,7 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
     // it is safe to negate the condition here as the predicate pushdown for group-based row-level
     // operations is handled in a special way
     val remainingRowsFilter = Not(EqualNullSafe(cond, TrueLiteral))
-    val remainingRowsPlan = Filter(remainingRowsFilter, readRelation)
+    val remainingRowsPlan = Filter(remainingRowsFilter, readPlan)
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
@@ -99,16 +99,22 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val operation = operationTable.operation.asInstanceOf[SupportsDelta]
-    val rowIdAttrs = resolveRowIdAttrs(relation, operation)
+    val rowIdRefs = resolveRowIdRefs(relation, operation)
+    val rowIdAttrs = rowIdRefs.rowIdAttrs
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
 
-    // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+    // construct a read plan with all required row ID and metadata columns
+    val readRelation = buildRelationWithAttrs(
+      relation, operationTable, metadataAttrs, rowIdRefs.scanAttrs)
+    val readPlan = withExtractedRowIds(readRelation, rowIdRefs.extractionAliases)
 
     // construct a plan that only contains records to delete
-    val deletedRowsPlan = Filter(cond, readRelation)
+    val deletedRowsPlan = Filter(cond, readPlan)
     val operationType = Alias(Literal(DELETE_OPERATION), OPERATION_COLUMN)()
-    val requiredWriteAttrs = nullifyMetadataOnDelete(dedupAttrs(rowIdAttrs ++ metadataAttrs))
+    // preserve row IDs even when they are also required metadata attributes
+    val rowIdExprIds = rowIdAttrs.map(_.exprId).toSet
+    val metadataOnlyAttrs = metadataAttrs.filterNot(attr => rowIdExprIds.contains(attr.exprId))
+    val requiredWriteAttrs = rowIdAttrs ++ nullifyMetadataOnDelete(metadataOnlyAttrs)
     val project = Project(operationType +: requiredWriteAttrs, deletedRowsPlan)
 
     // build a plan to write deletes to the table

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
@@ -69,10 +69,15 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
 
     // resolve all required metadata attrs that may be used for grouping data on write
     // for instance, JDBC data source may cluster data by shard/host before writing
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val metadataRefs = resolveRequiredMetadataRefs(relation, operationTable.operation)
+    val metadataAttrs = metadataRefs.attrs
 
     // construct a read relation and include all required metadata columns
-    val readPlan = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataRefs.scanAttrs)
+    val readPlan = projectWithExtractedRefs(
+      readRelation,
+      relation.output ++ metadataAttrs,
+      metadataRefs.extractionAliases)
 
     // construct a plan that contains unmatched rows in matched groups that must be carried over
     // such rows do not match the condition but have to be copied over as the source can replace
@@ -99,14 +104,19 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val operation = operationTable.operation.asInstanceOf[SupportsDelta]
-    val rowIdRefs = resolveRowIdRefs(relation, operation)
+    val resolvedRefs = resolveDeltaRefs(relation, operation)
+    val rowIdRefs = resolvedRefs.rowIdRefs
     val rowIdAttrs = rowIdRefs.rowIdAttrs
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val metadataRefs = resolvedRefs.metadataRefs
+    val metadataAttrs = metadataRefs.attrs
 
     // construct a read plan with all required row ID and metadata columns
     val readRelation = buildRelationWithAttrs(
-      relation, operationTable, metadataAttrs, rowIdRefs.scanAttrs)
-    val readPlan = withExtractedRowIds(readRelation, rowIdRefs.extractionAliases)
+      relation, operationTable, metadataRefs.scanAttrs, rowIdRefs.scanAttrs)
+    val readPlan = projectWithExtractedRefs(
+      readRelation,
+      dedupAttrs(relation.output ++ metadataAttrs ++ rowIdRefs.attrs),
+      metadataRefs.extractionAliases ++ rowIdRefs.extractionAliases)
 
     // construct a plan that only contains records to delete
     val deletedRowsPlan = Filter(cond, readPlan)
@@ -116,10 +126,12 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
     val metadataOnlyAttrs = metadataAttrs.filterNot(attr => rowIdExprIds.contains(attr.exprId))
     val requiredWriteAttrs = rowIdAttrs ++ nullifyMetadataOnDelete(metadataOnlyAttrs)
     val project = Project(operationType +: requiredWriteAttrs, deletedRowsPlan)
+    val rowDelta = bindRowDeltaPlan(
+      project, requiredWriteAttrs.map(_.toAttribute), project.output.tail)
 
     // build a plan to write deletes to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(project, Nil, rowIdAttrs, metadataAttrs)
+    val projections = buildWriteDeltaProjections(rowDelta, Nil, rowIdAttrs, metadataAttrs)
     WriteDelta(writeRelation, cond, project, relation, projections)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, Exists, Expression, IsNotNull, Literal, MetadataAttribute, MonotonicallyIncreasingID, OuterReference, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
@@ -270,18 +271,20 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val rowAttrs = relation.output
-    val rowIdAttrs = resolveRowIdAttrs(relation, operation)
+    val rowIdRefs = resolveRowIdRefs(relation, operation)
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
 
-    // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+    // construct a read plan with all required row ID and metadata columns
+    val readRelation = buildRelationWithAttrs(
+      relation, operationTable, metadataAttrs, rowIdRefs.scanAttrs)
+    val readPlan = withExtractedRowIds(readRelation, rowIdRefs.extractionAliases)
 
     // if there is no NOT MATCHED BY SOURCE clause, predicates of the ON condition that
     // reference only the target table can be pushed down
     val (filteredReadRelation, joinCond) = if (notMatchedBySourceActions.isEmpty) {
-      pushDownTargetPredicates(readRelation, cond)
+      pushDownTargetPredicates(readPlan, cond)
     } else {
-      (readRelation, cond)
+      (readPlan, cond)
     }
 
     val checkCardinality = shouldCheckCardinality(matchedActions)
@@ -289,20 +292,21 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val joinType = chooseWriteDeltaJoinType(notMatchedActions, notMatchedBySourceActions)
     val joinPlan = join(filteredReadRelation, source, joinType, joinCond, checkCardinality)
 
-    val mergeRowsPlan = buildWriteDeltaMergeRowsPlan(
-      readRelation, joinPlan, matchedActions, notMatchedActions,
-      notMatchedBySourceActions, rowIdAttrs, checkCardinality,
+    val rowDelta = buildWriteDeltaMergeRowsPlan(
+      readPlan, joinPlan, matchedActions, notMatchedActions,
+      notMatchedBySourceActions, rowIdRefs, checkCardinality,
       operation.representUpdateAsDeleteAndInsert)
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(mergeRowsPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+    val projections = buildWriteDeltaProjections(
+      rowDelta.plan, rowAttrs, rowDelta.rowIdAttrs, metadataAttrs)
     val groupFilterCond = if (notMatchedBySourceActions.isEmpty && groupFilterEnabled) {
       Some(toGroupFilterCondition(relation, source, cond))
     } else {
       None
     }
-    WriteDelta(writeRelation, cond, mergeRowsPlan, relation, projections, groupFilterCond)
+    WriteDelta(writeRelation, cond, rowDelta.plan, relation, projections, groupFilterCond)
   }
 
   private def chooseWriteDeltaJoinType(
@@ -324,17 +328,26 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
   }
 
   private def buildWriteDeltaMergeRowsPlan(
-      targetTable: DataSourceV2Relation,
+      targetTable: LogicalPlan,
       joinPlan: LogicalPlan,
       matchedActions: Seq[MergeAction],
       notMatchedActions: Seq[MergeAction],
       notMatchedBySourceActions: Seq[MergeAction],
-      rowIdAttrs: Seq[Attribute],
+      rowIdRefs: ResolvedRowIdRefs,
       checkCardinality: Boolean,
-      splitUpdates: Boolean): MergeRows = {
+      splitUpdates: Boolean): RowDeltaPlan = {
 
-    val (metadataAttrs, rowAttrs) = targetTable.output.partition { attr =>
+    val extractionExprIds = rowIdRefs.extractionAttrs.map(_.exprId).toSet
+    val (extractionAttrs, nonExtractionAttrs) = targetTable.output.partition { attr =>
+      extractionExprIds.contains(attr.exprId)
+    }
+    val (metadataAttrs, rowAttrs) = nonExtractionAttrs.partition { attr =>
       MetadataAttribute.isValid(attr.metadata)
+    }
+    // buildRowDeltaPlan rebinds extracted row IDs by position
+    if (extractionAttrs.map(_.exprId) != rowIdRefs.extractionAttrs.map(_.exprId)) {
+      throw SparkException.internalError(
+        "Extracted row ID attributes are missing or out of order")
     }
 
     val originalRowIdValues = if (splitUpdates) {
@@ -346,19 +359,25 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
         case UpdateAction(_, assignments, _) => assignments
         case _ => Nil
       }
-      buildOriginalRowIdValues(rowIdAttrs, updateAssignments)
+      buildOriginalRowIdValues(rowIdRefs.rowIdAttrs, updateAssignments)
     }
 
     val matchedInstructions = matchedActions.map { action =>
-      toInstruction(action, rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues, splitUpdates)
+      toInstruction(
+        action, rowAttrs, rowIdRefs.rowIdAttrs, metadataAttrs, originalRowIdValues,
+        extractionAttrs, splitUpdates)
     }
 
     val notMatchedInstructions = notMatchedActions.map { action =>
-      toInstruction(action, rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues, splitUpdates)
+      toInstruction(
+        action, rowAttrs, rowIdRefs.rowIdAttrs, metadataAttrs, originalRowIdValues,
+        extractionAttrs, splitUpdates)
     }
 
     val notMatchedBySourceInstructions = notMatchedBySourceActions.map { action =>
-      toInstruction(action, rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues, splitUpdates)
+      toInstruction(
+        action, rowAttrs, rowIdRefs.rowIdAttrs, metadataAttrs, originalRowIdValues,
+        extractionAttrs, splitUpdates)
     }
 
     val rowFromSourceAttr = resolveAttrRef(ROW_FROM_SOURCE, joinPlan)
@@ -370,17 +389,19 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
     val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
     val originalRowIdAttrs = originalRowIdValues.map(_.toAttribute)
-    val attrs = Seq(operationTypeAttr) ++ targetTable.output ++ originalRowIdAttrs
+    val baseAttrs = Seq(operationTypeAttr) ++ rowAttrs ++ metadataAttrs ++ originalRowIdAttrs
 
-    MergeRows(
-      isSourceRowPresent = IsNotNull(rowFromSourceAttr),
-      isTargetRowPresent = IsNotNull(rowFromTargetAttr),
-      matchedInstructions = matchedInstructions,
-      notMatchedInstructions = notMatchedInstructions,
-      notMatchedBySourceInstructions = notMatchedBySourceInstructions,
-      checkCardinality = checkCardinality,
-      output = generateExpandOutput(attrs, outputs),
-      joinPlan)
+    buildRowDeltaPlan(baseAttrs, outputs, rowIdRefs) { output =>
+      MergeRows(
+        isSourceRowPresent = IsNotNull(rowFromSourceAttr),
+        isTargetRowPresent = IsNotNull(rowFromTargetAttr),
+        matchedInstructions = matchedInstructions,
+        notMatchedInstructions = notMatchedInstructions,
+        notMatchedBySourceInstructions = notMatchedBySourceInstructions,
+        checkCardinality = checkCardinality,
+        output = output,
+        joinPlan)
+    }
   }
 
   private def pushDownTargetPredicates(
@@ -472,24 +493,33 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       rowIdAttrs: Seq[Attribute],
       metadataAttrs: Seq[Attribute],
       originalRowIdValues: Seq[Alias],
+      extractionAttrs: Seq[Attribute],
       splitUpdates: Boolean): Instruction = {
+
+    // inserts and reinserts have no existing row ID, so use null placeholders
+    val nullExtractionValues = extractionAttrs.map(attr => Literal(null, attr.dataType))
 
     action match {
       case UpdateAction(cond, assignments, _) if splitUpdates =>
-        val output = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues)
-        val otherOutput = deltaReinsertOutput(assignments, metadataAttrs, originalRowIdValues)
+        val output = deltaDeleteOutput(
+          rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues) ++ extractionAttrs
+        val otherOutput = deltaReinsertOutput(
+          assignments, metadataAttrs, originalRowIdValues) ++ nullExtractionValues
         Split(cond.getOrElse(TrueLiteral), output, otherOutput)
 
       case UpdateAction(cond, assignments, _) =>
-        val output = deltaUpdateOutput(assignments, metadataAttrs, originalRowIdValues)
+        val output = deltaUpdateOutput(
+          assignments, metadataAttrs, originalRowIdValues) ++ extractionAttrs
         Keep(Update, cond.getOrElse(TrueLiteral), output)
 
       case DeleteAction(cond) =>
-        val output = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues)
+        val output = deltaDeleteOutput(
+          rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues) ++ extractionAttrs
         Keep(Delete, cond.getOrElse(TrueLiteral), output)
 
       case InsertAction(cond, assignments) =>
-        val output = deltaInsertOutput(assignments, metadataAttrs, originalRowIdValues)
+        val output = deltaInsertOutput(
+          assignments, metadataAttrs, originalRowIdValues) ++ nullExtractionValues
         Keep(Insert, cond.getOrElse(TrueLiteral), output)
 
       case other =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLite
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{DeleteAction, Filter, HintInfo, InsertAction, InsertOnlyMerge, Join, JoinHint, LogicalPlan, MergeAction, MergeIntoTable, MergeRows, NO_BROADCAST_AND_REPLICATION, Project, ReplaceData, UpdateAction, WriteDelta}
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Discard, Insert, Instruction, Keep, ROW_ID, Split, Update}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Discard, Insert, Instruction, Keep, Split, Update}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{COPY_OPERATION, INSERT_OPERATION, OPERATION_COLUMN, UPDATE_OPERATION}
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
@@ -112,7 +112,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
             matchedInstructions = Nil,
             notMatchedInstructions = notMatchedInstructions,
             notMatchedBySourceInstructions = Nil,
-            checkCardinality = false,
+            cardinalityRowId = None,
             output = generateExpandOutput(r.output, outputs),
             joinPlan)
 
@@ -157,21 +157,27 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
     // resolve all required metadata attrs that may be used for grouping data on write
     // for instance, JDBC data source may cluster data by shard/host before writing
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val metadataRefs = resolveRequiredMetadataRefs(relation, operationTable.operation)
+    val metadataAttrs = metadataRefs.attrs
 
     // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val relationWithMetadata =
+      buildRelationWithAttrs(relation, operationTable, metadataRefs.scanAttrs)
+    val readRelation = projectWithExtractedRefs(
+      relationWithMetadata,
+      relation.output ++ metadataAttrs,
+      metadataRefs.extractionAliases)
 
     val checkCardinality = shouldCheckCardinality(matchedActions)
 
     // use left outer join if there is no NOT MATCHED action, unmatched source rows can be discarded
     // use full outer join in all other cases, unmatched source rows may be needed
     val joinType = if (notMatchedActions.isEmpty) LeftOuter else FullOuter
-    val joinPlan = join(readRelation, source, joinType, cond, checkCardinality)
+    val mergeJoin = join(readRelation, source, joinType, cond, checkCardinality)
 
     val mergeRowsPlan = buildReplaceDataMergeRowsPlan(
-      readRelation, joinPlan, matchedActions, notMatchedActions,
-      notMatchedBySourceActions, metadataAttrs, checkCardinality)
+      readRelation, mergeJoin, matchedActions, notMatchedActions,
+      notMatchedBySourceActions, metadataAttrs)
 
     // predicates of the ON condition can be used to filter the target table (planning & runtime)
     // only if there is no NOT MATCHED BY SOURCE clause
@@ -193,12 +199,11 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
   private def buildReplaceDataMergeRowsPlan(
       targetTable: LogicalPlan,
-      joinPlan: LogicalPlan,
+      mergeJoin: MergeJoin,
       matchedActions: Seq[MergeAction],
       notMatchedActions: Seq[MergeAction],
       notMatchedBySourceActions: Seq[MergeAction],
-      metadataAttrs: Seq[Attribute],
-      checkCardinality: Boolean): MergeRows = {
+      metadataAttrs: Seq[Attribute]): MergeRows = {
 
     // target records that were read but did not match any MATCHED or NOT MATCHED BY SOURCE actions
     // must be copied over and included in the new state of the table as groups are being replaced
@@ -220,9 +225,6 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       toInstruction(action, metadataAttrs)
     } :+ keepCarryoverRowsInstruction
 
-    val rowFromSourceAttr = resolveAttrRef(ROW_FROM_SOURCE, joinPlan)
-    val rowFromTargetAttr = resolveAttrRef(ROW_FROM_TARGET, joinPlan)
-
     val outputs = matchedInstructions.flatMap(_.outputs) ++
       notMatchedInstructions.flatMap(_.outputs) ++
       notMatchedBySourceInstructions.flatMap(_.outputs)
@@ -231,14 +233,14 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val attrs = operationTypeAttr +: targetTable.output
 
     MergeRows(
-      isSourceRowPresent = IsNotNull(rowFromSourceAttr),
-      isTargetRowPresent = IsNotNull(rowFromTargetAttr),
+      isSourceRowPresent = IsNotNull(mergeJoin.sourcePresent),
+      isTargetRowPresent = IsNotNull(mergeJoin.targetPresent),
       matchedInstructions = matchedInstructions,
       notMatchedInstructions = notMatchedInstructions,
       notMatchedBySourceInstructions = notMatchedBySourceInstructions,
-      checkCardinality = checkCardinality,
+      cardinalityRowId = mergeJoin.cardinalityRowId,
       output = generateExpandOutput(attrs, outputs),
-      joinPlan)
+      mergeJoin.plan)
   }
 
   // converts a MERGE condition into an EXISTS subquery for runtime filtering
@@ -271,13 +273,18 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val rowAttrs = relation.output
-    val rowIdRefs = resolveRowIdRefs(relation, operation)
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val resolvedRefs = resolveDeltaRefs(relation, operation)
+    val rowIdRefs = resolvedRefs.rowIdRefs
+    val metadataRefs = resolvedRefs.metadataRefs
+    val metadataAttrs = metadataRefs.attrs
 
     // construct a read plan with all required row ID and metadata columns
     val readRelation = buildRelationWithAttrs(
-      relation, operationTable, metadataAttrs, rowIdRefs.scanAttrs)
-    val readPlan = withExtractedRowIds(readRelation, rowIdRefs.extractionAliases)
+      relation, operationTable, metadataRefs.scanAttrs, rowIdRefs.scanAttrs)
+    val readPlan = projectWithExtractedRefs(
+      readRelation,
+      dedupAttrs(relation.output ++ metadataAttrs ++ rowIdRefs.attrs),
+      metadataRefs.extractionAliases ++ rowIdRefs.extractionAliases)
 
     // if there is no NOT MATCHED BY SOURCE clause, predicates of the ON condition that
     // reference only the target table can be pushed down
@@ -290,17 +297,17 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val checkCardinality = shouldCheckCardinality(matchedActions)
 
     val joinType = chooseWriteDeltaJoinType(notMatchedActions, notMatchedBySourceActions)
-    val joinPlan = join(filteredReadRelation, source, joinType, joinCond, checkCardinality)
+    val mergeJoin = join(filteredReadRelation, source, joinType, joinCond, checkCardinality)
 
     val rowDelta = buildWriteDeltaMergeRowsPlan(
-      readPlan, joinPlan, matchedActions, notMatchedActions,
-      notMatchedBySourceActions, rowIdRefs, checkCardinality,
+      readPlan, mergeJoin, matchedActions, notMatchedActions,
+      notMatchedBySourceActions, rowIdRefs,
       operation.representUpdateAsDeleteAndInsert)
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
     val projections = buildWriteDeltaProjections(
-      rowDelta.plan, rowAttrs, rowDelta.rowIdAttrs, metadataAttrs)
+      rowDelta, rowAttrs, rowIdRefs.rowIdAttrs, metadataAttrs)
     val groupFilterCond = if (notMatchedBySourceActions.isEmpty && groupFilterEnabled) {
       Some(toGroupFilterCondition(relation, source, cond))
     } else {
@@ -329,12 +336,11 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
   private def buildWriteDeltaMergeRowsPlan(
       targetTable: LogicalPlan,
-      joinPlan: LogicalPlan,
+      mergeJoin: MergeJoin,
       matchedActions: Seq[MergeAction],
       notMatchedActions: Seq[MergeAction],
       notMatchedBySourceActions: Seq[MergeAction],
-      rowIdRefs: ResolvedRowIdRefs,
-      checkCardinality: Boolean,
+      rowIdRefs: ResolvedConnectorRefs,
       splitUpdates: Boolean): RowDeltaPlan = {
 
     val extractionExprIds = rowIdRefs.extractionAttrs.map(_.exprId).toSet
@@ -380,9 +386,6 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
         extractionAttrs, splitUpdates)
     }
 
-    val rowFromSourceAttr = resolveAttrRef(ROW_FROM_SOURCE, joinPlan)
-    val rowFromTargetAttr = resolveAttrRef(ROW_FROM_TARGET, joinPlan)
-
     val outputs = matchedInstructions.flatMap(_.outputs) ++
       notMatchedInstructions.flatMap(_.outputs) ++
       notMatchedBySourceInstructions.flatMap(_.outputs)
@@ -391,16 +394,20 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val originalRowIdAttrs = originalRowIdValues.map(_.toAttribute)
     val baseAttrs = Seq(operationTypeAttr) ++ rowAttrs ++ metadataAttrs ++ originalRowIdAttrs
 
-    buildRowDeltaPlan(baseAttrs, outputs, rowIdRefs) { output =>
+    buildRowDeltaPlan(
+        baseAttrs,
+        outputs,
+        rowIdRefs,
+        originalRowIdValues) { output =>
       MergeRows(
-        isSourceRowPresent = IsNotNull(rowFromSourceAttr),
-        isTargetRowPresent = IsNotNull(rowFromTargetAttr),
+        isSourceRowPresent = IsNotNull(mergeJoin.sourcePresent),
+        isTargetRowPresent = IsNotNull(mergeJoin.targetPresent),
         matchedInstructions = matchedInstructions,
         notMatchedInstructions = notMatchedInstructions,
         notMatchedBySourceInstructions = notMatchedBySourceInstructions,
-        checkCardinality = checkCardinality,
+        cardinalityRowId = mergeJoin.cardinalityRowId,
         output = output,
-        joinPlan)
+        mergeJoin.plan)
     }
   }
 
@@ -417,22 +424,28 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     (Filter(targetCond, targetTable), joinCond)
   }
 
+  private case class MergeJoin(
+      plan: LogicalPlan,
+      sourcePresent: Attribute,
+      targetPresent: Attribute,
+      cardinalityRowId: Option[Attribute])
+
   private def join(
       targetTable: LogicalPlan,
       source: LogicalPlan,
       joinType: JoinType,
       joinCond: Expression,
-      checkCardinality: Boolean): LogicalPlan = {
+      checkCardinality: Boolean): MergeJoin = {
 
     // project an extra column to check if a target row exists after the join
     // if needed, project a synthetic row ID used to perform the cardinality check later
     val rowFromTarget = Alias(TrueLiteral, ROW_FROM_TARGET)()
-    val targetTableProjExprs = if (checkCardinality) {
-      val rowId = Alias(MonotonicallyIncreasingID(), ROW_ID)()
-      targetTable.output ++ Seq(rowFromTarget, rowId)
+    val cardinalityRowId = if (checkCardinality) {
+      Some(Alias(MonotonicallyIncreasingID(), "__row_id")())
     } else {
-      targetTable.output :+ rowFromTarget
+      None
     }
+    val targetTableProjExprs = targetTable.output ++ Seq(rowFromTarget) ++ cardinalityRowId
     val targetTableProj = Project(targetTableProjExprs, targetTable)
 
     // project an extra column to check if a source row exists after the join
@@ -447,7 +460,9 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     } else {
       JoinHint.NONE
     }
-    Join(targetTableProj, sourceTableProj, joinType, Some(joinCond), joinHint)
+    val plan = Join(targetTableProj, sourceTableProj, joinType, Some(joinCond), joinHint)
+    MergeJoin(plan, rowFromSource.toAttribute, rowFromTarget.toAttribute,
+      cardinalityRowId.map(_.toAttribute))
   }
 
   // skip the cardinality check in these cases:
@@ -509,7 +524,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
       case UpdateAction(cond, assignments, _) =>
         val output = deltaUpdateOutput(
-          assignments, metadataAttrs, originalRowIdValues) ++ extractionAttrs
+          assignments, rowIdAttrs, metadataAttrs, originalRowIdValues) ++ extractionAttrs
         Keep(Update, cond.getOrElse(TrueLiteral), output)
 
       case DeleteAction(cond) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ReplaceDataProjectio
   WriteDeltaProjections}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
-import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
 import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -100,29 +100,108 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     }
   }
 
+  protected case class ResolvedRowIdRefs(
+      // row ID attributes used by the write projections
+      rowIdAttrs: Seq[AttributeReference],
+      // aliases that materialize nested row IDs as top-level attributes
+      extractionAliases: Seq[Alias],
+      // scan attributes needed to read or extract the row IDs
+      scanAttrs: Seq[AttributeReference]) {
+
+    lazy val extractionAttrs: Seq[AttributeReference] = extractionAliases.map { alias =>
+      rowIdAttrs.find(_.exprId == alias.exprId).getOrElse {
+        throw SparkException.internalError(s"Cannot find extracted row ID attribute: $alias")
+      }
+    }
+
+    // rebind nested row IDs after Expand or MergeRows generates fresh output attributes
+    // top-level row IDs retain their original attributes for update handling
+    def rebindExtractions(reboundAttrs: Seq[Attribute]): Seq[Attribute] = {
+      if (extractionAttrs.size != reboundAttrs.size) {
+        throw SparkException.internalError(
+          s"Expected ${extractionAttrs.size} extracted row ID attributes, " +
+            s"but found ${reboundAttrs.size}")
+      }
+      val reboundByExprId = extractionAttrs.zip(reboundAttrs).map { case (attr, reboundAttr) =>
+        attr.exprId -> reboundAttr
+      }.toMap
+      rowIdAttrs.map(attr => reboundByExprId.getOrElse(attr.exprId, attr))
+    }
+  }
+
+  protected case class RowDeltaPlan(plan: LogicalPlan, rowIdAttrs: Seq[Attribute])
+
+  // generate fresh output attributes and rebind nested row IDs to the trailing extracted fields
+  protected def buildRowDeltaPlan(
+      baseAttrs: Seq[Attribute],
+      outputs: Seq[Seq[Expression]],
+      rowIdRefs: ResolvedRowIdRefs)(buildPlan: Seq[Attribute] => LogicalPlan): RowDeltaPlan = {
+    val attrs = baseAttrs ++ rowIdRefs.extractionAttrs
+    outputs.find(_.size != attrs.size).foreach { output =>
+      throw SparkException.internalError(
+        s"Expected ${attrs.size} row delta values, but found ${output.size}")
+    }
+    val output = generateExpandOutput(attrs, outputs)
+    // nested row ID attributes are the output suffix
+    val reboundRowIdAttrs = rowIdRefs.rebindExtractions(
+      output.takeRight(rowIdRefs.extractionAttrs.size))
+    RowDeltaPlan(buildPlan(output), reboundRowIdAttrs)
+  }
+
+  private def resolveRefs(
+      relation: DataSourceV2Relation,
+      refs: Seq[NamedReference]): ResolvedRowIdRefs = {
+    val rowIdAttrs = mutable.ArrayBuffer.empty[AttributeReference]
+    val extractionAliases = mutable.ArrayBuffer.empty[Alias]
+    val scanAttrs = mutable.ArrayBuffer.empty[AttributeReference]
+    refs.foreach { ref =>
+      V2ExpressionUtils.resolveRowIdRef(ref, relation) match {
+        case attr: AttributeReference =>
+          rowIdAttrs += attr
+          scanAttrs += attr
+        case alias: Alias =>
+          extractionAliases += alias
+          scanAttrs ++= alias.references.collect { case ref: AttributeReference => ref }
+          alias.toAttribute match {
+            case attr: AttributeReference => rowIdAttrs += attr
+            case other =>
+              throw SparkException.internalError(s"Row ID reference did not resolve: $other")
+          }
+        case other =>
+          throw SparkException.internalError("Unexpected resolved row-level reference: " + other)
+      }
+    }
+    ResolvedRowIdRefs(
+      rowIdAttrs.toSeq, extractionAliases.toSeq, dedupAttrs(scanAttrs.toSeq))
+  }
+
   protected def resolveRequiredMetadataAttrs(
       relation: DataSourceV2Relation,
       operation: RowLevelOperation): Seq[AttributeReference] = {
-
     V2ExpressionUtils.resolveRefs[AttributeReference](
-      operation.requiredMetadataAttributes.toImmutableArraySeq,
-      relation)
+      operation.requiredMetadataAttributes.toImmutableArraySeq, relation)
   }
 
-  protected def resolveRowIdAttrs(
+  protected def resolveRowIdRefs(
       relation: DataSourceV2Relation,
-      operation: SupportsDelta): Seq[AttributeReference] = {
-
-    val rowIdAttrs = V2ExpressionUtils.resolveRefs[AttributeReference](
-      operation.rowId.toImmutableArraySeq,
-      relation)
-
-    val nullableRowIdAttrs = rowIdAttrs.filter(_.nullable)
+      operation: SupportsDelta): ResolvedRowIdRefs = {
+    val resolved = resolveRefs(relation, operation.rowId.toImmutableArraySeq)
+    val nullableRowIdAttrs = resolved.rowIdAttrs.filter(_.nullable)
     if (nullableRowIdAttrs.nonEmpty) {
       throw QueryCompilationErrors.nullableRowIdError(nullableRowIdAttrs)
     }
+    resolved
+  }
 
-    rowIdAttrs
+  // materialize nested row IDs as top-level attributes
+  protected def withExtractedRowIds(
+      plan: LogicalPlan,
+      extractionAliases: Seq[Alias]): LogicalPlan = {
+    if (extractionAliases.isEmpty) {
+      plan
+    } else {
+      Project(plan.output ++ extractionAliases, plan)
+    }
   }
 
   protected def resolveAttrRef(name: String, plan: LogicalPlan): AttributeReference = {
@@ -279,7 +358,11 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       plan: LogicalPlan,
       outputs: Seq[Seq[Expression]],
       attrs: Seq[Attribute]): ProjectingInternalRow = {
-    val colOrdinals = attrs.map(attr => findColOrdinal(plan, attr.name))
+    val colOrdinals = attrs.map { attr =>
+      val byExprId = findColOrdinalByExprId(plan, attr.exprId)
+      // generated outputs have fresh exprIds, so fall back to the column name
+      if (byExprId != -1) byExprId else findColOrdinal(plan, attr.name)
+    }
     createProjectingInternalRow(outputs, colOrdinals, attrs)
   }
 
@@ -290,8 +373,15 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       outputs: Seq[Seq[Expression]],
       rowIdAttrs: Seq[Attribute]): ProjectingInternalRow = {
     val colOrdinals = rowIdAttrs.map { attr =>
-      val originalValueIndex = findColOrdinal(plan, ORIGINAL_ROW_ID_VALUE_PREFIX + attr.name)
-      if (originalValueIndex != -1) originalValueIndex else findColOrdinal(plan, attr.name)
+      // prefer exprId to avoid binding nested row IDs to same-named data columns
+      // updated top-level row IDs fall back to their saved original values
+      val byExprId = findColOrdinalByExprId(plan, attr.exprId)
+      if (byExprId != -1) {
+        byExprId
+      } else {
+        val originalValueIndex = findColOrdinal(plan, ORIGINAL_ROW_ID_VALUE_PREFIX + attr.name)
+        if (originalValueIndex != -1) originalValueIndex else findColOrdinal(plan, attr.name)
+      }
     }
     createProjectingInternalRow(outputs, colOrdinals, rowIdAttrs)
   }
@@ -309,6 +399,10 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
 
   private def findColOrdinal(plan: LogicalPlan, name: String): Int = {
     plan.output.indexWhere(attr => conf.resolver(attr.name, name))
+  }
+
+  private def findColOrdinalByExprId(plan: LogicalPlan, exprId: ExprId): Int = {
+    plan.output.indexWhere(_.exprId == exprId)
   }
 
   protected def buildOriginalRowIdValues(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -148,7 +148,7 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     RowDeltaPlan(buildPlan(output), reboundRowIdAttrs)
   }
 
-  private def resolveRefs(
+  private def resolveRowIdRefsToAttrs(
       relation: DataSourceV2Relation,
       refs: Seq[NamedReference]): ResolvedRowIdRefs = {
     val rowIdAttrs = mutable.ArrayBuffer.empty[AttributeReference]
@@ -161,7 +161,7 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
           scanAttrs += attr
         case alias: Alias =>
           extractionAliases += alias
-          scanAttrs ++= alias.references.collect { case ref: AttributeReference => ref }
+          scanAttrs ++= alias.references.collect { case scanRef: AttributeReference => scanRef }
           alias.toAttribute match {
             case attr: AttributeReference => rowIdAttrs += attr
             case other =>
@@ -178,14 +178,16 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   protected def resolveRequiredMetadataAttrs(
       relation: DataSourceV2Relation,
       operation: RowLevelOperation): Seq[AttributeReference] = {
+
     V2ExpressionUtils.resolveRefs[AttributeReference](
-      operation.requiredMetadataAttributes.toImmutableArraySeq, relation)
+      operation.requiredMetadataAttributes.toImmutableArraySeq,
+      relation)
   }
 
   protected def resolveRowIdRefs(
       relation: DataSourceV2Relation,
       operation: SupportsDelta): ResolvedRowIdRefs = {
-    val resolved = resolveRefs(relation, operation.rowId.toImmutableArraySeq)
+    val resolved = resolveRowIdRefsToAttrs(relation, operation.rowId.toImmutableArraySeq)
     val nullableRowIdAttrs = resolved.rowIdAttrs.filter(_.nullable)
     if (nullableRowIdAttrs.nonEmpty) {
       throw QueryCompilationErrors.nullableRowIdError(nullableRowIdAttrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -237,7 +237,9 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       shouldPreserve: Attribute => Boolean): Seq[NamedExpression] = {
     attrs.map {
       case MetadataAttribute(attr) if !shouldPreserve(attr) =>
-        Alias(Literal(null, attr.dataType), attr.name)(explicitMetadata = Some(attr.metadata))
+        // keep the exprId so the projection binds this by id, not by a name a row id may share
+        Alias(Literal(null, attr.dataType), attr.name)(
+          exprId = attr.exprId, explicitMetadata = Some(attr.metadata))
       case attr =>
         attr
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ReplaceDataProjectio
   WriteDeltaProjections}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
-import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
+import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -100,114 +100,168 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     }
   }
 
-  protected case class ResolvedRowIdRefs(
-      // row ID attributes used by the write projections
-      rowIdAttrs: Seq[AttributeReference],
-      // aliases that materialize nested row IDs as top-level attributes
+  protected case class ResolvedConnectorRefs(
+      attrs: Seq[AttributeReference],
       extractionAliases: Seq[Alias],
-      // scan attributes needed to read or extract the row IDs
       scanAttrs: Seq[AttributeReference]) {
 
     lazy val extractionAttrs: Seq[AttributeReference] = extractionAliases.map { alias =>
-      rowIdAttrs.find(_.exprId == alias.exprId).getOrElse {
-        throw SparkException.internalError(s"Cannot find extracted row ID attribute: $alias")
+      attrs.find(_.exprId == alias.exprId).getOrElse {
+        throw SparkException.internalError(s"Cannot find extracted attribute: $alias")
       }
     }
 
-    // rebind nested row IDs after Expand or MergeRows generates fresh output attributes
-    // top-level row IDs retain their original attributes for update handling
-    def rebindExtractions(reboundAttrs: Seq[Attribute]): Seq[Attribute] = {
-      if (extractionAttrs.size != reboundAttrs.size) {
-        throw SparkException.internalError(
-          s"Expected ${extractionAttrs.size} extracted row ID attributes, " +
-            s"but found ${reboundAttrs.size}")
+    def rowIdAttrs: Seq[AttributeReference] = attrs
+  }
+
+  protected case class ResolvedDeltaRefs(
+      rowIdRefs: ResolvedConnectorRefs,
+      metadataRefs: ResolvedConnectorRefs)
+
+  protected case class RowDeltaPlan(
+      plan: LogicalPlan,
+      bindings: Map[ExprId, Attribute],
+      originalRowIdBindings: Map[ExprId, Attribute] = Map.empty) {
+
+    def projectionAttrs(attrs: Seq[Attribute]): Seq[Attribute] = {
+      attrs.map(attr => binding(attr.exprId))
+    }
+
+    def rowIdProjectionAttrs(attrs: Seq[Attribute]): Seq[Attribute] = {
+      attrs.map { attr =>
+        originalRowIdBindings.getOrElse(attr.exprId, binding(attr.exprId))
       }
-      val reboundByExprId = extractionAttrs.zip(reboundAttrs).map { case (attr, reboundAttr) =>
-        attr.exprId -> reboundAttr
-      }.toMap
-      rowIdAttrs.map(attr => reboundByExprId.getOrElse(attr.exprId, attr))
+    }
+
+    private def binding(exprId: ExprId): Attribute = {
+      bindings.getOrElse(exprId,
+        throw SparkException.internalError(s"Cannot find projected attribute: $exprId"))
     }
   }
 
-  protected case class RowDeltaPlan(plan: LogicalPlan, rowIdAttrs: Seq[Attribute])
-
-  // generate fresh output attributes and rebind nested row IDs to the trailing extracted fields
   protected def buildRowDeltaPlan(
       baseAttrs: Seq[Attribute],
       outputs: Seq[Seq[Expression]],
-      rowIdRefs: ResolvedRowIdRefs)(buildPlan: Seq[Attribute] => LogicalPlan): RowDeltaPlan = {
+      rowIdRefs: ResolvedConnectorRefs,
+      originalRowIdValues: Seq[Alias] = Nil)(
+      buildPlan: Seq[Attribute] => LogicalPlan): RowDeltaPlan = {
     val attrs = baseAttrs ++ rowIdRefs.extractionAttrs
     outputs.find(_.size != attrs.size).foreach { output =>
       throw SparkException.internalError(
         s"Expected ${attrs.size} row delta values, but found ${output.size}")
     }
     val output = generateExpandOutput(attrs, outputs)
-    // nested row ID attributes are the output suffix
-    val reboundRowIdAttrs = rowIdRefs.rebindExtractions(
-      output.takeRight(rowIdRefs.extractionAttrs.size))
-    RowDeltaPlan(buildPlan(output), reboundRowIdAttrs)
+    bindRowDeltaPlan(buildPlan(output), attrs, output, originalRowIdValues)
   }
 
-  private def resolveRowIdRefsToAttrs(
+  protected def bindRowDeltaPlan(
+      plan: LogicalPlan,
+      sourceAttrs: Seq[Attribute],
+      outputAttrs: Seq[Attribute],
+      originalRowIdValues: Seq[Alias] = Nil): RowDeltaPlan = {
+    if (sourceAttrs.size != outputAttrs.size) {
+      throw SparkException.internalError(
+        s"Expected ${sourceAttrs.size} projected attributes, but found ${outputAttrs.size}")
+    }
+    val bindings = sourceAttrs.zip(outputAttrs).map { case (sourceAttr, outputAttr) =>
+      sourceAttr.exprId -> outputAttr
+    }.toMap
+    val originalRowIdBindings = originalRowIdValues.map { alias =>
+      val originalAttr = alias.child.asInstanceOf[Attribute]
+      originalAttr.exprId -> bindings(alias.exprId)
+    }.toMap
+    RowDeltaPlan(plan, bindings, originalRowIdBindings)
+  }
+
+  private def resolveConnectorRefs(
       relation: DataSourceV2Relation,
-      refs: Seq[NamedReference]): ResolvedRowIdRefs = {
-    val rowIdAttrs = mutable.ArrayBuffer.empty[AttributeReference]
+      refs: Seq[NamedReference]): ResolvedConnectorRefs = {
+    resolveConnectorRefs(relation, refs, V2ExpressionUtils.resolveMetadataRef(_, relation))
+  }
+
+  private def resolveConnectorRefs(
+      relation: DataSourceV2Relation,
+      refs: Seq[NamedReference],
+      refResolver: NamedReference => NamedExpression): ResolvedConnectorRefs = {
+    val attrs = mutable.ArrayBuffer.empty[AttributeReference]
     val extractionAliases = mutable.ArrayBuffer.empty[Alias]
     val scanAttrs = mutable.ArrayBuffer.empty[AttributeReference]
     refs.foreach { ref =>
-      V2ExpressionUtils.resolveRowIdRef(ref, relation) match {
+      refResolver(ref) match {
         case attr: AttributeReference =>
-          rowIdAttrs += attr
+          attrs += attr
           scanAttrs += attr
         case alias: Alias =>
           extractionAliases += alias
           scanAttrs ++= alias.references.collect { case scanRef: AttributeReference => scanRef }
           alias.toAttribute match {
-            case attr: AttributeReference => rowIdAttrs += attr
+            case attr: AttributeReference => attrs += attr
             case other =>
-              throw SparkException.internalError(s"Row ID reference did not resolve: $other")
+              throw SparkException.internalError(s"Connector reference did not resolve: $other")
           }
         case other =>
           throw SparkException.internalError("Unexpected resolved row-level reference: " + other)
       }
     }
-    ResolvedRowIdRefs(
-      rowIdAttrs.toSeq, extractionAliases.toSeq, dedupAttrs(scanAttrs.toSeq))
+    ResolvedConnectorRefs(attrs.toSeq, extractionAliases.toSeq, dedupAttrs(scanAttrs.toSeq))
   }
 
-  protected def resolveRequiredMetadataAttrs(
+  protected def resolveRequiredMetadataRefs(
       relation: DataSourceV2Relation,
-      operation: RowLevelOperation): Seq[AttributeReference] = {
-
-    V2ExpressionUtils.resolveRefs[AttributeReference](
-      operation.requiredMetadataAttributes.toImmutableArraySeq,
-      relation)
+      operation: RowLevelOperation): ResolvedConnectorRefs = {
+    resolveConnectorRefs(relation, operation.requiredMetadataAttributes.toImmutableArraySeq)
   }
 
-  protected def resolveRowIdRefs(
+  protected def resolveDeltaRefs(
       relation: DataSourceV2Relation,
-      operation: SupportsDelta): ResolvedRowIdRefs = {
-    val resolved = resolveRowIdRefsToAttrs(relation, operation.rowId.toImmutableArraySeq)
-    val nullableRowIdAttrs = resolved.rowIdAttrs.filter(_.nullable)
+      operation: SupportsDelta): ResolvedDeltaRefs = {
+    val resolvedRefs = mutable.ArrayBuffer.empty[(NamedReference, NamedExpression)]
+    // Resolve a reference declared as both row ID and metadata once so both roles share its exprId.
+    def resolveRef(ref: NamedReference): NamedExpression = {
+      resolvedRefs.collectFirst {
+        case (resolvedRef, resolved) if sameRef(resolvedRef, ref) => resolved
+      }.getOrElse {
+        val resolved = V2ExpressionUtils.resolveMetadataRef(ref, relation)
+        resolvedRefs += ref -> resolved
+        resolved
+      }
+    }
+
+    val rowIdRefs = resolveConnectorRefs(
+      relation, operation.rowId.toImmutableArraySeq, resolveRef)
+    val metadataRefs = resolveConnectorRefs(
+      relation, operation.requiredMetadataAttributes.toImmutableArraySeq, resolveRef)
+    val nullableRowIdAttrs = rowIdRefs.rowIdAttrs.filter(_.nullable)
     if (nullableRowIdAttrs.nonEmpty) {
       throw QueryCompilationErrors.nullableRowIdError(nullableRowIdAttrs)
     }
-    resolved
+    ResolvedDeltaRefs(rowIdRefs, metadataRefs)
   }
 
-  // materialize nested row IDs as top-level attributes
-  protected def withExtractedRowIds(
+  private def sameRef(left: NamedReference, right: NamedReference): Boolean = {
+    left.fieldNames.length == right.fieldNames.length &&
+      left.fieldNames.zip(right.fieldNames).forall { case (leftName, rightName) =>
+        conf.resolver(leftName, rightName)
+      }
+  }
+
+  protected def withExtractedRefs(
       plan: LogicalPlan,
       extractionAliases: Seq[Alias]): LogicalPlan = {
-    if (extractionAliases.isEmpty) {
+    val exprIds = mutable.Set.empty[ExprId]
+    val aliases = extractionAliases.filter(alias => exprIds.add(alias.exprId))
+    if (aliases.isEmpty) {
       plan
     } else {
-      Project(plan.output ++ extractionAliases, plan)
+      Project(plan.output ++ aliases, plan)
     }
   }
 
-  protected def resolveAttrRef(name: String, plan: LogicalPlan): AttributeReference = {
-    V2ExpressionUtils.resolveRef[AttributeReference](FieldReference(name), plan)
+  protected def projectWithExtractedRefs(
+      plan: LogicalPlan,
+      output: Seq[Attribute],
+      extractionAliases: Seq[Alias]): LogicalPlan = {
+    Project(output, withExtractedRefs(plan, extractionAliases))
   }
 
   protected def deltaDeleteOutput(
@@ -216,26 +270,35 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       metadataAttrs: Seq[Attribute],
       originalRowIdValues: Seq[Expression] = Seq.empty): Seq[Expression] = {
     val rowValues = buildDeltaDeleteRowValues(rowAttrs, rowIdAttrs)
-    val metadataValues = nullifyMetadataOnDelete(metadataAttrs)
+    val metadataValues = nullifyMetadataOnDelete(metadataAttrs, rowIdAttrs)
     Seq(Literal(DELETE_OPERATION)) ++ rowValues ++ metadataValues ++ originalRowIdValues
   }
 
-  protected def nullifyMetadataOnDelete(attrs: Seq[Attribute]): Seq[NamedExpression] = {
-    nullifyMetadata(attrs, MetadataAttribute.isPreservedOnDelete)
+  protected def nullifyMetadataOnDelete(
+      attrs: Seq[Attribute],
+      rowIdAttrs: Seq[Attribute] = Nil): Seq[NamedExpression] = {
+    nullifyMetadata(attrs, rowIdAttrs, MetadataAttribute.isPreservedOnDelete)
   }
 
-  protected def nullifyMetadataOnUpdate(attrs: Seq[Attribute]): Seq[NamedExpression] = {
-    nullifyMetadata(attrs, MetadataAttribute.isPreservedOnUpdate)
+  protected def nullifyMetadataOnUpdate(
+      attrs: Seq[Attribute],
+      rowIdAttrs: Seq[Attribute] = Nil): Seq[NamedExpression] = {
+    nullifyMetadata(attrs, rowIdAttrs, MetadataAttribute.isPreservedOnUpdate)
   }
 
   private def nullifyMetadataOnReinsert(attrs: Seq[Attribute]): Seq[NamedExpression] = {
-    nullifyMetadata(attrs, MetadataAttribute.isPreservedOnReinsert)
+    nullifyMetadata(attrs, Nil, MetadataAttribute.isPreservedOnReinsert)
   }
 
   private def nullifyMetadata(
       attrs: Seq[Attribute],
+      rowIdAttrs: Seq[Attribute],
       shouldPreserve: Attribute => Boolean): Seq[NamedExpression] = {
+    val rowIdAttrSet = AttributeSet(rowIdAttrs)
     attrs.map {
+      // A row ID must remain available to identify the affected row.
+      case attr if rowIdAttrSet.contains(attr) =>
+        attr
       case MetadataAttribute(attr) if !shouldPreserve(attr) =>
         // keep the exprId so the projection binds this by id, not by a name a row id may share
         Alias(Literal(null, attr.dataType), attr.name)(
@@ -268,10 +331,11 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
 
   protected def deltaUpdateOutput(
       assignments: Seq[Assignment],
+      rowIdAttrs: Seq[Attribute],
       metadataAttrs: Seq[Attribute],
       originalRowIdValues: Seq[Expression]): Seq[Expression] = {
     val rowValues = assignments.map(_.value)
-    val metadataValues = nullifyMetadataOnUpdate(metadataAttrs)
+    val metadataValues = nullifyMetadataOnUpdate(metadataAttrs, rowIdAttrs)
     Seq(Literal(UPDATE_OPERATION)) ++ rowValues ++ metadataValues ++ originalRowIdValues
   }
 
@@ -295,13 +359,17 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       rowAttrs: Seq[Attribute],
       metadataAttrs: Seq[Attribute]): ReplaceDataProjections = {
     val outputs = extractOutputs(plan)
+    val rowProjectionAttrs = plan.output.slice(1, 1 + rowAttrs.size)
+    val metadataProjectionAttrs =
+      plan.output.slice(1 + rowAttrs.size, 1 + rowAttrs.size + metadataAttrs.size)
 
     val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
-    val rowProjection = newLazyProjection(plan, outputsWithRow, rowAttrs)
+    val rowProjection = newLazyProjection(plan, outputsWithRow, rowProjectionAttrs, rowAttrs)
 
     val metadataProjection = if (metadataAttrs.nonEmpty) {
       val outputsWithMetadata = filterOutputs(outputs, OPERATIONS_WITH_METADATA)
-      Some(newLazyProjection(plan, outputsWithMetadata, metadataAttrs))
+      Some(newLazyProjection(
+        plan, outputsWithMetadata, metadataProjectionAttrs, metadataAttrs))
     } else {
       None
     }
@@ -310,25 +378,29 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   }
 
   protected def buildWriteDeltaProjections(
-      plan: LogicalPlan,
+      rowDelta: RowDeltaPlan,
       rowAttrs: Seq[Attribute],
       rowIdAttrs: Seq[Attribute],
       metadataAttrs: Seq[Attribute]): WriteDeltaProjections = {
+    val plan = rowDelta.plan
     val outputs = extractOutputs(plan)
 
     val rowProjection = if (rowAttrs.nonEmpty) {
       val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
-      Some(newLazyProjection(plan, outputsWithRow, rowAttrs))
+      Some(newLazyProjection(
+        plan, outputsWithRow, rowDelta.projectionAttrs(rowAttrs), rowAttrs))
     } else {
       None
     }
 
     val outputsWithRowId = filterOutputs(outputs, OPERATIONS_WITH_ROW_ID)
-    val rowIdProjection = newLazyRowIdProjection(plan, outputsWithRowId, rowIdAttrs)
+    val rowIdProjection = newLazyProjection(
+      plan, outputsWithRowId, rowDelta.rowIdProjectionAttrs(rowIdAttrs), rowIdAttrs)
 
     val metadataProjection = if (metadataAttrs.nonEmpty) {
       val outputsWithMetadata = filterOutputs(outputs, OPERATIONS_WITH_METADATA)
-      Some(newLazyProjection(plan, outputsWithMetadata, metadataAttrs))
+      Some(newLazyProjection(
+        plan, outputsWithMetadata, rowDelta.projectionAttrs(metadataAttrs), metadataAttrs))
     } else {
       None
     }
@@ -361,33 +433,20 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   private def newLazyProjection(
       plan: LogicalPlan,
       outputs: Seq[Seq[Expression]],
-      attrs: Seq[Attribute]): ProjectingInternalRow = {
-    val colOrdinals = attrs.map { attr =>
-      val byExprId = findColOrdinalByExprId(plan, attr.exprId)
-      // generated outputs have fresh exprIds, so fall back to the column name
-      if (byExprId != -1) byExprId else findColOrdinal(plan, attr.name)
+      projectionAttrs: Seq[Attribute],
+      schemaAttrs: Seq[Attribute]): ProjectingInternalRow = {
+    if (projectionAttrs.size != schemaAttrs.size) {
+      throw SparkException.internalError(
+        s"Expected ${schemaAttrs.size} projection attributes, but found ${projectionAttrs.size}")
     }
-    createProjectingInternalRow(outputs, colOrdinals, attrs)
-  }
-
-  // if there are assignment to row ID attributes, original values are projected as special columns
-  // this method honors such special columns if present
-  private def newLazyRowIdProjection(
-      plan: LogicalPlan,
-      outputs: Seq[Seq[Expression]],
-      rowIdAttrs: Seq[Attribute]): ProjectingInternalRow = {
-    val colOrdinals = rowIdAttrs.map { attr =>
-      // prefer exprId to avoid binding nested row IDs to same-named data columns
-      // updated top-level row IDs fall back to their saved original values
-      val byExprId = findColOrdinalByExprId(plan, attr.exprId)
-      if (byExprId != -1) {
-        byExprId
-      } else {
-        val originalValueIndex = findColOrdinal(plan, ORIGINAL_ROW_ID_VALUE_PREFIX + attr.name)
-        if (originalValueIndex != -1) originalValueIndex else findColOrdinal(plan, attr.name)
+    val colOrdinals = projectionAttrs.map { attr =>
+      val ordinal = findColOrdinalByExprId(plan, attr.exprId)
+      if (ordinal == -1) {
+        throw SparkException.internalError(s"Cannot find projection attribute: $attr")
       }
+      ordinal
     }
-    createProjectingInternalRow(outputs, colOrdinals, rowIdAttrs)
+    createProjectingInternalRow(outputs, colOrdinals, schemaAttrs)
   }
 
   private def createProjectingInternalRow(
@@ -399,10 +458,6 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       StructField(attr.name, attr.dataType, nullable, attr.metadata)
     })
     ProjectingInternalRow(schema, colOrdinals)
-  }
-
-  private def findColOrdinal(plan: LogicalPlan, name: String): Int = {
-    plan.output.indexWhere(attr => conf.resolver(attr.name, name))
   }
 
   private def findColOrdinalByExprId(plan: LogicalPlan, exprId: ExprId): Int = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, ReplaceData, Union, UpdateTable, WriteDelta}
@@ -69,10 +70,10 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
 
     // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readPlan = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
 
     // build a plan with updated and copied over records
-    val query = buildReplaceDataUpdateProjection(readRelation, assignments, cond)
+    val query = buildReplaceDataUpdateProjection(readPlan, assignments, cond)
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
@@ -95,16 +96,16 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     // construct a read relation and include all required metadata columns
     // the same read relation will be used to read records that must be updated and copied over
     // the analyzer will take care of duplicated attr IDs
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readPlan = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
 
     // build a plan for updated records that match the condition
-    val matchedRowsPlan = Filter(cond, readRelation)
+    val matchedRowsPlan = Filter(cond, readPlan)
     val updatedRowsPlan = buildReplaceDataUpdateProjection(matchedRowsPlan, assignments)
 
     // build a plan that contains unmatched rows in matched groups that must be copied over
     val remainingRowFilter = Not(EqualNullSafe(cond, Literal.TrueLiteral))
     val remainingRowsPlan = addOperationColumn(COPY_OPERATION,
-      Filter(remainingRowFilter, readRelation))
+      Filter(remainingRowFilter, readPlan))
 
     // the new state is a union of updated and copied over records
     val query = Union(updatedRowsPlan, remainingRowsPlan)
@@ -157,40 +158,50 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val rowAttrs = relation.output
-    val rowIdAttrs = resolveRowIdAttrs(relation, operation)
+    val rowIdRefs = resolveRowIdRefs(relation, operation)
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val rowIdAttrs = rowIdRefs.rowIdAttrs
 
-    // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+    // construct a read plan with all required row ID and metadata columns
+    val readRelation = buildRelationWithAttrs(
+      relation, operationTable, metadataAttrs, rowIdRefs.scanAttrs)
+    val readPlan = withExtractedRowIds(readRelation, rowIdRefs.extractionAliases)
 
     // build a plan for updated records that match the condition
-    val matchedRowsPlan = Filter(cond, readRelation)
-    val rowDeltaPlan = if (operation.representUpdateAsDeleteAndInsert) {
-      buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
+    val matchedRowsPlan = Filter(cond, readPlan)
+    val rowDelta = if (operation.representUpdateAsDeleteAndInsert) {
+      buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdRefs)
     } else {
-      buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
+      val updatePlan = buildWriteDeltaUpdateProjection(
+        matchedRowsPlan, assignments, rowIdAttrs, rowIdRefs.extractionAttrs)
+      RowDeltaPlan(updatePlan, rowIdAttrs)
     }
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(rowDeltaPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+    val projections = buildWriteDeltaProjections(
+      rowDelta.plan, rowAttrs, rowDelta.rowIdAttrs, metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
-    WriteDelta(writeRelation, cond, rowDeltaPlan, relation, projections, groupFilterCond)
+    WriteDelta(writeRelation, cond, rowDelta.plan, relation, projections, groupFilterCond)
   }
 
   // this method assumes the assignments have been already aligned before
   private def buildWriteDeltaUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
-      rowIdAttrs: Seq[Attribute]): LogicalPlan = {
+      rowIdAttrs: Seq[Attribute],
+      rowIdExtractionAttrs: Seq[Attribute]): LogicalPlan = {
 
-    // the plan output may include immutable metadata columns at the end
-    // that's why the number of assignments may not match the number of plan output columns
+    // the plan output may include immutable metadata columns and extracted row IDs at the end
     val assignedValues = assignments.map(_.value)
+    val extractionExprIds = rowIdExtractionAttrs.map(_.exprId).toSet
     val updatedValues = plan.output.zipWithIndex.map { case (attr, index) =>
       if (index < assignments.size) {
         val assignedExpr = assignedValues(index)
         Alias(assignedExpr, attr.name)()
+      } else if (extractionExprIds.contains(attr.exprId)) {
+        // preserve the original nested row ID for update encoding
+        attr
       } else {
         assert(MetadataAttribute.isValid(attr.metadata))
         if (MetadataAttribute.isPreservedOnUpdate(attr)) {
@@ -213,17 +224,31 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   private def buildDeletesAndInserts(
       matchedRowsPlan: LogicalPlan,
       assignments: Seq[Assignment],
-      rowIdAttrs: Seq[Attribute]): Expand = {
+      rowIdRefs: ResolvedRowIdRefs): RowDeltaPlan = {
 
-    val (metadataAttrs, rowAttrs) = matchedRowsPlan.output.partition { attr =>
+    val extractionExprIds = rowIdRefs.extractionAttrs.map(_.exprId).toSet
+    val (extractionAttrs, nonExtractionAttrs) = matchedRowsPlan.output.partition { attr =>
+      extractionExprIds.contains(attr.exprId)
+    }
+    val (metadataAttrs, rowAttrs) = nonExtractionAttrs.partition { attr =>
       MetadataAttribute.isValid(attr.metadata)
     }
-    val deleteOutput = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs)
-    val insertOutput = deltaReinsertOutput(assignments, metadataAttrs)
+    // buildRowDeltaPlan rebinds extracted row IDs by position
+    if (extractionAttrs.map(_.exprId) != rowIdRefs.extractionAttrs.map(_.exprId)) {
+      throw SparkException.internalError(
+        "Extracted row ID attributes are missing or out of order")
+    }
+
+    // only the delete half needs the old row ID
+    val deleteOutput =
+      deltaDeleteOutput(rowAttrs, rowIdRefs.rowIdAttrs, metadataAttrs) ++ extractionAttrs
+    val insertOutput = deltaReinsertOutput(assignments, metadataAttrs) ++
+      extractionAttrs.map(attr => Literal(null, attr.dataType))
     val outputs = Seq(deleteOutput, insertOutput)
     val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
-    val attrs = operationTypeAttr +: matchedRowsPlan.output
-    val expandOutput = generateExpandOutput(attrs, outputs)
-    Expand(outputs, expandOutput, matchedRowsPlan)
+    val baseAttrs = operationTypeAttr +: (rowAttrs ++ metadataAttrs)
+    buildRowDeltaPlan(baseAttrs, outputs, rowIdRefs) { output =>
+      Expand(outputs, output, matchedRowsPlan)
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -67,10 +67,15 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       cond: Expression): ReplaceData = {
 
     // resolve all required metadata attrs that may be used for grouping data on write
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val metadataRefs = resolveRequiredMetadataRefs(relation, operationTable.operation)
+    val metadataAttrs = metadataRefs.attrs
 
     // construct a read relation and include all required metadata columns
-    val readPlan = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataRefs.scanAttrs)
+    val readPlan = projectWithExtractedRefs(
+      readRelation,
+      relation.output ++ metadataAttrs,
+      metadataRefs.extractionAliases)
 
     // build a plan with updated and copied over records
     val query = buildReplaceDataUpdateProjection(readPlan, assignments, cond)
@@ -91,12 +96,17 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       cond: Expression): ReplaceData = {
 
     // resolve all required metadata attrs that may be used for grouping data on write
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val metadataRefs = resolveRequiredMetadataRefs(relation, operationTable.operation)
+    val metadataAttrs = metadataRefs.attrs
 
     // construct a read relation and include all required metadata columns
     // the same read relation will be used to read records that must be updated and copied over
     // the analyzer will take care of duplicated attr IDs
-    val readPlan = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataRefs.scanAttrs)
+    val readPlan = projectWithExtractedRefs(
+      readRelation,
+      relation.output ++ metadataAttrs,
+      metadataRefs.extractionAliases)
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readPlan)
@@ -158,29 +168,35 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val rowAttrs = relation.output
-    val rowIdRefs = resolveRowIdRefs(relation, operation)
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val resolvedRefs = resolveDeltaRefs(relation, operation)
+    val rowIdRefs = resolvedRefs.rowIdRefs
+    val metadataRefs = resolvedRefs.metadataRefs
+    val metadataAttrs = metadataRefs.attrs
     val rowIdAttrs = rowIdRefs.rowIdAttrs
 
     // construct a read plan with all required row ID and metadata columns
     val readRelation = buildRelationWithAttrs(
-      relation, operationTable, metadataAttrs, rowIdRefs.scanAttrs)
-    val readPlan = withExtractedRowIds(readRelation, rowIdRefs.extractionAliases)
+      relation, operationTable, metadataRefs.scanAttrs, rowIdRefs.scanAttrs)
+    val readPlan = projectWithExtractedRefs(
+      readRelation,
+      dedupAttrs(relation.output ++ metadataAttrs ++ rowIdRefs.attrs),
+      metadataRefs.extractionAliases ++ rowIdRefs.extractionAliases)
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readPlan)
     val rowDelta = if (operation.representUpdateAsDeleteAndInsert) {
       buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdRefs)
     } else {
-      val updatePlan = buildWriteDeltaUpdateProjection(
-        matchedRowsPlan, assignments, rowIdAttrs, rowIdRefs.extractionAttrs)
-      RowDeltaPlan(updatePlan, rowIdAttrs)
+      buildWriteDeltaUpdateProjection(
+        matchedRowsPlan,
+        assignments,
+        rowIdAttrs)
     }
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(
-      rowDelta.plan, rowAttrs, rowDelta.rowIdAttrs, metadataAttrs)
+    val projections =
+      buildWriteDeltaProjections(rowDelta, rowAttrs, rowIdAttrs, metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     WriteDelta(writeRelation, cond, rowDelta.plan, relation, projections, groupFilterCond)
   }
@@ -189,18 +205,17 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   private def buildWriteDeltaUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
-      rowIdAttrs: Seq[Attribute],
-      rowIdExtractionAttrs: Seq[Attribute]): LogicalPlan = {
+      rowIdAttrs: Seq[Attribute]): RowDeltaPlan = {
 
     // the plan output may include immutable metadata columns and extracted row IDs at the end
     val assignedValues = assignments.map(_.value)
-    val extractionExprIds = rowIdExtractionAttrs.map(_.exprId).toSet
+    val rowIdExprIds = rowIdAttrs.map(_.exprId).toSet
     val updatedValues = plan.output.zipWithIndex.map { case (attr, index) =>
       if (index < assignments.size) {
         val assignedExpr = assignedValues(index)
         Alias(assignedExpr, attr.name)()
-      } else if (extractionExprIds.contains(attr.exprId)) {
-        // preserve the original nested row ID for update encoding
+      } else if (rowIdExprIds.contains(attr.exprId)) {
+        // preserve the original row ID for update encoding
         attr
       } else {
         assert(MetadataAttribute.isValid(attr.metadata))
@@ -218,13 +233,18 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     val operationType = Alias(Literal(UPDATE_OPERATION), OPERATION_COLUMN)()
 
-    Project(Seq(operationType) ++ updatedValues ++ originalRowIdValues, plan)
+    val project = Project(Seq(operationType) ++ updatedValues ++ originalRowIdValues, plan)
+    bindRowDeltaPlan(
+      project,
+      plan.output ++ originalRowIdValues.map(_.toAttribute),
+      project.output.tail,
+      originalRowIdValues)
   }
 
   private def buildDeletesAndInserts(
       matchedRowsPlan: LogicalPlan,
       assignments: Seq[Assignment],
-      rowIdRefs: ResolvedRowIdRefs): RowDeltaPlan = {
+      rowIdRefs: ResolvedConnectorRefs): RowDeltaPlan = {
 
     val extractionExprIds = rowIdRefs.extractionAttrs.map(_.exprId).toSet
     val (extractionAttrs, nonExtractionAttrs) = matchedRowsPlan.output.partition { attr =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
@@ -85,7 +85,7 @@ object SelectedField {
     expr match {
       case a: Attribute =>
         dataTypeOpt.map { dt =>
-          StructField(a.name, dt, a.nullable)
+          StructField(a.name, dt, a.nullable, a.metadata)
         }
       case c: GetStructField =>
         val field = c.childSchema(c.ordinal)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
@@ -60,6 +60,27 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
     refs.map(ref => resolveRef[T](ref, plan))
   }
 
+  // resolve metadata-rooted row IDs by logical name to avoid collisions with data columns
+  def resolveRowIdRef(ref: NamedReference, plan: LogicalPlan): NamedExpression = {
+    val parts = ref.fieldNames.toImmutableArraySeq
+    plan.getMetadataAttributeByNameOpt(parts.head) match {
+      case Some(struct) if parts.length == 1 =>
+        struct
+      case Some(struct) =>
+        val extracted = parts.tail.foldLeft(struct: Expression) { (base, field) =>
+          ExtractValue.applyOrNull(base, Literal(field), conf.resolver)
+        }
+        Alias(extracted, parts.last)()
+      case None =>
+        resolveRef[NamedExpression](ref, plan)
+    }
+  }
+
+  def resolveRowIdRefs(
+      refs: Seq[NamedReference], plan: LogicalPlan): Seq[NamedExpression] = {
+    refs.map(ref => resolveRowIdRef(ref, plan))
+  }
+
   /**
    * Resolves [[NamedReference]]s against the given output and returns them as an [[AttributeSet]].
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
@@ -60,8 +60,7 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
     refs.map(ref => resolveRef[T](ref, plan))
   }
 
-  // resolve metadata-rooted row IDs by logical name to avoid collisions with data columns
-  def resolveRowIdRef(ref: NamedReference, plan: LogicalPlan): NamedExpression = {
+  def resolveMetadataRef(ref: NamedReference, plan: LogicalPlan): NamedExpression = {
     val parts = ref.fieldNames.toImmutableArraySeq
     plan.getMetadataAttributeByNameOpt(parts.head) match {
       case Some(struct) if parts.length == 1 =>
@@ -70,10 +69,20 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
         val extracted = parts.tail.foldLeft(struct: Expression) { (base, field) =>
           ExtractValue.applyOrNull(base, Literal(field), conf.resolver)
         }
-        Alias(extracted, parts.last)()
+        Alias(extracted, parts.last)(explicitMetadata = Some(struct.metadata))
       case None =>
         resolveRef[NamedExpression](ref, plan)
     }
+  }
+
+  def resolveMetadataRefs(
+      refs: Seq[NamedReference], plan: LogicalPlan): Seq[NamedExpression] = {
+    refs.map(ref => resolveMetadataRef(ref, plan))
+  }
+
+  // resolve metadata-rooted row IDs by logical name to avoid collisions with data columns
+  def resolveRowIdRef(ref: NamedReference, plan: LogicalPlan): NamedExpression = {
+    resolveMetadataRef(ref, plan)
   }
 
   def resolveRowIdRefs(
@@ -91,6 +100,13 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
     AttributeSet(resolveRefs[Attribute](refs.toImmutableArraySeq, plan))
   }
 
+  def resolveMetadataAttributeRefs(
+      refs: Array[NamedReference],
+      output: Seq[Attribute]): AttributeSet = {
+    val plan = LocalRelation(output)
+    AttributeSet(resolveMetadataRefs(refs.toImmutableArraySeq, plan).flatMap(_.references))
+  }
+
   /**
    * Converts the array of input V2 [[V2SortOrder]] into their counterparts in catalyst.
    */
@@ -98,14 +114,33 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
       ordering: Array[V2SortOrder],
       query: LogicalPlan,
       funCatalogOpt: Option[FunctionCatalog] = None): Seq[SortOrder] = {
-    ordering.map(toCatalyst(_, query, funCatalogOpt).asInstanceOf[SortOrder]).toImmutableArraySeq
+    toCatalystOrdering(
+      ordering, query, funCatalogOpt, resolveRef[NamedExpression](_, query))
+  }
+
+  def toCatalystOrdering(
+      ordering: Array[V2SortOrder],
+      query: LogicalPlan,
+      funCatalogOpt: Option[FunctionCatalog],
+      refResolver: NamedReference => NamedExpression): Seq[SortOrder] = {
+    ordering.map(
+      toCatalyst(_, query, funCatalogOpt, refResolver).asInstanceOf[SortOrder])
+      .toImmutableArraySeq
   }
 
   def toCatalyst(
       expr: V2Expression,
       query: LogicalPlan,
-      funCatalogOpt: Option[FunctionCatalog] = None): Expression =
-    toCatalystOpt(expr, query, funCatalogOpt)
+      funCatalogOpt: Option[FunctionCatalog] = None): Expression = {
+    toCatalyst(expr, query, funCatalogOpt, resolveRef[NamedExpression](_, query))
+  }
+
+  def toCatalyst(
+      expr: V2Expression,
+      query: LogicalPlan,
+      funCatalogOpt: Option[FunctionCatalog],
+      refResolver: NamedReference => NamedExpression): Expression =
+    toCatalystOpt(expr, query, funCatalogOpt, refResolver)
         .getOrElse(throw new AnalysisException(
           errorClass = "_LEGACY_ERROR_TEMP_3054", messageParameters = Map("expr" -> expr.toString)))
 
@@ -113,17 +148,25 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
       expr: V2Expression,
       query: LogicalPlan,
       funCatalogOpt: Option[FunctionCatalog] = None): Option[Expression] = {
+    toCatalystOpt(expr, query, funCatalogOpt, resolveRef[NamedExpression](_, query))
+  }
+
+  def toCatalystOpt(
+      expr: V2Expression,
+      query: LogicalPlan,
+      funCatalogOpt: Option[FunctionCatalog],
+      refResolver: NamedReference => NamedExpression): Option[Expression] = {
     expr match {
       case l: V2Literal[_] =>
         Some(Literal.create(l.value, l.dataType))
       case t: Transform =>
-        toCatalystTransformOpt(t, query, funCatalogOpt)
+        toCatalystTransformOpt(t, query, funCatalogOpt, refResolver)
       case SortValue(child, direction, nullOrdering) =>
-        toCatalystOpt(child, query, funCatalogOpt).map { catalystChild =>
+        toCatalystOpt(child, query, funCatalogOpt, refResolver).map { catalystChild =>
           SortOrder(catalystChild, toCatalyst(direction), toCatalyst(nullOrdering), Seq.empty)
         }
       case ref: FieldReference =>
-        Some(resolveRef[NamedExpression](ref, query))
+        Some(refResolver(ref))
       case _ =>
         throw new AnalysisException(
           errorClass = "_LEGACY_ERROR_TEMP_3054",
@@ -134,12 +177,20 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
   def toCatalystTransformOpt(
       trans: Transform,
       query: LogicalPlan,
-      funCatalogOpt: Option[FunctionCatalog] = None): Option[Expression] = trans match {
+      funCatalogOpt: Option[FunctionCatalog] = None): Option[Expression] = {
+    toCatalystTransformOpt(trans, query, funCatalogOpt, resolveRef[NamedExpression](_, query))
+  }
+
+  def toCatalystTransformOpt(
+      trans: Transform,
+      query: LogicalPlan,
+      funCatalogOpt: Option[FunctionCatalog],
+      refResolver: NamedReference => NamedExpression): Option[Expression] = trans match {
     case IdentityTransform(ref) =>
-      Some(resolveRef[NamedExpression](ref, query))
+      Some(refResolver(ref))
     case BucketTransform(numBuckets, refs, sorted)
         if sorted.isEmpty && refs.length == 1 && refs.forall(_.isInstanceOf[NamedReference]) =>
-      val resolvedRefs = refs.map(r => resolveRef[NamedExpression](r, query))
+      val resolvedRefs = refs.map(refResolver)
       // Create a dummy reference for `numBuckets` here and use that, together with `refs`, to
       // look up the V2 function.
       val numBucketsRef = AttributeReference("numBuckets", IntegerType, nullable = false)()
@@ -149,7 +200,7 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
         }
       }
     case NamedTransform(name, args) =>
-      val catalystArgs = args.map(toCatalyst(_, query, funCatalogOpt))
+      val catalystArgs = args.map(toCatalyst(_, query, funCatalogOpt, refResolver))
       funCatalogOpt.flatMap { catalog =>
         loadV2FunctionOpt(catalog, name, catalystArgs).map { bound =>
           TransformExpression(bound, catalystArgs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, Unevaluable}
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, ROW_ID}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.Instruction
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.types.{DataType, NullType}
@@ -29,9 +29,11 @@ case class MergeRows(
     matchedInstructions: Seq[Instruction],
     notMatchedInstructions: Seq[Instruction],
     notMatchedBySourceInstructions: Seq[Instruction],
-    checkCardinality: Boolean,
+    cardinalityRowId: Option[Attribute],
     output: Seq[Attribute],
     child: LogicalPlan) extends UnaryNode {
+
+  def checkCardinality: Boolean = cardinalityRowId.isDefined
 
   override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -39,13 +41,7 @@ case class MergeRows(
 
   @transient
   override lazy val references: AttributeSet = {
-    val usedExprs = if (checkCardinality) {
-      val rowIdAttr = child.output.find(attr => conf.resolver(attr.name, ROW_ID))
-      assert(rowIdAttr.isDefined, "Cannot find row ID attr")
-      rowIdAttr.get +: expressions
-    } else {
-      expressions
-    }
+    val usedExprs = cardinalityRowId.toSeq ++ expressions
     AttributeSet.fromAttributeSets(usedExprs.map(_.references)) -- producedAttributes
   }
 
@@ -65,7 +61,6 @@ case class MergeRows(
 }
 
 object MergeRows {
-  final val ROW_ID = "__row_id"
 
   /**
    * When a MERGE operation is rewritten, the target table is joined with the source and each

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -515,9 +515,10 @@ case class WriteDelta(
 
   // validates row ID projection output is compatible with row ID attributes
   private def rowIdAttrsResolved: Boolean = {
-    val outRowIdAttrs = V2ExpressionUtils.resolveRefs[AttributeReference](
+    // must match the rewrite so a data column can't shadow a metadata-rooted row ID
+    val outRowIdAttrs = V2ExpressionUtils.resolveRowIdRefs(
       operation.rowId.toImmutableArraySeq,
-      originalTable)
+      originalTable).map(_.toAttribute)
     val inRowIdAttrs = DataTypeUtils.toAttributes(projections.rowIdProjection.schema)
     areCompatible(inRowIdAttrs, outRowIdAttrs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -361,9 +361,9 @@ trait RowLevelWrite extends V2WriteCommand with SupportsSubquery {
   }
 
   protected def projectedMetadataAttrs: Seq[Attribute] = {
-    V2ExpressionUtils.resolveRefs[AttributeReference](
+    V2ExpressionUtils.resolveMetadataRefs(
       operation.requiredMetadataAttributes.toImmutableArraySeq,
-      originalTable)
+      originalTable).map(_.toAttribute)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -38,7 +38,6 @@ import org.apache.spark.sql.connector.read.streaming.{Offset, SparkDataStream}
 import org.apache.spark.sql.internal.connector.{SupportsRuntimeCatalystFiltering, V2StatisticsUtils}
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
 /**
@@ -207,8 +206,7 @@ case class DataSourceV2ScanRelation(
       case s: SupportsRuntimeCatalystFiltering => s.filterAttributes()
       case _ => Array.empty[NamedReference]
     }
-    AttributeSet(V2ExpressionUtils.resolveRefs[Attribute](
-      filterAttrs.toImmutableArraySeq, this))
+    V2ExpressionUtils.resolveMetadataAttributeRefs(filterAttrs, output)
   }
 
   /**
@@ -221,8 +219,7 @@ case class DataSourceV2ScanRelation(
       case s: SupportsRuntimeCatalystFiltering => s.fullyPushedFilterAttributes()
       case _ => Array.empty[NamedReference]
     }
-    AttributeSet(V2ExpressionUtils.resolveRefs[Attribute](
-      filterAttrs.toImmutableArraySeq, this))
+    V2ExpressionUtils.resolveMetadataAttributeRefs(filterAttrs, output)
   }
 
   override def name: String = relation.name

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
 import org.apache.spark.sql.connector.expressions._
-import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType, StructType}
 
 class V2ExpressionUtilsSuite extends SparkFunSuite {
 
@@ -36,5 +37,25 @@ class V2ExpressionUtilsSuite extends SparkFunSuite {
         LocalRelation.apply(AttributeReference("a", StringType)()))
     }
     assert(exc.message.contains("v2Fun(a) ASC NULLS FIRST is not currently supported"))
+  }
+
+  test("resolveRowIdRef resolves a metadata-rooted ref past a colliding data column") {
+    // simulate a metadata column renamed after colliding with a user `_metadata` column
+    val userColumn = AttributeReference("_metadata", IntegerType)()
+    val metadataStruct = AttributeReference(
+      "__metadata",
+      new StructType().add("row_index", IntegerType),
+      nullable = false,
+      metadata = new MetadataBuilder().putString(METADATA_COL_ATTR_KEY, "_metadata").build())()
+    val dataColumn = AttributeReference("id", IntegerType)()
+    val plan = LocalRelation(Seq(userColumn, metadataStruct, dataColumn))
+
+    val metadataRowId = V2ExpressionUtils.resolveRowIdRef(
+      FieldReference(Seq("_metadata", "row_index")), plan)
+    assert(metadataRowId.references.contains(metadataStruct))
+    assert(!metadataRowId.references.contains(userColumn))
+
+    val dataRowId = V2ExpressionUtils.resolveRowIdRef(FieldReference("id"), plan)
+    assert(dataRowId == dataColumn)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
@@ -55,6 +55,17 @@ class V2ExpressionUtilsSuite extends SparkFunSuite {
     assert(metadataRowId.references.contains(metadataStruct))
     assert(!metadataRowId.references.contains(userColumn))
 
+    val requiredMetadata = V2ExpressionUtils.resolveMetadataRef(
+      FieldReference(Seq("_metadata", "row_index")), plan)
+    assert(requiredMetadata.references.contains(metadataStruct))
+    assert(!requiredMetadata.references.contains(userColumn))
+    assert(MetadataAttribute.isValid(requiredMetadata.toAttribute.metadata))
+
+    val runtimeFilterAttrs = V2ExpressionUtils.resolveMetadataAttributeRefs(
+      Array(FieldReference(Seq("_metadata", "row_index"))), plan.output)
+    assert(runtimeFilterAttrs.contains(metadataStruct))
+    assert(!runtimeFilterAttrs.contains(userColumn))
+
     val dataRowId = V2ExpressionUtils.resolveRowIdRef(FieldReference("id"), plan)
     assert(dataRowId == dataColumn)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -378,12 +378,14 @@ abstract class InMemoryBaseTable(
     dataMap.update(key, Seq(new BufferedRows(key, schema)))
   }
 
-  def withDeletes(data: Array[BufferedRows]): InMemoryBaseTable = {
+  def withDeletes(
+      data: Array[BufferedRows],
+      rowId: InternalRow => Int = _.getInt(0)): InMemoryBaseTable = {
     data.foreach { p =>
       dataMap ++= dataMap.map { case (key, currentSplits) =>
         val newSplits = currentSplits.map { currentRows =>
           val newRows = new BufferedRows(currentRows.key, currentRows.schema)
-          newRows.rows ++= currentRows.rows.filter(r => !p.deletes.contains(r.getInt(0)))
+          newRows.rows ++= currentRows.rows.filter(r => !p.deletes.contains(rowId(r)))
           newRows
         }
         key -> newSplits

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -166,6 +166,12 @@ abstract class InMemoryBaseTable(
     }
   }
 
+  protected object MetadataStructColumn extends MetadataColumn {
+    override def name: String = "_metadata"
+    override def dataType: DataType = new StructType().add("row_index", IntegerType, false)
+    override def isNullable: Boolean = false
+  }
+
   override def schema(): StructType = CatalogV2Util.v2ColumnsToStructType(columns())
 
   override def supportsColumnChange(change: TableChange.ColumnChange): Boolean = change match {
@@ -182,7 +188,14 @@ abstract class InMemoryBaseTable(
   }
 
   // purposely exposes a metadata column that conflicts with a data column in some tests
-  override val metadataColumns: Array[MetadataColumn] = Array(IndexColumn, PartitionKeyColumn)
+  override val metadataColumns: Array[MetadataColumn] = {
+    val columns = Array[MetadataColumn](IndexColumn, PartitionKeyColumn)
+    if (properties.getOrDefault("nested-metadata", "false").toBoolean) {
+      columns :+ MetadataStructColumn
+    } else {
+      columns
+    }
+  }
   private val metadataColumnNames = metadataColumns.map(_.name).toSet
 
   // Metadata column renaming is supported -- see [[InMemoryScanBuilder.pruneColumns]] and
@@ -782,9 +795,18 @@ abstract class InMemoryBaseTable(
     var pushedFilters: Array[Filter] = Array.empty
 
     override def filterAttributes(): Array[NamedReference] = {
-      val scanFields = readSchema.fields.map(_.name).toSet
-      partitioning.flatMap(_.references)
-        .filter(ref => scanFields.contains(ref.fieldNames.mkString(".")))
+      val hasNestedMetadata = readSchema.exists {
+        case MetadataStructFieldWithLogicalName(_, "_metadata") => true
+        case _ => false
+      }
+      if (properties.getOrDefault("nested-metadata-filter", "false").toBoolean &&
+          hasNestedMetadata) {
+        Array(FieldReference(Seq("_metadata", "row_index")))
+      } else {
+        val scanFields = readSchema.fields.map(_.name).toSet
+        partitioning.flatMap(_.references)
+          .filter(ref => scanFields.contains(ref.fieldNames.mkString(".")))
+      }
     }
 
     override def filter(filters: Array[Filter]): Unit = {
@@ -1169,6 +1191,7 @@ private class BufferedRowsReader(
     val metadataRow = new GenericInternalRow(metadataColumnNames.map {
       case "index" => index
       case "_partition" => UTF8String.fromString(partition.keyString())
+      case "_metadata" => new GenericInternalRow(Array[Any](index))
     }.toArray)
     new JoinedRow(row, metadataRow)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -75,11 +75,16 @@ class InMemoryRowLevelOperationTable private (
 
   private final val PARTITION_COLUMN_REF = FieldReference(PartitionKeyColumn.name)
   private final val INDEX_COLUMN_REF = FieldReference(IndexColumn.name)
+  private final val NESTED_METADATA_COLUMN_REF =
+    FieldReference(Seq(MetadataStructColumn.name, "row_index"))
   private final val SUPPORTS_DELTAS = "supports-deltas"
   private final val SPLIT_UPDATES = "split-updates"
   private final val NESTED_ROW_ID = "nested-row-id"
   // row id is nested.index, whose leaf collides with the `index` metadata column
   private final val NESTED_METADATA_NAME_ROW_ID = "nested-metadata-name-row-id"
+  private final val NESTED_METADATA = "nested-metadata"
+  private final val METADATA_ROW_ID = "metadata-row-id"
+  private final val NESTED_METADATA_ROW_ID = "nested-metadata-row-id"
   private final val NO_METADATA = "no-metadata"
   private final val USE_CATALYST_RUNTIME_FILTERING = "use-catalyst-runtime-filtering"
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
@@ -88,6 +93,21 @@ class InMemoryRowLevelOperationTable private (
   private final val nestedRowId = properties.getOrDefault(NESTED_ROW_ID, "false") == "true"
   private final val nestedMetadataNameRowId =
     properties.getOrDefault(NESTED_METADATA_NAME_ROW_ID, "false") == "true"
+  private final val nestedMetadata =
+    properties.getOrDefault(NESTED_METADATA, "false") == "true"
+  private final val metadataRowId =
+    properties.getOrDefault(METADATA_ROW_ID, "false") == "true"
+  private final val nestedMetadataRowId =
+    properties.getOrDefault(NESTED_METADATA_ROW_ID, "false") == "true"
+
+  private def requiredMetadataRefs: Array[NamedReference] = {
+    val refs = if (metadataRowId) {
+      Array[NamedReference](PARTITION_COLUMN_REF)
+    } else {
+      Array[NamedReference](PARTITION_COLUMN_REF, INDEX_COLUMN_REF)
+    }
+    if (nestedMetadata) refs :+ NESTED_METADATA_COLUMN_REF else refs
+  }
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
@@ -148,7 +168,7 @@ class InMemoryRowLevelOperationTable private (
       if (noMetadata) {
         Array.empty
       } else {
-        Array(PARTITION_COLUMN_REF, INDEX_COLUMN_REF)
+        requiredMetadataRefs
       }
     }
 
@@ -216,11 +236,15 @@ class InMemoryRowLevelOperationTable private (
       if (noMetadata) {
         Array.empty
       } else {
-        Array(PARTITION_COLUMN_REF, INDEX_COLUMN_REF)
+        requiredMetadataRefs
       }
     }
 
-    override def rowId(): Array[NamedReference] = if (nestedMetadataNameRowId) {
+    override def rowId(): Array[NamedReference] = if (nestedMetadataRowId) {
+      Array(NESTED_METADATA_COLUMN_REF)
+    } else if (metadataRowId) {
+      Array(INDEX_COLUMN_REF)
+    } else if (nestedMetadataNameRowId) {
       Array(NESTED_INDEX_COLUMN_REF)
     } else if (nestedRowId) {
       Array(NESTED_PK_COLUMN_REF)
@@ -242,14 +266,22 @@ class InMemoryRowLevelOperationTable private (
         } else {
           new DeltaWrite with RequiresDistributionAndOrdering {
 
+            private val distributionRef = if (nestedMetadata) {
+              NESTED_METADATA_COLUMN_REF
+            } else if (metadataRowId || nestedRowId || nestedMetadataNameRowId) {
+              rowId().head
+            } else {
+              PARTITION_COLUMN_REF
+            }
+
             override def requiredDistribution(): Distribution = {
-              Distributions.clustered(Array(PARTITION_COLUMN_REF))
+              Distributions.clustered(Array(distributionRef))
             }
 
             override def requiredOrdering(): Array[SortOrder] = {
               Array[SortOrder](
                 LogicalExpressions.sort(
-                  PARTITION_COLUMN_REF,
+                  distributionRef,
                   SortDirection.ASCENDING,
                   SortDirection.ASCENDING.defaultNullOrdering())
               )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -77,11 +77,13 @@ class InMemoryRowLevelOperationTable private (
   private final val INDEX_COLUMN_REF = FieldReference(IndexColumn.name)
   private final val SUPPORTS_DELTAS = "supports-deltas"
   private final val SPLIT_UPDATES = "split-updates"
+  private final val NESTED_ROW_ID = "nested-row-id"
   private final val NO_METADATA = "no-metadata"
   private final val USE_CATALYST_RUNTIME_FILTERING = "use-catalyst-runtime-filtering"
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
   private final val useCatalystRuntimeFiltering =
     properties.getOrDefault(USE_CATALYST_RUNTIME_FILTERING, "false") == "true"
+  private final val nestedRowId = properties.getOrDefault(NESTED_ROW_ID, "false") == "true"
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
@@ -203,6 +205,7 @@ class InMemoryRowLevelOperationTable private (
   case class DeltaBasedOperation(command: Command, options: CaseInsensitiveStringMap)
     extends RowLevelOperation with SupportsDelta with RowLevelOperationWithOptions {
     private final val PK_COLUMN_REF = FieldReference("pk")
+    private final val NESTED_PK_COLUMN_REF = FieldReference(Seq("nested", "pk"))
 
     override def requiredMetadataAttributes(): Array[NamedReference] = {
       if (noMetadata) {
@@ -212,7 +215,8 @@ class InMemoryRowLevelOperationTable private (
       }
     }
 
-    override def rowId(): Array[NamedReference] = Array(PK_COLUMN_REF)
+    override def rowId(): Array[NamedReference] =
+      if (nestedRowId) Array(NESTED_PK_COLUMN_REF) else Array(PK_COLUMN_REF)
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       newRowLevelScanBuilder(options)(_ => ())
@@ -259,7 +263,18 @@ class InMemoryRowLevelOperationTable private (
 
     override protected def doCommit(messages: Array[WriterCommitMessage]): Unit = {
       val newData = messages.map(_.asInstanceOf[BufferedRows])
-      withDeletes(newData)
+      // delete rows using the configured row ID
+      val tableSchema = schema()
+      val rowId: InternalRow => Int = if (nestedRowId) {
+        val nestedOrdinal = tableSchema.fieldIndex("nested")
+        val nestedType = tableSchema(nestedOrdinal).dataType.asInstanceOf[StructType]
+        val pkOrdinal = nestedType.fieldIndex("pk")
+        row => row.getStruct(nestedOrdinal, nestedType.length).getInt(pkOrdinal)
+      } else {
+        val pkOrdinal = tableSchema.fieldIndex("pk")
+        row => row.getInt(pkOrdinal)
+      }
+      withDeletes(newData, rowId)
       withData(newData, columns())
       lastWriteLog = newData.flatMap(buffer => buffer.log).toIndexedSeq
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -78,12 +78,16 @@ class InMemoryRowLevelOperationTable private (
   private final val SUPPORTS_DELTAS = "supports-deltas"
   private final val SPLIT_UPDATES = "split-updates"
   private final val NESTED_ROW_ID = "nested-row-id"
+  // row id is nested.index, whose leaf collides with the `index` metadata column
+  private final val NESTED_METADATA_NAME_ROW_ID = "nested-metadata-name-row-id"
   private final val NO_METADATA = "no-metadata"
   private final val USE_CATALYST_RUNTIME_FILTERING = "use-catalyst-runtime-filtering"
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
   private final val useCatalystRuntimeFiltering =
     properties.getOrDefault(USE_CATALYST_RUNTIME_FILTERING, "false") == "true"
   private final val nestedRowId = properties.getOrDefault(NESTED_ROW_ID, "false") == "true"
+  private final val nestedMetadataNameRowId =
+    properties.getOrDefault(NESTED_METADATA_NAME_ROW_ID, "false") == "true"
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
@@ -206,6 +210,7 @@ class InMemoryRowLevelOperationTable private (
     extends RowLevelOperation with SupportsDelta with RowLevelOperationWithOptions {
     private final val PK_COLUMN_REF = FieldReference("pk")
     private final val NESTED_PK_COLUMN_REF = FieldReference(Seq("nested", "pk"))
+    private final val NESTED_INDEX_COLUMN_REF = FieldReference(Seq("nested", "index"))
 
     override def requiredMetadataAttributes(): Array[NamedReference] = {
       if (noMetadata) {
@@ -215,8 +220,13 @@ class InMemoryRowLevelOperationTable private (
       }
     }
 
-    override def rowId(): Array[NamedReference] =
-      if (nestedRowId) Array(NESTED_PK_COLUMN_REF) else Array(PK_COLUMN_REF)
+    override def rowId(): Array[NamedReference] = if (nestedMetadataNameRowId) {
+      Array(NESTED_INDEX_COLUMN_REF)
+    } else if (nestedRowId) {
+      Array(NESTED_PK_COLUMN_REF)
+    } else {
+      Array(PK_COLUMN_REF)
+    }
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       newRowLevelScanBuilder(options)(_ => ())
@@ -265,11 +275,12 @@ class InMemoryRowLevelOperationTable private (
       val newData = messages.map(_.asInstanceOf[BufferedRows])
       // delete rows using the configured row ID
       val tableSchema = schema()
-      val rowId: InternalRow => Int = if (nestedRowId) {
+      val rowId: InternalRow => Int = if (nestedRowId || nestedMetadataNameRowId) {
+        val field = if (nestedMetadataNameRowId) "index" else "pk"
         val nestedOrdinal = tableSchema.fieldIndex("nested")
         val nestedType = tableSchema(nestedOrdinal).dataType.asInstanceOf[StructType]
-        val pkOrdinal = nestedType.fieldIndex("pk")
-        row => row.getStruct(nestedOrdinal, nestedType.length).getInt(pkOrdinal)
+        val fieldOrdinal = nestedType.fieldIndex(field)
+        row => row.getStruct(nestedOrdinal, nestedType.length).getInt(fieldOrdinal)
       } else {
         val pkOrdinal = tableSchema.fieldIndex("pk")
         row => row.getInt(pkOrdinal)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -602,9 +602,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         r.name) :: Nil
 
     case MergeRows(isSourceRowPresent, isTargetRowPresent, matchedInstructions,
-        notMatchedInstructions, notMatchedBySourceInstructions, checkCardinality, output, child) =>
+        notMatchedInstructions, notMatchedBySourceInstructions, cardinalityRowId, output, child) =>
       MergeRowsExec(isSourceRowPresent, isTargetRowPresent, matchedInstructions,
-        notMatchedInstructions, notMatchedBySourceInstructions, checkCardinality,
+        notMatchedInstructions, notMatchedBySourceInstructions, cardinalityRowId,
         output, planLater(child)) :: Nil
 
     case WriteToContinuousDataSource(writer, query, customMetrics) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, ResolveTimeZone, TypeCoercion}
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, SortOrder, TransformExpression, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, NamedExpression, SortOrder, TransformExpression, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, RebalancePartitions, RepartitionByExpression, Sort}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.connector.catalog.FunctionCatalog
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
 import org.apache.spark.sql.connector.distributions._
+import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.util.ArrayImplicits._
@@ -34,17 +35,26 @@ object DistributionAndOrderingUtils {
   def prepareQuery(
       write: Write,
       query: LogicalPlan,
-      funCatalogOpt: Option[FunctionCatalog]): LogicalPlan = write match {
+      funCatalogOpt: Option[FunctionCatalog]): LogicalPlan = {
+    prepareQuery(
+      write, query, funCatalogOpt, V2ExpressionUtils.resolveRef[NamedExpression](_, query))
+  }
+
+  def prepareQuery(
+      write: Write,
+      query: LogicalPlan,
+      funCatalogOpt: Option[FunctionCatalog],
+      refResolver: NamedReference => NamedExpression): LogicalPlan = write match {
     case write: RequiresDistributionAndOrdering =>
       val numPartitions = write.requiredNumPartitions()
       val partitionSize = write.advisoryPartitionSizeInBytes()
 
       val distribution = write.requiredDistribution match {
         case d: OrderedDistribution =>
-          toCatalystOrdering(d.ordering(), query, funCatalogOpt)
+          toCatalystOrdering(d.ordering(), query, funCatalogOpt, refResolver)
             .map(e => resolveTransformExpression(e).asInstanceOf[SortOrder])
         case d: ClusteredDistribution =>
-          d.clustering.map(e => toCatalyst(e, query, funCatalogOpt))
+          d.clustering.map(e => toCatalyst(e, query, funCatalogOpt, refResolver))
             .map(e => resolveTransformExpression(e)).toImmutableArraySeq
         case _: UnspecifiedDistribution => Seq.empty[Expression]
       }
@@ -74,7 +84,7 @@ object DistributionAndOrderingUtils {
         query
       }
 
-      val ordering = toCatalystOrdering(write.requiredOrdering, query, funCatalogOpt)
+      val ordering = toCatalystOrdering(write.requiredOrdering, query, funCatalogOpt, refResolver)
       val queryWithDistributionAndOrdering = if (ordering.nonEmpty) {
         Sort(
           ordering.map(e => resolveTransformExpression(e).asInstanceOf[SortOrder]),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.Projection
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, FalseLiteral, GeneratePredicate, JavaCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Context, Copy, Delete, Discard, Insert, Instruction, Keep, ROW_ID, Split, Update}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Context, Copy, Delete, Discard, Insert, Instruction, Keep, Split, Update}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{CodegenSupport, SparkPlan, UnaryExecNode}
@@ -45,9 +45,11 @@ case class MergeRowsExec(
     matchedInstructions: Seq[Instruction],
     notMatchedInstructions: Seq[Instruction],
     notMatchedBySourceInstructions: Seq[Instruction],
-    checkCardinality: Boolean,
+    cardinalityRowId: Option[Attribute],
     output: Seq[Attribute],
     child: SparkPlan) extends UnaryExecNode with CodegenSupport {
+
+  def checkCardinality: Boolean = cardinalityRowId.isDefined
 
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numTargetRowsCopied" -> SQLLastAttemptMetrics.createMetric(sparkContext,
@@ -73,13 +75,7 @@ case class MergeRowsExec(
 
   @transient
   override lazy val references: AttributeSet = {
-    val usedExprs = if (checkCardinality) {
-      val rowIdAttr = child.output.find(attr => conf.resolver(attr.name, ROW_ID))
-      assert(rowIdAttr.isDefined, "Cannot find row ID attr")
-      rowIdAttr.get +: expressions
-    } else {
-      expressions
-    }
+    val usedExprs = cardinalityRowId.toSeq ++ expressions
     AttributeSet.fromAttributeSets(usedExprs.map(_.references)) -- producedAttributes
   }
 
@@ -179,7 +175,7 @@ case class MergeRowsExec(
       ctx, notMatchedBySourceInstructions, inputExprs, sourcePresent = false)
 
     val cardinalityValidationCode = if (checkCardinality) {
-      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+      val rowIdOrdinal = child.output.indexWhere(_.exprId == cardinalityRowId.get.exprId)
       assert(rowIdOrdinal != -1, "Cannot find row ID attr")
       generateCardinalityValidationCode(ctx, rowIdOrdinal, inputExprs).code
     } else {
@@ -412,7 +408,7 @@ case class MergeRowsExec(
     val notMatchedBySourceInstructionExecs = planInstructions(notMatchedBySourceInstructions)
 
     val cardinalityValidator = if (checkCardinality) {
-      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+      val rowIdOrdinal = child.output.indexWhere(_.exprId == cardinalityRowId.get.exprId)
       assert(rowIdOrdinal != -1, "Cannot find row ID attr")
       BitmapCardinalityValidator(rowIdOrdinal)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -212,7 +212,7 @@ object PushDownUtils extends Logging {
         // filters whose translation was not already accepted in the first pass.  (See SPARK-55596)
         // Only candidates whose referenced columns are declared in filterAttributes() are eligible.
         val partPredicatesPushed = filterableScan.supportsIterativePushdown() && {
-          val filterAttrs = V2ExpressionUtils.resolveAttributeRefs(
+          val filterAttrs = V2ExpressionUtils.resolveMetadataAttributeRefs(
             filterableScan.filterAttributes(), output)
           val pushed = filterableScan.pushedPredicates().toSet
           val candidates = runtimeFilters.filter { f =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -21,14 +21,17 @@ import java.util.UUID
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.ProjectingInternalRow
+import org.apache.spark.sql.catalyst.expressions.{NamedExpression, PredicateHelper, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, InsertOnlyMerge, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, ReplaceData, WriteDelta}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.catalyst.util.WriteDeltaProjections
 import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.write.{DeltaWriteBuilder, LogicalWriteInfoImpl, SupportsDynamicOverwrite, SupportsOverwriteV2, SupportsTruncate, Write, WriteBuilder}
+import org.apache.spark.sql.connector.write.{DeltaWriteBuilder, LogicalWriteInfoImpl, RowLevelOperationTable, SupportsDelta, SupportsDynamicOverwrite, SupportsOverwriteV2, SupportsTruncate, Write, WriteBuilder}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.streaming.sources.{MicroBatchWrite, WriteToMicroBatchDataSource}
 import org.apache.spark.sql.internal.connector.SupportsStreamingUpdateAsAppend
@@ -114,15 +117,62 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
       val writeOptions = mergeOptions(Map.empty, r.options.asCaseSensitiveMap.asScala.toMap)
       val writeBuilder = newWriteBuilder(r.table, writeOptions, rowSchema, metadataSchema)
       val write = writeBuilder.build()
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, r.funCatalog)
+      val operation = r.table.asInstanceOf[RowLevelOperationTable].operation
+      val refResolver = rowLevelWriteRefResolver(
+        query,
+        projections.metadataProjection.toSeq.map { projection =>
+          operation.requiredMetadataAttributes() -> projection
+        })
+      val newQuery =
+        DistributionAndOrderingUtils.prepareQuery(write, query, r.funCatalog, refResolver)
       rd.copy(write = Some(write), query = newQuery)
 
     case wd @ WriteDelta(r: DataSourceV2Relation, _, query, _, projections, _, None) =>
       val writeOptions = mergeOptions(Map.empty, r.options.asCaseSensitiveMap.asScala.toMap)
       val deltaWriteBuilder = newDeltaWriteBuilder(r.table, writeOptions, projections)
       val deltaWrite = deltaWriteBuilder.build()
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(deltaWrite, query, r.funCatalog)
+      val operation = r.table.asInstanceOf[RowLevelOperationTable].operation
+      val deltaOperation = operation.asInstanceOf[SupportsDelta]
+      val refBindings = projections.metadataProjection.toSeq.map { projection =>
+        operation.requiredMetadataAttributes() -> projection
+      } :+
+        (deltaOperation.rowId() -> projections.rowIdProjection)
+      val refResolver = rowLevelWriteRefResolver(query, refBindings)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(
+        deltaWrite, query, r.funCatalog, refResolver)
       wd.copy(write = Some(deltaWrite), query = newQuery)
+  }
+
+  private def rowLevelWriteRefResolver(
+      query: LogicalPlan,
+      refBindings: Seq[(Array[NamedReference], ProjectingInternalRow)])
+      : NamedReference => NamedExpression = {
+    val bindings = refBindings.flatMap { case (refs, projection) =>
+      if (refs.length != projection.colOrdinals.length) {
+        throw SparkException.internalError(
+          s"Expected ${refs.length} projection ordinals, " +
+            s"but found ${projection.colOrdinals.length}")
+      }
+      refs.zip(projection.colOrdinals).map { case (ref, ordinal) =>
+        ref -> query.output(ordinal)
+      }
+    }
+    ref => {
+      val matchingAttrs = bindings.collect {
+      case (boundRef, attr) if boundRef.fieldNames().length == ref.fieldNames().length &&
+          boundRef.fieldNames().zip(ref.fieldNames()).forall { case (left, right) =>
+            conf.resolver(left, right)
+          } =>
+        attr
+      }
+      if (matchingAttrs.map(_.exprId).distinct.size > 1) {
+        throw SparkException.internalError(
+          s"Connector reference $ref is bound to multiple write attributes")
+      }
+      matchingAttrs.headOption.getOrElse {
+        V2ExpressionUtils.resolveRef[NamedExpression](ref, query)
+      }
+    }
   }
 
   private def mergeOptions(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -80,7 +80,7 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
           None
         }
       case (resExp, r @ ExtractV2Scan(scan: SupportsRuntimeV2Filtering)) =>
-        val filterAttrs = V2ExpressionUtils.resolveAttributeRefs(
+        val filterAttrs = V2ExpressionUtils.resolveMetadataAttributeRefs(
           scan.filterAttributes, r.output)
         if (resExp.references.subsetOf(filterAttrs)) {
           Some(r)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.execution.dynamicpruning
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, DynamicPruningExpression, Expression, InSubquery, ListQuery, PredicateHelper, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, DynamicPruningExpression, Expression, InSubquery, ListQuery, NamedExpression, PredicateHelper, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery
 import org.apache.spark.sql.catalyst.planning.{DeltaBasedRowLevelOperation, GroupBasedRowLevelOperation}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan, RowLevelWrite}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan, Project, RowLevelWrite}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeV2Filtering}
@@ -95,8 +95,8 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
         val relation = r.relation.copy(table = originalTable)
         val matchingRowsPlan = buildMatchingRowsPlan(write, relation, cond)
         val filterAttrsSeq = filterAttrs.toImmutableArraySeq
-        val buildKeys = V2ExpressionUtils.resolveRefs[Attribute](filterAttrsSeq, matchingRowsPlan)
-        val pruningKeys = V2ExpressionUtils.resolveRefs[Attribute](filterAttrsSeq, r)
+        val buildKeys = V2ExpressionUtils.resolveMetadataRefs(filterAttrsSeq, matchingRowsPlan)
+        val pruningKeys = V2ExpressionUtils.resolveMetadataRefs(filterAttrsSeq, r)
         Filter(buildDynamicPruningCond(matchingRowsPlan, buildKeys, pruningKeys), r)
     }
     // optimize subqueries to rewrite them as joins and trigger job planning
@@ -141,13 +141,23 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
 
   private def buildDynamicPruningCond(
       matchingRowsPlan: LogicalPlan,
-      buildKeys: Seq[Attribute],
-      pruningKeys: Seq[Attribute]): Expression = {
+      buildKeys: Seq[NamedExpression],
+      pruningKeys: Seq[NamedExpression]): Expression = {
     assert(buildKeys.nonEmpty && pruningKeys.nonEmpty)
 
-    val buildQuery = Aggregate(buildKeys, buildKeys, matchingRowsPlan)
+    def valueExpression(expr: NamedExpression): Expression = expr match {
+      case alias: Alias => alias.child
+      case other => other
+    }
+    val buildKeyAliases = buildKeys.map { key =>
+      Alias(valueExpression(key), key.name)()
+    }
+    val buildProject = Project(buildKeyAliases, matchingRowsPlan)
+    val buildQuery = Aggregate(buildProject.output, buildProject.output, buildProject)
     DynamicPruningExpression(
-      InSubquery(pruningKeys, ListQuery(buildQuery, numCols = buildQuery.output.length)))
+      InSubquery(
+        pruningKeys.map(valueExpression),
+        ListQuery(buildQuery, numCols = buildQuery.output.length)))
   }
 
   private def buildTableToScanAttrMap(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
+import org.apache.spark.sql.connector.catalog.CatalogV2Util
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType, StructField, StructType}
+
+abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
+  extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
+
+  override protected def extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props.put("nested-row-id", "true")
+    if (splitUpdates) props.put("split-updates", "true")
+    props
+  }
+
+  // mirror the metadata marker on file-source row IDs
+  private val nestedPkMetadata =
+    new MetadataBuilder().putString(METADATA_COL_ATTR_KEY, "row_index").build()
+
+  private val tableSchema = StructType(Seq(
+    StructField("pk", IntegerType, nullable = false),
+    StructField("nested", StructType(Seq(
+      StructField("pk", IntegerType, nullable = false, metadata = nestedPkMetadata))),
+      nullable = false),
+    StructField("id", IntegerType),
+    StructField("dep", StringType)))
+
+  // use different top-level and nested PK values to expose name-based binding
+  private val initialRows =
+    """{ "pk": 10, "nested": { "pk": 1 }, "id": 1, "dep": "hr" }
+      |{ "pk": 20, "nested": { "pk": 2 }, "id": 2, "dep": "software" }
+      |{ "pk": 30, "nested": { "pk": 3 }, "id": 3, "dep": "hr" }
+      |""".stripMargin
+
+  private def createNestedRowIdTable(): Unit = {
+    createTable(CatalogV2Util.structTypeToV2Columns(tableSchema))
+    append(tableSchema.toDDL, initialRows)
+  }
+
+  private def checkTable(expected: Seq[Row]): Unit = {
+    checkAnswer(
+      sql(s"SELECT pk, nested.pk, id, dep FROM $tableNameAsString ORDER BY pk"),
+      expected)
+  }
+
+  test("delete with nested row id") {
+    createNestedRowIdTable()
+    // use a multi-value IN to force the row-level delta path instead of metadata-only deleteWhere
+    sql(s"DELETE FROM $tableNameAsString WHERE id IN (1, 100)")
+    checkTable(Seq(
+      Row(20, 2, 2, "software"),
+      Row(30, 3, 3, "hr")))
+  }
+
+  test("update with nested row id") {
+    createNestedRowIdTable()
+    sql(s"UPDATE $tableNameAsString SET dep = 'it' WHERE id = 1")
+    checkTable(Seq(
+      Row(10, 1, 1, "it"),
+      Row(20, 2, 2, "software"),
+      Row(30, 3, 3, "hr")))
+  }
+
+  test("update replacing the struct that holds the nested row id") {
+    createNestedRowIdTable()
+    sql(
+      s"""UPDATE $tableNameAsString
+         |SET nested = named_struct('pk', 11)
+         |WHERE id = 1
+         |""".stripMargin)
+    checkTable(Seq(
+      Row(10, 11, 1, "hr"),
+      Row(20, 2, 2, "software"),
+      Row(30, 3, 3, "hr")))
+  }
+
+  test("merge update with nested row id") {
+    withTempView("source") {
+      createNestedRowIdTable()
+      Seq((1, "it")).toDF("id", "dep").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |""".stripMargin)
+      checkTable(Seq(
+        Row(10, 1, 1, "it"),
+        Row(20, 2, 2, "software"),
+        Row(30, 3, 3, "hr")))
+    }
+  }
+
+  test("merge delete with nested row id") {
+    withTempView("source") {
+      createNestedRowIdTable()
+      Seq(2).toDF("id").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN DELETE
+           |""".stripMargin)
+      checkTable(Seq(
+        Row(10, 1, 1, "hr"),
+        Row(30, 3, 3, "hr")))
+    }
+  }
+
+  test("merge not matched by source update with nested row id") {
+    withTempView("source") {
+      createNestedRowIdTable()
+      Seq(1).toDF("id").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN NOT MATCHED BY SOURCE THEN UPDATE SET t.dep = 'gone'
+           |""".stripMargin)
+      checkTable(Seq(
+        Row(10, 1, 1, "hr"),
+        Row(20, 2, 2, "gone"),
+        Row(30, 3, 3, "gone")))
+    }
+  }
+
+  test("merge with matched update and not-matched insert with nested row id") {
+    withTempView("source") {
+      createNestedRowIdTable()
+      Seq((1, "it"), (4, "new")).toDF("id", "dep").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |WHEN NOT MATCHED THEN
+           |INSERT (pk, nested, id, dep) VALUES (s.id * 10, named_struct('pk', s.id), s.id, s.dep)
+           |""".stripMargin)
+      checkTable(Seq(
+        Row(10, 1, 1, "it"),
+        Row(20, 2, 2, "software"),
+        Row(30, 3, 3, "hr"),
+        Row(40, 4, 4, "new")))
+    }
+  }
+}
+
+class DeltaBasedNestedRowIdTableSuite
+  extends DeltaBasedNestedRowIdTableSuiteBase(splitUpdates = false)
+
+class DeltaBasedNestedRowIdUpdateAsDeleteAndInsertTableSuite
+  extends DeltaBasedNestedRowIdTableSuiteBase(splitUpdates = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
@@ -242,3 +242,75 @@ class DeltaBasedNestedRowIdTableSuite
 
 class DeltaBasedNestedRowIdUpdateAsDeleteAndInsertTableSuite
   extends DeltaBasedNestedRowIdTableSuiteBase(splitUpdates = true)
+
+// Row id is nested.index, whose leaf name collides with the `index` metadata column
+// (PRESERVE_ON_DELETE = false). The metadata must be nulled on write, not bound to the row id
+// value it shares a name with.
+abstract class DeltaBasedNestedRowIdMetadataCollisionSuiteBase(splitUpdates: Boolean)
+  extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
+
+  override protected def extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props.put("nested-metadata-name-row-id", "true")
+    if (splitUpdates) props.put("split-updates", "true")
+    props
+  }
+
+  private def createCollisionTable(): Unit = {
+    val schema = StructType(Seq(
+      StructField("pk", IntegerType, nullable = false),
+      StructField("nested", StructType(Seq(
+        StructField("index", IntegerType, nullable = false))),
+        nullable = false),
+      StructField("id", IntegerType),
+      StructField("dep", StringType)))
+    createTable(CatalogV2Util.structTypeToV2Columns(schema))
+    append(schema.toDDL,
+      """{ "pk": 10, "nested": { "index": 1 }, "id": 1, "dep": "hr" }
+        |{ "pk": 20, "nested": { "index": 2 }, "id": 2, "dep": "software" }
+        |{ "pk": 30, "nested": { "index": 3 }, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+  }
+
+  test("delete nulls a metadata column colliding with the nested row id") {
+    createCollisionTable()
+    sql(s"DELETE FROM $tableNameAsString WHERE id IN (1, 100)")
+    checkLastWriteLog(deleteWriteLogEntry(id = 1, metadata = Row("hr", null)))
+  }
+
+  test("update nulls a metadata column colliding with the nested row id") {
+    createCollisionTable()
+    sql(s"UPDATE $tableNameAsString SET dep = 'it' WHERE id = 1")
+    if (splitUpdates) {
+      checkLastWriteLog(
+        deleteWriteLogEntry(id = 1, metadata = Row("hr", null)),
+        reinsertWriteLogEntry(metadata = Row("hr", null), data = Row(10, Row(1), 1, "it")))
+    } else {
+      checkLastWriteLog(
+        updateWriteLogEntry(id = 1, metadata = Row("hr", null), data = Row(10, Row(1), 1, "it")))
+    }
+  }
+
+  test("merge delete nulls a metadata column colliding with the nested row id") {
+    withTempView("source") {
+      createCollisionTable()
+      Seq(1).toDF("id").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN DELETE
+           |""".stripMargin)
+      checkLastWriteLog(deleteWriteLogEntry(id = 1, metadata = Row("hr", null)))
+    }
+  }
+}
+
+class DeltaBasedNestedRowIdMetadataCollisionSuite
+  extends DeltaBasedNestedRowIdMetadataCollisionSuiteBase(splitUpdates = false)
+
+class DeltaBasedNestedRowIdMetadataCollisionUpdateAsDeleteAndInsertSuite
+  extends DeltaBasedNestedRowIdMetadataCollisionSuiteBase(splitUpdates = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
@@ -18,8 +18,12 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.plans.logical.{RebalancePartitions, RepartitionByExpression, Sort, WriteDelta}
+import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
 import org.apache.spark.sql.connector.catalog.CatalogV2Util
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, V2Writes}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
 
 abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
   extends RowLevelOperationSuiteBase {
@@ -92,6 +96,30 @@ abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
       checkLastWriteLog(
         updateWriteLogEntry(id = 1, metadata = Row("hr", null), data = Row(10, Row(1), 1, "it")))
     }
+  }
+
+  test("write distribution and ordering use the nested row id") {
+    createNestedRowIdTable()
+
+    val command = sql(s"UPDATE $tableNameAsString SET dep = 'it' WHERE id = 1")
+    val writeDelta = V2Writes(command.queryExecution.analyzed).collectFirst {
+      case write: WriteDelta => write
+    }.getOrElse(fail("Cannot find WriteDelta"))
+    val rowIdAttr = writeDelta.query.output(
+      writeDelta.projections.rowIdProjection.colOrdinals.head)
+
+    val distributionAttr = writeDelta.query.collectFirst {
+      case repartition: RepartitionByExpression =>
+        repartition.partitionExpressions.flatMap(_.references).head
+      case rebalance: RebalancePartitions =>
+        rebalance.partitionExpressions.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required distribution"))
+    val orderingAttr = writeDelta.query.collectFirst {
+      case sort: Sort => sort.order.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required ordering"))
+
+    assert(distributionAttr.exprId == rowIdAttr.exprId)
+    assert(orderingAttr.exprId == rowIdAttr.exprId)
   }
 
   test("update replacing the struct that holds the nested row id") {
@@ -233,6 +261,99 @@ abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
         Row(10, 1, 1, 100, "it"),
         Row(20, 2, 2, 200, "software"),
         Row(30, 3, 3, 300, "hr")))
+      if (splitUpdates) {
+        checkLastWriteLog(
+          deleteWriteLogEntry(id = 1, metadata = Row("hr", null)),
+          reinsertWriteLogEntry(
+            metadata = Row("hr", null), data = Row(10, Row(1), 1, 100, "it")))
+      } else {
+        checkLastWriteLog(
+          updateWriteLogEntry(id = 1, metadata = Row("hr", null),
+            data = Row(10, Row(1), 1, 100, "it")))
+      }
+    }
+  }
+
+  test("merge target-presence marker is not shadowed by a data column") {
+    withTempView("source") {
+      val schema = StructType(Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("nested", StructType(Seq(
+          StructField("pk", IntegerType, nullable = false))), nullable = false),
+        StructField("id", IntegerType),
+        StructField("__row_from_target", StringType),
+        StructField("dep", StringType)))
+      createTable(CatalogV2Util.structTypeToV2Columns(schema))
+      append(schema.toDDL,
+        """{ "pk": 10, "nested": { "pk": 1 }, "id": 1, "__row_from_target": "user", "dep": "hr" }
+          |""".stripMargin)
+      Seq((1, "it")).toDF("id", "dep").createOrReplaceTempView("source")
+
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |""".stripMargin)
+
+      checkAnswer(
+        sql(s"SELECT pk, __row_from_target, dep FROM $tableNameAsString"),
+        Seq(Row(10, "user", "it")))
+    }
+  }
+
+  test("merge source-presence marker is not shadowed by a source column") {
+    withTempView("source") {
+      createNestedRowIdTable()
+      Seq((1, "source", "it"))
+        .toDF("id", "__row_from_source", "dep")
+        .createOrReplaceTempView("source")
+
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |""".stripMargin)
+
+      checkTable(Seq(
+        Row(10, 1, 1, "it"),
+        Row(20, 2, 2, "software"),
+        Row(30, 3, 3, "hr")))
+    }
+  }
+
+  test("merge cardinality row id is not shadowed by a data column") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+      withTempView("source") {
+      val schema = StructType(Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("nested", StructType(Seq(
+          StructField("pk", IntegerType, nullable = false))), nullable = false),
+        StructField("id", IntegerType),
+        StructField("__row_id", LongType),
+        StructField("dep", StringType)))
+      createTable(CatalogV2Util.structTypeToV2Columns(schema))
+      append(schema.toDDL,
+        """{ "pk": 10, "nested": { "pk": 1 }, "id": 1, "__row_id": 0, "dep": "hr" }
+          |{ "pk": 20, "nested": { "pk": 2 }, "id": 2, "__row_id": 0, "dep": "software" }
+          |""".stripMargin)
+      Seq((1, "it"), (2, "sales")).toDF("id", "dep").createOrReplaceTempView("source")
+
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |""".stripMargin)
+
+      checkAnswer(
+        sql(s"SELECT pk, __row_id, dep FROM $tableNameAsString ORDER BY pk"),
+        Seq(Row(10, 0L, "it"), Row(20, 0L, "sales")))
+      }
     }
   }
 }
@@ -314,3 +435,142 @@ class DeltaBasedNestedRowIdMetadataCollisionSuite
 
 class DeltaBasedNestedRowIdMetadataCollisionUpdateAsDeleteAndInsertSuite
   extends DeltaBasedNestedRowIdMetadataCollisionSuiteBase(splitUpdates = true)
+
+abstract class DeltaBasedMetadataRowIdTableSuiteBase(
+    nested: Boolean,
+    splitUpdates: Boolean) extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
+
+  override protected def extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    if (nested) {
+      props.put("nested-metadata", "true")
+      props.put("nested-metadata-filter", "true")
+      props.put("nested-metadata-row-id", "true")
+    } else {
+      props.put("metadata-row-id", "true")
+    }
+    if (splitUpdates) props.put("split-updates", "true")
+    props
+  }
+
+  protected val schema: String = if (nested) {
+    "pk INT NOT NULL, id INT, _metadata STRUCT<row_index: INT>, dep STRING"
+  } else {
+    "pk INT NOT NULL, id INT, dep STRING"
+  }
+
+  protected def createMetadataRowIdTable(): Unit = {
+    createAndInitTable(schema,
+      (if (nested) {
+        """{ "pk": 0, "id": 0, "_metadata": { "row_index": 100 }, "dep": "hr" }
+          |{ "pk": 1, "id": 1, "_metadata": { "row_index": 200 }, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "_metadata": { "row_index": 300 }, "dep": "hr" }
+          |""".stripMargin
+      } else {
+        """{ "pk": 0, "id": 0, "dep": "hr" }
+          |{ "pk": 1, "id": 1, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "dep": "hr" }
+          |""".stripMargin
+      }))
+  }
+
+  protected def checkMetadataRowIdTable(expected: Seq[Row]): Unit = {
+    checkAnswer(
+      sql(s"SELECT pk, id, dep FROM $tableNameAsString ORDER BY pk"),
+      expected)
+  }
+
+  test("delete with a metadata row id") {
+    createMetadataRowIdTable()
+    sql(s"DELETE FROM $tableNameAsString WHERE id IN (1, 100)")
+    checkMetadataRowIdTable(Seq(Row(0, 0, "hr"), Row(2, 2, "hr")))
+  }
+
+  test("update with a metadata row id") {
+    createMetadataRowIdTable()
+    sql(s"UPDATE $tableNameAsString SET dep = 'it' WHERE id = 1")
+    checkMetadataRowIdTable(
+      Seq(Row(0, 0, "hr"), Row(1, 1, "it"), Row(2, 2, "hr")))
+  }
+
+  test("merge with a metadata row id") {
+    withTempView("source") {
+      createMetadataRowIdTable()
+      Seq((1, "it")).toDF("id", "dep").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |""".stripMargin)
+      checkMetadataRowIdTable(
+        Seq(Row(0, 0, "hr"), Row(1, 1, "it"), Row(2, 2, "hr")))
+    }
+  }
+}
+
+class DeltaBasedMetadataRowIdTableSuite
+  extends DeltaBasedMetadataRowIdTableSuiteBase(nested = false, splitUpdates = false)
+
+class DeltaBasedMetadataRowIdUpdateAsDeleteAndInsertTableSuite
+  extends DeltaBasedMetadataRowIdTableSuiteBase(nested = false, splitUpdates = true)
+
+abstract class DeltaBasedNestedMetadataRowIdTableSuiteBase(splitUpdates: Boolean)
+  extends DeltaBasedMetadataRowIdTableSuiteBase(nested = true, splitUpdates = splitUpdates) {
+
+  test("shared nested metadata and row ID reference has one binding") {
+    createMetadataRowIdTable()
+    val command = sql(s"UPDATE $tableNameAsString SET id = -1 WHERE id = 1")
+    val writeDelta = V2Writes(command.queryExecution.analyzed).collectFirst {
+      case write: WriteDelta => write
+    }.getOrElse(fail("Cannot find WriteDelta"))
+
+    val rowIdAttr = writeDelta.query.output(
+      writeDelta.projections.rowIdProjection.colOrdinals.head)
+    val metadataProjection = writeDelta.projections.metadataProjection.get
+    val metadataOrdinal = metadataProjection.schema.fields.indexWhere { field =>
+      field.name == "row_index" &&
+        field.metadata.contains(METADATA_COL_ATTR_KEY) &&
+        field.metadata.getString(METADATA_COL_ATTR_KEY) == "_metadata"
+    }
+    assert(metadataOrdinal >= 0)
+    val metadataAttr = writeDelta.query.output(
+      metadataProjection.colOrdinals(metadataOrdinal))
+
+    val distributionAttr = writeDelta.query.collectFirst {
+      case repartition: RepartitionByExpression =>
+        repartition.partitionExpressions.flatMap(_.references).head
+      case rebalance: RebalancePartitions =>
+        rebalance.partitionExpressions.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required distribution"))
+    val orderingAttr = writeDelta.query.collectFirst {
+      case sort: Sort => sort.order.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required ordering"))
+
+    assert(metadataAttr.exprId == rowIdAttr.exprId)
+    assert(distributionAttr.exprId == rowIdAttr.exprId)
+    assert(orderingAttr.exprId == rowIdAttr.exprId)
+  }
+
+  test("runtime group filtering supports nested metadata") {
+    createMetadataRowIdTable()
+    val executedPlan = executeAndKeepPlan {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE id = 1")
+    }
+    val filteredScans = collect(executedPlan) {
+      case scan: BatchScanExec if scan.runtimeFilters.nonEmpty => scan
+    }
+    assert(filteredScans.nonEmpty, "could not find a runtime-filtered scan")
+    checkMetadataRowIdTable(
+      Seq(Row(0, 0, "hr"), Row(1, -1, "hr"), Row(2, 2, "hr")))
+  }
+}
+
+class DeltaBasedNestedMetadataRowIdTableSuite
+  extends DeltaBasedNestedMetadataRowIdTableSuiteBase(splitUpdates = false)
+
+class DeltaBasedNestedMetadataRowIdUpdateAsDeleteAndInsertTableSuite
+  extends DeltaBasedNestedMetadataRowIdTableSuiteBase(splitUpdates = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
@@ -69,6 +69,11 @@ abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
     checkTable(Seq(
       Row(20, 2, 2, "software"),
       Row(30, 3, 3, "hr")))
+    // the row id written to the delta is the nested pk (1), not the top-level pk (10)
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+    checkLastWriteLog(deleteWriteLogEntry(id = 1, metadata = Row("hr", null)))
   }
 
   test("update with nested row id") {
@@ -78,6 +83,15 @@ abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
       Row(10, 1, 1, "it"),
       Row(20, 2, 2, "software"),
       Row(30, 3, 3, "hr")))
+    // the row id written to the delta is the nested pk (1), not the top-level pk (10)
+    if (splitUpdates) {
+      checkLastWriteLog(
+        deleteWriteLogEntry(id = 1, metadata = Row("hr", null)),
+        reinsertWriteLogEntry(metadata = Row("hr", null), data = Row(10, Row(1), 1, "it")))
+    } else {
+      checkLastWriteLog(
+        updateWriteLogEntry(id = 1, metadata = Row("hr", null), data = Row(10, Row(1), 1, "it")))
+    }
   }
 
   test("update replacing the struct that holds the nested row id") {
@@ -160,6 +174,65 @@ abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
         Row(20, 2, 2, "software"),
         Row(30, 3, 3, "hr"),
         Row(40, 4, 4, "new")))
+    }
+  }
+
+  // A data column `index` collides with the in-memory table's `index` metadata column: the row
+  // level rewrite must still resolve the nested row id and the metadata column correctly.
+  private def createDataMetadataConflictTable(): Unit = {
+    val schema = StructType(Seq(
+      StructField("pk", IntegerType, nullable = false),
+      StructField("nested", StructType(Seq(
+        StructField("pk", IntegerType, nullable = false))),
+        nullable = false),
+      StructField("id", IntegerType),
+      StructField("index", IntegerType),
+      StructField("dep", StringType)))
+    createTable(CatalogV2Util.structTypeToV2Columns(schema))
+    append(schema.toDDL,
+      """{ "pk": 10, "nested": { "pk": 1 }, "id": 1, "index": 100, "dep": "hr" }
+        |{ "pk": 20, "nested": { "pk": 2 }, "id": 2, "index": 200, "dep": "software" }
+        |{ "pk": 30, "nested": { "pk": 3 }, "id": 3, "index": 300, "dep": "hr" }
+        |""".stripMargin)
+  }
+
+  private def checkConflictTable(expected: Seq[Row]): Unit = {
+    checkAnswer(
+      sql(s"SELECT pk, nested.pk, id, index, dep FROM $tableNameAsString ORDER BY pk"),
+      expected)
+  }
+
+  test("delete with a data column named like a metadata column") {
+    createDataMetadataConflictTable()
+    sql(s"DELETE FROM $tableNameAsString WHERE id IN (1, 100)")
+    checkConflictTable(Seq(
+      Row(20, 2, 2, 200, "software"),
+      Row(30, 3, 3, 300, "hr")))
+  }
+
+  test("update with a data column named like a metadata column") {
+    createDataMetadataConflictTable()
+    sql(s"UPDATE $tableNameAsString SET dep = 'it' WHERE id = 1")
+    checkConflictTable(Seq(
+      Row(10, 1, 1, 100, "it"),
+      Row(20, 2, 2, 200, "software"),
+      Row(30, 3, 3, 300, "hr")))
+  }
+
+  test("merge with a data column named like a metadata column") {
+    withTempView("source") {
+      createDataMetadataConflictTable()
+      Seq((1, "it")).toDF("id", "dep").createOrReplaceTempView("source")
+      sql(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN UPDATE SET t.dep = s.dep
+           |""".stripMargin)
+      checkConflictTable(Seq(
+        Row(10, 1, 1, 100, "it"),
+        Row(20, 2, 2, 200, "software"),
+        Row(30, 3, 3, 300, "hr")))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedNestedRowIdTableSuite.scala
@@ -18,9 +18,8 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
 import org.apache.spark.sql.connector.catalog.CatalogV2Util
-import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
   extends RowLevelOperationSuiteBase {
@@ -35,14 +34,12 @@ abstract class DeltaBasedNestedRowIdTableSuiteBase(splitUpdates: Boolean)
     props
   }
 
-  // mirror the metadata marker on file-source row IDs
-  private val nestedPkMetadata =
-    new MetadataBuilder().putString(METADATA_COL_ATTR_KEY, "row_index").build()
-
+  // the nested row ID pk shares its leaf name with the top-level pk data column, so a name-based
+  // bind would confuse the two; the suite checks that the nested field is used
   private val tableSchema = StructType(Seq(
     StructField("pk", IntegerType, nullable = false),
     StructField("nested", StructType(Seq(
-      StructField("pk", IntegerType, nullable = false, metadata = nestedPkMetadata))),
+      StructField("pk", IntegerType, nullable = false))),
       nullable = false),
     StructField("id", IntegerType),
     StructField("dep", StringType)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
@@ -19,6 +19,12 @@ package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.InSubquery
+import org.apache.spark.sql.catalyst.plans.logical.{RebalancePartitions, RepartitionByExpression, Sort, WriteDelta}
+import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, TableInfo}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions.{identity, reference}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.datasources.v2.V2Writes
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
@@ -55,6 +61,106 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
 
     checkLastWriteLog(
       updateWriteLogEntry(id = 1, metadata = Row("hr", null), data = Row(1, -1, "hr")))
+  }
+
+  test("updated row ID is not shadowed by a data column named like its saved value") {
+    createAndInitTable("pk INT NOT NULL, __original_row_id_pk INT, id INT, dep STRING",
+      """{ "pk": 1, "__original_row_id_pk": 100, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "__original_row_id_pk": 200, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET pk = pk + 10 WHERE id = 1")
+
+    checkAnswer(
+      sql(s"SELECT pk, __original_row_id_pk, id, dep FROM $tableNameAsString ORDER BY pk"),
+      Seq(Row(2, 200, 2, "software"), Row(11, 100, 1, "hr")))
+    checkLastWriteLog(
+      updateWriteLogEntry(id = 1, metadata = Row("hr", null),
+        data = Row(11, 100, 1, "hr")))
+  }
+
+  test("write distribution is not shadowed by a same-named data column") {
+    createAndInitTable("pk INT NOT NULL, id INT, _partition STRING, dep STRING",
+      """{ "pk": 1, "id": 1, "_partition": "user", "dep": "hr" }
+        |{ "pk": 2, "id": 2, "_partition": "user", "dep": "software" }
+        |""".stripMargin)
+
+    val command = sql(s"UPDATE $tableNameAsString SET id = -1 WHERE id = 1")
+    val preparedCommand = V2Writes(command.queryExecution.analyzed)
+    val writeDelta = preparedCommand.collectFirst {
+      case write: WriteDelta => write
+    }.getOrElse(fail("Cannot find WriteDelta"))
+    val metadataProjection = writeDelta.projections.metadataProjection.get
+    val metadataOrdinal = metadataProjection.schema.fields.indexWhere { field =>
+      field.metadata.contains(METADATA_COL_ATTR_KEY) &&
+        field.metadata.getString(METADATA_COL_ATTR_KEY) == "_partition"
+    }
+    assert(metadataOrdinal >= 0)
+    val metadataAttr = writeDelta.query.output(metadataProjection.colOrdinals(metadataOrdinal))
+    val rowProjection = writeDelta.projections.rowProjection.get
+    val rowOrdinal = rowProjection.schema.fieldIndex("_partition")
+    val rowAttr = writeDelta.query.output(rowProjection.colOrdinals(rowOrdinal))
+
+    val distributionAttr = writeDelta.query.collectFirst {
+      case repartition: RepartitionByExpression =>
+        repartition.partitionExpressions.flatMap(_.references).head
+      case rebalance: RebalancePartitions =>
+        rebalance.partitionExpressions.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required distribution"))
+    val orderingAttr = writeDelta.query.collectFirst {
+      case sort: Sort => sort.order.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required ordering"))
+
+    assert(distributionAttr.exprId == metadataAttr.exprId)
+    assert(orderingAttr.exprId == metadataAttr.exprId)
+    assert(distributionAttr.exprId != rowAttr.exprId)
+  }
+
+  test("write distribution resolves a nested metadata field past a colliding data column") {
+    val schema = "pk INT NOT NULL, id INT, _metadata STRUCT<row_index: INT>, dep STRING"
+    val props = new java.util.HashMap[String, String](extraTableProps)
+    props.put("nested-metadata", "true")
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schema)))
+      .withPartitions(Array[Transform](identity(reference(Seq("dep")))))
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schema,
+      """{ "pk": 1, "id": 1, "_metadata": { "row_index": 100 }, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "_metadata": { "row_index": 200 }, "dep": "software" }
+        |""".stripMargin)
+
+    val command = sql(s"UPDATE $tableNameAsString SET id = -1 WHERE id = 1")
+    val writeDelta = V2Writes(command.queryExecution.analyzed).collectFirst {
+      case write: WriteDelta => write
+    }.getOrElse(fail("Cannot find WriteDelta"))
+    val metadataProjection = writeDelta.projections.metadataProjection.get
+    val nestedMetadataOrdinal = metadataProjection.schema.fields.indexWhere { field =>
+      field.name == "row_index" &&
+        field.metadata.contains(METADATA_COL_ATTR_KEY) &&
+        field.metadata.getString(METADATA_COL_ATTR_KEY) == "_metadata"
+    }
+    assert(nestedMetadataOrdinal >= 0)
+    val nestedMetadataAttr = writeDelta.query.output(
+      metadataProjection.colOrdinals(nestedMetadataOrdinal))
+    val rowProjection = writeDelta.projections.rowProjection.get
+    val dataMetadataAttr = writeDelta.query.output(
+      rowProjection.colOrdinals(rowProjection.schema.fieldIndex("_metadata")))
+
+    val distributionAttr = writeDelta.query.collectFirst {
+      case repartition: RepartitionByExpression =>
+        repartition.partitionExpressions.flatMap(_.references).head
+      case rebalance: RebalancePartitions =>
+        rebalance.partitionExpressions.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required distribution"))
+    val orderingAttr = writeDelta.query.collectFirst {
+      case sort: Sort => sort.order.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required ordering"))
+
+    assert(distributionAttr.exprId == nestedMetadataAttr.exprId)
+    assert(orderingAttr.exprId == nestedMetadataAttr.exprId)
+    assert(distributionAttr.exprId != dataMetadataAttr.exprId)
   }
 
   test("update with subquery handles metadata columns correctly") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedUpdateTableSuite.scala
@@ -19,8 +19,10 @@ package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, InSubquery}
+import org.apache.spark.sql.catalyst.plans.logical.{RebalancePartitions, RepartitionByExpression, ReplaceData, Sort}
+import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
 import org.apache.spark.sql.execution.{InSubqueryExec, ReusedSubqueryExec}
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, V2Writes}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
@@ -48,6 +50,43 @@ class GroupBasedUpdateTableSuite extends UpdateTableSuiteBase {
     checkLastWriteLog(
       writeWithMetadataLogEntry(metadata = Row("hr", null), data = Row(1, -1, "hr")),
       writeWithMetadataLogEntry(metadata = Row("hr", 1), data = Row(3, 3, "hr")))
+  }
+
+  test("write distribution is not shadowed by a same-named data column") {
+    createAndInitTable("pk INT NOT NULL, id INT, _partition STRING, dep STRING",
+      """{ "pk": 1, "id": 1, "_partition": "user", "dep": "hr" }
+        |{ "pk": 2, "id": 2, "_partition": "user", "dep": "software" }
+        |""".stripMargin)
+
+    val command = sql(s"UPDATE $tableNameAsString SET id = -1 WHERE id = 1")
+    val preparedCommand = V2Writes(command.queryExecution.analyzed)
+    val replaceData = preparedCommand.collectFirst {
+      case write: ReplaceData => write
+    }.getOrElse(fail("Cannot find ReplaceData"))
+    val metadataProjection = replaceData.projections.metadataProjection.get
+    val metadataOrdinal = metadataProjection.schema.fields.indexWhere { field =>
+      field.metadata.contains(METADATA_COL_ATTR_KEY) &&
+        field.metadata.getString(METADATA_COL_ATTR_KEY) == "_partition"
+    }
+    assert(metadataOrdinal >= 0)
+    val metadataAttr = replaceData.query.output(metadataProjection.colOrdinals(metadataOrdinal))
+    val rowProjection = replaceData.projections.rowProjection
+    val rowOrdinal = rowProjection.schema.fieldIndex("_partition")
+    val rowAttr = replaceData.query.output(rowProjection.colOrdinals(rowOrdinal))
+
+    val distributionAttr = replaceData.query.collectFirst {
+      case repartition: RepartitionByExpression =>
+        repartition.partitionExpressions.flatMap(_.references).head
+      case rebalance: RebalancePartitions =>
+        rebalance.partitionExpressions.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required distribution"))
+    val orderingAttr = replaceData.query.collectFirst {
+      case sort: Sort => sort.order.flatMap(_.references).head
+    }.getOrElse(fail("Cannot find required ordering"))
+
+    assert(distributionAttr.exprId == metadataAttr.exprId)
+    assert(orderingAttr.exprId == metadataAttr.exprId)
+    assert(distributionAttr.exprId != rowAttr.exprId)
   }
 
   test("update with subquery handles metadata columns correctly") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/MergeRowsExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/MergeRowsExecBenchmark.scala
@@ -107,7 +107,7 @@ object MergeRowsExecBenchmark extends SqlBasedBenchmark with ClassicConversions 
       matchedInstructions = matchedInstr,
       notMatchedInstructions = notMatchedInstr,
       notMatchedBySourceInstructions = notMatchedBySourceInstr,
-      checkCardinality = false,
+      cardinalityRowId = None,
       output = outputAttrs,
       child = inputPlan
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

DataSource V2 row-level operations identify affected rows using connector-provided row IDs and metadata references. This PR addresses two related issues:

- [SPARK-56942](https://issues.apache.org/jira/browse/SPARK-56942) allows row IDs to reference nested fields such as `_metadata.row_index`.
- [SPARK-58815](https://issues.apache.org/jira/browse/SPARK-58815) makes row-level attribute binding collision-safe instead of rediscovering attributes by generated names.

The implementation resolves connector references once, gives them stable expression identities, materializes nested fields above the scan, and carries those identities through `Project`, `Expand`, and `MergeRows`. Downstream writer projections, required distribution and ordering, runtime group filtering, and MERGE cardinality checks consume those bindings directly.

#### Walkthrough

1. **Resolve connector references in the correct namespace.**

```scala
val refs = resolveDeltaRefs(relation, operation)

// refs.rowIdRefs: ResolvedConnectorRefs
// refs.metadataRefs: ResolvedConnectorRefs
```

`ResolvedDeltaRefs` groups the row IDs and required metadata. If the same reference serves both roles, it receives one shared `Attribute` and `exprId`.

2. **Materialize nested references as top-level attributes.** For `_metadata.row_index`:

```scala
ResolvedConnectorRefs(
  attrs = Seq(rowIndex#2),
  extractionAliases =
    Seq(Alias(_metadata#1.row_index, "row_index")#2),
  scanAttrs = Seq(_metadata#1))
```

This produces:

```text
Project [<table columns>, row_index#2]
+- RelationV2 [<table columns>, _metadata#1]
```

The scan reads `_metadata#1`; subsequent row-level operators use the top-level `row_index#2`.

3. **Track attribute identities through the rewrite.** `Expand` and `MergeRows` create new output attributes with new `exprId`s. `RowDeltaPlan` records the correspondence explicitly:

```scala
RowDeltaPlan(
  plan = expand,
  bindings = Map(
    originalRowId.exprId -> expandedRowId,
    metadataAttr.exprId -> expandedMetadata))
```

When an update changes the row ID, it separately tracks the updated value and the saved original value:

```text
pk#1                    updated row ID
__original_row_id_pk#7  row ID used to identify the old row
```

This avoids rediscovering either attribute from its generated name.

4. **Build consumers from the bindings.** Write projections, row-ID preservation/nullification, distribution and ordering requirements, runtime filters, and MERGE cardinality checks now use the bound attributes and their expression IDs. A data column, row ID, and metadata column may therefore share a name without being confused.

### Why are the changes needed?

A nested row ID previously resolved to an alias around `GetStructField`, while the rewrite assumed every row ID was already a top-level `AttributeReference`; analysis could fail with a `ClassCastException`. More generally, later rewrite stages found attributes by name after generating new plans. This could bind a row ID or required metadata reference to an unrelated same-named column, even when all connector references were top-level.

Together, these changes let connectors use file-source metadata as DSv2 row IDs and make DELETE, UPDATE, and MERGE correct in the presence of name collisions.

### Does this PR introduce _any_ user-facing change?

No API behavior changes for existing connectors. This adds nested row-ID support and fixes incorrect internal attribute binding for row-level operations.

### How was this patch tested?

- `V2ExpressionUtilsSuite` covers nested metadata resolution and metadata/data-column name collisions.
- 250 tests across 11 focused `DeltaBased*` and `GroupBased*` suites cover DELETE, UPDATE, and MERGE, including nested row IDs, split updates, metadata overlap, runtime filtering, cardinality checks, and required distribution/ordering.
- Catalyst and SQL test compilation passed on current master.
