### PR TITLE
[SPARK-58404][SQL] Support bypassing partial WindowGroupLimit

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -136,18 +136,6 @@ Configuration of in-memory caching can be done via `spark.conf.set` or by runnin
     </td>
     <td>2.1.1</td>
   </tr>
-  <tr>
-    <td><code>spark.sql.execution.bypassPartialWindowGroupLimit</code></td>
-    <td>false</td>
-    <td>
-      When true, skips the pre-shuffle partial window group limit for top-k window queries (such as
-      filtering on <code>row_number</code>, <code>rank</code> or <code>dense_rank</code>) and runs
-      only a single window group limit after the shuffle. Bypassing the partial window group limit
-      can improve performance when the pre-shuffle reduction ratio is low. When false, a partial
-      window group limit runs before the shuffle and a final one runs after it.
-    </td>
-    <td>4.3.0</td>
-  </tr>
 </table>
 
 ### Coalesce Hints
@@ -179,6 +167,31 @@ SELECT /*+ REBALANCE_BY_SIZE('128m', c) */ * FROM t;
 ```
 
 For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
+
+## Tuning Window Functions
+
+Top-k window queries (such as filtering on <code>row_number</code>, <code>rank</code> or
+<code>dense_rank</code>) plan a window group limit on both sides of the shuffle: a partial one
+before the shuffle to reduce the data feeding it, and a final one after. The following configuration
+tunes that behavior.
+
+<table class="spark-config">
+  <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
+  <tr>
+    <td><code>spark.sql.execution.bypassPartialWindowGroupLimit</code></td>
+    <td>false</td>
+    <td>
+      When true, skips the pre-shuffle partial window group limit for partitioned top-k window
+      queries and runs only a single window group limit after the shuffle. Bypassing the partial
+      window group limit can improve performance when the pre-shuffle reduction ratio is low. The
+      bypass only applies to windows with a non-empty partition spec; for an unpartitioned window
+      the partial pass is always kept since the shuffle funnels the whole input into a single
+      reducer. When false, a partial window group limit runs before the shuffle and a final one
+      runs after it.
+    </td>
+    <td>4.3.0</td>
+  </tr>
+</table>
 
 ## Leveraging Statistics
 Apache Spark's ability to choose the best execution plan among many possible options is determined in part by its estimates of how many rows will be output by every node in the execution plan (read, filter, join, etc.). Those estimates in turn are based on statistics that are made available to Spark in one of several ways:

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -136,6 +136,18 @@ Configuration of in-memory caching can be done via `spark.conf.set` or by runnin
     </td>
     <td>2.1.1</td>
   </tr>
+  <tr>
+    <td><code>spark.sql.execution.bypassPartialWindowGroupLimit</code></td>
+    <td>false</td>
+    <td>
+      When true, skips the pre-shuffle partial window group limit for top-k window queries (such as
+      filtering on <code>row_number</code>, <code>rank</code> or <code>dense_rank</code>) and runs
+      only a single window group limit after the shuffle. Bypassing the partial window group limit
+      can improve performance when the pre-shuffle reduction ratio is low. When false, a partial
+      window group limit runs before the shuffle and a final one runs after it.
+    </td>
+    <td>4.3.0</td>
+  </tr>
 </table>
 
 ### Coalesce Hints

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -185,9 +185,9 @@ tunes that behavior.
       queries and runs only a single window group limit after the shuffle. Bypassing the partial
       window group limit can improve performance when the pre-shuffle reduction ratio is low. The
       bypass only applies to windows with a non-empty partition spec; for an unpartitioned window
-      the partial pass is always kept since the shuffle funnels the whole input into a single
-      reducer. When false, a partial window group limit runs before the shuffle and a final one
-      runs after it.
+      the partial pass is always kept, since for a multi-partition input the shuffle funnels the
+      whole input into a single reducer. When false, a partial window group limit runs before the
+      shuffle and a final one runs after it.
     </td>
     <td>4.3.0</td>
   </tr>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4531,10 +4531,13 @@ object SQLConf {
     buildConf("spark.sql.execution.bypassPartialWindowGroupLimit")
       .doc("When true, skips the pre-shuffle partial WindowGroupLimit and runs only a single " +
         "WindowGroupLimit after the shuffle. Bypassing the partial window group limit can " +
-        "improve performance when the pre-shuffle reduction ratio is low. When false (default), " +
-        "a partial WindowGroupLimit runs before the shuffle and a final one runs after it.")
+        "improve performance when the pre-shuffle reduction ratio is low. This only applies to " +
+        "windows with a non-empty partition spec; an unpartitioned window always keeps the " +
+        "partial pass since the shuffle funnels the whole input into a single reducer. When " +
+        "false (default), a partial WindowGroupLimit runs before the shuffle and a final one " +
+        "runs after it.")
       .version("4.3.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4527,6 +4527,17 @@ object SQLConf {
         "The threshold of window group limit must be -1, 0 or positive integer.")
       .createWithDefault(1000)
 
+  val BYPASS_PARTIAL_WINDOW_GROUP_LIMIT =
+    buildConf("spark.sql.execution.bypassPartialWindowGroupLimit")
+      .doc("When true, skips the pre-shuffle partial WindowGroupLimit and runs only a single " +
+        "WindowGroupLimit after the shuffle. Bypassing the partial window group limit can " +
+        "improve performance when the pre-shuffle reduction ratio is low. When false (default), " +
+        "a partial WindowGroupLimit runs before the shuffle and a final one runs after it.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
+      .createWithDefault(false)
+
   val WINDOW_SEGMENT_TREE_ENABLED =
     buildConf("spark.sql.window.segmentTree.enabled")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
@@ -8909,6 +8920,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def windowExecBufferSpillSizeThreshold: Long = getConf(WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD)
 
   def windowGroupLimitThreshold: Int = getConf(WINDOW_GROUP_LIMIT_THRESHOLD)
+
+  def bypassPartialWindowGroupLimit: Boolean = getConf(BYPASS_PARTIAL_WINDOW_GROUP_LIMIT)
 
   def windowSegmentTreeEnabled: Boolean = getConf(WINDOW_SEGMENT_TREE_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4533,9 +4533,9 @@ object SQLConf {
         "WindowGroupLimit after the shuffle. Bypassing the partial window group limit can " +
         "improve performance when the pre-shuffle reduction ratio is low. This only applies to " +
         "windows with a non-empty partition spec; an unpartitioned window always keeps the " +
-        "partial pass since the shuffle funnels the whole input into a single reducer. When " +
-        "false (default), a partial WindowGroupLimit runs before the shuffle and a final one " +
-        "runs after it.")
+        "partial pass, since for a multi-partition input the shuffle funnels the whole input " +
+        "into a single reducer. When false (default), a partial WindowGroupLimit runs before " +
+        "the shuffle and a final one runs after it.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -805,7 +805,15 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         // When the partial window group limit is bypassed, skip the pre-shuffle partial
         // WindowGroupLimit and run only a single WindowGroupLimit after the shuffle. This can
         // improve performance when the pre-shuffle reduction ratio is low.
-        val finalChild = if (conf.bypassPartialWindowGroupLimit) {
+        //
+        // The bypass is only gated on a non-empty partitionSpec. With an empty partitionSpec the
+        // final WindowGroupLimit requires AllTuples, so the shuffle funnels the whole input into a
+        // single reducer; the partial pass we would drop bounds each input partition to `limit`
+        // rank groups before that shuffle, so it always helps and should never be skipped.
+        // Bypassing it would shuffle all raw rows to a single partition, which is strictly worse
+        // than the normal Partial+Final path. This mirrors the grouping-keys carve-out in
+        // bypassPartialAggregation (see AggUtils.planAggregateWithoutDistinct).
+        val finalChild = if (conf.bypassPartialWindowGroupLimit && partitionSpec.nonEmpty) {
           planLater(child)
         } else {
           execution.window.WindowGroupLimitExec(partitionSpec,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -802,10 +802,17 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   object WindowGroupLimit extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case logical.WindowGroupLimit(partitionSpec, orderSpec, rankLikeFunction, limit, child) =>
-        val partialWindowGroupLimit = execution.window.WindowGroupLimitExec(partitionSpec,
-          orderSpec, rankLikeFunction, limit, execution.window.Partial, planLater(child))
+        // When the partial window group limit is bypassed, skip the pre-shuffle partial
+        // WindowGroupLimit and run only a single WindowGroupLimit after the shuffle. This can
+        // improve performance when the pre-shuffle reduction ratio is low.
+        val finalChild = if (conf.bypassPartialWindowGroupLimit) {
+          planLater(child)
+        } else {
+          execution.window.WindowGroupLimitExec(partitionSpec,
+            orderSpec, rankLikeFunction, limit, execution.window.Partial, planLater(child))
+        }
         val finalWindowGroupLimit = execution.window.WindowGroupLimitExec(partitionSpec, orderSpec,
-          rankLikeFunction, limit, execution.window.Final, partialWindowGroupLimit)
+          rankLikeFunction, limit, execution.window.Final, finalChild)
         finalWindowGroupLimit :: Nil
       case _ => Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -807,12 +807,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         // improve performance when the pre-shuffle reduction ratio is low.
         //
         // The bypass is only gated on a non-empty partitionSpec. With an empty partitionSpec the
-        // final WindowGroupLimit requires AllTuples, so the shuffle funnels the whole input into a
-        // single reducer; the partial pass we would drop bounds each input partition to `limit`
-        // rank groups before that shuffle, so it always helps and should never be skipped.
-        // Bypassing it would shuffle all raw rows to a single partition, which is strictly worse
-        // than the normal Partial+Final path. This mirrors the grouping-keys carve-out in
-        // bypassPartialAggregation (see AggUtils.planAggregateWithoutDistinct).
+        // final WindowGroupLimit requires AllTuples, so for a multi-partition input the shuffle
+        // funnels everything into a single reducer; the partial pass we would drop bounds each
+        // input partition to `limit` rank groups before that shuffle, so keeping it is a sensible
+        // default (an already-single-partition child needs no shuffle, so the partial cannot reduce
+        // the shuffle input there and only adds another pass). This mirrors the grouping-keys
+        // carve-out in bypassPartialAggregation (see AggUtils.planAggregateWithoutDistinct).
         val finalChild = if (conf.bypassPartialWindowGroupLimit && partitionSpec.nonEmpty) {
           planLater(child)
         } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -1692,6 +1692,16 @@ class DataFrameWindowFunctionsSuite extends SharedSparkSession
       ("c", 1, "z"),
       ("c", 2, "a")).toDF("key", "value", "order")
 
+    def countWindowGroupLimits(df: DataFrame): Int = {
+      collect(df.queryExecution.executedPlan) {
+        case w: WindowGroupLimitExec => w
+      }.size
+    }
+
+    val rankLikeFunctions = Seq(row_number(), rank(), dense_rank())
+
+    // Partitioned window: a shuffle is required, so without the bypass both the partial and the
+    // final WindowGroupLimit are present; with the bypass only the final one remains.
     val window = Window.partitionBy($"key").orderBy($"order")
     val expected = Seq(
       Row("a", 0, "c", 1),
@@ -1702,15 +1712,30 @@ class DataFrameWindowFunctionsSuite extends SharedSparkSession
       withSQLConf(
         SQLConf.BYPASS_PARTIAL_WINDOW_GROUP_LIMIT.key -> bypass.toString,
         SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "100") {
-        val result = df.withColumn("rn", row_number().over(window)).where($"rn" === 1)
-        checkAnswer(result, expected)
-
-        val limits = collect(result.queryExecution.executedPlan) {
-          case w: WindowGroupLimitExec => w
+        rankLikeFunctions.foreach { rankLikeFunction =>
+          val result = df.withColumn("rn", rankLikeFunction.over(window)).where($"rn" === 1)
+          checkAnswer(result, expected)
+          assert(countWindowGroupLimits(result) === (if (bypass) 1 else 2))
         }
-        // When bypassed, only the final WindowGroupLimit remains; otherwise both partial and
-        // final are present since a shuffle is required.
-        assert(limits.size === (if (bypass) 1 else 2))
+      }
+    }
+
+    // Unpartitioned window: the final WindowGroupLimit requires AllTuples distribution. When the
+    // bypass is on, the partial pass (which cannot reduce cardinality across partitions here) is
+    // skipped, leaving a single WindowGroupLimit. Note row_number() is excluded: with an empty
+    // partition spec InferWindowGroupLimit rewrites it to a Limit + Sort (top-n) rather than a
+    // WindowGroupLimit, so no WindowGroupLimit node is produced.
+    val unpartitionedWindow = Window.orderBy($"order")
+    val unpartitionedExpected = Seq(Row("c", 2, "a", 1))
+
+    withSQLConf(
+      SQLConf.BYPASS_PARTIAL_WINDOW_GROUP_LIMIT.key -> "true",
+      SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "100") {
+      Seq(rank(), dense_rank()).foreach { rankLikeFunction =>
+        val result =
+          df.withColumn("rn", rankLikeFunction.over(unpartitionedWindow)).where($"rn" === 1)
+        checkAnswer(result, unpartitionedExpected)
+        assert(countWindowGroupLimits(result) === 1)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, Exchange, ShuffleExchangeExec}
-import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExec}
 import org.apache.spark.sql.expressions.{Aggregator, MutableAggregationBuffer, UserDefinedAggregateFunction, Window}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -1678,6 +1678,39 @@ class DataFrameWindowFunctionsSuite extends SharedSparkSession
             )
           }
         }
+      }
+    }
+  }
+
+  test("SPARK-58404: bypass partial WindowGroupLimit") {
+    val df = Seq(
+      ("a", 0, "c"),
+      ("a", 1, "x"),
+      ("a", 2, "y"),
+      ("b", 1, "h"),
+      ("b", 1, "n"),
+      ("c", 1, "z"),
+      ("c", 2, "a")).toDF("key", "value", "order")
+
+    val window = Window.partitionBy($"key").orderBy($"order")
+    val expected = Seq(
+      Row("a", 0, "c", 1),
+      Row("b", 1, "h", 1),
+      Row("c", 2, "a", 1))
+
+    Seq(true, false).foreach { bypass =>
+      withSQLConf(
+        SQLConf.BYPASS_PARTIAL_WINDOW_GROUP_LIMIT.key -> bypass.toString,
+        SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "100") {
+        val result = df.withColumn("rn", row_number().over(window)).where($"rn" === 1)
+        checkAnswer(result, expected)
+
+        val limits = collect(result.queryExecution.executedPlan) {
+          case w: WindowGroupLimitExec => w
+        }
+        // When bypassed, only the final WindowGroupLimit remains; otherwise both partial and
+        // final are present since a shuffle is required.
+        assert(limits.size === (if (bypass) 1 else 2))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -1720,22 +1720,26 @@ class DataFrameWindowFunctionsSuite extends SharedSparkSession
       }
     }
 
-    // Unpartitioned window: the final WindowGroupLimit requires AllTuples distribution. When the
-    // bypass is on, the partial pass (which cannot reduce cardinality across partitions here) is
-    // skipped, leaving a single WindowGroupLimit. Note row_number() is excluded: with an empty
-    // partition spec InferWindowGroupLimit rewrites it to a Limit + Sort (top-n) rather than a
-    // WindowGroupLimit, so no WindowGroupLimit node is produced.
+    // Unpartitioned window: the final WindowGroupLimit requires AllTuples, so the shuffle funnels
+    // the whole input into a single reducer. The partial pass bounds each input partition to
+    // `limit` rank groups before that shuffle, so the bypass is gated off for an empty partition
+    // spec and both the partial and the final WindowGroupLimit remain even when the flag is on.
+    // Note row_number() is excluded: with an empty partition spec and a limit below
+    // topKSortFallbackThreshold, InferWindowGroupLimit rewrites it to a Limit + Sort (top-n)
+    // rather than a WindowGroupLimit, so no WindowGroupLimit node is produced.
     val unpartitionedWindow = Window.orderBy($"order")
     val unpartitionedExpected = Seq(Row("c", 2, "a", 1))
 
-    withSQLConf(
-      SQLConf.BYPASS_PARTIAL_WINDOW_GROUP_LIMIT.key -> "true",
-      SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "100") {
-      Seq(rank(), dense_rank()).foreach { rankLikeFunction =>
-        val result =
-          df.withColumn("rn", rankLikeFunction.over(unpartitionedWindow)).where($"rn" === 1)
-        checkAnswer(result, unpartitionedExpected)
-        assert(countWindowGroupLimits(result) === 1)
+    Seq(true, false).foreach { bypass =>
+      withSQLConf(
+        SQLConf.BYPASS_PARTIAL_WINDOW_GROUP_LIMIT.key -> bypass.toString,
+        SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "100") {
+        Seq(rank(), dense_rank()).foreach { rankLikeFunction =>
+          val result =
+            df.withColumn("rn", rankLikeFunction.over(unpartitionedWindow)).where($"rn" === 1)
+          checkAnswer(result, unpartitionedExpected)
+          assert(countWindowGroupLimits(result) === 2)
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new config `spark.sql.execution.bypassPartialWindowGroupLimit` (default `false`). When enabled, the `WindowGroupLimit` planner strategy emits only the final `WindowGroupLimitExec` after the shuffle and skips constructing the pre-shuffle partial `WindowGroupLimitExec`, provided the window has a non-empty partition spec.

The final node still declares its required child distribution (`ClusteredDistribution(partitionSpec)`), so `EnsureRequirements` inserts the shuffle regardless; dropping the partial node removes both the pre-shuffle local top-k filter and the local `SortExec` that the partial node's `requiredChildOrdering` forces via `EnsureRequirements`. Skipping that local sort is a good part of the win. This mirrors the shape of the existing partial/final split for window group limit and is analogous to bypassing partial aggregation.

The bypass is gated on a non-empty partition spec. With an empty partition spec the final node requires `AllTuples`, so the shuffle funnels the whole input into a single reducer, while the partial pass we would drop bounds each input partition to `limit` rank groups before that shuffle. Bypassing it there would shuffle all raw rows to a single partition and is strictly worse than the normal Partial+Final path, so the partial is always kept. This mirrors the grouping-keys carve-out in `bypassPartialAggregation` (`AggUtils.planAggregateWithoutDistinct`).

### Why are the changes needed?

The pre-shuffle partial `WindowGroupLimitExec` only pays off when it actually reduces rows. When each pre-shuffle partition already has few rows per window-partition group (a low reduction ratio), the partial node adds sorting/iteration cost with little benefit. This config lets users bypass the partial phase for such workloads.

### Does this PR introduce _any_ user-facing change?

Yes. A new config `spark.sql.execution.bypassPartialWindowGroupLimit` is added, defaulting to `false`, which preserves the existing behavior. It is also documented in the SQL performance tuning guide.

### How was this patch tested?

Added a unit test in `DataFrameWindowFunctionsSuite` covering `row_number`/`rank`/`dense_rank`. For a partitioned window it asserts the executed plan contains a single `WindowGroupLimitExec` when the config is on and two when it is off; for an unpartitioned window it asserts both nodes remain regardless of the config, since the bypass is gated off there. Results are unchanged across all settings.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
