### PR TITLE
[SPARK-58417][PS] Remove stale Python 2 reference in DataFrame.to_latex docstring

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -2633,8 +2633,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             By default the value will be read from the pandas config module. When set to False
             prevents from escaping latex special characters in column names.
         encoding : str, optional
-            A string representing the encoding to use in the output file, defaults to 'ascii' on
-            Python 2 and 'utf-8' on Python 3.
+            A string representing the encoding to use in the output file, defaults to 'utf-8'.
         decimal : str, default '.'
             Character recognized as decimal separator, e.g. ',' in Europe.
         multicolumn : bool, default True


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes the stale Python 2 branch from the `encoding` parameter docstring of `DataFrame.to_latex`, collapsing it to a single accurate line stating the default is `utf-8`.

### Why are the changes needed?
Spark requires Python >= 3.11 (`python_requires` in setup.py), so the "'ascii' on Python 2" note is dead and misleading.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Docstring-only change. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)