### PR TITLE
[SPARK-58351][CORE] Assign a name to the error condition _LEGACY_ERROR_TEMP_3014

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2383,6 +2383,12 @@
     ],
     "sqlState" : "42815"
   },
+  "EMPTY_COLLECTION_NOT_ALLOWED" : {
+    "message" : [
+      "empty collection"
+    ],
+    "sqlState" : "0A000"
+  },
   "EMPTY_JSON_FIELD_VALUE" : {
     "message" : [
       "Failed to parse an empty string for data type <dataType>."
@@ -11280,11 +11286,6 @@
   "_LEGACY_ERROR_TEMP_3013" : {
     "message" : [
       "Can only zip RDDs with same number of elements in each partition"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3014" : {
-    "message" : [
-      "empty collection"
     ]
   },
   "_LEGACY_ERROR_TEMP_3015" : {

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -140,7 +140,7 @@ private[spark] object SparkCoreErrors {
   }
 
   def emptyCollectionError(): Throwable = {
-    new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3014")
+    new SparkUnsupportedOperationException("EMPTY_COLLECTION_NOT_ALLOWED")
   }
 
   def countByValueApproxNotSupportArraysError(): Throwable = {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -325,10 +325,12 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
     assert(empty.count() === 0)
     assert(empty.collect().length === 0)
 
-    val thrown = intercept[UnsupportedOperationException]{
-      empty.reduce(_ + _)
-    }
-    assert(thrown.getMessage.contains("empty"))
+    checkError(
+      exception = intercept[SparkUnsupportedOperationException] {
+        empty.reduce(_ + _)
+      },
+      condition = "EMPTY_COLLECTION_NOT_ALLOWED",
+      parameters = Map.empty[String, String])
 
     val emptyKv = new EmptyRDD[(Int, Int)](sc)
     val rdd = sc.parallelize(1 to 2, 2).map(x => (x, x))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Assign the name `EMPTY_COLLECTION_NOT_ALLOWED` to the legacy error condition
`_LEGACY_ERROR_TEMP_3014`. This error is a `SparkUnsupportedOperationException`
raised by `SparkCoreErrors.emptyCollectionError`, thrown by RDD reduce/first-style
operations on an empty RDD (`RDD.scala`). The new condition is given SQLSTATE
`0A000`; the message text ("empty collection") and its parameterless shape are
unchanged.

### Why are the changes needed?

The error conditions [README](https://github.com/apache/spark/blob/master/common/utils/src/main/resources/error/README.md)
disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be assigned
proper names. This resolves one of them, under the umbrella
[SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Does this PR introduce _any_ user-facing change?

No. The `_LEGACY_ERROR_TEMP_*` names are not part of the public API. The error
condition name changes to `EMPTY_COLLECTION_NOT_ALLOWED` and now reports SQLSTATE
`0A000`; the underlying message text ("empty collection") is unchanged.

### How was this patch tested?

Updated the "empty RDD" test in `RDDSuite` from a `getMessage.contains` assertion to
`checkError` on the `EMPTY_COLLECTION_NOT_ALLOWED` condition. Other RDD tests that hit
this path assert only the exception type (`UnsupportedOperationException`), which still
holds since `SparkUnsupportedOperationException` extends it. `SparkThrowableSuite`
validates SQLSTATE presence and error-file formatting/sorting for the new entry.

### Was this patch authored or co-authored using generative AI tooling?

Yes
