### PR TITLE
[SPARK-57805][SQL] Support TimestampNTZ, ANSI interval, and TIME in CBO estimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -135,7 +135,9 @@ object EstimationUtils {
    */
   def toDouble(value: Any, dataType: DataType): Double = {
     dataType match {
-      case _: NumericType | DateType | TimestampType => value.toString.toDouble
+      case _: NumericType | DateType | TimestampType | TimestampNTZType |
+          _: TimeType | _: AnsiIntervalType =>
+        value.toString.toDouble
       case BooleanType => if (value.asInstanceOf[Boolean]) 1 else 0
     }
   }
@@ -143,8 +145,9 @@ object EstimationUtils {
   def fromDouble(double: Double, dataType: DataType): Any = {
     dataType match {
       case BooleanType => double.toInt == 1
-      case DateType => double.toInt
-      case TimestampType => double.toLong
+      case DateType | _: YearMonthIntervalType => double.toInt
+      case TimestampType | TimestampNTZType | _: TimeType | _: DayTimeIntervalType =>
+        double.toLong
       case ByteType => double.toByte
       case ShortType => double.toShort
       case IntegerType => double.toInt

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -291,7 +291,8 @@ case class FilterEstimation(plan: Filter) extends Logging {
     }
 
     attr.dataType match {
-      case _: NumericType | DateType | TimestampType | BooleanType =>
+      case _: NumericType | DateType | TimestampType | TimestampNTZType | BooleanType |
+          _: TimeType | _: AnsiIntervalType =>
         evaluateBinaryForNumeric(op, attr, literal, update)
       case StringType | BinaryType =>
         // TODO: It is difficult to support other binary comparisons for String/Binary
@@ -413,7 +414,8 @@ case class FilterEstimation(plan: Filter) extends Logging {
 
     // use [min, max] to filter the original hSet
     dataType match {
-      case _: NumericType | BooleanType | DateType | TimestampType =>
+      case _: NumericType | BooleanType | DateType | TimestampType | TimestampNTZType |
+          _: TimeType | _: AnsiIntervalType =>
         if (ndv.toDouble == 0) {
           return Some(0.0)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -523,6 +523,53 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 3)
   }
 
+  test("SPARK-57805: filters for timestamp NTZ, time and ANSI intervals") {
+    val testCases: Seq[(DataType, Any, Any, Any, Any, Any, Any)] = Seq(
+      (TimestampNTZType, 1L, 10L, 3L, 2L, 5L, 20L),
+      (TimeType(), 1_000L, 10_000L, 3_000L, 2_000L, 5_000L, 20_000L),
+      (YearMonthIntervalType(), 1, 10, 3, 2, 5, 20),
+      (DayTimeIntervalType(), 1L, 10L, 3L, 2L, 5L, 20L))
+
+    testCases.foreach { case (dataType, min, max, boundary, inMin, inMax, outside) =>
+      withClue(s"For data type $dataType") {
+        val attr = AttributeReference("cvalue", dataType)()
+        val colStat = ColumnStat(
+          distinctCount = Some(10),
+          min = Some(min),
+          max = Some(max),
+          nullCount = Some(0),
+          avgLen = Some(dataType.defaultSize),
+          maxLen = Some(dataType.defaultSize))
+        val localAttributeMap = AttributeMap(Seq(attr -> colStat))
+        val equalityColStat = colStat.copy(
+          distinctCount = Some(1), min = Some(boundary), max = Some(boundary))
+        validateEstimatedStats(
+          Filter(
+            EqualTo(attr, Literal(boundary, dataType)),
+            childStatsTestPlan(Seq(attr), 10L, localAttributeMap)),
+          Seq(attr -> equalityColStat),
+          expectedRowCount = 1)
+
+        validateEstimatedStats(
+          Filter(
+            LessThan(attr, Literal(boundary, dataType)),
+            childStatsTestPlan(Seq(attr), 10L, localAttributeMap)),
+          Seq(attr -> colStat.copy(distinctCount = Some(3), max = Some(boundary))),
+          expectedRowCount = 3)
+
+        validateEstimatedStats(
+          Filter(
+            InSet(attr, Set[Any](inMin, inMax, outside)),
+            childStatsTestPlan(Seq(attr), 10L, localAttributeMap)),
+          Seq(attr -> colStat.copy(
+            distinctCount = Some(2),
+            min = Some(inMin),
+            max = Some(inMax))),
+          expectedRowCount = 2)
+      }
+    }
+  }
+
   test("cdecimal = 0.400000000000000000") {
     val dec_0_40 = Decimal("0.400000000000000000")
     validateEstimatedStats(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/JoinEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/JoinEstimationSuite.scala
@@ -506,6 +506,18 @@ class JoinEstimationSuite extends StatsEstimationTestBase {
           nullCount = Some(0), avgLen = Some(4), maxLen = Some(4)),
         AttributeReference("ctimestamp", TimestampType)() -> ColumnStat(distinctCount = Some(1),
           min = Some(timestamp), max = Some(timestamp),
+          nullCount = Some(0), avgLen = Some(8), maxLen = Some(8)),
+        AttributeReference("ctimestamp_ntz", TimestampNTZType)() -> ColumnStat(
+          distinctCount = Some(1), min = Some(timestamp), max = Some(timestamp),
+          nullCount = Some(0), avgLen = Some(8), maxLen = Some(8)),
+        AttributeReference("ctime", TimeType())() -> ColumnStat(distinctCount = Some(1),
+          min = Some(1L), max = Some(1L),
+          nullCount = Some(0), avgLen = Some(8), maxLen = Some(8)),
+        AttributeReference("cym_interval", YearMonthIntervalType())() -> ColumnStat(
+          distinctCount = Some(1), min = Some(1), max = Some(1),
+          nullCount = Some(0), avgLen = Some(4), maxLen = Some(4)),
+        AttributeReference("cdt_interval", DayTimeIntervalType())() -> ColumnStat(
+          distinctCount = Some(1), min = Some(1L), max = Some(1L),
           nullCount = Some(0), avgLen = Some(8), maxLen = Some(8))
       )
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends CBO filter and join statistics estimation to support
TimestampNTZType, TimeType, YearMonthIntervalType, and DayTimeIntervalType.

It updates EstimationUtils to convert these Catalyst internal numeric values
to and from Double, and routes range and IN predicates for these types through
the existing numeric estimation path.

It also adds regression coverage for equality, range, IN, and equi-join
estimation. UnionEstimation is intentionally excluded because TimeType support
there is handled by apache/spark#53312.

### Why are the changes needed?

When CBO is enabled and column statistics exist, filters or equi-joins on
TimestampNTZ, ANSI interval, or TIME columns can reach non-exhaustive type
matches in the statistics-estimation layer and throw scala.MatchError during
query optimization.

These types use numeric Catalyst internal representations, so they can reuse
the existing NumericValueInterval estimation path once conversion and dispatch
recognize them.

### Does this PR introduce _any_ user-facing change?

Yes. Queries using CBO and collected statistics on TimestampNTZ, ANSI interval,
or TIME columns no longer fail with scala.MatchError during query planning.
There is no new API or configuration.

### How was this patch tested?

On CentOS 7 with JDK 21:

- `catalyst/Test/compile`
- `catalyst/testOnly org.apache.spark.sql.catalyst.statsEstimation.FilterEstimationSuite`
  (86 tests passed)
- `catalyst/testOnly org.apache.spark.sql.catalyst.statsEstimation.JoinEstimationSuite`
  (19 tests passed)

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: OpenAI Codex (GPT-5).
