### PR TITLE
[MINOR][DOCS] Document pointing the s3a connector at an S3-compatible object store

### DIFF
--- a/docs/cloud-integration.md
+++ b/docs/cloud-integration.md
@@ -140,6 +140,22 @@ configuration and security options.
 Each cloud connector has its own set of configuration parameters, again, 
 consult the relevant documentation.
 
+### Working with S3-compatible object stores
+
+The `s3a` connector talks to Amazon S3 by default, and it also works with any
+S3-compatible object store, such as Backblaze B2, Cloudflare R2, or MinIO. To
+use a compatible store, point the connector at its endpoint (and set the region
+where the store requires one) instead of the default Amazon S3 endpoint:
+
+```
+spark.hadoop.fs.s3a.endpoint          <s3-compatible-endpoint>
+spark.hadoop.fs.s3a.endpoint.region   <region>
+```
+
+Supply credentials for the chosen store through the same options described in
+[Authenticating](#authenticating), and consult the store's own documentation for
+its endpoint, region, and any connector-specific settings.
+
 ### Recommended settings for writing to object stores
 
 For object stores whose consistency model means that rename-based commits are safe


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds a short `Working with S3-compatible object stores` subsection to the `Configuring` section of `docs/cloud-integration.md`. It notes that the `s3a` connector targets Amazon S3 by default and also works against S3-compatible object stores (Backblaze B2, Cloudflare R2, MinIO are named as examples), shows the two settings used to point it elsewhere with placeholder values:

```
spark.hadoop.fs.s3a.endpoint          <s3-compatible-endpoint>
spark.hadoop.fs.s3a.endpoint.region   <region>
```

and refers back to the existing `Authenticating` section for credentials plus the store's own documentation for the remaining connector settings. 16 added lines, no existing text changed.

### Why are the changes needed?
The page currently covers the `s3a` connector as the Amazon S3 connector. `AWS_ENDPOINT_URL` appears once under `Authenticating`, but the `spark.hadoop.fs.s3a.endpoint` and `spark.hadoop.fs.s3a.endpoint.region` settings are not shown anywhere, so a reader pointing `s3a` at a compatible store has to leave the page to find them. This is a discoverability fix only; no connector behavior is being described that Spark and Hadoop do not already support.

### Does this PR introduce _any_ user-facing change?
No. This is a documentation-only change.

### How was this patch tested?
Docs-only change. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 5)
