### PR TITLE
[4.2] Upgrade Jetty, Ivy, lz4-java, and tink to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <javaxservlet.version>4.0.1</javaxservlet.version>
     <chill.version>0.10.0</chill.version>
     <kryo.version>4.0.3</kryo.version>
-    <ivy.version>2.5.3</ivy.version>
+    <ivy.version>2.6.0</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
     If you change codahale.metrics.version, you also need to change
@@ -214,7 +214,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.11.0</commons-cli.version>
     <bouncycastle.version>1.84</bouncycastle.version>
-    <tink.version>1.20.0</tink.version>
+    <tink.version>1.21.0</tink.version>
     <!--
       TODO: Once upgrade datasketches to a version that supports Java 25,
             SPARK-53327 workaround should be reverted.
@@ -894,7 +894,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.0</version>
+        <version>1.11.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <parquet.version>1.17.0</parquet.version>
     <orc.version>2.3.0</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>12.1.8</jetty.version>
+    <jetty.version>12.1.11</jetty.version>
     <jakartaservlet.version>6.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade four dependencies in pom.xml to their latest patched versions.

### Why are the changes needed?
CVEs detected by internal security scan. Security team requires these upgrades:

| CVE | Severity | Package | From | To |
|-----|----------|---------|------|-----|
| CVE-2026-10050 | High 8.7 | jetty | 12.1.8 | 12.1.11 |
| CVE-2026-6790 | Medium | jetty-server | 12.1.8 | 12.1.11 |
| CVE-2026-10051 | High | jetty-server | 12.1.8 | 12.1.11 |
| CVE-2026-8384 | Medium | jetty-util | 12.1.8 | 12.1.11 |
| CVE-2026-26032 | Medium 5.4 | ivy | 2.5.3 | 2.6.0 |
| CVE-2026-59949 | Medium | lz4-java | 1.11.0 | 1.11.1 |
| CVE-2026-15432 | High 8.2 | tink | 1.20.0 | 1.21.0 |

### Does this PR introduce any user-facing change?
No. Internal dependency bumps only for security scan in every monthly releases.

### How was this patch tested?
mvn -pl core -am compile -DskipTests passed.

### Was this patch authored or co-authored using generative AI tooling?
Yes, GitHub Copilot assisted with dependency version updates.