### PR TITLE
[SPARK-58357][SQL] Remove unused withCatalogIdentClause in SparkSqlAstBuilder

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -25,11 +25,10 @@ import scala.jdk.CollectionConverters._
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.tree.TerminalNode
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{CurrentNamespace,
   GlobalTempView, LocalTempView, PersistedView,
-  PlanWithUnresolvedIdentifier, SchemaEvolution, SchemaTypeEvolution, UnresolvedAttribute,
+  SchemaEvolution, SchemaTypeEvolution, UnresolvedAttribute,
   UnresolvedIdentifier, UnresolvedNamespace, UnresolvedPartitionSpec, UnresolvedProcedure,
   UnresolvedTableOrViewSearchPathMode}
 import org.apache.spark.sql.catalyst.catalog._
@@ -311,25 +310,6 @@ class SparkSqlAstBuilder extends AstBuilder {
       case _ =>
         throw QueryParsingErrors.invalidTempObjQualifierError(
           "VIEW", viewIdentifier.last, viewIdentifier.init.mkString("."), ctx)
-    }
-  }
-
-  private def withCatalogIdentClause(
-      ctx: CatalogIdentifierReferenceContext,
-      builder: Seq[String] => LogicalPlan): LogicalPlan = {
-    val exprCtx = ctx.expression
-    if (exprCtx != null) {
-      // resolve later in analyzer
-      PlanWithUnresolvedIdentifier(withOrigin(exprCtx) { expression(exprCtx) }, Nil,
-        (ident, _) => builder(ident))
-    } else if (ctx.errorCapturingIdentifier() != null) {
-      // resolve immediately
-      builder.apply(Seq(getIdentifierText(ctx.errorCapturingIdentifier())))
-    } else if (ctx.stringLit() != null) {
-      // resolve immediately
-      builder.apply(Seq(string(visitStringLit(ctx.stringLit()))))
-    } else {
-      throw SparkException.internalError("Invalid catalog name")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes the unused private method `withCatalogIdentClause` in `SparkSqlAstBuilder`, along with the `SparkException` and `PlanWithUnresolvedIdentifier` imports that it was the sole remaining user of.

### Why are the changes needed?
Its only caller (`visitSetCatalog`) was rewritten to call `expression(...)` directly, leaving the method with zero references. Removing it and its now-orphaned imports is dead-code cleanup with no behavior change.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pure removal of unreferenced code; existing parser tests unaffected. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)