### PR TITLE
[MINOR][DOCS] Fix insecure HTTP links in documentation

### DIFF
--- a/docs/ml-advanced.md
+++ b/docs/ml-advanced.md
@@ -42,7 +42,7 @@ license: |
 # Optimization of linear methods (developer)
 
 ## Limited-memory BFGS (L-BFGS)
-[L-BFGS](http://en.wikipedia.org/wiki/Limited-memory_BFGS) is an optimization 
+[L-BFGS](https://en.wikipedia.org/wiki/Limited-memory_BFGS) is an optimization 
 algorithm in the family of quasi-Newton methods to solve the optimization problems of the form 
 `$\min_{\wv \in\R^d} \; f(\wv)$`. The L-BFGS method approximates the objective function locally as a 
 quadratic without evaluating the second partial derivatives of the objective function to construct the 

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -436,7 +436,7 @@ Refer to the [R API docs](api/R/reference/spark.svmLinear.html) for more details
 
 ## One-vs-Rest classifier (a.k.a. One-vs-All)
 
-[OneVsRest](http://en.wikipedia.org/wiki/Multiclass_classification#One-vs.-rest) is an example of a machine learning reduction for performing multiclass classification given a base classifier that can perform binary classification efficiently.  It is also known as "One-vs-All."
+[OneVsRest](https://en.wikipedia.org/wiki/Multiclass_classification#One-vs.-rest) is an example of a machine learning reduction for performing multiclass classification given a base classifier that can perform binary classification efficiently.  It is also known as "One-vs-All."
 
 `OneVsRest` is implemented as an `Estimator`. For the base classifier, it takes instances of `Classifier` and creates a binary classification problem for each of the k classes. The classifier for class i is trained to predict whether the label is i or not, distinguishing class i from all other classes.
 
@@ -474,7 +474,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/OneVsRe
 
 ## Naive Bayes
 
-[Naive Bayes classifiers](http://en.wikipedia.org/wiki/Naive_Bayes_classifier) are a family of simple
+[Naive Bayes classifiers](https://en.wikipedia.org/wiki/Naive_Bayes_classifier) are a family of simple
 probabilistic, multiclass classifiers based on applying Bayes' theorem with strong (naive) independence
 assumptions between every pair of features.
 
@@ -483,7 +483,7 @@ it computes the conditional probability distribution of each feature given each 
 For prediction, it applies Bayes' theorem to compute the conditional probability distribution
 of each label given an observation.
 
-MLlib supports [Multinomial naive Bayes](http://en.wikipedia.org/wiki/Naive_Bayes_classifier#Multinomial_naive_Bayes),
+MLlib supports [Multinomial naive Bayes](https://en.wikipedia.org/wiki/Naive_Bayes_classifier#Multinomial_naive_Bayes),
 [Complement naive Bayes](https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf),
 [Bernoulli naive Bayes](http://nlp.stanford.edu/IR-book/html/htmledition/the-bernoulli-model-1.html)
 and [Gaussian naive Bayes](https://en.wikipedia.org/wiki/Naive_Bayes_classifier#Gaussian_naive_Bayes).
@@ -498,7 +498,7 @@ Feature values for Multinomial and Bernoulli models must be *non-negative*. The 
 For document classification, the input feature vectors should usually be sparse vectors.
 Since the training data is only used once, it is not necessary to cache it.
 
-[Additive smoothing](http://en.wikipedia.org/wiki/Lidstone_smoothing) can be used by
+[Additive smoothing](https://en.wikipedia.org/wiki/Lidstone_smoothing) can be used by
 setting the parameter $\lambda$ (default to $1.0$).
 
 **Examples**
@@ -1003,7 +1003,7 @@ Refer to the [R API docs](api/R/reference/spark.survreg.html) for more details.
 
 
 ## Isotonic regression
-[Isotonic regression](http://en.wikipedia.org/wiki/Isotonic_regression)
+[Isotonic regression](https://en.wikipedia.org/wiki/Isotonic_regression)
 belongs to the family of regression algorithms. Formally isotonic regression is a problem where
 given a finite set of real numbers `$Y = {y_1, y_2, ..., y_n}$` representing observed responses
 and `$X = {x_1, x_2, ..., x_n}$` the unknown response values to be fitted
@@ -1018,7 +1018,7 @@ with respect to complete order subject to
 The resulting function is called isotonic regression and it is unique.
 It can be viewed as least squares problem under order restriction.
 Essentially isotonic regression is a
-[monotonic function](http://en.wikipedia.org/wiki/Monotonic_function)
+[monotonic function](https://en.wikipedia.org/wiki/Monotonic_function)
 best fitting the original data points.
 
 We implement a
@@ -1136,7 +1136,7 @@ Refer to [the linear methods guide for the RDD-based API](mllib-linear-methods.h
 details about implementation and tuning; this information is still relevant.
 
 We also include a DataFrame API for [Elastic
-net](http://en.wikipedia.org/wiki/Elastic_net_regularization), a hybrid
+net](https://en.wikipedia.org/wiki/Elastic_net_regularization), a hybrid
 of $L_1$ and $L_2$ regularization proposed in [Zou et al, Regularization
 and variable selection via the elastic
 net](http://users.stat.umn.edu/~zouxx019/Papers/elasticnet.pdf).
@@ -1150,10 +1150,10 @@ regularization as special cases. For example, if a [linear
 regression](https://en.wikipedia.org/wiki/Linear_regression) model is
 trained with the elastic net parameter $\alpha$ set to $1$, it is
 equivalent to a
-[Lasso](http://en.wikipedia.org/wiki/Least_squares#Lasso_method) model.
+[Lasso](https://en.wikipedia.org/wiki/Least_squares#Lasso_method) model.
 On the other hand, if $\alpha$ is set to $0$, the trained model reduces
 to a [ridge
-regression](http://en.wikipedia.org/wiki/Tikhonov_regularization) model.
+regression](https://en.wikipedia.org/wiki/Tikhonov_regularization) model.
 We implement Pipelines API for both linear regression and logistic
 regression with elastic net regularization.
 
@@ -1195,7 +1195,7 @@ or bin the continuous features and one-hot encode them.
 
 # Decision trees
 
-[Decision trees](http://en.wikipedia.org/wiki/Decision_tree_learning)
+[Decision trees](https://en.wikipedia.org/wiki/Decision_tree_learning)
 and their ensembles are popular methods for the machine learning tasks of
 classification and regression. Decision trees are widely used since they are easy to interpret,
 handle categorical features, extend to the multiclass classification setting, do not require
@@ -1300,7 +1300,7 @@ All output columns are optional; to exclude an output column, set its correspond
 
 # Tree Ensembles
 
-The DataFrame API supports two major tree ensemble algorithms: [Random Forests](http://en.wikipedia.org/wiki/Random_forest) and [Gradient-Boosted Trees (GBTs)](http://en.wikipedia.org/wiki/Gradient_boosting).
+The DataFrame API supports two major tree ensemble algorithms: [Random Forests](https://en.wikipedia.org/wiki/Random_forest) and [Gradient-Boosted Trees (GBTs)](https://en.wikipedia.org/wiki/Gradient_boosting).
 Both use [`spark.ml` decision trees](ml-classification-regression.html#decision-trees) as their base models.
 
 Users can find more information about ensemble algorithms in the [MLlib Ensemble guide](mllib-ensembles.html).
@@ -1315,7 +1315,7 @@ The main differences between this API and the [original MLlib ensembles API](mll
 
 ## Random Forests
 
-[Random forests](http://en.wikipedia.org/wiki/Random_forest)
+[Random forests](https://en.wikipedia.org/wiki/Random_forest)
 are ensembles of [decision trees](ml-classification-regression.html#decision-trees).
 Random forests combine many decision trees in order to reduce the risk of overfitting.
 The `spark.ml` implementation supports random forests for binary and multiclass classification and for regression,
@@ -1396,7 +1396,7 @@ All output columns are optional; to exclude an output column, set its correspond
 
 ## Gradient-Boosted Trees (GBTs)
 
-[Gradient-Boosted Trees (GBTs)](http://en.wikipedia.org/wiki/Gradient_boosting)
+[Gradient-Boosted Trees (GBTs)](https://en.wikipedia.org/wiki/Gradient_boosting)
 are ensembles of [decision trees](ml-classification-regression.html#decision-trees).
 GBTs iteratively train decision trees in order to minimize a loss function.
 The `spark.ml` implementation supports GBTs for binary classification and for regression,

--- a/docs/ml-clustering.md
+++ b/docs/ml-clustering.md
@@ -30,10 +30,10 @@ about these algorithms.
 
 ## K-means
 
-[k-means](http://en.wikipedia.org/wiki/K-means_clustering) is one of the
+[k-means](https://en.wikipedia.org/wiki/K-means_clustering) is one of the
 most commonly used clustering algorithms that clusters the data points into a
 predefined number of clusters. The MLlib implementation includes a parallelized
-variant of the [k-means++](http://en.wikipedia.org/wiki/K-means%2B%2B) method
+variant of the [k-means++](https://en.wikipedia.org/wiki/K-means%2B%2B) method
 called [kmeans||](http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf).
 
 `KMeans` is implemented as an `Estimator` and generates a `KMeansModel` as the base model.
@@ -193,10 +193,10 @@ Refer to the [R API docs](api/R/reference/spark.bisectingKmeans.html) for more d
 
 ## Gaussian Mixture Model (GMM)
 
-A [Gaussian Mixture Model](http://en.wikipedia.org/wiki/Mixture_model#Multivariate_Gaussian_mixture_model)
+A [Gaussian Mixture Model](https://en.wikipedia.org/wiki/Mixture_model#Multivariate_Gaussian_mixture_model)
 represents a composite distribution whereby points are drawn from one of *k* Gaussian sub-distributions,
 each with its own probability. The `spark.ml` implementation uses the
-[expectation-maximization](http://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)
+[expectation-maximization](https://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)
 algorithm to induce the maximum-likelihood model given a set of samples.
 
 `GaussianMixture` is implemented as an `Estimator` and generates a `GaussianMixtureModel` as the base

--- a/docs/ml-collaborative-filtering.md
+++ b/docs/ml-collaborative-filtering.md
@@ -24,7 +24,7 @@ license: |
 
 ## Collaborative filtering 
 
-[Collaborative filtering](http://en.wikipedia.org/wiki/Recommender_system#Collaborative_filtering)
+[Collaborative filtering](https://en.wikipedia.org/wiki/Recommender_system#Collaborative_filtering)
 is commonly used for recommender systems.  These techniques aim to fill in the
 missing entries of a user-item association matrix.  `spark.ml` currently supports
 model-based collaborative filtering, in which users and products are described

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -36,7 +36,7 @@ This section covers algorithms for working with features, roughly divided into t
 
 ## TF-IDF
 
-[Term frequency-inverse document frequency (TF-IDF)](http://en.wikipedia.org/wiki/Tf%E2%80%93idf) 
+[Term frequency-inverse document frequency (TF-IDF)](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) 
 is a feature vectorization method widely used in text mining to reflect the importance of a term 
 to a document in the corpus. Denote a term by `$t$`, a document by `$d$`, and the corpus by `$D$`.
 Term frequency `$TF(t, d)$` is the number of times that term `$t$` appears in document `$d$`, while 
@@ -61,7 +61,7 @@ In MLlib, we separate TF and IDF to make them flexible.
 
 `HashingTF` is a `Transformer` which takes sets of terms and converts those sets into 
 fixed-length feature vectors.  In text processing, a "set of terms" might be a bag of words.
-`HashingTF` utilizes the [hashing trick](http://en.wikipedia.org/wiki/Feature_hashing).
+`HashingTF` utilizes the [hashing trick](https://en.wikipedia.org/wiki/Feature_hashing).
 A raw feature is mapped into an index (term) by applying a hash function. The hash function
 used here is [MurmurHash 3](https://en.wikipedia.org/wiki/MurmurHash). Then term frequencies
 are calculated based on the mapped indices. This approach avoids the need to compute a global 
@@ -321,7 +321,7 @@ for more details on the API.
 
 ## Tokenizer
 
-[Tokenization](http://en.wikipedia.org/wiki/Lexical_analysis#Tokenization) is the process of taking text (such as a sentence) and breaking it into individual terms (usually words).  A simple [Tokenizer](api/scala/org/apache/spark/ml/feature/Tokenizer.html) class provides this functionality.  The example below shows how to split sentences into sequences of words.
+[Tokenization](https://en.wikipedia.org/wiki/Lexical_analysis#Tokenization) is the process of taking text (such as a sentence) and breaking it into individual terms (usually words).  A simple [Tokenizer](api/scala/org/apache/spark/ml/feature/Tokenizer.html) class provides this functionality.  The example below shows how to split sentences into sequences of words.
 
 [RegexTokenizer](api/scala/org/apache/spark/ml/feature/RegexTokenizer.html) allows more
  advanced tokenization based on regular expression (regex) matching.
@@ -507,7 +507,7 @@ for more details on the API.
 
 ## PCA
 
-[PCA](http://en.wikipedia.org/wiki/Principal_component_analysis) is a statistical procedure that uses an orthogonal transformation to convert a set of observations of possibly correlated variables into a set of values of linearly uncorrelated variables called principal components. A [PCA](api/scala/org/apache/spark/ml/feature/PCA.html) class trains a model to project vectors to a low-dimensional space using PCA. The example below shows how to project 5-dimensional feature vectors into 3-dimensional principal components.
+[PCA](https://en.wikipedia.org/wiki/Principal_component_analysis) is a statistical procedure that uses an orthogonal transformation to convert a set of observations of possibly correlated variables into a set of values of linearly uncorrelated variables called principal components. A [PCA](api/scala/org/apache/spark/ml/feature/PCA.html) class trains a model to project vectors to a low-dimensional space using PCA. The example below shows how to project 5-dimensional feature vectors into 3-dimensional principal components.
 
 **Examples**
 
@@ -541,7 +541,7 @@ for more details on the API.
 
 ## PolynomialExpansion
 
-[Polynomial expansion](http://en.wikipedia.org/wiki/Polynomial_expansion) is the process of expanding your features into a polynomial space, which is formulated by an n-degree combination of original dimensions. A [PolynomialExpansion](api/scala/org/apache/spark/ml/feature/PolynomialExpansion.html) class provides this functionality.  The example below shows how to expand your features into a 3-degree polynomial space.
+[Polynomial expansion](https://en.wikipedia.org/wiki/Polynomial_expansion) is the process of expanding your features into a polynomial space, which is formulated by an n-degree combination of original dimensions. A [PolynomialExpansion](api/scala/org/apache/spark/ml/feature/PolynomialExpansion.html) class provides this functionality.  The example below shows how to expand your features into a 3-degree polynomial space.
 
 **Examples**
 
@@ -821,7 +821,7 @@ for more details on the API.
 
 ## OneHotEncoder
 
-[One-hot encoding](http://en.wikipedia.org/wiki/One-hot) maps a categorical feature, represented as a label index, to a binary vector with at most a single one-value indicating the presence of a specific feature value from among the set of all feature values. This encoding allows algorithms which expect continuous features, such as Logistic Regression, to use categorical features. For string type input data, it is common to encode categorical features using [StringIndexer](ml-features.html#stringindexer) first.
+[One-hot encoding](https://en.wikipedia.org/wiki/One-hot) maps a categorical feature, represented as a label index, to a binary vector with at most a single one-value indicating the presence of a specific feature value from among the set of all feature values. This encoding allows algorithms which expect continuous features, such as Logistic Regression, to use categorical features. For string type input data, it is common to encode categorical features using [StringIndexer](ml-features.html#stringindexer) first.
 
 `OneHotEncoder` can transform multiple columns, returning an one-hot-encoded output vector column for each input column. It is common to merge these vectors into a single feature vector using [VectorAssembler](ml-features.html#vectorassembler).
 
@@ -1074,7 +1074,7 @@ for more details on the API.
 
 ## Normalizer
 
-`Normalizer` is a `Transformer` which transforms a dataset of `Vector` rows, normalizing each `Vector` to have unit norm.  It takes parameter `p`, which specifies the [p-norm](http://en.wikipedia.org/wiki/Norm_%28mathematics%29#p-norm) used for normalization.  ($p = 2$ by default.)  This normalization can help standardize your input data and improve the behavior of learning algorithms.
+`Normalizer` is a `Transformer` which transforms a dataset of `Vector` rows, normalizing each `Vector` to have unit norm.  It takes parameter `p`, which specifies the [p-norm](https://en.wikipedia.org/wiki/Norm_%28mathematics%29#p-norm) used for normalization.  ($p = 2$ by default.)  This normalization can help standardize your input data and improve the behavior of learning algorithms.
 
 **Examples**
 

--- a/docs/ml-frequent-pattern-mining.md
+++ b/docs/ml-frequent-pattern-mining.md
@@ -22,7 +22,7 @@ license: |
 Mining frequent items, itemsets, subsequences, or other substructures is usually among the
 first steps to analyze a large-scale dataset, which has been an active research topic in
 data mining for years.
-We refer users to Wikipedia's [association rule learning](http://en.wikipedia.org/wiki/Association_rule_learning)
+We refer users to Wikipedia's [association rule learning](https://en.wikipedia.org/wiki/Association_rule_learning)
 for more information.
 
 **Table of Contents**
@@ -36,7 +36,7 @@ The FP-growth algorithm is described in the paper
 [Han et al., Mining frequent patterns without candidate generation](https://doi.org/10.1145/335191.335372),
 where "FP" stands for frequent pattern.
 Given a dataset of transactions, the first step of FP-growth is to calculate item frequencies and identify frequent items.
-Different from [Apriori-like](http://en.wikipedia.org/wiki/Apriori_algorithm) algorithms designed for the same purpose,
+Different from [Apriori-like](https://en.wikipedia.org/wiki/Apriori_algorithm) algorithms designed for the same purpose,
 the second step of FP-growth uses a suffix tree (FP-tree) structure to encode transactions without generating candidate sets
 explicitly, which are usually expensive to generate.
 After the second step, the frequent itemsets can be extracted from the FP-tree.

--- a/docs/mllib-classification-regression.md
+++ b/docs/mllib-classification-regression.md
@@ -20,10 +20,10 @@ license: |
 ---
 
 The `spark.mllib` package supports various methods for
-[binary classification](http://en.wikipedia.org/wiki/Binary_classification),
+[binary classification](https://en.wikipedia.org/wiki/Binary_classification),
 [multiclass
-classification](http://en.wikipedia.org/wiki/Multiclass_classification), and
-[regression analysis](http://en.wikipedia.org/wiki/Regression_analysis). The table below outlines
+classification](https://en.wikipedia.org/wiki/Multiclass_classification), and
+[regression analysis](https://en.wikipedia.org/wiki/Regression_analysis). The table below outlines
 the supported algorithms for each type of problem.
 
 <table>

--- a/docs/mllib-clustering.md
+++ b/docs/mllib-clustering.md
@@ -32,10 +32,10 @@ The `spark.mllib` package supports the following models:
 
 ## K-means
 
-[K-means](http://en.wikipedia.org/wiki/K-means_clustering) is one of the
+[K-means](https://en.wikipedia.org/wiki/K-means_clustering) is one of the
 most commonly used clustering algorithms that clusters the data points into a
 predefined number of clusters. The `spark.mllib` implementation includes a parallelized
-variant of the [k-means++](http://en.wikipedia.org/wiki/K-means%2B%2B) method
+variant of the [k-means++](https://en.wikipedia.org/wiki/K-means%2B%2B) method
 called [kmeans||](http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf).
 The implementation in `spark.mllib` has the following parameters:
 
@@ -95,10 +95,10 @@ Refer to the [`KMeans` Java docs](api/java/org/apache/spark/mllib/clustering/KMe
 
 ## Gaussian mixture
 
-A [Gaussian Mixture Model](http://en.wikipedia.org/wiki/Mixture_model#Multivariate_Gaussian_mixture_model)
+A [Gaussian Mixture Model](https://en.wikipedia.org/wiki/Mixture_model#Multivariate_Gaussian_mixture_model)
 represents a composite distribution whereby points are drawn from one of *k* Gaussian sub-distributions,
 each with its own probability.  The `spark.mllib` implementation uses the
-[expectation-maximization](http://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)
+[expectation-maximization](https://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)
  algorithm to induce the maximum-likelihood model given a set of samples.  The implementation
 has the following parameters:
 
@@ -153,7 +153,7 @@ Power iteration clustering (PIC) is a scalable and efficient algorithm for clust
 graph given pairwise similarities as edge properties,
 described in [Lin and Cohen, Power Iteration Clustering](http://www.cs.cmu.edu/~frank/papers/icml2010-pic-final.pdf).
 It computes a pseudo-eigenvector of the normalized affinity matrix of the graph via
-[power iteration](http://en.wikipedia.org/wiki/Power_iteration)  and uses it to cluster vertices.
+[power iteration](https://en.wikipedia.org/wiki/Power_iteration)  and uses it to cluster vertices.
 `spark.mllib` includes an implementation of PIC using GraphX as its backend.
 It takes an `RDD` of `(srcId, dstId, similarity)` tuples and outputs a model with the clustering assignments.
 The similarities must be nonnegative.
@@ -222,7 +222,7 @@ Refer to the [`PowerIterationClustering` Java docs](api/java/org/apache/spark/ml
 
 ## Latent Dirichlet allocation (LDA)
 
-[Latent Dirichlet allocation (LDA)](http://en.wikipedia.org/wiki/Latent_Dirichlet_allocation)
+[Latent Dirichlet allocation (LDA)](https://en.wikipedia.org/wiki/Latent_Dirichlet_allocation)
 is a topic model which infers topics from a collection of text documents.
 LDA can be thought of as a clustering algorithm as follows:
 
@@ -236,7 +236,7 @@ generated.
 
 LDA supports different inference algorithms via `setOptimizer` function.
 `EMLDAOptimizer` learns clustering using
-[expectation-maximization](http://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)
+[expectation-maximization](https://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)
 on the likelihood function and yields comprehensive results, while
 `OnlineLDAOptimizer` uses iterative mini-batch sampling for [online
 variational

--- a/docs/mllib-collaborative-filtering.md
+++ b/docs/mllib-collaborative-filtering.md
@@ -24,7 +24,7 @@ license: |
 
 ## Collaborative filtering 
 
-[Collaborative filtering](http://en.wikipedia.org/wiki/Recommender_system#Collaborative_filtering)
+[Collaborative filtering](https://en.wikipedia.org/wiki/Recommender_system#Collaborative_filtering)
 is commonly used for recommender systems.  These techniques aim to fill in the
 missing entries of a user-item association matrix.  `spark.mllib` currently supports
 model-based collaborative filtering, in which users and products are described

--- a/docs/mllib-decision-tree.md
+++ b/docs/mllib-decision-tree.md
@@ -22,7 +22,7 @@ license: |
 * Table of contents
 {:toc}
 
-[Decision trees](http://en.wikipedia.org/wiki/Decision_tree_learning)
+[Decision trees](https://en.wikipedia.org/wiki/Decision_tree_learning)
 and their ensembles are popular methods for the machine learning tasks of
 classification and regression. Decision trees are widely used since they are easy to interpret,
 handle categorical features, extend to the multiclass classification setting, do not require
@@ -233,7 +233,7 @@ The example below demonstrates how to load a
 parse it as an RDD of `LabeledPoint` and then
 perform regression using a decision tree with variance as an impurity measure and a maximum tree
 depth of 5. The Mean Squared Error (MSE) is computed at the end to evaluate
-[goodness of fit](http://en.wikipedia.org/wiki/Goodness_of_fit).
+[goodness of fit](https://en.wikipedia.org/wiki/Goodness_of_fit).
 
 <div class="codetabs">
 

--- a/docs/mllib-dimensionality-reduction.md
+++ b/docs/mllib-dimensionality-reduction.md
@@ -22,7 +22,7 @@ license: |
 * Table of contents
 {:toc}
 
-[Dimensionality reduction](http://en.wikipedia.org/wiki/Dimensionality_reduction) is the process 
+[Dimensionality reduction](https://en.wikipedia.org/wiki/Dimensionality_reduction) is the process 
 of reducing the number of variables under consideration.
 It can be used to extract latent features from raw and noisy features
 or compress data while maintaining the structure.
@@ -30,7 +30,7 @@ or compress data while maintaining the structure.
 
 ## Singular value decomposition (SVD)
 
-[Singular value decomposition (SVD)](http://en.wikipedia.org/wiki/Singular_value_decomposition)
+[Singular value decomposition (SVD)](https://en.wikipedia.org/wiki/Singular_value_decomposition)
 factorizes a matrix into three matrices: $U$, $\Sigma$, and $V$ such that
 
 `\[
@@ -109,7 +109,7 @@ The same code applies to `IndexedRowMatrix` if `U` is defined as an
 
 ## Principal component analysis (PCA)
 
-[Principal component analysis (PCA)](http://en.wikipedia.org/wiki/Principal_component_analysis) is a
+[Principal component analysis (PCA)](https://en.wikipedia.org/wiki/Principal_component_analysis) is a
 statistical method to find a rotation such that the first coordinate has the largest variance
 possible, and each succeeding coordinate, in turn, has the largest variance possible. The columns of
 the rotation matrix are called principal components. PCA is used widely in dimensionality reduction.

--- a/docs/mllib-ensembles.md
+++ b/docs/mllib-ensembles.md
@@ -22,7 +22,7 @@ license: |
 * Table of contents
 {:toc}
 
-An [ensemble method](http://en.wikipedia.org/wiki/Ensemble_learning)
+An [ensemble method](https://en.wikipedia.org/wiki/Ensemble_learning)
 is a learning algorithm which creates a model composed of a set of other base models.
 `spark.mllib` supports two major ensemble algorithms: [`GradientBoostedTrees`](api/scala/org/apache/spark/mllib/tree/GradientBoostedTrees.html) and [`RandomForest`](api/scala/org/apache/spark/mllib/tree/RandomForest$.html).
 Both use [decision trees](mllib-decision-tree.html) as their base models.
@@ -40,7 +40,7 @@ In short, both algorithms can be effective, and the choice should be based on th
 
 ## Random Forests
 
-[Random forests](http://en.wikipedia.org/wiki/Random_forest)
+[Random forests](https://en.wikipedia.org/wiki/Random_forest)
 are ensembles of [decision trees](mllib-decision-tree.html).
 Random forests are one of the most successful machine learning models for classification and
 regression.  They combine many decision trees in order to reduce the risk of overfitting.
@@ -137,7 +137,7 @@ The example below demonstrates how to load a
 parse it as an RDD of `LabeledPoint` and then
 perform regression using a Random Forest.
 The Mean Squared Error (MSE) is computed at the end to evaluate
-[goodness of fit](http://en.wikipedia.org/wiki/Goodness_of_fit).
+[goodness of fit](https://en.wikipedia.org/wiki/Goodness_of_fit).
 
 <div class="codetabs">
 
@@ -163,7 +163,7 @@ Refer to the [`RandomForest` Java docs](api/java/org/apache/spark/mllib/tree/Ran
 
 ## Gradient-Boosted Trees (GBTs)
 
-[Gradient-Boosted Trees (GBTs)](http://en.wikipedia.org/wiki/Gradient_boosting)
+[Gradient-Boosted Trees (GBTs)](https://en.wikipedia.org/wiki/Gradient_boosting)
 are ensembles of [decision trees](mllib-decision-tree.html).
 GBTs iteratively train decision trees in order to minimize a loss function.
 Like decision trees, GBTs handle categorical features,
@@ -278,7 +278,7 @@ The example below demonstrates how to load a
 parse it as an RDD of `LabeledPoint` and then
 perform regression using Gradient-Boosted Trees with Squared Error as the loss.
 The Mean Squared Error (MSE) is computed at the end to evaluate
-[goodness of fit](http://en.wikipedia.org/wiki/Goodness_of_fit).
+[goodness of fit](https://en.wikipedia.org/wiki/Goodness_of_fit).
 
 <div class="codetabs">
 

--- a/docs/mllib-feature-extraction.md
+++ b/docs/mllib-feature-extraction.md
@@ -28,7 +28,7 @@ license: |
 **Note** We recommend using the DataFrame-based API, which is detailed in the [ML user guide on 
 TF-IDF](ml-features.html#tf-idf).
 
-[Term frequency-inverse document frequency (TF-IDF)](http://en.wikipedia.org/wiki/Tf%E2%80%93idf) is a feature 
+[Term frequency-inverse document frequency (TF-IDF)](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) is a feature 
 vectorization method widely used in text mining to reflect the importance of a term to a document in the corpus.
 Denote a term by `$t$`, a document by `$d$`, and the corpus by `$D$`.
 Term frequency `$TF(t, d)$` is the number of times that term `$t$` appears in document `$d$`,
@@ -52,7 +52,7 @@ There are several variants on the definition of term frequency and document freq
 In `spark.mllib`, we separate TF and IDF to make them flexible.
 
 Our implementation of term frequency utilizes the
-[hashing trick](http://en.wikipedia.org/wiki/Feature_hashing).
+[hashing trick](https://en.wikipedia.org/wiki/Feature_hashing).
 A raw feature is mapped into an index (term) by applying a hash function.
 Then term frequencies are calculated based on the mapped indices.
 This approach avoids the need to compute a global term-to-index map,
@@ -245,7 +245,7 @@ Refer to the [`Normalizer` Scala docs](api/scala/org/apache/spark/mllib/feature/
 
 ## ChiSqSelector
 
-[Feature selection](http://en.wikipedia.org/wiki/Feature_selection) tries to identify relevant
+[Feature selection](https://en.wikipedia.org/wiki/Feature_selection) tries to identify relevant
 features for use in model construction. It reduces the size of the feature space, which can improve
 both speed and statistical learning behavior.
 

--- a/docs/mllib-frequent-pattern-mining.md
+++ b/docs/mllib-frequent-pattern-mining.md
@@ -22,7 +22,7 @@ license: |
 Mining frequent items, itemsets, subsequences, or other substructures is usually among the
 first steps to analyze a large-scale dataset, which has been an active research topic in
 data mining for years.
-We refer users to Wikipedia's [association rule learning](http://en.wikipedia.org/wiki/Association_rule_learning)
+We refer users to Wikipedia's [association rule learning](https://en.wikipedia.org/wiki/Association_rule_learning)
 for more information.
 `spark.mllib` provides a parallel implementation of FP-growth,
 a popular algorithm to mining frequent itemsets.
@@ -33,7 +33,7 @@ The FP-growth algorithm is described in the paper
 [Han et al., Mining frequent patterns without candidate generation](https://doi.org/10.1145/335191.335372),
 where "FP" stands for frequent pattern.
 Given a dataset of transactions, the first step of FP-growth is to calculate item frequencies and identify frequent items.
-Different from [Apriori-like](http://en.wikipedia.org/wiki/Apriori_algorithm) algorithms designed for the same purpose,
+Different from [Apriori-like](https://en.wikipedia.org/wiki/Apriori_algorithm) algorithms designed for the same purpose,
 the second step of FP-growth uses a suffix tree (FP-tree) structure to encode transactions without generating candidate sets
 explicitly, which are usually expensive to generate.
 After the second step, the frequent itemsets can be extracted from the FP-tree.

--- a/docs/mllib-isotonic-regression.md
+++ b/docs/mllib-isotonic-regression.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 ## Isotonic regression
-[Isotonic regression](http://en.wikipedia.org/wiki/Isotonic_regression)
+[Isotonic regression](https://en.wikipedia.org/wiki/Isotonic_regression)
 belongs to the family of regression algorithms. Formally isotonic regression is a problem where
 given a finite set of real numbers `$Y = {y_1, y_2, ..., y_n}$` representing observed responses
 and `$X = {x_1, x_2, ..., x_n}$` the unknown response values to be fitted
@@ -35,7 +35,7 @@ with respect to complete order subject to
 The resulting function is called isotonic regression and it is unique.
 It can be viewed as least squares problem under order restriction.
 Essentially isotonic regression is a
-[monotonic function](http://en.wikipedia.org/wiki/Monotonic_function)
+[monotonic function](https://en.wikipedia.org/wiki/Monotonic_function)
 best fitting the original data points.
 
 `spark.mllib` supports a

--- a/docs/mllib-linear-methods.md
+++ b/docs/mllib-linear-methods.md
@@ -101,7 +101,7 @@ multiclass labeling.
 ### Regularizers
 
 The purpose of the
-[regularizer](http://en.wikipedia.org/wiki/Regularization_(mathematics)) is to
+[regularizer](https://en.wikipedia.org/wiki/Regularization_(mathematics)) is to
 encourage simple models and avoid overfitting.  We support the following
 regularizers in `spark.mllib`:
 
@@ -130,7 +130,7 @@ of `$\wv$`.
 
 L2-regularized problems are generally easier to solve than L1-regularized due to smoothness.
 However, L1 regularization can help promote sparsity in weights leading to smaller and more interpretable models, the latter of which can be useful for feature selection.
-[Elastic net](http://en.wikipedia.org/wiki/Elastic_net_regularization) is a combination of L1 and L2 regularization. It is not recommended to train models without any regularization,
+[Elastic net](https://en.wikipedia.org/wiki/Elastic_net_regularization) is a combination of L1 and L2 regularization. It is not recommended to train models without any regularization,
 especially when the number of training examples is small.
 
 ### Optimization
@@ -142,13 +142,13 @@ Refer to [this optimization section](mllib-optimization.html#choosing-an-optimiz
 
 ## Classification
 
-[Classification](http://en.wikipedia.org/wiki/Statistical_classification) aims to divide items into
+[Classification](https://en.wikipedia.org/wiki/Statistical_classification) aims to divide items into
 categories.
 The most common classification type is
-[binary classification](http://en.wikipedia.org/wiki/Binary_classification), where there are two
+[binary classification](https://en.wikipedia.org/wiki/Binary_classification), where there are two
 categories, usually named positive and negative.
 If there are more than two categories, it is called
-[multiclass classification](http://en.wikipedia.org/wiki/Multiclass_classification).
+[multiclass classification](https://en.wikipedia.org/wiki/Multiclass_classification).
 `spark.mllib` supports two linear methods for classification: linear Support Vector Machines (SVMs)
 and logistic regression.
 Linear SVMs supports only binary classification, while logistic regression supports both binary and
@@ -159,7 +159,7 @@ where labels are class indices starting from zero: $0, 1, 2, \ldots$.
 
 ### Linear Support Vector Machines (SVMs)
 
-The [linear SVM](http://en.wikipedia.org/wiki/Support_vector_machine#Linear_SVM)
+The [linear SVM](https://en.wikipedia.org/wiki/Support_vector_machine#Linear_SVM)
 is a standard method for large-scale classification tasks. It is a linear method as described above in equation `$\eqref{eq:regPrimal}$`, with the loss function in the formulation given by the hinge loss:
 
 `\[
@@ -167,7 +167,7 @@ L(\wv;\x,y) := \max \{0, 1-y \wv^T \x \}.
 \]`
 By default, linear SVMs are trained with an L2 regularization.
 We also support alternative L1 regularization. In this case,
-the problem becomes a [linear program](http://en.wikipedia.org/wiki/Linear_programming).
+the problem becomes a [linear program](https://en.wikipedia.org/wiki/Linear_programming).
 
 The linear SVMs algorithm outputs an SVM model. Given a new data point,
 denoted by $\x$, the model makes predictions based on the value of $\wv^T \x$.
@@ -260,7 +260,7 @@ a dependency.
 
 ### Logistic regression
 
-[Logistic regression](http://en.wikipedia.org/wiki/Logistic_regression) is widely used to predict a
+[Logistic regression](https://en.wikipedia.org/wiki/Logistic_regression) is widely used to predict a
 binary response. It is a linear method as described above in equation `$\eqref{eq:regPrimal}$`,
 with the loss function in the formulation given by the logistic loss:
 `\[
@@ -280,7 +280,7 @@ model, $\mathrm{f}(z)$, has a probabilistic interpretation (i.e., the probabilit
 that $\x$ is positive).
 
 Binary logistic regression can be generalized into
-[multinomial logistic regression](http://en.wikipedia.org/wiki/Multinomial_logistic_regression) to
+[multinomial logistic regression](https://en.wikipedia.org/wiki/Multinomial_logistic_regression) to
 train and predict multiclass classification problems.
 For example, for $K$ possible outcomes, one of the outcomes can be chosen as a "pivot", and the
 other $K - 1$ outcomes can be separately regressed against the pivot outcome.
@@ -355,12 +355,12 @@ L(\wv;\x,y) :=  \frac{1}{2} (\wv^T \x - y)^2.
 \]`
 
 Various related regression methods are derived by using different types of regularization:
-[*ordinary least squares*](http://en.wikipedia.org/wiki/Ordinary_least_squares) or
-[*linear least squares*](http://en.wikipedia.org/wiki/Linear_least_squares_(mathematics)) uses
- no regularization; [*ridge regression*](http://en.wikipedia.org/wiki/Ridge_regression) uses L2
-regularization; and [*Lasso*](http://en.wikipedia.org/wiki/Lasso_(statistics)) uses L1
+[*ordinary least squares*](https://en.wikipedia.org/wiki/Ordinary_least_squares) or
+[*linear least squares*](https://en.wikipedia.org/wiki/Linear_least_squares_(mathematics)) uses
+ no regularization; [*ridge regression*](https://en.wikipedia.org/wiki/Ridge_regression) uses L2
+regularization; and [*Lasso*](https://en.wikipedia.org/wiki/Lasso_(statistics)) uses L1
 regularization.  For all of these models, the average loss or training error, $\frac{1}{n} \sum_{i=1}^n (\wv^T x_i - y_i)^2$, is
-known as the [mean squared error](http://en.wikipedia.org/wiki/Mean_squared_error).
+known as the [mean squared error](https://en.wikipedia.org/wiki/Mean_squared_error).
 
 ### Streaming linear regression
 

--- a/docs/mllib-naive-bayes.md
+++ b/docs/mllib-naive-bayes.md
@@ -19,7 +19,7 @@ license: |
   limitations under the License.
 ---
 
-[Naive Bayes](http://en.wikipedia.org/wiki/Naive_Bayes_classifier) is a simple
+[Naive Bayes](https://en.wikipedia.org/wiki/Naive_Bayes_classifier) is a simple
 multiclass classification algorithm with the assumption of independence between
 every pair of features. Naive Bayes can be trained very efficiently. Within a
 single pass to the training data, it computes the conditional probability
@@ -28,7 +28,7 @@ compute the conditional probability distribution of label given an observation
 and use it for prediction.
 
 `spark.mllib` supports [multinomial naive
-Bayes](http://en.wikipedia.org/wiki/Naive_Bayes_classifier#Multinomial_naive_Bayes)
+Bayes](https://en.wikipedia.org/wiki/Naive_Bayes_classifier#Multinomial_naive_Bayes)
 and [Bernoulli naive Bayes](http://nlp.stanford.edu/IR-book/html/htmledition/the-bernoulli-model-1.html).
 These models are typically used for [document classification](http://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html).
 Within that context, each observation is a document and each
@@ -36,7 +36,7 @@ feature represents a term whose value is the frequency of the term (in multinomi
 a zero or one indicating whether the term was found in the document (in Bernoulli naive Bayes).
 Feature values must be nonnegative. The model type is selected with an optional parameter
 "multinomial" or "bernoulli" with "multinomial" as the default.
-[Additive smoothing](http://en.wikipedia.org/wiki/Lidstone_smoothing) can be used by
+[Additive smoothing](https://en.wikipedia.org/wiki/Lidstone_smoothing) can be used by
 setting the parameter $\lambda$ (default to $1.0$). For document classification, the input feature
 vectors are usually sparse, and sparse vectors should be supplied as input to take advantage of
 sparsity. Since the training data is only used once, it is not necessary to cache it.

--- a/docs/mllib-optimization.md
+++ b/docs/mllib-optimization.md
@@ -45,13 +45,13 @@ license: |
 
 ### Gradient descent
 The simplest method to solve optimization problems of the form `$\min_{\wv \in\R^d} \; f(\wv)$`
-is [gradient descent](http://en.wikipedia.org/wiki/Gradient_descent).
+is [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent).
 Such first-order optimization methods (including gradient descent and stochastic variants
 thereof) are well-suited for large-scale and distributed computation.
 
 Gradient descent methods aim to find a local minimum of a function by iteratively taking steps in
 the direction of steepest descent, which is the negative of the derivative (called the
-[gradient](http://en.wikipedia.org/wiki/Gradient)) of the function at the current point, i.e., at
+[gradient](https://en.wikipedia.org/wiki/Gradient)) of the function at the current point, i.e., at
 the current parameter value.
 If the objective function `$f$` is not differentiable at all arguments, but still convex, then a
 *sub-gradient* 
@@ -144,7 +144,7 @@ standard SGD. In that case, the step direction depends from the uniformly random
 point.
 
 ### Limited-memory BFGS (L-BFGS)
-[L-BFGS](http://en.wikipedia.org/wiki/Limited-memory_BFGS) is an optimization 
+[L-BFGS](https://en.wikipedia.org/wiki/Limited-memory_BFGS) is an optimization 
 algorithm in the family of quasi-Newton methods to solve the optimization problems of the form 
 `$\min_{\wv \in\R^d} \; f(\wv)$`. The L-BFGS method approximates the objective function locally as a 
 quadratic without evaluating the second partial derivatives of the objective function to construct the 

--- a/docs/mllib-pmml-model-export.md
+++ b/docs/mllib-pmml-model-export.md
@@ -24,7 +24,7 @@ license: |
 
 ## spark.mllib supported models
 
-`spark.mllib` supports model export to Predictive Model Markup Language ([PMML](http://en.wikipedia.org/wiki/Predictive_Model_Markup_Language)).
+`spark.mllib` supports model export to Predictive Model Markup Language ([PMML](https://en.wikipedia.org/wiki/Predictive_Model_Markup_Language)).
 
 The table below outlines the `spark.mllib` models that can be exported to PMML and their equivalent PMML model.
 

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -9,7 +9,7 @@ license: |
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## Summary

Update insecure HTTP links to HTTPS in documentation files.

## Changes

- Update Wikipedia links from HTTP to HTTPS across ML/MLlib documentation
- Update Apache license URL to HTTPS in Avro data sources doc

## Testing

N/A — documentation link updates only. Verified all target URLs resolve over HTTPS.