### PR TITLE
[SPARK-58437][SQL] Fix invalid Java constructs in generated code

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -402,6 +402,18 @@ class CodegenContext extends Logging {
   }
 
   def declareMutableStates(): String = {
+    def rawJavaType(javaType: String): String = {
+      val builder = new StringBuilder
+      var depth = 0
+      javaType.foreach {
+        case '<' => depth += 1
+        case '>' => depth -= 1
+        case c if depth == 0 => builder.append(c)
+        case _ =>
+      }
+      builder.toString
+    }
+
     // It's possible that we add same mutable state twice, e.g. the `mergeExpressions` in
     // `TypedAggregateExpression`, we should call `distinct` here to remove the duplicated ones.
     val inlinedStates = inlinedMutableStates.distinct.map { case (javaType, variableName) =>
@@ -419,10 +431,10 @@ class CodegenContext extends Logging {
         if (javaType.contains("[]")) {
           // initializer had an one-dimensional array variable
           val baseType = javaType.substring(0, javaType.length - 2)
-          s"private $javaType[] $arrayName = new $baseType[$length][];"
+          s"private $javaType[] $arrayName = new ${rawJavaType(baseType)}[$length][];"
         } else {
           // initializer had a scalar variable
-          s"private $javaType[] $arrayName = new $javaType[$length];"
+          s"private $javaType[] $arrayName = new ${rawJavaType(javaType)}[$length];"
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -303,7 +303,8 @@ class CodegenContext extends Logging {
    *                 e.g. InternalRow, UnsafeRow, UnsafeArrayData, etc. Other types will have to
    *                 specify the fully-qualified Java type name. See the code in doCompile() for
    *                 the list of default imports available.
-   *                 Also, generic type arguments are accepted but ignored.
+   *                 Also, generic type arguments are kept in field declarations, but stripped
+   *                 from array creation expressions because Java forbids generic array creation.
    * @param variableName Name of the field.
    * @param initFunc Function includes statement(s) to put into the init() method to initialize
    *                 this field. The argument is the name of the mutable state variable.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3992,9 +3992,9 @@ object Sequence {
        |  ($estimatedStep < 0 && $start >= $stop) ||
        |  ($estimatedStep == 0 && $start == $stop))) {
        |  java.util.Map<String, String> params = new java.util.HashMap<String, String>();
-       |  params.put("start", String.valueOf($start));
-       |  params.put("stop", String.valueOf($stop));
-       |  params.put("step", String.valueOf($step));
+       |  params.put("start", $start);
+       |  params.put("stop", $stop);
+       |  params.put("step", $step);
        |  throw new org.apache.spark.SparkIllegalArgumentException(
        |    "_LEGACY_ERROR_TEMP_3243", params);
        |}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3535,7 +3535,7 @@ case class Sequence(
       val arr = ctx.freshName("arr")
       val arrElemType = CodeGenerator.javaType(dataType.elementType)
       s"""
-         |final $arrElemType[] $arr = null;
+         |$arrElemType[] $arr = null;
          |${impl.genCode(ctx, startGen.value, stopGen.value, stepGen.value, arr, arrElemType)}
          |${ev.value} = UnsafeArrayData.fromPrimitiveArray($arr);
        """.stripMargin
@@ -3992,9 +3992,9 @@ object Sequence {
        |  ($estimatedStep < 0 && $start >= $stop) ||
        |  ($estimatedStep == 0 && $start == $stop))) {
        |  java.util.Map<String, String> params = new java.util.HashMap<String, String>();
-       |  params.put("start", $start);
-       |  params.put("stop", $stop);
-       |  params.put("step", $step);
+       |  params.put("start", String.valueOf($start));
+       |  params.put("stop", String.valueOf($stop));
+       |  params.put("step", String.valueOf($step));
        |  throw new org.apache.spark.SparkIllegalArgumentException(
        |    "_LEGACY_ERROR_TEMP_3243", params);
        |}
@@ -4467,7 +4467,7 @@ case class ArrayDistinct(child: Expression)
         val classTag = s"scala.reflect.ClassTag$$.MODULE$$.$hsTypeName()"
         val hashSet = ctx.freshName("hashSet")
         val arrayBuilder = classOf[mutable.ArrayBuilder[_]].getName
-        val arrayBuilderClass = s"$arrayBuilder$$of$ptName"
+        val arrayBuilderClass = s"$arrayBuilder.of$ptName"
 
         // Only need to track null element index when array's element is nullable.
         val declareNullTrackVariables = if (resultArrayElementNullable) {
@@ -4668,7 +4668,7 @@ case class ArrayUnion(left: Expression, right: Expression) extends ArrayBinaryLi
         val classTag = s"scala.reflect.ClassTag$$.MODULE$$.$hsTypeName()"
         val hashSet = ctx.freshName("hashSet")
         val arrayBuilder = classOf[mutable.ArrayBuilder[_]].getName
-        val arrayBuilderClass = s"$arrayBuilder$$of$ptName"
+        val arrayBuilderClass = s"$arrayBuilder.of$ptName"
 
         val body =
           s"""
@@ -4893,7 +4893,7 @@ case class ArrayIntersect(left: Expression, right: Expression) extends ArrayBina
         val hashSet = ctx.freshName("hashSet")
         val hashSetResult = ctx.freshName("hashSetResult")
         val arrayBuilder = classOf[mutable.ArrayBuilder[_]].getName
-        val arrayBuilderClass = s"$arrayBuilder$$of$ptName"
+        val arrayBuilderClass = s"$arrayBuilder.of$ptName"
 
         val withArray2NaNCheckCodeGenerator =
           (array: String, index: String) =>
@@ -5118,7 +5118,7 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
         val classTag = s"scala.reflect.ClassTag$$.MODULE$$.$hsTypeName()"
         val hashSet = ctx.freshName("hashSet")
         val arrayBuilder = classOf[mutable.ArrayBuilder[_]].getName
-        val arrayBuilderClass = s"$arrayBuilder$$of$ptName"
+        val arrayBuilderClass = s"$arrayBuilder.of$ptName"
 
         val withArray2NaNCheckCodeGenerator =
           (array: String, index: String) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -442,6 +442,48 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(ctx2.mutableStateInitCode.size == CodeGenerator.MUTABLESTATEARRAY_SIZE_LIMIT + 10)
   }
 
+  test("SPARK-58437: declare generic mutable state arrays with raw array creation") {
+    val ctx = new CodegenContext
+    val samplerType =
+      "org.apache.spark.util.random.BernoulliCellSampler" +
+        "<org.apache.spark.sql.catalyst.expressions.UnsafeRow>"
+    for (_ <- 1 to CodeGenerator.OUTER_CLASS_VARIABLES_THRESHOLD + 1) {
+      ctx.addMutableState(samplerType, "sampler")
+    }
+
+    val states = ctx.declareMutableStates()
+    assert(states.contains(s"private $samplerType[]"))
+    assert(!states.contains(s"new $samplerType["))
+    assert(states.contains("new org.apache.spark.util.random.BernoulliCellSampler["))
+  }
+
+  test("SPARK-58437: generate javac-compatible source for collection expressions") {
+    val intArray =
+      BoundReference(0, ArrayType(IntegerType, containsNull = false), nullable = false)
+    val intArray2 =
+      BoundReference(1, ArrayType(IntegerType, containsNull = false), nullable = false)
+    val collectionExprs = Seq(
+      ArrayDistinct(intArray),
+      ArrayUnion(intArray, intArray2),
+      ArrayIntersect(intArray, intArray2),
+      ArrayExcept(intArray, intArray2))
+
+    collectionExprs.foreach { expr =>
+      val ctx = new CodegenContext
+      val exprCode = expr.genCode(ctx).code.toString
+      val code = exprCode + "\n" + ctx.declareAddedFunctions()
+      assert(!code.contains("ArrayBuilder$ofInt"))
+      assert(code.contains("ArrayBuilder.ofInt"))
+    }
+
+    val sequence = new Sequence(
+      BoundReference(0, IntegerType, nullable = false),
+      BoundReference(1, IntegerType, nullable = false),
+      BoundReference(2, IntegerType, nullable = false))
+    val sequenceCode = sequence.genCode(new CodegenContext).code.toString
+    assert(!sequenceCode.contains("final int[]"))
+  }
+
   test("SPARK-22750: addImmutableStateIfNotExists") {
     val ctx = new CodegenContext
     val mutableState1 = "field1"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -24,8 +24,7 @@ import java.util.TimeZone
 import scala.language.implicitConversions
 import scala.util.Random
 
-import org.apache.spark.{SparkArrayIndexOutOfBoundsException, SparkFunSuite}
-import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException}
+import org.apache.spark.{SparkArrayIndexOutOfBoundsException, SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
@@ -1114,21 +1113,6 @@ class CollectionExpressionsSuite
       new Sequence(Literal(2), Literal(1), Literal(1)), EmptyRow, "boundaries: 2 to 1 by 1")
     checkExceptionInExpression[IllegalArgumentException](
       new Sequence(Literal(1), Literal(2), Literal(-1)), EmptyRow, "boundaries: 1 to 2 by -1")
-
-    withSQLConf(
-      SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.CODEGEN_ONLY.toString) {
-      checkError(
-        exception = intercept[SparkIllegalArgumentException] {
-          evaluateWithMutableProjection(
-            new Sequence(
-              BoundReference(0, IntegerType, nullable = false),
-              Literal(1),
-              Literal(1)),
-            InternalRow(2))
-        },
-        condition = "_LEGACY_ERROR_TEMP_3243",
-        parameters = Map("start" -> "2", "stop" -> "1", "step" -> "1"))
-    }
 
     // SPARK-43393: test Sequence overflow checking
     checkErrorInExpression[SparkRuntimeException](

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -24,7 +24,8 @@ import java.util.TimeZone
 import scala.language.implicitConversions
 import scala.util.Random
 
-import org.apache.spark.{SparkArrayIndexOutOfBoundsException, SparkFunSuite, SparkRuntimeException}
+import org.apache.spark.{SparkArrayIndexOutOfBoundsException, SparkFunSuite}
+import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
@@ -1113,6 +1114,21 @@ class CollectionExpressionsSuite
       new Sequence(Literal(2), Literal(1), Literal(1)), EmptyRow, "boundaries: 2 to 1 by 1")
     checkExceptionInExpression[IllegalArgumentException](
       new Sequence(Literal(1), Literal(2), Literal(-1)), EmptyRow, "boundaries: 1 to 2 by -1")
+
+    withSQLConf(
+      SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.CODEGEN_ONLY.toString) {
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          evaluateWithMutableProjection(
+            new Sequence(
+              BoundReference(0, IntegerType, nullable = false),
+              Literal(1),
+              Literal(1)),
+            InternalRow(2))
+        },
+        condition = "_LEGACY_ERROR_TEMP_3243",
+        parameters = Map("start" -> "2", "stop" -> "1", "step" -> "1"))
+    }
 
     // SPARK-43393: test Sequence overflow checking
     checkErrorInExpression[SparkRuntimeException](

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -146,7 +146,7 @@ case class SortExec(
       v => s"$v = $thisPlan.createSorter();", forceInline = true)
     val metrics = ctx.addMutableState(classOf[TaskMetrics].getName, "metrics",
       v => s"$v = org.apache.spark.TaskContext.get().taskMetrics();", forceInline = true)
-    val sortedIterator = ctx.addMutableState("scala.collection.Iterator<UnsafeRow>", "sortedIter",
+    val sortedIterator = ctx.addMutableState("scala.collection.Iterator<InternalRow>", "sortedIter",
       forceInline = true)
 
     val addToSorter = ctx.freshName("addToSorter")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -753,6 +753,12 @@ class WholeStageCodegenSuite extends SharedSparkSession
     assert(df.collect() === Array(Row(1), Row(2), Row(3)))
   }
 
+  test("SPARK-58437: SortExec generates assignable iterator type") {
+    val code = genCode(spark.range(3, 0, -1).toDF().sort(col("id"))).map(_.body).mkString("\n")
+    assert(!code.contains("scala.collection.Iterator<UnsafeRow>"))
+    assert(code.contains("scala.collection.Iterator<InternalRow>"))
+  }
+
   test("MapElements should be included in WholeStageCodegen") {
     import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes several generated-code patterns that Janino accepts but javac rejects:

- Avoids declaring the generated `sequence` array local as `final` before assigning to it.
- Emits primitive `ArrayBuilder` inner class references with source-compatible names such as `ArrayBuilder.ofInt`.
- Uses `Iterator<InternalRow>` for `SortExec`'s generated sorted iterator state, matching the sorter return type.
- Creates mutable state arrays for generic Java types with raw array creation while preserving the generic field type.

It also adds focused regression coverage for these generated-code shapes.

### Why are the changes needed?

Spark currently relies on Janino for whole-stage codegen, and Janino tolerates some constructs that are not valid Java source for javac. These changes remove invalid Java source patterns as preparatory work for javac-compatible generated-code paths.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added regression tests and ran:

```
build/sbt 'catalyst/testOnly org.apache.spark.sql.catalyst.expressions.CodeGenerationSuite -- -z "SPARK-58437"' 'sql/testOnly org.apache.spark.sql.execution.WholeStageCodegenSuite -- -z "SPARK-58437"'
```

Also ran:

```
git diff --check
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (OpenAI GPT-5) was used for code assistance and review support; the patch was guided by the contributor.