### PR TITLE
[SPARK-58402][PYTHON] Consolidate UNKNOWN_EXPLAIN_MODE into VALUE_NOT_ALLOWED

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1083,11 +1083,6 @@
       "Unexpected tuple <tuple> with StructType."
     ]
   },
-  "UNKNOWN_EXPLAIN_MODE": {
-    "message": [
-      "Unknown explain mode: '<explain_mode>'. Accepted explain modes are 'simple', 'extended', 'codegen', 'cost', 'formatted'."
-    ]
-  },
   "UNKNOWN_INTERRUPT_TYPE": {
     "message": [
       "Unknown interrupt type: '<interrupt_type>'. Accepted interrupt types are 'all'."

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1577,11 +1577,13 @@ class SparkConnectClient(object):
         elif method == "explain":
             req.explain.plan.CopyFrom(cast(pb2.Plan, kwargs.get("plan")))
             explain_mode = kwargs.get("explain_mode")
-            if explain_mode not in ["simple", "extended", "codegen", "cost", "formatted"]:
+            allowed_explain_modes = ["simple", "extended", "codegen", "cost", "formatted"]
+            if explain_mode not in allowed_explain_modes:
                 raise PySparkValueError(
-                    errorClass="UNKNOWN_EXPLAIN_MODE",
+                    errorClass="VALUE_NOT_ALLOWED",
                     messageParameters={
-                        "explain_mode": str(explain_mode),
+                        "arg_name": "explain_mode",
+                        "allowed_values": str(allowed_explain_modes),
                     },
                 )
             if explain_mode == "simple":

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1119,8 +1119,11 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.connect.sql("SELECT 1")._explain_string(mode="unknown")
         self.check_error(
             exception=pe.exception,
-            errorClass="UNKNOWN_EXPLAIN_MODE",
-            messageParameters={"explain_mode": "unknown"},
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
+                "arg_name": "explain_mode",
+                "allowed_values": "['simple', 'extended', 'codegen', 'cost', 'formatted']",
+            },
         )
 
     def test_count(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Consolidate the specialized Spark Connect `UNKNOWN_EXPLAIN_MODE` error condition into `VALUE_NOT_ALLOWED`. Invalid explain modes now report the generic allowed-values condition, and the existing Spark Connect test asserts the new condition.

### Why are the changes needed?

`UNKNOWN_EXPLAIN_MODE` duplicates the generic allowed-values condition for a fixed argument allowlist. Removing it reduces narrowly scoped PySpark error conditions and aligns the validation with similar APIs.

### Does this PR introduce _any_ user-facing change?

Yes. Invalid Spark Connect explain modes now use `VALUE_NOT_ALLOWED` and its generic message. The exception type remains `PySparkValueError`.

### How was this patch tested?

Updated the existing Spark Connect explain-mode assertion. Static validation passed: `git diff --check`, JSON parsing, and a changed-Python-file line-length scan. The focused test suite was not run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)