### PR TITLE
[SPARK-58447][CONNECT] Preserve operation tags in Python foreachBatch callbacks

### DIFF
--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -27,6 +27,7 @@ from pyspark import worker
 from pyspark.serializers import (
     CPickleSerializer,
     UTF8Deserializer,
+    read_int,
     read_long,
     write_int,
 )
@@ -75,6 +76,9 @@ def main(infile: IO, outfile: IO) -> None:
         func = worker.read_command(pickle_ser, infile)
         write_int(0, outfile)
         outfile.flush()
+
+        for _ in range(read_int(infile)):
+            spark_connect_session.addTag(utf8_deserializer.loads(infile))
 
         while True:
             df_ref_id = utf8_deserializer.loads(infile)

--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -25,6 +25,7 @@ import os
 from pyspark.worker_util import get_sock_file_to_executor
 from pyspark.serializers import (
     write_int,
+    read_int,
     read_long,
     UTF8Deserializer,
     CPickleSerializer,
@@ -76,6 +77,9 @@ def main(infile: IO, outfile: IO) -> None:
         func = worker.read_command(pickle_ser, infile)
         write_int(0, outfile)
         outfile.flush()
+
+        for _ in range(read_int(infile)):
+            spark_connect_session.addTag(utf8_deserializer.loads(infile))
 
         while True:
             df_ref_id = utf8_deserializer.loads(infile)

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
@@ -120,6 +120,24 @@ class StreamingTestsForeachBatchMixin:
             )
             self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
+    def test_streaming_foreach_batch_operation_tags(self):
+        tag = "foreach-batch"
+        q = None
+
+        def func(batch_df, _):
+            assert tag in batch_df.sparkSession.getTags()
+            batch_df.count()
+
+        self.spark.addTag(tag)
+        try:
+            df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
+            q = df.writeStream.foreachBatch(func).start()
+            q.processAllAvailable()
+        finally:
+            if q:
+                q.stop()
+            self.spark.removeTag(tag)
+
     def test_streaming_foreach_batch_path_access(self):
         table_name = "testTable_foreach_batch_path"
         with self.table(table_name):

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreach_batch.py
@@ -119,6 +119,24 @@ class StreamingTestsForeachBatchMixin:
             )
             self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
+    def test_streaming_foreach_batch_operation_tags(self):
+        tag = "foreach-batch"
+        q = None
+
+        def func(batch_df, _):
+            assert tag in batch_df.sparkSession.getTags()
+            batch_df.count()
+
+        self.spark.addTag(tag)
+        try:
+            df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
+            q = df.writeStream.foreachBatch(func).start()
+            q.processAllAvailable()
+        finally:
+            if q:
+                q.stop()
+            self.spark.removeTag(tag)
+
     def test_streaming_foreach_batch_path_access(self):
         table_name = "testTable_foreach_batch_path"
         with self.table(table_name):

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -3565,7 +3565,10 @@ class SparkConnectPlanner(
         case StreamingForeachFunction.FunctionCase.PYTHON_FUNCTION =>
           val pythonFn = transformPythonFunction(writeOp.getForeachBatch.getPythonFunction)
           val (fn, cleaner) =
-            StreamingForeachBatchHelper.pythonForeachBatchWrapper(pythonFn, sessionHolder)
+            StreamingForeachBatchHelper.pythonForeachBatchWrapper(
+              pythonFn,
+              sessionHolder,
+              executeHolder.sparkSessionTags)
           foreachBatchRunnerCleaner = Some(cleaner)
           fn
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -134,7 +134,8 @@ object StreamingForeachBatchHelper extends Logging {
    */
   def pythonForeachBatchWrapper(
       pythonFn: SimplePythonFunction,
-      sessionHolder: SessionHolder): (ForeachBatchFnType, AutoCloseable) = {
+      sessionHolder: SessionHolder,
+      sessionTags: Set[String] = Set.empty): (ForeachBatchFnType, AutoCloseable) = {
 
     val port = SparkConnectService.localPort
     var connectUrl = s"sc://localhost:$port/;user_id=${sessionHolder.userId}"
@@ -153,6 +154,9 @@ object StreamingForeachBatchHelper extends Logging {
         log"pythonExec: ${MDC(PYTHON_EXEC, pythonFn.pythonExec)})")
 
     val (dataOut, dataIn) = runner.init()
+    dataOut.writeInt(sessionTags.size)
+    sessionTags.toSeq.sorted.foreach(tag => PythonWorkerUtils.writeUTF(tag, dataOut))
+    dataOut.flush()
 
     val foreachBatchRunnerFn: FnArgsWithId => Unit = (args: FnArgsWithId) => {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR propagates the operation tags from the `writeStream.start()` request to the Spark Connect session used by a Python `foreachBatch` callback.

The tags are transferred through the internal server-worker protocol when the Python worker starts and restored before processing micro-batches. A regression test verifies that the callback session preserves the tags and can execute a nested action with them.

### Why are the changes needed?

Spark Connect executes Python `foreachBatch` callbacks in a separate Python worker that creates a local Connect client. Operation tags are client thread-local, so the new client does not contain the tags from the originating request.

As a result, operations executed inside the callback, such as actions, writes, and SQL commands, cannot be identified or interrupted using those tags.

### Does this PR introduce _any_ user-facing change?

Yes. Operations executed inside a Spark Connect Python `foreachBatch` callback now inherit the operation tags captured when the streaming query starts. This does not introduce a new API.

### How was this patch tested?

- Added `test_streaming_foreach_batch_operation_tags` and verified that it fails before the fix and passes after the fix.
- `python/run-tests --testnames pyspark.sql.tests.connect.streaming.test_parity_foreach_batch`
- `build/sbt -Phive package`
- `build/sbt connect/scalastyle`
- `SparkConnectSessionHolderSuite` with the `python foreachBatch process` test filter

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5.6)
