### PR TITLE
[SPARK-58448][CONNECT] Estimate IsotonicRegressionModel size

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
@@ -250,7 +250,9 @@ class IsotonicRegressionModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     if (oldModel != null) {
+      // boundaries: Array[Double]
       size += SizeEstimator.estimate(oldModel.boundaries)
+      // predictions: Array[Double]
       size += SizeEstimator.estimate(oldModel.predictions)
     }
     size

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.SizeEstimator
 
 /**
  * Params for isotonic regression.
@@ -244,6 +245,15 @@ class IsotonicRegressionModel private[ml] (
   @Since("1.5.0")
   override def copy(extra: ParamMap): IsotonicRegressionModel = {
     copyValues(new IsotonicRegressionModel(uid, oldModel), extra).setParent(parent)
+  }
+
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    if (oldModel != null) {
+      size += SizeEstimator.estimate(oldModel.boundaries)
+      size += SizeEstimator.estimate(oldModel.predictions)
+    }
+    size
   }
 
   @Since("2.0.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/IsotonicRegressionSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.col
+import org.apache.spark.util.SizeEstimator
 
 class IsotonicRegressionSuite extends MLTest with DefaultReadWriteTest {
 
@@ -65,6 +66,16 @@ class IsotonicRegressionSuite extends MLTest with DefaultReadWriteTest {
       val predictions = rows.map(_.getDouble(0))
       assert(predictions === Array(7, 7, 6, 5.5, 5, 4, 1))
     }
+  }
+
+  test("model size estimation") {
+    val dataset = generateIsotonicInput(Seq(1, 2, 3, 1, 6, 17, 16, 17, 18))
+    val model = new IsotonicRegression().fit(dataset)
+
+    val expectedSize = model.estimateMatadataSize +
+      SizeEstimator.estimate(model.boundaries.toArray) +
+      SizeEstimator.estimate(model.predictions.toArray)
+    assert(model.estimatedSize === expectedSize)
   }
 
   test("params validation") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an explicit `estimatedSize` implementation for `IsotonicRegressionModel`. It accounts for model metadata and the legacy model's boundary and prediction arrays.

### Why are the changes needed?

ML Connect cache accounting needs a bounded, model-specific estimate of the state retained by `IsotonicRegressionModel`, rather than relying on generic object-graph traversal.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a focused `IsotonicRegressionSuite` assertion that verifies the estimate includes metadata and both learned arrays.

```
build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 'mllib/testOnly *IsotonicRegressionSuite'
```

Passed: 36 tests, 0 failures.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)