### PR TITLE
[SPARK-58356][CORE] Use exists instead of filter(...).nonEmpty in MasterPage

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -101,7 +101,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
   def render(request: HttpServletRequest): Seq[Node] = {
     val state = getMasterState
 
-    val showResourceColumn = state.workers.filter(_.resourcesInfoUsed.nonEmpty).nonEmpty
+    val showResourceColumn = state.workers.exists(_.resourcesInfoUsed.nonEmpty)
     val workerHeaders = if (showResourceColumn) {
       Seq("Worker Id", "Address", "State", "Cores", "Memory", "Resources")
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replaces `filter(_.resourcesInfoUsed.nonEmpty).nonEmpty` with `exists(_.resourcesInfoUsed.nonEmpty)` in `MasterPage` when deciding whether to show the resources column.

### Why are the changes needed?
`state.workers` is an `Array[WorkerInfo]`; the `filter(...).nonEmpty` form allocates a throwaway filtered array and scans every worker, while `exists` allocates nothing and short-circuits on the first match. The resulting Boolean is identical.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Equivalent, behavior-preserving change on a UI code path. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)