### PR TITLE
[SPARK-58343][SQL][TESTS] Add unit test for TypeUtils.typeWithProperEquals

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TypeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TypeUtilsSuite.scala
@@ -48,6 +48,24 @@ class TypeUtilsSuite extends SparkFunSuite with SQLHelper {
       ArrayType(StringType, containsNull = false) :: Nil)
   }
 
+  test("typeWithProperEquals") {
+    // Atomic types have proper equals.
+    assert(TypeUtils.typeWithProperEquals(IntegerType))
+    assert(TypeUtils.typeWithProperEquals(DoubleType))
+    assert(TypeUtils.typeWithProperEquals(BooleanType))
+    assert(TypeUtils.typeWithProperEquals(TimestampType))
+    // UTF8_BINARY strings support binary equality.
+    assert(TypeUtils.typeWithProperEquals(StringType))
+    // Non-UTF8_BINARY (collated) strings do not support binary equality.
+    assert(!TypeUtils.typeWithProperEquals(StringType("UTF8_LCASE")))
+    // Binary type does not have proper equals.
+    assert(!TypeUtils.typeWithProperEquals(BinaryType))
+    // Complex types are not covered.
+    assert(!TypeUtils.typeWithProperEquals(ArrayType(IntegerType)))
+    assert(!TypeUtils.typeWithProperEquals(MapType(StringType, IntegerType)))
+    assert(!TypeUtils.typeWithProperEquals(new StructType().add("a", IntegerType)))
+  }
+
   test("TIMESTAMP_NANOS_TYPES_ENABLED defaults to Utils.isTesting") {
     assert(SQLConf.get.timestampNanosTypesEnabled === Utils.isTesting)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds a focused unit test for `TypeUtils.typeWithProperEquals` in `TypeUtilsSuite`. The predicate was previously only referenced in a code comment, never directly asserted. The test covers atomic types (true), UTF8_BINARY string (true), a collated string (false), binary type (false), and complex types (false).

### Why are the changes needed?
`typeWithProperEquals` gates several expressions (higher-order functions, complex-type extractors, collection ops, PivotFirst) but had no direct coverage. The added assertions pin its contract, including the special-cased BinaryType and collation branches.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
This PR is the test. `build/sbt "catalyst/testOnly *TypeUtilsSuite"`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)
