### PR TITLE
[SPARK-58349][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1081

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7661,6 +7661,12 @@
     },
     "sqlState" : "42601"
   },
+  "TABLE_LOCATION_URI_NOT_SPECIFIED" : {
+    "message" : [
+      "Table <identifier> did not specify locationUri."
+    ],
+    "sqlState" : "42601"
+  },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create table or view <relationName> because it already exists.",
@@ -9757,11 +9763,6 @@
   "_LEGACY_ERROR_TEMP_1080" : {
     "message" : [
       "Table <identifier> did not specify database."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1081" : {
-    "message" : [
-      "Table <identifier> did not specify locationUri."
     ]
   },
   "_LEGACY_ERROR_TEMP_1082" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1439,7 +1439,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def tableNotSpecifyLocationUriError(identifier: TableIdentifier): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1081",
+      errorClass = "TABLE_LOCATION_URI_NOT_SPECIFIED",
       messageParameters = Map("identifier" -> identifier.toString))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -22,6 +22,8 @@ import java.util.IllegalFormatException
 import org.apache.spark.{SPARK_DOC_ROOT, SparkIllegalArgumentException, SparkUnsupportedOperationException}
 import org.apache.spark.sql._
 import org.apache.spark.sql.api.java.{UDF1, UDF2, UDF23Test}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.expressions.{Coalesce, Literal, UnsafeRow}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand
@@ -1118,6 +1120,22 @@ class QueryCompilationErrorsSuite
       },
       condition = "RESERVED_DATABASE_NAME",
       parameters = Map("database" -> s"`$globalTempDB`")
+    )
+  }
+
+  test("SPARK-58349: TABLE_LOCATION_URI_NOT_SPECIFIED: table does not specify locationUri") {
+    val identifier = TableIdentifier("t", Some("db"))
+    val table = CatalogTable(
+      identifier = identifier,
+      tableType = CatalogTableType.MANAGED,
+      storage = CatalogStorageFormat.empty,
+      schema = new StructType())
+    checkError(
+      exception = intercept[AnalysisException] {
+        table.location
+      },
+      condition = "TABLE_LOCATION_URI_NOT_SPECIFIED",
+      parameters = Map("identifier" -> identifier.toString)
     )
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Assign the name `TABLE_LOCATION_URI_NOT_SPECIFIED` to the legacy error condition
`_LEGACY_ERROR_TEMP_1081`. This error is raised by
`QueryCompilationErrors.tableNotSpecifyLocationUriError`, called from
`CatalogTable.location`, when a table's storage `locationUri` is absent. The new
condition is given SQLSTATE `42601`; the message text and the `identifier`
parameter are unchanged.

### Why are the changes needed?

The error conditions [README](https://github.com/apache/spark/blob/master/common/utils/src/main/resources/error/README.md)
disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be assigned
proper names. This resolves one of them, under the umbrella
[SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Does this PR introduce _any_ user-facing change?

No. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API. The error
condition name changes to `TABLE_LOCATION_URI_NOT_SPECIFIED` and now reports
SQLSTATE `42601`; the rendered message ("Table `<identifier>` did not specify
locationUri.") is unchanged.

### How was this patch tested?

Added a `checkError` test in `QueryCompilationErrorsSuite` that constructs a
`CatalogTable` with empty storage and asserts the `TABLE_LOCATION_URI_NOT_SPECIFIED`
condition when `location` is accessed. `SparkThrowableSuite` validates error-file
formatting/sorting and that non-legacy conditions carry a SQLSTATE.

### Was this patch authored or co-authored using generative AI tooling?

Yes. 
