### PR TITLE
[MINOR][CONNECT][PYTHON] Fix stale running-task count in progress bar

### DIFF
--- a/python/pyspark/sql/connect/shell/progress.py
+++ b/python/pyspark/sql/connect/shell/progress.py
@@ -174,10 +174,10 @@ class Progress:
             self._ticks = total_tasks
             self._tick = completed_tasks
             self._bytes_read = sum(map(lambda x: x.num_bytes_read, stages))
-            if self._tick is not None and self._tick >= 0:
-                self.output()
             self._running = inflight_tasks
             self._stages = stages
+            if self._tick is not None and self._tick >= 0:
+                self.output()
             self._notify(False)
 
     def finish(self) -> None:

--- a/python/pyspark/sql/tests/connect/shell/test_progress.py
+++ b/python/pyspark/sql/tests/connect/shell/test_progress.py
@@ -41,6 +41,7 @@ class ProgressBarTest(unittest.TestCase, PySparkErrorTestUtils):
         self.assertIn("50.00%", val, "Current progress is 50%")
         self.assertIn("****", val, "Should use the default char to print.")
         self.assertIn("Scanned 999.0 B", val, "Should contain the bytes scanned metric.")
+        self.assertIn("10 Tasks running", val, "Should contain current running tasks.")
         self.assertFalse(val.endswith("\r"), "Line should not be empty")
         p.finish()
         val = buffer.getvalue()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the running-task and stage state before rendering the Spark Connect progress bar. Add a regression assertion for the displayed running-task count.

### Why are the changes needed?

`Progress.update_ticks()` previously called `output()` before storing the latest `inflight_tasks` value. Each progress message therefore displayed the running-task count from the previous update.

For example, the first update with 10 running tasks displayed `0 Tasks running`. This change ensures that the rendered message uses values from the same progress update.

### Does this PR introduce _any_ user-facing change?

Yes. The Spark Connect progress bar now displays the current running-task count instead of the count from the previous update.

### How was this patch tested?

Added a regression assertion to `ProgressBarTest.test_simple_progress`.

    PYTHONPATH=python python -m unittest \
      pyspark.sql.tests.connect.shell.test_progress.ProgressBarTest

All five tests passed. Ruff lint and formatting checks also passed.

### Was this patch authored or co-authored using generative AI tooling?

No