### PR TITLE
[SPARK-58326][K8S][TESTS] Pin MinIO image version in DepsTestsSuite

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -68,8 +68,8 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     ).asJava
 
     new ContainerBuilder()
-      .withImage("minio/minio:latest")
-      .withImagePullPolicy("Always")
+      .withImage("minio/minio:RELEASE.2025-09-07T16-13-09Z")
+      .withImagePullPolicy("IfNotPresent")
       .withName(cName)
       .withArgs("server", "/data")
       .withPorts(new ContainerPortBuilder()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin the MinIO image in `DepsTestsSuite` to `RELEASE.2025-09-07T16-13-09Z`
(the current `latest`) instead of the floating `latest` tag, and to change `imagePullPolicy`
from `Always` to `IfNotPresent` accordingly.

### Why are the changes needed?

The floating `latest` tag makes the K8s integration tests non-reproducible: a new MinIO
release can break CI without any change in Spark. Pinning the tag also allows `IfNotPresent`,
avoiding a registry pull on every test run.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs, including the K8s integration tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5