### PR TITLE
[SPARK-58350][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1228

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2203,6 +2203,12 @@
     ],
     "sqlState" : "22003"
   },
+  "DECIMAL_SCALE_EXCEEDS_PRECISION" : {
+    "message" : [
+      "Decimal scale (<scale>) cannot be greater than precision (<precision>)."
+    ],
+    "sqlState" : "22003"
+  },
   "DEFAULT_DATABASE_NOT_EXISTS" : {
     "message" : [
       "Default database <defaultDatabase> does not exist, please create it first or change default database to `<defaultDatabase>`."
@@ -10133,11 +10139,6 @@
   "_LEGACY_ERROR_TEMP_1226" : {
     "message" : [
       "The SQL config '<configName>' was removed in the version <version>. <comment>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1228" : {
-    "message" : [
-      "Decimal scale (<scale>) cannot be greater than precision (<precision>)."
     ]
   },
   "_LEGACY_ERROR_TEMP_1232" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
@@ -134,7 +134,7 @@ private[sql] object DataTypeErrors extends DataTypeErrorsBase {
 
   def decimalCannotGreaterThanPrecisionError(scale: Int, precision: Int): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1228",
+      errorClass = "DECIMAL_SCALE_EXCEEDS_PRECISION",
       messageParameters = Map("scale" -> scale.toString, "precision" -> precision.toString))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -24,6 +24,7 @@ import org.json4s.jackson.JsonMethods
 
 import org.apache.spark.{SparkClassNotFoundException, SparkException, SparkFunSuite}
 import org.apache.spark.SparkIllegalArgumentException
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{caseInsensitiveResolution, caseSensitiveResolution}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
@@ -1728,5 +1729,15 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
       assert(PhysicalDataType(nonSingleton) != UninitializedPhysicalType,
         s"${clazz.getSimpleName}: PhysicalDataType should recognize non-singleton instance")
     }
+  }
+
+  test("SPARK-58350: DecimalType with scale greater than precision throws " +
+    "DECIMAL_SCALE_EXCEEDS_PRECISION") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        DecimalType(2, 3)
+      },
+      condition = "DECIMAL_SCALE_EXCEEDS_PRECISION",
+      parameters = Map("scale" -> "3", "precision" -> "2"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Assign the name `DECIMAL_SCALE_EXCEEDS_PRECISION` to the legacy error condition
`_LEGACY_ERROR_TEMP_1228`. This error is raised by
`DataTypeErrors.decimalCannotGreaterThanPrecisionError` when a `DecimalType` is
constructed with scale greater than precision. The new condition is given SQLSTATE
`22003` (matching the sibling `DECIMAL_PRECISION_EXCEEDS_MAX_PRECISION`); the message
text and the `scale`/`precision` parameters are unchanged.

### Why are the changes needed?

The error conditions [README](https://github.com/apache/spark/blob/master/common/utils/src/main/resources/error/README.md)
disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be assigned
proper names. This resolves one of them, under the umbrella
[SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Does this PR introduce _any_ user-facing change?

No. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API. The error
condition name changes to `DECIMAL_SCALE_EXCEEDS_PRECISION` and now reports SQLSTATE
`22003`; the rendered message ("Decimal scale (`<scale>`) cannot be greater than
precision (`<precision>`).") is unchanged.

### How was this patch tested?

Added a `checkError` test in `DataTypeSuite` that constructs `DecimalType(2, 3)` and
asserts the `DECIMAL_SCALE_EXCEEDS_PRECISION` condition. `SparkThrowableSuite`
validates error-file formatting/sorting and that non-legacy conditions carry a
SQLSTATE.

### Was this patch authored or co-authored using generative AI tooling?

Yes
