### PR TITLE
[SPARK-57561][SQL] Add size validation to bitmap_or_agg and bitmap_and_agg

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -472,6 +472,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "BITMAP_INPUT_TOO_LARGE" : {
+    "message" : [
+      "The input bitmap has <inputNumBytes> bytes, which exceeds the maximum supported size of <maxNumBytes> bytes."
+    ],
+    "sqlState" : "22001"
+  },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [
       "The method <methodName> can not be called on streaming Dataset/DataFrame."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitmapExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitmapExpressions.scala
@@ -248,7 +248,9 @@ case class BitmapConstructAgg(child: Expression,
 @ExpressionDescription(
   usage = """
     _FUNC_(child) - Returns a bitmap that is the bitwise OR of all of the bitmaps from the child
-    expression. The input should be bitmaps created from bitmap_construct_agg().
+    expression. Input bitmaps shorter than 4096 bytes are merged into the corresponding byte
+    positions of the result; inputs produced by bitmap_construct_agg() are always exactly 4096
+    bytes. Inputs longer than 4096 bytes are not supported and will cause a runtime error.
   """,
   // scalastyle:off line.size.limit
   examples = """
@@ -322,6 +324,10 @@ case class BitmapOrAgg(child: Expression,
   override def update(buffer: InternalRow, input: InternalRow): Unit = {
     val input_bitmap = child.eval(input).asInstanceOf[Array[Byte]]
     if (input_bitmap != null) {
+      if (input_bitmap.length > BitmapExpressionUtils.NUM_BYTES) {
+        throw QueryExecutionErrors.bitmapInputTooLargeError(
+          input_bitmap.length, BitmapExpressionUtils.NUM_BYTES)
+      }
       val bitmap = buffer.getBinary(mutableAggBufferOffset)
       BitmapExpressionUtils.bitmapMerge(bitmap, input_bitmap)
     }
@@ -341,7 +347,11 @@ case class BitmapOrAgg(child: Expression,
 @ExpressionDescription(
   usage = """
     _FUNC_(child) - Returns a bitmap that is the bitwise AND of all of the bitmaps from the child
-    expression. The input should be bitmaps created from bitmap_construct_agg().
+    expression. The aggregation buffer is initialized to all 0xFF bytes (ones). Input bitmaps
+    shorter than 4096 bytes are ANDed into the corresponding byte positions of the result; tail
+    bytes not covered by a short input remain all-ones. Inputs produced by bitmap_construct_agg()
+    are always exactly 4096 bytes. Inputs longer than 4096 bytes are not supported and will cause
+    a runtime error.
   """,
   // scalastyle:off line.size.limit
   examples = """
@@ -415,6 +425,10 @@ case class BitmapAndAgg(
   override def update(buffer: InternalRow, input: InternalRow): Unit = {
     val input_bitmap = child.eval(input).asInstanceOf[Array[Byte]]
     if (input_bitmap != null) {
+      if (input_bitmap.length > BitmapExpressionUtils.NUM_BYTES) {
+        throw QueryExecutionErrors.bitmapInputTooLargeError(
+          input_bitmap.length, BitmapExpressionUtils.NUM_BYTES)
+      }
       val bitmap = buffer.getBinary(mutableAggBufferOffset)
       BitmapExpressionUtils.bitmapAndMerge(bitmap, input_bitmap)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -257,6 +257,15 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       summary = getSummary(context))
   }
 
+  def bitmapInputTooLargeError(inputNumBytes: Int, maxNumBytes: Int): SparkRuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "BITMAP_INPUT_TOO_LARGE",
+      messageParameters = Map(
+        "inputNumBytes" -> inputNumBytes.toString,
+        "maxNumBytes" -> maxNumBytes.toString),
+      cause = null)
+  }
+
   def invalidBitmapPositionError(bitPosition: Long,
                                  bitmapNumBytes: Long): ArrayIndexOutOfBoundsException = {
     new SparkArrayIndexOutOfBoundsException(

--- a/sql/core/src/test/scala/org/apache/spark/sql/BitmapExpressionsQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/BitmapExpressionsQuerySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.functions.{bitmap_and_agg, bitmap_bit_position, bitmap_bucket_number, bitmap_construct_agg, bitmap_count, bitmap_or_agg, col, expr, hex, lit, substring, to_binary}
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -355,5 +356,37 @@ class BitmapExpressionsQuerySuite extends SharedSparkSession {
         "inputSql" -> "\"a\"",
         "inputType" -> "\"INT\""),
       context = ExpectedContext(fragment = "bitmap_and_agg(a)", start = 0, stop = 16))
+  }
+
+  test("bitmap_or_agg rejects input larger than 4096 bytes") {
+    // 4097 bytes exceeds the 4096-byte limit
+    val oversized = Array.fill[Byte](4097)(0xFF.toByte)
+    val df = Seq(oversized).toDF("a")
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        df.select(bitmap_or_agg(col("a"))).collect()
+      },
+      condition = "BITMAP_INPUT_TOO_LARGE",
+      parameters = Map(
+        "inputNumBytes" -> "4097",
+        "maxNumBytes" -> "4096"
+      )
+    )
+  }
+
+  test("bitmap_and_agg rejects input larger than 4096 bytes") {
+    // 4097 bytes exceeds the 4096-byte limit
+    val oversized = Array.fill[Byte](4097)(0xFF.toByte)
+    val df = Seq(oversized).toDF("a")
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        df.select(bitmap_and_agg(col("a"))).collect()
+      },
+      condition = "BITMAP_INPUT_TOO_LARGE",
+      parameters = Map(
+        "inputNumBytes" -> "4097",
+        "maxNumBytes" -> "4096"
+      )
+    )
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`bitmap_or_agg` and `bitmap_and_agg` silently accept input bitmaps of any size. When an input bitmap is larger than `BitmapExpressionUtils.NUM_BYTES` (4096 bytes), `bitmapMerge` / `bitmapAndMerge` silently reads only the first 4096 bytes, discarding the rest. This can produce incorrect results without any indication that data was dropped.

This PR adds an explicit runtime check in the `update()` methods of both `BitmapOrAgg` and `BitmapAndAgg`. If the input exceeds 4096 bytes, a `SparkRuntimeException` with error class `BITMAP_INPUT_TOO_LARGE` is thrown.

Changes:
- Add `BITMAP_INPUT_TOO_LARGE` error condition to `error-conditions.json` (SQLSTATE `22001` — string/binary data right truncation).
- Add `bitmapInputTooLargeError` factory method to `QueryExecutionErrors`.
- Add size guard in `BitmapOrAgg.update()` and `BitmapAndAgg.update()`.
- Update `@ExpressionDescription` for both aggregates to accurately document short-input behavior and the size limit.
- Add two tests in `BitmapExpressionsQuerySuite` verifying the error is thrown.

### Why are the changes needed?

Without validation, oversized inputs are silently truncated, producing incorrect aggregate results with no warning. Explicit validation follows Spark's design principle of failing fast with a structured error rather than silently producing wrong results.

### Does this PR introduce _any_ user-facing change?

Yes. Queries that pass bitmaps larger than 4096 bytes to `bitmap_or_agg` or `bitmap_and_agg` will now fail with `BITMAP_INPUT_TOO_LARGE` instead of silently truncating. Inputs created by `bitmap_construct_agg()` are always exactly 4096 bytes and are unaffected.

### How was this patch tested?

- New tests `"bitmap_or_agg rejects input larger than 4096 bytes"` and `"bitmap_and_agg rejects input larger than 4096 bytes"` in `BitmapExpressionsQuerySuite`.
- Existing bitmap expression tests pass.

Closes #57561

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>