### PR TITLE
[MINOR][DOCS] Fix typo 'commited' in state data source docs

### DIFF
--- a/docs/streaming/structured-streaming-state-data-source.md
+++ b/docs/streaming/structured-streaming-state-data-source.md
@@ -171,7 +171,7 @@ The following configurations are optional:
 <tr>
   <td>changeEndBatchId</td>
   <td>numeric value</td>
-  <td>latest commited batchId</td>
+  <td>latest committed batchId</td>
   <td>Represents the last batch to read in the read change feed mode. This option requires 'readChangeFeed' to be set to true.</td>
 </tr>
 <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Corrects the spelling "commited" to "committed" in the `changeEndBatchId` default-value description in the Structured Streaming state data source docs.

### Why are the changes needed?
`committed` doubles both the m and the t. The description is also semantically accurate: the default resolves to the latest committed batchId.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Docs-only change. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)