### PR TITLE
[SPARK-58364][CORE] Rename the configuration namespace from `spark.security.credentials` to `spark.security.oidc`

### DIFF
--- a/core/src/main/java/org/apache/spark/security/CredentialProvider.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProvider.java
@@ -50,13 +50,13 @@ public interface CredentialProvider {
    * they need (e.g., endpoint URLs, role ARNs) from the provided map.
    * <p>
    * The configuration map passed to this method is scoped to keys starting with
-   * {@code spark.security.credentials.} only. Keys from other subsystems are not included,
+   * {@code spark.security.oidc.} only. Keys from other subsystems are not included,
    * preventing accidental leakage of unrelated secrets to third-party providers.
    * <p>
    * If init() throws, it may be retried on the next resolution attempt. Implementations
    * should be safe to call again after a prior failure.
    *
-   * @param conf Spark configuration properties scoped to {@code spark.security.credentials.*}
+   * @param conf Spark configuration properties scoped to {@code spark.security.oidc.*}
    *     keys (must not be null)
    * @since 4.3.0
    */

--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -73,7 +73,7 @@ public final class CredentialProviderLoader {
    * {@link CredentialProvider#init(Map)}. Only keys starting with this prefix are forwarded,
    * preventing unrelated secrets from leaking to third-party provider implementations.
    */
-  private static final String CREDENTIALS_CONF_PREFIX = "spark.security.oidc.";
+  private static final String OIDC_CONF_PREFIX = "spark.security.oidc.";
 
   private static volatile List<CredentialProvider> cachedProviders;
 
@@ -180,7 +180,7 @@ public final class CredentialProviderLoader {
       if (!initializedProviders.contains(selected)) {
         Map<String, String> filteredConf = new HashMap<>();
         for (Map.Entry<String, String> entry : conf.entrySet()) {
-          if (entry.getKey().startsWith(CREDENTIALS_CONF_PREFIX)) {
+          if (entry.getKey().startsWith(OIDC_CONF_PREFIX)) {
             filteredConf.put(entry.getKey(), entry.getValue());
           }
         }

--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -42,7 +42,7 @@ import org.apache.spark.annotation.Private;
  * with the configuration from the first call that selects it (first-conf-wins semantics);
  * subsequent resolutions reuse the already-initialized instance without re-calling {@code init}.
  * <p>
- * When the configuration key {@code spark.security.credentials.provider.<scheme>} is set
+ * When the configuration key {@code spark.security.oidc.provider.<scheme>} is set
  * (non-empty), the loader validates the configured fully-qualified class name against the
  * discovered candidates for that scheme regardless of candidate count. If the configured class
  * does not match any candidate, an {@link IllegalArgumentException} is thrown listing the
@@ -66,14 +66,14 @@ public final class CredentialProviderLoader {
    * When set (non-empty), the configured fully-qualified class name must match a discovered
    * provider that supports the scheme; a mismatch results in an {@link IllegalArgumentException}.
    */
-  private static final String CONF_PREFIX = "spark.security.credentials.provider.";
+  private static final String CONF_PREFIX = "spark.security.oidc.provider.";
 
   /**
    * Configuration key prefix used to scope the configuration passed to
    * {@link CredentialProvider#init(Map)}. Only keys starting with this prefix are forwarded,
    * preventing unrelated secrets from leaking to third-party provider implementations.
    */
-  private static final String CREDENTIALS_CONF_PREFIX = "spark.security.credentials.";
+  private static final String CREDENTIALS_CONF_PREFIX = "spark.security.oidc.";
 
   private static volatile List<CredentialProvider> cachedProviders;
 
@@ -92,7 +92,7 @@ public final class CredentialProviderLoader {
    * Returns the {@link CredentialProvider} for the given URI scheme, applying Binding Policy A:
    * <ol>
    *   <li>If no candidate supports the scheme, {@link Optional#empty()} is returned.</li>
-   *   <li>If {@code spark.security.credentials.provider.<scheme>} is set (non-empty) in
+   *   <li>If {@code spark.security.oidc.provider.<scheme>} is set (non-empty) in
    *       {@code conf}, the provider whose fully-qualified class name matches is selected
    *       regardless of candidate count. If the configured class does not match any candidate,
    *       an {@link IllegalArgumentException} is thrown naming the scheme, the configured class,
@@ -104,7 +104,7 @@ public final class CredentialProviderLoader {
    * The selected provider is initialized exactly once per provider instance via
    * {@link CredentialProvider#init(Map)} (first-conf-wins semantics); later resolutions reuse
    * the initialized instance without re-calling {@code init}. The configuration passed to
-   * {@code init()} is scoped to {@code spark.security.credentials.*} keys only; keys from
+   * {@code init()} is scoped to {@code spark.security.oidc.*} keys only; keys from
    * other subsystems are filtered out to prevent secret leakage to third-party providers.
    * <p>
    * Spark-internal callers pass their configuration as a {@code Map<String, String>} for
@@ -171,7 +171,7 @@ public final class CredentialProviderLoader {
     }
 
     // Initialize exactly once under the lock (first-conf-wins).
-    // Only pass spark.security.credentials.* keys to init() to avoid leaking secrets
+    // Only pass spark.security.oidc.* keys to init() to avoid leaking secrets
     // from other subsystems to third-party ServiceLoader providers. This follows the
     // precedent of DataSourceV2Utils.extractSessionConfigs() which scopes configuration
     // to a specific prefix. We keep the full key (unlike extractSessionConfigs which

--- a/core/src/main/java/org/apache/spark/security/FileTokenIngestor.java
+++ b/core/src/main/java/org/apache/spark/security/FileTokenIngestor.java
@@ -38,7 +38,7 @@ import org.apache.spark.internal.SparkLoggerFactory;
  * <p>
  * The file path is typically a Kubernetes projected service account token
  * (e.g., {@code /var/run/secrets/tokens/spark-identity}) or a path configured via
- * {@code spark.security.credentials.identityToken.file}.
+ * {@code spark.security.oidc.identityToken.file}.
  * <p>
  * This implementation:
  * <ul>

--- a/core/src/test/java/org/apache/spark/security/CredentialProviderLoaderSuite.java
+++ b/core/src/test/java/org/apache/spark/security/CredentialProviderLoaderSuite.java
@@ -77,7 +77,7 @@ public class CredentialProviderLoaderSuite {
         "Should mention multiple providers: " + e.getMessage());
     assertTrue(e.getMessage().contains("shared"),
         "Should mention the scheme: " + e.getMessage());
-    assertTrue(e.getMessage().contains("spark.security.credentials.provider.shared"),
+    assertTrue(e.getMessage().contains("spark.security.oidc.provider.shared"),
         "Should mention the config key: " + e.getMessage());
     assertTrue(e.getMessage().contains(FakeCredentialProvider.class.getName()),
         "Should list FakeCredentialProvider: " + e.getMessage());
@@ -90,7 +90,7 @@ public class CredentialProviderLoaderSuite {
     // An empty-string value for the explicit provider conf key should be equivalent to unset,
     // meaning the ambiguity error is still raised for multi-candidate schemes.
     Map<String, String> conf = new HashMap<>();
-    conf.put("spark.security.credentials.provider.shared", "");
+    conf.put("spark.security.oidc.provider.shared", "");
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
         () -> CredentialProviderLoader.providerFor("shared", conf));
     assertTrue(e.getMessage().contains("Multiple credential providers"),
@@ -100,7 +100,7 @@ public class CredentialProviderLoaderSuite {
   @Test
   public void testSharedSchemeWithExplicitConfSelectsFake() {
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.shared",
+        "spark.security.oidc.provider.shared",
         FakeCredentialProvider.class.getName());
     Optional<CredentialProvider> result = CredentialProviderLoader.providerFor("shared", conf);
     assertTrue(result.isPresent());
@@ -110,7 +110,7 @@ public class CredentialProviderLoaderSuite {
   @Test
   public void testSharedSchemeWithExplicitConfSelectsAnother() {
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.shared",
+        "spark.security.oidc.provider.shared",
         AnotherFakeCredentialProvider.class.getName());
     Optional<CredentialProvider> result = CredentialProviderLoader.providerFor("shared", conf);
     assertTrue(result.isPresent());
@@ -120,7 +120,7 @@ public class CredentialProviderLoaderSuite {
   @Test
   public void testConfNamingUnknownClassThrowsClearError() {
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.fake",
+        "spark.security.oidc.provider.fake",
         "com.example.NonExistentProvider");
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
         () -> CredentialProviderLoader.providerFor("fake", conf));
@@ -136,7 +136,7 @@ public class CredentialProviderLoaderSuite {
   public void testConfNamingNonSupportingClassThrowsClearError() {
     // AnotherFakeCredentialProvider does NOT support "fake" scheme
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.fake",
+        "spark.security.oidc.provider.fake",
         AnotherFakeCredentialProvider.class.getName());
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
         () -> CredentialProviderLoader.providerFor("fake", conf));
@@ -152,7 +152,7 @@ public class CredentialProviderLoaderSuite {
   public void testSingleCandidateWithCorrectExplicitConfSelectsIt() {
     // "fake" is supported only by FakeCredentialProvider; conf names the correct class.
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.fake",
+        "spark.security.oidc.provider.fake",
         FakeCredentialProvider.class.getName());
     Optional<CredentialProvider> result = CredentialProviderLoader.providerFor("fake", conf);
     assertTrue(result.isPresent());
@@ -164,7 +164,7 @@ public class CredentialProviderLoaderSuite {
     // "fake" is supported only by FakeCredentialProvider but conf names a different class.
     // This validates that explicit conf is enforced even for single-candidate schemes.
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.fake",
+        "spark.security.oidc.provider.fake",
         "org.apache.spark.security.SomeOtherProvider");
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
         () -> CredentialProviderLoader.providerFor("fake", conf));
@@ -187,17 +187,17 @@ public class CredentialProviderLoaderSuite {
   @Test
   public void testInitConfIsInvokedOnSelectedProvider() {
     Map<String, String> conf = new HashMap<>();
-    conf.put("spark.security.credentials.endpoint", "https://sts.example.com");
-    conf.put("spark.security.credentials.roleArn", "arn:aws:iam::123456:role/test");
+    conf.put("spark.security.oidc.endpoint", "https://sts.example.com");
+    conf.put("spark.security.oidc.roleArn", "arn:aws:iam::123456:role/test");
 
     Optional<CredentialProvider> result = CredentialProviderLoader.providerFor("fake", conf);
     assertTrue(result.isPresent());
     FakeCredentialProvider fake = (FakeCredentialProvider) result.get();
     assertNotNull(fake.getInitConf(), "init() should have been called");
     assertEquals("https://sts.example.com",
-        fake.getInitConf().get("spark.security.credentials.endpoint"));
+        fake.getInitConf().get("spark.security.oidc.endpoint"));
     assertEquals("arn:aws:iam::123456:role/test",
-        fake.getInitConf().get("spark.security.credentials.roleArn"));
+        fake.getInitConf().get("spark.security.oidc.roleArn"));
   }
 
   @Test
@@ -206,9 +206,9 @@ public class CredentialProviderLoaderSuite {
     // (a) the SAME provider instance is returned
     // (b) init was invoked EXACTLY ONCE
     Map<String, String> conf1 = new HashMap<>();
-    conf1.put("spark.security.credentials.tag", "first-call");
+    conf1.put("spark.security.oidc.tag", "first-call");
     Map<String, String> conf2 = new HashMap<>();
-    conf2.put("spark.security.credentials.tag", "second-call");
+    conf2.put("spark.security.oidc.tag", "second-call");
 
     Optional<CredentialProvider> result1 = CredentialProviderLoader.providerFor("fake", conf1);
     Optional<CredentialProvider> result2 = CredentialProviderLoader.providerFor("fake", conf2);
@@ -221,7 +221,7 @@ public class CredentialProviderLoaderSuite {
     FakeCredentialProvider fake = (FakeCredentialProvider) result1.get();
     assertEquals(1, fake.getInitCount(),
         "init() should be called exactly once (first-conf-wins)");
-    assertEquals("first-call", fake.getInitConf().get("spark.security.credentials.tag"),
+    assertEquals("first-call", fake.getInitConf().get("spark.security.oidc.tag"),
         "First call's conf should win");
   }
 
@@ -296,7 +296,7 @@ public class CredentialProviderLoaderSuite {
   public void testExplicitSelectionWithUppercaseSchemeNormalizesConfKey() {
     // The conf key uses normalized (lowercase) scheme
     Map<String, String> conf = Map.of(
-        "spark.security.credentials.provider.shared",
+        "spark.security.oidc.provider.shared",
         FakeCredentialProvider.class.getName());
     Optional<CredentialProvider> result = CredentialProviderLoader.providerFor("SHARED", conf);
     assertTrue(result.isPresent());
@@ -329,12 +329,12 @@ public class CredentialProviderLoaderSuite {
 
   @Test
   public void testInitConfScopedToCredentialsKeysOnly() {
-    // Verify that init() receives only spark.security.credentials.* keys,
+    // Verify that init() receives only spark.security.oidc.* keys,
     // and foreign secrets from other subsystems are NOT leaked to providers.
     Map<String, String> conf = new HashMap<>();
-    conf.put("spark.security.credentials.provider.fake",
+    conf.put("spark.security.oidc.provider.fake",
         FakeCredentialProvider.class.getName());
-    conf.put("spark.security.credentials.endpoint", "https://sts.example.com");
+    conf.put("spark.security.oidc.endpoint", "https://sts.example.com");
     conf.put("spark.authenticate.secret", "TOPSECRET");
     conf.put("spark.ssl.keyPassword", "keypass");
 
@@ -346,8 +346,8 @@ public class CredentialProviderLoaderSuite {
 
     // Credentials keys should be present
     assertEquals("https://sts.example.com",
-        initConf.get("spark.security.credentials.endpoint"));
-    assertTrue(initConf.containsKey("spark.security.credentials.provider.fake"),
+        initConf.get("spark.security.oidc.endpoint"));
+    assertTrue(initConf.containsKey("spark.security.oidc.provider.fake"),
         "Provider selection key should be included (it starts with the prefix)");
 
     // Foreign secrets must NOT be present

--- a/core/src/test/java/org/apache/spark/security/CredentialProviderLoaderSuite.java
+++ b/core/src/test/java/org/apache/spark/security/CredentialProviderLoaderSuite.java
@@ -328,7 +328,7 @@ public class CredentialProviderLoaderSuite {
   }
 
   @Test
-  public void testInitConfScopedToCredentialsKeysOnly() {
+  public void testInitConfScopedToOidcKeysOnly() {
     // Verify that init() receives only spark.security.oidc.* keys,
     // and foreign secrets from other subsystems are NOT leaked to providers.
     Map<String, String> conf = new HashMap<>();
@@ -344,7 +344,7 @@ public class CredentialProviderLoaderSuite {
     Map<String, String> initConf = fake.getInitConf();
     assertNotNull(initConf, "init() should have been called");
 
-    // Credentials keys should be present
+    // OIDC keys should be present
     assertEquals("https://sts.example.com",
         initConf.get("spark.security.oidc.endpoint"));
     assertTrue(initConf.containsKey("spark.security.oidc.provider.fake"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR renames the configuration namespace for the OIDC credential propagation feature from `spark.security.credentials` to `spark.security.oidc`.
This PR also renames relevant words in comments, strings and identifiers.

### Why are the changes needed?
During the discussion on another [PR](https://github.com/apache/spark/pull/57387#issuecomment-5084689771), reusing the spark.security.credentials.* for OIDC creates confusion

### Does this PR introduce _any_ user-facing change?
No. This feature is under development.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
