### PR TITLE
[SPARK-58361][ML][CONNECT] Include clustering model metadata in size estimates

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -179,8 +179,17 @@ class BisectingKMeansModel private[ml] (
   @Since("2.1.0")
   override def summary: BisectingKMeansSummary = super.summary
 
-  private[spark] override def estimatedSize: Long =
-    estimateMatadataSize + SizeEstimator.estimate(parentModel)
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    if (parentModel != null) {
+      // parentModel contains:
+      // - root: ClusteringTreeNode containing centers, costs, and children.
+      // - distanceMeasure: String and trainingCost: Double.
+      // - distanceMeasureInstance, derived from distanceMeasure.
+      size += SizeEstimator.estimate(parentModel)
+    }
+    size
+  }
 
   // BisectingKMeans model hasn't supported offloading, so put an empty `saveSummary` here for now
   override private[spark] def saveSummary(path: String): Unit = {}

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -180,7 +180,7 @@ class BisectingKMeansModel private[ml] (
   override def summary: BisectingKMeansSummary = super.summary
 
   private[spark] override def estimatedSize: Long =
-    SizeEstimator.estimate(parentModel)
+    estimateMatadataSize + SizeEstimator.estimate(parentModel)
 
   // BisectingKMeans model hasn't supported offloading, so put an empty `saveSummary` here for now
   override private[spark] def saveSummary(path: String): Unit = {}

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -223,7 +223,7 @@ class GaussianMixtureModel private[ml] (
   override def summary: GaussianMixtureSummary = super.summary
 
   private[spark] override def estimatedSize: Long =
-    SizeEstimator.estimate((weights, gaussians))
+    estimateMatadataSize + SizeEstimator.estimate((weights, gaussians))
 
   private[spark] def createSummary(
     predictions: DataFrame, logLikelihood: Double, iteration: Int

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -222,8 +222,24 @@ class GaussianMixtureModel private[ml] (
   @Since("2.0.0")
   override def summary: GaussianMixtureSummary = super.summary
 
-  private[spark] override def estimatedSize: Long =
-    estimateMatadataSize + SizeEstimator.estimate((weights, gaussians))
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    // weights: Array[Double]
+    size += SizeEstimator.estimate(weights)
+    if (gaussians != null) {
+      gaussians.foreach { gaussian =>
+        if (gaussian != null && gaussian.mean != null) {
+          // gaussian.mean: Vector
+          size += gaussian.mean.getSizeInBytes
+        }
+        if (gaussian != null && gaussian.cov != null) {
+          // gaussian.cov: Matrix
+          size += gaussian.cov.getSizeInBytes
+        }
+      }
+    }
+    size
+  }
 
   private[spark] def createSummary(
     predictions: DataFrame, logLikelihood: Double, iteration: Int

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -225,19 +225,8 @@ class GaussianMixtureModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     // weights: Array[Double]
-    size += SizeEstimator.estimate(weights)
-    if (gaussians != null) {
-      gaussians.foreach { gaussian =>
-        if (gaussian != null && gaussian.mean != null) {
-          // gaussian.mean: Vector
-          size += gaussian.mean.getSizeInBytes
-        }
-        if (gaussian != null && gaussian.cov != null) {
-          // gaussian.cov: Matrix
-          size += gaussian.cov.getSizeInBytes
-        }
-      }
-    }
+    // gaussians: Array[MultivariateGaussian], each containing a mean Vector and covariance Matrix
+    size += SizeEstimator.estimate((weights, gaussians))
     size
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -214,7 +214,7 @@ class KMeansModel private[ml] (
   override def summary: KMeansSummary = super.summary
 
   private[spark] override def estimatedSize: Long =
-    SizeEstimator.estimate(parentModel.clusterCenters)
+    estimateMatadataSize + SizeEstimator.estimate(parentModel.clusterCenters)
 
   private[spark] def createSummary(
     predictions: DataFrame, numIter: Int, trainingCost: Double

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -215,17 +215,9 @@ class KMeansModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     if (parentModel != null) {
-      // parentModel.distanceMeasure is included in estimateMatadataSize.
-      // parentModel.trainingCost: Double, parentModel.numIter: Int
-      size += java.lang.Double.BYTES + java.lang.Integer.BYTES
-      // parentModel.clusterCenters: Array[org.apache.spark.mllib.linalg.Vector]
-      if (parentModel.clusterCenters != null) {
-        parentModel.clusterCenters.foreach { center =>
-          if (center != null) {
-            size += center.asML.getSizeInBytes
-          }
-        }
-      }
+      // parentModel contains clusterCenters, distanceMeasure, trainingCost, and numIter.
+      // It also has transient derived fields for distance calculation and statistics.
+      size += SizeEstimator.estimate(parentModel)
     }
     size
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
-import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorVersion
 
 /**
@@ -213,8 +212,23 @@ class KMeansModel private[ml] (
   @Since("2.0.0")
   override def summary: KMeansSummary = super.summary
 
-  private[spark] override def estimatedSize: Long =
-    estimateMatadataSize + SizeEstimator.estimate(parentModel.clusterCenters)
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    if (parentModel != null) {
+      // parentModel.distanceMeasure is included in estimateMatadataSize.
+      // parentModel.trainingCost: Double, parentModel.numIter: Int
+      size += java.lang.Double.BYTES + java.lang.Integer.BYTES
+      // parentModel.clusterCenters: Array[org.apache.spark.mllib.linalg.Vector]
+      if (parentModel.clusterCenters != null) {
+        parentModel.clusterCenters.foreach { center =>
+          if (center != null) {
+            size += center.asML.getSizeInBytes
+          }
+        }
+      }
+    }
+    size
+  }
 
   private[spark] def createSummary(
     predictions: DataFrame, numIter: Int, trainingCost: Double

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.SizeEstimator
 import org.apache.spark.util.VersionUtils.majorVersion
 
 /**

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/BisectingKMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/BisectingKMeansSuite.scala
@@ -56,6 +56,14 @@ class BisectingKMeansSuite extends MLTest with DefaultReadWriteTest {
     assert(copiedModel.hasSummary)
   }
 
+  test("BisectingKMeansModel estimated size") {
+    val model = new BisectingKMeans().setK(2).fit(dataset)
+    val maxSize = 1024 * 16
+    assert(
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
   test("BisectingKMeans validate input dataset") {
     testInvalidWeights(new BisectingKMeans().setWeightCol("weight").fit(_))
     testInvalidVectors(new BisectingKMeans().fit(_))

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -87,6 +87,14 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     assert(copiedModel.hasSummary)
   }
 
+  test("GaussianMixtureModel estimated size") {
+    val model = new GaussianMixture().setK(2).fit(dataset)
+    val maxSize = 1024 * 16
+    assert(
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
   test("GaussianMixture validate input dataset") {
     testInvalidWeights(new GaussianMixture().setWeightCol("weight").fit(_))
     testInvalidVectors(new GaussianMixture().fit(_))

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -70,6 +70,14 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
     assert(copiedModel.hasSummary)
   }
 
+  test("KMeansModel estimated size") {
+    val model = new KMeans().setK(2).fit(dataset)
+    val maxSize = 1024 * 16
+    assert(
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
   test("KMeans validate input dataset") {
     testInvalidWeights(new KMeans().setWeightCol("weight").fit(_))
     testInvalidVectors(new KMeans().fit(_))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `KMeansModel`, `BisectingKMeansModel`, and `GaussianMixtureModel` size estimates to include their parameter metadata in addition to learned clustering state.

### Why are the changes needed?

These models override the default estimator and previously omitted their parameter-map and UID metadata. Counting this metadata makes their cache accounting consistent with other Spark ML models.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added one fitted-model upper-bound size-estimation test in each model's existing clustering suite.

Also ran `git diff --check`, ASCII, and source-line-length checks.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)