### PR TITLE
[SPARK-58422][K8S][TESTS] Upgrade the minimum Minikube version to 1.38.0

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
@@ -48,9 +48,9 @@ private[spark] object Minikube extends Logging {
 
     versionArrayOpt match {
       case Some(Array(x, y, z)) =>
-        if (Ordering.Tuple3[Int, Int, Int].lt((x, y, z), (1, 28, 0))) {
+        if (Ordering.Tuple3[Int, Int, Int].lt((x, y, z), (1, 38, 0))) {
           assert(false, s"Unsupported Minikube version is detected: $minikubeVersionString." +
-            "For integration testing Minikube version 1.28.0 or greater is expected.")
+            "For integration testing Minikube version 1.38.0 or greater is expected.")
         }
       case _ =>
         assert(false, s"Unexpected version format detected in `$minikubeVersionString`." +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update the Minikube minimum version check in `Minikube.getKubernetesClient` from `1.28.0` to `1.38.0`, along with the corresponding assertion message, for Apache Spark 5.0.0.

### Why are the changes needed?

Apache Spark 5 dropped the support of K8s v1.34 and below and also upgraded the minimum Minikube version to `1.38.0` already. This PR only makes the code consistent with the documentation.
- #57048
- #56605

Minikube v1.38.x has been used stably with K8s v1.35+ since 2026-01-28 in our CIs.
- https://github.com/kubernetes/minikube/releases/tag/v1.38.1 (2026-02-19)
  - https://github.com/kubernetes/minikube/pull/22665
- https://github.com/kubernetes/minikube/releases/tag/v1.38.0 (2026-01-28)
  - https://github.com/kubernetes/minikube/pull/22328


### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5