### PR TITLE
[SPARK-58376][BUILD] Upgrade `byte-buddy` to 1.18.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1284,13 +1284,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.18.4</version>
+        <version>1.18.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.18.4</version>
+        <version>1.18.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `byte-buddy` and `byte-buddy-agent` to 1.18.11.

### Why are the changes needed?

To bring the latest bug fixes and official support for the newest JDKs. Note that version 1.18.6 was never released. The full release notes are available below:

- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.11 (2026-07-02)
  - Add SBOM to published artifacts, and check for traversable paths injected into class files.
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.10 (2026-06-26)
  - Delay the change of default for unsafe use to Java 26 and improve the error message.
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.9 (2026-06-01)
  - Disable use of `Unsafe` by default on Java 25+, improve OpenJ9 attachment and diagnostics, avoid NPE on missing annotation types, and update ASM.
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.8 (2026-04-01)
  - Improve support for repeatable builds and fix reordering of the exception table in type initializers when instrumenting.
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.7 (2026-03-03)
  - Introduce a new versioning concept with the *-jdk5* suffix jar and a Java 8 baseline for the regular jar.
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.5 (2026-02-14)
  - Eagerly resolve canonical files during attach emulation and add missing super classes to hash code / equals computation in `Advice`.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5