### PR TITLE
[SPARK-58435][SQL] Use named containsNull argument in KLL sketch ArrayType results

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -564,7 +564,7 @@ abstract class KllSketchGetQuantileBase
 
   override def dataType: DataType = {
     right.dataType match {
-      case ArrayType(_, _) => ArrayType(outputDataType, false)
+      case ArrayType(_, _) => ArrayType(outputDataType, containsNull = false)
       case _ => outputDataType
     }
   }
@@ -750,7 +750,7 @@ abstract class KllSketchGetRankBase
   }
   override def dataType: DataType = {
     right.dataType match {
-      case ArrayType(_, _) => ArrayType(DoubleType, false)
+      case ArrayType(_, _) => ArrayType(DoubleType, containsNull = false)
       case _ => DoubleType
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Uses the named `containsNull = false` argument in the two `dataType` overrides of the KLL sketch expressions, matching the named form already used by the `inputTypes` declarations in the same classes.

### Why are the changes needed?
`ArrayType`'s second (and final) parameter is `containsNull`, so bare positional `false` and `containsNull = false` compile identically; this only aligns the two outliers with the file's own dominant idiom.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Stylistic, behavior-identical change. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)