### PR TITLE
[WIP][INFRA] Run post-merge build every ten commits

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -45,21 +45,25 @@ jobs:
     permissions:
       packages: write
     name: Run
-    # Skip:
-    #   - pushes to `branch-4.x` on apache/spark: post-merge CI on this
-    #     integration/staging branch is disabled to save resources.
-    #   - pushes to `master` on forks: the "Sync fork" button mirrors
-    #     apache/spark and would otherwise re-run the full build on every sync.
     needs: count-commits
     # GitHub Actions expressions do not support modulo. A non-negative decimal
     # count is divisible by five when it ends in 0 or 5.
+    # `branch-4.x` remains disabled to save post-merge CI resources. Fork master
+    # remains disabled because the Sync fork button would rerun the full build.
     if: >-
-      (
-        (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
-        || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
-      ) && (
-        github.ref != 'refs/heads/master'
-        || endsWith(needs.count-commits.outputs.commit-count, '0')
-        || endsWith(needs.count-commits.outputs.commit-count, '5')
+      github.repository == 'apache/spark' && (
+        (
+          github.ref == 'refs/heads/master'
+          && (
+            endsWith(needs.count-commits.outputs.commit-count, '0')
+            || endsWith(needs.count-commits.outputs.commit-count, '5')
+          )
+        ) || (
+          github.ref != 'refs/heads/master'
+          && github.ref != 'refs/heads/branch-4.x'
+        )
+      ) || (
+        github.repository != 'apache/spark'
+        && github.ref != 'refs/heads/master'
       )
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -25,32 +25,21 @@ on:
     - '**'
 
 jobs:
-  count-post-merge-commits:
-    name: Count post-merge commits
-    if: github.repository == 'apache/spark' && github.ref == 'refs/heads/master'
+  count-commits:
+    name: Count commits
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
       commit-count: ${{ steps.count.outputs.commit-count }}
     steps:
-      - name: Count commits since the cadence was enabled
-        id: count
-        uses: actions/github-script@v9
+      - name: Check out the full branch history
+        uses: actions/checkout@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // This is the master commit immediately before the cadence was enabled.
-            const cadenceBase = 'f6975c913fd1107143d0dd0a42b265496a99149a'
-            const { data: comparison } = await github.rest.repos.compareCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: cadenceBase,
-              head: context.sha
-            })
-
-            console.log(`Master commits since ${cadenceBase}: ${comparison.ahead_by}`)
-            core.setOutput('commit-count', comparison.ahead_by)
+          fetch-depth: 0
+      - name: Count commits on the pushed branch
+        id: count
+        run: echo "commit-count=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
 
   call-build-and-test:
     permissions:
@@ -61,16 +50,16 @@ jobs:
     #     integration/staging branch is disabled to save resources.
     #   - pushes to `master` on forks: the "Sync fork" button mirrors
     #     apache/spark and would otherwise re-run the full build on every sync.
-    needs: count-post-merge-commits
+    needs: count-commits
     # GitHub Actions expressions do not support modulo. A non-negative decimal
     # count is divisible by five when it ends in 0 or 5.
     if: >-
-      always() && (
+      (
         (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
         || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
       ) && (
         github.ref != 'refs/heads/master'
-        || endsWith(needs.count-post-merge-commits.outputs.commit-count, '0')
-        || endsWith(needs.count-post-merge-commits.outputs.commit-count, '5')
+        || endsWith(needs.count-commits.outputs.commit-count, '0')
+        || endsWith(needs.count-commits.outputs.commit-count, '5')
       )
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -47,17 +47,14 @@ jobs:
     name: Run
     needs: count-commits
     # GitHub Actions expressions do not support modulo. A non-negative decimal
-    # count is divisible by five when it ends in 0 or 5.
+    # count is divisible by ten when it ends in 0.
     # `branch-4.x` remains disabled to save post-merge CI resources. Fork master
     # remains disabled because the Sync fork button would rerun the full build.
     if: >-
       github.repository == 'apache/spark' && (
         (
           github.ref == 'refs/heads/master'
-          && (
-            endsWith(needs.count-commits.outputs.commit-count, '0')
-            || endsWith(needs.count-commits.outputs.commit-count, '5')
-          )
+          && endsWith(needs.count-commits.outputs.commit-count, '0')
         ) || (
           github.ref != 'refs/heads/master'
           && github.ref != 'refs/heads/branch-4.x'

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -25,6 +25,33 @@ on:
     - '**'
 
 jobs:
+  count-post-merge-commits:
+    name: Count post-merge commits
+    if: github.repository == 'apache/spark' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      commit-count: ${{ steps.count.outputs.commit-count }}
+    steps:
+      - name: Count commits since the cadence was enabled
+        id: count
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // This is the master commit immediately before the cadence was enabled.
+            const cadenceBase = 'f6975c913fd1107143d0dd0a42b265496a99149a'
+            const { data: comparison } = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: cadenceBase,
+              head: context.sha
+            })
+
+            console.log(`Master commits since ${cadenceBase}: ${comparison.ahead_by}`)
+            core.setOutput('commit-count', comparison.ahead_by)
+
   call-build-and-test:
     permissions:
       packages: write
@@ -34,7 +61,16 @@ jobs:
     #     integration/staging branch is disabled to save resources.
     #   - pushes to `master` on forks: the "Sync fork" button mirrors
     #     apache/spark and would otherwise re-run the full build on every sync.
+    needs: count-post-merge-commits
+    # GitHub Actions expressions do not support modulo. A non-negative decimal
+    # count is divisible by five when it ends in 0 or 5.
     if: >-
-      (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
-      || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
+      always() && (
+        (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
+        || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
+      ) && (
+        github.ref != 'refs/heads/master'
+        || endsWith(needs.count-post-merge-commits.outputs.commit-count, '0')
+        || endsWith(needs.count-post-merge-commits.outputs.commit-count, '5')
+      )
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a commit-count job to the Build workflow. The post-merge build on Apache `master` runs only when the count is divisible by ten. The count job runs for every pushed branch; existing handling remains unchanged for `branch-4.x`, fork `master`, and other branches.

### Why are the changes needed?

Running the post-merge build after every `master` commit consumes substantial CI capacity. Running it every ten commits preserves regular validation while reducing that load.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran `git diff --check`.

No unit test was run because this change modifies only GitHub Actions orchestration.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)