### PR TITLE
[SPARK-58397][ML][CONNECT] Add Bucketizer size estimate

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala
@@ -217,6 +217,8 @@ final class Bucketizer @Since("1.4.0") (@Since("1.4.0") override val uid: String
     defaultCopy[Bucketizer](extra).setParent(parent)
   }
 
+  private[spark] override def estimatedSize: Long = estimateMatadataSize
+
   @Since("3.0.0")
   override def toString: String = {
     s"Bucketizer: uid=$uid" +

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -37,6 +37,14 @@ class BucketizerSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(new Bucketizer)
   }
 
+  test("Bucketizer estimated size") {
+    val model = new Bucketizer().setSplits(Array(-1.0, 0.0, 1.0))
+    val maxSize = 1024 * 4
+    assert(
+      model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
   test("Bucket continuous features, without -inf,inf") {
     // Check a set of valid feature values.
     val splits = Array(-0.5, 0.0, 0.5)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a specialized `Bucketizer.estimatedSize` implementation that charges its parameter metadata. Adds a bounded-size regression test.

### Why are the changes needed?

Bucketizer is a model whose state is entirely represented by its parameter maps, so its cache charge can use the precise metadata estimate instead of a generic object-graph walk.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `Bucketizer estimated size` coverage in `BucketizerSuite`. The suite was not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)