### PR TITLE
[SPARK-56460][CORE][FOLLOWUP][4.x] Fix `common/config` module POM version

### DIFF
--- a/common/config/pom.xml
+++ b/common/config/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.13</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the `common/config` module was backported to `branch-4.x` in
[SPARK-56460](https://issues.apache.org/jira/browse/SPARK-56460) (commit abc39b74f75),
its parent POM version in `common/config/pom.xml` was left at `5.0.0-SNAPSHOT`
(the `master` version) instead of `4.3.0-SNAPSHOT`. This one-line change
corrects it.


### Why are the changes needed?

`branch-4.x` is at `4.3.0-SNAPSHOT`, but `common/config/pom.xml` referenced
parent `spark-parent_2.13:5.0.0-SNAPSHOT`.  This breaks sbt build

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local sbt build


### Was this patch authored or co-authored using generative AI tooling?
Authored by Cursor
