### PR TITLE
[SPARK-58465][PS] Use native expressions for NumPy reciprocal of floating-point columns

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -24,9 +24,6 @@ from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
 
-_pandas_udf_reciprocal = pandas_udf(np.reciprocal, DoubleType())  # type: ignore[call-overload]
-
-
 unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
@@ -79,7 +76,9 @@ unary_np_spark_mappings = {
             ),
         )
         .otherwise(F.lit(1.0) / c),
-    ).otherwise(_pandas_udf_reciprocal(c)),
+    ).otherwise(
+        pandas_udf(np.reciprocal, DoubleType())(c)  # type: ignore[call-overload]
+    ),
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -71,9 +71,7 @@ unary_np_spark_mappings = {
         F.when(c.isNull(), c.cast("double"))
         .when(
             c == 0,
-            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(
-                F.lit(float("inf"))
-            ),
+            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
         )
         .otherwise(F.lit(1.0) / c),
     ).otherwise(

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -24,6 +24,11 @@ from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
 
+_pandas_udf_reciprocal = pandas_udf(
+    lambda s: np.reciprocal(s), DoubleType()
+)  # type: ignore[call-overload]
+
+
 unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
@@ -66,9 +71,17 @@ unary_np_spark_mappings = {
     "positive": F.positive,
     "rad2deg": F.degrees,
     "radians": F.radians,
-    "reciprocal": pandas_udf(  # type: ignore[call-overload]
-        lambda s: np.reciprocal(s), DoubleType()
-    ),
+    "reciprocal": lambda c: F.when(
+        F.typeof(c).isin("float", "double"),
+        F.when(c.isNull(), c.cast("double"))
+        .when(
+            c == 0,
+            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(
+                F.lit(float("inf"))
+            ),
+        )
+        .otherwise(F.lit(1.0) / c),
+    ).otherwise(_pandas_udf_reciprocal(c)),
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -24,7 +24,12 @@ from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
 
-_pandas_udf_reciprocal = pandas_udf(np.reciprocal, DoubleType())  # type: ignore[call-overload]
+def _reciprocal(c):
+    c = c.cast("double")
+    return F.when(c.isNull(), c).when(
+        c == 0,
+        F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
+    ).otherwise(F.lit(1.0) / c)
 
 
 unary_np_spark_mappings = {
@@ -69,15 +74,7 @@ unary_np_spark_mappings = {
     "positive": F.positive,
     "rad2deg": F.degrees,
     "radians": F.radians,
-    "reciprocal": lambda c: F.when(
-        F.typeof(c).isin("float", "double"),
-        F.when(c.isNull(), c.cast("double"))
-        .when(
-            c == 0,
-            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
-        )
-        .otherwise(F.lit(1.0) / c),
-    ).otherwise(_pandas_udf_reciprocal(c)),
+    "reciprocal": _reciprocal,
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -23,15 +23,6 @@ from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
-
-def _reciprocal(c):
-    c = c.cast("double")
-    return F.when(c.isNull(), c).when(
-        c == 0,
-        F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
-    ).otherwise(F.lit(1.0) / c)
-
-
 unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
@@ -74,7 +65,14 @@ unary_np_spark_mappings = {
     "positive": F.positive,
     "rad2deg": F.degrees,
     "radians": F.radians,
-    "reciprocal": _reciprocal,
+    "reciprocal": lambda c: F.when(c.cast("double").isNull(), c.cast("double"))
+    .when(
+        c.cast("double") == 0,
+        F.when(c.cast("double").cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(
+            F.lit(float("inf"))
+        ),
+    )
+    .otherwise(F.lit(1.0) / c.cast("double")),
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -24,9 +24,7 @@ from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
 
-_pandas_udf_reciprocal = pandas_udf(
-    lambda s: np.reciprocal(s), DoubleType()
-)  # type: ignore[call-overload]
+_pandas_udf_reciprocal = pandas_udf(np.reciprocal, DoubleType())  # type: ignore[call-overload]
 
 
 unary_np_spark_mappings = {
@@ -76,9 +74,7 @@ unary_np_spark_mappings = {
         F.when(c.isNull(), c.cast("double"))
         .when(
             c == 0,
-            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(
-                F.lit(float("inf"))
-            ),
+            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
         )
         .otherwise(F.lit(1.0) / c),
     ).otherwise(_pandas_udf_reciprocal(c)),

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -23,6 +23,10 @@ from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
+
+_pandas_udf_reciprocal = pandas_udf(np.reciprocal, DoubleType())  # type: ignore[call-overload]
+
+
 unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
@@ -65,14 +69,17 @@ unary_np_spark_mappings = {
     "positive": F.positive,
     "rad2deg": F.degrees,
     "radians": F.radians,
-    "reciprocal": lambda c: F.when(c.cast("double").isNull(), c.cast("double"))
-    .when(
-        c.cast("double") == 0,
-        F.when(c.cast("double").cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(
-            F.lit(float("inf"))
-        ),
-    )
-    .otherwise(F.lit(1.0) / c.cast("double")),
+    "reciprocal": lambda c: F.when(
+        F.typeof(c).isin("float", "double"),
+        F.when(c.isNull(), c.cast("double"))
+        .when(
+            c == 0,
+            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(
+                F.lit(float("inf"))
+            ),
+        )
+        .otherwise(F.lit(1.0) / c),
+    ).otherwise(_pandas_udf_reciprocal(c)),
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -105,6 +105,10 @@ class NumPyCompatTestsMixin:
             (np.positive, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.rad2deg, [-np.inf, -64.0, -np.pi, 0.0, np.pi, 64.0, np.inf, np.nan]),
             (np.rint, [-np.inf, -2.5, -1.5, -0.5, -0.0, 0.0, 0.5, 1.5, 2.5, np.inf, np.nan]),
+            (
+                np.reciprocal,
+                [-np.inf, -64.0, -2.0, -1.0, -0.0, 0.0, 1.0, 2.0, 64.0, np.inf, np.nan],
+            ),
             (np.sign, [-np.inf, -64.0, -2.0, -0.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.sinh, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.square, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use native Spark SQL expressions for NumPy reciprocal on pandas-on-Spark columns with Spark `float` or `double` types. The expressions preserve nulls, NaN, infinity, and signed zero. Inputs with other types continue to use the existing pandas UDF.

### Why are the changes needed?

Native expressions avoid the Python worker boundary for floating-point reciprocal while retaining the established behavior for input types with NumPy-specific semantics.

### Does this PR introduce _any_ user-facing change?

No. The behavior and result type remain unchanged.

### How was this patch tested?

- Added reciprocal coverage for negative zero in `NumPyCompatTests.test_np_math_functions`.
- Passed `NumPyCompatTests.test_np_math_functions` and `NumPyCompatTests.test_np_spark_compat_series`.
- Passed Ruff format and lint checks for `python/pyspark/pandas/numpy_compat.py`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)