### PR TITLE
[MINOR][ML] Fix doubled word in HasTrainingSummary scaladoc

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/HasTrainingSummary.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/HasTrainingSummary.scala
@@ -38,7 +38,7 @@ private[spark] trait HasTrainingSummary[T] {
 
   /**
    * Gets summary of model on training set. An exception is
-   * thrown if if `hasSummary` is false.
+   * thrown if `hasSummary` is false.
    */
   @Since("3.0.0")
   def summary: T = trainingSummary.getOrElse {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes a duplicated word in the `summary` scaladoc of `HasTrainingSummary`: "thrown if if `hasSummary` is false" becomes "thrown if `hasSummary` is false".

### Why are the changes needed?
The doubled "if" is a plain typo in a public API doc comment.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Comment-only change. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)