### PR TITLE
[SPARK-58459][INFRA] Manage build_main.yml per-branch instead of gating on github.ref

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -29,12 +29,9 @@ jobs:
     permissions:
       packages: write
     name: Run
-    # Skip:
-    #   - pushes to `branch-4.x` on apache/spark: post-merge CI on this
-    #     integration/staging branch is disabled to save resources.
-    #   - pushes to `master` on forks: the "Sync fork" button mirrors
-    #     apache/spark and would otherwise re-run the full build on every sync.
+    # Skip pushes to `master` on forks: the "Sync fork" button mirrors
+    # apache/spark and would otherwise re-run the full build on every sync.
     if: >-
-      (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
-      || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
+      github.repository == 'apache/spark'
+      || github.ref != 'refs/heads/master'
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `github.ref != 'refs/heads/branch-4.x'` clause from the `call-build-and-test` job condition in `build_main.yml` on `master`. For a `push` event, GitHub Actions always evaluates the workflow file from the ref being pushed, so `master`'s copy of this file is only ever evaluated for pushes to `master` -- meaning that comparison can never be false and is dead. Disabling post-merge CI on `branch-4.x` is instead handled in that branch's own copy of the workflow (separate PR against `branch-4.x`).

The fork sync-`master` skip is retained:

```yaml
if: >-
  github.repository == 'apache/spark'
  || github.ref != 'refs/heads/master'
```

### Why are the changes needed?

The other build workflows (e.g. `build_java21.yml`, `build_python_3.11.yml`) are already managed per-branch, diverging in name/schedule/`branch:` between `master` and `branch-4.x`. `build_main.yml` was the exception, encoding branch-specific behavior via a runtime `github.ref` check that is inert on `master`. Aligning it with the rest keeps each branch's workflow file self-describing.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A. CI-configuration-only change; behavior on `master` is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

This pull request and its description were written by Isaac.