### PR TITLE
[SPARK-57498][CORE] Fix ResourceProfile ID collision when custom profile is created before default

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -371,7 +371,8 @@ object ResourceProfile extends Logging {
   val UNKNOWN_RESOURCE_PROFILE_ID = -1
   val DEFAULT_RESOURCE_PROFILE_ID = 0
 
-  private lazy val nextProfileId = new AtomicInteger(0)
+  // Start at 1: ID 0 is reserved for DEFAULT_RESOURCE_PROFILE_ID.
+  private lazy val nextProfileId = new AtomicInteger(1)
   private val DEFAULT_PROFILE_LOCK = new Object()
 
   // The default resource profile uses the application level configs.
@@ -471,6 +472,11 @@ object ResourceProfile extends Logging {
       defaultProfile = None
       defaultProfileExecutorResources = None
     }
+  }
+
+  // for testing only
+  private[spark] def resetNextProfileIdForTesting(): Unit = {
+    nextProfileId.set(1)
   }
 
   /*

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -38,6 +38,7 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
   override def afterEach(): Unit = {
     try {
       ResourceProfile.clearDefaultProfile()
+      ResourceProfile.resetNextProfileIdForTesting()
     } finally {
       super.afterEach()
     }
@@ -496,6 +497,27 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
 
     treqs = new TaskResourceRequests().cpus(1).resource("gpu", 0.7)
     new ResourceProfileBuilder().require(treqs).build()
+  }
+
+  test("custom ResourceProfile id must not collide with DEFAULT_RESOURCE_PROFILE_ID") {
+    // Create a custom ResourceProfile *before* the default profile is initialised.
+    // Prior to the fix, getNextProfileId started at 0 so the first custom profile
+    // received ID 0, which is identical to DEFAULT_RESOURCE_PROFILE_ID.
+    val customRp = new ResourceProfileBuilder()
+      .require(new ExecutorResourceRequests().cores(2).memory("2048"))
+      .require(new TaskResourceRequests().cpus(1))
+      .build()
+
+    val defaultRp = ResourceProfile.getOrCreateDefaultProfile(new SparkConf)
+
+    assert(customRp.id != ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID,
+      s"Custom profile id (${customRp.id}) must not equal DEFAULT_RESOURCE_PROFILE_ID " +
+        s"(${ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID})")
+    assert(customRp.id != defaultRp.id,
+      s"Custom profile id (${customRp.id}) must not equal the default profile id (${defaultRp.id})")
+    assert(defaultRp.id == ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID,
+      s"Default profile id (${defaultRp.id}) must equal DEFAULT_RESOURCE_PROFILE_ID " +
+        s"(${ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID})")
   }
 
   private def withMockSparkEnv(conf: SparkConf)(f: => Unit): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ResourceProfile.nextProfileId` was initialized to `new AtomicInteger(0)`, so the first call to `getNextProfileId()` returned `0` — which is identical to `DEFAULT_RESOURCE_PROFILE_ID`. Any custom `ResourceProfile` created before the default profile was initialized would receive ID `0`, colliding with the default profile.

This PR fixes the counter to start at `1`, so ID `0` remains exclusively reserved for the default profile.

Changes:
- Start `nextProfileId` at `1` instead of `0` in `ResourceProfile` companion object.
- Add `resetNextProfileIdForTesting()` (`private[spark]`) to enable test isolation without exposing the reset in production code paths.
- Add `afterEach` reset call in `ResourceProfileSuite` to prevent test-order-dependent failures.
- Add a regression test that creates a custom profile before the default and asserts no ID collision.

### Why are the changes needed?

Without this fix, `new ResourceProfileBuilder().build()` called before `ResourceProfile.getOrCreateDefaultProfile()` produces a profile with `id == 0 == DEFAULT_RESOURCE_PROFILE_ID`, which can lead to incorrect resource allocation or scheduling decisions.

### Does this PR introduce _any_ user-facing change?

No. The fix only affects internal ID assignment. The default profile always receives ID `0` and custom profiles now always start at ID `1`.

### How was this patch tested?

- Existing `ResourceProfileSuite` passes.
- New test `"custom ResourceProfile id must not collide with DEFAULT_RESOURCE_PROFILE_ID"` covers the regression case.

Closes #57498

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>