### PR TITLE
[SPARK-58353][CONNECT] Extract parseExplainMode helper in Connect Dataset

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
@@ -220,7 +220,11 @@ class Dataset[T] private[sql] (
 
   /** @inheritdoc */
   def explain(mode: String): Unit = {
-    val protoMode = mode.trim.toLowerCase(util.Locale.ROOT) match {
+    explain(parseExplainMode(mode))
+  }
+
+  private def parseExplainMode(mode: String): proto.AnalyzePlanRequest.Explain.ExplainMode = {
+    mode.trim.toLowerCase(util.Locale.ROOT) match {
       case "simple" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_SIMPLE
       case "extended" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_EXTENDED
       case "codegen" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_CODEGEN
@@ -228,7 +232,6 @@ class Dataset[T] private[sql] (
       case "formatted" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_FORMATTED
       case _ => throw new IllegalArgumentException("Unsupported explain mode: " + mode)
     }
-    explain(protoMode)
   }
 
   private def explain(mode: proto.AnalyzePlanRequest.Explain.ExplainMode): Unit = {
@@ -242,16 +245,8 @@ class Dataset[T] private[sql] (
   }
 
   private[connect] def explainString(mode: String): String = {
-    val protoMode = mode.trim.toLowerCase(util.Locale.ROOT) match {
-      case "simple" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_SIMPLE
-      case "extended" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_EXTENDED
-      case "codegen" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_CODEGEN
-      case "cost" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_COST
-      case "formatted" => proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_FORMATTED
-      case _ => throw new IllegalArgumentException("Unsupported explain mode: " + mode)
-    }
     sparkSession
-      .analyze(plan, proto.AnalyzePlanRequest.AnalyzeCase.EXPLAIN, Some(protoMode))
+      .analyze(plan, proto.AnalyzePlanRequest.AnalyzeCase.EXPLAIN, Some(parseExplainMode(mode)))
       .getExplain
       .getExplainString
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extracts the two byte-identical explain-mode parsing blocks in Connect's `Dataset` (`explain(String)` and `explainString(String)`) into a single private `parseExplainMode(mode: String)` helper, and calls it from both sites.

### Why are the changes needed?
The seven-line string-to-`ExplainMode` match was duplicated verbatim. Factoring it out removes the duplication with no behavior change (same case arms, same `"Unsupported explain mode: "` error on the untrimmed input).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Behavior-preserving refactor; the private helper is exercised by existing explain-mode coverage. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)