### PR TITLE
[MINOR][TESTS] Add catch-all case to non-total onOtherEvent in test listeners

### DIFF
--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -290,6 +290,7 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
           case _: TestSparkPluginEvent =>
             // Count down upon receiving the event sent from the plugin during shutdown.
             countDownLatch.countDown()
+          case _ =>
         }
       }
     })

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -302,6 +302,7 @@ private class SparkConnectServiceLifeCycleListener extends SparkListener {
         SparkConnectServiceLifeCycleListener.checksOnServiceEndEvent.foreach { checks =>
           checks.foreach(_(serviceEnd))
         }
+      case _ =>
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
@@ -351,6 +351,7 @@ class SQLExecutionSuite extends SparkFunSuite with SQLConfHelper {
           event match {
             case e: SparkListenerSQLExecutionStart =>
               sqlJobTags = e.jobTags
+            case _ =>
           }
         }
       })
@@ -383,6 +384,7 @@ class SQLExecutionSuite extends SparkFunSuite with SQLConfHelper {
           event match {
             case e: SparkListenerSQLExecutionStart =>
               sqlJobGroupIdOpt = e.jobGroupId
+            case _ =>
           }
         }
       })


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a catch-all `case _ =>` as the final arm to a few SparkListener.onOtherEvent match blocks in test suites that enumerate only the specific event type(s) they care about and omit a catch-all: PluginContainerSuite, SQLExecutionSuite (jobTags / jobGroupId tests), and SparkConnectServiceInternalServerSuite.

### Why are the changes needed?

SparkListenerBus.doPostEvent routes every non-built-in event to onOtherEvent, so a shared-queue listener receives all such events, not just the ones it enumerates. A match block with no `case _ =>` throws a scala.MatchError on every other event; ListenerBus.postToAll logs and swallows it, so tests pass but the logs are spammed with MatchError stack traces. The catch-all matches the convention the built-in listeners already follow and is always added last, so it never shadows an existing case.

### How was this patch tested?

This change is test-only.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored w/ Claude Code.