### PR TITLE
[MINOR][BUILD] Fix duplicated word in spark-profiler POM description

### DIFF
--- a/connector/profiler/pom.xml
+++ b/connector/profiler/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <name>Spark Profiler</name>
   <description>
-    Enables code profiling of executors based on the the async profiler.
+    Enables code profiling of executors based on the async profiler.
   </description>
   <url>https://spark.apache.org/</url>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes a duplicated word in the `spark-profiler` module's Maven `<description>`: "based on the the async profiler" becomes "based on the async profiler".

### Why are the changes needed?
A plain typo in the POM description string; the sibling README already uses the correct wording.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
POM description string only; no functional or build impact. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)