### PR TITLE
[SPARK-58375][BUILD] Upgrade `ap-loader` to 4.5-13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <mima.version>1.1.4</mima.version>
 
     <!-- Version used in Profiler -->
-    <ap-loader.version>4.3-13</ap-loader.version>
+    <ap-loader.version>4.5-13</ap-loader.version>
 
     <CodeCacheSize>128m</CodeCacheSize>
     <!-- Needed for consistent times -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `ap-loader` dependency to 4.5-13 for Apache Spark 5.

### Why are the changes needed?

To bring the latest bug fixes and improvements from `ap-loader`.

- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.5-13 (2026-07-21)
  - https://github.com/async-profiler/async-profiler/releases/tag/v4.5
    - https://github.com/async-profiler/async-profiler/issues/1765: JDK 27 support
    - https://github.com/async-profiler/async-profiler/issues/1755: Span API for latency profiling
    - https://github.com/async-profiler/async-profiler/issues/1406: Long time-to-safepoint pause when attaching asprof
    - https://github.com/async-profiler/async-profiler/issues/1756: Runtime attach fails on JVMs with many native libraries
  - https://github.com/async-profiler/async-profiler/releases/tag/v4.4
    - https://github.com/async-profiler/async-profiler/issues/1553: Differential Flame Graphs
    - https://github.com/async-profiler/async-profiler/issues/1705: `memlimit` option to limit size of the call trace storage
    - https://github.com/async-profiler/async-profiler/issues/1715: Fix Zing crash when profiling cpu+wall together

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5