### PR TITLE
[MINOR][SQL] Remove redundant trailing semicolons in the SQL module

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -794,7 +794,7 @@ class CodegenContext extends Logging {
     val isNullA = freshName("isNullA")
     val elementB = freshName("elementB")
     val isNullB = freshName("isNullB")
-    val jt = javaType(elementType);
+    val jt = javaType(elementType)
     s"""
        |boolean $isNullA = $arrayA.isNullAt($i);
        |boolean $isNullB = $arrayB.isNullAt($i);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -997,7 +997,7 @@ case class StringReplace(srcExpr: Expression, searchExpr: Expression, replaceExp
 
   override def nullSafeEval(srcEval: Any, searchEval: Any, replaceEval: Any): Any = {
     CollationSupport.StringReplace.exec(srcEval.asInstanceOf[UTF8String],
-      searchEval.asInstanceOf[UTF8String], replaceEval.asInstanceOf[UTF8String], collationId);
+      searchEval.asInstanceOf[UTF8String], replaceEval.asInstanceOf[UTF8String], collationId)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -1939,7 +1939,7 @@ case class SubstringIndex(strExpr: Expression, delimExpr: Expression, countExpr:
 
   override def nullSafeEval(str: Any, delim: Any, count: Any): Any = {
     CollationSupport.SubstringIndex.exec(str.asInstanceOf[UTF8String],
-      delim.asInstanceOf[UTF8String], count.asInstanceOf[Int], collationId);
+      delim.asInstanceOf[UTF8String], count.asInstanceOf[Int], collationId)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -2023,7 +2023,7 @@ case class StringLocate(substr: Expression, str: Expression, start: Expression)
             0
           } else {
             CollationSupport.StringLocate.exec(l.asInstanceOf[UTF8String],
-              r.asInstanceOf[UTF8String], s.asInstanceOf[Int] - 1, collationId) + 1;
+              r.asInstanceOf[UTF8String], s.asInstanceOf[Int] - 1, collationId) + 1
           }
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
@@ -1006,7 +1006,7 @@ object DecorrelateInnerQuery extends PredicateHelper {
               // predicate does, and the correlations can not be replaced via equivalences.
               // Introduce a domain join on the left side of the join
               // (chosen arbitrarily) to provide values for the correlated attribute reference.
-              shouldPushToLeft = true;
+              shouldPushToLeft = true
             }
             val (newLeft, leftJoinCond, leftOuterReferenceMap) = if (shouldPushToLeft) {
               decorrelate(left, newOuterReferences, aggregated, underSetOp)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2738,7 +2738,7 @@ object ReplaceDeduplicateWithAggregate extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transformUpWithNewOutput {
     case d @ Deduplicate(keys, child, _) if !child.isStreaming =>
       val keyExprIds = keys.map(_.exprId)
-      val generatedAliasesMap = new mutable.HashMap[Attribute, Alias]();
+      val generatedAliasesMap = new mutable.HashMap[Attribute, Alias]()
       val aggCols = child.output.map { attr =>
         if (keyExprIds.contains(attr.exprId)) {
           attr

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -136,7 +136,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
             case _ => false
           }
         }
-      case _ => false;
+      case _ => false
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -198,11 +198,11 @@ case object NO_BROADCAST_AND_REPLICATION extends JoinStrategyHint {
   override def hintAliases: Set[String] = Set.empty
 }
 
-abstract class AggregateHint;
+abstract class AggregateHint
 
-abstract class WindowHint;
+abstract class WindowHint
 
-abstract class SortHint;
+abstract class SortHint
 
 /**
  * The callback for implementing customized strategies of handling hint errors.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -560,7 +560,7 @@ class StaxXmlParser(
       } else {
         newRow(i) = row(i)
       }
-      i += 1;
+      i += 1
     }
 
     if (badRecordException.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -688,7 +688,7 @@ private[arrow] class IntervalYearWriter(val valueVector: IntervalYearVector)
   }
 
   override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
-    valueVector.setSafe(count, input.getInt(ordinal));
+    valueVector.setSafe(count, input.getInt(ordinal))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ExpressionWithToString.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ExpressionWithToString.scala
@@ -21,5 +21,5 @@ import org.apache.spark.sql.connector.expressions.Expression
 
 abstract class ExpressionWithToString extends Expression with Serializable {
   private val builder = new ToStringSQLBuilder()
-  override def toString(): String = builder.build(this);
+  override def toString(): String = builder.build(this)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionOffsetWithIndex.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionOffsetWithIndex.scala
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.internal.connector;
+package org.apache.spark.sql.internal.connector
 
-import org.apache.spark.sql.connector.read.streaming.PartitionOffset;
+import org.apache.spark.sql.connector.read.streaming.PartitionOffset
 
 /**
  * Internal class for real time mode to pass partition offset from executors to the driver.
  */
-private[sql] case class PartitionOffsetWithIndex(index: Long, partitionOffset: PartitionOffset);
+private[sql] case class PartitionOffsetWithIndex(index: Long, partitionOffset: PartitionOffset)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -1207,7 +1207,7 @@ object SparkConnectClient {
           applier.apply(headers)
         } catch {
           case e: Throwable =>
-            applier.fail(Status.UNAUTHENTICATED.withCause(e));
+            applier.fail(Status.UNAUTHENTICATED.withCause(e))
         }
       })
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/CustomDecimal.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/CustomDecimal.scala
@@ -33,7 +33,7 @@ private[spark] class CustomDecimal(schema: Schema) extends LogicalType(CustomDec
     val obj = schema.getObjectProp("scale")
     obj match {
       case null =>
-        throw new IllegalArgumentException(s"Invalid ${CustomDecimal.TYPE_NAME}: missing scale");
+        throw new IllegalArgumentException(s"Invalid ${CustomDecimal.TYPE_NAME}: missing scale")
       case i : Integer =>
         i
       case other =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -122,7 +122,7 @@ class ExternalAppendOnlyUnsafeRowArray(
       spillableArray = null
     } else if (inMemoryBuffer != null) {
       inMemoryBuffer.clear()
-      inMemoryBufferSizeInBytes = 0;
+      inMemoryBufferSizeInBytes = 0
     }
     numFieldsPerRow = 0
     numRows = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -686,7 +686,7 @@ class SparkSqlAstBuilder extends AstBuilder {
   }
 
   override def visitFailSetRole(ctx: FailSetRoleContext): LogicalPlan = withOrigin(ctx) {
-    invalidStatement("SET ROLE", ctx);
+    invalidStatement("SET ROLE", ctx)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -107,7 +107,7 @@ trait TypedAggregateExpression extends AggregateFunction {
 
   // aggregator.getClass.getSimpleName can cause Malformed class name error,
   // call safer `Utils.getSimpleName` instead
-  override def nodeName: String = Utils.getSimpleName(aggregator.getClass).stripSuffix("$");
+  override def nodeName: String = Utils.getSimpleName(aggregator.getClass).stripSuffix("$")
 }
 
 // TODO: merge these 2 implementations once we refactor the `AggregateFunction` interface.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -428,7 +428,7 @@ object ParquetUtils extends Logging {
           "filePath" -> filePath,
           "config" -> PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key))
     }
-    statistics.getNumNulls;
+    statistics.getNumNulls
   }
 
   // Replaces each VariantType in the schema with the corresponding type in the shredding schema.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -148,7 +148,7 @@ case class JDBCScanBuilder(
       JDBCOptions.JDBC_QUERY_STRING
 
     filteredJDBCOptions == otherSideFilteredJDBCOptions
-  };
+  }
 
   /**
    * Helper method to calculate StructType based on the SupportsPushDownJoin.ColumnWithAlias and

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
@@ -177,7 +177,7 @@ case class BroadcastNestedLoopJoinExec(
             nextIndex += 1
             if (boundCondition(resultRow)) {
               if (foundMatch && singleJoin) {
-                throw QueryExecutionErrors.scalarSubqueryReturnsMultipleRows();
+                throw QueryExecutionErrors.scalarSubqueryReturnsMultipleRows()
               }
               foundMatch = true
               return true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -224,7 +224,7 @@ trait HashJoin extends JoinCodegenSupport {
               val nextBuildRow = buildIter.next()
               if (boundCondition(joinedRow.withRight(nextBuildRow))) {
                 if (found && singleJoin) {
-                  throw QueryExecutionErrors.scalarSubqueryReturnsMultipleRows();
+                  throw QueryExecutionErrors.scalarSubqueryReturnsMultipleRows()
                 }
                 found = true
                 return true

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -587,7 +587,7 @@ abstract class JdbcDialect extends Serializable with Logging {
   def schemasExists(conn: Connection, options: JDBCOptions, schema: String): Boolean = {
     val rs = conn.getMetaData.getSchemas(null, schema)
     while (rs.next()) {
-      if (rs.getString(1) == schema) return true;
+      if (rs.getString(1) == schema) return true
     }
     false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -350,7 +350,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
           } else {
             // The only property we are building here is `COMMENT` because it's the only one
             // we can get from `SHOW INDEXES`.
-            val properties = new util.Properties();
+            val properties = new util.Properties()
             if (indexComment.nonEmpty) properties.put("COMMENT", indexComment)
             val index = new TableIndex(indexName, indexType, Array(FieldReference(colName)),
               new util.HashMap[NamedReference, util.Properties](), properties)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -121,7 +121,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
         case (_, lit: Literal[_]) if lit.dataType == BinaryType =>
           compareBlob(le, name, lit)
         case _ =>
-          super.visitBinaryComparison(name, le, re);
+          super.visitBinaryComparison(name, le, re)
       }
     }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetFunctionsOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetFunctionsOperation.scala
@@ -88,7 +88,7 @@ private[hive] class SparkGetFunctionsOperation(
               s"Usage: ${info.getUsage}\nExtended Usage:${info.getExtended}", // REMARKS
               DatabaseMetaData.functionResultUnknown.asInstanceOf[AnyRef], // FUNCTION_TYPE
               info.getClassName) // SPECIFIC_NAME
-            rowSet.addRow(rowData);
+            rowSet.addRow(rowData)
         }
       }
       setState(OperationState.FINISHED)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes redundant trailing semicolons from Scala statements across the SQL module (catalyst, core, connect, hive-thriftserver) - 29 occurrences in 23 files. Trailing semicolons are no-op statement terminators in Scala.

### Why are the changes needed?
These stray semicolons are inconsistent with the surrounding code (Scala relies on newline inference and omits them everywhere else) and are not caught by scalastyle. Each removal was verified to be a genuine redundant terminator - none is a for-comprehension generator separator, a multi-statement-per-line separator, or inside a string/codegen block, so there is no behavior or compilation change.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Style-only change; every edited line differs from the original solely by the removed trailing semicolon. Existing tests cover the affected files. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)
