### PR TITLE
[SPARK-58416][EXAMPLES] Fix wrong class name in SqlNetworkWordCount usage messages

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaSqlNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaSqlNetworkWordCount.java
@@ -48,7 +48,7 @@ public final class JavaSqlNetworkWordCount {
 
   public static void main(String[] args) throws Exception {
     if (args.length < 2) {
-      System.err.println("Usage: JavaNetworkWordCount <hostname> <port>");
+      System.err.println("Usage: JavaSqlNetworkWordCount <hostname> <port>");
       System.exit(1);
     }
 

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/SqlNetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/SqlNetworkWordCount.scala
@@ -40,7 +40,7 @@ import org.apache.spark.streaming.{Seconds, StreamingContext, Time}
 object SqlNetworkWordCount {
   def main(args: Array[String]): Unit = {
     if (args.length < 2) {
-      System.err.println("Usage: NetworkWordCount <hostname> <port>")
+      System.err.println("Usage: SqlNetworkWordCount <hostname> <port>")
       System.exit(1)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes the usage message in the `SqlNetworkWordCount` streaming examples, which printed the wrong class name (`JavaNetworkWordCount` / `NetworkWordCount`, copied from the sibling example). Corrected in both the Java and Scala versions.

### Why are the changes needed?
A user running the example with too few arguments saw a usage line naming a different class. Every other reference in each file already uses the correct class name.

### Does this PR introduce _any_ user-facing change?
Yes (minor): the stderr usage message now prints the correct class name.

### How was this patch tested?
Example-only string change; verified the corrected name matches each file's class and header. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)