### PR TITLE
Pin GitHub Actions runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -70,7 +70,7 @@ on:
 jobs:
   matrix-gen:
     name: Generate matrix for job splits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
@@ -84,7 +84,7 @@ jobs:
   tpcds-1g-gen:
     name: "Generate an TPC-DS dataset with SF=1"
     if: inputs.generate-tpcds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -144,7 +144,7 @@ jobs:
     name: "Run benchmarks: ${{ inputs.class }} (JDK ${{ inputs.jdk }}, Scala ${{ inputs.scala }}, ${{ matrix.split }} out of ${{ inputs.num-splits }} splits)"
     if: always()
     needs: [matrix-gen, tpcds-1g-gen]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/.github/workflows/branch35_scheduler.yml
+++ b/.github/workflows/branch35_scheduler.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   schedule:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/branch40_scheduler.yml
+++ b/.github/workflows/branch40_scheduler.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   schedule:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/branch41_scheduler.yml
+++ b/.github/workflows/branch41_scheduler.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   schedule:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/branch42_scheduler.yml
+++ b/.github/workflows/branch42_scheduler.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   schedule:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/branch4x_scheduler.yml
+++ b/.github/workflows/branch4x_scheduler.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   schedule:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   precondition:
     name: Check changes
-    # `ubuntu-slim` is lighter than `ubuntu-latest`.
+    # `ubuntu-slim` is lighter than `ubuntu-24.04`.
     # Please see https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
     runs-on: ubuntu-slim
     env:
@@ -253,7 +253,7 @@ jobs:
     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     needs: [precondition, precompile]
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).build == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     strategy:
       fail-fast: false
@@ -456,7 +456,7 @@ jobs:
       fromJson(needs.precondition.outputs.required).lint == 'true' ||
       fromJson(needs.precondition.outputs.required).docs == 'true' ||
       fromJson(needs.precondition.outputs.required).sparkr == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     steps:
@@ -550,7 +550,7 @@ jobs:
         fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true' ||
         fromJson(needs.precondition.outputs.required).tpcds-1g == 'true')
     name: "Precompile Spark"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     # Optional optimization: if this job fails or is cancelled, the pyspark
     # matrix entries fall back to running the SBT build locally as before.
@@ -620,7 +620,7 @@ jobs:
       fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
       fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true'
     name: "Build modules: ${{ matrix.modules }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     container:
       image: ${{ needs.precondition.outputs.image_pyspark_url_link }}
@@ -846,7 +846,7 @@ jobs:
     needs: [precondition, infra-image, precompile]
     if: fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     container:
       image: ${{ needs.precondition.outputs.image_sparkr_url_link }}
@@ -947,7 +947,7 @@ jobs:
     needs: [precondition]
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).buf == 'true'
     name: Protobuf breaking change detection and Python CodeGen check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6
@@ -990,7 +990,7 @@ jobs:
     needs: [precondition, infra-image]
     if: fromJson(needs.precondition.outputs.required).lint == 'true'
     name: Linters, licenses, and dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     env:
       LC_ALL: C.UTF-8
@@ -1113,7 +1113,7 @@ jobs:
     needs: [precondition]
     if: fromJson(needs.precondition.outputs.required).java25 == 'true'
     name: Java 25 build with Maven
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v6
@@ -1132,7 +1132,7 @@ jobs:
     needs: [precondition, infra-image]
     if: fromJson(needs.precondition.outputs.required).docs == 'true'
     name: Documentation generation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     env:
       LC_ALL: C.UTF-8
@@ -1242,7 +1242,7 @@ jobs:
     needs: [precondition, precompile]
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).tpcds-1g == 'true'
     name: Run TPC-DS queries with SF=1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     env:
       SPARK_LOCAL_IP: localhost
@@ -1366,7 +1366,7 @@ jobs:
     needs: [precondition, precompile]
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true'
     name: Run Docker integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     env:
       HADOOP_PROFILE: ${{ inputs.hadoop }}
@@ -1460,7 +1460,7 @@ jobs:
     needs: [precondition, precompile]
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true'
     name: Run Spark on Kubernetes Integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout Spark repository
@@ -1555,7 +1555,7 @@ jobs:
     needs: [precondition]
     if: fromJson(needs.precondition.outputs.required).ui == 'true'
     name: Run Spark UI tests
-    # `ubuntu-slim` is lighter than `ubuntu-latest`.
+    # `ubuntu-slim` is lighter than `ubuntu-24.04`.
     # Please see https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
     runs-on: ubuntu-slim
     timeout-minutes: 120

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   main:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     steps:

--- a/.github/workflows/build_python_3.9.yml
+++ b/.github/workflows/build_python_3.9.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   noop:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: No-op
         run: echo "Python 3.9 is not built on this branch. See branches that still support it (e.g. branch-3.5)."

--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -28,7 +28,7 @@ jobs:
   # Build: build Spark and run the tests for specified modules using SBT
   build:
     name: "Build modules: pyspark-client"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     if: github.repository == 'apache/spark'
     steps:

--- a/.github/workflows/build_python_connect40.yml
+++ b/.github/workflows/build_python_connect40.yml
@@ -28,7 +28,7 @@ jobs:
   # Build: build Spark and run the tests for specified modules using SBT
   build:
     name: "Build modules: pyspark-connect"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     if: github.repository == 'apache/spark'
     steps:

--- a/.github/workflows/build_python_pypy3.10.yml
+++ b/.github/workflows/build_python_pypy3.10.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   noop:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: No-op
         run: echo "PyPy 3.10 is not built on this branch. See branches that still support it (e.g. branch-4.1)."

--- a/.github/workflows/build_scala213.yml
+++ b/.github/workflows/build_scala213.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   noop:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: No-op
         run: echo "Scala 2.13 is the default on master and is not built separately. See branches that run it as a separate build (e.g. branch-3.5)."

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -40,7 +40,7 @@ on:
         description: OS to run this build.
         required: false
         type: string
-        default: ubuntu-latest
+        default: ubuntu-24.04
       arch:
         description: The target architecture (x86, x64, arm64) of the Python interpreter.
         required: false

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   docs:
     name: Build and deploy documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       pages: write

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   publish-snapshot:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ on:
 jobs:
   release:
     name: Release Apache Spark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Allow workflow to run only in the following cases:
     # 1. In the apache/spark repository:
     #    - Only allow dry runs (i.e., both 'branch' and 'release-version' inputs are empty).

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   stale:
     if: github.repository == 'apache/spark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/stale@v10
       with:

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -29,7 +29,7 @@ jobs:
     if: >
       github.event.workflow_run.path != '.github/workflows/pages.yml' &&
       !contains(fromJson('["skipped", "cancelled"]'), github.event.workflow_run.conclusion)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       checks: write


### PR DESCRIPTION
## Summary

Pin `ubuntu-latest` to `ubuntu-24.04` in GitHub Actions workflows to prevent unexpected CI breakage when GitHub updates the `ubuntu-latest` tag to a newer Ubuntu version.

## Changes

- Replace `ubuntu-latest` with `ubuntu-24.04` across all workflow files

## Testing

No functional change — pins the currently-resolved version to prevent future drift.