### PR TITLE
[SPARK-58323][SQL][3.5] Materialize AliasAware output ordering and partitioning to avoid StackOverflowError

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/AliasAwareOutputExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/AliasAwareOutputExpression.scala
@@ -107,6 +107,12 @@ trait AliasAwareQueryOutputOrdering[T <: QueryPlan[T]]
           .flatMap(projectExpression)
           .filter(e => orderingSet.add(e.canonicalized))
           .take(aliasCandidateLimit)
+          // Materialize the bounded result into a strict collection. The `Stream` above is only
+          // needed so `take` can short-circuit candidate generation; storing `sameOrderExpressions`
+          // as an unforced `Stream` lets each plan node re-wrap the child ordering's lazy stream,
+          // and across a deep projection chain that nesting overflows the stack when the ordering
+          // is later serialized or deeply traversed.
+          .toList
         if (sameOrderings.nonEmpty) {
           Some(sortOrder.copy(child = sameOrderings.head,
             sameOrderExpressions = sameOrderings.tail))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
@@ -44,7 +44,12 @@ trait PartitioningPreservingUnaryExecNode extends UnaryExecNode
             .take(aliasCandidateLimit)
             .asInstanceOf[Stream[Partitioning]]
         case o => Seq(o)
-      }.take(aliasCandidateLimit).toSeq
+      }.take(aliasCandidateLimit)
+        // Materialize the bounded result into a strict `List`. On Scala 2.12 `Iterator.toSeq` is
+        // lazy (a `Stream`); storing an unforced `Stream` in the `PartitioningCollection` below
+        // lets each plan node re-wrap the child's lazy stream, and across a deep projection chain
+        // that nesting overflows the stack when the partitioning is later serialized or traversed.
+        .toList
     } else {
       // Filter valid partitiongs (only reference output attributes of the current plan node)
       val outputSet = AttributeSet(outputExpressions.map(_.toAttribute))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -117,7 +117,10 @@ case class BroadcastHashJoinExec(
       case e: Expression if streamedKeyToBuildKeyMapping.contains(e.canonicalized) =>
         e +: streamedKeyToBuildKeyMapping(e.canonicalized)
     }.asInstanceOf[Stream[HashPartitioningLike]]
-      .take(conf.broadcastHashJoinOutputPartitioningExpandLimit))
+      .take(conf.broadcastHashJoinOutputPartitioningExpandLimit)
+      // Materialize the bounded expansion into a strict `List` -- never an unforced `Stream`,
+      // which chained across nodes can overflow the stack when serialized or deeply traversed.
+      .toList)
   }
 
   protected override def doExecute(): RDD[InternalRow] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
@@ -84,6 +84,32 @@ class ProjectedOrderingAndPartitioningSuite
     }
   }
 
+  test("SPARK-58323: AliasAware output ordering and partitioning are strict, not lazy") {
+    // A multi-alias projection makes `sameOrderExpressions` and the projected partitionings
+    // non-trivial. They must be strict collections: the underlying `multiTransform` produces a
+    // `Stream`, and storing it unforced lets each plan node re-wrap the child's lazy stream.
+    // Across a deep projection chain that nesting overflows the stack when the ordering or
+    // partitioning is later serialized or deeply traversed.
+    withSQLConf(SQLConf.EXPRESSION_PROJECTION_CANDIDATE_LIMIT.key -> "5") {
+      // id -> {x, y, z} gives sameOrderExpressions.
+      val df = spark.range(2).orderBy($"id").selectExpr("id as x", "id as y", "id as z")
+      val outputOrdering = df.queryExecution.optimizedPlan.outputOrdering
+      assert(outputOrdering.head.sameOrderExpressions.nonEmpty)
+      outputOrdering.foreach { so =>
+        assert(!so.sameOrderExpressions.isInstanceOf[Stream[_]],
+          s"sameOrderExpressions must be strict, was ${so.sameOrderExpressions.getClass.getName}")
+      }
+      // id -> {x, y, z} gives a multi-partitioning PartitioningCollection.
+      val dfp = spark.range(2).repartition($"id").selectExpr("id as x", "id as y", "id as z")
+      val partitionings =
+        stripAQEPlan(dfp.queryExecution.executedPlan).outputPartitioning
+          .asInstanceOf[PartitioningCollection].partitionings
+      assert(partitionings.size > 1)
+      assert(!partitionings.isInstanceOf[Stream[_]],
+        s"partitionings must be strict, was ${partitionings.getClass.getName}")
+    }
+  }
+
   test("SPARK-42049: Improve AliasAwareOutputExpression - ordering - multi-references") {
     val df = spark.range(2).selectExpr("id as a", "id as b")
       .orderBy($"a" + $"b").selectExpr("a as x", "b as y")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport of SPARK-58323 (#57502) to branch-3.5.

`AliasAwareQueryOutputOrdering.outputOrdering`, `PartitioningPreservingUnaryExecNode.outputPartitioning` and `BroadcastHashJoinExec`'s output-partitioning expansion build their results with `multiTransform`, which returns a `Stream` (Scala 2.12), and store the bounded result unforced. This forces them into strict collections with `.toList`, right after the existing `.take(...)` so the lazy short-circuit during candidate generation is preserved.

Tailored for branch-3.5 (differs from the master PR):
- Scala 2.12: the lazy collection here is `Stream`, not `LazyList` (its 2.13 successor).
- `PartitioningPreservingUnaryExecNode.outputPartitioning` IS fixed on 3.5, unlike the 4.0/4.1 backports: on Scala 2.12 the outer `Iterator.toSeq` there is lazy (a `Stream`), so the projected `PartitioningCollection` stored an unforced `Stream`. On Scala 2.13 the same `Iterator.toSeq` is strict (`List`), so 4.0/4.1 need no change there.
- The `BroadcastJoinSuite` single-element assertion change is omitted: on branch-3.5 `expandOutputPartitioning` always returns a `PartitioningCollection` (no `case p :: Nil` unwrap), so the single-element output shape is unchanged.

### Why are the changes needed?

Each plan node re-wraps the child ordering/partitioning's unforced `Stream`, so across a deep projection chain the deferred nesting grows unbounded and overflows the stack when the ordering/partitioning is later serialized or deeply traversed. On master this was observed as a driver `StackOverflowError` at `DAGScheduler.submitMissingTasks` during task serialization of a `SortedMergeCoalescedRDD` (SPARK-55715) on a large bucketed `MERGE`. That RDD and code path do not exist on branch-3.5, so this backport is defensive hardening of the same latent lazy-collection-in-output-ordering/partitioning hazard, which has existed since the `multiTransform` path was introduced in SPARK-42049.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test in `ProjectedOrderingAndPartitioningSuite` asserting both `sameOrderExpressions` and the projected `PartitioningCollection.partitionings` are strict (not a `Stream`); it fails before this change and passes after. Existing `ProjectedOrderingAndPartitioningSuite` / `BroadcastJoinSuite` / `BroadcastJoinSuiteAE` pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
