### PR TITLE
[SPARK-58355][SS] Fix grammar in metadata log null-check message

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
@@ -83,7 +83,7 @@ class AsyncOffsetSeqLog(
    *         to indicate some write error.
    */
   def addAsync(batchId: Long, metadata: OffsetSeqBase): CompletableFuture[(Long, Boolean)] = {
-    require(metadata != null, "'null' metadata cannot written to a metadata log")
+    require(metadata != null, "'null' metadata cannot be written to a metadata log")
 
     def issueAsyncWrite(batchId: Long): CompletableFuture[Long] = {
       lastCommitIssuedTimestampMs.set(clock.getTimeMillis())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala
@@ -133,7 +133,7 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](
    * metadata has already been stored, this method will return `false`.
    */
   override def add(batchId: Long, metadata: T): Boolean = {
-    require(metadata != null, "'null' metadata cannot written to a metadata log")
+    require(metadata != null, "'null' metadata cannot be written to a metadata log")
     val res = addNewBatchByStream(batchId) { output => serialize(metadata, output) }
     if (metadataCacheEnabled && res) batchCache.put(batchId, metadata)
     res


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes the grammar of the null-metadata `require(...)` message in `HDFSMetadataLog` and `AsyncOffsetSeqLog`: "'null' metadata cannot written to a metadata log" becomes "... cannot be written ...".

### Why are the changes needed?
The message was missing the word "be". The sibling `AsyncCommitLog` already uses the correct phrasing, so this brings the two outliers in line. The message is a plain `require()` string, not part of the error-condition framework, so it is not golden-tested.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Message-text-only change; no behavior change. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)