### PR TITLE
[MINOR][SQL] Simplify redundant boolean ternary in visitDeclareCursorStatement

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -7641,7 +7641,7 @@ class AstBuilder extends DataTypeAstBuilder
     // Extract original SQL text to preserve parameter markers
     val queryText = getOriginalText(ctx.query())
 
-    val asensitive = if (ctx.INSENSITIVE() != null) false else true
+    val asensitive = ctx.INSENSITIVE() == null
     DeclareCursor(cursorName, queryText, asensitive)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Simplifies a redundant boolean ternary in `visitDeclareCursorStatement`: `if (ctx.INSENSITIVE() != null) false else true` becomes `ctx.INSENSITIVE() == null`.

### Why are the changes needed?
The ternary maps a null check to a negated boolean; the direct comparison has the identical truth table and reads more clearly (asensitive is true exactly when the INSENSITIVE token is absent).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Behavior-preserving one-line simplification; existing parser tests cover it. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)