### PR TITLE
[SPARK-58444][SQL] Do not enable concurrent output writer when ordering already matched

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -125,6 +125,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         OptimizeRepartition,
         EliminateWindowPartitions,
         TransposeWindow,
+        PullUpProjectAliasThroughWindow,
         NullPropagation,
         // NullPropagation may introduce Exists subqueries, so RewriteNonCorrelatedExists must run
         // after.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindow.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeSet, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Window}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.WINDOW
+
+/**
+ * A [[Window]] operator does not project its output partitioning or ordering through aliases: its
+ * physical `outputPartitioning`/`outputOrdering` are pure pass-throughs of the child's. So when a
+ * window partitioned/ordered by `k` is followed by a consumer (aggregate, repartition, a chained
+ * window, ...) that requires distribution/ordering on a rename `k AS a`, a redundant shuffle and/or
+ * sort is inserted: the window already shuffled/sorted on `k`, but `HashPartitioning(k)` does not
+ * satisfy `ClusteredDistribution(a)` because the rename lives in a [[Project]] *below* the window
+ * while the analyzer-inserted [[Project]] *above* references `a` as a bare [[Attribute]] (empty
+ * alias map), and `k` and `a`, though value-identical, have distinct expr ids.
+ *
+ * This rule pulls such aliases up from the bottom [[Project]] into the top [[Project]], across the
+ * chain of one or more [[Window]] operators in between (`Project - Window+ - Project`; adjacent
+ * windows that cannot be collapsed, e.g. with different order specs, leave no [[Project]] between
+ * them). The top project's alias map then maps `k -> a`, and the
+ * `PartitioningPreservingUnaryExecNode` / `OrderPreservingUnaryExecNode` machinery that
+ * `ProjectExec` mixes in projects the windows' `HashPartitioning(k)`/`SortOrder(k)` up through the
+ * alias, satisfying the consumer. The [[Window]] operators themselves are left untouched.
+ *
+ * Besides removing the redundant shuffle/sort, this also narrows the data crossing the window's
+ * shuffle: the alias no longer flows through the window as a separate column (only its input `k`,
+ * already needed for partitioning, does) and is recomputed cheaply in the top project above the
+ * exchange.
+ *
+ * An entry of the bottom project is pulled up only when:
+ *   - it is an [[Alias]] (bare pass-through attributes stay below so the windows keep producing
+ *     them for the top project to reference);
+ *   - no window in the chain references it, so window semantics are unaffected;
+ *   - all of its input attributes remain produced by the pruned bottom project (i.e. they are
+ *     referenced by some window and thus retained), so a computed alias whose inputs would be
+ *     dropped is not lifted above windows that no longer output them;
+ *   - the top project consumes its output solely as a bare pass-through attribute (never inside a
+ *     larger expression), so replacing that attribute with the alias fully preserves it.
+ *
+ * The rewrite is a no-op on its own output (a moved alias is no longer a bare attribute above nor
+ * present below), so it converges immediately at the fixed point.
+ */
+object PullUpProjectAliasThroughWindow extends Rule[LogicalPlan] {
+
+  /**
+   * Matches a non-empty chain of [[Window]] operators bottomed out by a [[Project]], returning the
+   * windows top-to-bottom and that bottom project.
+   */
+  private object WindowChain {
+    def unapply(plan: LogicalPlan): Option[(Seq[Window], Project)] = plan match {
+      case w @ Window(_, _, _, lower: Project, _) => Some((Seq(w), lower))
+      case w @ Window(_, _, _, WindowChain(windows, lower), _) => Some((w +: windows, lower))
+      case _ => None
+    }
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsPattern(WINDOW), ruleId) {
+    // Match the `Project - Window+ - Project` shape: the top project is the windows' parent
+    // scaffolding, and the bottom project is where the rename (`key AS userid`) is defined.
+    case p @ Project(projectList, WindowChain(windows, lower)) =>
+      // Entries any window references must stay below: they define what the bottom project must
+      // keep producing, and in particular carry the partition/order key attributes the pulled-up
+      // aliases reuse.
+      val windowRefs = AttributeSet(windows.flatMap(_.references))
+      val (retained, candidates) =
+        lower.projectList.partition(e => windowRefs.contains(e.toAttribute))
+      val retainedAttrs = AttributeSet(retained.map(_.toAttribute))
+      // Attributes the top project consumes as bare pass-through entries, and those it consumes
+      // inside a larger expression (an alias child, a window-output reference, ...).
+      val bareAttrs = AttributeSet(projectList.collect { case a: Attribute => a })
+      val referencedByExpr = AttributeSet(projectList.flatMap {
+        case _: Attribute => Nil
+        case other => other.references
+      })
+      // Pull up an alias only when: its inputs survive in the pruned bottom project, the top
+      // project passes its output through as a bare attribute, and the top project does not also
+      // consume that output inside an expression (which would require the windows to keep it).
+      val pullUp = candidates.collect {
+        case a: Alias
+            if a.references.subsetOf(retainedAttrs) &&
+              bareAttrs.contains(a.toAttribute) &&
+              !referencedByExpr.contains(a.toAttribute) => a
+      }
+      if (pullUp.isEmpty) {
+        p
+      } else {
+        val pullUpSet: Set[NamedExpression] = pullUp.toSet
+        // Key the lookup by expr id (not by `Attribute.equals`, which also compares qualifier):
+        // the top project may reference these attributes with a different qualifier than the alias
+        // carries below (e.g. across a subquery alias).
+        val pullUpMap = AttributeMap(pullUp.map(a => a.toAttribute -> a))
+        val newProjectList = projectList.map {
+          case attr: Attribute => pullUpMap.getOrElse(attr, attr)
+          case other => other
+        }
+        val newLower = lower.copy(projectList = lower.projectList.filterNot(pullUpSet.contains))
+        val newChild = windows.foldRight(newLower: LogicalPlan) { (w, child) =>
+          w.withNewChildren(child :: Nil)
+        }
+        Project(newProjectList, newChild)
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindow.scala
@@ -48,6 +48,9 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.WINDOW
  * An entry of the bottom project is pulled up only when:
  *   - it is an [[Alias]] (bare pass-through attributes stay below so the windows keep producing
  *     them for the top project to reference);
+ *   - it is deterministic: a nondeterministic alias (e.g. `rand()`, `spark_partition_id()`)
+ *     evaluated above the window's exchange/sort instead of below it could produce different
+ *     values, so it must stay below;
  *   - no window in the chain references it, so window semantics are unaffected;
  *   - all of its input attributes remain produced by the pruned bottom project (i.e. they are
  *     referenced by some window and thus retained), so a computed alias whose inputs would be
@@ -91,12 +94,15 @@ object PullUpProjectAliasThroughWindow extends Rule[LogicalPlan] {
         case _: Attribute => Nil
         case other => other.references
       })
-      // Pull up an alias only when: its inputs survive in the pruned bottom project, the top
-      // project passes its output through as a bare attribute, and the top project does not also
-      // consume that output inside an expression (which would require the windows to keep it).
+      // Pull up an alias only when: it is deterministic (a nondeterministic alias must not move
+      // across the window's exchange/sort, which would change its per-partition/per-row values);
+      // its inputs survive in the pruned bottom project; the top project passes its output through
+      // as a bare attribute; and the top project does not also consume that output inside an
+      // expression (which would require the windows to keep it).
       val pullUp = candidates.collect {
         case a: Alias
-            if a.references.subsetOf(retainedAttrs) &&
+            if a.deterministic &&
+              a.references.subsetOf(retainedAttrs) &&
               bareAttrs.contains(a.toAttribute) &&
               !referencedByExpr.contains(a.toAttribute) => a
       }
@@ -109,7 +115,15 @@ object PullUpProjectAliasThroughWindow extends Rule[LogicalPlan] {
         // carries below (e.g. across a subquery alias).
         val pullUpMap = AttributeMap(pullUp.map(a => a.toAttribute -> a))
         val newProjectList = projectList.map {
-          case attr: Attribute => pullUpMap.getOrElse(attr, attr)
+          // Rename the pulled-up alias to the top attribute's name: the lookup is keyed by expr id
+          // only, so a resolved top attribute may carry a different (but equivalent) cosmetic name
+          // than the lower alias. `withName` keeps the alias's child and expr id, so the output
+          // schema stays byte-for-byte identical.
+          case attr: Attribute =>
+            pullUpMap.get(attr) match {
+              case Some(a) => a.withName(attr.name)
+              case None => attr
+            }
           case other => other
         }
         val newLower = lower.copy(projectList = lower.projectList.filterNot(pullUpSet.contains))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -162,6 +162,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.Optimizer$OptimizeSubqueries" ::
       "org.apache.spark.sql.catalyst.optimizer.PropagateEmptyRelation" ::
       "org.apache.spark.sql.catalyst.optimizer.PruneFilters" ::
+      "org.apache.spark.sql.catalyst.optimizer.PullUpProjectAliasThroughWindow" ::
       "org.apache.spark.sql.catalyst.optimizer.PushDownJoinThroughUnion" ::
       "org.apache.spark.sql.catalyst.optimizer.PushDownLeftSemiAntiJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughJoin" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindowSuite.scala
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class PullUpProjectAliasThroughWindowSuite extends PlanTest {
+
+  private object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Pull up project alias through window", FixedPoint(20),
+        PullUpProjectAliasThroughWindow) :: Nil
+  }
+
+  private val testRelation = LocalRelation($"key".int, $"key2".int, $"value".string)
+  private val key = testRelation.output(0)
+  private val key2 = testRelation.output(1)
+  private val value = testRelation.output(2)
+  private val windowFrame = SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow)
+
+  // Builds `Window [row_number() ... AS <name>], <partitionSpec>, <orderSpec>` over `child`.
+  private def windowOver(
+      child: LogicalPlan,
+      name: String,
+      partitionSpec: Seq[Expression],
+      orderSpec: Seq[SortOrder] = Nil): Window = {
+    val spec = windowSpec(partitionSpec, orderSpec, windowFrame)
+    val winExpr = windowExpr(RowNumber(), spec).as(name)
+    Window(Seq(winExpr), partitionSpec, orderSpec, child)
+  }
+
+  test("pull up a rename of the window partition key") {
+    // Project [userid, w]            <- both bare attributes
+    // +- Window [... AS w], [key]
+    //    +- Project [key AS userid, value, key]
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, w), window)
+
+    // `userid` is pulled up into the parent project; the lower project keeps the rest.
+    val prunedBottom = Project(Seq(value, key), testRelation)
+    val expected = Project(
+      Seq(Alias(key, "userid")(exprId = userid.exprId), w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("pull up every applicable key in a multi-key window") {
+    val u1 = Alias(key, "u1")()
+    val u2 = Alias(key2, "u2")()
+    val bottom = Project(Seq(u1, u2, value, key, key2), testRelation)
+    val window = windowOver(bottom, "w", key :: key2 :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(u1.toAttribute, u2.toAttribute, w), window)
+
+    val prunedBottom = Project(Seq(value, key, key2), testRelation)
+    val expected = Project(
+      Seq(
+        Alias(key, "u1")(exprId = u1.exprId),
+        Alias(key2, "u2")(exprId = u2.exprId),
+        w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("pull up a rename of the window order key") {
+    // Window ordered by `value`; the top Project passes `tstamp` (a rename of `value`) through as
+    // a bare attribute. It must be pulled up so the window's output ordering projects through it.
+    val tstamp = Alias(value, "tstamp")()
+    val bottom = Project(Seq(key, tstamp, value), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil, SortOrder(value, Ascending) :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(key, tstamp.toAttribute, w), window)
+
+    val prunedBottom = Project(Seq(key, value), testRelation)
+    val expected = Project(
+      Seq(key, Alias(value, "tstamp")(exprId = tstamp.exprId), w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("pull up renames of both partition and order keys") {
+    val userid = Alias(key, "userid")()
+    val tstamp = Alias(value, "tstamp")()
+    val bottom = Project(Seq(userid, tstamp, key, value), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil, SortOrder(value, Ascending) :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, tstamp.toAttribute, w), window)
+
+    val prunedBottom = Project(Seq(key, value), testRelation)
+    val expected = Project(
+      Seq(
+        Alias(key, "userid")(exprId = userid.exprId),
+        Alias(value, "tstamp")(exprId = tstamp.exprId),
+        w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("keep a bare pass-through column the window does not reference below the window") {
+    // `key2` is a bare pass-through that the window neither partitions nor orders by. It must stay
+    // below the window so the window keeps producing it for the parent project to reference; only
+    // the rename `key AS userid` is pulled up.
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, key2, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, key2, w), window)
+
+    val prunedBottom = Project(Seq(key2, value, key), testRelation)
+    val expected = Project(
+      Seq(Alias(key, "userid")(exprId = userid.exprId), key2, w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("no rewrite when the renamed column is not a window key") {
+    // `userid` renames `key`, but the window is partitioned by `value`.
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, value, key), testRelation)
+    val window = windowOver(bottom, "w", value :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, w), window)
+
+    comparePlans(Optimize.execute(originalQuery), originalQuery)
+  }
+
+  test("no rewrite for a computed alias whose input is not a window key") {
+    // `(key2 + 1) AS z` depends on `key2`, which the window does not produce once pruned, so it
+    // cannot be pulled above the window and must stay below.
+    val z = Alias(key2 + 1, "z")()
+    val bottom = Project(Seq(z, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(z.toAttribute, w), window)
+
+    comparePlans(Optimize.execute(originalQuery), originalQuery)
+  }
+
+  test("pull up a computed alias whose inputs are all window keys") {
+    // `(key + 1) AS z` is computed rather than a pure rename, but its only input `key` is the
+    // window partition key and is retained below. It is pulled up so the expression is evaluated
+    // in the top project, above the window's shuffle rather than being carried across it. This
+    // narrows the shuffled data even though it yields no partitioning benefit (`HashPartitioning`
+    // on `key` does not project through `key + 1`).
+    val z = Alias(key + 1, "z")()
+    val bottom = Project(Seq(z, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(z.toAttribute, w), window)
+
+    val prunedBottom = Project(Seq(value, key), testRelation)
+    val expected = Project(
+      Seq(Alias(key + 1, "z")(exprId = z.exprId), w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("pull up a computed alias combining a partition key and an order key") {
+    // `(key + key2) AS z` combines the partition key `key` and the order key `key2`; both are
+    // retained below, so the whole expression lifts above the window.
+    val z = Alias(key + key2, "z")()
+    val bottom = Project(Seq(z, key, key2), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil, SortOrder(key2, Ascending) :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(z.toAttribute, w), window)
+
+    val prunedBottom = Project(Seq(key, key2), testRelation)
+    val expected = Project(
+      Seq(Alias(key + key2, "z")(exprId = z.exprId), w),
+      window.copy(child = prunedBottom))
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("no rewrite when the window child is not a Project") {
+    val window = windowOver(testRelation, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(key, w), window)
+
+    comparePlans(Optimize.execute(originalQuery), originalQuery)
+  }
+
+  test("pull up an alias across a chain of windows") {
+    // Project [userid, w1, w2]
+    // +- Window [... AS w2], [key], [value DESC]
+    //    +- Window [... AS w1], [key], [value]     <- adjacent, no Project between
+    //       +- Project [key AS userid, value, key]
+    // `userid` renames `key` and is referenced by neither window, so it is pulled all the way up
+    // to the top project, through both windows.
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, value, key), testRelation)
+    val w1 = windowOver(bottom, "w1", key :: Nil, SortOrder(value, Ascending) :: Nil)
+    val w1a = w1.windowExpressions.head.toAttribute
+    val w2 = windowOver(w1, "w2", key :: Nil, SortOrder(value, Descending) :: Nil)
+    val w2a = w2.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, w1a, w2a), w2)
+
+    val prunedBottom = Project(Seq(value, key), testRelation)
+    val newW1 = w1.copy(child = prunedBottom)
+    val newW2 = w2.copy(child = newW1)
+    val expected = Project(
+      Seq(Alias(key, "userid")(exprId = userid.exprId), w1a, w2a), newW2)
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("keep an alias referenced by an inner window below the chain") {
+    // The chain's inner window orders by `tstamp` (a rename of `value`), so `tstamp` is referenced
+    // by a window and must stay below; only `userid` (referenced by no window) is pulled up.
+    val userid = Alias(key, "userid")()
+    val tstamp = Alias(value, "tstamp")()
+    val bottom = Project(Seq(userid, tstamp, key, value), testRelation)
+    val w1 = windowOver(bottom, "w1", key :: Nil, SortOrder(tstamp.toAttribute, Ascending) :: Nil)
+    val w1a = w1.windowExpressions.head.toAttribute
+    val w2 = windowOver(w1, "w2", key :: Nil)
+    val w2a = w2.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, tstamp.toAttribute, w1a, w2a), w2)
+
+    // `tstamp` stays below (referenced by w1's order spec); `userid` is pulled up.
+    val prunedBottom = Project(Seq(tstamp, key, value), testRelation)
+    val newW1 = w1.copy(child = prunedBottom)
+    val newW2 = w2.copy(child = newW1)
+    val expected = Project(
+      Seq(Alias(key, "userid")(exprId = userid.exprId), tstamp.toAttribute, w1a, w2a), newW2)
+    comparePlans(Optimize.execute(originalQuery), expected)
+  }
+
+  test("rewrite is idempotent") {
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, w), window)
+
+    val once = Optimize.execute(originalQuery)
+    val twice = Optimize.execute(once)
+    comparePlans(once, twice)
+  }
+
+  test("rewrite preserves the output schema (exprId, name, type, nullability)") {
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(userid.toAttribute, w), window)
+
+    val optimized = Optimize.execute(originalQuery)
+    // The output must be byte-for-byte identical so that downstream references still resolve.
+    assert(optimized.output === originalQuery.output)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullUpProjectAliasThroughWindowSuite.scala
@@ -245,6 +245,41 @@ class PullUpProjectAliasThroughWindowSuite extends PlanTest {
     comparePlans(Optimize.execute(originalQuery), expected)
   }
 
+  test("no rewrite for a nondeterministic alias") {
+    // `spark_partition_id() AS pid` is a leaf with no references, so it would pass the input-
+    // survival check vacuously, but moving it above the window's exchange/sort would change its
+    // per-partition value. It must stay below.
+    val pid = Alias(SparkPartitionID(), "pid")()
+    val bottom = Project(Seq(pid, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    val originalQuery = Project(Seq(pid.toAttribute, w), window)
+
+    comparePlans(Optimize.execute(originalQuery), originalQuery)
+  }
+
+  test("rewrite preserves the top attribute's name when it differs from the lower alias") {
+    // The lookup is keyed by expr id only, so a resolved top attribute can carry a different
+    // cosmetic name than the lower alias (same expr id). The rebuilt alias must keep the top
+    // attribute's name so the output schema is unchanged.
+    val userid = Alias(key, "userid")()
+    val bottom = Project(Seq(userid, value, key), testRelation)
+    val window = windowOver(bottom, "w", key :: Nil)
+    val w = window.windowExpressions.head.toAttribute
+    // The top project references `userid` under a different (but expr-id-equivalent) name.
+    val renamed = userid.toAttribute.withName("external")
+    val originalQuery = Project(Seq(renamed, w), window)
+
+    val prunedBottom = Project(Seq(value, key), testRelation)
+    val expected = Project(
+      Seq(Alias(key, "external")(exprId = userid.exprId), w),
+      window.copy(child = prunedBottom))
+    val optimized = Optimize.execute(originalQuery)
+    comparePlans(optimized, expected)
+    // The output name must be preserved as `external`, not reverted to the lower alias's `userid`.
+    assert(optimized.output.head.name == "external")
+  }
+
   test("rewrite is idempotent") {
     val userid = Alias(key, "userid")()
     val bottom = Project(Seq(userid, value, key), testRelation)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -189,9 +189,13 @@ object FileFormatWriter extends Logging {
 
       if (writeFilesOpt.isDefined) {
         // build `WriteFilesSpec` for `WriteFiles`
-        val concurrentOutputWriterSpecFunc = (plan: SparkPlan) => {
-          val sortPlan = createSortPlan(plan, requiredOrdering, outputSpec)
-          createConcurrentOutputWriterSpec(sparkSession, sortPlan, sortColumns)
+        val concurrentOutputWriterSpecFunc = if (orderingMatched) {
+          (_: SparkPlan) => None
+        } else {
+          (plan: SparkPlan) => {
+            val sortPlan = createSortPlan(plan, requiredOrdering, outputSpec)
+            createConcurrentOutputWriterSpec(sparkSession, sortPlan, sortColumns)
+          }
         }
         val writeSpec = WriteFilesSpec(
           description = description,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
@@ -32,8 +32,6 @@ class ProjectedOrderingAndPartitioningSuite
   extends SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
-  setupTestData()
-
   test("SPARK-42049: Improve AliasAwareOutputExpression - ordering - multi-alias") {
     Seq(0, 1, 2, 5).foreach { limit =>
       withSQLConf(SQLConf.EXPRESSION_PROJECTION_CANDIDATE_LIMIT.key -> limit.toString) {
@@ -707,6 +705,8 @@ class ProjectedOrderingAndPartitioningSuite
 
   test("SPARK-58405: eliminate redundant shuffle when aggregate groups by an alias of " +
     "the window partition key") {
+    // Register the `testData` view (scoped to just these tests that need it).
+    testData
     // The window output `vset` is consumed downstream so the window is not eliminated.
     // The window is hash-partitioned by `key`; the outer aggregate groups by `userid`, which is
     // an alias of `key`. Since `key` is already a partition key of the window, the outer
@@ -745,6 +745,8 @@ class ProjectedOrderingAndPartitioningSuite
 
   test("SPARK-58405: eliminate redundant shuffle for a repartition consumer of a window " +
     "partitioned by an aliased key") {
+    // Register the `testData` view (scoped to just these tests that need it).
+    testData
     // Consumer-agnostic: a repartition on `userid` (an alias of the window key `key`) reuses the
     // window's shuffle rather than adding its own.
     val df = sql(
@@ -766,6 +768,8 @@ class ProjectedOrderingAndPartitioningSuite
 
   test("SPARK-58405: eliminate redundant shuffle and sort for a window consumer partitioned " +
     "and ordered by aliased keys") {
+    // Register the `testData` view (scoped to just these tests that need it).
+    testData
     // Stacked windows: the outer window is PARTITION BY userid ORDER BY tstamp, where `userid`
     // and `tstamp` are aliases of the inner window's partition key `key` and order key `value`.
     // The inner window's child is already partitioned by `key` and ordered by `[key, value]`;
@@ -796,6 +800,8 @@ class ProjectedOrderingAndPartitioningSuite
   }
 
   test("SPARK-58405: eliminate redundant shuffle across a chain of windows over an aliased key") {
+    // Register the `testData` view (scoped to just these tests that need it).
+    testData
     // Two adjacent windows (different order specs, so they are not collapsed and leave no Project
     // between them) both partition by `key`; the aggregate downstream groups by `userid`, an alias
     // of `key`. Pulling `key AS userid` up across the whole window chain lets the parent project's

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeRef
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, HashPartitioning, KeyedPartitioning, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, YearsFunction}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, TimestampType}
@@ -30,6 +31,8 @@ import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, Timestam
 class ProjectedOrderingAndPartitioningSuite
   extends SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
+
+  setupTestData()
 
   test("SPARK-42049: Improve AliasAwareOutputExpression - ordering - multi-alias") {
     Seq(0, 1, 2, 5).foreach { limit =>
@@ -700,6 +703,133 @@ class ProjectedOrderingAndPartitioningSuite
       case p: UnknownPartitioning => assert(p.numPartitions === 4)
       case other => fail(s"Expected UnknownPartitioning, got $other")
     }
+  }
+
+  test("SPARK-58405: eliminate redundant shuffle when aggregate groups by an alias of " +
+    "the window partition key") {
+    // The window output `vset` is consumed downstream so the window is not eliminated.
+    // The window is hash-partitioned by `key`; the outer aggregate groups by `userid`, which is
+    // an alias of `key`. Since `key` is already a partition key of the window, the outer
+    // aggregate's shuffle on `userid` is redundant.
+    val df = sql(
+      """
+        |SELECT userid, count(*), sum(size(vset))
+        |FROM (
+        |  SELECT key AS userid,
+        |         collect_set(value) OVER (PARTITION BY key) AS vset
+        |  FROM testData
+        |) u
+        |GROUP BY 1
+      """.stripMargin)
+
+    // Correctness: results must match grouping the same window output by `key` directly.
+    val expected = sql(
+      """
+        |SELECT key, count(*), sum(size(vset))
+        |FROM (
+        |  SELECT key,
+        |         collect_set(value) OVER (PARTITION BY key) AS vset
+        |  FROM testData
+        |)
+        |GROUP BY 1
+      """.stripMargin)
+    checkAnswer(df, expected.collect())
+
+    // `collect` from `AdaptiveSparkPlanHelper` descends into the finalized AQE plan, so AQE can
+    // stay enabled. `checkAnswer` above has already materialized the query.
+    val plan = df.queryExecution.executedPlan
+    val shuffles = collect(plan) { case e: ShuffleExchangeExec => e }
+    assert(shuffles.size == 1,
+      s"Expected 1 shuffle but found ${shuffles.size}:\n$plan")
+  }
+
+  test("SPARK-58405: eliminate redundant shuffle for a repartition consumer of a window " +
+    "partitioned by an aliased key") {
+    // Consumer-agnostic: a repartition on `userid` (an alias of the window key `key`) reuses the
+    // window's shuffle rather than adding its own.
+    val df = sql(
+      """
+        |SELECT /*+ REPARTITION(userid) */ userid, vset
+        |FROM (
+        |  SELECT key AS userid,
+        |         collect_set(value) OVER (PARTITION BY key) AS vset
+        |  FROM testData
+        |) u
+      """.stripMargin)
+
+    df.collect()
+    val plan = df.queryExecution.executedPlan
+    val shuffles = collect(plan) { case e: ShuffleExchangeExec => e }
+    assert(shuffles.size == 1,
+      s"Expected 1 shuffle but found ${shuffles.size}:\n$plan")
+  }
+
+  test("SPARK-58405: eliminate redundant shuffle and sort for a window consumer partitioned " +
+    "and ordered by aliased keys") {
+    // Stacked windows: the outer window is PARTITION BY userid ORDER BY tstamp, where `userid`
+    // and `tstamp` are aliases of the inner window's partition key `key` and order key `value`.
+    // The inner window's child is already partitioned by `key` and ordered by `[key, value]`;
+    // pulling both `key AS userid` and `value AS tstamp` above the inner window projects the
+    // partitioning and the full ordering up through the aliases, so the outer window needs
+    // neither a redundant shuffle nor a redundant sort. Without the rule the outer window adds
+    // one of each (2 shuffles, 2 sorts). `size(vset)` keeps the inner window output live so it
+    // is not pruned away.
+    val df = sql(
+      """
+        |SELECT userid, tstamp,
+        |       sum(size(vset)) OVER (PARTITION BY userid ORDER BY tstamp) AS s
+        |FROM (
+        |  SELECT key AS userid, value AS tstamp,
+        |         collect_set(value) OVER (PARTITION BY key ORDER BY value) AS vset
+        |  FROM testData
+        |) u
+      """.stripMargin)
+
+    df.collect()
+    val plan = df.queryExecution.executedPlan
+    val shuffles = collect(plan) { case e: ShuffleExchangeExec => e }
+    val sorts = collect(plan) { case s: SortExec => s }
+    assert(shuffles.size == 1,
+      s"Expected 1 shuffle but found ${shuffles.size}:\n$plan")
+    assert(sorts.size == 1,
+      s"Expected 1 sort but found ${sorts.size}:\n$plan")
+  }
+
+  test("SPARK-58405: eliminate redundant shuffle across a chain of windows over an aliased key") {
+    // Two adjacent windows (different order specs, so they are not collapsed and leave no Project
+    // between them) both partition by `key`; the aggregate downstream groups by `userid`, an alias
+    // of `key`. Pulling `key AS userid` up across the whole window chain lets the parent project's
+    // `HashPartitioning(userid)` satisfy the aggregate, so no redundant shuffle is inserted.
+    // `sum(r1)`/`sum(r2)` keep both window outputs live so the chain is not pruned away.
+    val df = sql(
+      """
+        |SELECT userid, count(*), sum(r1), sum(r2)
+        |FROM (
+        |  SELECT key AS userid,
+        |         row_number() OVER (PARTITION BY key ORDER BY value) AS r1,
+        |         rank()       OVER (PARTITION BY key ORDER BY value DESC) AS r2
+        |  FROM testData
+        |) u
+        |GROUP BY 1
+      """.stripMargin)
+
+    val expected = sql(
+      """
+        |SELECT key, count(*), sum(r1), sum(r2)
+        |FROM (
+        |  SELECT key,
+        |         row_number() OVER (PARTITION BY key ORDER BY value) AS r1,
+        |         rank()       OVER (PARTITION BY key ORDER BY value DESC) AS r2
+        |  FROM testData
+        |)
+        |GROUP BY 1
+      """.stripMargin)
+    checkAnswer(df, expected.collect())
+
+    val plan = df.queryExecution.executedPlan
+    val shuffles = collect(plan) { case e: ShuffleExchangeExec => e }
+    assert(shuffles.size == 1,
+      s"Expected 1 shuffle but found ${shuffles.size}:\n$plan")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -438,4 +438,61 @@ class V1WriteCommandSuite extends SharedSparkSession with V1WriteCommandSuiteBas
       }
     }
   }
+
+  test("SPARK-58444: planned write should not enable concurrent writer when ordering " +
+    "already matched") {
+    // The concurrent output writer keeps one open writer per dynamic partition and falls back
+    // to the sort-based sequential writer once the number of open writers exceeds
+    // `maxConcurrentOutputFileWriters`. When the input is already sorted by the required
+    // ordering, FileFormatWriter should NOT enable the concurrent writer at all, so that this
+    // wasteful fall-back never happens. This test pins that behavior via the fall-back log.
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.PLANNED_WRITE_ENABLED.key -> "true",
+      SQLConf.MAX_CONCURRENT_OUTPUT_FILE_WRITERS.key -> "2") {
+      withTable("t") {
+        sql("CREATE TABLE t(i INT, k STRING) USING PARQUET PARTITIONED BY (j INT)")
+
+        // t0 has 5 distinct values of `j` (i % 5), which is greater than the
+        // maxConcurrentOutputFileWriters threshold (2), so a single-task concurrent write over
+        // all partitions would trigger the fall-back. Use an int partition column to avoid the
+        // empty2null projection that a string partition column would add.
+        val fallbackMsg = "Fall back from concurrent writers"
+        val loggerName = classOf[DynamicPartitionDataConcurrentWriter].getName
+        val expected = spark.table("t0").select($"i", $"k", $"j")
+
+        // Case 1: input already sorted by the dynamic partition column, collapsed into a single
+        // task. The output ordering matches the required ordering, so the concurrent writer must
+        // be disabled -> no fall-back log.
+        val matchedAppender = new LogAppender("ordering matched, no concurrent writer")
+        withLogAppender(matchedAppender, Seq(loggerName)) {
+          expected.repartition(1).sortWithinPartitions("j")
+            .write.mode("overwrite").insertInto("t")
+        }
+        assert(FileFormatWriter.outputOrderingMatched,
+          "Expected the output ordering to match the required ordering.")
+        assert(!matchedAppender.loggingEvents.exists(
+          _.getMessage.getFormattedMessage.contains(fallbackMsg)),
+          "Concurrent writer should be disabled when ordering already matches, " +
+            "so no fall-back to the sort-based writer should happen.")
+        checkAnswer(spark.table("t"), expected)
+
+        // Case 2 (control): input NOT sorted. Ordering does not match, so the concurrent writer
+        // stays enabled and falls back once open writers exceed the threshold. This proves the
+        // log assertion above is actually discriminating and not vacuously true.
+        val unmatchedAppender = new LogAppender("ordering not matched, concurrent writer")
+        withLogAppender(unmatchedAppender, Seq(loggerName)) {
+          expected.repartition(1)
+            .write.mode("overwrite").insertInto("t")
+        }
+        assert(!FileFormatWriter.outputOrderingMatched,
+          "Expected the output ordering NOT to match the required ordering.")
+        assert(unmatchedAppender.loggingEvents.exists(
+          _.getMessage.getFormattedMessage.contains(fallbackMsg)),
+          "Concurrent writer should fall back to the sort-based writer when ordering " +
+            "does not match.")
+        checkAnswer(spark.table("t"), expected)
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When planned write is enabled, `FileFormatWriter` builds a `concurrentOutputWriterSpecFunc` that always wraps the plan with a sort and creates a concurrent output writer spec. This PR skips building the concurrent output writer spec when the output ordering already matches the required ordering, by making the func return `None` in that case.

### Why are the changes needed?

The concurrent output writer keeps one open writer per dynamic partition and falls back to the sort-based sequential writer once the number of open writers exceeds `spark.sql.maxConcurrentOutputFileWriters`. When the input is already sorted by the required ordering, enabling the concurrent writer is pure overhead: it may open many writers and then fall back to the sort-based writer anyway. Skipping it avoids this wasteful fall-back.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New UT in `V1WriteCommandSuite` that asserts, via the fall-back log, that the concurrent writer is disabled when the ordering already matches, with a control case (unsorted input) proving the assertion is discriminating.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)