### PR TITLE
[SPARK-58459][4.x][INFRA] Manage build_main.yml per-branch instead of gating on github.ref

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -29,12 +29,7 @@ jobs:
     permissions:
       packages: write
     name: Run
-    # Skip:
-    #   - pushes to `branch-4.x` on apache/spark: post-merge CI on this
-    #     integration/staging branch is disabled to save resources.
-    #   - pushes to `master` on forks: the "Sync fork" button mirrors
-    #     apache/spark and would otherwise re-run the full build on every sync.
-    if: >-
-      (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
-      || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
+    # Skip pushes on apache/spark: post-merge CI on this integration/staging
+    # branch is disabled to save resources.
+    if: github.repository != 'apache/spark'
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the `github.ref`-based job condition in `build_main.yml` on `branch-4.x` with a simple `github.repository != 'apache/spark'` check. Post-merge CI on the `branch-4.x` integration/staging branch is disabled to save resources; since this branch's copy of the workflow is only ever evaluated for pushes to `branch-4.x`, no `github.ref` comparison is needed to express that.

```yaml
if: github.repository != 'apache/spark'
```

### Why are the changes needed?

The other build workflows (e.g. `build_java21.yml`, `build_python_3.11.yml`) are already managed per-branch, diverging in name/schedule/`branch:` between `master` and `branch-4.x`. `build_main.yml` was the exception, encoding branch-specific behavior via a runtime `github.ref` check. Aligning it with the rest keeps each branch's workflow file self-describing.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A. CI-configuration-only change; post-merge CI remains disabled on `branch-4.x` while fork pushes still run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

This pull request and its description were written by Isaac.