### PR TITLE
[CONNECT] Skip redundant DSv2 table refreshes in Spark Connect

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5412,6 +5412,15 @@ object SQLConf {
     .stringConf
     .createWithDefault("avro,csv,json,kafka,orc,parquet,text")
 
+  val SKIP_V2_TABLE_REFRESH = buildConf("spark.sql.execution.skipV2TableRefresh")
+    .internal()
+    .doc("When true, skips the Data Source V2 table refresh phase between query analysis and " +
+      "execution. This is intended for execution environments where analysis always happens " +
+      "immediately before execution.")
+    .version("4.3.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val ALLOW_EMPTY_SCHEMAS_FOR_WRITES = buildConf("spark.sql.legacy.allowEmptySchemaWrite")
     .internal()
     .doc("When this option is set to true, validation of empty or empty nested schemas that " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CountingInMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CountingInMemoryTableCatalog.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class CountingInMemoryTableCatalog extends InMemoryTableCatalog {
+  override def loadTable(ident: Identifier): Table = {
+    CountingInMemoryTableCatalog.incrementLoadCount()
+    super.loadTable(ident)
+  }
+}
+
+object CountingInMemoryTableCatalog {
+  private val loadCounter = new AtomicInteger()
+
+  def loadCount: Int = loadCounter.get()
+
+  def resetLoadCount(): Unit = loadCounter.set(0)
+
+  private def incrementLoadCount(): Unit = loadCounter.incrementAndGet()
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -43,6 +43,8 @@ import org.apache.spark.sql.connect.pipelines.DataflowGraphRegistry
 import org.apache.spark.sql.connect.planner.PythonStreamingQueryListener
 import org.apache.spark.sql.connect.planner.StreamingForeachBatchHelper
 import org.apache.spark.sql.connect.service.SessionHolder.{ERROR_CACHE_SIZE, ERROR_CACHE_TIMEOUT_SEC}
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.pipelines.graph.PipelineUpdateContext
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.util.{SystemClock, Utils}
@@ -617,7 +619,16 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
           Option(cache.getIfPresent(rel)) match {
             case Some(plan) =>
               logDebug(s"Using cached plan for relation '$rel': $plan")
-              Some(plan)
+              val hasResolvedV2Table = plan.collectWithSubqueries {
+                case _: DataSourceV2Relation => true
+              }.nonEmpty
+              if (hasResolvedV2Table) {
+                val planCopy = plan.clone()
+                planCopy.setTagValue(QueryExecution.REQUIRES_V2_TABLE_REFRESH, ())
+                Some(planCopy)
+              } else {
+                Some(plan)
+              }
             case None => None
           }
         case _ => None

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManager.scala
@@ -32,6 +32,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{INTERVAL, SESSION_HOLD_INFO}
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connect.config.Connect.{CONNECT_SESSION_MANAGER_CLOSED_SESSIONS_TOMBSTONES_SIZE, CONNECT_SESSION_MANAGER_DEFAULT_SESSION_TIMEOUT, CONNECT_SESSION_MANAGER_MAINTENANCE_INTERVAL}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -166,7 +167,8 @@ class SparkConnectSessionManager extends Logging {
         if (session == null) {
           // Clone the underlying SparkSession using cloneSession() which preserves
           // configuration, catalog, session state, temporary views, and registered functions
-          val clonedSparkSession = sourceSessionHolder.session.cloneSession()
+          val clonedSparkSession =
+            configureConnectSession(sourceSessionHolder.session.cloneSession())
 
           val newHolder = SessionHolder(newKey.userId, newKey.sessionId, clonedSparkSession)
           newHolder.initializeSession()
@@ -356,13 +358,19 @@ class SparkConnectSessionManager extends Logging {
   }
 
   private def newIsolatedSession(): SparkSession = {
-    val session = baseSession.get
-    if (session.sparkContext.isStopped) {
+    val base = baseSession.get
+    val session = if (base.sparkContext.isStopped) {
       assert(SparkSession.getDefaultSession.nonEmpty)
       SparkSession.getDefaultSession.get.newSession()
     } else {
-      session.newSession()
+      base.newSession()
     }
+    configureConnectSession(session)
+  }
+
+  private def configureConnectSession(session: SparkSession): SparkSession = {
+    session.sessionState.conf.setConf(SQLConf.SKIP_V2_TABLE_REFRESH, true)
+    session
   }
 
   private def validateSessionCreate(key: SessionKey): Unit = {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTestSuite.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.connect
 
 import org.scalatest.time.SpanSugar._
 
+import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
+import org.apache.spark.sql.connector.catalog.CountingInMemoryTableCatalog
+
 /**
  * Test suite showcasing the APIs provided by SparkConnectServerTest trait.
  *
@@ -28,6 +31,62 @@ import org.scalatest.time.SpanSugar._
  *   - Assertion helpers for execution state
  */
 class SparkConnectServerTestSuite extends SparkConnectServerTest {
+
+  test("Spark Connect avoids redundant DSv2 table refreshes across server call sites") {
+    withSession { clientSession =>
+      val table = "countingcat.ns.tbl"
+      clientSession.conf.set(
+        "spark.sql.catalog.countingcat",
+        classOf[CountingInMemoryTableCatalog].getName)
+      clientSession.conf.set("spark.sql.catalog.countingcat.copyOnLoad", "true")
+      clientSession.sql(s"CREATE TABLE $table (id INT) USING foo").collect()
+
+      val serverSession = getServerSession(clientSession)
+
+      def assertRefreshSkipped(expectedLoads: Int)(f: => Unit): Unit = {
+        CountingInMemoryTableCatalog.resetLoadCount()
+        val queryExecutions = withQueryExecutionsCaptured(serverSession)(f)
+        assert(CountingInMemoryTableCatalog.loadCount == expectedLoads)
+        assert(queryExecutions.nonEmpty)
+        assert(queryExecutions.forall(!_.refreshPhaseEnabled))
+      }
+
+      try {
+        assertRefreshSkipped(expectedLoads = 1) {
+          clientSession.table(table).collect()
+        }
+
+        val dropMissing = clientSession.table(table).drop("missing")
+        assertRefreshSkipped(expectedLoads = 1) {
+          dropMissing.collect()
+        }
+
+        CountingInMemoryTableCatalog.resetLoadCount()
+        val cachedQueryExecutions = withQueryExecutionsCaptured(serverSession) {
+          dropMissing.collect()
+        }
+        assert(CountingInMemoryTableCatalog.loadCount == 1)
+        assert(cachedQueryExecutions.exists(_.refreshPhaseEnabled))
+
+        assertRefreshSkipped(expectedLoads = 2) {
+          clientSession.sql(s"SELECT * FROM $table").collect()
+        }
+
+        assertRefreshSkipped(expectedLoads = 1) {
+          clientSession.table(table).localCheckpoint(eager = true)
+        }
+
+        withTempDir { checkpointDir =>
+          serverSession.sparkContext.setCheckpointDir(checkpointDir.getCanonicalPath)
+          assertRefreshSkipped(expectedLoads = 1) {
+            clientSession.table(table).checkpoint(eager = true)
+          }
+        }
+      } finally {
+        clientSession.sql(s"DROP TABLE IF EXISTS $table").collect()
+      }
+    }
+  }
 
   test("withSession: execute SQL and collect results") {
     withSession { session =>

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTestSuite.scala
@@ -18,8 +18,10 @@ package org.apache.spark.sql.connect
 
 import org.scalatest.time.SpanSugar._
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
 import org.apache.spark.sql.connector.catalog.CountingInMemoryTableCatalog
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Test suite showcasing the APIs provided by SparkConnectServerTest trait.
@@ -40,6 +42,7 @@ class SparkConnectServerTestSuite extends SparkConnectServerTest {
         classOf[CountingInMemoryTableCatalog].getName)
       clientSession.conf.set("spark.sql.catalog.countingcat.copyOnLoad", "true")
       clientSession.sql(s"CREATE TABLE $table (id INT) USING foo").collect()
+      clientSession.sql(s"INSERT INTO $table VALUES (1)").collect()
 
       val serverSession = getServerSession(clientSession)
 
@@ -52,21 +55,43 @@ class SparkConnectServerTestSuite extends SparkConnectServerTest {
       }
 
       try {
+        var rows = Array.empty[Row]
         assertRefreshSkipped(expectedLoads = 1) {
-          clientSession.table(table).collect()
+          rows = clientSession.table(table).collect()
+        }
+        assert(rows.toSeq == Seq(Row(1)))
+
+        serverSession.sessionState.conf.setConf(SQLConf.SKIP_V2_TABLE_REFRESH, false)
+        try {
+          CountingInMemoryTableCatalog.resetLoadCount()
+          val queryExecutions = withQueryExecutionsCaptured(serverSession) {
+            rows = clientSession.table(table).collect()
+          }
+          assert(CountingInMemoryTableCatalog.loadCount == 2)
+          assert(queryExecutions.nonEmpty)
+          assert(queryExecutions.forall(_.refreshPhaseEnabled))
+          assert(rows.toSeq == Seq(Row(1)))
+        } finally {
+          serverSession.sessionState.conf.setConf(SQLConf.SKIP_V2_TABLE_REFRESH, true)
         }
 
         val dropMissing = clientSession.table(table).drop("missing")
         assertRefreshSkipped(expectedLoads = 1) {
-          dropMissing.collect()
+          rows = dropMissing.collect()
         }
+        assert(rows.toSeq == Seq(Row(1)))
+
+        // Mutate the live table after the resolved plan has been cached. The cache hit below
+        // must refresh its stale DataSourceV2Relation to make the new row visible.
+        serverSession.sql(s"INSERT INTO $table VALUES (2)").collect()
 
         CountingInMemoryTableCatalog.resetLoadCount()
         val cachedQueryExecutions = withQueryExecutionsCaptured(serverSession) {
-          dropMissing.collect()
+          rows = dropMissing.collect()
         }
         assert(CountingInMemoryTableCatalog.loadCount == 1)
         assert(cachedQueryExecutions.exists(_.refreshPhaseEnabled))
+        assert(rows.toSet == Set(Row(1), Row(2)))
 
         assertRefreshSkipped(expectedLoads = 2) {
           clientSession.sql(s"SELECT * FROM $table").collect()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectCloneSessionSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectCloneSessionSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.connect.service
 import java.util.UUID
 
 import org.apache.spark.SparkSQLException
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class SparkConnectCloneSessionSuite extends SharedSparkSession {
@@ -119,6 +120,19 @@ class SparkConnectCloneSessionSuite extends SharedSparkSession {
 
     // Both sessions should be different objects
     assert(clonedSession != sourceSession)
+  }
+
+  test("cloned Connect session restores the server-side refresh setting") {
+    val sourceKey = SessionKey("testUser", UUID.randomUUID.toString)
+    val targetSessionId = UUID.randomUUID.toString
+    val sourceSession = SparkConnectService.sessionManager
+      .getOrCreateIsolatedSession(sourceKey, None)
+
+    sourceSession.session.sessionState.conf.setConf(SQLConf.SKIP_V2_TABLE_REFRESH, false)
+    val clonedSession = SparkConnectService.sessionManager
+      .cloneSession(sourceKey, targetSessionId, None)
+
+    assert(clonedSession.session.sessionState.conf.getConf(SQLConf.SKIP_V2_TABLE_REFRESH))
   }
 
   test("cloned session copies all state (configs, temp views, UDFs, current database)") {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManagerSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkSQLException
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl}
 import org.apache.spark.sql.pipelines.logging.PipelineEvent
 import org.apache.spark.sql.test.SharedSparkSession
@@ -41,6 +42,15 @@ class SparkConnectSessionManagerSuite extends SharedSparkSession {
       SparkConnectService.sessionManager.getOrCreateIsolatedSession(key, None)
     }
     assert(exGetOrCreate.getCondition == "INVALID_HANDLE.FORMAT")
+  }
+
+  test("isolated Connect sessions skip the DSv2 table refresh phase") {
+    assert(!spark.sessionState.conf.getConf(SQLConf.SKIP_V2_TABLE_REFRESH))
+
+    val key = SessionKey("user", UUID.randomUUID().toString)
+    val sessionHolder = SparkConnectService.sessionManager.getOrCreateIsolatedSession(key, None)
+
+    assert(sessionHolder.session.sessionState.conf.getConf(SQLConf.SKIP_V2_TABLE_REFRESH))
   }
 
   test(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, Command, CommandResult, CompoundBody, CreateTableAsSelect, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, ReplaceTableAsSelect, ReturnAnswer, Union, UnresolvedWith, WithCTE}
 import org.apache.spark.sql.catalyst.rules.{PlanChangeLogger, Rule, RuleExecutor}
 import org.apache.spark.sql.catalyst.transactions.TransactionUtils
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.classic.SparkSession
@@ -70,13 +71,16 @@ class QueryExecution(
     val tracker: QueryPlanningTracker = new QueryPlanningTracker,
     val mode: CommandExecutionMode.Value = CommandExecutionMode.ALL,
     val shuffleCleanupModeOpt: Option[ShuffleCleanupMode] = None,
-    val refreshPhaseEnabled: Boolean = true,
+    refreshPhaseEnabledParam: Boolean = true,
     val queryId: UUID = UUIDv7Generator.generate(),
     // When a transaction is active, callers creating nested QueryExecution instances MUST pass
     // the enclosing QueryExecution's analyzer here to propagate the transaction context.
     // Omitting it causes the nested QE to use sessionState.analyzer, which has no knowledge
     // of the transaction and will load tables outside the transaction's catalog scope.
     val analyzerOpt: Option[Analyzer] = None) extends LookupCatalog {
+
+  val refreshPhaseEnabled: Boolean = refreshPhaseEnabledParam &&
+    QueryExecution.defaultRefreshPhaseEnabled(sparkSession, logical)
 
   val id: Long = QueryExecution.nextExecutionId
 
@@ -729,7 +733,20 @@ case object RemoveShuffleFiles extends ShuffleCleanupMode
 object QueryExecution {
   private val _nextExecutionId = new AtomicLong(0)
 
+  private[sql] val REQUIRES_V2_TABLE_REFRESH =
+    TreeNodeTag[Unit]("requires_v2_table_refresh")
+
   private def nextExecutionId: Long = _nextExecutionId.getAndIncrement
+
+  private def defaultRefreshPhaseEnabled(
+      sparkSession: SparkSession,
+      logical: LogicalPlan): Boolean = {
+    val skipRefresh = sparkSession.sessionState.conf.getConf(SQLConf.SKIP_V2_TABLE_REFRESH)
+    val requiresRefresh = logical.collectWithSubqueries {
+      case plan if plan.getTagValue(REQUIRES_V2_TABLE_REFRESH).isDefined => true
+    }.nonEmpty
+    !skipRefresh || requiresRefresh
+  }
 
   private[execution] def create(
       sparkSession: SparkSession,
@@ -740,7 +757,7 @@ object QueryExecution {
       logical,
       mode = CommandExecutionMode.ALL,
       shuffleCleanupModeOpt = Some(determineShuffleCleanupMode(sparkSession.sessionState.conf)),
-      refreshPhaseEnabled = refreshPhaseEnabled)
+      refreshPhaseEnabledParam = refreshPhaseEnabled)
   }
 
   /**
@@ -954,7 +971,7 @@ object QueryExecution {
       command,
       mode = mode,
       shuffleCleanupModeOpt = shuffleCleanupModeOpt,
-      refreshPhaseEnabled = refreshPhaseEnabled,
+      refreshPhaseEnabledParam = refreshPhaseEnabled,
       analyzerOpt = analyzerOpt)
     val result = QueryExecution.withInternalError(s"Executed $name failed.") {
       SQLExecution.withNewExecutionId(qe, Some(name)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
+import org.apache.spark.sql.connector.catalog.CountingInMemoryTableCatalog
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
 import org.apache.spark.sql.execution.datasources.v2.ShowTablesExec
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
@@ -50,6 +51,45 @@ case class QueryExecutionTestRecord(
     c25: Int, c26: Int)
 
 class QueryExecutionSuite extends SharedSparkSession {
+
+  test("QueryExecution derives the refresh phase default from SQLConf") {
+    val plan = OneRowRelation()
+
+    assert(new QueryExecution(spark, plan).refreshPhaseEnabled)
+    assert(spark.sessionState.executePlan(plan).refreshPhaseEnabled)
+    assert(Dataset.ofRows(spark, plan).queryExecution.refreshPhaseEnabled)
+
+    withSQLConf(SQLConf.SKIP_V2_TABLE_REFRESH.key -> "true") {
+      assert(!new QueryExecution(spark, plan).refreshPhaseEnabled)
+      assert(!spark.sessionState.executePlan(plan).refreshPhaseEnabled)
+      assert(!Dataset.ofRows(spark, plan).queryExecution.refreshPhaseEnabled)
+
+      val cachedPlan = OneRowRelation()
+      cachedPlan.setTagValue(QueryExecution.REQUIRES_V2_TABLE_REFRESH, ())
+      assert(new QueryExecution(spark, cachedPlan).refreshPhaseEnabled)
+    }
+  }
+
+  test("skipping the refresh phase avoids a redundant DSv2 catalog load") {
+    val table = "countingcat.ns.tbl"
+    withSQLConf(
+      "spark.sql.catalog.countingcat" -> classOf[CountingInMemoryTableCatalog].getName,
+      "spark.sql.catalog.countingcat.copyOnLoad" -> "true") {
+      withTable(table) {
+        spark.sql(s"CREATE TABLE $table (id INT) USING foo")
+
+        CountingInMemoryTableCatalog.resetLoadCount()
+        spark.table(table).collect()
+        assert(CountingInMemoryTableCatalog.loadCount == 2)
+
+        CountingInMemoryTableCatalog.resetLoadCount()
+        withSQLConf(SQLConf.SKIP_V2_TABLE_REFRESH.key -> "true") {
+          spark.table(table).collect()
+        }
+        assert(CountingInMemoryTableCatalog.loadCount == 1)
+      }
+    }
+  }
   import testImplicits._
 
   override protected def sparkConf =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements the server-side SQL configuration approach suggested in https://github.com/apache/spark/pull/57043#issuecomment-5097384606.

It adds the internal `spark.sql.execution.skipV2TableRefresh` configuration, defaulting to `false`, and sets it to `true` whenever the Spark Connect server creates or clones a session. `QueryExecution` uses this setting when deriving its effective `refreshPhaseEnabled` value, so the optimization covers every Connect path that creates a query execution, including SQL, DataFrame operations, checkpoint, local checkpoint, and future call sites.

Spark Connect's plan cache is handled conservatively. A cache hit can contain an already-resolved `DataSourceV2Relation`, for which analysis alone cannot reload current table metadata. Such cached plans are cloned and tagged so their `QueryExecution` retains the refresh phase. Freshly analyzed Connect plans still skip it.

The existing `QueryExecution` constructor signature and `refreshPhaseEnabled` accessor remain binary-compatible.

### Why are the changes needed?

Spark Connect normally analyzes a plan immediately before execution. The DSv2 table refresh phase then performs another catalog `loadTable` request without changing the outcome, adding an avoidable catalog round trip and latency.

Using `spark.api.mode` on the server is not reliable because it is a client-side builder/launcher directive and is not propagated to Spark Connect server sessions. A server-side session setting explicitly records the execution environment and avoids having to update every Connect call site.

The plan-cache exception preserves correctness for resolved DSv2 relations that may outlive the table metadata captured during their original analysis.

### Does this PR introduce _any_ user-facing change?

No. The new configuration is internal. Spark Classic keeps the refresh phase enabled, while Spark Connect avoids redundant catalog refresh requests for freshly analyzed plans.

### How was this patch tested?

Added a counting DSv2 catalog and tests that assert the exact number of `loadTable` calls, not only query results. Coverage includes:

- Classic defaults and explicit refresh skipping.
- Connect-created sessions and cloned sessions.
- DataFrame `table`, `drop`, SQL, checkpoint, and local checkpoint paths.
- Repeated execution through the Connect plan cache, where cached resolved DSv2 plans retain the refresh.
- Existing Connect DSv2 freshness scenarios.

The following suites passed (119 tests total):

- `QueryExecutionSuite`: 29 tests.
- `SparkConnectSessionManagerSuite`: 11 tests.
- `SparkConnectCloneSessionSuite`: 9 tests.
- `SparkConnectServerTestSuite`: 21 tests.
- `DataSourceV2DataFrameConnectSuite`: 49 tests.

Compilation passed for `catalyst/Test/compile`, `sql/Test/compile`, and `connect/Test/compile`. Scalastyle passed for the catalyst, SQL, and Connect modules.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
