### PR TITLE
[SPARK-58249][PS][FOLLOWUP] Use native function for NumPy invert

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -49,7 +49,7 @@ unary_np_spark_mappings = {
     "floor": F.floor,
     "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
     # and it cannot be supported via pandas UDF.
-    "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore[call-overload]
+    "invert": F.bitwise_not,
     "isfinite": lambda c: c != float("inf"),
     "isinf": lambda c: c == float("inf"),
     "isnan": F.isnan,

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -98,6 +98,7 @@ class NumPyCompatTestsMixin:
             (np.exp2, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.fabs, [np.iinfo(np.int64).min, -2, 0, 2]),
             (np.fabs, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
+            (np.invert, [np.iinfo(np.int64).min, -2, -1, 0, 1, 2, np.iinfo(np.int64).max]),
             (np.negative, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.positive, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.rad2deg, [-np.inf, -64.0, -np.pi, 0.0, np.pi, 64.0, np.inf, np.nan]),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the scalar pandas UDF mapping for NumPy `invert` on pandas-on-Spark objects with the native Spark SQL `bitwise_not` function. Add the `int64` boundary-value coverage to the existing native NumPy ufunc parity test.

### Why are the changes needed?

Spark already provides a native, Spark Connect-compatible bitwise-not function. Using it removes the Python worker boundary and preserves NumPy integer results.

### Does this PR introduce _any_ user-facing change?

Yes. `np.invert` now preserves its integral result type, matching NumPy, instead of using the scalar pandas UDF mapping declared with a double result type.

### How was this patch tested?

- Added pandas-on-Spark parity coverage for `np.invert` using `int64` boundary values.
- Ran `build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 -Phive package`.
- Ran `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 SPARK_TESTING=1 SPARK_PREPEND_CLASSES=1 PYSPARK_PYTHON=.venv/bin/python PYSPARK_DRIVER_PYTHON=.venv/bin/python python/run-tests --testnames pyspark.pandas.tests.test_numpy_compat`.
- Ran `git diff --check`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)