### PR TITLE
[SPARK-58521][UI] Forward `X-Forwarded-Context` header and skip Master CSP on reverse-proxied UI requests

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
+++ b/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
@@ -49,9 +49,11 @@ private class HttpSecurityFilter(
     val hres = res.asInstanceOf[HttpServletResponse]
     hres.setHeader("Cache-Control", "no-cache, no-store, must-revalidate")
 
+    val isProxyRequest = hreq.getContextPath == "/proxy"
+
     val cspNonce = CspNonce.generate()
     try {
-      if (conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED)) {
+      if (conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED) && !isProxyRequest) {
         // Use CSP frame-ancestors as the primary clickjacking protection mechanism.
         // X-Frame-Options ALLOW-FROM is deprecated and ignored by modern browsers
         // (Chrome, Firefox, Edge, Safari), so frame-ancestors is used instead.

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -27,7 +27,7 @@ import scala.xml.Node
 
 import jakarta.servlet.{DispatcherType, Filter, FilterChain, ServletRequest, ServletResponse}
 import jakarta.servlet.http._
-import org.eclipse.jetty.client.{Response => CResponse}
+import org.eclipse.jetty.client.{Request => CRequest, Response => CResponse}
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP
 import org.eclipse.jetty.compression.server.CompressionHandler
@@ -207,6 +207,25 @@ private[spark] object JettyUtils extends Logging {
           .filter(uri => uri != null && validateDestination(uri.getHost, uri.getPort))
           .map(_.toString)
           .orNull
+      }
+
+      override def addProxyHeaders(
+          clientRequest: HttpServletRequest,
+          proxyRequest: CRequest): Unit = {
+        super.addProxyHeaders(clientRequest, proxyRequest)
+        val path = clientRequest.getPathInfo
+        if (path != null) {
+          val prefixTrailingSlashIndex = path.indexOf('/', 1)
+          val prefix = if (prefixTrailingSlashIndex == -1) {
+            path
+          } else {
+            path.substring(0, prefixTrailingSlashIndex)
+          }
+          val existingContext = Option(clientRequest.getHeader("X-Forwarded-Context")).getOrElse("")
+          val contextPath = Option(clientRequest.getContextPath).getOrElse("")
+          val proxyContext = existingContext + contextPath + prefix
+          proxyRequest.headers(headers => headers.put("X-Forwarded-Context", proxyContext))
+        }
       }
 
       override def newHttpClient(): HttpClient = {

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -534,9 +534,39 @@ class UISuite extends SparkFunSuite {
       lastRequest = req
       res.sendError(HttpServletResponse.SC_OK)
     }
-
   }
 
+  test("SPARK-47232: createProxyHandler forwards X-Forwarded-Context header") {
+    val (conf, securityMgr, sslOptions) = sslDisabledConf()
+    val targetServer = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+    val proxyServer = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+
+    @volatile var forwardedContext: String = null
+    val targetHandler = new ServletContextHandler()
+    targetHandler.setContextPath("/")
+    targetHandler.addServlet(new ServletHolder(new HttpServlet {
+      override def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+        forwardedContext = req.getHeader("X-Forwarded-Context")
+        resp.setStatus(HttpServletResponse.SC_OK)
+      }
+    }), "/*")
+    targetServer.addHandler(targetHandler, securityMgr)
+
+    val targetAddr = s"http://$localhost:${targetServer.boundPort}"
+    val proxyHandler = JettyUtils.createProxyHandler(_ => Some(targetAddr))
+    proxyServer.addHandler(proxyHandler, securityMgr)
+
+    try {
+      val proxyUrl = s"http://$localhost:${proxyServer.boundPort}/proxy/app-123/stages/"
+      TestUtils.withHttpConnection(new URI(proxyUrl).toURL) { conn =>
+        assert(conn.getResponseCode === HttpServletResponse.SC_OK)
+        assert(forwardedContext === "/proxy/app-123")
+      }
+    } finally {
+      stopServer(proxyServer)
+      stopServer(targetServer)
+    }
+  }
 }
 
 // Filter for testing; returns a configurable code for every request.

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -536,7 +536,7 @@ class UISuite extends SparkFunSuite {
     }
   }
 
-  test("SPARK-47232: createProxyHandler forwards X-Forwarded-Context header") {
+  test("SPARK-58521: createProxyHandler forwards X-Forwarded-Context header") {
     val (conf, securityMgr, sslOptions) = sslDisabledConf()
     val targetServer = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
     val proxyServer = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)


### PR DESCRIPTION

### What changes were proposed in this pull request?
1. Overrode `addProxyHeaders` in `JettyUtils.createProxyHandler` to automatically attach/chain the `X-Forwarded-Context` header to all proxied HTTP requests.
2. Updated `HttpSecurityFilter` to skip setting Master's CSP nonce header on proxied requests (`/proxy/*`), preventing browser CSP blocking of inline scripts like Event Timeline.
3. Added unit test in `UISuite.scala`.


### Why are the changes needed?
When `spark.ui.reverseProxy=true` is enabled in Standalone mode, navigating UI tabs stripped the `/proxy/<id>` prefix. Additionally, Master's CSP header conflicted with Driver's inline script nonces, blocking Event Timeline scripts.


### Does this PR introduce _any_ user-facing change?
Yes. Fixes navigation links and interactive UI elements (such as Event Timeline) when viewing Application UI through Master's reverse proxy (spark.ui.reverseProxy=true).


### How was this patch tested?
Added unit test in UISuite: SPARK-47232: createProxyHandler forwards X-Forwarded-Context header.
Manually tested batch (SparkPi) and streaming (NetworkWordCount) applications on a local Standalone cluster (Master, Worker, SparkSubmit in cluster mode), verifying that all UI tabs and Event Timeline work cleanly.



### Was this patch authored or co-authored using generative AI tooling?
No
