### PR TITLE
[SPARK-58396][ML][CONNECT] Include FPGrowth metadata in size estimates

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/fpm/FPGrowth.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/fpm/FPGrowth.scala
@@ -324,13 +324,17 @@ class FPGrowthModel private[ml] (
   }
 
   private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    // freqItemsets: DataFrame("items": Array, "freq": Long)
     freqItemsets match {
       case df: org.apache.spark.sql.classic.DataFrame =>
-        df.toArrowBatchRdd.map(_.length.toLong).reduce(_ + _) +
-          SizeEstimator.estimate(itemSupport)
+        size += df.toArrowBatchRdd.map(_.length.toLong).reduce(_ + _)
       case o => throw new UnsupportedOperationException(
         s"Unsupported dataframe type: ${o.getClass.getName}")
     }
+    // itemSupport: scala.collection.Map[Any, Double]
+    size += SizeEstimator.estimate(itemSupport)
+    size
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
@@ -154,6 +154,14 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     ParamsSuite.checkParams(model)
   }
 
+  test("FPGrowthModel estimated size") {
+    val model = new FPGrowth().setMinSupport(0.5).fit(dataset)
+    val maxSize = 1024 * 16
+    assert(
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
   test("read/write") {
     def checkModelData(model: FPGrowthModel, model2: FPGrowthModel): Unit = {
       assert(model.freqItemsets.collect().toSet.equals(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds parameter metadata to `FPGrowthModel.estimatedSize` while retaining its existing frequent-itemset and item-support estimates. Adds regression coverage using the suite's small FP-growth dataset.

### Why are the changes needed?

The specialized estimate counted learned data but omitted the model's parameter metadata.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `FPGrowthModel estimated size` coverage in `FPGrowthSuite`. The suite was not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)