### PR TITLE
[SPARK-58013][PS] Fix loc setitem dropping writes for reordered columns on pandas 3

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -741,7 +741,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             cond, limit, remaining_index = self._select_rows(rows_sel)
             missing_keys: List[Name] = []
             (
-                selected_column_labels,
+                _,
                 data_spark_columns,
                 _,
                 _,

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -763,30 +763,6 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 if isinstance(value, Series):
                     value = value.spark.column
             else:
-                if (
-                    # Only apply this behavior for pandas 3+, where CoW semantics changed.
-                    LooseVersion(pd.__version__) >= "3.0.0"
-                    # Only for multi-column assignment (single-column assignment is unaffected).
-                    and len(selected_column_labels) > 1
-                    # Column selector must be list-like (e.g. ["shield", "max_speed"]), not scalar label access.
-                    and is_list_like(cols_sel)
-                    # Excludes string/bytes (single label), tuple (e.g. MultiIndex label),
-                    # and slice selectors; keeps this narrowly on explicit column lists.
-                    and not isinstance(cols_sel, (str, bytes, tuple, slice))
-                    # Only trigger when cached/anchored Series exist on the frame,
-                    # matching the problematic case where views were materialized before assignment.
-                    and hasattr(self._psdf_or_psser, "_psseries")
-                ):
-                    selected_column_labels_set = set(selected_column_labels)
-                    selected_labels_in_internal_order = [
-                        label
-                        for label in self._internal.column_labels
-                        if label in selected_column_labels_set
-                    ]
-                    if selected_column_labels != selected_labels_in_internal_order:
-                        # If requested columns are in different order than the DataFrame's internal order,
-                        # it returns early (no-op), matching pandas 3 behavior for that edge case.
-                        return
                 value = F.lit(value)
 
             new_data_spark_columns = []


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes an early-return in `LocIndexerLike.__setitem__` (`python/pyspark/pandas/indexing.py`) that, under pandas 3, turned a scalar `.loc` assignment into a no-op when the target columns were passed in a different order than the frame's internal column order.

### Why are the changes needed?

The branch (added in SPARK-55296) assumed pandas 3 does not apply such writes. pandas 3.0.0 through 3.0.4 indeed no-op'd here, but pandas treated that as a bug and fixed it during maintenance, so from 3.0.5 onwards `df.loc[["viper", "sidewinder"], ["shield", "max_speed"]] = 10` sets both columns.

Rather than pinning bug-for-bug parity to that narrow patch range with an upper bound on the version check, this drops the guard and matches fixed pandas. An upper bound would mean carrying a known pandas bug in pandas-on-Spark and adding a matching version guard in `test_frame_loc_setitem` so the test asserts the buggy no-op, both of which become dead weight once 3.0.0-3.0.4 stops mattering.

For a scalar assignment the column order is irrelevant, and the CoW view-decoupling the branch was meant to protect is already handled by the normal assignment path.

### Does this PR introduce _any_ user-facing change?

Yes. On pandas 3, `DataFrame.loc[rows, cols] = scalar` now applies when `cols` is a list in non-internal order; previously it was a silent no-op. This matches pandas >= 3.0.5. On pandas 3.0.0-3.0.4 pandas-on-Spark now applies the write while pandas itself still no-ops, an intentional divergence from those buggy patch releases. No change on pandas 2 (the removed code was behind a `pandas >= 3.0.0` check).

### How was this patch tested?

Ran `pyspark.pandas.tests.indexes.test_indexing_loc` (classic and Connect parity) on pandas 3.0.5. The previously failing `test_frame_loc_setitem` passes, and the full `indexes` suite is green with no regressions.

Note that `test_frame_loc_setitem` compares against live pandas behavior, so it fails on pandas 3.0.0-3.0.4 by design of that divergence. CI is unaffected: `dev/requirements.txt` pins `pandas>=2.2.0,<3.0.0` and no workflow installs pandas 3.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code