### PR TITLE
[SPARK-58403][SQL] Assign appropriate error condition for `_LEGACY_ERROR_TEMP_3201-3205`: `MALFORMED_EXPRESSION_INFO`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5586,6 +5586,39 @@
     ],
     "sqlState" : "KD000"
   },
+  "MALFORMED_EXPRESSION_INFO" : {
+    "message" : [
+      "'<fieldName>' is malformed in the expression [<exprName>]:"
+    ],
+    "subClass" : {
+      "DEPRECATED" : {
+        "message" : [
+          "it should start with a newline and 4 leading spaces; end with a newline and two spaces; however, got [<deprecated>]."
+        ]
+      },
+      "GROUP" : {
+        "message" : [
+          "it should be a value in <validGroups>; however, got [<group>]."
+        ]
+      },
+      "NOTE" : {
+        "message" : [
+          "it should start with a newline and 4 leading spaces; end with a newline and two spaces; however, got [<note>]."
+        ]
+      },
+      "SINCE" : {
+        "message" : [
+          "it should not start with a negative number; however, got [<since>]."
+        ]
+      },
+      "SOURCE" : {
+        "message" : [
+          "it should be a value in <validSources>; however, got [<source>]."
+        ]
+      }
+    },
+    "sqlState" : "22023"
+  },
   "MALFORMED_LOG_FILE" : {
     "message" : [
       "Log file was malformed: failed to read correct log version from <text>."
@@ -11867,31 +11900,6 @@
   "_LEGACY_ERROR_TEMP_3200" : {
     "message" : [
       "Read-ahead limit < 0"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3201" : {
-    "message" : [
-      "'note' is malformed in the expression [<exprName>]. It should start with a newline and 4 leading spaces; end with a newline and two spaces; however, got [<note>]."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3202" : {
-    "message" : [
-      "'group' is malformed in the expression [<exprName>]. It should be a value in <validGroups>; however, got <group>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3203" : {
-    "message" : [
-      "'source' is malformed in the expression [<exprName>]. It should be a value in <validSources>; however, got [<source>]."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3204" : {
-    "message" : [
-      "'since' is malformed in the expression [<exprName>]. It should not start with a negative number; however, got [<since>]."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3205" : {
-    "message" : [
-      "'deprecated' is malformed in the expression [<exprName>]. It should start with a newline and 4 leading spaces; end with a newline and two spaces; however, got [<deprecated>]."
     ]
   },
   "_LEGACY_ERROR_TEMP_3206" : {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -150,36 +150,39 @@ public class ExpressionInfo {
         if (!note.isEmpty()) {
             if (!note.contains("    ") || !note.endsWith("  ")) {
                 throw new SparkIllegalArgumentException(
-                  "_LEGACY_ERROR_TEMP_3201", Map.of("exprName", this.name, "note", note));
+                  "MALFORMED_EXPRESSION_INFO.NOTE",
+                  Map.of("fieldName", "note", "exprName", this.name, "note", note));
             }
             this.extended += "\n    Note:\n      " + note.trim() + "\n";
         }
         if (!group.isEmpty() && !validGroups.contains(group)) {
             throw new SparkIllegalArgumentException(
-              "_LEGACY_ERROR_TEMP_3202",
-              Map.of("exprName", this.name,
+              "MALFORMED_EXPRESSION_INFO.GROUP",
+              Map.of("fieldName", "group", "exprName", this.name,
                 "validGroups", String.valueOf(validGroups.stream().sorted().toList()),
                 "group", group));
         }
         if (!source.isEmpty() && !validSources.contains(source)) {
             throw new SparkIllegalArgumentException(
-              "_LEGACY_ERROR_TEMP_3203",
-              Map.of("exprName", this.name,
+              "MALFORMED_EXPRESSION_INFO.SOURCE",
+              Map.of("fieldName", "source", "exprName", this.name,
                 "validSources", String.valueOf(validSources.stream().sorted().toList()),
                 "source", source));
         }
         if (!since.isEmpty()) {
             if (Integer.parseInt(since.split("\\.")[0]) < 0) {
                 throw new SparkIllegalArgumentException(
-                  "_LEGACY_ERROR_TEMP_3204", Map.of("exprName", this.name, "since", since));
+                  "MALFORMED_EXPRESSION_INFO.SINCE",
+                  Map.of("fieldName", "since", "exprName", this.name, "since", since));
             }
             this.extended += "\n    Since: " + since + "\n";
         }
         if (!deprecated.isEmpty()) {
             if (!deprecated.contains("    ") || !deprecated.endsWith("  ")) {
                 throw new SparkIllegalArgumentException(
-                  "_LEGACY_ERROR_TEMP_3205",
-                  Map.of("exprName", this.name, "deprecated", deprecated));
+                  "MALFORMED_EXPRESSION_INFO.DEPRECATED",
+                  Map.of("fieldName", "deprecated", "exprName", this.name,
+                    "deprecated", deprecated));
             }
             this.extended += "\n    Deprecated:\n      " + deprecated.trim() + "\n";
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -68,8 +68,10 @@ class ExpressionInfoSuite extends SharedSparkSession {
         new ExpressionInfo(
           "testClass", null, "testName", null, "", "", "", invalidGroupName, "", "", "")
       },
-      condition = "_LEGACY_ERROR_TEMP_3202",
+      condition = "MALFORMED_EXPRESSION_INFO.GROUP",
+      sqlState = Some("22023"),
       parameters = Map(
+        "fieldName" -> "group",
         "exprName" -> "testName",
         "group" -> invalidGroupName,
         "validGroups" -> validGroups.mkString("[", ", ", "]")))
@@ -93,8 +95,10 @@ class ExpressionInfoSuite extends SharedSparkSession {
         new ExpressionInfo(
           "testClass", null, "testName", null, "", "", "", "", "", "", invalidSource)
       },
-      condition = "_LEGACY_ERROR_TEMP_3203",
+      condition = "MALFORMED_EXPRESSION_INFO.SOURCE",
+      sqlState = Some("22023"),
       parameters = Map(
+        "fieldName" -> "source",
         "exprName" -> "testName",
         "source" -> invalidSource,
         "validSources" -> validSources.sorted.mkString("[", ", ", "]")))
@@ -106,8 +110,9 @@ class ExpressionInfoSuite extends SharedSparkSession {
       exception = intercept[SparkIllegalArgumentException] {
         new ExpressionInfo("testClass", null, "testName", null, "", "", invalidNote, "", "", "", "")
       },
-      condition = "_LEGACY_ERROR_TEMP_3201",
-      parameters = Map("exprName" -> "testName", "note" -> invalidNote))
+      condition = "MALFORMED_EXPRESSION_INFO.NOTE",
+      sqlState = Some("22023"),
+      parameters = Map("fieldName" -> "note", "exprName" -> "testName", "note" -> invalidNote))
 
     val invalidSince = "-3.0.0"
     checkError(
@@ -115,8 +120,9 @@ class ExpressionInfoSuite extends SharedSparkSession {
         new ExpressionInfo(
           "testClass", null, "testName", null, "", "", "", "", invalidSince, "", "")
       },
-      condition = "_LEGACY_ERROR_TEMP_3204",
-      parameters = Map("since" -> invalidSince, "exprName" -> "testName"))
+      condition = "MALFORMED_EXPRESSION_INFO.SINCE",
+      sqlState = Some("22023"),
+      parameters = Map("fieldName" -> "since", "since" -> invalidSince, "exprName" -> "testName"))
 
     val invalidDeprecated = "  invalid deprecated"
     checkError(
@@ -124,8 +130,12 @@ class ExpressionInfoSuite extends SharedSparkSession {
         new ExpressionInfo(
           "testClass", null, "testName", null, "", "", "", "", "", invalidDeprecated, "")
       },
-      condition = "_LEGACY_ERROR_TEMP_3205",
-      parameters = Map("exprName" -> "testName", "deprecated" -> invalidDeprecated))
+      condition = "MALFORMED_EXPRESSION_INFO.DEPRECATED",
+      sqlState = Some("22023"),
+      parameters = Map(
+        "fieldName" -> "deprecated",
+        "exprName" -> "testName",
+        "deprecated" -> invalidDeprecated))
   }
 
   test("using _FUNC_ instead of function names in examples") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to assign a proper error condition for the legacy error conditions `_LEGACY_ERROR_TEMP_3201`, `_3202`, `_3203`, `_3204` and `_3205`, which are all thrown from the constructor of `ExpressionInfo` when the metadata describing an expression is malformed.

The five legacy conditions are folded into a single umbrella condition `MALFORMED_EXPRESSION_INFO` with five subclasses, one per validated field:

| Legacy | New condition | Field |
|---|---|---|
| `_LEGACY_ERROR_TEMP_3201` | `MALFORMED_EXPRESSION_INFO.NOTE` | `note` |
| `_LEGACY_ERROR_TEMP_3202` | `MALFORMED_EXPRESSION_INFO.GROUP` | `group` |
| `_LEGACY_ERROR_TEMP_3203` | `MALFORMED_EXPRESSION_INFO.SOURCE` | `source` |
| `_LEGACY_ERROR_TEMP_3204` | `MALFORMED_EXPRESSION_INFO.SINCE` | `since` |
| `_LEGACY_ERROR_TEMP_3205` | `MALFORMED_EXPRESSION_INFO.DEPRECATED` | `deprecated` |

The shared umbrella message names the offending field and expression (`'<fieldName>' is malformed in the expression [<exprName>]:`), and each subclass carries the field-specific detail. `fieldName` is a new message parameter, so `getMessageParameters()` for these errors now carries one extra key.

The assigned SQLSTATE is `22023` (invalid parameter value), consistent with the sibling `MALFORMED_*` conditions that validate a value against an allowed set or format (`MALFORMED_RECORD_IN_PARSING`, `MALFORMED_VARIANT`, and the `INVALID_PARAMETER_VALUE` archetype all use `22023`).

**On reachability, and why these get a proper name rather than `INTERNAL_ERROR`:** none of the five throw sites is reachable from a user query. `FunctionRegistryBase.expressionInfo` reads the compile-time `@ExpressionDescription` annotation, and `SessionCatalog.makeExprInfoForHiveFunction` / `SQLFunction.toExpressionInfo` pass constants (`""` / `"hive"` / `"sql_udf"`). A malformed value can only come from extension or third-party code: constructing `new ExpressionInfo(...)` directly (which is what `SparkSessionExtensions.injectFunction` takes, see the example in `SparkSessionExtensionsProvider`), or calling `FunctionRegistryBase.createOrReplaceTempFunction(name, builder, source)` with an arbitrary `source`. That makes these developer-facing rather than engine-internal invariants: the person who triggers the error is the one who can fix it, so a named, actionable condition fits better than an internal error. This mirrors existing extension/configuration-author-facing conditions such as `CANNOT_LOAD_CATALOG` and `CANNOT_LOAD_FUNCTION_CLASS`, which also carry standard SQLSTATEs.

### Why are the changes needed?

`_LEGACY_ERROR_TEMP_*` conditions are placeholders that should be replaced with proper, named error conditions per the guideline in `common/utils/src/main/resources/error/README.md`. This is part of the ongoing effort to migrate legacy error conditions to the structured error framework.

### Does this PR introduce _any_ user-facing change?

No. As described above, these conditions are only reachable by extension or third-party code that builds an `ExpressionInfo` itself, and the `_LEGACY_ERROR_TEMP_*` names were never part of the public API.

For completeness, the message text is preserved with four deliberate changes:

- the `GROUP` value is now bracketed (`however, got <group>.` -> `however, got [<group>].`) for consistency with the other four subclasses;
- the split between the field and the detail moved from `.` to `:`, and the detail therefore starts with a lowercase `it should` instead of `It should`;
- the rendered message now carries the `[MALFORMED_EXPRESSION_INFO.<SUBCLASS>] ` prefix, which `SparkThrowableHelper.formatErrorMessage` omits only for `_LEGACY_ERROR_`-prefixed names;
- the rendered message now carries a ` SQLSTATE: 22023` suffix, since these five legacy entries previously had no `sqlState` at all.

Before and after, for `GROUP`:

```
OLD: 'group' is malformed in the expression [testName]. It should be a value in [...]; however, got invalid_group_funcs.
NEW: [MALFORMED_EXPRESSION_INFO.GROUP] 'group' is malformed in the expression [testName]: it should be a value in [...]; however, got [invalid_group_funcs]. SQLSTATE: 22023
```

### How was this patch tested?

Updated the existing assertions in `ExpressionInfoSuite` to check the new conditions and parameters, and added `sqlState = Some("22023")` to each so the assigned SQLSTATE is pinned by a test. Ran:

- `ExpressionInfoSuite` - 10/10 passed
- `SparkThrowableSuite` - 34/34 passed (JSON validity, alphabetical ordering, mandatory SQLSTATE, round-trip)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
