### PR TITLE
[MINOR][SS] Use filterNot in HDFSBackedStateStoreProvider snapshot filtering

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -1077,7 +1077,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       if (files.nonEmpty) {
         val lastVersion = files.last.version
         val deltaFilesForLastVersion =
-          filesForVersion(files, lastVersion).filter(_.isSnapshot == false)
+          filesForVersion(files, lastVersion).filterNot(_.isSnapshot)
         synchronized { Option(loadedMaps.get(lastVersion)) } match {
           case Some(map) =>
             if (deltaFilesForLastVersion.size > storeConf.minDeltasForSnapshot) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replaces `filter(_.isSnapshot == false)` with the equivalent, idiomatic `filterNot(_.isSnapshot)` in `HDFSBackedStateStoreProvider.doSnapshot`.

### Why are the changes needed?
`StoreFile.isSnapshot` is a plain `Boolean` field, so comparing it to `false` is redundant. `filterNot` is the idiomatic form used throughout Spark and reads more clearly.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Behavior-preserving one-line change; existing state-store tests cover the path. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)