### PR TITLE
[SPARK-58371][DOC] Update `json` gem version to 2.21.1

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.12.2)
+    json (2.21.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `json` gem from 2.12.2 to 2.21.1 in `docs/Gemfile.lock`. It is a transitive dependency (pulled in by `jekyll`, which requires `json (~> 2.6)`), and 2.21.1 satisfies that constraint, so only the locked spec version changes.

`json` has no runtime dependencies, so no other lock entries change and `docs/Gemfile` does not need to be touched.

### Why are the changes needed?

2.21.1 includes the fix for a security advisory that affects all versions in `>= 2.9.0, < 2.19.9`:

- [GHSA-x2f5-4prf-w687](https://github.com/advisories/GHSA-x2f5-4prf-w687) / CVE-2026-54696 (low): heap out-of-bounds write in the JSON generator when streaming to an IO. On the IO path, `fbuffer_do_inc_capa()` compared the requested size against the buffer's total capacity instead of its remaining capacity, so `JSON.dump(obj, io)` or `JSON::State#generate(obj, io)` could write past the buffer when serializing a string near 16 KB. Fixed in 2.19.9.

Following the same pattern as SPARK-57633 (`concurrent-ruby` 1.3.7), this picks up the latest release rather than the minimum patched version.

### Does this PR introduce _any_ user-facing change?

No. This only affects the documentation build toolchain.

### How was this patch tested?

Manually verified in a scratch copy of `docs/Gemfile` and `docs/Gemfile.lock`:

1. Lock resolution matches. Running `bundle lock --update=json` produces a lock file byte-identical to the hand-edited one, confirming 2.21.1 satisfies jekyll's `json (~> 2.6)` and that no other locked spec is affected.

2. Frozen install succeeds. `BUNDLE_FROZEN=true bundle install` installs all 36 gems without modifying the lock file, and `bundle list` reports `json (2.21.1)`.

3. The advisory's PoC no longer crashes:

```ruby
require "json"
require "stringio"

io = StringIO.new
big = "a" * 16385
big[16382] = '"'          # escapable byte near the buffer boundary

JSON.dump([big], io)
```

```text
json version: 2.21.1
PoC (JSON.dump with IO): no crash, output bytes = 16390
roundtrip ok: true
```

4. The docs site builds:

```
$ cd docs && SKIP_API=1 bundle exec jekyll build
Configuration file: .../docs/_config.yml

************************
* Building error docs. *
************************
Generated: docs/_generated/error-conditions.html
            Source: .../docs
       Destination: .../docs/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
Warning: Tolerating missing API files because the following skip flags are set: SKIP_API
                    done in 3.125 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
