### PR TITLE
[SPARK-58378][SQL] Fuse compatible approximate percentile sketches

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, CreateArray, Expression, ExprId, GetArrayItem, LeafExpression, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, ExprId, GetArrayItem, LeafExpression, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, ApproximatePercentile}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
@@ -45,7 +45,6 @@ private[optimizer] case class PercentileFusionIdentity(
 private[optimizer] case class PercentileFusionArray(identity: PercentileFusionIdentity)
     extends LeafExpression with CodegenFallback {
   override def foldable: Boolean = true
-  override def contextIndependentFoldable: Boolean = true
   override def nullable: Boolean = false
   override def dataType: ArrayType = ArrayType(DoubleType, containsNull = false)
 
@@ -104,8 +103,7 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     key.child.canonicalized,
     accuracy.canonicalized,
     key.mode,
-    // OptimizeOneRowPlan can remove DISTINCT later, including during AQE.
-    isDistinct = false,
+    key.isDistinct,
     key.filter.map(_.canonicalized))
 
   private def hasSafePhysicalFusion(
@@ -136,7 +134,6 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     // key that shares a physical key so fusion does not change that existing deduplication.
     val physicalCompatibilityKeys = mutable.HashMap.empty[
       PhysicalCompatibilityKey, mutable.HashSet[CompatibilityKey]]
-    val arrayPercentiles = mutable.ArrayBuffer.empty[AggregateExpression]
 
     aggregate.aggregateExpressions.foreach(_.foreach {
       case expression @ AggregateExpression(
@@ -155,8 +152,6 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
           mutable.HashSet.empty) += key
         if (percentile.percentageExpression.dataType == DoubleType) {
           compatible.getOrElseUpdate(key, mutable.ArrayBuffer.empty) += expression
-        } else {
-          arrayPercentiles += expression
         }
       case _ =>
     })
@@ -179,24 +174,18 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
           .percentageExpression
       }
       val percentageValues = percentages.map(_.eval().asInstanceOf[Double]).toSeq
-      val combinedPercentile = percentile.copy(
-        percentageExpression = CreateArray(percentages.toSeq))
-      val combined = first.copy(aggregateFunction = combinedPercentile)
-      if (!arrayPercentiles.exists(_.semanticEquals(combined))) {
-        val identity = PercentileFusionIdentity(
-          expressions.map { expression =>
-            structurallyNormalize(expression.aggregateFunction, aggregate.child.output)
-          }.toSeq,
-          key.mode,
-          key.isDistinct,
-          key.filter.map(structurallyNormalize(_, aggregate.child.output)),
-          percentageValues.map(java.lang.Double.doubleToRawLongBits))
-        val identifiedCombined = combined.copy(
-          aggregateFunction = combinedPercentile.copy(
-            percentageExpression = PercentileFusionArray(identity)))
-        expressions.zipWithIndex.foreach { case (expression, index) =>
-          replacements.put(expression.resultId, (identifiedCombined, index))
-        }
+      val identity = PercentileFusionIdentity(
+        expressions.map { expression =>
+          structurallyNormalize(expression.aggregateFunction, aggregate.child.output)
+        }.toSeq,
+        key.mode,
+        key.isDistinct,
+        key.filter.map(structurallyNormalize(_, aggregate.child.output)),
+        percentageValues.map(java.lang.Double.doubleToRawLongBits))
+      val combined = first.copy(aggregateFunction = percentile.copy(
+        percentageExpression = PercentileFusionArray(identity)))
+      expressions.zipWithIndex.foreach { case (expression, index) =>
+        replacements.put(expression.resultId, (combined, index))
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.AGGREGATE
 import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, DoubleType}
 
 private[optimizer] case class PercentileFusionIdentity(
@@ -119,10 +120,13 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     }
   }
 
-  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
-    _.containsPattern(AGGREGATE), ruleId) {
-    case aggregate: Aggregate if aggregate.resolved && !aggregate.isStreaming =>
-      combine(aggregate)
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!conf.getConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED)) return plan
+
+    plan.transformUpWithPruning(_.containsPattern(AGGREGATE), ruleId) {
+      case aggregate: Aggregate if aggregate.resolved && !aggregate.isStreaming =>
+        combine(aggregate)
+    }
   }
 
   private def combine(aggregate: Aggregate): Aggregate = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -47,6 +47,22 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
       isDistinct: Boolean,
       filter: Option[Expression])
 
+  private case class PhysicalCompatibilityKey(
+      child: Expression,
+      accuracy: Expression,
+      mode: AggregateMode,
+      isDistinct: Boolean,
+      filter: Option[Expression])
+
+  private def physicalCompatibilityKey(
+      key: CompatibilityKey,
+      accuracy: Expression): PhysicalCompatibilityKey = PhysicalCompatibilityKey(
+    key.child.canonicalized,
+    accuracy.canonicalized,
+    key.mode,
+    key.isDistinct,
+    key.filter.map(_.canonicalized))
+
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
     _.containsPattern(AGGREGATE), ruleId) {
     case aggregate: Aggregate if aggregate.resolved && !aggregate.isStreaming =>
@@ -56,25 +72,40 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
   private def combine(aggregate: Aggregate): Aggregate = {
     val compatible = mutable.LinkedHashMap.empty[
       CompatibilityKey, mutable.ArrayBuffer[AggregateExpression]]
+    val physicalCompatibilityKeys = mutable.HashMap.empty[
+      PhysicalCompatibilityKey, mutable.HashSet[CompatibilityKey]]
+    val arrayPercentiles = mutable.ArrayBuffer.empty[AggregateExpression]
 
     aggregate.aggregateExpressions.foreach(_.foreach {
       case expression @ AggregateExpression(
           percentile: ApproximatePercentile, mode, isDistinct, filter, _)
           if percentile.child.deterministic &&
-            filter.forall(_.deterministic) &&
-            percentile.percentageExpression.dataType == DoubleType =>
+            filter.forall(_.deterministic) =>
         val key = CompatibilityKey(
           percentile.child,
           percentile.accuracyExpression.eval().asInstanceOf[Number].longValue,
           mode,
           isDistinct,
           filter)
-        compatible.getOrElseUpdate(key, mutable.ArrayBuffer.empty) += expression
+        physicalCompatibilityKeys.getOrElseUpdate(
+          physicalCompatibilityKey(key, percentile.accuracyExpression),
+          mutable.HashSet.empty) += key
+        if (percentile.percentageExpression.dataType == DoubleType) {
+          compatible.getOrElseUpdate(key, mutable.ArrayBuffer.empty) += expression
+        } else {
+          arrayPercentiles += expression
+        }
       case _ =>
     })
 
     val replacements = mutable.HashMap.empty[ExprId, (AggregateExpression, Int)]
-    compatible.valuesIterator.filter(_.sizeCompare(1) > 0).foreach { expressions =>
+    compatible.iterator.filter { case (key, expressions) =>
+      expressions.sizeCompare(1) > 0 && expressions.forall { expression =>
+        val percentile = expression.aggregateFunction.asInstanceOf[ApproximatePercentile]
+        physicalCompatibilityKeys(
+          physicalCompatibilityKey(key, percentile.accuracyExpression)).sizeCompare(1) == 0
+      }
+    }.foreach { case (_, expressions) =>
       val first = expressions.head
       val percentile = first.aggregateFunction.asInstanceOf[ApproximatePercentile]
       val percentages = expressions.map { expression =>
@@ -85,8 +116,10 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
       val combined = first.copy(
         aggregateFunction = percentile.copy(
           percentageExpression = CreateArray(percentages.toSeq)))
-      expressions.zipWithIndex.foreach { case (expression, index) =>
-        replacements.put(expression.resultId, (combined, index))
+      if (!arrayPercentiles.exists(_.semanticEquals(combined))) {
+        expressions.zipWithIndex.foreach { case (expression, index) =>
+          replacements.put(expression.resultId, (combined, index))
+        }
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -81,6 +81,7 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
 
   private case class PhysicalCompatibilityKey(
       child: Expression,
+      percentage: Expression,
       accuracy: Expression,
       mode: AggregateMode,
       isDistinct: Boolean,
@@ -98,9 +99,10 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
 
   private def physicalCompatibilityKey(
       key: CompatibilityKey,
-      accuracy: Expression): PhysicalCompatibilityKey = PhysicalCompatibilityKey(
+      percentile: ApproximatePercentile): PhysicalCompatibilityKey = PhysicalCompatibilityKey(
     key.child.canonicalized,
-    accuracy.canonicalized,
+    percentile.percentageExpression.canonicalized,
+    percentile.accuracyExpression.canonicalized,
     key.mode,
     key.isDistinct,
     key.filter.map(_.canonicalized))
@@ -150,7 +152,7 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
           isDistinct,
           filter)
         physicalCompatibilityKeys.getOrElseUpdate(
-          physicalCompatibilityKey(key, percentile.accuracyExpression),
+          physicalCompatibilityKey(key, percentile),
           mutable.HashSet.empty) += key
         if (percentile.percentageExpression.dataType == DoubleType) {
           compatible.getOrElseUpdate(key, mutable.ArrayBuffer.empty) += expression
@@ -171,7 +173,7 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     }.filter { case (key, expressions) =>
       hasSafePhysicalFusion(expressions) && expressions.forall { expression =>
         val percentile = expression.aggregateFunction.asInstanceOf[ApproximatePercentile]
-        val physicalKey = physicalCompatibilityKey(key, percentile.accuracyExpression)
+        val physicalKey = physicalCompatibilityKey(key, percentile)
         // OptimizeOneRowPlan can erase DISTINCT after fusion. Across distinctness boundaries,
         // canonical matches are safe only when their original inputs and filters also match.
         physicalCompatibilityKeys(physicalKey).sizeCompare(1) == 0 &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -19,12 +19,44 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.expressions.{CreateArray, Expression, ExprId, GetArrayItem, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, CreateArray, Expression, ExprId, GetArrayItem, LeafExpression, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, ApproximatePercentile}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.AGGREGATE
-import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.types.{ArrayType, DoubleType}
+
+private[optimizer] case class PercentileFusionIdentity(
+    aggregateFunctions: Seq[Expression],
+    mode: AggregateMode,
+    isDistinct: Boolean,
+    filter: Option[Expression],
+    percentageBits: Seq[Long])
+
+/**
+ * Foldable percentage array that retains the original scalar aggregate structures in equality.
+ *
+ * Fusion removes those structures from the physical aggregate. Keeping them here prevents
+ * subquery or exchange reuse from equating plans that were distinct before fusion.
+ */
+private[optimizer] case class PercentileFusionArray(identity: PercentileFusionIdentity)
+    extends LeafExpression with CodegenFallback {
+  override def foldable: Boolean = true
+  override def contextIndependentFoldable: Boolean = true
+  override def nullable: Boolean = false
+  override def dataType: ArrayType = ArrayType(DoubleType, containsNull = false)
+
+  private lazy val value = new GenericArrayData(
+    identity.percentageBits.map(java.lang.Double.longBitsToDouble))
+  private lazy val literal = Literal(value, dataType)
+
+  override def eval(input: InternalRow): Any = value
+  override def toString: String = literal.toString
+  override def sql: String = literal.sql
+}
 
 /**
  * Combines scalar approximate percentiles that can share the same percentile digest.
@@ -54,14 +86,42 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
       isDistinct: Boolean,
       filter: Option[Expression])
 
+  private def structurallyNormalize(
+      expression: Expression,
+      input: Seq[Attribute]): Expression = expression.transformUp {
+    case attribute: AttributeReference =>
+      val ordinal = input.indexWhere(_.exprId == attribute.exprId)
+      if (ordinal < 0) {
+        attribute
+      } else {
+        AttributeReference("none", attribute.dataType)(ExprId(ordinal))
+      }
+  }
+
   private def physicalCompatibilityKey(
       key: CompatibilityKey,
       accuracy: Expression): PhysicalCompatibilityKey = PhysicalCompatibilityKey(
     key.child.canonicalized,
     accuracy.canonicalized,
     key.mode,
-    key.isDistinct,
+    // OptimizeOneRowPlan can remove DISTINCT later, including during AQE.
+    isDistinct = false,
     key.filter.map(_.canonicalized))
+
+  private def hasSafePhysicalFusion(
+      expressions: scala.collection.Iterable[AggregateExpression]): Boolean = {
+    val physicalGroups = expressions.groupBy(_.canonicalized)
+    // PhysicalAggregation already shares a digest within each canonical group. Fusion must both
+    // remove a digest and preserve cases where canonical percentages evaluate differently.
+    physicalGroups.sizeCompare(1) > 0 && physicalGroups.values.forall { group =>
+      group.iterator.map { expression =>
+        expression.aggregateFunction
+          .asInstanceOf[ApproximatePercentile]
+          .percentageExpression
+          .eval()
+      }.toSet.sizeCompare(1) == 0
+    }
+  }
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
     _.containsPattern(AGGREGATE), ruleId) {
@@ -72,6 +132,8 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
   private def combine(aggregate: Aggregate): Aggregate = {
     val compatible = mutable.LinkedHashMap.empty[
       CompatibilityKey, mutable.ArrayBuffer[AggregateExpression]]
+    // PhysicalAggregation deduplicates semantically equivalent aggregates. Track every logical
+    // key that shares a physical key so fusion does not change that existing deduplication.
     val physicalCompatibilityKeys = mutable.HashMap.empty[
       PhysicalCompatibilityKey, mutable.HashSet[CompatibilityKey]]
     val arrayPercentiles = mutable.ArrayBuffer.empty[AggregateExpression]
@@ -83,6 +145,7 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
             filter.forall(_.deterministic) =>
         val key = CompatibilityKey(
           percentile.child,
+          // Analysis already validates that accuracy is foldable, non-null, and in range.
           percentile.accuracyExpression.eval().asInstanceOf[Number].longValue,
           mode,
           isDistinct,
@@ -99,13 +162,15 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     })
 
     val replacements = mutable.HashMap.empty[ExprId, (AggregateExpression, Int)]
-    compatible.iterator.filter { case (key, expressions) =>
-      expressions.sizeCompare(1) > 0 && expressions.forall { expression =>
+    compatible.iterator.map { case (key, expressions) =>
+      key -> expressions.distinctBy(_.resultId)
+    }.filter { case (key, expressions) =>
+      hasSafePhysicalFusion(expressions) && expressions.forall { expression =>
         val percentile = expression.aggregateFunction.asInstanceOf[ApproximatePercentile]
         physicalCompatibilityKeys(
           physicalCompatibilityKey(key, percentile.accuracyExpression)).sizeCompare(1) == 0
       }
-    }.foreach { case (_, expressions) =>
+    }.foreach { case (key, expressions) =>
       val first = expressions.head
       val percentile = first.aggregateFunction.asInstanceOf[ApproximatePercentile]
       val percentages = expressions.map { expression =>
@@ -113,12 +178,24 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
           .asInstanceOf[ApproximatePercentile]
           .percentageExpression
       }
-      val combined = first.copy(
-        aggregateFunction = percentile.copy(
-          percentageExpression = CreateArray(percentages.toSeq)))
+      val percentageValues = percentages.map(_.eval().asInstanceOf[Double]).toSeq
+      val combinedPercentile = percentile.copy(
+        percentageExpression = CreateArray(percentages.toSeq))
+      val combined = first.copy(aggregateFunction = combinedPercentile)
       if (!arrayPercentiles.exists(_.semanticEquals(combined))) {
+        val identity = PercentileFusionIdentity(
+          expressions.map { expression =>
+            structurallyNormalize(expression.aggregateFunction, aggregate.child.output)
+          }.toSeq,
+          key.mode,
+          key.isDistinct,
+          key.filter.map(structurallyNormalize(_, aggregate.child.output)),
+          percentageValues.map(java.lang.Double.doubleToRawLongBits))
+        val identifiedCombined = combined.copy(
+          aggregateFunction = combinedPercentile.copy(
+            percentageExpression = PercentileFusionArray(identity)))
         expressions.zipWithIndex.foreach { case (expression, index) =>
-          replacements.put(expression.resultId, (combined, index))
+          replacements.put(expression.resultId, (identifiedCombined, index))
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -194,7 +194,8 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
         percentageValues.map(java.lang.Double.doubleToRawLongBits))
       val combinedFunction = percentile.copy(percentageExpression = PercentileFusionArray(identity))
       combinedFunction.copyTagsFrom(percentile)
-      val combined = first.copy(aggregateFunction = combinedFunction)
+      val combined = first.copy(
+        aggregateFunction = combinedFunction, resultId = NamedExpression.newExprId)
       expressions.zipWithIndex.foreach { case (expression, index) =>
         replacements.put(expression.resultId, (combined, index))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -113,12 +113,14 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     // PhysicalAggregation already shares a digest within each canonical group. Fusion must both
     // remove a digest and preserve cases where canonical percentages evaluate differently.
     physicalGroups.sizeCompare(1) > 0 && physicalGroups.values.forall { group =>
-      group.iterator.map { expression =>
+      val percentages = group.iterator.map { expression =>
         expression.aggregateFunction
           .asInstanceOf[ApproximatePercentile]
           .percentageExpression
           .eval()
-      }.toSet.sizeCompare(1) == 0
+      }
+      val first = percentages.next()
+      percentages.forall(_ == first)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, ExprId, GetArrayItem, LeafExpression, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, ExprId, GetArrayItem, LeafExpression, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, ApproximatePercentile}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
@@ -87,13 +87,11 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
 
   private def structurallyNormalize(
       expression: Expression,
-      input: Seq[Attribute]): Expression = expression.transformUp {
+      inputOrdinals: scala.collection.Map[ExprId, Int]): Expression = expression.transformUp {
     case attribute: AttributeReference =>
-      val ordinal = input.indexWhere(_.exprId == attribute.exprId)
-      if (ordinal < 0) {
-        attribute
-      } else {
-        AttributeReference("none", attribute.dataType)(ExprId(ordinal))
+      inputOrdinals.get(attribute.exprId) match {
+        case Some(ordinal) => AttributeReference("none", attribute.dataType)(ExprId(ordinal))
+        case None => attribute
       }
   }
 
@@ -157,13 +155,25 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
     })
 
     val replacements = mutable.HashMap.empty[ExprId, (AggregateExpression, Int)]
+    lazy val inputOrdinals = {
+      val ordinals = mutable.HashMap.empty[ExprId, Int]
+      aggregate.child.output.zipWithIndex.foreach { case (attribute, ordinal) =>
+        ordinals.getOrElseUpdate(attribute.exprId, ordinal)
+      }
+      ordinals
+    }
     compatible.iterator.map { case (key, expressions) =>
       key -> expressions.distinctBy(_.resultId)
     }.filter { case (key, expressions) =>
       hasSafePhysicalFusion(expressions) && expressions.forall { expression =>
         val percentile = expression.aggregateFunction.asInstanceOf[ApproximatePercentile]
-        physicalCompatibilityKeys(
-          physicalCompatibilityKey(key, percentile.accuracyExpression)).sizeCompare(1) == 0
+        val physicalKey = physicalCompatibilityKey(key, percentile.accuracyExpression)
+        // OptimizeOneRowPlan can erase DISTINCT after fusion. Across distinctness boundaries,
+        // canonical matches are safe only when their original inputs and filters also match.
+        physicalCompatibilityKeys(physicalKey).sizeCompare(1) == 0 &&
+          physicalCompatibilityKeys
+            .get(physicalKey.copy(isDistinct = !physicalKey.isDistinct))
+            .forall(_.forall(other => other.child == key.child && other.filter == key.filter))
       }
     }.foreach { case (key, expressions) =>
       val first = expressions.head
@@ -176,14 +186,15 @@ object CombineApproximatePercentiles extends Rule[LogicalPlan] {
       val percentageValues = percentages.map(_.eval().asInstanceOf[Double]).toSeq
       val identity = PercentileFusionIdentity(
         expressions.map { expression =>
-          structurallyNormalize(expression.aggregateFunction, aggregate.child.output)
+          structurallyNormalize(expression.aggregateFunction, inputOrdinals)
         }.toSeq,
         key.mode,
         key.isDistinct,
-        key.filter.map(structurallyNormalize(_, aggregate.child.output)),
+        key.filter.map(structurallyNormalize(_, inputOrdinals)),
         percentageValues.map(java.lang.Double.doubleToRawLongBits))
-      val combined = first.copy(aggregateFunction = percentile.copy(
-        percentageExpression = PercentileFusionArray(identity)))
+      val combinedFunction = percentile.copy(percentageExpression = PercentileFusionArray(identity))
+      combinedFunction.copyTagsFrom(percentile)
+      val combined = first.copy(aggregateFunction = combinedFunction)
       expressions.zipWithIndex.foreach { case (expression, index) =>
         replacements.put(expression.resultId, (combined, index))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentiles.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.{CreateArray, Expression, ExprId, GetArrayItem, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, ApproximatePercentile}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.AGGREGATE
+import org.apache.spark.sql.types.DoubleType
+
+/**
+ * Combines scalar approximate percentiles that can share the same percentile digest.
+ *
+ * An approximate percentile digest depends on its input, accuracy, filter, distinctness, and
+ * aggregate mode, but not on the percentile requested from the completed digest. Consequently,
+ * compatible scalar percentiles can be calculated by one array-valued aggregate and projected
+ * back to their original scalar outputs.
+ *
+ * Inputs and filters must retain their original expression structure so that floating-point
+ * evaluation and ANSI overflow behavior are preserved. Streaming aggregates are left unchanged
+ * to preserve the value schemas of existing checkpoints.
+ */
+object CombineApproximatePercentiles extends Rule[LogicalPlan] {
+
+  private case class CompatibilityKey(
+      child: Expression,
+      accuracy: Long,
+      mode: AggregateMode,
+      isDistinct: Boolean,
+      filter: Option[Expression])
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
+    _.containsPattern(AGGREGATE), ruleId) {
+    case aggregate: Aggregate if aggregate.resolved && !aggregate.isStreaming =>
+      combine(aggregate)
+  }
+
+  private def combine(aggregate: Aggregate): Aggregate = {
+    val compatible = mutable.LinkedHashMap.empty[
+      CompatibilityKey, mutable.ArrayBuffer[AggregateExpression]]
+
+    aggregate.aggregateExpressions.foreach(_.foreach {
+      case expression @ AggregateExpression(
+          percentile: ApproximatePercentile, mode, isDistinct, filter, _)
+          if percentile.child.deterministic &&
+            filter.forall(_.deterministic) &&
+            percentile.percentageExpression.dataType == DoubleType =>
+        val key = CompatibilityKey(
+          percentile.child,
+          percentile.accuracyExpression.eval().asInstanceOf[Number].longValue,
+          mode,
+          isDistinct,
+          filter)
+        compatible.getOrElseUpdate(key, mutable.ArrayBuffer.empty) += expression
+      case _ =>
+    })
+
+    val replacements = mutable.HashMap.empty[ExprId, (AggregateExpression, Int)]
+    compatible.valuesIterator.filter(_.sizeCompare(1) > 0).foreach { expressions =>
+      val first = expressions.head
+      val percentile = first.aggregateFunction.asInstanceOf[ApproximatePercentile]
+      val percentages = expressions.map { expression =>
+        expression.aggregateFunction
+          .asInstanceOf[ApproximatePercentile]
+          .percentageExpression
+      }
+      val combined = first.copy(
+        aggregateFunction = percentile.copy(
+          percentageExpression = CreateArray(percentages.toSeq)))
+      expressions.zipWithIndex.foreach { case (expression, index) =>
+        replacements.put(expression.resultId, (combined, index))
+      }
+    }
+
+    if (replacements.isEmpty) {
+      aggregate
+    } else {
+      val rewrittenExpressions = aggregate.aggregateExpressions.map { expression =>
+        expression.transformUp {
+          case original: AggregateExpression if replacements.contains(original.resultId) =>
+            val (combined, index) = replacements(original.resultId)
+            GetArrayItem(combined, Literal(index), failOnError = false)
+        }.asInstanceOf[NamedExpression]
+      }
+      aggregate.copy(aggregateExpressions = rewrittenExpressions)
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -255,6 +255,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Eliminate Sorts", Once,
       EliminateSorts,
       RemoveRedundantSorts),
+    // Run after operator optimization normally folds accuracy expressions and before
+    // RewriteDistinctAggregates so fused distinct percentiles are rewritten correctly.
     Batch("Combine Approximate Percentiles", Once,
       CombineApproximatePercentiles),
     Batch("Decimal Optimizations", fixedPoint,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -255,6 +255,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Eliminate Sorts", Once,
       EliminateSorts,
       RemoveRedundantSorts),
+    Batch("Combine Approximate Percentiles", Once,
+      CombineApproximatePercentiles),
     Batch("Decimal Optimizations", fixedPoint,
       DecimalAggregates),
     // This batch must run after "Decimal Optimizations", as that one may change the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -84,6 +84,9 @@ object ConstantFolding extends Rule[LogicalPlan] {
     // object and running eval unnecessarily.
     case l: Literal => l
 
+    // This foldable expression carries planning identity that must survive later optimizer batches.
+    case p: PercentileFusionArray => p
+
     case Size(c: CreateArray, _) if c.children.forall(hasNoSideEffect) =>
       Literal(c.children.length)
     case Size(c: CreateMap, _) if c.children.forall(hasNoSideEffect) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -127,6 +127,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.CollapseRepartition" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseWindow" ::
       "org.apache.spark.sql.catalyst.optimizer.ColumnPruning" ::
+      "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles" ::
       "org.apache.spark.sql.catalyst.optimizer.CombineConcats" ::
       "org.apache.spark.sql.catalyst.optimizer.CombineFilters" ::
       "org.apache.spark.sql.catalyst.optimizer.CombineTypedFilters" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -886,6 +886,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val COMBINE_APPROXIMATE_PERCENTILES_ENABLED =
+    buildConf("spark.sql.optimizer.combineApproximatePercentiles.enabled")
+      .doc("When true, combines compatible scalar approximate percentile aggregates into a " +
+        "single array-valued aggregate so they share one percentile digest.")
+      .version("5.0.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(false)
+
   val EXPRESSION_PROJECTION_CANDIDATE_LIMIT =
     buildConf("spark.sql.optimizer.expressionProjectionCandidateLimit")
       .doc("The maximum number of the candidate of output expressions whose alias are replaced." +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.IntegerType
 
 class CombineApproximatePercentilesSuite extends PlanTest {
@@ -52,7 +53,9 @@ class CombineApproximatePercentilesSuite extends PlanTest {
 
   private def optimizedAggregate(expressions: Alias*): Aggregate = {
     val plan = Aggregate(Seq.empty, expressions, relation)
-    Optimize.execute(plan.analyze).asInstanceOf[Aggregate]
+    withSQLConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "true") {
+      Optimize.execute(plan.analyze).asInstanceOf[Aggregate]
+    }
   }
 
   private def percentileAggregates(aggregate: Aggregate): Seq[AggregateExpression] = {
@@ -77,6 +80,20 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(!aggregate.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
   }
 
+  test("do not combine approximate percentiles when disabled") {
+    assert(!new SQLConf().getConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED))
+    val original = Aggregate(
+      Seq.empty,
+      Seq(
+        Alias(percentile(value, 0.5), "p50")(),
+        Alias(percentile(value, 0.9), "p90")()),
+      relation).analyze.asInstanceOf[Aggregate]
+
+    withSQLConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "false") {
+      assertNotCombined(Optimize.execute(original).asInstanceOf[Aggregate])
+    }
+  }
+
   test("combine compatible percentiles and preserve output shape") {
     val firstPercentile = percentile(value, 0.9)
     firstPercentile.aggregateFunction.setTagValue(FunctionRegistry.FUNC_ALIAS, "approx_percentile")
@@ -86,7 +103,9 @@ class CombineApproximatePercentilesSuite extends PlanTest {
       Alias(percentile(value, 0.9), "third")())
     val original = Aggregate(Seq(group), group +: aliases, relation).analyze
       .asInstanceOf[Aggregate]
-    val result = Optimize.execute(original).asInstanceOf[Aggregate]
+    val result = withSQLConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "true") {
+      Optimize.execute(original).asInstanceOf[Aggregate]
+    }
     val aggregates = percentileAggregates(result)
     val combined = aggregates.head.aggregateFunction.asInstanceOf[ApproximatePercentile]
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -105,6 +105,7 @@ class CombineApproximatePercentilesSuite extends PlanTest {
       .asInstanceOf[ApproximatePercentile]
 
     assert(combined.percentageExpression.isInstanceOf[PercentileFusionArray])
+    assert(!combined.percentageExpression.contextIndependentFoldable)
   }
 
   test("avoid redundant entries for duplicate physical aggregates") {
@@ -151,8 +152,8 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     val compatible = optimizedAggregate(
       Alias(percentile(value, 0.5, filter = Some(filter)), "filtered_p50")(),
       Alias(percentile(value, 0.9, filter = Some(filter)), "filtered_p90")(),
-      Alias(percentile(value, 0.5, isDistinct = true), "distinct_p50")(),
-      Alias(percentile(value, 0.9, isDistinct = true), "distinct_p90")())
+      Alias(percentile(value, 0.5, isDistinct = true, filter = Some(filter)), "distinct_p50")(),
+      Alias(percentile(value, 0.9, isDistinct = true, filter = Some(filter)), "distinct_p90")())
     assert(percentileAggregates(compatible).map(_.resultId).distinct.size == 2)
   }
 
@@ -229,7 +230,13 @@ class CombineApproximatePercentilesSuite extends PlanTest {
       Alias(arrayPercentile, "percentiles")(),
       Alias(percentileWithPercentage(secondPercentage), "p0")(),
       Alias(percentile(value, 0.9), "p90")())
-    assertNotCombined(arrayResult)
+    val arrayAggregates = percentileAggregates(arrayResult)
+    assert(arrayAggregates.map(_.resultId).distinct.size == 2)
+    assert(percentageValues(arrayAggregates.head.aggregateFunction
+      .asInstanceOf[ApproximatePercentile]) == Seq(0.5, 0.9))
+    assert(percentageValues(arrayAggregates(1).aggregateFunction
+      .asInstanceOf[ApproximatePercentile]) == Seq(0.0, 0.9))
+    assert(ordinals(arrayResult) == Seq(None, Some(0), Some(1)))
   }
 
   test("preserve existing arrays while combining compatible scalars") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.IntegerType
 
 class CombineApproximatePercentilesSuite extends PlanTest {
 
@@ -129,6 +130,46 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
   }
 
+  test("do not fuse canonically equivalent but structurally different input groups") {
+    val firstInput = value + (other + group)
+    val secondInput = (value + other) + group
+    val result = optimizedAggregate(
+      Alias(percentile(firstInput, 0.5), "first_p50")(),
+      Alias(percentile(secondInput, 0.5), "second_p50")(),
+      Alias(percentile(secondInput, 0.9), "second_p90")(),
+      Alias(percentile(firstInput, 0.9), "first_p90")())
+
+    assert(firstInput != secondInput)
+    assert(firstInput.canonicalized == secondInput.canonicalized)
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 4)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not fuse canonically equivalent but differently evaluated accuracies") {
+    val firstAccuracy =
+      ((Literal(1.0e16) + Literal(-1.0e16)) + Literal(3.0)).cast(IntegerType)
+    val secondAccuracy =
+      (Literal(1.0e16) + (Literal(-1.0e16) + Literal(3.0))).cast(IntegerType)
+
+    def percentileWithAccuracy(
+        percentage: Double,
+        accuracy: Expression): AggregateExpression = {
+      new ApproximatePercentile(value, Literal(percentage), accuracy).toAggregateExpression()
+    }
+
+    val result = optimizedAggregate(
+      Alias(percentileWithAccuracy(0.5, firstAccuracy), "first_p50")(),
+      Alias(percentileWithAccuracy(0.5, secondAccuracy), "second_p50")(),
+      Alias(percentileWithAccuracy(0.9, secondAccuracy), "second_p90")(),
+      Alias(percentileWithAccuracy(0.9, firstAccuracy), "first_p90")())
+
+    assert(firstAccuracy.eval() == 3)
+    assert(secondAccuracy.eval() == 4)
+    assert(firstAccuracy.canonicalized == secondAccuracy.canonicalized)
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 4)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
   test("do not combine percentiles with different input columns") {
     val result = optimizedAggregate(
       Alias(percentile(value, 0.5), "value_p50")(),
@@ -208,6 +249,29 @@ class CombineApproximatePercentilesSuite extends PlanTest {
       Alias(percentile(value, 0.95), "p95")())
 
     assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not fuse percentages that collide with an existing array percentile") {
+    val firstPercentage =
+      (Literal(1.0e16) + Literal(-1.0e16)) + Literal(0.5)
+    val secondPercentage =
+      Literal(1.0e16) + (Literal(-1.0e16) + Literal(0.5))
+    val arrayPercentile = new ApproximatePercentile(
+      value,
+      CreateArray(Seq(firstPercentage, Literal(0.9))),
+      Literal(10000)).toAggregateExpression()
+    val scalarPercentile = new ApproximatePercentile(
+      value, secondPercentage, Literal(10000)).toAggregateExpression()
+    val result = optimizedAggregate(
+      Alias(arrayPercentile, "percentiles")(),
+      Alias(scalarPercentile, "p0")(),
+      Alias(percentile(value, 0.9), "p90")())
+
+    assert(firstPercentage.eval() == 0.5d)
+    assert(secondPercentage.eval() == 0.0d)
+    assert(firstPercentage.canonicalized == secondPercentage.canonicalized)
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 3)
     assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -64,27 +64,36 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     percentile.percentageExpression.eval().asInstanceOf[ArrayData].toDoubleArray().toSeq
   }
 
-  test("combine scalar percentiles into one shared array-valued digest") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5), "p50")(),
-      Alias(percentile(value, 0.9), "p90")(),
-      Alias(percentile(value, 0.95), "p95")())
-
-    val aggregateExpressions = percentileAggregates(result)
-    assert(aggregateExpressions.size == 3)
-    assert(aggregateExpressions.map(_.resultId).distinct.size == 1)
-
-    val combined = aggregateExpressions.head.aggregateFunction
-      .asInstanceOf[ApproximatePercentile]
-    assert(percentageValues(combined) == Seq(0.5, 0.9, 0.95))
-    assert(combined.percentageExpression.toString == "[0.5,0.9,0.95]")
-    assert(combined.percentageExpression.sql == "ARRAY(0.5D, 0.9D, 0.95D)")
-
-    val ordinals = result.aggregateExpressions.map(_.collectFirst {
+  private def ordinals(aggregate: Aggregate): Seq[Option[Int]] = {
+    aggregate.aggregateExpressions.map(_.collectFirst {
       case GetArrayItem(_, Literal(index: Int, _), false) => index
     })
-    assert(ordinals == Seq(Some(0), Some(1), Some(2)))
-    assert(result.output.map(_.name) == Seq("p50", "p90", "p95"))
+  }
+
+  private def assertNotCombined(aggregate: Aggregate): Unit = {
+    val expressions = percentileAggregates(aggregate)
+    assert(expressions.map(_.resultId).distinct.size == expressions.size)
+    assert(!aggregate.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("combine compatible percentiles and preserve output shape") {
+    val aliases = Seq(
+      Alias(percentile(value, 0.9), "first")(),
+      Alias(percentile(value, 0.5), "second")(),
+      Alias(percentile(value, 0.9), "third")())
+    val original = Aggregate(Seq(group), group +: aliases, relation).analyze
+      .asInstanceOf[Aggregate]
+    val result = Optimize.execute(original).asInstanceOf[Aggregate]
+    val aggregates = percentileAggregates(result)
+    val combined = aggregates.head.aggregateFunction.asInstanceOf[ApproximatePercentile]
+
+    assert(aggregates.map(_.resultId).distinct.size == 1)
+    assert(percentageValues(combined) == Seq(0.9, 0.5, 0.9))
+    assert(combined.percentageExpression.toString == "[0.9,0.5,0.9]")
+    assert(combined.percentageExpression.sql == "ARRAY(0.9D, 0.5D, 0.9D)")
+    assert(ordinals(result) == Seq(None, Some(0), Some(1), Some(2)))
+    assert(result.groupingExpressions == original.groupingExpressions)
+    assert(result.output.map(_.exprId) == original.output.map(_.exprId))
   }
 
   test("preserve fusion identity through later constant folding") {
@@ -98,83 +107,59 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(combined.percentageExpression.isInstanceOf[PercentileFusionArray])
   }
 
-  test("preserve duplicate and non-monotonic percentile order") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.9), "first")(),
-      Alias(percentile(value, 0.5), "second")(),
-      Alias(percentile(value, 0.9), "third")())
-
-    val combined = percentileAggregates(result).head.aggregateFunction
-      .asInstanceOf[ApproximatePercentile]
-    assert(percentageValues(combined) == Seq(0.9, 0.5, 0.9))
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
-  }
-
-  test("do not combine duplicate percentiles when physical planning already shares the digest") {
-    val result = optimizedAggregate(
+  test("avoid redundant entries for duplicate physical aggregates") {
+    val duplicateOnly = optimizedAggregate(
       Alias(percentile(value, 0.5), "first")(),
       Alias(percentile(value, 0.5), "second")())
+    assertNotCombined(duplicateOnly)
 
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("deduplicate repeated aggregate expression instances before combining") {
     val p50 = percentile(value, 0.5)
-    val result = optimizedAggregate(
+    val mixed = optimizedAggregate(
       Alias(p50, "first")(),
       Alias(p50, "second")(),
       Alias(percentile(value, 0.9), "third")())
-
-    val combined = percentileAggregates(result).head.aggregateFunction
+    val combined = percentileAggregates(mixed).head.aggregateFunction
       .asInstanceOf[ApproximatePercentile]
     assert(percentageValues(combined) == Seq(0.5, 0.9))
-    val ordinals = result.aggregateExpressions.map(_.collectFirst {
-      case GetArrayItem(_, Literal(index: Int, _), false) => index
-    })
-    assert(ordinals == Seq(Some(0), Some(0), Some(1)))
+    assert(ordinals(mixed) == Seq(Some(0), Some(0), Some(1)))
   }
 
-  test("combine scalar percentiles nested in a result expression") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5) + percentile(value, 0.9), "percentile_sum")())
+  test("respect basic compatibility boundaries") {
+    val incompatible = Seq(
+      "input" -> (
+        percentile(value, 0.5),
+        percentile(other, 0.9)),
+      "accuracy" -> (
+        percentile(value, 0.5, accuracy = 1000),
+        percentile(value, 0.9, accuracy = 10000)),
+      "filter" -> (
+        percentile(value, 0.5),
+        percentile(value, 0.9, filter = Some(value > Literal(0)))),
+      "distinct" -> (
+        percentile(value, 0.5),
+        percentile(value, 0.9, isDistinct = true)))
 
-    val expressions = percentileAggregates(result)
-    assert(expressions.size == 2)
-    assert(expressions.map(_.resultId).distinct.size == 1)
-    assert(result.output.head.name == "percentile_sum")
+    incompatible.foreach { case (name, (first, second)) =>
+      withClue(name) {
+        assertNotCombined(optimizedAggregate(
+          Alias(first, "first")(),
+          Alias(second, "second")()))
+      }
+    }
+
+    val filter = value > Literal(0)
+    val compatible = optimizedAggregate(
+      Alias(percentile(value, 0.5, filter = Some(filter)), "filtered_p50")(),
+      Alias(percentile(value, 0.9, filter = Some(filter)), "filtered_p90")(),
+      Alias(percentile(value, 0.5, isDistinct = true), "distinct_p50")(),
+      Alias(percentile(value, 0.9, isDistinct = true), "distinct_p90")())
+    assert(percentileAggregates(compatible).map(_.resultId).distinct.size == 2)
   }
 
-  test("combine structurally equivalent input expressions") {
-    val result = optimizedAggregate(
-      Alias(percentile(value + Literal(1), 0.5), "p50")(),
-      Alias(percentile(value + Literal(1), 0.9), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
-  }
-
-  test("do not combine differently ordered input expressions") {
-    val result = optimizedAggregate(
-      Alias(percentile(value + Literal(1), 0.5), "p50")(),
-      Alias(percentile(Literal(1) + value, 0.9), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not combine differently associated input expressions") {
-    val result = optimizedAggregate(
-      Alias(percentile((value + other) + group, 0.5), "p50")(),
-      Alias(percentile(value + (other + group), 0.9), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not fuse canonically equivalent but structurally different input groups") {
+  test("require structural equality for inputs and filters") {
     val firstInput = value + (other + group)
     val secondInput = (value + other) + group
-    val result = optimizedAggregate(
+    val inputResult = optimizedAggregate(
       Alias(percentile(firstInput, 0.5), "first_p50")(),
       Alias(percentile(secondInput, 0.5), "second_p50")(),
       Alias(percentile(secondInput, 0.9), "second_p90")(),
@@ -182,8 +167,16 @@ class CombineApproximatePercentilesSuite extends PlanTest {
 
     assert(firstInput != secondInput)
     assert(firstInput.canonicalized == secondInput.canonicalized)
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 4)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+    assertNotCombined(inputResult)
+
+    val firstFilter = firstInput > Literal(0)
+    val secondFilter = secondInput > Literal(0)
+    val filterResult = optimizedAggregate(
+      Alias(percentile(value, 0.5, filter = Some(firstFilter)), "first_p50")(),
+      Alias(percentile(value, 0.5, filter = Some(secondFilter)), "second_p50")(),
+      Alias(percentile(value, 0.9, filter = Some(secondFilter)), "second_p90")(),
+      Alias(percentile(value, 0.9, filter = Some(firstFilter)), "first_p90")())
+    assertNotCombined(filterResult)
   }
 
   test("do not fuse canonically equivalent but differently evaluated accuracies") {
@@ -207,116 +200,10 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(firstAccuracy.eval() == 3)
     assert(secondAccuracy.eval() == 4)
     assert(firstAccuracy.canonicalized == secondAccuracy.canonicalized)
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 4)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+    assertNotCombined(result)
   }
 
-  test("do not combine percentiles with different input columns") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5), "value_p50")(),
-      Alias(percentile(other, 0.9), "other_p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not combine percentiles with different accuracies") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5, accuracy = 1000), "p50")(),
-      Alias(percentile(value, 0.9, accuracy = 10000), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("combine only percentiles with structurally equivalent filters") {
-    val firstFilter = value > Literal(0)
-    val equivalentFilter = value > Literal(0)
-    val secondFilter = value > Literal(1)
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5, filter = Some(firstFilter)), "p50")(),
-      Alias(percentile(value, 0.9, filter = Some(equivalentFilter)), "p90")(),
-      Alias(percentile(value, 0.95, filter = Some(secondFilter)), "p95")())
-
-    val expressions = percentileAggregates(result)
-    assert(expressions.take(2).map(_.resultId).distinct.size == 1)
-    assert(expressions.map(_.resultId).distinct.size == 2)
-  }
-
-  test("do not combine percentiles with differently associated filters") {
-    val firstFilter = ((value + other) + group) > Literal(0)
-    val secondFilter = (value + (other + group)) > Literal(0)
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5, filter = Some(firstFilter)), "p50")(),
-      Alias(percentile(value, 0.9, filter = Some(secondFilter)), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not combine filtered and unfiltered percentiles") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5), "p50")(),
-      Alias(percentile(value, 0.9, filter = Some(value > Literal(0))), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not combine distinct and non-distinct percentiles") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5), "p50")(),
-      Alias(percentile(value, 0.9, isDistinct = true), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("combine distinct percentiles with the same input") {
-    val result = optimizedAggregate(
-      Alias(percentile(value, 0.5, isDistinct = true), "p50")(),
-      Alias(percentile(value, 0.9, isDistinct = true), "p90")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
-  }
-
-  test("leave existing array percentiles unchanged") {
-    val arrayPercentile = new ApproximatePercentile(
-      value,
-      CreateArray(Seq(Literal(0.5), Literal(0.9))),
-      Literal(10000)).toAggregateExpression()
-    val result = optimizedAggregate(
-      Alias(arrayPercentile, "percentiles")(),
-      Alias(percentile(value, 0.95), "p95")())
-
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not fuse percentages that collide with an existing array percentile") {
-    val firstPercentage =
-      (Literal(1.0e16) + Literal(-1.0e16)) + Literal(0.5)
-    val secondPercentage =
-      Literal(1.0e16) + (Literal(-1.0e16) + Literal(0.5))
-    val arrayPercentile = new ApproximatePercentile(
-      value,
-      CreateArray(Seq(firstPercentage, Literal(0.9))),
-      Literal(10000)).toAggregateExpression()
-    val scalarPercentile = new ApproximatePercentile(
-      value, secondPercentage, Literal(10000)).toAggregateExpression()
-    val result = optimizedAggregate(
-      Alias(arrayPercentile, "percentiles")(),
-      Alias(scalarPercentile, "p0")(),
-      Alias(percentile(value, 0.9), "p90")())
-
-    assert(firstPercentage.eval() == 0.5d)
-    assert(secondPercentage.eval() == 0.0d)
-    assert(firstPercentage.canonicalized == secondPercentage.canonicalized)
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 3)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
-  }
-
-  test("do not fuse canonically equivalent but differently evaluated scalar percentages") {
+  test("do not fuse canonically equal percentages that evaluate differently") {
     val firstPercentage =
       (Literal(1.0e16) + Literal(-1.0e16)) + Literal(0.5)
     val secondPercentage =
@@ -324,51 +211,38 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     def percentileWithPercentage(percentage: Expression): AggregateExpression = {
       new ApproximatePercentile(value, percentage, Literal(10000)).toAggregateExpression()
     }
-    val result = optimizedAggregate(
+
+    val scalarResult = optimizedAggregate(
       Alias(percentileWithPercentage(firstPercentage), "p50")(),
       Alias(percentileWithPercentage(secondPercentage), "p0")(),
       Alias(percentile(value, 0.9), "p90")())
-
     assert(firstPercentage.eval() == 0.5d)
     assert(secondPercentage.eval() == 0.0d)
     assert(firstPercentage.canonicalized == secondPercentage.canonicalized)
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 3)
-    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+    assertNotCombined(scalarResult)
+
+    val arrayPercentile = new ApproximatePercentile(
+      value,
+      CreateArray(Seq(firstPercentage, Literal(0.9))),
+      Literal(10000)).toAggregateExpression()
+    val arrayResult = optimizedAggregate(
+      Alias(arrayPercentile, "percentiles")(),
+      Alias(percentileWithPercentage(secondPercentage), "p0")(),
+      Alias(percentile(value, 0.9), "p90")())
+    assertNotCombined(arrayResult)
   }
 
-  test("preserve grouping expressions and output expression identifiers") {
-    val p50 = Alias(percentile(value, 0.5), "p50")()
-    val p90 = Alias(percentile(value, 0.9), "p90")()
-    val original = Aggregate(Seq(group), Seq(group, p50, p90), relation).analyze
-      .asInstanceOf[Aggregate]
-    val result = Optimize.execute(original).asInstanceOf[Aggregate]
+  test("preserve existing arrays while combining compatible scalars") {
+    val arrayPercentile = new ApproximatePercentile(
+      value,
+      CreateArray(Seq(Literal(0.25), Literal(0.75))),
+      Literal(10000)).toAggregateExpression()
+    val result = optimizedAggregate(
+      Alias(arrayPercentile, "percentiles")(),
+      Alias(percentile(value, 0.5), "p50")(),
+      Alias(percentile(value, 0.9), "p90")())
 
-    assert(result.groupingExpressions == original.groupingExpressions)
-    assert(result.output.map(_.exprId) == original.output.map(_.exprId))
-    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
-  }
-
-  test("do not rewrite streaming aggregates") {
-    val streamingRelation = relation.copy(isStreaming = true)
-    val streamingValue = streamingRelation.output.head
-    val original = Aggregate(
-      Seq.empty,
-      Seq(
-        Alias(percentile(streamingValue, 0.5), "p50")(),
-        Alias(percentile(streamingValue, 0.9), "p90")()),
-      streamingRelation).analyze.asInstanceOf[Aggregate]
-
-    assert(original.isStreaming)
-    assert(percentileAggregates(original).map(_.resultId).distinct.size == 2)
-    assert(Optimize.execute(original).fastEquals(original))
-  }
-
-  test("do not rewrite a single scalar percentile") {
-    val original = Aggregate(
-      Seq.empty,
-      Seq(Alias(percentile(value, 0.5), "p50")()),
-      relation).analyze
-
-    assert(Optimize.execute(original).fastEquals(original))
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(result.aggregateExpressions.drop(1).forall(_.exists(_.isInstanceOf[GetArrayItem])))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.IntegerType
 
 class CombineApproximatePercentilesSuite extends PlanTest {
@@ -59,6 +60,10 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     })
   }
 
+  private def percentageValues(percentile: ApproximatePercentile): Seq[Double] = {
+    percentile.percentageExpression.eval().asInstanceOf[ArrayData].toDoubleArray().toSeq
+  }
+
   test("combine scalar percentiles into one shared array-valued digest") {
     val result = optimizedAggregate(
       Alias(percentile(value, 0.5), "p50")(),
@@ -71,14 +76,26 @@ class CombineApproximatePercentilesSuite extends PlanTest {
 
     val combined = aggregateExpressions.head.aggregateFunction
       .asInstanceOf[ApproximatePercentile]
-    assert(combined.percentageExpression ==
-      CreateArray(Seq(Literal(0.5), Literal(0.9), Literal(0.95))))
+    assert(percentageValues(combined) == Seq(0.5, 0.9, 0.95))
+    assert(combined.percentageExpression.toString == "[0.5,0.9,0.95]")
+    assert(combined.percentageExpression.sql == "ARRAY(0.5D, 0.9D, 0.95D)")
 
     val ordinals = result.aggregateExpressions.map(_.collectFirst {
       case GetArrayItem(_, Literal(index: Int, _), false) => index
     })
     assert(ordinals == Seq(Some(0), Some(1), Some(2)))
     assert(result.output.map(_.name) == Seq("p50", "p90", "p95"))
+  }
+
+  test("preserve fusion identity through later constant folding") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5), "p50")(),
+      Alias(percentile(value, 0.9), "p90")())
+    val folded = ConstantFolding(result).asInstanceOf[Aggregate]
+    val combined = percentileAggregates(folded).head.aggregateFunction
+      .asInstanceOf[ApproximatePercentile]
+
+    assert(combined.percentageExpression.isInstanceOf[PercentileFusionArray])
   }
 
   test("preserve duplicate and non-monotonic percentile order") {
@@ -89,9 +106,33 @@ class CombineApproximatePercentilesSuite extends PlanTest {
 
     val combined = percentileAggregates(result).head.aggregateFunction
       .asInstanceOf[ApproximatePercentile]
-    assert(combined.percentageExpression ==
-      CreateArray(Seq(Literal(0.9), Literal(0.5), Literal(0.9))))
+    assert(percentageValues(combined) == Seq(0.9, 0.5, 0.9))
     assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
+  }
+
+  test("do not combine duplicate percentiles when physical planning already shares the digest") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5), "first")(),
+      Alias(percentile(value, 0.5), "second")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("deduplicate repeated aggregate expression instances before combining") {
+    val p50 = percentile(value, 0.5)
+    val result = optimizedAggregate(
+      Alias(p50, "first")(),
+      Alias(p50, "second")(),
+      Alias(percentile(value, 0.9), "third")())
+
+    val combined = percentileAggregates(result).head.aggregateFunction
+      .asInstanceOf[ApproximatePercentile]
+    assert(percentageValues(combined) == Seq(0.5, 0.9))
+    val ordinals = result.aggregateExpressions.map(_.collectFirst {
+      case GetArrayItem(_, Literal(index: Int, _), false) => index
+    })
+    assert(ordinals == Seq(Some(0), Some(0), Some(1)))
   }
 
   test("combine scalar percentiles nested in a result expression") {
@@ -266,6 +307,26 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     val result = optimizedAggregate(
       Alias(arrayPercentile, "percentiles")(),
       Alias(scalarPercentile, "p0")(),
+      Alias(percentile(value, 0.9), "p90")())
+
+    assert(firstPercentage.eval() == 0.5d)
+    assert(secondPercentage.eval() == 0.0d)
+    assert(firstPercentage.canonicalized == secondPercentage.canonicalized)
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 3)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not fuse canonically equivalent but differently evaluated scalar percentages") {
+    val firstPercentage =
+      (Literal(1.0e16) + Literal(-1.0e16)) + Literal(0.5)
+    val secondPercentage =
+      Literal(1.0e16) + (Literal(-1.0e16) + Literal(0.5))
+    def percentileWithPercentage(percentage: Expression): AggregateExpression = {
+      new ApproximatePercentile(value, percentage, Literal(10000)).toAggregateExpression()
+    }
+    val result = optimizedAggregate(
+      Alias(percentileWithPercentage(firstPercentage), "p50")(),
+      Alias(percentileWithPercentage(secondPercentage), "p0")(),
       Alias(percentile(value, 0.9), "p90")())
 
     assert(firstPercentage.eval() == 0.5d)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Alias, CreateArray, Expression, GetArrayItem, Literal}
@@ -77,8 +78,10 @@ class CombineApproximatePercentilesSuite extends PlanTest {
   }
 
   test("combine compatible percentiles and preserve output shape") {
+    val firstPercentile = percentile(value, 0.9)
+    firstPercentile.aggregateFunction.setTagValue(FunctionRegistry.FUNC_ALIAS, "approx_percentile")
     val aliases = Seq(
-      Alias(percentile(value, 0.9), "first")(),
+      Alias(firstPercentile, "first")(),
       Alias(percentile(value, 0.5), "second")(),
       Alias(percentile(value, 0.9), "third")())
     val original = Aggregate(Seq(group), group +: aliases, relation).analyze
@@ -91,6 +94,7 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(percentageValues(combined) == Seq(0.9, 0.5, 0.9))
     assert(combined.percentageExpression.toString == "[0.9,0.5,0.9]")
     assert(combined.percentageExpression.sql == "ARRAY(0.9D, 0.5D, 0.9D)")
+    assert(combined.prettyName == "approx_percentile")
     assert(ordinals(result) == Seq(None, Some(0), Some(1), Some(2)))
     assert(result.groupingExpressions == original.groupingExpressions)
     assert(result.output.map(_.exprId) == original.output.map(_.exprId))
@@ -170,6 +174,13 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(firstInput.canonicalized == secondInput.canonicalized)
     assertNotCombined(inputResult)
 
+    val crossDistinctInput = optimizedAggregate(
+      Alias(percentile(firstInput, 0.5), "first_p50")(),
+      Alias(percentile(firstInput, 0.9), "first_p90")(),
+      Alias(percentile(secondInput, 0.5, isDistinct = true), "distinct_p50")(),
+      Alias(percentile(secondInput, 0.9, isDistinct = true), "distinct_p90")())
+    assertNotCombined(crossDistinctInput)
+
     val firstFilter = firstInput > Literal(0)
     val secondFilter = secondInput > Literal(0)
     val filterResult = optimizedAggregate(
@@ -178,6 +189,15 @@ class CombineApproximatePercentilesSuite extends PlanTest {
       Alias(percentile(value, 0.9, filter = Some(secondFilter)), "second_p90")(),
       Alias(percentile(value, 0.9, filter = Some(firstFilter)), "first_p90")())
     assertNotCombined(filterResult)
+
+    val crossDistinctFilter = optimizedAggregate(
+      Alias(percentile(value, 0.5, filter = Some(firstFilter)), "first_p50")(),
+      Alias(percentile(value, 0.9, filter = Some(firstFilter)), "first_p90")(),
+      Alias(percentile(
+        value, 0.5, isDistinct = true, filter = Some(secondFilter)), "distinct_p50")(),
+      Alias(percentile(
+        value, 0.9, isDistinct = true, filter = Some(secondFilter)), "distinct_p90")())
+    assertNotCombined(crossDistinctFilter)
   }
 
   test("do not fuse canonically equivalent but differently evaluated accuracies") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{Alias, CreateArray, Expression, GetArrayItem, Literal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, ApproximatePercentile}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class CombineApproximatePercentilesSuite extends PlanTest {
+
+  private object Optimize extends RuleExecutor[LogicalPlan] {
+    override val batches: Seq[Batch] =
+      Batch("Combine Approximate Percentiles", Once, CombineApproximatePercentiles) :: Nil
+  }
+
+  private val relation = LocalRelation($"value".int, $"other".int, $"group".int)
+  private val value = relation.output(0)
+  private val other = relation.output(1)
+  private val group = relation.output(2)
+
+  private def percentile(
+      child: Expression,
+      percentage: Double,
+      accuracy: Int = 10000,
+      isDistinct: Boolean = false,
+      filter: Option[Expression] = None): AggregateExpression = {
+    new ApproximatePercentile(child, Literal(percentage), Literal(accuracy))
+      .toAggregateExpression(isDistinct = isDistinct, filter = filter)
+  }
+
+  private def optimizedAggregate(expressions: Alias*): Aggregate = {
+    val plan = Aggregate(Seq.empty, expressions, relation)
+    Optimize.execute(plan.analyze).asInstanceOf[Aggregate]
+  }
+
+  private def percentileAggregates(aggregate: Aggregate): Seq[AggregateExpression] = {
+    aggregate.aggregateExpressions.flatMap(_.collect {
+      case expression @ AggregateExpression(_: ApproximatePercentile, _, _, _, _) => expression
+    })
+  }
+
+  test("combine scalar percentiles into one shared array-valued digest") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5), "p50")(),
+      Alias(percentile(value, 0.9), "p90")(),
+      Alias(percentile(value, 0.95), "p95")())
+
+    val aggregateExpressions = percentileAggregates(result)
+    assert(aggregateExpressions.size == 3)
+    assert(aggregateExpressions.map(_.resultId).distinct.size == 1)
+
+    val combined = aggregateExpressions.head.aggregateFunction
+      .asInstanceOf[ApproximatePercentile]
+    assert(combined.percentageExpression ==
+      CreateArray(Seq(Literal(0.5), Literal(0.9), Literal(0.95))))
+
+    val ordinals = result.aggregateExpressions.map(_.collectFirst {
+      case GetArrayItem(_, Literal(index: Int, _), false) => index
+    })
+    assert(ordinals == Seq(Some(0), Some(1), Some(2)))
+    assert(result.output.map(_.name) == Seq("p50", "p90", "p95"))
+  }
+
+  test("preserve duplicate and non-monotonic percentile order") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.9), "first")(),
+      Alias(percentile(value, 0.5), "second")(),
+      Alias(percentile(value, 0.9), "third")())
+
+    val combined = percentileAggregates(result).head.aggregateFunction
+      .asInstanceOf[ApproximatePercentile]
+    assert(combined.percentageExpression ==
+      CreateArray(Seq(Literal(0.9), Literal(0.5), Literal(0.9))))
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
+  }
+
+  test("combine scalar percentiles nested in a result expression") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5) + percentile(value, 0.9), "percentile_sum")())
+
+    val expressions = percentileAggregates(result)
+    assert(expressions.size == 2)
+    assert(expressions.map(_.resultId).distinct.size == 1)
+    assert(result.output.head.name == "percentile_sum")
+  }
+
+  test("combine structurally equivalent input expressions") {
+    val result = optimizedAggregate(
+      Alias(percentile(value + Literal(1), 0.5), "p50")(),
+      Alias(percentile(value + Literal(1), 0.9), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
+  }
+
+  test("do not combine differently ordered input expressions") {
+    val result = optimizedAggregate(
+      Alias(percentile(value + Literal(1), 0.5), "p50")(),
+      Alias(percentile(Literal(1) + value, 0.9), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not combine differently associated input expressions") {
+    val result = optimizedAggregate(
+      Alias(percentile((value + other) + group, 0.5), "p50")(),
+      Alias(percentile(value + (other + group), 0.9), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not combine percentiles with different input columns") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5), "value_p50")(),
+      Alias(percentile(other, 0.9), "other_p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not combine percentiles with different accuracies") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5, accuracy = 1000), "p50")(),
+      Alias(percentile(value, 0.9, accuracy = 10000), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("combine only percentiles with structurally equivalent filters") {
+    val firstFilter = value > Literal(0)
+    val equivalentFilter = value > Literal(0)
+    val secondFilter = value > Literal(1)
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5, filter = Some(firstFilter)), "p50")(),
+      Alias(percentile(value, 0.9, filter = Some(equivalentFilter)), "p90")(),
+      Alias(percentile(value, 0.95, filter = Some(secondFilter)), "p95")())
+
+    val expressions = percentileAggregates(result)
+    assert(expressions.take(2).map(_.resultId).distinct.size == 1)
+    assert(expressions.map(_.resultId).distinct.size == 2)
+  }
+
+  test("do not combine percentiles with differently associated filters") {
+    val firstFilter = ((value + other) + group) > Literal(0)
+    val secondFilter = (value + (other + group)) > Literal(0)
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5, filter = Some(firstFilter)), "p50")(),
+      Alias(percentile(value, 0.9, filter = Some(secondFilter)), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not combine filtered and unfiltered percentiles") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5), "p50")(),
+      Alias(percentile(value, 0.9, filter = Some(value > Literal(0))), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("do not combine distinct and non-distinct percentiles") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5), "p50")(),
+      Alias(percentile(value, 0.9, isDistinct = true), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("combine distinct percentiles with the same input") {
+    val result = optimizedAggregate(
+      Alias(percentile(value, 0.5, isDistinct = true), "p50")(),
+      Alias(percentile(value, 0.9, isDistinct = true), "p90")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
+  }
+
+  test("leave existing array percentiles unchanged") {
+    val arrayPercentile = new ApproximatePercentile(
+      value,
+      CreateArray(Seq(Literal(0.5), Literal(0.9))),
+      Literal(10000)).toAggregateExpression()
+    val result = optimizedAggregate(
+      Alias(arrayPercentile, "percentiles")(),
+      Alias(percentile(value, 0.95), "p95")())
+
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 2)
+    assert(!result.aggregateExpressions.exists(_.exists(_.isInstanceOf[GetArrayItem])))
+  }
+
+  test("preserve grouping expressions and output expression identifiers") {
+    val p50 = Alias(percentile(value, 0.5), "p50")()
+    val p90 = Alias(percentile(value, 0.9), "p90")()
+    val original = Aggregate(Seq(group), Seq(group, p50, p90), relation).analyze
+      .asInstanceOf[Aggregate]
+    val result = Optimize.execute(original).asInstanceOf[Aggregate]
+
+    assert(result.groupingExpressions == original.groupingExpressions)
+    assert(result.output.map(_.exprId) == original.output.map(_.exprId))
+    assert(percentileAggregates(result).map(_.resultId).distinct.size == 1)
+  }
+
+  test("do not rewrite streaming aggregates") {
+    val streamingRelation = relation.copy(isStreaming = true)
+    val streamingValue = streamingRelation.output.head
+    val original = Aggregate(
+      Seq.empty,
+      Seq(
+        Alias(percentile(streamingValue, 0.5), "p50")(),
+        Alias(percentile(streamingValue, 0.9), "p90")()),
+      streamingRelation).analyze.asInstanceOf[Aggregate]
+
+    assert(original.isStreaming)
+    assert(percentileAggregates(original).map(_.resultId).distinct.size == 2)
+    assert(Optimize.execute(original).fastEquals(original))
+  }
+
+  test("do not rewrite a single scalar percentile") {
+    val original = Aggregate(
+      Seq.empty,
+      Seq(Alias(percentile(value, 0.5), "p50")()),
+      relation).analyze
+
+    assert(Optimize.execute(original).fastEquals(original))
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -91,6 +91,7 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     val combined = aggregates.head.aggregateFunction.asInstanceOf[ApproximatePercentile]
 
     assert(aggregates.map(_.resultId).distinct.size == 1)
+    assert(aggregates.head.resultId != firstPercentile.resultId)
     assert(percentageValues(combined) == Seq(0.9, 0.5, 0.9))
     assert(combined.percentageExpression.toString == "[0.9,0.5,0.9]")
     assert(combined.percentageExpression.sql == "ARRAY(0.9D, 0.5D, 0.9D)")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineApproximatePercentilesSuite.scala
@@ -194,6 +194,15 @@ class CombineApproximatePercentilesSuite extends PlanTest {
     assert(firstInput.canonicalized == secondInput.canonicalized)
     assertNotCombined(inputResult)
 
+    val disjointInputPercentages = optimizedAggregate(
+      Alias(percentile(firstInput, 0.5), "first_p50")(),
+      Alias(percentile(firstInput, 0.9), "first_p90")(),
+      Alias(percentile(secondInput, 0.25), "second_p25")(),
+      Alias(percentile(secondInput, 0.75), "second_p75")())
+    assert(percentileAggregates(disjointInputPercentages).map(_.resultId).distinct.size == 2)
+    assert(ordinals(disjointInputPercentages) ==
+      Seq(Some(0), Some(1), Some(0), Some(1)))
+
     val crossDistinctInput = optimizedAggregate(
       Alias(percentile(firstInput, 0.5), "first_p50")(),
       Alias(percentile(firstInput, 0.9), "first_p90")(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -71,6 +71,7 @@ class SparkOptimizer(
       InjectRuntimeFilter),
     Batch("MergeSubplans", Once,
       MergeSubplans,
+      CombineApproximatePercentiles,
       RewriteDistinctAggregates),
     Batch("Pushdown Filters from PartitionPruning", fixedPoint,
       PushDownPredicates),

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -20,10 +20,14 @@ package org.apache.spark.sql
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, LocalDateTime, LocalTime, Period}
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
+import org.apache.spark.SparkArithmeticException
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
+  ApproximatePercentile, Final, Partial}
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.PercentileDigest
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.TimeType
 import org.apache.spark.tags.SlowSQLTest
@@ -36,6 +40,334 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   private val table = "percentile_approx"
+
+  test("compatible scalar percentiles share one physical percentile digest") {
+    withTempView(table) {
+      (1 to 1000).toDF("col").createOrReplaceTempView(table)
+      val query = spark.sql(
+        s"""SELECT
+           |  percentile_approx(col, 0.5, 10000) AS p50,
+           |  percentile_approx(col, 0.9, 10000) AS p90,
+           |  percentile_approx(col, 0.95, 10000) AS p95
+           |FROM $table
+           |""".stripMargin)
+
+      checkAnswer(query, Row(500, 900, 950))
+
+      val aggregates = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec => aggregate
+      }
+      assert(aggregates.nonEmpty)
+      val aggregateModes = aggregates.flatMap { aggregate =>
+        aggregate.aggregateExpressions.collect {
+          case expression @ AggregateExpression(_: ApproximatePercentile, _, _, _, _) =>
+            expression.mode
+        }
+      }.toSet
+      assert(aggregateModes == Set(Partial, Final))
+      aggregates.foreach { aggregate =>
+        val percentiles = aggregate.aggregateExpressions.collect {
+          case expression @ AggregateExpression(_: ApproximatePercentile, _, _, _, _) =>
+            expression
+        }
+        assert(percentiles.size == 1)
+      }
+    }
+  }
+
+  test("do not combine scalar percentiles with differently associated floating-point inputs") {
+    checkAnswer(
+      spark.sql(
+        """SELECT
+          |  percentile_approx((a + b) + c, 0.5D),
+          |  percentile_approx(a + (b + c), 0.9D)
+          |FROM VALUES (
+          |  CAST(10000000000000000 AS DOUBLE),
+          |  CAST(-10000000000000000 AS DOUBLE),
+          |  CAST(1 AS DOUBLE)
+          |) AS t(a, b, c)
+          |""".stripMargin),
+      Row(1.0d, 0.0d))
+  }
+
+  test("do not combine scalar percentiles with differently associated filters") {
+    checkAnswer(
+      spark.sql(
+        """SELECT
+          |  percentile_approx(v, 0.5D)
+          |    FILTER (WHERE (a + b) + c = 1D),
+          |  percentile_approx(v, 0.9D)
+          |    FILTER (WHERE a + (b + c) = 1D)
+          |FROM VALUES (
+          |  7,
+          |  CAST(10000000000000000 AS DOUBLE),
+          |  CAST(-10000000000000000 AS DOUBLE),
+          |  CAST(1 AS DOUBLE)
+          |) AS t(v, a, b, c)
+          |""".stripMargin),
+      Row(7, null))
+  }
+
+  test("do not combine scalar percentiles when reassociation suppresses ANSI overflow") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val exception = intercept[SparkArithmeticException] {
+        spark.sql(
+          """SELECT
+            |  percentile_approx(a + (b + c), 0.5D),
+            |  percentile_approx((a + b) + c, 0.9D)
+            |FROM VALUES (
+            |  CAST(2147483647 AS INT),
+            |  CAST(1 AS INT),
+            |  CAST(-1 AS INT)
+            |) AS t(a, b, c)
+            |""".stripMargin).collect()
+      }
+
+      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
+    }
+  }
+
+  test("combined scalar percentiles preserve empty-input nulls with ANSI enabled") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      withTempView(table) {
+        Seq.empty[Int].toDF("col").createOrReplaceTempView(table)
+        checkAnswer(
+          spark.sql(
+            s"""SELECT
+               |  percentile_approx(col, 0.5),
+               |  percentile_approx(col, 0.9),
+               |  percentile_approx(col, 0.95)
+               |FROM $table
+               |""".stripMargin),
+          Row(null, null, null))
+      }
+    }
+  }
+
+  test("combined scalar percentiles preserve all-null groups") {
+    withTempView(table) {
+      Seq((0, null: Integer), (0, null: Integer), (1, Integer.valueOf(10)))
+        .toDF("group_key", "col")
+        .createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  group_key,
+             |  percentile_approx(col, 0.5),
+             |  percentile_approx(col, 0.9)
+             |FROM $table
+             |GROUP BY group_key
+             |""".stripMargin),
+        Seq(Row(0, null, null), Row(1, 10, 10)))
+    }
+  }
+
+  test("combined scalar percentiles preserve grouping sets") {
+    withTempView(table) {
+      Seq((0, 1), (0, 2), (1, 3), (1, 4))
+        .toDF("group_key", "col")
+        .createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  group_key,
+             |  percentile_approx(col, 0.5),
+             |  percentile_approx(col, 1.0)
+             |FROM $table
+             |GROUP BY GROUPING SETS ((group_key), ())
+             |""".stripMargin),
+        Seq(Row(0, 1, 2), Row(1, 3, 4), Row(null, 2, 4)))
+    }
+  }
+
+  test("combined scalar percentiles preserve decimal and temporal result types") {
+    withTempView(table) {
+      (1 to 4).map { value =>
+        (
+          new java.math.BigDecimal(value),
+          DateTimeUtils.toJavaDate(value),
+          DateTimeUtils.toJavaTimestamp(value.toLong),
+          DateTimeUtils.microsToLocalDateTime(value.toLong),
+          Period.ofMonths(value),
+          Duration.ofSeconds(value.toLong))
+      }.toDF("decimal_col", "date_col", "timestamp_col", "timestamp_ntz_col",
+        "year_month_col", "day_time_col")
+        .createOrReplaceTempView(table)
+
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(decimal_col, 0.5),
+             |  percentile_approx(decimal_col, 1.0),
+             |  percentile_approx(date_col, 0.5),
+             |  percentile_approx(date_col, 1.0),
+             |  percentile_approx(timestamp_col, 0.5),
+             |  percentile_approx(timestamp_col, 1.0),
+             |  percentile_approx(timestamp_ntz_col, 0.5),
+             |  percentile_approx(timestamp_ntz_col, 1.0),
+             |  percentile_approx(year_month_col, 0.5),
+             |  percentile_approx(year_month_col, 1.0),
+             |  percentile_approx(day_time_col, 0.5),
+             |  percentile_approx(day_time_col, 1.0)
+             |FROM $table
+             |""".stripMargin),
+        Row(
+          new java.math.BigDecimal("2.000000000000000000"),
+          new java.math.BigDecimal("4.000000000000000000"),
+          DateTimeUtils.toJavaDate(2),
+          DateTimeUtils.toJavaDate(4),
+          DateTimeUtils.toJavaTimestamp(2L),
+          DateTimeUtils.toJavaTimestamp(4L),
+          DateTimeUtils.microsToLocalDateTime(2L),
+          DateTimeUtils.microsToLocalDateTime(4L),
+          Period.ofMonths(2).normalized(),
+          Period.ofMonths(4).normalized(),
+          Duration.ofSeconds(2L),
+          Duration.ofSeconds(4L)))
+    }
+  }
+
+  test("combined scalar percentiles preserve TIME result types") {
+    withTempView(table) {
+      spark.sql(
+        s"""SELECT * FROM VALUES
+           |  (TIME '01:00:00'), (TIME '02:00:00'), (TIME '03:00:00'),
+           |  (TIME '04:00:00'), (TIME '05:00:00') AS tab(c)
+           |""".stripMargin).createOrReplaceTempView(table)
+      val query = spark.sql(
+        s"""SELECT
+           |  percentile_approx(c, 0.2D) AS p20,
+           |  percentile_approx(c, 0.5D) AS p50,
+           |  percentile_approx(c, 0.8D) AS p80
+           |FROM $table
+           |""".stripMargin)
+
+      assert(query.schema.fields.map(_.dataType).toSeq ==
+        Seq(TimeType(), TimeType(), TimeType()))
+      checkAnswer(query, Row(LocalTime.of(1, 0), LocalTime.of(3, 0), LocalTime.of(4, 0)))
+
+      val aggregates = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec => aggregate
+      }
+      assert(aggregates.nonEmpty)
+      aggregates.foreach { aggregate =>
+        assert(aggregate.aggregateExpressions.count {
+          case AggregateExpression(_: ApproximatePercentile, _, _, _, _) => true
+          case _ => false
+        } == 1)
+      }
+    }
+  }
+
+  test("combine scalar percentiles without changing an existing array percentile") {
+    withTempView(table) {
+      (1 to 1000).toDF("col").createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(col, array(0.25, 0.75)),
+             |  percentile_approx(col, 0.5),
+             |  percentile_approx(col, 0.9)
+             |FROM $table
+             |""".stripMargin),
+        Row(Seq(250, 750), 500, 900))
+    }
+  }
+
+  test("combined scalar percentiles preserve filtered and distinct results") {
+    withTempView(table) {
+      Seq(1, 1, 2, 3, 4, 5).toDF("col").createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(col, 0.5) FILTER (WHERE col > 1),
+             |  percentile_approx(col, 1.0) FILTER (WHERE col > 1),
+             |  percentile_approx(DISTINCT col, 0.5),
+             |  percentile_approx(DISTINCT col, 1.0)
+             |FROM $table
+             |""".stripMargin),
+        Row(3, 5, 3, 5))
+    }
+  }
+
+  test("combined scalar percentiles preserve non-monotonic and repeated percentages") {
+    withTempView(table) {
+      (1 to 1000).toDF("col").createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(col, 0.9),
+             |  percentile_approx(col, 0.5),
+             |  percentile_approx(col, 0.9)
+             |FROM $table
+             |""".stripMargin),
+        Row(900, 500, 900))
+    }
+  }
+
+  test("combine approximate percentile function aliases") {
+    withTempView(table) {
+      (1 to 1000).toDF("col").createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(col, 0.5),
+             |  approx_percentile(col, 0.9),
+             |  percentile_approx(col, 0.95)
+             |FROM $table
+             |""".stripMargin),
+        Row(500, 900, 950))
+    }
+  }
+
+  test("combine scalar percentiles with constant-folded equivalent accuracies") {
+    withTempView(table) {
+      (1 to 1000).toDF("col").createOrReplaceTempView(table)
+      val query = spark.sql(
+        s"""SELECT
+           |  percentile_approx(col, 0.5, 10000),
+           |  percentile_approx(col, 0.9, 1000 * 10),
+           |  percentile_approx(col, 0.95, 5000 + 5000)
+           |FROM $table
+           |""".stripMargin)
+
+      checkAnswer(query, Row(500, 900, 950))
+
+      val aggregates = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec => aggregate
+      }
+      assert(aggregates.nonEmpty)
+      aggregates.foreach { aggregate =>
+        assert(aggregate.aggregateExpressions.count {
+          case AggregateExpression(_: ApproximatePercentile, _, _, _, _) => true
+          case _ => false
+        } == 1)
+      }
+    }
+  }
+
+  test("do not combine scalar percentiles with differently evaluated accuracies") {
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+      checkAnswer(
+        spark.sql(
+          """SELECT
+            |  percentile_approx(
+            |    id,
+            |    0.5D,
+            |    CAST((1e16D + -1e16D) + 3D AS INT)
+            |  ),
+            |  percentile_approx(
+            |    id,
+            |    0.7D,
+            |    CAST(1e16D + (-1e16D + 3D) AS INT)
+            |  )
+            |FROM range(0, 3, 1, 1)
+            |""".stripMargin),
+        Row(0L, 1L))
+    }
+  }
 
   test("percentile_approx, single percentile value") {
     withTempView(table) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -43,38 +43,66 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   private val table = "percentile_approx"
+  private val constantFoldingRule =
+    "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+  private val fusionRule =
+    "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
+
+  private def excludedRules: Seq[String] = {
+    spark.sessionState.conf.optimizerExcludedRules.toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+  }
+
+  private def assertPercentileDigestCount(query: DataFrame, expected: Int): Unit = {
+    val counts = query.queryExecution.sparkPlan.collect {
+      case aggregate: ObjectHashAggregateExec =>
+        aggregate.aggregateExpressions.count(
+          _.aggregateFunction.isInstanceOf[ApproximatePercentile])
+    }
+    assert(counts.nonEmpty)
+    assert(counts.forall(_ == expected), counts)
+  }
+
+  private def checkMatchesUnfusedBaseline(sql: String, expectedDigests: Int): Unit = {
+    val withoutConstantFolding = (excludedRules :+ constantFoldingRule).distinct
+    val baseline = withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
+      spark.sql(sql).collect().toSeq
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
+      val query = spark.sql(sql)
+      checkAnswer(query, baseline)
+      assertPercentileDigestCount(query, expectedDigests)
+    }
+  }
 
   test("compatible scalar percentiles share one physical percentile digest") {
     withTempView(table) {
       (1 to 1000).toDF("col").createOrReplaceTempView(table)
       val query = spark.sql(
         s"""SELECT
-           |  percentile_approx(col, 0.5, 10000) AS p50,
-           |  percentile_approx(col, 0.9, 10000) AS p90,
-           |  percentile_approx(col, 0.95, 10000) AS p95
+           |  percentile_approx(col, 0.5, 10000),
+           |  percentile_approx(col, 0.9, 10000),
+           |  percentile_approx(col, 0.95, 10000)
            |FROM $table
            |""".stripMargin)
 
       checkAnswer(query, Row(500, 900, 950))
-
-      val aggregates = query.queryExecution.sparkPlan.collect {
-        case aggregate: ObjectHashAggregateExec => aggregate
-      }
-      assert(aggregates.nonEmpty)
-      val aggregateModes = aggregates.flatMap { aggregate =>
-        aggregate.aggregateExpressions.collect {
-          case expression @ AggregateExpression(_: ApproximatePercentile, _, _, _, _) =>
-            expression.mode
-        }
-      }.toSet
-      assert(aggregateModes == Set(Partial, Final))
-      aggregates.foreach { aggregate =>
-        val percentiles = aggregate.aggregateExpressions.collect {
-          case expression @ AggregateExpression(_: ApproximatePercentile, _, _, _, _) =>
-            expression
-        }
-        assert(percentiles.size == 1)
-      }
+      assertPercentileDigestCount(query, 1)
+      val modes = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec =>
+          aggregate.aggregateExpressions.collect {
+            case expression @ AggregateExpression(_: ApproximatePercentile, _, _, _, _) =>
+              expression.mode
+          }
+      }.flatten.toSet
+      assert(modes == Set(Partial, Final))
     }
   }
 
@@ -101,7 +129,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("do not combine scalar percentiles with differently associated floating-point inputs") {
+  test("preserve structural input and filter evaluation") {
     checkAnswer(
       spark.sql(
         """SELECT
@@ -114,9 +142,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |) AS t(a, b, c)
           |""".stripMargin),
       Row(1.0d, 0.0d))
-  }
 
-  test("do not combine scalar percentiles with differently associated filters") {
     checkAnswer(
       spark.sql(
         """SELECT
@@ -132,9 +158,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |) AS t(v, a, b, c)
           |""".stripMargin),
       Row(7, null))
-  }
 
-  test("do not combine scalar percentiles when reassociation suppresses ANSI overflow") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       val exception = intercept[SparkArithmeticException] {
         spark.sql(
@@ -148,71 +172,11 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
             |) AS t(a, b, c)
             |""".stripMargin).collect()
       }
-
       assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
     }
   }
 
-  test("do not fuse input groups when physical deduplication suppresses ANSI overflow") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val exception = intercept[SparkArithmeticException] {
-        spark.sql(
-          """SELECT
-            |  percentile_approx(a + (b + c), 0.5D),
-            |  percentile_approx((a + b) + c, 0.5D),
-            |  percentile_approx((a + b) + c, 0.9D),
-            |  percentile_approx(a + (b + c), 0.9D)
-            |FROM VALUES (
-            |  CAST(2147483647 AS INT),
-            |  CAST(1 AS INT),
-            |  CAST(-1 AS INT)
-            |) AS t(a, b, c)
-            |""".stripMargin).collect()
-      }
-
-      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
-    }
-  }
-
-  test("do not fuse inputs that collide with a scalar percentile") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      checkAnswer(
-        spark.sql(
-          """SELECT
-            |  percentile_approx(a + (b + c), 0.5D),
-            |  percentile_approx((a + b) + c, 0.5D),
-            |  percentile_approx(a + (b + c), 0.9D)
-            |FROM VALUES (
-            |  CAST(2147483647 AS INT),
-            |  CAST(1 AS INT),
-            |  CAST(-1 AS INT)
-            |) AS t(a, b, c)
-            |""".stripMargin),
-        Row(Int.MaxValue, Int.MaxValue, Int.MaxValue))
-    }
-  }
-
-  test("do not fuse inputs that collide with an existing array percentile") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val exception = intercept[SparkArithmeticException] {
-        spark.sql(
-          """SELECT
-            |  percentile_approx(a + (b + c), 0.5D),
-            |  percentile_approx((a + b) + c, array(0.5D, 0.9D)),
-            |  percentile_approx(a + (b + c), 0.9D)
-            |FROM VALUES (
-            |  CAST(2147483647 AS INT),
-            |  CAST(1 AS INT),
-            |  CAST(-1 AS INT)
-            |) AS t(a, b, c)
-            |""".stripMargin).collect()
-      }
-
-      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
-    }
-  }
-
-  test("do not fuse floating-point inputs that collide during physical deduplication") {
+  test("do not fuse canonical input or filter collisions") {
     checkAnswer(
       spark.sql(
         """SELECT
@@ -227,47 +191,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |) AS t(a, b, c)
           |""".stripMargin),
       Row(0.0d, 0.0d, 1.0d, 1.0d))
-  }
 
-  test("do not fuse floating-point inputs that collide with an existing array percentile") {
-    checkAnswer(
-      spark.sql(
-        """SELECT
-          |  percentile_approx(a + (b + c), array(0.5D, 0.9D)),
-          |  percentile_approx((a + b) + c, 0.5D),
-          |  percentile_approx((a + b) + c, 0.9D)
-          |FROM VALUES (
-          |  CAST(10000000000000000 AS DOUBLE),
-          |  CAST(-10000000000000000 AS DOUBLE),
-          |  CAST(1 AS DOUBLE)
-          |) AS t(a, b, c)
-          |""".stripMargin),
-      Row(Seq(0.0d, 0.0d), 1.0d, 1.0d))
-  }
-
-  test("do not fuse filter groups when physical deduplication suppresses ANSI overflow") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val exception = intercept[SparkArithmeticException] {
-        spark.sql(
-          """SELECT
-            |  percentile_approx(v, 0.5D) FILTER (WHERE a + (b + c) > 0),
-            |  percentile_approx(v, 0.5D) FILTER (WHERE (a + b) + c > 0),
-            |  percentile_approx(v, 0.9D) FILTER (WHERE (a + b) + c > 0),
-            |  percentile_approx(v, 0.9D) FILTER (WHERE a + (b + c) > 0)
-            |FROM VALUES (
-            |  7,
-            |  CAST(2147483647 AS INT),
-            |  CAST(1 AS INT),
-            |  CAST(-1 AS INT)
-            |) AS t(v, a, b, c)
-            |""".stripMargin).collect()
-      }
-
-      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
-    }
-  }
-
-  test("do not fuse filters that collide with an existing array percentile") {
     checkAnswer(
       spark.sql(
         """SELECT
@@ -287,139 +211,34 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       Row(Seq(7, 7), null, null))
   }
 
-  test("do not fuse canonically equivalent but differently evaluated accuracies") {
-    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
-    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
-    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
-      .flatMap(_.split(","))
-      .map(_.trim)
-      .filter(_.nonEmpty)
-    val withoutConstantFolding = (existingRules :+ constantFoldingRule).distinct
-    val sql =
-      """SELECT
-        |  percentile_approx(
-        |    v, 0.5D, CAST((1e16D + -1e16D) + 3D AS INT)),
-        |  percentile_approx(
-        |    v, 0.5D, CAST(1e16D + (-1e16D + 3D) AS INT)),
-        |  percentile_approx(
-        |    v, 0.9D, CAST(1e16D + (-1e16D + 3D) AS INT)),
-        |  percentile_approx(
-        |    v, 0.9D, CAST((1e16D + -1e16D) + 3D AS INT))
-        |FROM range(100) AS t(v)
-        |""".stripMargin
+  test("do not fuse canonically colliding parameters") {
+    val cases = Seq(
+      (
+        """SELECT
+          |  percentile_approx(
+          |    v, 0.5D, CAST((1e16D + -1e16D) + 3D AS INT)),
+          |  percentile_approx(
+          |    v, 0.5D, CAST(1e16D + (-1e16D + 3D) AS INT)),
+          |  percentile_approx(
+          |    v, 0.9D, CAST(1e16D + (-1e16D + 3D) AS INT)),
+          |  percentile_approx(
+          |    v, 0.9D, CAST((1e16D + -1e16D) + 3D AS INT))
+          |FROM range(100) AS t(v)
+          |""".stripMargin,
+        2),
+      (
+        """SELECT
+          |  percentile_approx(
+          |    id, array((1e16D + -1e16D) + 0.5D, 0.9D)),
+          |  percentile_approx(
+          |    id, 1e16D + (-1e16D + 0.5D)),
+          |  percentile_approx(id, 0.9D)
+          |FROM range(100)
+          |""".stripMargin,
+        3))
 
-    def assertTwoDigests(query: DataFrame): Unit = {
-      val counts = query.queryExecution.sparkPlan.collect {
-        case aggregate: ObjectHashAggregateExec =>
-          aggregate.aggregateExpressions.count(
-            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
-      }
-      assert(counts.nonEmpty)
-      assert(counts.forall(_ == 2))
-    }
-
-    val baseline = withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
-      val query = spark.sql(sql)
-      assertTwoDigests(query)
-      query.collect().toSeq
-    }
-
-    withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
-      val query = spark.sql(sql)
-      checkAnswer(query, baseline)
-      assertTwoDigests(query)
-    }
-  }
-
-  test("do not fuse percentages that collide with an existing array percentile") {
-    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
-    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
-    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
-      .flatMap(_.split(","))
-      .map(_.trim)
-      .filter(_.nonEmpty)
-    val withoutConstantFolding = (existingRules :+ constantFoldingRule).distinct
-    val sql =
-      """SELECT
-        |  percentile_approx(
-        |    id, array((1e16D + -1e16D) + 0.5D, 0.9D)),
-        |  percentile_approx(
-        |    id, 1e16D + (-1e16D + 0.5D)),
-        |  percentile_approx(id, 0.9D)
-        |FROM range(100)
-        |""".stripMargin
-
-    def assertThreeDigests(query: DataFrame): Unit = {
-      val counts = query.queryExecution.sparkPlan.collect {
-        case aggregate: ObjectHashAggregateExec =>
-          aggregate.aggregateExpressions.count(
-            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
-      }
-      assert(counts.nonEmpty)
-      assert(counts.forall(_ == 3))
-    }
-
-    val baseline = withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
-      val query = spark.sql(sql)
-      assertThreeDigests(query)
-      query.collect().toSeq
-    }
-
-    withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
-      val query = spark.sql(sql)
-      checkAnswer(query, baseline)
-      assertThreeDigests(query)
-    }
-  }
-
-  test("do not fuse canonically equivalent but differently evaluated scalar percentages") {
-    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
-    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
-    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
-      .flatMap(_.split(","))
-      .map(_.trim)
-      .filter(_.nonEmpty)
-    val withoutConstantFolding = (existingRules :+ constantFoldingRule).distinct
-    val sql =
-      """SELECT
-        |  percentile_approx(id, (1e16D + -1e16D) + 0.5D),
-        |  percentile_approx(id, 1e16D + (-1e16D + 0.5D)),
-        |  percentile_approx(id, 0.9D)
-        |FROM range(100)
-        |""".stripMargin
-
-    def assertTwoDigests(query: DataFrame): Unit = {
-      val counts = query.queryExecution.sparkPlan.collect {
-        case aggregate: ObjectHashAggregateExec =>
-          aggregate.aggregateExpressions.count(
-            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
-      }
-      assert(counts.nonEmpty)
-      assert(counts.forall(_ == 2))
-    }
-
-    val baseline = withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
-      val query = spark.sql(sql)
-      assertTwoDigests(query)
-      query.collect().toSeq
-    }
-
-    withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
-      val query = spark.sql(sql)
-      checkAnswer(query, baseline)
-      assertTwoDigests(query)
+    cases.foreach { case (sql, expectedDigests) =>
+      checkMatchesUnfusedBaseline(sql, expectedDigests)
     }
   }
 
@@ -468,66 +287,26 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true",
       SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
-      val result = spark.sql(query)
-      checkAnswer(result, Row(Row(1.0d, 1.0d), Row(0.0d, 0.0d)))
-    }
-  }
-
-  test("preserve grouping expressions across exchange reuse") {
-    withSQLConf(
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
-      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "false",
-      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
       checkAnswer(
-        spark.sql(
-          """SELECT
-            |  (a + b) + c,
-            |  array(
-            |    percentile_approx(1D, 0.5D),
-            |    percentile_approx(1D, 0.9D))
-            |FROM VALUES (
-            |  CAST(10000000000000000 AS DOUBLE),
-            |  CAST(-10000000000000000 AS DOUBLE),
-            |  CAST(1 AS DOUBLE)
-            |) AS t1(a, b, c)
-            |GROUP BY (a + b) + c
-            |UNION ALL
-            |SELECT
-            |  a + (b + c),
-            |  percentile_approx(1D, array(0.5D, 0.9D))
-            |FROM VALUES (
-            |  CAST(10000000000000000 AS DOUBLE),
-            |  CAST(-10000000000000000 AS DOUBLE),
-            |  CAST(1 AS DOUBLE)
-            |) AS t2(a, b, c)
-            |GROUP BY a + (b + c)
-            |""".stripMargin),
-        Seq(
-          Row(1.0d, Seq(1.0d, 1.0d)),
-          Row(0.0d, Seq(1.0d, 1.0d))))
+        spark.sql(query),
+        Row(Row(1.0d, 1.0d), Row(0.0d, 0.0d)))
     }
   }
 
-  test("preserve original percentile parameters across exchange reuse") {
-    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
-    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
-    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
-      .flatMap(_.split(","))
-      .map(_.trim)
-      .filter(_.nonEmpty)
-    val excludedRules = (existingRules :+ constantFoldingRule)
-      .filterNot(_ == fusionRule)
-      .distinct
-      .mkString(",")
+  test("preserve pre-fusion identity across exchange reuse") {
     val parameterPairs = Seq(
       ("(1e16D + -1e16D) + 0.5D", "100"),
       ("0.5D", "CAST((1e16D + -1e16D) + 100D AS INT)"))
+    val activeRules = (excludedRules :+ constantFoldingRule)
+      .filterNot(_ == fusionRule)
+      .distinct
+      .mkString(",")
 
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.SUBQUERY_REUSE_ENABLED.key -> "false",
       SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> excludedRules) {
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> activeRules) {
       parameterPairs.foreach { case (firstPercentage, secondAccuracy) =>
         val query = spark.sql(
           s"""SELECT
@@ -570,8 +349,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
   test("identical fused percentiles remain reusable") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
-      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true",
-      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
+      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true") {
       val subquery =
         """(SELECT array(
           |  percentile_approx(v, 0D),
@@ -583,28 +361,6 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       checkAnswer(query, Row(Seq(1, 3), Seq(1, 3)))
       assert(query.queryExecution.executedPlan.collectWithSubqueries {
         case _: ReusedSubqueryExec => true
-      }.nonEmpty)
-
-      val branch =
-        """SELECT
-          |  id % 2 AS k,
-          |  array(
-          |    percentile_approx(id, 0D),
-          |    percentile_approx(id, 1D)) AS percentiles
-          |FROM range(10)
-          |GROUP BY id % 2
-          |""".stripMargin
-      val union = spark.sql(s"$branch UNION ALL $branch")
-
-      checkAnswer(
-        union,
-        Seq(
-          Row(0L, Seq(0L, 8L)),
-          Row(1L, Seq(1L, 9L)),
-          Row(0L, Seq(0L, 8L)),
-          Row(1L, Seq(1L, 9L))))
-      assert(union.queryExecution.executedPlan.collect {
-        case _: ReusedExchangeExec => true
       }.nonEmpty)
     }
   }
@@ -619,274 +375,23 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
         |""".stripMargin)
 
     checkAnswer(query, Row(10L, 4L, 8L))
+    assertPercentileDigestCount(query, 1)
     assert(query.queryExecution.optimizedPlan.collect {
       case _: Expand => true
     }.isEmpty)
   }
 
-  test("combined distinct literal percentiles preserve results") {
+  test("combined scalar percentiles preserve empty-input nulls") {
     withTempView(table) {
       Seq.empty[Int].toDF("col").createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(DISTINCT 1D, 0.5D),
-             |  percentile_approx(DISTINCT 1D, 0.9D)
-             |FROM $table
-             |""".stripMargin),
-        Row(null, null))
-
-      Seq(1, 2).toDF("col").createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(DISTINCT 1D, 0.5D),
-             |  percentile_approx(DISTINCT 1D, 0.9D)
-             |FROM $table
-             |""".stripMargin),
-        Row(1.0d, 1.0d))
-    }
-  }
-
-  test("combined scalar percentiles preserve empty-input nulls with ANSI enabled") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      withTempView(table) {
-        Seq.empty[Int].toDF("col").createOrReplaceTempView(table)
-        checkAnswer(
-          spark.sql(
-            s"""SELECT
-               |  percentile_approx(col, 0.5),
-               |  percentile_approx(col, 0.9),
-               |  percentile_approx(col, 0.95)
-               |FROM $table
-               |""".stripMargin),
-          Row(null, null, null))
-      }
-    }
-  }
-
-  test("combined scalar percentiles preserve all-null groups") {
-    withTempView(table) {
-      Seq((0, null: Integer), (0, null: Integer), (1, Integer.valueOf(10)))
-        .toDF("group_key", "col")
-        .createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  group_key,
-             |  percentile_approx(col, 0.5),
-             |  percentile_approx(col, 0.9)
-             |FROM $table
-             |GROUP BY group_key
-             |""".stripMargin),
-        Seq(Row(0, null, null), Row(1, 10, 10)))
-    }
-  }
-
-  test("combined scalar percentiles preserve grouping sets") {
-    withTempView(table) {
-      Seq((0, 1), (0, 2), (1, 3), (1, 4))
-        .toDF("group_key", "col")
-        .createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  group_key,
-             |  percentile_approx(col, 0.5),
-             |  percentile_approx(col, 1.0)
-             |FROM $table
-             |GROUP BY GROUPING SETS ((group_key), ())
-             |""".stripMargin),
-        Seq(Row(0, 1, 2), Row(1, 3, 4), Row(null, 2, 4)))
-    }
-  }
-
-  test("combined scalar percentiles preserve decimal and temporal result types") {
-    withTempView(table) {
-      (1 to 4).map { value =>
-        (
-          new java.math.BigDecimal(value),
-          DateTimeUtils.toJavaDate(value),
-          DateTimeUtils.toJavaTimestamp(value.toLong),
-          DateTimeUtils.microsToLocalDateTime(value.toLong),
-          Period.ofMonths(value),
-          Duration.ofSeconds(value.toLong))
-      }.toDF("decimal_col", "date_col", "timestamp_col", "timestamp_ntz_col",
-        "year_month_col", "day_time_col")
-        .createOrReplaceTempView(table)
-
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(decimal_col, 0.5),
-             |  percentile_approx(decimal_col, 1.0),
-             |  percentile_approx(date_col, 0.5),
-             |  percentile_approx(date_col, 1.0),
-             |  percentile_approx(timestamp_col, 0.5),
-             |  percentile_approx(timestamp_col, 1.0),
-             |  percentile_approx(timestamp_ntz_col, 0.5),
-             |  percentile_approx(timestamp_ntz_col, 1.0),
-             |  percentile_approx(year_month_col, 0.5),
-             |  percentile_approx(year_month_col, 1.0),
-             |  percentile_approx(day_time_col, 0.5),
-             |  percentile_approx(day_time_col, 1.0)
-             |FROM $table
-             |""".stripMargin),
-        Row(
-          new java.math.BigDecimal("2.000000000000000000"),
-          new java.math.BigDecimal("4.000000000000000000"),
-          DateTimeUtils.toJavaDate(2),
-          DateTimeUtils.toJavaDate(4),
-          DateTimeUtils.toJavaTimestamp(2L),
-          DateTimeUtils.toJavaTimestamp(4L),
-          DateTimeUtils.microsToLocalDateTime(2L),
-          DateTimeUtils.microsToLocalDateTime(4L),
-          Period.ofMonths(2).normalized(),
-          Period.ofMonths(4).normalized(),
-          Duration.ofSeconds(2L),
-          Duration.ofSeconds(4L)))
-    }
-  }
-
-  test("combined scalar percentiles preserve TIME result types") {
-    withTempView(table) {
-      spark.sql(
-        s"""SELECT * FROM VALUES
-           |  (TIME '01:00:00'), (TIME '02:00:00'), (TIME '03:00:00'),
-           |  (TIME '04:00:00'), (TIME '05:00:00') AS tab(c)
-           |""".stripMargin).createOrReplaceTempView(table)
       val query = spark.sql(
         s"""SELECT
-           |  percentile_approx(c, 0.2D) AS p20,
-           |  percentile_approx(c, 0.5D) AS p50,
-           |  percentile_approx(c, 0.8D) AS p80
+           |  percentile_approx(col, 0.5D),
+           |  percentile_approx(col, 0.9D)
            |FROM $table
            |""".stripMargin)
-
-      assert(query.schema.fields.map(_.dataType).toSeq ==
-        Seq(TimeType(), TimeType(), TimeType()))
-      checkAnswer(query, Row(LocalTime.of(1, 0), LocalTime.of(3, 0), LocalTime.of(4, 0)))
-
-      val aggregates = query.queryExecution.sparkPlan.collect {
-        case aggregate: ObjectHashAggregateExec => aggregate
-      }
-      assert(aggregates.nonEmpty)
-      aggregates.foreach { aggregate =>
-        assert(aggregate.aggregateExpressions.count {
-          case AggregateExpression(_: ApproximatePercentile, _, _, _, _) => true
-          case _ => false
-        } == 1)
-      }
-    }
-  }
-
-  test("combine scalar percentiles without changing an existing array percentile") {
-    withTempView(table) {
-      (1 to 1000).toDF("col").createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(col, array(0.25, 0.75)),
-             |  percentile_approx(col, 0.5),
-             |  percentile_approx(col, 0.9)
-             |FROM $table
-             |""".stripMargin),
-        Row(Seq(250, 750), 500, 900))
-    }
-  }
-
-  test("combined scalar percentiles preserve filtered and distinct results") {
-    withTempView(table) {
-      Seq(1, 1, 2, 3, 4, 5).toDF("col").createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(col, 0.5) FILTER (WHERE col > 1),
-             |  percentile_approx(col, 1.0) FILTER (WHERE col > 1),
-             |  percentile_approx(DISTINCT col, 0.5),
-             |  percentile_approx(DISTINCT col, 1.0)
-             |FROM $table
-             |""".stripMargin),
-        Row(3, 5, 3, 5))
-    }
-  }
-
-  test("combined scalar percentiles preserve non-monotonic and repeated percentages") {
-    withTempView(table) {
-      (1 to 1000).toDF("col").createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(col, 0.9),
-             |  percentile_approx(col, 0.5),
-             |  percentile_approx(col, 0.9)
-             |FROM $table
-             |""".stripMargin),
-        Row(900, 500, 900))
-    }
-  }
-
-  test("combine approximate percentile function aliases") {
-    withTempView(table) {
-      (1 to 1000).toDF("col").createOrReplaceTempView(table)
-      checkAnswer(
-        spark.sql(
-          s"""SELECT
-             |  percentile_approx(col, 0.5),
-             |  approx_percentile(col, 0.9),
-             |  percentile_approx(col, 0.95)
-             |FROM $table
-             |""".stripMargin),
-        Row(500, 900, 950))
-    }
-  }
-
-  test("combine scalar percentiles with constant-folded equivalent accuracies") {
-    withTempView(table) {
-      (1 to 1000).toDF("col").createOrReplaceTempView(table)
-      val query = spark.sql(
-        s"""SELECT
-           |  percentile_approx(col, 0.5, 10000),
-           |  percentile_approx(col, 0.9, 1000 * 10),
-           |  percentile_approx(col, 0.95, 5000 + 5000)
-           |FROM $table
-           |""".stripMargin)
-
-      checkAnswer(query, Row(500, 900, 950))
-
-      val aggregates = query.queryExecution.sparkPlan.collect {
-        case aggregate: ObjectHashAggregateExec => aggregate
-      }
-      assert(aggregates.nonEmpty)
-      aggregates.foreach { aggregate =>
-        assert(aggregate.aggregateExpressions.count {
-          case AggregateExpression(_: ApproximatePercentile, _, _, _, _) => true
-          case _ => false
-        } == 1)
-      }
-    }
-  }
-
-  test("do not combine scalar percentiles with differently evaluated accuracies") {
-    withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
-      checkAnswer(
-        spark.sql(
-          """SELECT
-            |  percentile_approx(
-            |    id,
-            |    0.5D,
-            |    CAST((1e16D + -1e16D) + 3D AS INT)
-            |  ),
-            |  percentile_approx(
-            |    id,
-            |    0.7D,
-            |    CAST(1e16D + (-1e16D + 3D) AS INT)
-            |  )
-            |FROM range(0, 3, 1, 1)
-            |""".stripMargin),
-        Row(0L, 1L))
+      checkAnswer(query, Row(null, null))
+      assertPercentileDigestCount(query, 1)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -25,11 +25,14 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
   ApproximatePercentile, Final, Partial}
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.PercentileDigest
+import org.apache.spark.sql.catalyst.plans.logical.Expand
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.execution.ReusedSubqueryExec
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.TimeType
+import org.apache.spark.sql.types.{DoubleType, TimeType}
 import org.apache.spark.tags.SlowSQLTest
 
 /**
@@ -72,6 +75,29 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
         }
         assert(percentiles.size == 1)
       }
+    }
+  }
+
+  test("do not fuse duplicate percentages already shared by physical planning") {
+    withTempView(table) {
+      (1 to 1000).toDF("col").createOrReplaceTempView(table)
+      val query = spark.sql(
+        s"""SELECT
+           |  percentile_approx(col, 0.5D),
+           |  percentile_approx(col, 0.25D + 0.25D)
+           |FROM $table
+           |""".stripMargin)
+
+      checkAnswer(query, Row(500, 500))
+      val percentiles = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec =>
+          aggregate.aggregateExpressions.collect {
+            case AggregateExpression(
+                percentile: ApproximatePercentile, _, _, _, _) => percentile
+          }
+      }.flatten
+      assert(percentiles.nonEmpty)
+      assert(percentiles.forall(_.percentageExpression.dataType == DoubleType))
     }
   }
 
@@ -351,6 +377,274 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       val query = spark.sql(sql)
       checkAnswer(query, baseline)
       assertThreeDigests(query)
+    }
+  }
+
+  test("do not fuse canonically equivalent but differently evaluated scalar percentages") {
+    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
+    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+    val withoutConstantFolding = (existingRules :+ constantFoldingRule).distinct
+    val sql =
+      """SELECT
+        |  percentile_approx(id, (1e16D + -1e16D) + 0.5D),
+        |  percentile_approx(id, 1e16D + (-1e16D + 0.5D)),
+        |  percentile_approx(id, 0.9D)
+        |FROM range(100)
+        |""".stripMargin
+
+    def assertTwoDigests(query: DataFrame): Unit = {
+      val counts = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec =>
+          aggregate.aggregateExpressions.count(
+            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
+      }
+      assert(counts.nonEmpty)
+      assert(counts.forall(_ == 2))
+    }
+
+    val baseline = withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
+      val query = spark.sql(sql)
+      assertTwoDigests(query)
+      query.collect().toSeq
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
+      val query = spark.sql(sql)
+      checkAnswer(query, baseline)
+      assertTwoDigests(query)
+    }
+  }
+
+  test("do not fuse with an existing array that collides after distinct removal") {
+    checkAnswer(
+      spark.sql(
+        """SELECT
+          |  percentile_approx(
+          |    DISTINCT a + (b + c), array(0.5D, 0.9D)),
+          |  percentile_approx(DISTINCT a + (b + c), 0.1D),
+          |  percentile_approx((a + b) + c, 0.5D),
+          |  percentile_approx((a + b) + c, 0.9D)
+          |FROM VALUES (
+          |  CAST(10000000000000000 AS DOUBLE),
+          |  CAST(-10000000000000000 AS DOUBLE),
+          |  CAST(1 AS DOUBLE)
+          |) AS t(a, b, c)
+          |""".stripMargin),
+      Row(Seq(0.0d, 0.0d), 0.0d, 1.0d, 1.0d))
+  }
+
+  test("preserve percentile inputs across scalar subquery reuse") {
+    val query =
+      """SELECT
+        |  (SELECT named_struct(
+        |    'p50', percentile_approx((a + b) + c, 0.5D),
+        |    'p90', percentile_approx((a + b) + c, 0.9D))
+        |   FROM VALUES (
+        |     CAST(10000000000000000 AS DOUBLE),
+        |     CAST(-10000000000000000 AS DOUBLE),
+        |     CAST(1 AS DOUBLE)
+        |   ) AS t(a, b, c)),
+        |  (SELECT named_struct(
+        |    'p50', get(percentile_approx(
+        |      a + (b + c), array(0.5D, 0.9D)), 0),
+        |    'p90', get(percentile_approx(
+        |      a + (b + c), array(0.5D, 0.9D)), 1))
+        |   FROM VALUES (
+        |     CAST(10000000000000000 AS DOUBLE),
+        |     CAST(-10000000000000000 AS DOUBLE),
+        |     CAST(1 AS DOUBLE)
+        |   ) AS t(a, b, c))
+        |""".stripMargin
+
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      val result = spark.sql(query)
+      checkAnswer(result, Row(Row(1.0d, 1.0d), Row(0.0d, 0.0d)))
+    }
+  }
+
+  test("preserve grouping expressions across exchange reuse") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
+      checkAnswer(
+        spark.sql(
+          """SELECT
+            |  (a + b) + c,
+            |  array(
+            |    percentile_approx(1D, 0.5D),
+            |    percentile_approx(1D, 0.9D))
+            |FROM VALUES (
+            |  CAST(10000000000000000 AS DOUBLE),
+            |  CAST(-10000000000000000 AS DOUBLE),
+            |  CAST(1 AS DOUBLE)
+            |) AS t1(a, b, c)
+            |GROUP BY (a + b) + c
+            |UNION ALL
+            |SELECT
+            |  a + (b + c),
+            |  percentile_approx(1D, array(0.5D, 0.9D))
+            |FROM VALUES (
+            |  CAST(10000000000000000 AS DOUBLE),
+            |  CAST(-10000000000000000 AS DOUBLE),
+            |  CAST(1 AS DOUBLE)
+            |) AS t2(a, b, c)
+            |GROUP BY a + (b + c)
+            |""".stripMargin),
+        Seq(
+          Row(1.0d, Seq(1.0d, 1.0d)),
+          Row(0.0d, Seq(1.0d, 1.0d))))
+    }
+  }
+
+  test("preserve original percentile parameters across exchange reuse") {
+    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
+    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+    val excludedRules = (existingRules :+ constantFoldingRule)
+      .filterNot(_ == fusionRule)
+      .distinct
+      .mkString(",")
+    val parameterPairs = Seq(
+      ("(1e16D + -1e16D) + 0.5D", "100"),
+      ("0.5D", "CAST((1e16D + -1e16D) + 100D AS INT)"))
+
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> excludedRules) {
+      parameterPairs.foreach { case (firstPercentage, secondAccuracy) =>
+        val query = spark.sql(
+          s"""SELECT
+             |  (a + b) + c,
+             |  array(
+             |    percentile_approx(1D, $firstPercentage, 100),
+             |    percentile_approx(1D, 0.9D, $secondAccuracy))
+             |FROM VALUES (
+             |  CAST(10000000000000000 AS DOUBLE),
+             |  CAST(-10000000000000000 AS DOUBLE),
+             |  CAST(1 AS DOUBLE)
+             |) AS t1(a, b, c)
+             |GROUP BY (a + b) + c
+             |UNION ALL
+             |SELECT
+             |  a + (b + c),
+             |  array(
+             |    percentile_approx(1D, 0.5D, 100),
+             |    percentile_approx(1D, 0.9D, 100))
+             |FROM VALUES (
+             |  CAST(10000000000000000 AS DOUBLE),
+             |  CAST(-10000000000000000 AS DOUBLE),
+             |  CAST(1 AS DOUBLE)
+             |) AS t2(a, b, c)
+             |GROUP BY a + (b + c)
+             |""".stripMargin)
+
+        checkAnswer(
+          query,
+          Seq(
+            Row(1.0d, Seq(1.0d, 1.0d)),
+            Row(0.0d, Seq(1.0d, 1.0d))))
+        assert(query.queryExecution.executedPlan.collect {
+          case _: ReusedExchangeExec => true
+        }.isEmpty)
+      }
+    }
+  }
+
+  test("identical fused percentiles remain reusable") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
+      val subquery =
+        """(SELECT array(
+          |  percentile_approx(v, 0D),
+          |  percentile_approx(v, 1D))
+          | FROM VALUES (1), (2), (3) AS t(v))
+          |""".stripMargin
+      val query = spark.sql(s"SELECT $subquery, $subquery")
+
+      checkAnswer(query, Row(Seq(1, 3), Seq(1, 3)))
+      assert(query.queryExecution.executedPlan.collectWithSubqueries {
+        case _: ReusedSubqueryExec => true
+      }.nonEmpty)
+
+      val branch =
+        """SELECT
+          |  id % 2 AS k,
+          |  array(
+          |    percentile_approx(id, 0D),
+          |    percentile_approx(id, 1D)) AS percentiles
+          |FROM range(10)
+          |GROUP BY id % 2
+          |""".stripMargin
+      val union = spark.sql(s"$branch UNION ALL $branch")
+
+      checkAnswer(
+        union,
+        Seq(
+          Row(0L, Seq(0L, 8L)),
+          Row(1L, Seq(1L, 9L)),
+          Row(0L, Seq(0L, 8L)),
+          Row(1L, Seq(1L, 9L))))
+      assert(union.queryExecution.executedPlan.collect {
+        case _: ReusedExchangeExec => true
+      }.nonEmpty)
+    }
+  }
+
+  test("fused distinct percentiles keep a single distinct group") {
+    val query = spark.sql(
+      """SELECT
+        |  count(DISTINCT id),
+        |  percentile_approx(DISTINCT id, 0.5D),
+        |  percentile_approx(DISTINCT id, 0.9D)
+        |FROM range(10)
+        |""".stripMargin)
+
+    checkAnswer(query, Row(10L, 4L, 8L))
+    assert(query.queryExecution.optimizedPlan.collect {
+      case _: Expand => true
+    }.isEmpty)
+  }
+
+  test("combined distinct literal percentiles preserve results") {
+    withTempView(table) {
+      Seq.empty[Int].toDF("col").createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(DISTINCT 1D, 0.5D),
+             |  percentile_approx(DISTINCT 1D, 0.9D)
+             |FROM $table
+             |""".stripMargin),
+        Row(null, null))
+
+      Seq(1, 2).toDF("col").createOrReplaceTempView(table)
+      checkAnswer(
+        spark.sql(
+          s"""SELECT
+             |  percentile_approx(DISTINCT 1D, 0.5D),
+             |  percentile_approx(DISTINCT 1D, 0.9D)
+             |FROM $table
+             |""".stripMargin),
+        Row(1.0d, 1.0d))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -87,14 +87,19 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       (1 to 1000).toDF("col").createOrReplaceTempView(table)
       val query = spark.sql(
         s"""SELECT
-           |  percentile_approx(col, 0.5, 10000),
-           |  percentile_approx(col, 0.9, 10000),
-           |  percentile_approx(col, 0.95, 10000)
+           |  approx_percentile(col, 0.5, 10000),
+           |  approx_percentile(col, 0.9, 10000),
+           |  approx_percentile(col, 0.95, 10000)
            |FROM $table
            |""".stripMargin)
 
       checkAnswer(query, Row(500, 900, 950))
       assertPercentileDigestCount(query, 1)
+      val optimizedPercentiles = query.queryExecution.optimizedPlan.expressions.flatMap {
+        _.collect { case percentile: ApproximatePercentile => percentile }
+      }
+      assert(optimizedPercentiles.nonEmpty)
+      assert(optimizedPercentiles.forall(_.prettyName == "approx_percentile"))
       val modes = query.queryExecution.sparkPlan.collect {
         case aggregate: ObjectHashAggregateExec =>
           aggregate.aggregateExpressions.collect {
@@ -191,6 +196,25 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |) AS t(a, b, c)
           |""".stripMargin),
       Row(0.0d, 0.0d, 1.0d, 1.0d))
+
+    val crossDistinctCollision =
+      """SELECT
+        |  percentile_approx(DISTINCT a + (b + c), 0.5D),
+        |  percentile_approx(DISTINCT a + (b + c), 0.9D),
+        |  percentile_approx((a + b) + c, 0.5D),
+        |  percentile_approx((a + b) + c, 0.9D)
+        |FROM VALUES (
+        |  CAST(10000000000000000 AS DOUBLE),
+        |  CAST(-10000000000000000 AS DOUBLE),
+        |  CAST(1 AS DOUBLE)
+        |) AS t(a, b, c)
+        |""".stripMargin
+    val unfusedBaseline = withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        (excludedRules :+ fusionRule).distinct.mkString(",")) {
+      spark.sql(crossDistinctCollision).collect().toSeq
+    }
+    checkAnswer(spark.sql(crossDistinctCollision), unfusedBaseline)
 
     checkAnswer(
       spark.sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -127,6 +127,233 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
+  test("do not fuse input groups when physical deduplication suppresses ANSI overflow") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val exception = intercept[SparkArithmeticException] {
+        spark.sql(
+          """SELECT
+            |  percentile_approx(a + (b + c), 0.5D),
+            |  percentile_approx((a + b) + c, 0.5D),
+            |  percentile_approx((a + b) + c, 0.9D),
+            |  percentile_approx(a + (b + c), 0.9D)
+            |FROM VALUES (
+            |  CAST(2147483647 AS INT),
+            |  CAST(1 AS INT),
+            |  CAST(-1 AS INT)
+            |) AS t(a, b, c)
+            |""".stripMargin).collect()
+      }
+
+      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
+    }
+  }
+
+  test("do not fuse inputs that collide with a scalar percentile") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      checkAnswer(
+        spark.sql(
+          """SELECT
+            |  percentile_approx(a + (b + c), 0.5D),
+            |  percentile_approx((a + b) + c, 0.5D),
+            |  percentile_approx(a + (b + c), 0.9D)
+            |FROM VALUES (
+            |  CAST(2147483647 AS INT),
+            |  CAST(1 AS INT),
+            |  CAST(-1 AS INT)
+            |) AS t(a, b, c)
+            |""".stripMargin),
+        Row(Int.MaxValue, Int.MaxValue, Int.MaxValue))
+    }
+  }
+
+  test("do not fuse inputs that collide with an existing array percentile") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val exception = intercept[SparkArithmeticException] {
+        spark.sql(
+          """SELECT
+            |  percentile_approx(a + (b + c), 0.5D),
+            |  percentile_approx((a + b) + c, array(0.5D, 0.9D)),
+            |  percentile_approx(a + (b + c), 0.9D)
+            |FROM VALUES (
+            |  CAST(2147483647 AS INT),
+            |  CAST(1 AS INT),
+            |  CAST(-1 AS INT)
+            |) AS t(a, b, c)
+            |""".stripMargin).collect()
+      }
+
+      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
+    }
+  }
+
+  test("do not fuse floating-point inputs that collide during physical deduplication") {
+    checkAnswer(
+      spark.sql(
+        """SELECT
+          |  percentile_approx(a + (b + c), 0.5D),
+          |  percentile_approx((a + b) + c, 0.5D),
+          |  percentile_approx((a + b) + c, 0.9D),
+          |  percentile_approx(a + (b + c), 0.9D)
+          |FROM VALUES (
+          |  CAST(10000000000000000 AS DOUBLE),
+          |  CAST(-10000000000000000 AS DOUBLE),
+          |  CAST(1 AS DOUBLE)
+          |) AS t(a, b, c)
+          |""".stripMargin),
+      Row(0.0d, 0.0d, 1.0d, 1.0d))
+  }
+
+  test("do not fuse floating-point inputs that collide with an existing array percentile") {
+    checkAnswer(
+      spark.sql(
+        """SELECT
+          |  percentile_approx(a + (b + c), array(0.5D, 0.9D)),
+          |  percentile_approx((a + b) + c, 0.5D),
+          |  percentile_approx((a + b) + c, 0.9D)
+          |FROM VALUES (
+          |  CAST(10000000000000000 AS DOUBLE),
+          |  CAST(-10000000000000000 AS DOUBLE),
+          |  CAST(1 AS DOUBLE)
+          |) AS t(a, b, c)
+          |""".stripMargin),
+      Row(Seq(0.0d, 0.0d), 1.0d, 1.0d))
+  }
+
+  test("do not fuse filter groups when physical deduplication suppresses ANSI overflow") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val exception = intercept[SparkArithmeticException] {
+        spark.sql(
+          """SELECT
+            |  percentile_approx(v, 0.5D) FILTER (WHERE a + (b + c) > 0),
+            |  percentile_approx(v, 0.5D) FILTER (WHERE (a + b) + c > 0),
+            |  percentile_approx(v, 0.9D) FILTER (WHERE (a + b) + c > 0),
+            |  percentile_approx(v, 0.9D) FILTER (WHERE a + (b + c) > 0)
+            |FROM VALUES (
+            |  7,
+            |  CAST(2147483647 AS INT),
+            |  CAST(1 AS INT),
+            |  CAST(-1 AS INT)
+            |) AS t(v, a, b, c)
+            |""".stripMargin).collect()
+      }
+
+      assert(exception.getCondition == "ARITHMETIC_OVERFLOW")
+    }
+  }
+
+  test("do not fuse filters that collide with an existing array percentile") {
+    checkAnswer(
+      spark.sql(
+        """SELECT
+          |  percentile_approx(v, array(0.5D, 0.9D))
+          |    FILTER (WHERE a + (b + c) = 0D),
+          |  percentile_approx(v, 0.5D)
+          |    FILTER (WHERE (a + b) + c = 0D),
+          |  percentile_approx(v, 0.9D)
+          |    FILTER (WHERE (a + b) + c = 0D)
+          |FROM VALUES (
+          |  7,
+          |  CAST(10000000000000000 AS DOUBLE),
+          |  CAST(-10000000000000000 AS DOUBLE),
+          |  CAST(1 AS DOUBLE)
+          |) AS t(v, a, b, c)
+          |""".stripMargin),
+      Row(Seq(7, 7), null, null))
+  }
+
+  test("do not fuse canonically equivalent but differently evaluated accuracies") {
+    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
+    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+    val withoutConstantFolding = (existingRules :+ constantFoldingRule).distinct
+    val sql =
+      """SELECT
+        |  percentile_approx(
+        |    v, 0.5D, CAST((1e16D + -1e16D) + 3D AS INT)),
+        |  percentile_approx(
+        |    v, 0.5D, CAST(1e16D + (-1e16D + 3D) AS INT)),
+        |  percentile_approx(
+        |    v, 0.9D, CAST(1e16D + (-1e16D + 3D) AS INT)),
+        |  percentile_approx(
+        |    v, 0.9D, CAST((1e16D + -1e16D) + 3D AS INT))
+        |FROM range(100) AS t(v)
+        |""".stripMargin
+
+    def assertTwoDigests(query: DataFrame): Unit = {
+      val counts = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec =>
+          aggregate.aggregateExpressions.count(
+            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
+      }
+      assert(counts.nonEmpty)
+      assert(counts.forall(_ == 2))
+    }
+
+    val baseline = withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
+      val query = spark.sql(sql)
+      assertTwoDigests(query)
+      query.collect().toSeq
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
+      val query = spark.sql(sql)
+      checkAnswer(query, baseline)
+      assertTwoDigests(query)
+    }
+  }
+
+  test("do not fuse percentages that collide with an existing array percentile") {
+    val constantFoldingRule = "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val fusionRule = "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
+    val existingRules = spark.sessionState.conf.optimizerExcludedRules.toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+    val withoutConstantFolding = (existingRules :+ constantFoldingRule).distinct
+    val sql =
+      """SELECT
+        |  percentile_approx(
+        |    id, array((1e16D + -1e16D) + 0.5D, 0.9D)),
+        |  percentile_approx(
+        |    id, 1e16D + (-1e16D + 0.5D)),
+        |  percentile_approx(id, 0.9D)
+        |FROM range(100)
+        |""".stripMargin
+
+    def assertThreeDigests(query: DataFrame): Unit = {
+      val counts = query.queryExecution.sparkPlan.collect {
+        case aggregate: ObjectHashAggregateExec =>
+          aggregate.aggregateExpressions.count(
+            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
+      }
+      assert(counts.nonEmpty)
+      assert(counts.forall(_ == 3))
+    }
+
+    val baseline = withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
+      val query = spark.sql(sql)
+      assertThreeDigests(query)
+      query.collect().toSeq
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
+      val query = spark.sql(sql)
+      checkAnswer(query, baseline)
+      assertThreeDigests(query)
+    }
+  }
+
   test("combined scalar percentiles preserve empty-input nulls with ANSI enabled") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       withTempView(table) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, LocalDateTime, LocalTime, Period}
 
-import org.apache.spark.SparkArithmeticException
+import org.apache.spark.{SparkArithmeticException, SparkConf}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
   ApproximatePercentile, Final, Partial}
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY
@@ -42,11 +42,12 @@ import org.apache.spark.tags.SlowSQLTest
 class ApproximatePercentileQuerySuite extends SharedSparkSession {
   import testImplicits._
 
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key, "true")
+
   private val table = "percentile_approx"
   private val constantFoldingRule =
     "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
-  private val fusionRule =
-    "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles"
 
   private def excludedRules: Seq[String] = {
     spark.sessionState.conf.optimizerExcludedRules.toSeq
@@ -68,17 +69,25 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
   private def checkMatchesUnfusedBaseline(sql: String, expectedDigests: Int): Unit = {
     val withoutConstantFolding = (excludedRules :+ constantFoldingRule).distinct
     val baseline = withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        (withoutConstantFolding :+ fusionRule).distinct.mkString(",")) {
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> withoutConstantFolding.mkString(","),
+      SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "false") {
       spark.sql(sql).collect().toSeq
     }
 
     withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        withoutConstantFolding.filterNot(_ == fusionRule).mkString(",")) {
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> withoutConstantFolding.mkString(",")) {
       val query = spark.sql(sql)
       checkAnswer(query, baseline)
       assertPercentileDigestCount(query, expectedDigests)
+    }
+  }
+
+  test("approximate percentile fusion can be disabled") {
+    withSQLConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "false") {
+      val query = spark.sql(
+        "SELECT percentile_approx(id, 0.5D), percentile_approx(id, 0.9D) FROM range(10)")
+      checkAnswer(query, Row(4L, 8L))
+      assertPercentileDigestCount(query, 2)
     }
   }
 
@@ -210,8 +219,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
         |) AS t(a, b, c)
         |""".stripMargin
     val unfusedBaseline = withSQLConf(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        (excludedRules :+ fusionRule).distinct.mkString(",")) {
+      SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "false") {
       spark.sql(crossDistinctCollision).collect().toSeq
     }
     checkAnswer(spark.sql(crossDistinctCollision), unfusedBaseline)
@@ -337,10 +345,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       ("(1e16D + -1e16D) + 0.5D", "100"),
       ("0.5D", "CAST((1e16D + -1e16D) + 100D AS INT)"),
       ("0.5D", "100L"))
-    val activeRules = (excludedRules :+ constantFoldingRule)
-      .filterNot(_ == fusionRule)
-      .distinct
-      .mkString(",")
+    val activeRules = (excludedRules :+ constantFoldingRule).distinct.mkString(",")
 
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -284,6 +284,21 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       Row(Seq(0.0d, 0.0d), 0.0d, 1.0d, 1.0d))
   }
 
+  test("fused percentiles use fresh result IDs across CTE references") {
+    checkAnswer(
+      spark.sql(
+        """WITH c AS (
+          |  SELECT
+          |    percentile_approx(v, 0.5D) AS a,
+          |    percentile_approx(v, 0.9D) AS b
+          |  FROM VALUES (1), (2), (3), (4), (5) AS t(v)
+          |)
+          |SELECT c1.a, c1.b, c2.a
+          |FROM c AS c1 JOIN c AS c2
+          |""".stripMargin),
+      Row(3, 5, 3))
+  }
+
   test("preserve percentile inputs across scalar subquery reuse") {
     val query =
       """SELECT

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, LocalDateTime, LocalTime, Period}
 
-import org.apache.spark.{SparkArithmeticException, SparkConf}
+import org.apache.spark.SparkArithmeticException
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
   ApproximatePercentile, Final, Partial}
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{DoubleType, TimeType}
+import org.apache.spark.sql.types.{ArrayType, DoubleType, TimeType}
 import org.apache.spark.tags.SlowSQLTest
 
 /**
@@ -42,12 +42,15 @@ import org.apache.spark.tags.SlowSQLTest
 class ApproximatePercentileQuerySuite extends SharedSparkSession {
   import testImplicits._
 
-  override protected def sparkConf: SparkConf =
-    super.sparkConf.set(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key, "true")
-
   private val table = "percentile_approx"
   private val constantFoldingRule =
     "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+
+  private def fusionTest(name: String)(body: => Unit): Unit = test(name) {
+    withSQLConf(SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "true") {
+      body
+    }
+  }
 
   private def excludedRules: Seq[String] = {
     spark.sessionState.conf.optimizerExcludedRules.toSeq
@@ -91,7 +94,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("compatible scalar percentiles share one physical percentile digest") {
+  fusionTest("compatible scalar percentiles share one physical percentile digest") {
     withTempView(table) {
       (1 to 1000).toDF("col").createOrReplaceTempView(table)
       val query = spark.sql(
@@ -120,7 +123,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("do not fuse duplicate percentages already shared by physical planning") {
+  fusionTest("do not fuse duplicate percentages already shared by physical planning") {
     withTempView(table) {
       (1 to 1000).toDF("col").createOrReplaceTempView(table)
       val query = spark.sql(
@@ -143,7 +146,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("preserve structural input and filter evaluation") {
+  fusionTest("preserve structural input and filter evaluation") {
     checkAnswer(
       spark.sql(
         """SELECT
@@ -190,21 +193,20 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("do not fuse canonical input or filter collisions") {
-    checkAnswer(
-      spark.sql(
-        """SELECT
-          |  percentile_approx(a + (b + c), 0.5D),
-          |  percentile_approx((a + b) + c, 0.5D),
-          |  percentile_approx((a + b) + c, 0.9D),
-          |  percentile_approx(a + (b + c), 0.9D)
-          |FROM VALUES (
-          |  CAST(10000000000000000 AS DOUBLE),
-          |  CAST(-10000000000000000 AS DOUBLE),
-          |  CAST(1 AS DOUBLE)
-          |) AS t(a, b, c)
-          |""".stripMargin),
-      Row(0.0d, 0.0d, 1.0d, 1.0d))
+  fusionTest("do not fuse canonical input or filter collisions") {
+    checkMatchesUnfusedBaseline(
+      """SELECT
+        |  percentile_approx(a + (b + c), 0.5D),
+        |  percentile_approx((a + b) + c, 0.5D),
+        |  percentile_approx((a + b) + c, 0.9D),
+        |  percentile_approx(a + (b + c), 0.9D)
+        |FROM VALUES (
+        |  CAST(10000000000000000 AS DOUBLE),
+        |  CAST(-10000000000000000 AS DOUBLE),
+        |  CAST(1 AS DOUBLE)
+        |) AS t(a, b, c)
+        |""".stripMargin,
+      expectedDigests = 2)
 
     val crossDistinctCollision =
       """SELECT
@@ -224,9 +226,8 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
     checkAnswer(spark.sql(crossDistinctCollision), unfusedBaseline)
 
-    checkAnswer(
-      spark.sql(
-        """SELECT
+    val filteredArrayCollision = spark.sql(
+      """SELECT
           |  percentile_approx(v, array(0.5D, 0.9D))
           |    FILTER (WHERE a + (b + c) = 0D),
           |  percentile_approx(v, 0.5D)
@@ -239,11 +240,12 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |  CAST(-10000000000000000 AS DOUBLE),
           |  CAST(1 AS DOUBLE)
           |) AS t(v, a, b, c)
-          |""".stripMargin),
-      Row(Seq(7, 7), null, null))
+          |""".stripMargin)
+    checkAnswer(filteredArrayCollision, Row(Seq(7, 7), null, null))
+    assertPercentileDigestCount(filteredArrayCollision, 2)
   }
 
-  test("preserve canonically colliding parameters") {
+  fusionTest("preserve canonically colliding parameters") {
     val cases = Seq(
       (
         """SELECT
@@ -274,10 +276,9 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("do not fuse with an existing array that collides after distinct removal") {
-    checkAnswer(
-      spark.sql(
-        """SELECT
+  fusionTest("preserve existing arrays that collide after distinct removal") {
+    val query = spark.sql(
+      """SELECT
           |  percentile_approx(
           |    DISTINCT a + (b + c), array(0.5D, 0.9D)),
           |  percentile_approx(DISTINCT a + (b + c), 0.1D),
@@ -288,26 +289,32 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |  CAST(-10000000000000000 AS DOUBLE),
           |  CAST(1 AS DOUBLE)
           |) AS t(a, b, c)
-          |""".stripMargin),
-      Row(Seq(0.0d, 0.0d), 0.0d, 1.0d, 1.0d))
+          |""".stripMargin)
+    checkAnswer(query, Row(Seq(0.0d, 0.0d), 0.0d, 1.0d, 1.0d))
+    assertPercentileDigestCount(query, 3)
   }
 
-  test("fused percentiles use fresh result IDs across CTE references") {
-    checkAnswer(
-      spark.sql(
-        """WITH c AS (
+  fusionTest("fused percentiles use fresh result IDs across CTE references") {
+    val query = spark.sql(
+      """WITH c AS (
           |  SELECT
           |    percentile_approx(v, 0.5D) AS a,
           |    percentile_approx(v, 0.9D) AS b
-          |  FROM VALUES (1), (2), (3), (4), (5) AS t(v)
+          |  FROM range(1, 6) AS t(v)
           |)
           |SELECT c1.a, c1.b, c2.a
           |FROM c AS c1 JOIN c AS c2
-          |""".stripMargin),
-      Row(3, 5, 3))
+          |""".stripMargin)
+    checkAnswer(query, Row(3L, 5L, 3L))
+    val optimizedPlan = query.queryExecution.optimizedPlan
+    assert(optimizedPlan.subqueriesAll.exists(_.exists(_.expressions.exists(_.exists {
+      case percentile: ApproximatePercentile =>
+        percentile.percentageExpression.dataType.isInstanceOf[ArrayType]
+      case _ => false
+    }))), optimizedPlan.numberedTreeString)
   }
 
-  test("preserve percentile inputs across scalar subquery reuse") {
+  fusionTest("preserve percentile inputs across scalar subquery reuse") {
     val query =
       """SELECT
         |  (SELECT named_struct(
@@ -340,7 +347,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("preserve pre-fusion identity across exchange reuse") {
+  fusionTest("preserve pre-fusion identity across exchange reuse") {
     val parameterPairs = Seq(
       ("(1e16D + -1e16D) + 0.5D", "100"),
       ("0.5D", "CAST((1e16D + -1e16D) + 100D AS INT)"),
@@ -391,7 +398,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("identical fused percentiles remain reusable") {
+  fusionTest("identical fused percentiles remain reusable") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true") {
@@ -410,7 +417,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }
   }
 
-  test("fused distinct percentiles keep a single distinct group") {
+  fusionTest("fused distinct percentiles keep a single distinct group") {
     val query = spark.sql(
       """SELECT
         |  count(DISTINCT id),
@@ -426,7 +433,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
     }.isEmpty)
   }
 
-  test("combined scalar percentiles preserve empty-input nulls") {
+  fusionTest("combined scalar percentiles preserve empty-input nulls") {
     withTempView(table) {
       Seq.empty[Int].toDF("col").createOrReplaceTempView(table)
       val query = spark.sql(
@@ -438,6 +445,58 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       checkAnswer(query, Row(null, null))
       assertPercentileDigestCount(query, 1)
     }
+  }
+
+  fusionTest("preserve compressed and merged low-accuracy percentile digests") {
+    val sql =
+      """SELECT
+        |  percentile_approx(id, 0.1D, 100),
+        |  percentile_approx(id, 0.5D, 100),
+        |  percentile_approx(id, 0.9D, 100)
+        |FROM range(0, 50000, 1, 4)
+        |""".stripMargin
+    val baseline = withSQLConf(
+      SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "false") {
+      spark.sql(sql).collect().toSeq
+    }
+
+    val query = spark.sql(sql)
+    checkAnswer(query, baseline)
+    assertPercentileDigestCount(query, 1)
+  }
+
+  fusionTest("fuse compatible percentiles introduced by merged scalar subqueries") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true") {
+      val query = spark.sql(
+        """SELECT
+          |  (SELECT percentile_approx(id, 0.5D) FROM range(10)),
+          |  (SELECT percentile_approx(id, 0.9D) FROM range(10))
+          |""".stripMargin)
+
+      checkAnswer(query, Row(4L, 8L))
+      val digestCounts = query.queryExecution.executedPlan.collectWithSubqueries {
+        case aggregate: ObjectHashAggregateExec =>
+          aggregate.aggregateExpressions.count(
+            _.aggregateFunction.isInstanceOf[ApproximatePercentile])
+      }
+      assert(digestCounts.nonEmpty && digestCounts.forall(_ == 1), digestCounts)
+    }
+  }
+
+  fusionTest("fuse canonical input groups with disjoint percentages independently") {
+    val query = spark.sql(
+      """SELECT
+        |  percentile_approx(a + b, 0.5D),
+        |  percentile_approx(a + b, 0.9D),
+        |  percentile_approx(b + a, 0.25D),
+        |  percentile_approx(b + a, 0.75D)
+        |FROM VALUES (1D, 2D), (3D, 4D), (5D, 6D) AS t(a, b)
+        |""".stripMargin)
+
+    checkAnswer(query, Row(7.0d, 11.0d, 3.0d, 11.0d))
+    assertPercentileDigestCount(query, 2)
   }
 
   test("percentile_approx, single percentile value") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -211,7 +211,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
       Row(Seq(7, 7), null, null))
   }
 
-  test("do not fuse canonically colliding parameters") {
+  test("preserve canonically colliding parameters") {
     val cases = Seq(
       (
         """SELECT
@@ -235,7 +235,7 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
           |  percentile_approx(id, 0.9D)
           |FROM range(100)
           |""".stripMargin,
-        3))
+        2))
 
     cases.foreach { case (sql, expectedDigests) =>
       checkMatchesUnfusedBaseline(sql, expectedDigests)
@@ -296,7 +296,8 @@ class ApproximatePercentileQuerySuite extends SharedSparkSession {
   test("preserve pre-fusion identity across exchange reuse") {
     val parameterPairs = Seq(
       ("(1e16D + -1e16D) + 0.5D", "100"),
-      ("0.5D", "CAST((1e16D + -1e16D) + 100D AS INT)"))
+      ("0.5D", "CAST((1e16D + -1e16D) + 100D AS INT)"),
+      ("0.5D", "100L"))
     val activeRules = (excludedRules :+ constantFoldingRule)
       .filterNot(_ == fusionRule)
       .distinct

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -125,15 +125,17 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
         StartStream(
           checkpointLocation = checkpointDir.getAbsolutePath,
           additionalConfs = Map(
-            SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-              "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles")),
+            SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "false")),
         AddData(inputData, (0, 1), (0, 2), (0, 3)),
         CheckLastBatch((0, 2, 3)),
         StopStream)
 
-      // Start a separate stream so that the optimizer exclusion has been fully restored.
+      // Restart with percentile fusion enabled to verify the existing checkpoint stays valid.
       testStream(aggregated, Update)(
-        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        StartStream(
+          checkpointLocation = checkpointDir.getAbsolutePath,
+          additionalConfs = Map(
+            SQLConf.COMBINE_APPROXIMATE_PERCENTILES_ENABLED.key -> "true")),
         AddData(inputData, (0, 4)),
         CheckLastBatch((0, 2, 4)),
         StopStream)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -110,6 +110,36 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
     )
   }
 
+  testWithAllStateVersions("approximate percentiles preserve existing streaming checkpoints") {
+    withTempDir { checkpointDir =>
+      val inputData = MemoryStream[(Int, Int)]
+      val aggregated = inputData.toDF()
+        .groupBy($"_1")
+        .agg(
+          expr("percentile_approx(_2, 0.5)").as("p50"),
+          expr("percentile_approx(_2, 0.9)").as("p90"))
+        .as[(Int, Int, Int)]
+
+      // Create the two-digest checkpoint used before percentile fusion was introduced.
+      testStream(aggregated, Update)(
+        StartStream(
+          checkpointLocation = checkpointDir.getAbsolutePath,
+          additionalConfs = Map(
+            SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+              "org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentiles")),
+        AddData(inputData, (0, 1), (0, 2), (0, 3)),
+        CheckLastBatch((0, 2, 3)),
+        StopStream)
+
+      // Start a separate stream so that the optimizer exclusion has been fully restored.
+      testStream(aggregated, Update)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        AddData(inputData, (0, 4)),
+        CheckLastBatch((0, 2, 4)),
+        StopStream)
+    }
+  }
+
   testWithAllStateVersions("count distinct") {
     val inputData = MemoryStream[(Int, Seq[Int])]
 


### PR DESCRIPTION
### Why are the changes needed?

This addresses [SPARK-58378](https://issues.apache.org/jira/browse/SPARK-58378).

An approximate percentile sketch summarizes a distribution. Once the sketch exists,
Spark can read p50, p90, p95, or any other requested percentile from the same
state. Nevertheless, a query that writes those percentiles as separate scalar
aggregates currently constructs and maintains a separate sketch for each one.

For example:

```sql
SELECT
  service,
  percentile_approx(latency_ms, 0.50, 10000) AS p50,
  percentile_approx(latency_ms, 0.90, 10000) AS p90,
  percentile_approx(latency_ms, 0.95, 10000) AS p95
FROM request_metrics
GROUP BY service;
```

All three aggregates receive the same values and use the same accuracy. The
percentile only affects how the completed sketch is queried. Despite that, Spark
currently allocates three aggregate buffers per group, inserts every qualifying
input into all three, serializes three partial sketches, and merges three sketches
during final aggregation.

Callers can avoid that work by rewriting the query to use
`percentile_approx(latency_ms, array(0.50, 0.90, 0.95), 10000)` and extracting
individual array elements. However, requiring that rewrite is awkward for existing
SQL, generated reports, named scalar output columns, and expressions that consume
individual percentile values.

### What changes were proposed in this PR?

Add an opt-in Catalyst optimization that recognizes scalar approximate percentile
aggregates describing the same distribution, calculates that distribution once,
and extracts each original scalar result from the shared array-valued aggregate.
The optimization is controlled by the public SQL configuration
`spark.sql.optimizer.combineApproximatePercentiles.enabled`, which defaults to
`false`. Existing queries are unchanged until a user explicitly enables it.

For the example above, the resulting aggregation is equivalent to:

```sql
percentile_approx(latency_ms, array(0.50, 0.90, 0.95), 10000)
```

Catalyst returns elements `0`, `1`, and `2` under the original `p50`, `p90`, and
`p95` expressions. Callers do not change their query. Both partial and final
aggregation maintain one percentile sketch instead of three. Fusion only runs when
it removes a sketch that Spark would not already share: repeating the same scalar
percentile therefore does not add unnecessary array construction or lookups. It
also runs after subplan merging, which can bring independently written scalar
subqueries together into a newly eligible aggregate.

The fused percentage array also preserves the identity of the original scalar
aggregates. Otherwise, retaining only the first aggregate's accuracy expression
could make previously distinct plans appear identical; for example, `100` and
`100L` evaluate to the same accuracy but remain different Catalyst literals.
`PercentileFusionArray` wraps a `PercentileFusionIdentity` containing those
original aggregate structures, and `ConstantFolding` explicitly leaves that
internal expression intact. This prevents fusion from introducing incorrect
exchange or subquery reuse.

Fusion is intentionally limited to deterministic scalar aggregates with the same
input expression, evaluated accuracy, aggregation mode, distinctness, and filter.
Inputs and filters are compared structurally so that floating-point evaluation and
ANSI overflow behavior do not change. Accuracy is compared after evaluation, which
remains correct when `ConstantFolding` is excluded. Existing array-valued
aggregates retain their original identity, incompatible distributions are not
combined, and Structured Streaming aggregates remain unchanged to preserve
existing checkpoint state schemas.

### Does this PR introduce _any_ user-facing change?

Yes. It introduces the public SQL configuration
`spark.sql.optimizer.combineApproximatePercentiles.enabled`, which defaults to
`false`. The default preserves existing query behavior and lets users evaluate
the optimization explicitly before enabling it more broadly.

When enabled, eligible batch queries use fewer percentile aggregation buffers and
can perform less sketch update, serialization, shuffle, and merge work. Preserving
the original aggregate structures can also prevent an existing, unsafe exchange
or subquery reuse between canonically equivalent but differently evaluated
expressions; in those cases, enabling fusion can correct a result that was already
wrong without the optimization. SQL syntax, public APIs, and output schemas are
unchanged.

### How was this PR tested?

Added focused Catalyst optimizer tests, end-to-end physical-plan and result tests,
and streaming checkpoint-recovery coverage. The regressions cover the opt-in flag
and default-off behavior, duplicate percentages and aggregate identities,
structural input/filter matching, ANSI overflow, evaluated accuracy and percentage
collisions, existing array aggregates, mixed DISTINCT/non-DISTINCT groups,
DISTINCT rewriting and removal, scalar subqueries merged into a shared aggregate,
exchange/subquery reuse with differently typed accuracy literals, compressed and
merged low-accuracy sketches across multiple partitions, empty inputs, and
streaming checkpoint compatibility across both existing state-format versions.

```text
build/sbt \
  'catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.CombineApproximatePercentilesSuite' \
  'sql/testOnly org.apache.spark.sql.ApproximatePercentileQuerySuite' \
  'sql/testOnly org.apache.spark.sql.streaming.StreamingAggregationSuite -- -z "approximate percentiles preserve existing streaming checkpoints"' \
  'catalyst/scalastyle' \
  'sql/scalastyle' \
  'sql/Test/scalastyle'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
