### PR TITLE
[SPARK-58441][SQL] Fix wrong results in instr and substring_index for ICU collations caused by inconsistent StringSearch iteration

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1054,7 +1054,12 @@ public class CollationAwareUTF8String {
    *
    * Only the last {@code count} positions of a window are retained, in a ring buffer that grows
    * on demand so that a {@code count} far larger than the number of matches does not allocate up
-   * front.
+   * front. Retaining them is what forward enumeration costs that {@code previous()} did not:
+   * the buffer holds one int per match up to {@code count}, so a caller that asks for a large
+   * occurrence of a pattern that really does occur that many times allocates in proportion to
+   * it -- bounded by the match count, and hence by the length of the target, but no longer
+   * constant. A hard cap would mean a second pass (count the matches, then re-scan to the
+   * one wanted), trading the allocation for another walk of the target.
    */
   private static int findIndexFromEnd(final StringSearch stringSearch, final String text,
       final int count, final int maxStartIndex, final boolean matchEnd) {

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -58,6 +58,14 @@ public class CollationAwareUTF8String {
   private static final int INITIAL_MATCH_RING_CAPACITY = 16;
 
   /**
+   * The initial size, in UTF-16 code units, of the trailing window searched by
+   * `findIndexFromEnd`, and the factor by which that window grows when it does not hold enough
+   * matches. A target no longer than the initial window is searched in a single pass.
+   */
+  private static final int INITIAL_BACKWARD_SEARCH_WINDOW = 64;
+  private static final int BACKWARD_SEARCH_WINDOW_GROWTH = 4;
+
+  /**
    * `COMBINED_ASCII_SMALL_I_COMBINING_DOT` is an internal representation of the combined
    * lowercase code point for ASCII lowercase letter i with an additional combining dot character
    * (U+0307). This integer value is not a valid code point itself, but rather an artificial code
@@ -1011,9 +1019,22 @@ public class CollationAwareUTF8String {
    * The matches are enumerated forward with next() because StringSearch.previous() does not
    * visit the same match set as next(): it skips overlapping matches, and it skips or misaligns
    * matches when a character maps to multiple collation elements (see the note in
-   * collationTrimRight). Only the last {@code count} positions are retained, in a ring buffer
-   * that grows on demand so that a {@code count} far larger than the number of matches does not
-   * allocate up front.
+   * collationTrimRight).
+   *
+   * Enumerating from the start of the target would cost the length of the target on every call,
+   * even when the requested match is the last one. Instead the search runs over a trailing
+   * window that starts at {@code INITIAL_BACKWARD_SEARCH_WINDOW} code units and grows until it
+   * holds {@code count} matches or reaches the start of the target, so the cost tracks the
+   * distance back to the requested match. Once a window holds that many the answer is final:
+   * every remaining match starts before the window, so it precedes all of the window's matches
+   * and cannot be one of the last {@code count}. Only the search's start index moves; the target
+   * and its collation context stay the whole string, so unlike searching a substring a window
+   * boundary can never split a contraction or a combining sequence and report a match that does
+   * not exist in the target.
+   *
+   * Only the last {@code count} positions of a window are retained, in a ring buffer that grows
+   * on demand so that a {@code count} far larger than the number of matches does not allocate up
+   * front.
    */
   private static int findIndexFromEnd(final StringSearch stringSearch, final String text,
       final int count, final int maxStartIndex, final boolean matchEnd) {
@@ -1024,27 +1045,41 @@ public class CollationAwareUTF8String {
     // Match starts are distinct text offsets, so there can be at most text.length() matches.
     if (count > text.length()) return MATCH_NOT_FOUND;
     int[] lastMatches = new int[Math.min(count, INITIAL_MATCH_RING_CAPACITY)];
-    int found = 0;
-    int index = -1;
-    int nextIndex;
-    while ((nextIndex = stringSearch.next()) != StringSearch.DONE && nextIndex <= maxStartIndex) {
-      if (nextIndex == index) {
-        advancePastStuckMatch(stringSearch, text, nextIndex);
-        continue;
+    int window = INITIAL_BACKWARD_SEARCH_WINDOW;
+    while (true) {
+      int windowStart = Math.max(0, maxStartIndex - window);
+      // Never start the search inside a surrogate pair; widening the window is always safe.
+      if (windowStart > 0 && Character.isLowSurrogate(text.charAt(windowStart))) --windowStart;
+      stringSearch.setIndex(windowStart);
+      int found = 0;
+      int index = -1;
+      int nextIndex;
+      while ((nextIndex = stringSearch.next()) != StringSearch.DONE
+          && nextIndex <= maxStartIndex) {
+        if (nextIndex == index) {
+          advancePastStuckMatch(stringSearch, text, nextIndex);
+          continue;
+        }
+        // While the buffer is shorter than `count` no entry has been evicted yet, so `found` is
+        // below its length and indexes it directly; grow before the first write that would wrap.
+        if (found == lastMatches.length && lastMatches.length < count) {
+          lastMatches =
+            Arrays.copyOf(lastMatches, (int) Math.min(count, 2L * lastMatches.length));
+        }
+        lastMatches[found % lastMatches.length] =
+          matchEnd ? nextIndex + stringSearch.getMatchLength() : nextIndex;
+        found++;
+        index = nextIndex;
       }
-      // While the buffer is shorter than `count` no entry has been evicted yet, so `found` is
-      // below its length and indexes it directly; grow before the first write that would wrap.
-      if (found == lastMatches.length && lastMatches.length < count) {
-        lastMatches = Arrays.copyOf(lastMatches, (int) Math.min(count, 2L * lastMatches.length));
-      }
-      lastMatches[found % lastMatches.length] =
-        matchEnd ? nextIndex + stringSearch.getMatchLength() : nextIndex;
-      found++;
-      index = nextIndex;
+      // The buffer has grown to `count` entries by the time `found` reaches it, so the oldest
+      // entry still in the ring buffer is the {@code count}-th match from the end.
+      if (found >= count) return lastMatches[found % lastMatches.length];
+      // The window already reached the start of the target, so there really are fewer matches.
+      if (windowStart == 0) return MATCH_NOT_FOUND;
+      // Capping at the target length keeps the growth from overflowing and guarantees that the
+      // next window starts at 0, so the loop always terminates.
+      window = (int) Math.min((long) window * BACKWARD_SEARCH_WINDOW_GROWTH, text.length());
     }
-    if (found < count) return MATCH_NOT_FOUND;
-    // The count-th match from the end is the oldest entry still in the ring buffer.
-    return lastMatches[found % count];
   }
 
   public static UTF8String subStringIndex(final UTF8String string, final UTF8String delimiter,

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -50,24 +50,13 @@ public class CollationAwareUTF8String {
    */
   private static final int MATCH_NOT_FOUND = -1;
 
-  /**
-   * The initial capacity of the ring buffer used by `findIndexFromEnd` to retain the last
-   * `count` match positions. The buffer grows on demand, so a caller-supplied `count` that is
-   * far larger than the number of matches does not allocate up front.
-   */
+  /** Initial capacity of `findIndexFromEnd`'s ring buffer; it grows on demand up to `count`. */
   private static final int INITIAL_MATCH_RING_CAPACITY = 16;
 
-  /**
-   * The initial size, in UTF-16 code units, of the trailing window searched by
-   * `findIndexFromEnd`. A target no longer than this is searched in a single pass.
-   */
+  /** Initial size, in UTF-16 code units, of `findIndexFromEnd`'s trailing search window. */
   private static final int INITIAL_BACKWARD_SEARCH_WINDOW = 64;
 
-  /**
-   * The factor by which the trailing window searched by `findIndexFromEnd` grows when it does
-   * not hold enough matches. Each pass re-walks the window before it, so the total stays within
-   * a constant factor of the last window.
-   */
+  /** Growth factor of `findIndexFromEnd`'s window when it holds fewer than `count` matches. */
   private static final int BACKWARD_SEARCH_WINDOW_GROWTH = 4;
 
   /**
@@ -967,8 +956,9 @@ public class CollationAwareUTF8String {
       // Adjust the starting position from 1-based to 0-based.
       int realStart = start - 1;
       if (numCodePoints <= realStart) return MATCH_NOT_FOUND;
-      stringSearch.setIndex(targetStr.offsetByCodePoints(0, realStart));
-      searchIndex = findIndex(stringSearch, targetStr, occurrence);
+      int startIndex = targetStr.offsetByCodePoints(0, realStart);
+      stringSearch.setIndex(startIndex);
+      searchIndex = findIndex(stringSearch, targetStr, occurrence, startIndex);
     } else {
       // The last code point index at which a match is allowed to start. A start before the
       // beginning of the string matches nothing, as in UTF8String.indexOf.
@@ -983,12 +973,23 @@ public class CollationAwareUTF8String {
     return targetStr.codePointCount(0, searchIndex);
   }
 
-  private static int findIndex(final StringSearch stringSearch, final String text, int count) {
+  /**
+   * Returns the start of the {@code count}-th match of {@code stringSearch} counting forward from
+   * the iterator's current position, among the matches that start at or after
+   * {@code minStartIndex}, or {@code MATCH_NOT_FOUND} if there are fewer such matches. Both
+   * indices are in UTF-16 code units.
+   *
+   * Positioning the iterator does not bound the matches on its own: ICU snaps a start index
+   * falling inside a collation unit -- a contraction such as Czech "ch", or a surrogate pair --
+   * back to the beginning of that unit, so the first match reported can begin before
+   * {@code minStartIndex}. Such a match is out of range and is skipped without being counted, as
+   * in UTF8String.indexOf.
+   */
+  private static int findIndex(final StringSearch stringSearch, final String text, int count,
+      final int minStartIndex) {
     assert(count >= 0);
-    // -1 is a safe "no match seen yet" sentinel: StringSearch.DONE (also -1) is handled first,
-    // so next() can never store -1 in `index`. Using 0 here would fail to detect the iterator
-    // reporting the same match at index 0 again (e.g. an overlapping search on a pattern that
-    // starts with a surrogate pair), double-counting that match.
+    // "No match seen yet" sentinel. StringSearch.DONE is also -1 but is handled first, so this
+    // cannot collide with a real match; 0 would hide a match at index 0 being reported twice.
     int index = -1;
     while (count > 0) {
       int nextIndex = stringSearch.next();
@@ -997,7 +998,7 @@ public class CollationAwareUTF8String {
       } else if (nextIndex == index) {
         advancePastStuckMatch(stringSearch, text, nextIndex);
       } else {
-        count--;
+        if (nextIndex >= minStartIndex) count--;
         index = nextIndex;
       }
     }
@@ -1005,14 +1006,26 @@ public class CollationAwareUTF8String {
   }
 
   /**
-   * The overlapping search advances by one UTF-16 code unit past the last match start, which
-   * falls inside a surrogate pair when the match starts with a supplementary character, making
-   * next() report the same match again. Advance by one code point past the stuck match start so
-   * the search resumes at the next candidate without skipping an overlapping match.
+   * The overlapping search advances one UTF-16 code unit past the last match start, which lands
+   * inside the collation unit the match begins with whenever that unit spans more than one code
+   * unit -- a surrogate pair, or a contraction such as Czech "ch". ICU snaps such a start index
+   * back to the beginning of the unit, so next() reports the same match again. Advance one code
+   * point at a time until ICU accepts a start index past the stuck match: that is the nearest
+   * position the search can resume from without skipping an overlapping match. This terminates
+   * because each step moves at least one code point and the end of the text is always accepted.
    */
   private static void advancePastStuckMatch(final StringSearch stringSearch, final String text,
       final int matchStart) {
-    stringSearch.setIndex(matchStart + Character.charCount(text.codePointAt(matchStart)));
+    int position = matchStart;
+    while (true) {
+      position += Character.charCount(text.codePointAt(position));
+      if (position >= text.length()) {
+        stringSearch.setIndex(text.length());
+        return;
+      }
+      stringSearch.setIndex(position);
+      if (stringSearch.getIndex() > matchStart) return;
+    }
   }
 
   /**
@@ -1026,51 +1039,34 @@ public class CollationAwareUTF8String {
    * matches when a character maps to multiple collation elements (see the note in
    * {@link #trimRight}).
    *
-   * Enumerating from the start of the target would cost the length of the target on every call,
-   * even when the requested match is the last one. Instead the search runs over a trailing
-   * window that starts at {@code INITIAL_BACKWARD_SEARCH_WINDOW} code units and grows by
+   * A forward scan has to start somewhere before the answer. Rather than always starting at the
+   * beginning of the target, the search runs over a trailing window that starts at
+   * {@code INITIAL_BACKWARD_SEARCH_WINDOW} code units and grows by
    * {@code BACKWARD_SEARCH_WINDOW_GROWTH} until it holds {@code count} matches or reaches the
-   * start of the target, so the cost tracks the distance back to the requested match. A pass
-   * that finds no match past {@code maxStartIndex} runs on to the end of the target, so besides
-   * its own window it walks the whole stretch beyond the anchor. When that stretch is longer
-   * than the window it is what the pass cost, and every geometric step would walk it again, so
-   * such a pass widens straight to the start of the target instead. That fires on the first
-   * pass whose trailing stretch dominates, which caps the total at two passes over the target.
-   * When the anchor sits at or near the end of the target -- always for {@code subStringIndex},
-   * and for {@code indexOf} with a small negative start -- the stretch beyond it is empty and
-   * the growth stays geometric.
+   * start, so the cost tracks the distance back to the answer.
    *
-   * Once a window holds {@code count} matches the answer is final: every remaining match starts
-   * before the window, so it precedes all of the window's matches and cannot be one of the last
-   * {@code count}. Only the search's start index moves; the target stays the whole string, so a
-   * window can never manufacture a match the target does not contain, the way searching a
-   * detached substring could. A boundary can still cost a pass a match near its start -- the
-   * one that straddles it, and, because ICU adjusts a start index falling inside a contraction,
-   * possibly the one beginning at it. That loss is confined to the earliest match of the pass,
-   * and the answer is counted from the end, so it can only matter when the window holds fewer
-   * than {@code count} matches; the window then widens and a pass starting further back
-   * enumerates it. A start index inside a surrogate pair is not a character boundary at all, so
-   * it is backed off below rather than relied on.
+   * A window is safe because only the search's start index moves -- the target stays the whole
+   * string, so a window can never manufacture a match the target does not contain -- and once a
+   * window holds {@code count} matches the answer is final, since every remaining match starts
+   * before the window and cannot be one of the last {@code count}. A boundary can still cost a
+   * pass its earliest match, which only matters when the pass found fewer than {@code count};
+   * the window then widens and a pass starting further back enumerates it.
    *
-   * Only the last {@code count} positions of a window are retained, in a ring buffer that grows
-   * on demand so that a {@code count} far larger than the number of matches does not allocate up
-   * front. Retaining them is what forward enumeration costs that {@code previous()} did not:
-   * the buffer holds one int per match up to {@code count}, so a caller that asks for a large
-   * occurrence of a pattern that really does occur that many times allocates in proportion to
-   * it -- bounded by the match count, and hence by the length of the target, but no longer
-   * constant. A hard cap would mean a second pass (count the matches, then re-scan to the
-   * one wanted), trading the allocation for another walk of the target.
+   * Only the last {@code count} positions are retained, in a ring buffer that grows on demand so
+   * that a {@code count} far larger than the number of matches does not allocate up front.
    */
   private static int findIndexFromEnd(final StringSearch stringSearch, final String text,
       final int count, final int maxStartIndex, final boolean matchEnd) {
-    // The buffer sizing and ring arithmetic below both need a positive count, so reject any
-    // other value here rather than relying on an assertion, which is disabled outside of test
-    // JVMs.
+    // The buffer sizing and ring arithmetic below need a positive count, and assertions are
+    // disabled outside test JVMs, so reject other values here.
     if (count <= 0) return MATCH_NOT_FOUND;
     // Match starts are distinct text offsets, so there can be at most text.length() matches.
     if (count > text.length()) return MATCH_NOT_FOUND;
     int[] lastMatches = new int[Math.min(count, INITIAL_MATCH_RING_CAPACITY)];
     int window = INITIAL_BACKWARD_SEARCH_WINDOW;
+    // Distance walked past `maxStartIndex`, summed over passes. Every pass re-walks the stretch
+    // from the anchor to the first match beyond it; this bounds how far that repetition can go.
+    long walkedPastAnchor = 0;
     while (true) {
       int windowStart = Math.max(0, maxStartIndex - window);
       // Never start the search inside a surrogate pair; widening the window is always safe.
@@ -1078,15 +1074,16 @@ public class CollationAwareUTF8String {
       stringSearch.setIndex(windowStart);
       int found = 0;
       int index = -1;
-      // Whether the pass ran off the end of the target instead of stopping past `maxStartIndex`.
-      boolean reachedEnd = false;
+      // Where the pass stopped: the first match past `maxStartIndex`, or the end of the target
+      // when the iterator reported none.
+      int scanEnd = text.length();
       while (true) {
         int nextIndex = stringSearch.next();
-        if (nextIndex == StringSearch.DONE) {
-          reachedEnd = true;
+        if (nextIndex == StringSearch.DONE) break;
+        if (nextIndex > maxStartIndex) {
+          scanEnd = nextIndex;
           break;
         }
-        if (nextIndex > maxStartIndex) break;
         if (nextIndex == index) {
           advancePastStuckMatch(stringSearch, text, nextIndex);
           continue;
@@ -1107,13 +1104,11 @@ public class CollationAwareUTF8String {
       if (found >= count) return lastMatches[found % lastMatches.length];
       // The window already reached the start of the target, so there really are fewer matches.
       if (windowStart == 0) return MATCH_NOT_FOUND;
-      if (reachedEnd && text.length() - maxStartIndex > window) {
-        // The pass ran off the end of the target, so on top of its own window it walked the
-        // whole stretch past `maxStartIndex`, and that stretch is the longer of the two. Every
-        // geometric step would walk it again, which costs O(n log n) over a target whose tail
-        // holds no match; widening straight to the start bounds the total at two passes over
-        // the target. The comparison is against the window that just ran, so this fires on the
-        // first pass that sees such a stretch and there is never a second re-walk.
+      walkedPastAnchor += scanEnd - maxStartIndex;
+      if (walkedPastAnchor >= text.length()) {
+        // Re-walking the stretch past the anchor has now cost a full pass over the target on its
+        // own, so growing geometrically would keep paying for it. Widening straight to the start
+        // caps the total at a constant number of passes.
         window = text.length();
       } else {
         // Capping at the target length keeps the growth from overflowing and guarantees that the
@@ -1133,8 +1128,9 @@ public class CollationAwareUTF8String {
     StringSearch stringSearch = CollationFactory.getStringSearch(str, delim, collationId);
     stringSearch.setOverlapping(true);
     if (count > 0) {
-      // If the count is positive, we search for the count-th delimiter from the left.
-      int searchIndex = findIndex(stringSearch, str, count);
+      // If the count is positive, we search for the count-th delimiter from the left. The search
+      // starts at the beginning of the string, so every match is in range.
+      int searchIndex = findIndex(stringSearch, str, count, 0);
       if (searchIndex == MATCH_NOT_FOUND) {
         return string;
       } else if (searchIndex == 0) {

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -59,10 +59,15 @@ public class CollationAwareUTF8String {
 
   /**
    * The initial size, in UTF-16 code units, of the trailing window searched by
-   * `findIndexFromEnd`, and the factor by which that window grows when it does not hold enough
-   * matches. A target no longer than the initial window is searched in a single pass.
+   * `findIndexFromEnd`. A target no longer than this is searched in a single pass.
    */
   private static final int INITIAL_BACKWARD_SEARCH_WINDOW = 64;
+
+  /**
+   * The factor by which the trailing window searched by `findIndexFromEnd` grows when it does
+   * not hold enough matches. Each pass re-walks the window before it, so the total stays within
+   * a constant factor of the last window.
+   */
   private static final int BACKWARD_SEARCH_WINDOW_GROWTH = 4;
 
   /**
@@ -1019,7 +1024,7 @@ public class CollationAwareUTF8String {
    * The matches are enumerated forward with next() because StringSearch.previous() does not
    * visit the same match set as next(): it skips overlapping matches, and it skips or misaligns
    * matches when a character maps to multiple collation elements (see the note in
-   * collationTrimRight).
+   * {@link #trimRight}).
    *
    * Enumerating from the start of the target would cost the length of the target on every call,
    * even when the requested match is the last one. Instead the search runs over a trailing
@@ -1030,15 +1035,22 @@ public class CollationAwareUTF8String {
    * its own window it walks the whole stretch beyond the anchor. When that stretch is longer
    * than the window it is what the pass cost, and every geometric step would walk it again, so
    * such a pass widens straight to the start of the target instead. That fires on the first
-   * pass that sees it, which caps the total at two passes over the target. When the anchor sits
-   * at or near the end of the target -- always for {@code subStringIndex}, and for
-   * {@code indexOf} with a small negative start -- the stretch beyond it is empty and the
-   * growth stays geometric. Once a window holds that many the answer is final:
-   * every remaining match starts before the window, so it precedes all of the window's matches
-   * and cannot be one of the last {@code count}. Only the search's start index moves; the target
-   * and its collation context stay the whole string, so unlike searching a substring a window
-   * boundary can never split a contraction or a combining sequence and report a match that does
-   * not exist in the target.
+   * pass whose trailing stretch dominates, which caps the total at two passes over the target.
+   * When the anchor sits at or near the end of the target -- always for {@code subStringIndex},
+   * and for {@code indexOf} with a small negative start -- the stretch beyond it is empty and
+   * the growth stays geometric.
+   *
+   * Once a window holds {@code count} matches the answer is final: every remaining match starts
+   * before the window, so it precedes all of the window's matches and cannot be one of the last
+   * {@code count}. Only the search's start index moves; the target stays the whole string, so a
+   * window can never manufacture a match the target does not contain, the way searching a
+   * detached substring could. A boundary can still cost a pass a match near its start -- the
+   * one that straddles it, and, because ICU adjusts a start index falling inside a contraction,
+   * possibly the one beginning at it. That loss is confined to the earliest match of the pass,
+   * and the answer is counted from the end, so it can only matter when the window holds fewer
+   * than {@code count} matches; the window then widens and a pass starting further back
+   * enumerates it. A start index inside a surrogate pair is not a character boundary at all, so
+   * it is backed off below rather than relied on.
    *
    * Only the last {@code count} positions of a window are retained, in a ring buffer that grows
    * on demand so that a {@code count} far larger than the number of matches does not allocate up
@@ -1086,7 +1098,7 @@ public class CollationAwareUTF8String {
         index = nextIndex;
       }
       // The buffer has grown to `count` entries by the time `found` reaches it, so the oldest
-      // entry still in the ring buffer is the {@code count}-th match from the end.
+      // entry still in the ring buffer is the `count`-th match from the end.
       if (found >= count) return lastMatches[found % lastMatches.length];
       // The window already reached the start of the target, so there really are fewer matches.
       if (windowStart == 0) return MATCH_NOT_FOUND;

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1023,9 +1023,12 @@ public class CollationAwareUTF8String {
    *
    * Enumerating from the start of the target would cost the length of the target on every call,
    * even when the requested match is the last one. Instead the search runs over a trailing
-   * window that starts at {@code INITIAL_BACKWARD_SEARCH_WINDOW} code units and grows until it
-   * holds {@code count} matches or reaches the start of the target, so the cost tracks the
-   * distance back to the requested match. Once a window holds that many the answer is final:
+   * window that starts at {@code INITIAL_BACKWARD_SEARCH_WINDOW} code units and grows by
+   * {@code BACKWARD_SEARCH_WINDOW_GROWTH} until it holds {@code count} matches or reaches the
+   * start of the target, so the cost tracks the distance back to the requested match. A pass
+   * that runs off the end of the target instead widens straight to the start of the target: it
+   * has already enumerated every match from its own start onward, and growing geometrically
+   * would re-walk that stretch once per step. Once a window holds that many the answer is final:
    * every remaining match starts before the window, so it precedes all of the window's matches
    * and cannot be one of the last {@code count}. Only the search's start index moves; the target
    * and its collation context stay the whole string, so unlike searching a substring a window
@@ -1040,7 +1043,7 @@ public class CollationAwareUTF8String {
       final int count, final int maxStartIndex, final boolean matchEnd) {
     // The buffer sizing and ring arithmetic below both need a positive count, so reject any
     // other value here rather than relying on an assertion, which is disabled outside of test
-    // JVMs. This also covers a caller that negated Integer.MIN_VALUE and got it back unchanged.
+    // JVMs.
     if (count <= 0) return MATCH_NOT_FOUND;
     // Match starts are distinct text offsets, so there can be at most text.length() matches.
     if (count > text.length()) return MATCH_NOT_FOUND;
@@ -1053,9 +1056,15 @@ public class CollationAwareUTF8String {
       stringSearch.setIndex(windowStart);
       int found = 0;
       int index = -1;
-      int nextIndex;
-      while ((nextIndex = stringSearch.next()) != StringSearch.DONE
-          && nextIndex <= maxStartIndex) {
+      // Whether the pass ran off the end of the target instead of stopping past `maxStartIndex`.
+      boolean reachedEnd = false;
+      while (true) {
+        int nextIndex = stringSearch.next();
+        if (nextIndex == StringSearch.DONE) {
+          reachedEnd = true;
+          break;
+        }
+        if (nextIndex > maxStartIndex) break;
         if (nextIndex == index) {
           advancePastStuckMatch(stringSearch, text, nextIndex);
           continue;
@@ -1076,9 +1085,18 @@ public class CollationAwareUTF8String {
       if (found >= count) return lastMatches[found % lastMatches.length];
       // The window already reached the start of the target, so there really are fewer matches.
       if (windowStart == 0) return MATCH_NOT_FOUND;
-      // Capping at the target length keeps the growth from overflowing and guarantees that the
-      // next window starts at 0, so the loop always terminates.
-      window = (int) Math.min((long) window * BACKWARD_SEARCH_WINDOW_GROWTH, text.length());
+      if (reachedEnd) {
+        // The pass enumerated every match from `windowStart` to the end of the target, so the
+        // stretch it just walked holds nothing a wider window could add. Growing geometrically
+        // would walk that same stretch again on every step, which costs O(n log n) over a target
+        // whose tail holds no match; widening straight to the start bounds the total at two
+        // passes over the target.
+        window = text.length();
+      } else {
+        // Capping at the target length keeps the growth from overflowing and guarantees that the
+        // next window starts at 0, so the loop always terminates.
+        window = (int) Math.min((long) window * BACKWARD_SEARCH_WINDOW_GROWTH, text.length());
+      }
     }
   }
 

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1026,9 +1026,14 @@ public class CollationAwareUTF8String {
    * window that starts at {@code INITIAL_BACKWARD_SEARCH_WINDOW} code units and grows by
    * {@code BACKWARD_SEARCH_WINDOW_GROWTH} until it holds {@code count} matches or reaches the
    * start of the target, so the cost tracks the distance back to the requested match. A pass
-   * that runs off the end of the target instead widens straight to the start of the target: it
-   * has already enumerated every match from its own start onward, and growing geometrically
-   * would re-walk that stretch once per step. Once a window holds that many the answer is final:
+   * that finds no match past {@code maxStartIndex} runs on to the end of the target, so besides
+   * its own window it walks the whole stretch beyond the anchor. When that stretch is longer
+   * than the window it is what the pass cost, and every geometric step would walk it again, so
+   * such a pass widens straight to the start of the target instead. That fires on the first
+   * pass that sees it, which caps the total at two passes over the target. When the anchor sits
+   * at or near the end of the target -- always for {@code subStringIndex}, and for
+   * {@code indexOf} with a small negative start -- the stretch beyond it is empty and the
+   * growth stays geometric. Once a window holds that many the answer is final:
    * every remaining match starts before the window, so it precedes all of the window's matches
    * and cannot be one of the last {@code count}. Only the search's start index moves; the target
    * and its collation context stay the whole string, so unlike searching a substring a window
@@ -1085,12 +1090,13 @@ public class CollationAwareUTF8String {
       if (found >= count) return lastMatches[found % lastMatches.length];
       // The window already reached the start of the target, so there really are fewer matches.
       if (windowStart == 0) return MATCH_NOT_FOUND;
-      if (reachedEnd) {
-        // The pass enumerated every match from `windowStart` to the end of the target, so the
-        // stretch it just walked holds nothing a wider window could add. Growing geometrically
-        // would walk that same stretch again on every step, which costs O(n log n) over a target
-        // whose tail holds no match; widening straight to the start bounds the total at two
-        // passes over the target.
+      if (reachedEnd && text.length() - maxStartIndex > window) {
+        // The pass ran off the end of the target, so on top of its own window it walked the
+        // whole stretch past `maxStartIndex`, and that stretch is the longer of the two. Every
+        // geometric step would walk it again, which costs O(n log n) over a target whose tail
+        // holds no match; widening straight to the start bounds the total at two passes over
+        // the target. The comparison is against the window that just ran, so this fires on the
+        // first pass that sees such a stretch and there is never a second re-walk.
         window = text.length();
       } else {
         // Capping at the target length keeps the growth from overflowing and guarantees that the

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -32,6 +32,7 @@ import static org.apache.spark.unsafe.types.UTF8String.CodePointIteratorType;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -48,6 +49,13 @@ public class CollationAwareUTF8String {
    * string in a target string.
    */
   private static final int MATCH_NOT_FOUND = -1;
+
+  /**
+   * The initial capacity of the ring buffer used by `findIndexFromEnd` to retain the last
+   * `count` match positions. The buffer grows on demand, so a caller-supplied `count` that is
+   * far larger than the number of matches does not allocate up front.
+   */
+  private static final int INITIAL_MATCH_RING_CAPACITY = 16;
 
   /**
    * `COMBINED_ASCII_SMALL_I_COMBINING_DOT` is an internal representation of the combined
@@ -933,44 +941,48 @@ public class CollationAwareUTF8String {
 
     String targetStr = target.toValidString();
     String patternStr = pattern.toValidString();
-
-    // Adjust the starting position from 1-based to 0-based.
-    int realStart;
-    if (start > 0) {
-      realStart = start - 1;
-      if (targetStr.codePointCount(0, targetStr.length()) <= realStart) return MATCH_NOT_FOUND;
-    } else {
-      realStart = targetStr.codePointCount(0, targetStr.length()) + start + 1;
-      if (realStart < 0) return MATCH_NOT_FOUND;
-    }
+    int numCodePoints = targetStr.codePointCount(0, targetStr.length());
 
     StringSearch stringSearch =
             CollationFactory.getStringSearch(targetStr, patternStr, collationId);
     // Set Overlapping to true to support finding locations
     // similar to the second occurrence of 'aa' in 'aaa'.
     stringSearch.setOverlapping(true);
-    int startIndex = targetStr.offsetByCodePoints(0, realStart);
-    stringSearch.setIndex(startIndex);
 
-    // Search for target index.
     int searchIndex;
-    if (start > 0) searchIndex = findIndex(stringSearch, occurrence);
-    else searchIndex = findStartIndexReverse(stringSearch, occurrence);
+    if (start > 0) {
+      // Adjust the starting position from 1-based to 0-based.
+      int realStart = start - 1;
+      if (numCodePoints <= realStart) return MATCH_NOT_FOUND;
+      stringSearch.setIndex(targetStr.offsetByCodePoints(0, realStart));
+      searchIndex = findIndex(stringSearch, targetStr, occurrence);
+    } else {
+      // The last code point index at which a match is allowed to start. A start before the
+      // beginning of the string matches nothing, as in UTF8String.indexOf.
+      int anchor = numCodePoints + start;
+      if (anchor < 0) return MATCH_NOT_FOUND;
+      searchIndex = findIndexFromEnd(stringSearch, targetStr, occurrence,
+        targetStr.offsetByCodePoints(0, anchor), false);
+    }
 
     if (searchIndex == MATCH_NOT_FOUND) return MATCH_NOT_FOUND;
     // Convert the search index from character count to code point count.
     return targetStr.codePointCount(0, searchIndex);
   }
 
-  private static int findIndex(final StringSearch stringSearch, int count) {
+  private static int findIndex(final StringSearch stringSearch, final String text, int count) {
     assert(count >= 0);
-    int index = 0;
+    // -1 is a safe "no match seen yet" sentinel: StringSearch.DONE (also -1) is handled first,
+    // so next() can never store -1 in `index`. Using 0 here would fail to detect the iterator
+    // reporting the same match at index 0 again (e.g. an overlapping search on a pattern that
+    // starts with a surrogate pair), double-counting that match.
+    int index = -1;
     while (count > 0) {
       int nextIndex = stringSearch.next();
       if (nextIndex == StringSearch.DONE) {
         return MATCH_NOT_FOUND;
-      } else if (nextIndex == index && index != 0) {
-        stringSearch.setIndex(stringSearch.getIndex() + stringSearch.getMatchLength());
+      } else if (nextIndex == index) {
+        advancePastStuckMatch(stringSearch, text, nextIndex);
       } else {
         count--;
         index = nextIndex;
@@ -979,30 +991,60 @@ public class CollationAwareUTF8String {
     return index;
   }
 
-  private static int findIndexReverse(final StringSearch stringSearch, int count) {
-    assert(count >= 0);
-    int index = 0;
-    while (count > 0) {
-      index = stringSearch.previous();
-      if (index == StringSearch.DONE) {
-        return MATCH_NOT_FOUND;
-      }
-      count--;
-    }
-    return index + stringSearch.getMatchLength();
+  /**
+   * The overlapping search advances by one UTF-16 code unit past the last match start, which
+   * falls inside a surrogate pair when the match starts with a supplementary character, making
+   * next() report the same match again. Advance by one code point past the stuck match start so
+   * the search resumes at the next candidate without skipping an overlapping match.
+   */
+  private static void advancePastStuckMatch(final StringSearch stringSearch, final String text,
+      final int matchStart) {
+    stringSearch.setIndex(matchStart + Character.charCount(text.codePointAt(matchStart)));
   }
 
-  private static int findStartIndexReverse(final StringSearch stringSearch, int count) {
-    assert(count >= 0);
-    int index = 0;
-    while (count > 0) {
-      index = stringSearch.previous();
-      if (index == StringSearch.DONE) {
-        return MATCH_NOT_FOUND;
+  /**
+   * Returns the {@code count}-th match of {@code stringSearch} counting backward from the end,
+   * among the matches that start at or before {@code maxStartIndex}, or {@code MATCH_NOT_FOUND}
+   * if there are fewer such matches. The index returned (in UTF-16 code units) is the end of
+   * that match when {@code matchEnd} is true, and its start otherwise.
+   *
+   * The matches are enumerated forward with next() because StringSearch.previous() does not
+   * visit the same match set as next(): it skips overlapping matches, and it skips or misaligns
+   * matches when a character maps to multiple collation elements (see the note in
+   * collationTrimRight). Only the last {@code count} positions are retained, in a ring buffer
+   * that grows on demand so that a {@code count} far larger than the number of matches does not
+   * allocate up front.
+   */
+  private static int findIndexFromEnd(final StringSearch stringSearch, final String text,
+      final int count, final int maxStartIndex, final boolean matchEnd) {
+    // The buffer sizing and ring arithmetic below both need a positive count, so reject any
+    // other value here rather than relying on an assertion, which is disabled outside of test
+    // JVMs. This also covers a caller that negated Integer.MIN_VALUE and got it back unchanged.
+    if (count <= 0) return MATCH_NOT_FOUND;
+    // Match starts are distinct text offsets, so there can be at most text.length() matches.
+    if (count > text.length()) return MATCH_NOT_FOUND;
+    int[] lastMatches = new int[Math.min(count, INITIAL_MATCH_RING_CAPACITY)];
+    int found = 0;
+    int index = -1;
+    int nextIndex;
+    while ((nextIndex = stringSearch.next()) != StringSearch.DONE && nextIndex <= maxStartIndex) {
+      if (nextIndex == index) {
+        advancePastStuckMatch(stringSearch, text, nextIndex);
+        continue;
       }
-      count--;
+      // While the buffer is shorter than `count` no entry has been evicted yet, so `found` is
+      // below its length and indexes it directly; grow before the first write that would wrap.
+      if (found == lastMatches.length && lastMatches.length < count) {
+        lastMatches = Arrays.copyOf(lastMatches, (int) Math.min(count, 2L * lastMatches.length));
+      }
+      lastMatches[found % lastMatches.length] =
+        matchEnd ? nextIndex + stringSearch.getMatchLength() : nextIndex;
+      found++;
+      index = nextIndex;
     }
-    return index;
+    if (found < count) return MATCH_NOT_FOUND;
+    // The count-th match from the end is the oldest entry still in the ring buffer.
+    return lastMatches[found % count];
   }
 
   public static UTF8String subStringIndex(final UTF8String string, final UTF8String delimiter,
@@ -1016,7 +1058,7 @@ public class CollationAwareUTF8String {
     stringSearch.setOverlapping(true);
     if (count > 0) {
       // If the count is positive, we search for the count-th delimiter from the left.
-      int searchIndex = findIndex(stringSearch, count);
+      int searchIndex = findIndex(stringSearch, str, count);
       if (searchIndex == MATCH_NOT_FOUND) {
         return string;
       } else if (searchIndex == 0) {
@@ -1025,8 +1067,9 @@ public class CollationAwareUTF8String {
         return UTF8String.fromString(str.substring(0, searchIndex));
       }
     } else {
-      // If the count is negative, we search for the count-th delimiter from the right.
-      int searchIndex = findIndexReverse(stringSearch, -count);
+      // If the count is negative, we search for the count-th delimiter from the right. Any
+      // match start qualifies, so the search is not anchored.
+      int searchIndex = findIndexFromEnd(stringSearch, str, -count, str.length(), true);
       if (searchIndex == MATCH_NOT_FOUND) {
           return string;
       } else if (searchIndex == str.length()) {

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -2801,6 +2801,25 @@ public class CollationSupportSuite {
     // delimiter is the uppercase base plus the same combining mark.
     assertSubstringIndex("e\u0301".repeat(100) + "x", "E\u0301", -32, UNICODE_CI,
       "e\u0301".repeat(31) + "x");
+    // Collations whose delimiter is a contraction, i.e. a single collation unit spanning more
+    // than one code point. A start index inside such a unit is snapped back to its beginning, so
+    // the iterator only makes progress if it is advanced past the whole unit. Czech "ch" occurs
+    // at the same positions under UTF8_BINARY, which pins the expectations independently.
+    assertSubstringIndex("chch", "ch", 2, UTF8_BINARY, "ch");
+    assertSubstringIndex("chch", "ch", 2, "cs", "ch");
+    assertSubstringIndex("chch", "ch", -1, UTF8_BINARY, "");
+    assertSubstringIndex("chch", "ch", -1, "cs", "");
+    assertSubstringIndex("achbchcch", "ch", -2, UTF8_BINARY, "cch");
+    assertSubstringIndex("achbchcch", "ch", -2, "cs", "cch");
+    // Same, over a target long enough that the trailing window starts partway into it rather
+    // than at its beginning, so the contraction is crossed by a pass that did not walk the
+    // target from index 0.
+    assertSubstringIndex("ch".repeat(60), "ch", -3, UTF8_BINARY, "chch");
+    assertSubstringIndex("ch".repeat(60), "ch", -3, "cs", "chch");
+    // Danish "aa" is a contraction whose occurrences differ from the byte-wise ones: "aaaa"
+    // holds a delimiter at code points 0 and 2, but not at 1, which is inside the first one.
+    assertSubstringIndex("aaaa", "aa", 2, "da", "aa");
+    assertSubstringIndex("aaaa", "aa", -1, "da", "");
   }
 
   /**
@@ -4494,6 +4513,52 @@ public class CollationSupportSuite {
       "x".repeat(1000) + ("z" + "x".repeat(99)).repeat(5) + "y".repeat(500) + "z";
     assertStringInstrWithOccurrence(twoStepsWrap, "z", -2, 3, UTF8_BINARY, 1201);
     assertStringInstrWithOccurrence(twoStepsWrap, "z", -2, 3, UNICODE, 1201);
+    // Collations whose pattern is a contraction, i.e. a single collation unit spanning more than
+    // one code point. A start index inside such a unit is snapped back to its beginning, so the
+    // iterator only makes progress if it is advanced past the whole unit. Czech "ch" occurs at
+    // the same positions under UTF8_BINARY, which pins the expectations independently.
+    assertStringInstrWithOccurrence("chch", "ch", 1, 2, UTF8_BINARY, 3);
+    assertStringInstrWithOccurrence("chch", "ch", 1, 2, "cs", 3);
+    assertStringInstrWithOccurrence("chch", "ch", -1, 1, UTF8_BINARY, 3);
+    assertStringInstrWithOccurrence("chch", "ch", -1, 1, "cs", 3);
+    assertStringInstrWithOccurrence("achbchcch", "ch", -1, 2, UTF8_BINARY, 5);
+    assertStringInstrWithOccurrence("achbchcch", "ch", -1, 2, "cs", 5);
+    // Same, over a target long enough that the trailing window starts partway into it. The first
+    // window starts at code unit 55, which is inside the contraction beginning at 54, so ICU
+    // snaps it back to 54 and the pass enumerates 33 matches. Occurrences 32 and 33 are answered
+    // by that pass -- 33 is the match at the snapped-back boundary, the earliest one the pass can
+    // see -- and occurrence 40 is answered only after the window widens to the start of the
+    // target.
+    assertStringInstrWithOccurrence("ch".repeat(60), "ch", -1, 32, UTF8_BINARY, 57);
+    assertStringInstrWithOccurrence("ch".repeat(60), "ch", -1, 32, "cs", 57);
+    assertStringInstrWithOccurrence("ch".repeat(60), "ch", -1, 33, UTF8_BINARY, 55);
+    assertStringInstrWithOccurrence("ch".repeat(60), "ch", -1, 33, "cs", 55);
+    assertStringInstrWithOccurrence("ch".repeat(60), "ch", -1, 40, UTF8_BINARY, 41);
+    assertStringInstrWithOccurrence("ch".repeat(60), "ch", -1, 40, "cs", 41);
+    // A positive start that falls inside a contraction. ICU snaps the search index back to the
+    // beginning of the unit, so the first match it reports begins before the requested start;
+    // such a match is out of range and must not be counted. UTF8_BINARY pins the expectations.
+    assertStringInstrWithOccurrence("achch", "ch", 3, 1, UTF8_BINARY, 4);
+    assertStringInstrWithOccurrence("achch", "ch", 3, 1, "cs", 4);
+    assertStringInstrWithOccurrence("achch", "ch", 3, 2, UTF8_BINARY, 0);
+    assertStringInstrWithOccurrence("achch", "ch", 3, 2, "cs", 0);
+    assertStringInstrWithOccurrence("chchch", "ch", 2, 1, UTF8_BINARY, 3);
+    assertStringInstrWithOccurrence("chchch", "ch", 2, 1, "cs", 3);
+    assertStringInstrWithOccurrence("chchch", "ch", 2, 2, UTF8_BINARY, 5);
+    assertStringInstrWithOccurrence("chchch", "ch", 2, 2, "cs", 5);
+    assertStringInstrWithOccurrence("chchch", "ch", 4, 1, UTF8_BINARY, 5);
+    assertStringInstrWithOccurrence("chchch", "ch", 4, 1, "cs", 5);
+    assertStringInstrWithOccurrence("chchch", "ch", 6, 1, UTF8_BINARY, 0);
+    assertStringInstrWithOccurrence("chchch", "ch", 6, 1, "cs", 0);
+    // Danish "aa" is a contraction whose occurrences differ from the byte-wise ones: "aaaa"
+    // holds a match at code points 0 and 2, but not at 1, which is inside the first one.
+    assertStringInstrWithOccurrence("aaaa", "aa", 1, 2, "da", 3);
+    assertStringInstrWithOccurrence("aaaa", "aa", -1, 1, "da", 3);
+    // Same, with a positive start inside the first contraction. UTF8_BINARY cannot pin this one:
+    // "xaaaa" holds a match at code points 1 and 3 under "da", but at 1, 2 and 3 byte-wise. A
+    // start of 3 excludes the match at 1 under either.
+    assertStringInstrWithOccurrence("xaaaa", "aa", 3, 1, "da", 4);
+    assertStringInstrWithOccurrence("xaaaa", "aa", 3, 2, "da", 0);
   }
 
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -2737,6 +2737,25 @@ public class CollationSupportSuite {
     assertSubstringIndex("a🙃b🙃c", "d", -1, UTF8_LCASE, "a🙃b🙃c");
     assertSubstringIndex("a🙃b🙃c", "d", -1, UNICODE, "a🙃b🙃c");
     assertSubstringIndex("a🙃b🙃c", "d", -1, UNICODE_CI, "a🙃b🙃c");
+    // SPARK-58441: negative count with adjacent delimiter occurrences over characters that map
+    // to multiple collation elements: the ICU path previously used StringSearch.previous(),
+    // which skips such occurrences and returned the wrong suffix.
+    assertSubstringIndex("ééa", "é", -2, UNICODE, "éa");
+    assertSubstringIndex("ééa", "é", -2, UNICODE_CI, "éa");
+    assertSubstringIndex("aéééba", "é", -2, UNICODE, "éba");
+    assertSubstringIndex("aéééba", "é", -3, UNICODE, "ééba");
+    assertSubstringIndex("aéééba", "éé", -2, UNICODE, "éba");
+    assertSubstringIndex("ébééb", "é", -2, UNICODE, "éb");
+    assertSubstringIndex("ébééb", "é", -2, UNICODE_CI, "éb");
+    // Positive count with the first delimiter occurrence at position 0 and a delimiter
+    // starting with a surrogate pair: the stuck-iterator workaround previously used 0 as the
+    // "no match yet" sentinel and double-counted the first occurrence.
+    assertSubstringIndex("😀a😀b", "😀", 2, UNICODE, "😀a");
+    assertSubstringIndex("😀a😀b", "😀", 2, UNICODE_CI, "😀a");
+    assertSubstringIndex("😀😀😀", "😀😀", 2, UNICODE, "😀");
+    // A count larger than the string length cannot be satisfied by any input, and is rejected
+    // before the ICU path sizes a buffer after it.
+    assertSubstringIndex("a.b.c", ".", -1000000, UNICODE, "a.b.c");
   }
 
   /**
@@ -4340,6 +4359,31 @@ public class CollationSupportSuite {
     assertStringInstrWithOccurrence("aaaa", "aa", -2, 1, UNICODE, 3);
     assertStringInstrWithOccurrence("aaaa", "aa", -1, 3, UNICODE, 1);
     assertStringInstrWithOccurrence("aaaa", "aa", -2, 3, UNICODE, 1);
+    // SPARK-58441: backward search over characters that map to multiple collation elements: the
+    // ICU path previously used StringSearch.previous(), which skips or misaligns such matches.
+    assertStringInstrWithOccurrence("bbébébé", "bé", -3, 1, UNICODE, 4);
+    assertStringInstrWithOccurrence("bbébébé", "bé", -3, 2, UNICODE, 2);
+    assertStringInstrWithOccurrence("bbébébé", "bé", -3, 1, UNICODE_CI, 4);
+    assertStringInstrWithOccurrence("babaéa", "aé", -3, 1, UNICODE, 4);
+    assertStringInstrWithOccurrence("ééé", "é", -1, 2, UNICODE, 2);
+    assertStringInstrWithOccurrence("ééé", "é", -1, 3, UNICODE, 1);
+    assertStringInstrWithOccurrence("ééé", "é", -1, 2, UNICODE_CI, 2);
+    // A backward start one position before the beginning of the string matches nothing. The ICU
+    // path used to accept such a start and report a match, unlike every other collation, so the
+    // UTF8_BINARY expectation below is the reference the ICU ones are now aligned with.
+    assertStringInstrWithOccurrence("é", "é", -2, 1, UTF8_BINARY, 0);
+    assertStringInstrWithOccurrence("é", "é", -2, 1, UNICODE, 0);
+    assertStringInstrWithOccurrence("é", "é", -2, 1, UNICODE_CI, 0);
+    // A match at position 0 of a pattern starting with a surrogate pair: the stuck-iterator
+    // workaround previously used 0 as the "no match yet" sentinel and double-counted it.
+    assertStringInstrWithOccurrence("😀a😀b", "😀", 1, 2, UNICODE, 3);
+    assertStringInstrWithOccurrence("😀a😀b", "😀", 1, 2, UNICODE_CI, 3);
+    assertStringInstrWithOccurrence("😀abc", "😀", 1, 2, UNICODE, 0);
+    // Overlapping matches of a pattern starting with a surrogate pair.
+    assertStringInstrWithOccurrence("😀😀😀", "😀😀", 1, 2, UNICODE, 2);
+    // An occurrence larger than the string length cannot be satisfied by any input, and is
+    // rejected before the ICU path sizes a buffer after it.
+    assertStringInstrWithOccurrence("abc", "b", -1, 2000000000, UNICODE, 0);
   }
 
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -2742,20 +2742,47 @@ public class CollationSupportSuite {
     // which skips such occurrences and returned the wrong suffix.
     assertSubstringIndex("ééa", "é", -2, UNICODE, "éa");
     assertSubstringIndex("ééa", "é", -2, UNICODE_CI, "éa");
-    assertSubstringIndex("aéééba", "é", -2, UNICODE, "éba");
-    assertSubstringIndex("aéééba", "é", -3, UNICODE, "ééba");
+    // Same, with a delimiter spanning more than one such character, so that the suffix depends
+    // on the matched length and not just on the match position.
     assertSubstringIndex("aéééba", "éé", -2, UNICODE, "éba");
-    assertSubstringIndex("ébééb", "é", -2, UNICODE, "éb");
-    assertSubstringIndex("ébééb", "é", -2, UNICODE_CI, "éb");
     // Positive count with the first delimiter occurrence at position 0 and a delimiter
     // starting with a surrogate pair: the stuck-iterator workaround previously used 0 as the
     // "no match yet" sentinel and double-counted the first occurrence.
     assertSubstringIndex("😀a😀b", "😀", 2, UNICODE, "😀a");
-    assertSubstringIndex("😀a😀b", "😀", 2, UNICODE_CI, "😀a");
     assertSubstringIndex("😀😀😀", "😀😀", 2, UNICODE, "😀");
-    // A count larger than the string length cannot be satisfied by any input, and is rejected
-    // before the ICU path sizes a buffer after it.
-    assertSubstringIndex("a.b.c", ".", -1000000, UNICODE, "a.b.c");
+    // Targets long enough to exercise the backward search's trailing window. The window starts
+    // at 64 UTF-16 code units and grows by 4x, and the ring buffer that retains the last `count`
+    // match positions starts at 16 entries, so every case above resolves in the first window
+    // with an unresized buffer. The three below do not.
+    // Only delimiter occurrence is 300 code units before the end: the first window holds no
+    // occurrence and reaches the end of the target, so it widens to the start in one step.
+    assertSubstringIndex("z" + "x".repeat(300), "z", -1, UNICODE, "x".repeat(300));
+    // The 20th occurrence from the end lies outside the first window, and 20 exceeds the ring
+    // buffer's initial capacity: the window grows once and the buffer is resized and wraps.
+    assertSubstringIndex(("a" + "x".repeat(9)).repeat(30), "a", -20, UNICODE,
+      "x".repeat(9) + ("a" + "x".repeat(9)).repeat(19));
+    // The first window already holds far more than 20 occurrences, so only the ring buffer is
+    // resized, and it wraps several times.
+    assertSubstringIndex("a".repeat(100), "a", -20, UNICODE, "a".repeat(19));
+    // The window starts at an arbitrary UTF-16 offset, which the all-ASCII targets above cannot
+    // tell apart from a code point boundary. Each pair below differs by one trailing code unit,
+    // so one member starts the window on a base character and the other in the middle of the
+    // following combining sequence ("e" + combining acute) or surrogate pair; both must give
+    // the same answer.
+    assertSubstringIndex("z" + "e\u0301".repeat(200), "z", -1, UNICODE,
+      "e\u0301".repeat(200));
+    assertSubstringIndex("z" + "e\u0301".repeat(200) + "x", "z", -1, UNICODE,
+      "e\u0301".repeat(200) + "x");
+    assertSubstringIndex("z" + "😀".repeat(200), "z", -1, UNICODE, "😀".repeat(200));
+    assertSubstringIndex("z" + "😀".repeat(200) + "x", "z", -1, UNICODE, "😀".repeat(200) + "x");
+    // The 32nd occurrence from the end is the one the window boundary falls inside, so the
+    // answer is only right if widening the window recovers an occurrence the previous window
+    // started in the middle of. UTF8_BINARY does not use the windowed search and pins the
+    // expectation independently.
+    assertSubstringIndex("e\u0301".repeat(100) + "x", "e\u0301", -32, UTF8_BINARY,
+      "e\u0301".repeat(31) + "x");
+    assertSubstringIndex("e\u0301".repeat(100) + "x", "e\u0301", -32, UNICODE,
+      "e\u0301".repeat(31) + "x");
   }
 
   /**
@@ -4363,27 +4390,52 @@ public class CollationSupportSuite {
     // ICU path previously used StringSearch.previous(), which skips or misaligns such matches.
     assertStringInstrWithOccurrence("bbébébé", "bé", -3, 1, UNICODE, 4);
     assertStringInstrWithOccurrence("bbébébé", "bé", -3, 2, UNICODE, 2);
-    assertStringInstrWithOccurrence("bbébébé", "bé", -3, 1, UNICODE_CI, 4);
+    // A match that starts exactly at the backward anchor still counts.
     assertStringInstrWithOccurrence("babaéa", "aé", -3, 1, UNICODE, 4);
-    assertStringInstrWithOccurrence("ééé", "é", -1, 2, UNICODE, 2);
-    assertStringInstrWithOccurrence("ééé", "é", -1, 3, UNICODE, 1);
     assertStringInstrWithOccurrence("ééé", "é", -1, 2, UNICODE_CI, 2);
     // A backward start one position before the beginning of the string matches nothing. The ICU
     // path used to accept such a start and report a match, unlike every other collation, so the
     // UTF8_BINARY expectation below is the reference the ICU ones are now aligned with.
     assertStringInstrWithOccurrence("é", "é", -2, 1, UTF8_BINARY, 0);
     assertStringInstrWithOccurrence("é", "é", -2, 1, UNICODE, 0);
-    assertStringInstrWithOccurrence("é", "é", -2, 1, UNICODE_CI, 0);
     // A match at position 0 of a pattern starting with a surrogate pair: the stuck-iterator
     // workaround previously used 0 as the "no match yet" sentinel and double-counted it.
     assertStringInstrWithOccurrence("😀a😀b", "😀", 1, 2, UNICODE, 3);
-    assertStringInstrWithOccurrence("😀a😀b", "😀", 1, 2, UNICODE_CI, 3);
     assertStringInstrWithOccurrence("😀abc", "😀", 1, 2, UNICODE, 0);
     // Overlapping matches of a pattern starting with a surrogate pair.
     assertStringInstrWithOccurrence("😀😀😀", "😀😀", 1, 2, UNICODE, 2);
-    // An occurrence larger than the string length cannot be satisfied by any input, and is
-    // rejected before the ICU path sizes a buffer after it.
-    assertStringInstrWithOccurrence("abc", "b", -1, 2000000000, UNICODE, 0);
+    // Targets long enough to exercise the backward search's trailing window. The window starts
+    // at 64 UTF-16 code units and grows by 4x, and the ring buffer that retains the last
+    // `occurrence` match positions starts at 16 entries, so every case above resolves in the
+    // first window with an unresized buffer. The three below do not.
+    // Only match is 300 code units before the end: the first window holds no match and reaches
+    // the end of the target, so it widens to the start in one step.
+    assertStringInstrWithOccurrence("z" + "x".repeat(300), "z", -1, 1, UNICODE, 1);
+    // The 20th match from the end lies outside the first window, and 20 exceeds the ring
+    // buffer's initial capacity: the window grows once and the buffer is resized and wraps.
+    assertStringInstrWithOccurrence(("a" + "x".repeat(9)).repeat(30), "a", -1, 20, UNICODE, 101);
+    // The first window already holds far more than 20 matches, so only the ring buffer is
+    // resized, and it wraps several times.
+    assertStringInstrWithOccurrence("a".repeat(100), "a", -1, 20, UNICODE, 81);
+    // The window starts at an arbitrary UTF-16 offset, which the all-ASCII targets above cannot
+    // tell apart from a code point boundary. Each pair below differs by one trailing code unit,
+    // so one member starts the window on a base character and the other in the middle of the
+    // following combining sequence ("e" + combining acute) or surrogate pair; both must give
+    // the same answer.
+    assertStringInstrWithOccurrence("z" + "e\u0301".repeat(200), "z", -1, 1, UNICODE, 1);
+    assertStringInstrWithOccurrence("z" + "e\u0301".repeat(200) + "x", "z", -1, 1, UNICODE, 1);
+    assertStringInstrWithOccurrence("z" + "😀".repeat(200) + "x", "z", -1, 1,
+      UNICODE, 1);
+    assertStringInstrWithOccurrence("z" + "😀".repeat(200) + "xx", "z", -1, 1,
+      UNICODE, 1);
+    // The 32nd match from the end is the one the window boundary falls inside, so the answer is
+    // only right if widening the window recovers a match the previous window started in the
+    // middle of. UTF8_BINARY does not use the windowed search and pins the expectation
+    // independently.
+    assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "e\u0301", -1, 32,
+      UTF8_BINARY, 137);
+    assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "e\u0301", -1, 32,
+      UNICODE, 137);
   }
 
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -2754,8 +2754,9 @@ public class CollationSupportSuite {
     // at 64 UTF-16 code units and grows by 4x, and the ring buffer that retains the last `count`
     // match positions starts at 16 entries, so every case above resolves in the first window
     // with an unresized buffer. The three below do not.
-    // Only delimiter occurrence is 300 code units before the end: the first window holds no
-    // occurrence and reaches the end of the target, so it widens to the start in one step.
+    // Only delimiter occurrence is 300 code units before the end: the anchor is the end of the
+    // target, so there is no stretch beyond it for a pass to re-walk and the growth stays
+    // geometric until the window reaches the start.
     assertSubstringIndex("z" + "x".repeat(300), "z", -1, UNICODE, "x".repeat(300));
     // The 20th occurrence from the end lies outside the first window, and 20 exceeds the ring
     // buffer's initial capacity: the window grows once and the buffer is resized and wraps.
@@ -4408,8 +4409,9 @@ public class CollationSupportSuite {
     // at 64 UTF-16 code units and grows by 4x, and the ring buffer that retains the last
     // `occurrence` match positions starts at 16 entries, so every case above resolves in the
     // first window with an unresized buffer. The three below do not.
-    // Only match is 300 code units before the end: the first window holds no match and reaches
-    // the end of the target, so it widens to the start in one step.
+    // Only match is 300 code units before the end: the anchor is one code point from the end,
+    // so the stretch past it is never longer than the window and the growth stays geometric
+    // until it reaches the start.
     assertStringInstrWithOccurrence("z" + "x".repeat(300), "z", -1, 1, UNICODE, 1);
     // The 20th match from the end lies outside the first window, and 20 exceeds the ring
     // buffer's initial capacity: the window grows once and the buffer is resized and wraps.
@@ -4436,6 +4438,21 @@ public class CollationSupportSuite {
       UTF8_BINARY, 137);
     assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "e\u0301", -1, 32,
       UNICODE, 137);
+    // A backward start away from the end of the target, with a match after the anchor. The pass
+    // stops at the anchor instead of running off the end, so the stretch past the anchor never
+    // dominates and the window grows geometrically. Both cases below need two growth steps
+    // (64 -> 256 -> 1024) and resolve inside a window that has not reached the start of the
+    // target. UTF8_BINARY does not use the windowed search and pins the expectation
+    // independently.
+    String twoSteps = "x".repeat(2000) + "z" + "x".repeat(700) + "z";
+    assertStringInstrWithOccurrence(twoSteps, "z", -2, 1, UTF8_BINARY, 2001);
+    assertStringInstrWithOccurrence(twoSteps, "z", -2, 1, UNICODE, 2001);
+    // Same, with an occurrence that makes the ring buffer wrap while the window is still
+    // growing: the third window holds five matches and retains only the last three.
+    String twoStepsWrap =
+      "x".repeat(1000) + ("z" + "x".repeat(99)).repeat(5) + "y".repeat(500) + "z";
+    assertStringInstrWithOccurrence(twoStepsWrap, "z", -2, 3, UTF8_BINARY, 1201);
+    assertStringInstrWithOccurrence(twoStepsWrap, "z", -2, 3, UNICODE, 1201);
   }
 
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -2792,10 +2792,12 @@ public class CollationSupportSuite {
     // The windowed cases above all run under UNICODE, where the delimiter matches literally.
     // Repeat them under the collations that make the match set itself collation-dependent,
     // which is the property this fix turns on: case folding under UNICODE_CI and accent folding
-    // under UNICODE_AI, over targets long enough to need a second window.
+    // under UNICODE_CI_AI, over targets long enough to need a second window. UNICODE_AI is not
+    // used here: substring_index declares StringTypeNonCSAICollation, which rejects a collation
+    // that is accent-insensitive but case-sensitive, so no such call can reach this code.
     assertSubstringIndex(("A" + "x".repeat(9)).repeat(30), "a", -20, UNICODE_CI,
       "x".repeat(9) + ("A" + "x".repeat(9)).repeat(19));
-    assertSubstringIndex(("\u00e1" + "x".repeat(9)).repeat(30), "a", -20, "UNICODE_AI",
+    assertSubstringIndex(("\u00e1" + "x".repeat(9)).repeat(30), "a", -20, "UNICODE_CI_AI",
       "x".repeat(9) + ("\u00e1" + "x".repeat(9)).repeat(19));
     // Case folding across a window boundary that falls inside a combining sequence: the
     // delimiter is the uppercase base plus the same combining mark.
@@ -4486,18 +4488,20 @@ public class CollationSupportSuite {
     // The windowed cases above all run under UNICODE, where the pattern matches literally.
     // Repeat them under the collations that make the match set itself collation-dependent,
     // which is the property this fix turns on: case folding under UNICODE_CI and accent folding
-    // under UNICODE_AI, over targets long enough to need a second window.
+    // under UNICODE_CI_AI, over targets long enough to need a second window. UNICODE_AI is not
+    // used here: instr declares StringTypeNonCSAICollation, which rejects a collation that is
+    // accent-insensitive but case-sensitive, so no such call can reach this code.
     assertStringInstrWithOccurrence(("A" + "x".repeat(9)).repeat(30), "a", -1, 20,
       UNICODE_CI, 101);
     assertStringInstrWithOccurrence(("\u00e1" + "x".repeat(9)).repeat(30), "a", -1, 20,
-      "UNICODE_AI", 101);
+      "UNICODE_CI_AI", 101);
     // A window boundary that falls inside a combining sequence, where the pattern matches only
     // because of the collation: the uppercase base plus the same mark under UNICODE_CI, and the
-    // bare base under UNICODE_AI, which matches the whole sequence.
+    // bare base under UNICODE_CI_AI, which matches the whole sequence.
     assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "E\u0301", -1, 32,
       UNICODE_CI, 137);
     assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "e", -1, 32,
-      "UNICODE_AI", 137);
+      "UNICODE_CI_AI", 137);
     // A backward start away from the end of the target, with a match after the anchor. The pass
     // stops at the anchor instead of running off the end, so the stretch past the anchor never
     // dominates and the window grows geometrically. Both cases below need two growth steps
@@ -4513,6 +4517,20 @@ public class CollationSupportSuite {
       "x".repeat(1000) + ("z" + "x".repeat(99)).repeat(5) + "y".repeat(500) + "z";
     assertStringInstrWithOccurrence(twoStepsWrap, "z", -2, 3, UTF8_BINARY, 1201);
     assertStringInstrWithOccurrence(twoStepsWrap, "z", -2, 3, UNICODE, 1201);
+    // A backward start whose anchor sits mid-target with no match past it, so every pass runs on
+    // to the end of the target and re-walks the same trailing stretch. Here that stretch is half
+    // the target, so by the second pass the repetition has cost a full pass on its own and the
+    // window widens straight to the start instead of taking another geometric step. Only instr
+    // reaches this: substring_index anchors at the end of the target, leaving no stretch to
+    // re-walk. UTF8_BINARY does not use the windowed search and pins the expectation.
+    String tailRewalk = "z" + "x".repeat(4095);
+    assertStringInstrWithOccurrence(tailRewalk, "z", -2048, 1, UTF8_BINARY, 1);
+    assertStringInstrWithOccurrence(tailRewalk, "z", -2048, 1, UNICODE, 1);
+    // Same shape with the match a little later, so the answer is not the first code point of the
+    // target and a window that widened too far would still have to place it correctly.
+    String tailRewalkLate = "x".repeat(40) + "z" + "x".repeat(4055);
+    assertStringInstrWithOccurrence(tailRewalkLate, "z", -2048, 1, UTF8_BINARY, 41);
+    assertStringInstrWithOccurrence(tailRewalkLate, "z", -2048, 1, UNICODE, 41);
     // Collations whose pattern is a contraction, i.e. a single collation unit spanning more than
     // one code point. A start index inside such a unit is snapped back to its beginning, so the
     // iterator only makes progress if it is advanced past the whole unit. Czech "ch" occurs at

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -2739,16 +2739,21 @@ public class CollationSupportSuite {
     assertSubstringIndex("a🙃b🙃c", "d", -1, UNICODE_CI, "a🙃b🙃c");
     // SPARK-58441: negative count with adjacent delimiter occurrences over characters that map
     // to multiple collation elements: the ICU path previously used StringSearch.previous(),
-    // which skips such occurrences and returned the wrong suffix.
+    // which skips such occurrences and returned the wrong suffix. UTF8_BINARY does not go
+    // through the ICU path, so it pins each expectation independently of the code under test.
+    assertSubstringIndex("ééa", "é", -2, UTF8_BINARY, "éa");
     assertSubstringIndex("ééa", "é", -2, UNICODE, "éa");
     assertSubstringIndex("ééa", "é", -2, UNICODE_CI, "éa");
     // Same, with a delimiter spanning more than one such character, so that the suffix depends
     // on the matched length and not just on the match position.
+    assertSubstringIndex("aéééba", "éé", -2, UTF8_BINARY, "éba");
     assertSubstringIndex("aéééba", "éé", -2, UNICODE, "éba");
     // Positive count with the first delimiter occurrence at position 0 and a delimiter
     // starting with a surrogate pair: the stuck-iterator workaround previously used 0 as the
     // "no match yet" sentinel and double-counted the first occurrence.
+    assertSubstringIndex("😀a😀b", "😀", 2, UTF8_BINARY, "😀a");
     assertSubstringIndex("😀a😀b", "😀", 2, UNICODE, "😀a");
+    assertSubstringIndex("😀😀😀", "😀😀", 2, UTF8_BINARY, "😀");
     assertSubstringIndex("😀😀😀", "😀😀", 2, UNICODE, "😀");
     // Targets long enough to exercise the backward search's trailing window. The window starts
     // at 64 UTF-16 code units and grows by 4x, and the ring buffer that retains the last `count`
@@ -2783,6 +2788,18 @@ public class CollationSupportSuite {
     assertSubstringIndex("e\u0301".repeat(100) + "x", "e\u0301", -32, UTF8_BINARY,
       "e\u0301".repeat(31) + "x");
     assertSubstringIndex("e\u0301".repeat(100) + "x", "e\u0301", -32, UNICODE,
+      "e\u0301".repeat(31) + "x");
+    // The windowed cases above all run under UNICODE, where the delimiter matches literally.
+    // Repeat them under the collations that make the match set itself collation-dependent,
+    // which is the property this fix turns on: case folding under UNICODE_CI and accent folding
+    // under UNICODE_AI, over targets long enough to need a second window.
+    assertSubstringIndex(("A" + "x".repeat(9)).repeat(30), "a", -20, UNICODE_CI,
+      "x".repeat(9) + ("A" + "x".repeat(9)).repeat(19));
+    assertSubstringIndex(("\u00e1" + "x".repeat(9)).repeat(30), "a", -20, "UNICODE_AI",
+      "x".repeat(9) + ("\u00e1" + "x".repeat(9)).repeat(19));
+    // Case folding across a window boundary that falls inside a combining sequence: the
+    // delimiter is the uppercase base plus the same combining mark.
+    assertSubstringIndex("e\u0301".repeat(100) + "x", "E\u0301", -32, UNICODE_CI,
       "e\u0301".repeat(31) + "x");
   }
 
@@ -4389,10 +4406,16 @@ public class CollationSupportSuite {
     assertStringInstrWithOccurrence("aaaa", "aa", -2, 3, UNICODE, 1);
     // SPARK-58441: backward search over characters that map to multiple collation elements: the
     // ICU path previously used StringSearch.previous(), which skips or misaligns such matches.
+    // UTF8_BINARY does not go through the ICU path, so it pins each expectation independently
+    // of the code under test.
+    assertStringInstrWithOccurrence("bbébébé", "bé", -3, 1, UTF8_BINARY, 4);
     assertStringInstrWithOccurrence("bbébébé", "bé", -3, 1, UNICODE, 4);
+    assertStringInstrWithOccurrence("bbébébé", "bé", -3, 2, UTF8_BINARY, 2);
     assertStringInstrWithOccurrence("bbébébé", "bé", -3, 2, UNICODE, 2);
     // A match that starts exactly at the backward anchor still counts.
+    assertStringInstrWithOccurrence("babaéa", "aé", -3, 1, UTF8_BINARY, 4);
     assertStringInstrWithOccurrence("babaéa", "aé", -3, 1, UNICODE, 4);
+    assertStringInstrWithOccurrence("ééé", "é", -1, 2, UTF8_BINARY, 2);
     assertStringInstrWithOccurrence("ééé", "é", -1, 2, UNICODE_CI, 2);
     // A backward start one position before the beginning of the string matches nothing. The ICU
     // path used to accept such a start and report a match, unlike every other collation, so the
@@ -4401,9 +4424,12 @@ public class CollationSupportSuite {
     assertStringInstrWithOccurrence("é", "é", -2, 1, UNICODE, 0);
     // A match at position 0 of a pattern starting with a surrogate pair: the stuck-iterator
     // workaround previously used 0 as the "no match yet" sentinel and double-counted it.
+    assertStringInstrWithOccurrence("😀a😀b", "😀", 1, 2, UTF8_BINARY, 3);
     assertStringInstrWithOccurrence("😀a😀b", "😀", 1, 2, UNICODE, 3);
+    assertStringInstrWithOccurrence("😀abc", "😀", 1, 2, UTF8_BINARY, 0);
     assertStringInstrWithOccurrence("😀abc", "😀", 1, 2, UNICODE, 0);
     // Overlapping matches of a pattern starting with a surrogate pair.
+    assertStringInstrWithOccurrence("😀😀😀", "😀😀", 1, 2, UTF8_BINARY, 2);
     assertStringInstrWithOccurrence("😀😀😀", "😀😀", 1, 2, UNICODE, 2);
     // Targets long enough to exercise the backward search's trailing window. The window starts
     // at 64 UTF-16 code units and grows by 4x, and the ring buffer that retains the last
@@ -4438,6 +4464,21 @@ public class CollationSupportSuite {
       UTF8_BINARY, 137);
     assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "e\u0301", -1, 32,
       UNICODE, 137);
+    // The windowed cases above all run under UNICODE, where the pattern matches literally.
+    // Repeat them under the collations that make the match set itself collation-dependent,
+    // which is the property this fix turns on: case folding under UNICODE_CI and accent folding
+    // under UNICODE_AI, over targets long enough to need a second window.
+    assertStringInstrWithOccurrence(("A" + "x".repeat(9)).repeat(30), "a", -1, 20,
+      UNICODE_CI, 101);
+    assertStringInstrWithOccurrence(("\u00e1" + "x".repeat(9)).repeat(30), "a", -1, 20,
+      "UNICODE_AI", 101);
+    // A window boundary that falls inside a combining sequence, where the pattern matches only
+    // because of the collation: the uppercase base plus the same mark under UNICODE_CI, and the
+    // bare base under UNICODE_AI, which matches the whole sequence.
+    assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "E\u0301", -1, 32,
+      UNICODE_CI, 137);
+    assertStringInstrWithOccurrence("e\u0301".repeat(100) + "xx", "e", -1, 32,
+      "UNICODE_AI", 137);
     // A backward start away from the end of the target, with a match after the anchor. The pass
     // stops at the anchor instead of running off the end, so the stretch past the anchor never
     // dominates and the window grows geometrically. Both cases below need two growth steps


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix four defects in `CollationAwareUTF8String`'s use of ICU `StringSearch`, affecting `instr` (3/4-arg) and `substring_index` under ICU collations:

1. The backward search enumerated matches with `previous()`, which does not visit the same match set as `next()`: it skips overlapping matches, and skips or misaligns matches when a character maps to multiple collation elements. (`trimRight` already documents this and avoids `previous()`.) Both backward helpers now enumerate forward and select the requested occurrence from the end.
2. The forward search used 0 as its "no match seen yet" sentinel, double-counting a match at index 0; it is now -1. Its stuck-overlapping-iterator recovery skipped legitimate matches, and now advances past exactly one collation unit.
3. The forward search counted a match ICU reports *before* the requested start. ICU snaps a start index falling inside a collation unit back to that unit's beginning, so such a match can be reported; it is now skipped without being counted, as in `UTF8String.indexOf`.
4. A negative start one position before the beginning of the string reported a match, where `UTF8String.indexOf` reports none. The 0-based anchor is now `numCodePoints + start`.

Enumerating forward means the search cannot start at the answer, so the backward search runs over a trailing window that grows until it holds the requested match or reaches the start of the target. See the `findIndexFromEnd` Javadoc.

### Why are the changes needed?

`instr` and `substring_index` silently return wrong results under ICU collations:

```sql
SELECT instr(collate('bbébébé', 'UNICODE'), 'bé', -3, 1);       -- returns 6, expected 4
SELECT instr(collate('babaéa', 'UNICODE'), 'aé', -3, 1);        -- returns 0, expected 4
SELECT instr(collate('achch', 'cs'), 'ch', 3, 1);               -- returns 2, expected 4
SELECT substring_index(collate('ééa', 'UNICODE'), 'é', -2);     -- returns 'ééa', expected 'éa'
SELECT substring_index(collate('😀a😀b', 'UNICODE'), '😀', 2);  -- returns '', expected '😀a'
```

UTF8_BINARY and UTF8_LCASE are unaffected; they do not use these code paths.

#### Performance

Measured with an ad-hoc in-process harness over `CollationSupport` (`CollationBenchmark` has no `instr` / `substring_index` coverage today). On short targets, parity to about 2.4x slower — the worst case is `substring_index('/usr/local/share/spark/conf', '/', -1)` at 831ns -> 2,025ns. On long targets, parity to 1.4x slower while the answer is near the anchor, and 1.3x to 1.5x faster once it is far away or absent (200KB target, delimiter absent: 8.27ms -> 6.30ms), where `previous()` had to walk the whole target anyway.

One shape is much slower: `instr` with a large-magnitude negative start and no match before the anchor puts the anchor at index 0, so the search becomes a single forward scan of the whole target, where `previous()` from index 0 returned immediately. On a 100K target, 116us -> 2.21ms. Bounding that scan would mean truncating the target, which changes the match set, so I have left it.

### Does this PR introduce _any_ user-facing change?

Yes, bug fix: `instr` and `substring_index` return correct results under ICU collations in the cases above.

### How was this patch tested?

Test cases added to `CollationSupportSuite` covering each defect, the trailing window's growth steps, the ring buffer's resize and wrap, and window boundaries falling inside a surrogate pair, a combining sequence and a contraction. The new backward-search expectations are pinned against `UTF8_BINARY`, which does not use the windowed search, so they are anchored to an independent reference rather than to the new implementation.

Separately, the windowed search was checked against a single full forward pass from index 0 using the identical iteration protocol, over targets built from combining sequences, mixed precomposed/decomposed forms, sharp s, the fi ligature, surrogate pairs and contractions, against UNICODE, UNICODE_CI, UNICODE_CI_AI, cs, da and sr_Cyrl_SRB. No differences.

### Was this patch authored or co-authored using generative AI tooling?

Yes
