### PR TITLE
[SPARK-58374][BUILD] Upgrade `joda-time` to 2.14.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -142,7 +142,7 @@ jjwt-impl/0.13.0//jjwt-impl-0.13.0.jar
 jjwt-jackson/0.13.0//jjwt-jackson-0.13.0.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.29.0/jdk8/jline-3.29.0-jdk8.jar
-joda-time/2.14.2//joda-time-2.14.2.jar
+joda-time/2.14.3//joda-time-2.14.3.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar
 json4s-ast_2.13/4.0.7//json4s-ast_2.13-4.0.7.jar

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
     <gson.version>2.14.0</gson.version>
     <janino.version>3.1.9</janino.version>
     <jersey.version>3.1.11</jersey.version>
-    <joda.version>2.14.2</joda.version>
+    <joda.version>2.14.3</joda.version>
     <jsr305.version>3.0.0</jsr305.version>
     <jaxb.version>2.2.11</jaxb.version>
     <libthrift.version>0.16.0</libthrift.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `joda-time` to `2.14.3` for Apache Spark 5.

### Why are the changes needed?

To bring in the latest time zone data and keep the dependency up to date.
- https://www.joda.org/joda-time/changes-report.html#a2.14.3 (2026-07-26)
- https://github.com/JodaOrg/joda-time/releases/tag/v2.14.3
  - https://github.com/JodaOrg/joda-time/pull/833

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5