### PR TITLE
[MINOR][PYTHON] Fix wrong expected_type in DataFrame.sort ascending type error

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3351,7 +3351,7 @@ class DataFrame:
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
-                    "expected_type": "Column, int or str",
+                    "expected_type": "bool, int or list",
                     "arg_name": "ascending",
                     "arg_type": type(ascending).__name__,
                 },

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -261,6 +261,20 @@ class DataFrameTestsMixin:
             messageParameters={"expected_type": "dict", "arg_name": "colsMap", "arg_type": "tuple"},
         )
 
+    def test_sort_ascending_invalid_type(self):
+        df = self.spark.createDataFrame([("Alice", 10)], ["name", "age"])
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.sort("age", ascending="asc")
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "bool, int or list",
+                "arg_name": "ascending",
+                "arg_type": "str",
+            },
+        )
+
     def test_with_columns_renamed_with_duplicated_names(self):
         df1 = self.spark.createDataFrame([(1, "v1")], ["id", "value"])
         df2 = self.spark.createDataFrame([(1, "x", "v2")], ["id", "a", "value"])


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DataFrame.sort` / `orderBy` / `sortWithinPartitions` raise `NOT_EXPECTED_TYPE` for an invalid `ascending` argument with `expected_type` = `"Column, int or str"`. But `ascending` accepts `bool`, `int`, or `list` — never `Column` or `str`. The literal was copied from the column-argument error a few lines above in `_preapare_cols_for_sort`. This corrects it to `"bool, int or list"`.

### Why are the changes needed?

The message names types `ascending` never accepts (`Column`, `str`) and omits the ones it does (`bool`, `list`), misleading users about how to fix the call. The `ascending` parameter is documented as `bool or list`.

### Does this PR introduce _any_ user-facing change?

Yes, the error message changes.

Before:
```
[NOT_EXPECTED_TYPE] Argument `ascending` should be Column, int or str, got str.
```
After:
```
[NOT_EXPECTED_TYPE] Argument `ascending` should be bool, int or list, got str.
```

### How was this patch tested?

Added `test_sort_ascending_invalid_type` in `python/pyspark/sql/tests/test_dataframe.py` asserting the corrected `expected_type`. Verified against a released `pyspark` session: `df.sort("age", ascending="asc")` reports `bool, int or list` with the fix (previously `Column, int or str`); valid `ascending` values (`False`, `[True]`) are unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)