### PR TITLE
[SPARK-58360][ML][CONNECT] Avoid nested parent overcount in RFormulaModel size estimate

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -34,6 +34,7 @@ import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
+import org.apache.spark.util.SizeEstimator
 
 /**
  * Base trait for [[RFormula]] and [[RFormulaModel]].
@@ -353,6 +354,10 @@ class RFormulaModel private[feature](
 
   // For ml connect only
   private[ml] def this() = this("", null, null)
+
+  private[spark] override def estimatedSize: Long = {
+    estimateMatadataSize + SizeEstimator.estimate(resolvedFormula) + pipelineModel.estimatedSize
+  }
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -356,8 +356,12 @@ class RFormulaModel private[feature](
   private[ml] def this() = this("", null, null)
 
   private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
     // ResolvedRFormula(label: String, terms: Seq[Seq[String]], hasIntercept: Boolean)
-    estimateMatadataSize + SizeEstimator.estimate(resolvedFormula) + pipelineModel.estimatedSize
+    size += SizeEstimator.estimate(resolvedFormula)
+    // pipelineModel: PipelineModel
+    size += pipelineModel.estimatedSize
+    size
   }
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -356,6 +356,7 @@ class RFormulaModel private[feature](
   private[ml] def this() = this("", null, null)
 
   private[spark] override def estimatedSize: Long = {
+    // ResolvedRFormula(label: String, terms: Seq[Seq[String]], hasIntercept: Boolean)
     estimateMatadataSize + SizeEstimator.estimate(resolvedFormula) + pipelineModel.estimatedSize
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -54,6 +54,15 @@ class RFormulaSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(new RFormula())
   }
 
+  test("RFormulaModel estimated size") {
+    val dataset = Seq(("a", 1.0), ("b", 2.0), ("c", 3.0)).toDF("category", "label")
+    val model = new RFormula().setFormula("label ~ category").fit(dataset)
+    val maxSize = 1024 * 16
+    assert(
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
   test("transform numeric data") {
     val formula = new RFormula().setFormula("id ~ v1 + v2")
     val original = Seq((0, 1.0, 3.0), (2, 2.0, 5.0)).toDF("id", "v1", "v2")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -57,11 +57,10 @@ class RFormulaSuite extends MLTest with DefaultReadWriteTest {
   test("RFormulaModel estimated size") {
     val dataset = Seq(("a", 1.0), ("b", 2.0), ("c", 3.0)).toDF("category", "label")
     val model = new RFormula().setFormula("label ~ category").fit(dataset)
-    val minSize = 1024 * 8
-    val maxSize = 1024 * 16
+    val maxSize = 1024 * 8
     assert(
-      model.estimatedSize > minSize && model.estimatedSize < maxSize,
-      s"Estimation (${model.estimatedSize}) should be between $minSize and $maxSize")
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("transform numeric data") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -57,11 +57,10 @@ class RFormulaSuite extends MLTest with DefaultReadWriteTest {
   test("RFormulaModel estimated size") {
     val dataset = Seq(("a", 1.0), ("b", 2.0), ("c", 3.0)).toDF("category", "label")
     val model = new RFormula().setFormula("label ~ category").fit(dataset)
-    val minSize = 1024 * 8
     val maxSize = 1024 * 16
     assert(
-      model.estimatedSize > minSize && model.estimatedSize < maxSize,
-      s"Estimation (${model.estimatedSize}) should be between $minSize and $maxSize")
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
   }
 
   test("transform numeric data") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -57,10 +57,11 @@ class RFormulaSuite extends MLTest with DefaultReadWriteTest {
   test("RFormulaModel estimated size") {
     val dataset = Seq(("a", 1.0), ("b", 2.0), ("c", 3.0)).toDF("category", "label")
     val model = new RFormula().setFormula("label ~ category").fit(dataset)
+    val minSize = 1024 * 8
     val maxSize = 1024 * 16
     assert(
-      model.estimatedSize < maxSize,
-      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+      model.estimatedSize > minSize && model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be between $minSize and $maxSize")
   }
 
   test("transform numeric data") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -57,10 +57,11 @@ class RFormulaSuite extends MLTest with DefaultReadWriteTest {
   test("RFormulaModel estimated size") {
     val dataset = Seq(("a", 1.0), ("b", 2.0), ("c", 3.0)).toDF("category", "label")
     val model = new RFormula().setFormula("label ~ category").fit(dataset)
-    val maxSize = 1024 * 8
+    val minSize = 1024 * 8
+    val maxSize = 1024 * 16
     assert(
-      model.estimatedSize < maxSize,
-      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+      model.estimatedSize > minSize && model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be between $minSize and $maxSize")
   }
 
   test("transform numeric data") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a specialized `RFormulaModel.estimatedSize` implementation. It counts the model metadata, the resolved formula, and the nested `PipelineModel` through its parent-safe estimate.

### Why are the changes needed?

The default model-size estimate clears only the outer model parent. `RFormulaModel` retains its nested pipeline, whose stages can otherwise retain estimator-parent graphs and overcount Spark session or context state in ML Connect cache accounting.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `RFormulaSuite` coverage that fits a categorical R formula and verifies that the fitted model estimate stays below the expected upper bound.

Also ran `git diff --check`, ASCII, and source-line-length checks.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)