### PR TITLE
[MINOR][INFRA] Fix doubled braces in structured logging style-check hint

### DIFF
--- a/dev/structured_logging_style.py
+++ b/dev/structured_logging_style.py
@@ -82,7 +82,7 @@ def main():
                 print(f"[error] {file_path}:{line_number}:{start_char}", file=sys.stderr)
                 print(
                     "[error]\tPlease use the Structured Logging Framework for logging messages "
-                    'with variables. For example: log"...${{MDC(TASK_ID, taskId)}}..."'
+                    'with variables. For example: log"...${MDC(TASK_ID, taskId)}..."'
                     "\n\tRefer to the guidelines in the file `internal/Logging.scala`.",
                     file=sys.stderr,
                 )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes the developer-facing hint printed by the structured-logging style check so its MDC example shows single braces `${MDC(TASK_ID, taskId)}` instead of the doubled `${{...}}`.

### Why are the changes needed?
The example lives in a plain (non-f) string literal, so the doubled braces were rendered literally, teaching incorrect syntax to anyone who copied the hint. The real structured-logging API uses single braces.

### Does this PR introduce _any_ user-facing change?
No (developer tooling message only).

### How was this patch tested?
Manual inspection: confirmed the hint is emitted from a plain (non-f) string literal, so the doubled braces render literally, and that the real structured-logging API (`Logging.scala`) uses single braces. Reviewer can re-run `dev/structured_logging_style.py` to see the corrected hint.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)