### PR TITLE
[MINOR][DOCS] Fix grammar in spark.speculation.efficiency.processRateMultiplier doc

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2587,8 +2587,8 @@ package object config {
 
   private[spark] val SPECULATION_EFFICIENCY_TASK_PROCESS_RATE_MULTIPLIER =
     ConfigBuilder("spark.speculation.efficiency.processRateMultiplier")
-      .doc("A multiplier that used when evaluating inefficient tasks. The higher the multiplier " +
-        "is, the more tasks will be possibly considered as inefficient.")
+      .doc("A multiplier that is used when evaluating inefficient tasks. The higher the " +
+        "multiplier is, the more tasks will be possibly considered as inefficient.")
       .version("3.4.0")
       .doubleConf
       .checkValue(v => v > 0.0 && v <= 1.0, "multiplier must be in (0.0, 1.0]")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3144,7 +3144,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.speculation.efficiency.processRateMultiplier</code></td>
   <td>0.75</td>
   <td>
-    A multiplier that used when evaluating inefficient tasks. The higher the multiplier
+    A multiplier that is used when evaluating inefficient tasks. The higher the multiplier
     is, the more tasks will be possibly considered as inefficient.
   </td>
   <td>3.4.0</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes the grammar of the `spark.speculation.efficiency.processRateMultiplier` description: "A multiplier that used when evaluating inefficient tasks" becomes "A multiplier that is used ...". The fix is applied in both the config's `.doc()` string (`core/.../config/package.scala`) and the mirrored `docs/configuration.md` entry so they stay in sync.

### Why are the changes needed?
The relative clause was missing its verb. Both the source `.doc()` and the generated docs table had the same defect.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Docs/description-string change; no behavior change. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)