### PR TITLE
[SPARK-58379][BUILD] Upgrade `jnr-posix` to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -536,7 +536,7 @@
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
-        <version>3.1.15</version>
+        <version>3.2.1</version>
         <scope>test</scope>
       </dependency>
       <!-- This artifact is a shaded version of ASM 9.x. The POM that was used to produce this


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `jnr-posix` test dependency to 3.2.1.

### Why are the changes needed?

- [Release 3.2.0](https://github.com/jnr/jnr-posix/releases/tag/3.2.0) (2026-06-26)
- [Release 3.2.1](https://github.com/jnr/jnr-posix/releases/tag/3.2.1) (2026-06-27)

`jnr-posix` is a test-only dependency used by `DiskBlockManagerSuite` to get/set
the process umask (SPARK-37618). The 3.2.x line brings:

- `jnr-ffi` 2.2.11 -> 2.3.0 (internal ASM 9.2 -> 9.10.1) for better modern JDK
  class-file support
- JPMS module visibility improvements on newer JDKs
- Fallback to avoid `UnsatisfiedLinkError` on musl-based systems (Alpine)
- RISC-V64 and LoongArch64 support
- Temp-directory vulnerability fixes

### Does this PR introduce _any_ user-facing change?

No. This is a test-only dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5