### PR TITLE
[SPARK-58333][K8S] Add Java-friendly constructor to `KubernetesDriverConf`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -98,6 +98,20 @@ class KubernetesDriverConf(
     clock: Clock = new SystemClock())
   extends KubernetesConf(sparkConf) with Logging {
 
+  /**
+   * Java-friendly constructor that accepts a nullable String for proxyUser
+   * instead of Option[String].
+   */
+  @Since("4.3.0")
+  def this(
+      sparkConf: SparkConf,
+      appId: String,
+      mainAppResource: MainAppResource,
+      mainClass: String,
+      appArgs: Array[String],
+      proxyUser: String) =
+    this(sparkConf, appId, mainAppResource, mainClass, appArgs, Option(proxyUser))
+
   def driverNodeSelector: Map[String, String] =
     KubernetesUtils.parsePrefixedKeyValuePairs(sparkConf, KUBERNETES_DRIVER_NODE_SELECTOR_PREFIX)
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -130,6 +130,27 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(confWithProxy.proxyUser === Some("proxy"))
   }
 
+  test("SPARK-58333: Java-friendly KubernetesDriverConf constructor with nullable proxyUser") {
+    val sparkConf = new SparkConf(false)
+    val conf = new KubernetesDriverConf(
+      sparkConf,
+      KubernetesTestConf.APP_ID,
+      JavaMainAppResource(None),
+      KubernetesTestConf.MAIN_CLASS,
+      APP_ARGS,
+      null: String)
+    assert(conf.proxyUser === None)
+
+    val confWithProxy = new KubernetesDriverConf(
+      sparkConf,
+      KubernetesTestConf.APP_ID,
+      JavaMainAppResource(None),
+      KubernetesTestConf.MAIN_CLASS,
+      APP_ARGS,
+      "proxy")
+    assert(confWithProxy.proxyUser === Some("proxy"))
+  }
+
   test("Basic executor translated fields.") {
     val conf = KubernetesConf.createExecutorConf(
       new SparkConf(false),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a Java-friendly constructor to `KubernetesDriverConf` that accepts a nullable `String` for `proxyUser` instead of `Option[String]`.

### Why are the changes needed?

`KubernetesDriverConf` is a `DeveloperApi` used by Apache Spark K8s Operator. Since the operator's `SparkAppDriverConf` (Java) extends this class, it must call the constructor directly via `super(...)`, which currently requires Scala interop like `scala.Option.apply(...)` and passing `null` for the `clock` default argument.

### Does this PR introduce _any_ user-facing change?

No behavior change. This only adds a new constructor overload to a `DeveloperApi` class.

### How was this patch tested?

Pass the CIs with a newly added test case in `KubernetesConfSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5