### PR TITLE
[SPARK-58446][CORE] Prevent late task events from corrupting pending task state

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -945,11 +945,12 @@ private[spark] class ExecutorAllocationManager(
             stageAttemptToPendingSpeculativeTasks.get(stageAttempt).foreach(_.remove(taskIndex))
           case _: TaskKilled =>
           case _ =>
-            if (!hasPendingTasks) {
+            if (stageAttemptToNumTasks.contains(stageAttempt) && !hasPendingTasks) {
               // If the task failed (not intentionally killed), we expect it to be resubmitted
               // later. To ensure we have enough resources to run the resubmitted task, we need to
               // mark the scheduler as backlogged again if it's not already marked as such
-              // (SPARK-8366)
+              // (SPARK-8366). Skip this for completed stage attempts: the task will not be
+              // resubmitted and an armed timer would let a later stage bypass the backlog timeout.
               allocationManager.onSchedulerBacklogged()
             }
             if (!taskEnd.taskInfo.speculative) {

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -904,14 +904,16 @@ private[spark] class ExecutorAllocationManager(
         stageAttemptToNumRunningTask(stageAttempt) =
           stageAttemptToNumRunningTask.getOrElse(stageAttempt, 0) + 1
         // If this is the last pending task, mark the scheduler queue as empty
-        if (taskStart.taskInfo.speculative) {
-          stageAttemptToSpeculativeTaskIndices.getOrElseUpdate(stageAttempt,
-            new mutable.HashSet[Int]) += taskIndex
-          stageAttemptToPendingSpeculativeTasks
-            .get(stageAttempt).foreach(_.remove(taskIndex))
-        } else {
-          stageAttemptToTaskIndices.getOrElseUpdate(stageAttempt,
-            new mutable.HashSet[Int]) += taskIndex
+        if (stageAttemptToNumTasks.contains(stageAttempt)) {
+          if (taskStart.taskInfo.speculative) {
+            stageAttemptToSpeculativeTaskIndices.getOrElseUpdate(stageAttempt,
+              new mutable.HashSet[Int]) += taskIndex
+            stageAttemptToPendingSpeculativeTasks
+              .get(stageAttempt).foreach(_.remove(taskIndex))
+          } else {
+            stageAttemptToTaskIndices.getOrElseUpdate(stageAttempt,
+              new mutable.HashSet[Int]) += taskIndex
+          }
         }
         if (!hasPendingTasks) {
           allocationManager.onSchedulerQueueEmpty()
@@ -969,9 +971,11 @@ private[spark] class ExecutorAllocationManager(
       val stageAttempt = StageAttempt(stageId, stageAttemptId)
       val taskIndex = speculativeTask.taskIndex
       allocationManager.synchronized {
-        stageAttemptToPendingSpeculativeTasks.getOrElseUpdate(stageAttempt,
-          new mutable.HashSet[Int]).add(taskIndex)
-        allocationManager.onSchedulerBacklogged()
+        if (stageAttemptToNumTasks.contains(stageAttempt)) {
+          stageAttemptToPendingSpeculativeTasks.getOrElseUpdate(stageAttempt,
+            new mutable.HashSet[Int]).add(taskIndex)
+          allocationManager.onSchedulerBacklogged()
+        }
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1003,6 +1003,23 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(addTime(manager) === NOT_SET)
   }
 
+  test("ignore late failed task end events from completed stages") {
+    val manager = createManager(createConf(0, 10, 0))
+    val stage = createStageInfo(0, 1)
+    post(SparkListenerStageSubmitted(stage))
+
+    val task = createTaskInfo(0, 0, "executor-1")
+    post(SparkListenerTaskStart(0, 0, task))
+    post(SparkListenerStageCompleted(stage))
+    assert(addTime(manager) === NOT_SET)
+
+    val failure = ExceptionFailure(null, null, null, null, None)
+    post(SparkListenerTaskEnd(0, 0, null, failure, task, new ExecutorMetrics, null))
+
+    assert(numStageAttemptsForDefaultProfile(manager) === 0)
+    assert(addTime(manager) === NOT_SET)
+  }
+
   testRetry("cancel pending executors when no longer needed") {
     val manager = createManager(createConf(0, 10, 0))
     post(SparkListenerStageSubmitted(createStageInfo(2, 5)))

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -942,6 +942,67 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(totalRunningTasksPerResourceProfile(manager) === 0)
   }
 
+  test("ignore late task start events from completed stages") {
+    val manager = createManager(createConf(0, 10, 0))
+    val stage = createStageInfo(0, 2)
+    post(SparkListenerStageSubmitted(stage))
+
+    val earlyTask = createTaskInfo(0, 0, "executor-1")
+    post(SparkListenerTaskStart(0, 0, earlyTask))
+    post(SparkListenerStageCompleted(stage))
+
+    val lateTask = createTaskInfo(1, 1, "executor-1")
+    post(SparkListenerTaskStart(0, 0, lateTask))
+    post(SparkListenerTaskEnd(0, 0, null, Success, earlyTask, new ExecutorMetrics, null))
+    post(SparkListenerTaskEnd(0, 0, null, Success, lateTask, new ExecutorMetrics, null))
+
+    assert(pendingRegularTasksForDefaultProfile(manager) === 0)
+    assert(numStageAttemptsForDefaultProfile(manager) === 0)
+
+    post(SparkListenerStageSubmitted(createStageInfo(1, 1)))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 1)
+
+    val updatesNeeded =
+      new mutable.HashMap[ResourceProfile, ExecutorAllocationManager.TargetNumUpdates]
+    assert(addExecutorsToTargetForDefaultProfile(manager, updatesNeeded) === 1)
+    assert(numExecutorsTargetForDefaultProfileId(manager) === 1)
+  }
+
+  test("ignore late speculative task start events from completed stages") {
+    val manager = createManager(createConf(0, 10, 0))
+    val stage = createStageInfo(0, 2)
+    post(SparkListenerStageSubmitted(stage))
+
+    val regularTask = createTaskInfo(0, 0, "executor-1")
+    post(SparkListenerTaskStart(0, 0, regularTask))
+    post(speculativeTaskSubmitEventFromTaskIndex(0, taskIndex = 1))
+    post(SparkListenerStageCompleted(stage))
+
+    val speculativeTask = createTaskInfo(1, 1, "executor-1", speculative = true)
+    post(SparkListenerTaskStart(0, 0, speculativeTask))
+    post(SparkListenerTaskEnd(0, 0, null, Success, regularTask, new ExecutorMetrics, null))
+    post(SparkListenerTaskEnd(0, 0, null, Success, speculativeTask, new ExecutorMetrics, null))
+
+    assert(numSpeculativeTaskIndexMaps(manager) === 0)
+    assert(numStageAttemptsForDefaultProfile(manager) === 0)
+  }
+
+  test("ignore late speculative task submitted events from completed stages") {
+    val manager = createManager(createConf(0, 10, 0))
+    val stage = createStageInfo(0, 1)
+    post(SparkListenerStageSubmitted(stage))
+
+    val task = createTaskInfo(0, 0, "executor-1")
+    post(SparkListenerTaskStart(0, 0, task))
+    post(SparkListenerStageCompleted(stage))
+    post(speculativeTaskSubmitEventFromTaskIndex(0, taskIndex = 0))
+    post(SparkListenerTaskEnd(0, 0, null, Success, task, new ExecutorMetrics, null))
+
+    assert(pendingSpeculativeTasksForDefaultProfile(manager) === 0)
+    assert(numStageAttemptsForDefaultProfile(manager) === 0)
+    assert(addTime(manager) === NOT_SET)
+  }
+
   testRetry("cancel pending executors when no longer needed") {
     val manager = createManager(createConf(0, 10, 0))
     post(SparkListenerStageSubmitted(createStageInfo(2, 5)))
@@ -2113,6 +2174,12 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
     PrivateMethod[mutable.HashMap[Int, Int]](Symbol("numLocalityAwareTasksPerResourceProfileId"))
   private val _rpIdToHostToLocalTaskCount =
     PrivateMethod[Map[Int, Map[String, Int]]](Symbol("rpIdToHostToLocalTaskCount"))
+  private val _resourceProfileIdToStageAttempt =
+    PrivateMethod[mutable.HashMap[Int, mutable.Set[Any]]](
+      Symbol("resourceProfileIdToStageAttempt"))
+  private val _stageAttemptToSpeculativeTaskIndices =
+    PrivateMethod[mutable.HashMap[Any, mutable.HashSet[Int]]](
+      Symbol("stageAttemptToSpeculativeTaskIndices"))
 
   private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(new SparkConf)
 
@@ -2213,6 +2280,26 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
     manager.synchronized {
       manager.listener.totalRunningTasksPerResourceProfile(defaultProfile.id)
     }
+
+  private def pendingRegularTasksForDefaultProfile(manager: ExecutorAllocationManager): Int =
+    manager.synchronized {
+      manager.listener.pendingTasksPerResourceProfile(defaultProfile.id)
+    }
+
+  private def pendingSpeculativeTasksForDefaultProfile(manager: ExecutorAllocationManager): Int =
+    manager.synchronized {
+      manager.listener.pendingSpeculativeTasksPerResourceProfile(defaultProfile.id)
+    }
+
+  private def numStageAttemptsForDefaultProfile(manager: ExecutorAllocationManager): Int = {
+    val attempts = manager.listener invokePrivate _resourceProfileIdToStageAttempt()
+    attempts.get(defaultProfile.id).map(_.size).getOrElse(0)
+  }
+
+  private def numSpeculativeTaskIndexMaps(manager: ExecutorAllocationManager): Int = {
+    val taskIndices = manager.listener invokePrivate _stageAttemptToSpeculativeTaskIndices()
+    taskIndices.size
+  }
 
   private def hostToLocalTaskCount(
       manager: ExecutorAllocationManager): Map[String, Int] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR skips pending-task bookkeeping for `TaskStart` and `SpeculativeTaskSubmitted` events when the corresponding stage attempt has already completed.

Running-task accounting remains unchanged for late `TaskStart` events so that matching `TaskEnd` events are handled correctly.

Also skips the failed-task backlog timer in `onTaskEnd` when the stage attempt has already completed. The task will not be resubmitted in that case, and an armed `addTime` would let a later stage bypass `schedulerBacklogTimeout`.

Regression tests were added for regular task starts, speculative task starts, speculative task submissions, and failed task ends after `StageCompleted`.

### Why are the changes needed?

After `StageCompleted` removes the stage metadata, a late `TaskStart` event can recreate task-index state. Processing the matching `TaskEnd` can then produce a negative pending task count.

When dynamic allocation uses `minExecutors=0`, this can leave the executor target at zero and prevent later stages from requesting executors.

### Does this PR introduce _any_ user-facing change?

Yes. Late task events from completed stages no longer prevent subsequent stages from requesting executors when dynamic allocation is enabled.

### How was this patch tested?

Added regression tests covering late regular task starts, speculative task starts, speculative task submissions, and failed task ends.

The four new tests failed against `upstream/master` and passed with this patch.

```bash
build/sbt 'core/testOnly org.apache.spark.ExecutorAllocationManagerSuite'
```

All 51 tests passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5.6), Claude Code (Claude Fable 5)

