### PR TITLE
[MINOR][INFRA] Add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{scala,java,sbt}]
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.R]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+max_line_length = 100
 
 [*.{scala,java,sbt}]
 indent_size = 2


### PR DESCRIPTION
## Summary

Add an `.editorconfig` file to help maintain consistent coding style across editors, matching existing linter and style configurations.

## Changes

- Add `.editorconfig` with settings matching Spark's conventions: 2-space indent for Scala/Java/YAML, 4-space for Python, tab for Makefile

## Testing

N/A — editor configuration file only.