### PR TITLE
[SPARK-58467][SQL] Add scalar external UDF planning support

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8945,7 +8945,7 @@
       },
       "EXTERNAL_UDF" : {
         "message" : [
-          "External UDF expressions. Set <config> to true to enable them."
+          "External UDF expressions are disabled. Set <config> to true to enable planning."
         ]
       },
       "EXTERNAL_UDF_IN_ON_CLAUSE" : {
@@ -8955,7 +8955,7 @@
       },
       "EXTERNAL_UDF_WITH_MULTIPLE_CHILDREN" : {
         "message" : [
-          "External UDF whose arguments reference more than one child operator. Rewrite the query so the UDF is evaluated after the inputs are combined."
+          "External UDF <funcName> uses columns from more than one input relation. Rewrite the query so the UDF is evaluated after the inputs are combined."
         ]
       },
       "GEOSPATIAL_DISABLED" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8943,6 +8943,21 @@
           "Drop the namespace <namespace>."
         ]
       },
+      "EXTERNAL_UDF" : {
+        "message" : [
+          "External UDF expressions. Set <config> to true to enable them."
+        ]
+      },
+      "EXTERNAL_UDF_IN_ON_CLAUSE" : {
+        "message" : [
+          "External UDF in the ON clause of a <joinType> JOIN. In case of an INNER JOIN consider rewriting to a CROSS JOIN with a WHERE clause."
+        ]
+      },
+      "EXTERNAL_UDF_WITH_MULTIPLE_CHILDREN" : {
+        "message" : [
+          "External UDF whose arguments reference more than one child operator. Rewrite the query so the UDF is evaluated after the inputs are combined."
+        ]
+      },
       "GEOSPATIAL_DISABLED" : {
         "message" : [
           "Geospatial feature is disabled."
@@ -8966,6 +8981,12 @@
       "INTERRUPT_TYPE" : {
         "message" : [
           "Unsupported interrupt type: <interruptType>."
+        ]
+      },
+      "LAMBDA_FUNCTION_WITH_EXTERNAL_UDF" : {
+        "message" : [
+          "Cannot evaluate the external UDF <funcName> inside the lambda of a higher-order function.",
+          "This placement is not supported. Rewrite the query so the UDF is applied outside the lambda."
         ]
       },
       "LAMBDA_FUNCTION_WITH_PYTHON_UDF" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -528,6 +528,15 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_PYTHON_UDF",
               messageParameters = Map("funcName" -> toSQLExpr(u)))
 
+          case hof: HigherOrderFunction
+              if hof.resolved && hof.functions
+                .exists(_.exists(_.isInstanceOf[ExternalUserDefinedFunction])) =>
+            val u = hof.functions
+              .flatMap(_.find(_.isInstanceOf[ExternalUserDefinedFunction])).head
+            hof.failAnalysis(
+              errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF",
+              messageParameters = Map("funcName" -> toSQLExpr(u)))
+
           // If an attribute can't be resolved as a map key of string type, either the key should be
           // surrounded with single quotes, or there is a typo in the attribute name.
           case GetMapValue(map, key: Attribute) if isMapWithStringKey(map) && !key.resolved =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -264,6 +264,18 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
     )
   }
 
+  private object ResolvedHigherOrderFunctionWithExternalUDF {
+    def unapply(expression: Expression): Option[(HigherOrderFunction, Expression)] = {
+      expression match {
+        case hof: HigherOrderFunction if hof.resolved =>
+          hof.functions.iterator.flatMap(_.collectFirst {
+            case udf: ExternalUserDefinedFunction => udf
+          }).take(1).toSeq.headOption.map(udf => (hof, udf))
+        case _ => None
+      }
+    }
+  }
+
   private def containsUnsupportedLCA(e: Expression, operator: LogicalPlan): Boolean = {
     e.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE) && operator.expressions.exists {
       case a: Alias
@@ -528,14 +540,10 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_PYTHON_UDF",
               messageParameters = Map("funcName" -> toSQLExpr(u)))
 
-          case hof: HigherOrderFunction
-              if hof.resolved && hof.functions
-                .exists(_.exists(_.isInstanceOf[ExternalUserDefinedFunction])) =>
-            val u = hof.functions
-              .flatMap(_.find(_.isInstanceOf[ExternalUserDefinedFunction])).head
+          case ResolvedHigherOrderFunctionWithExternalUDF(hof, udf) =>
             hof.failAnalysis(
               errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF",
-              messageParameters = Map("funcName" -> toSQLExpr(u)))
+              messageParameters = Map("funcName" -> toSQLExpr(udf)))
 
           // If an attribute can't be resolved as a map key of string type, either the key should be
           // surrounded with single quotes, or there is a typo in the attribute name.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NondeterministicExpressionCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NondeterministicExpressionCollection.scala
@@ -31,6 +31,7 @@ object NondeterministicExpressionCollection {
         val leafNondeterministic = expr.collect {
           case nondeterministicExpr: Nondeterministic => nondeterministicExpr
           case udf: UserDefinedExpression if !udf.deterministic => udf
+          case udf: ExternalUserDefinedFunction if !udf.deterministic => udf
         }
 
         for (nondeterministicExpr <- leafNondeterministic.distinct) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -519,6 +519,8 @@ trait NonSQLExpression extends Expression {
       case a: Attribute => new PrettyAttribute(a)
       case a: Alias => PrettyAttribute(a.sql, a.dataType)
       case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
+      case udf: ExternalUserDefinedFunction =>
+        PrettyPythonUDF(udf.name.getOrElse(udf.prettyName), udf.dataType, udf.children)
       // Render a transpiled UDF like the UDF it wraps (options must not leak
       // into user-visible strings).
       case t: TranspiledPythonUDF => PrettyPythonUDF(t.name, t.dataType, t.pythonUDFExpr.children)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExternalUserDefinedFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExternalUserDefinedFunction.scala
@@ -21,6 +21,7 @@ import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckSuccess
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXTERNAL_UDF, TreePattern}
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.udf.worker.UDFWorkerSpecification
 
@@ -68,9 +69,20 @@ case class ExternalUserDefinedFunction(
 
   override def checkInputDataTypes(): TypeCheckResult = {
     inputTypes match {
-      case Some(types) => ExpectsInputTypes.checkInputDataTypes(children, types)
+      case Some(types) if types.length != children.length =>
+        throw QueryCompilationErrors.wrongNumArgsError(
+          name = name.getOrElse(prettyName),
+          validParametersCount = Seq(types.length),
+          actualNumber = children.length)
+      case Some(types) =>
+        ExpectsInputTypes.checkInputDataTypes(children, types)
       case None => TypeCheckSuccess
     }
+  }
+
+  // Worker specifications and payloads can contain sensitive execution details.
+  override def toString: String = {
+    s"${name.getOrElse(prettyName)}(${children.mkString(", ")})#${resultId.id}$typeSuffix"
   }
 
   override lazy val canonicalized: Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExternalUserDefinedFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExternalUserDefinedFunction.scala
@@ -18,8 +18,11 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckSuccess
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXTERNAL_UDF, TreePattern}
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.udf.worker.UDFWorkerSpecification
 
 /**
  * :: Experimental ::
@@ -37,6 +40,7 @@ import org.apache.spark.sql.types.DataType
  * to execute.
  *
  * @param name             Optional name of the UDF.
+ * @param workerSpec       Specification of the worker that executes this UDF.
  * @param payload          Opaque serialized function definition.
  * @param dataType         Return type of the UDF.
  * @param children         Input argument expressions.
@@ -48,6 +52,7 @@ import org.apache.spark.sql.types.DataType
 @Experimental
 case class ExternalUserDefinedFunction(
     name: Option[String],
+    workerSpec: UDFWorkerSpecification,
     payload: Array[Byte],
     dataType: DataType,
     children: Seq[Expression],
@@ -60,6 +65,13 @@ case class ExternalUserDefinedFunction(
   override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
 
   override def nullable: Boolean = udfNullable
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    inputTypes match {
+      case Some(types) => ExpectsInputTypes.checkInputDataTypes(children, types)
+      case None => TypeCheckSuccess
+    }
+  }
 
   override lazy val canonicalized: Expression = {
     val canonicalizedChildren = children.map(_.canonicalized)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -67,7 +67,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Set(
       "PartitionPruning",
       "RewriteSubquery",
-      "Extract Python UDFs",
+      "Extract UDFs",
       "Infer Filters")
 
   protected def fixedPoint =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1022,6 +1022,10 @@ object LimitPushDown extends Rule[LogicalPlan] {
       LocalLimit(le, udf.copy(child = maybePushLocalLimit(le, udf.child)))
     case LocalLimit(le, p @ Project(_, udf: ArrowEvalPython)) =>
       LocalLimit(le, p.copy(child = udf.copy(child = maybePushLocalLimit(le, udf.child))))
+    case LocalLimit(le, udf: ExecuteExternalUDF) =>
+      LocalLimit(le, udf.copy(child = maybePushLocalLimit(le, udf.child)))
+    case LocalLimit(le, p @ Project(_, udf: ExecuteExternalUDF)) =>
+      LocalLimit(le, p.copy(child = udf.copy(child = maybePushLocalLimit(le, udf.child))))
   }
 }
 
@@ -2452,6 +2456,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     case _: RebalancePartitions => true
     case _: ScriptTransformation => true
     case _: Sort => true
+    case _: ExecuteExternalUDF => true
     case _: BatchEvalPython => true
     case _: ArrowEvalPython => true
     case _: Expand => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/logicalExternalUDFOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/logicalExternalUDFOperators.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.resource.ResourceProfile
-import org.apache.spark.sql.catalyst.expressions.{Attribute,
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet,
   ExternalUserDefinedFunction}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.types.StructType
@@ -40,10 +40,45 @@ trait ExternalUDF extends UnaryNode {
 
 /**
  * :: Experimental ::
+ * Logical plan node for evaluating one scalar UDF expression in an external
+ * worker session.
+ *
+ * @param udf UDF expression evaluated by the worker session.
+ * @param resultAttr Output attribute for the UDF expression.
+ * @param child Input relation for the UDF.
+ */
+@Experimental
+case class ExecuteExternalUDF(
+    udf: ExternalUserDefinedFunction,
+    resultAttr: Attribute,
+    child: LogicalPlan)
+  extends ExternalUDF {
+
+  override def workerSpec: UDFWorkerSpecification = udf.workerSpec
+
+  assert(udf.dataType == resultAttr.dataType && udf.nullable == resultAttr.nullable,
+    "The UDF and result attribute must have matching types and nullability")
+  // TODO(SPARK-59049): Support UDF chaining before allowing nested UDFs in one node.
+  assert(!udf.children.exists(_.exists(_.isInstanceOf[ExternalUserDefinedFunction])),
+    "Nested external UDFs must use separate evaluation nodes")
+
+  override def output: Seq[Attribute] = child.output :+ resultAttr
+
+  override def producedAttributes: AttributeSet = AttributeSet(Seq(resultAttr))
+
+  override def maxRows: Option[Long] = child.maxRows
+
+  override def maxRowsPerPartition: Option[Long] = child.maxRowsPerPartition
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): ExecuteExternalUDF =
+    copy(child = newChild)
+}
+
+/**
+ * :: Experimental ::
  * Logical plan node for mapPartitions-style UDF execution in an
  * external worker process.
  *
- * @param workerSpec       Specification describing the UDF worker.
  * @param function         The UDF to invoke. Output attributes are
  *                         derived from `function.dataType`.
  * @param isBarrier        Whether to use barrier execution.
@@ -52,12 +87,13 @@ trait ExternalUDF extends UnaryNode {
  */
 @Experimental
 case class MapPartitionsExternalUDF(
-    workerSpec: UDFWorkerSpecification,
     function: ExternalUserDefinedFunction,
     isBarrier: Boolean,
     profile: Option[ResourceProfile],
     child: LogicalPlan)
   extends ExternalUDF {
+
+  override def workerSpec: UDFWorkerSpecification = function.workerSpec
 
   val nodeOutputAttributes = toAttributes(
     function.dataType.asInstanceOf[StructType]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3010,6 +3010,18 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("joinType" -> toSQLStmt(joinType.sql)))
   }
 
+  def useExternalUDFInJoinConditionUnsupportedError(joinType: JoinType): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE.EXTERNAL_UDF_IN_ON_CLAUSE",
+      messageParameters = Map("joinType" -> toSQLStmt(joinType.sql)))
+  }
+
+  def externalUDFWithMultipleChildrenUnsupportedError(): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE.EXTERNAL_UDF_WITH_MULTIPLE_CHILDREN",
+      messageParameters = Map.empty)
+  }
+
   def conflictingAttributesInJoinConditionError(
       conflictingAttrs: AttributeSet, outerPlan: LogicalPlan, subplan: LogicalPlan): Throwable = {
     new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3016,10 +3016,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("joinType" -> toSQLStmt(joinType.sql)))
   }
 
-  def externalUDFWithMultipleChildrenUnsupportedError(): Throwable = {
+  def externalUDFsDisabledError(config: String): SparkUnsupportedOperationException = {
+    new SparkUnsupportedOperationException(
+      errorClass = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
+      messageParameters = Map("config" -> toSQLConf(config)))
+  }
+
+  def externalUDFWithMultipleChildrenUnsupportedError(udf: Expression): Throwable = {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE.EXTERNAL_UDF_WITH_MULTIPLE_CHILDREN",
-      messageParameters = Map.empty)
+      messageParameters = Map("funcName" -> toSQLExpr(udf)))
   }
 
   def conflictingAttributesInJoinConditionError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5454,16 +5454,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val UNIFIED_UDF_EXECUTION_ENABLED =
-    buildConf("spark.sql.execution.udf.unified.execution.enabled")
-      .doc("When true, enable planning through the language-agnostic external UDF worker " +
-        "framework. Execution requires a supported external UDF physical operator. When false, " +
-        "external UDF expressions are rejected. Experimental.")
-      .version("4.2.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
-      .booleanConf
-      .createWithDefault(false)
-
   val PYTHON_UDF_ARROW_ENABLED =
     buildConf("spark.sql.execution.pythonUDF.arrow.enabled")
       .doc("Enable Arrow optimization in regular Python UDFs. This optimization " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5456,10 +5456,9 @@ object SQLConf {
 
   val UNIFIED_UDF_EXECUTION_ENABLED =
     buildConf("spark.sql.execution.udf.unified.execution.enabled")
-      .doc("When true, UDFs that support the language-agnostic " +
-        "UDF worker protocol are executed via the unified, " +
-        "external UDF worker framework instead of the " +
-        "language-specific runners. Experimental.")
+      .doc("When true, enable planning through the language-agnostic external UDF worker " +
+        "framework. Execution requires a supported external UDF physical operator. When false, " +
+        "external UDF expressions are rejected. Experimental.")
       .version("4.2.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -350,6 +350,17 @@ object StaticSQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val UNIFIED_UDF_EXECUTION_ENABLED =
+    buildStaticConf("spark.sql.execution.udf.unified.execution.enabled")
+      .doc("When true, enable planning through the language-agnostic external UDF worker " +
+        "framework. Execution requires a supported external UDF physical operator. When false, " +
+        "external UDF expressions are rejected. This config must be set before the SparkSession " +
+        "is created. Experimental.")
+      .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(false)
+
   val REFLECT_ALLOW_LIST = buildStaticConf("spark.sql.reflect.allowList")
     .doc("A comma-separated allow list of regular expressions matched against the canonical " +
       "static method name (in the form `class.method`, e.g. `java.util.UUID.randomUUID`) " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -60,6 +60,7 @@ import org.apache.spark.sql.execution.arrow.{ArrowBatchStreamWriter, ArrowConver
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.LogicalRelationWithTable
 import org.apache.spark.sql.execution.datasources.v2.{ExtractV2ScanInfo, ExtractV2Table, FileTable}
+import org.apache.spark.sql.execution.externalUDF.ExternalUDFPlanner
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.internal.SQLConf
@@ -1531,7 +1532,9 @@ class Dataset[T] private[sql](
       profile: ResourceProfile = null): DataFrame = {
     Dataset.ofRows(
       sparkSession,
-      sparkSession.sessionState.externalUDFPlanner.planPythonMapInPandas(
+      ExternalUDFPlanner.planPythonMapInPandas(
+        sparkSession.sessionState.conf,
+        sparkSession.sparkContext.conf,
         funcCol.expr, logicalPlan, isBarrier, Option(profile)))
   }
 
@@ -1546,7 +1549,9 @@ class Dataset[T] private[sql](
       profile: ResourceProfile = null): DataFrame = {
     Dataset.ofRows(
       sparkSession,
-      sparkSession.sessionState.externalUDFPlanner.planPythonMapInArrow(
+      ExternalUDFPlanner.planPythonMapInArrow(
+        sparkSession.sessionState.conf,
+        sparkSession.sparkContext.conf,
         funcCol.expr, logicalPlan, isBarrier, Option(profile)))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources.{MarkSingleTaskExecution, PruneFileSourcePartitions, PullOutVariantExtractions, PushVariantIntoScan, SchemaPruning, V1Writes}
 import org.apache.spark.sql.execution.datasources.v2.{GroupBasedRowLevelOperationScanPlanning, OptimizeMetadataOnlyDeleteFromTable, V2ScanPartitioningAndOrdering, V2ScanRelationPushDown, V2Writes}
 import org.apache.spark.sql.execution.dynamicpruning.{CleanupDynamicPruningFilters, PartitionPruning, RowLevelOperationRuntimeGroupFiltering}
+import org.apache.spark.sql.execution.externalUDF.{ExtractExternalUDFFromWindow, PlanExternalUDFs}
 import org.apache.spark.sql.execution.planmerging.MergeSubplans
 import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggregate, ExtractPythonUDFFromAggregate, ExtractPythonUDFs, ExtractPythonUDTFs}
 
@@ -85,11 +86,11 @@ class SparkOptimizer(
       BooleanSimplification,
       PruneFilters),
     postHocOptimizationBatches,
-    Batch("Extract Python UDFs", Once,
+    Batch("Extract UDFs", Once,
       ExtractPythonUDFFromJoinCondition,
-      // `ExtractPythonUDFFromJoinCondition` can convert a join to a cartesian product.
-      // Here, we rerun cartesian product check.
-      CheckCartesianProducts,
+      // Expose window results as attributes before creating external UDF evaluation nodes.
+      ExtractExternalUDFFromWindow,
+      PlanExternalUDFs,
       ExtractPythonUDFFromAggregate,
       // This must be executed after `ExtractPythonUDFFromAggregate` and before `ExtractPythonUDFs`.
       ExtractGroupingPythonUDFFromAggregate,
@@ -104,6 +105,10 @@ class SparkOptimizer(
       PushPredicateThroughNonJoin,
       PushProjectionThroughLimitAndOffset,
       RemoveNoopOperators),
+    // Join-condition UDF extraction can convert a join to a cartesian product. Keep this in a
+    // subsequent batch so validation structurally follows both join-condition extractors.
+    Batch("Check Cartesian Products After UDF Extraction", Once,
+      CheckCartesianProducts),
     Batch("Infer window group limit", Once,
       InferWindowGroupLimit,
       LimitPushDown,
@@ -121,6 +126,8 @@ class SparkOptimizer(
       ExtractPythonUDFFromJoinCondition.ruleName,
       ExtractPythonUDFFromAggregate.ruleName,
       ExtractGroupingPythonUDFFromAggregate.ruleName,
+      ExtractExternalUDFFromWindow.ruleName,
+      PlanExternalUDFs.ruleName,
       // Non-excludable: a plan with a Python UDF in a higher-order function lambda only works
       // because `ExtractPythonUDFs` lifts it out (via `ExtractPythonUDFFromLambda`).
       ExtractPythonUDFs.ruleName,
@@ -147,7 +154,7 @@ class SparkOptimizer(
    * batch executing the [[ExperimentalMethods]] optimizer rules. This hook can be used to add
    * custom optimizer batches to the Spark optimizer.
    *
-   * Note that 'Extract Python UDFs' batch is an exception and ran after the batches defined here.
+   * Note that 'Extract UDFs' batch is an exception and ran after the batches defined here.
    */
    def postHocOptimizationBatches: Seq[Batch] = Nil
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -154,7 +154,7 @@ class SparkOptimizer(
    * batch executing the [[ExperimentalMethods]] optimizer rules. This hook can be used to add
    * custom optimizer batches to the Spark optimizer.
    *
-   * Note that 'Extract UDFs' batch is an exception and ran after the batches defined here.
+   * Note that 'Extract UDFs' batch is an exception and runs after the batches defined here.
    */
    def postHocOptimizationBatches: Seq[Batch] = Nil
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -1137,11 +1137,13 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.python.MapInPandasExec(func, output, planLater(child), isBarrier, profile) :: Nil
       case logical.MapInArrow(func, output, child, isBarrier, profile) =>
         execution.python.MapInArrowExec(func, output, planLater(child), isBarrier, profile) :: Nil
+      case logical.ExecuteExternalUDF(udf, resultAttr, child) =>
+        execution.externalUDF.ExecuteExternalUDFExec(
+          udf, resultAttr, planLater(child)) :: Nil
       case logical.MapPartitionsExternalUDF(
-          workerSpec, functionExpr, isBarrier, profile, child) =>
+          functionExpr, isBarrier, profile, child) =>
         execution.externalUDF.MapPartitionsExternalUDFExec(
-          workerSpec, functionExpr,
-          isBarrier, profile, planLater(child)) :: Nil
+          functionExpr, isBarrier, profile, planLater(child)) :: Nil
       case logical.AttachDistributedSequence(attr, child, cache) =>
         execution.python.AttachDistributedSequenceExec(attr, planLater(child), cache) :: Nil
       case logical.PythonWorkerLogs(jsonAttr) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExecuteExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExecuteExternalUDFExec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.externalUDF
 
-import org.apache.spark.TaskContext
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -52,13 +51,9 @@ case class ExecuteExternalUDFExec(
   override def producedAttributes: AttributeSet = AttributeSet(Seq(resultAttr))
 
   override protected def doExecute(): RDD[InternalRow] = {
-    child.execute().mapPartitionsInternal { rows =>
-      withUDFWorkerSession(TaskContext.get(), securityScope = None) { session =>
-        // TODO(SPARK-55278): Stream rows to and from the worker through session.process().
-        throw QueryExecutionErrors.methodNotImplementedError(
-          "ExecuteExternalUDFExec.doExecute")
-      }
-    }
+    // TODO(SPARK-55278): Stream rows to and from the worker through session.process().
+    throw QueryExecutionErrors.methodNotImplementedError(
+      "ExecuteExternalUDFExec.doExecute")
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ExecuteExternalUDFExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExecuteExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExecuteExternalUDFExec.scala
@@ -20,56 +20,47 @@ package org.apache.spark.sql.execution.externalUDF
 import org.apache.spark.TaskContext
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.rdd.RDD
-import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{
   Attribute,
+  AttributeSet,
   ExternalUserDefinedFunction
 }
-import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.udf.worker.UDFWorkerSpecification
 
 /**
  * :: Experimental ::
- * Physical plan node that executes a mapPartitions-style UDF in an
- * external worker process.
+ * Physical plan node that evaluates one scalar UDF in an external worker process.
  *
- * @param function         The UDF to invoke.
- * @param isBarrier        Whether the UDF should be invoked using barrier execution.
- * @param profile          Optional resource profile for the UDF execution.
- * @param child            Child plan providing input partitions.
+ * @param udf UDF expression evaluated by the worker session.
+ * @param resultAttr Output attribute for the UDF expression.
+ * @param child Child plan providing input rows.
  */
 @Experimental
-case class MapPartitionsExternalUDFExec(
-    function: ExternalUserDefinedFunction,
-    isBarrier: Boolean,
-    profile: Option[ResourceProfile],
+case class ExecuteExternalUDFExec(
+    udf: ExternalUserDefinedFunction,
+    resultAttr: Attribute,
     child: SparkPlan)
   extends ExternalUDFExec {
 
-  override def workerSpec: UDFWorkerSpecification = function.workerSpec
+  override def workerSpec: UDFWorkerSpecification = udf.workerSpec
 
-  // Map partitions always operate on StructTypes
-  override def output: Seq[Attribute] = toAttributes(
-    function.dataType.asInstanceOf[StructType]
-  )
+  override def output: Seq[Attribute] = child.output :+ resultAttr
+
+  override def producedAttributes: AttributeSet = AttributeSet(Seq(resultAttr))
 
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitionsInternal { rows =>
-      withUDFWorkerSession(TaskContext.get(), securityScope = None) {
-        session =>
-          // TODO [SPARK-55278]: Stream rows to/from the worker
-          // via session.process().
-          throw QueryExecutionErrors.methodNotImplementedError(
-            "MapPartitionsExternalUDFExec.doExecute")
+      withUDFWorkerSession(TaskContext.get(), securityScope = None) { session =>
+        // TODO(SPARK-55278): Stream rows to and from the worker through session.process().
+        throw QueryExecutionErrors.methodNotImplementedError(
+          "ExecuteExternalUDFExec.doExecute")
       }
     }
   }
 
-  override protected def withNewChildInternal(
-      newChild: SparkPlan): MapPartitionsExternalUDFExec =
+  override protected def withNewChildInternal(newChild: SparkPlan): ExecuteExternalUDFExec =
     copy(child = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExecuteExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExecuteExternalUDFExec.scala
@@ -31,9 +31,10 @@ import org.apache.spark.udf.worker.UDFWorkerSpecification
 
 /**
  * :: Experimental ::
- * Physical plan node that evaluates one scalar UDF in an external worker process.
+ * Physical plan node representing one scalar UDF evaluation. Worker execution is intentionally
+ * unimplemented until the scalar worker path is added.
  *
- * @param udf UDF expression evaluated by the worker session.
+ * @param udf UDF expression represented by this node.
  * @param resultAttr Output attribute for the UDF expression.
  * @param child Child plan providing input rows.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanner.scala
@@ -105,12 +105,13 @@ class UnifiedExternalUDFPlanner(
         pythonUdf.func, conf)
     val udf = ExternalUserDefinedFunction(
       name = Some(pythonUdf.name),
+      workerSpec = workerSpec,
       payload = pythonUdf.func.command.toArray,
       dataType = pythonUdf.dataType,
       children = Seq.empty,
       udfDeterministic = pythonUdf.udfDeterministic,
       udfNullable = true)
-    MapPartitionsExternalUDF(workerSpec, udf, isBarrier, profile, child)
+    MapPartitionsExternalUDF(udf, isBarrier, profile, child)
   }
 
   override def planPythonMapInArrow(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanner.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression,
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan,
   MapInArrow, MapInPandas, MapPartitionsExternalUDF}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -32,8 +33,8 @@ import org.apache.spark.sql.types.StructType
  * language-specific runner or the unified external UDF worker
  * framework.
  *
- * Wired into [[org.apache.spark.sql.internal.SessionState]] via
- * [[org.apache.spark.sql.internal.BaseSessionStateBuilder]].
+ * Called by [[org.apache.spark.sql.classic.Dataset]] when constructing logical plans for
+ * partition-oriented UDF operations.
  */
 trait ExternalUDFPlanner {
 
@@ -56,6 +57,36 @@ trait ExternalUDFPlanner {
       child: LogicalPlan,
       isBarrier: Boolean,
       profile: Option[ResourceProfile]): LogicalPlan
+}
+
+object ExternalUDFPlanner {
+  private def planner(sqlConf: SQLConf, sparkConf: SparkConf): ExternalUDFPlanner = {
+    if (sqlConf.getConf(StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED)) {
+      new UnifiedExternalUDFPlanner(sparkConf)
+    } else {
+      new ClassicExternalUDFPlanner()
+    }
+  }
+
+  private[sql] def planPythonMapInPandas(
+      sqlConf: SQLConf,
+      sparkConf: SparkConf,
+      func: Expression,
+      child: LogicalPlan,
+      isBarrier: Boolean,
+      profile: Option[ResourceProfile]): LogicalPlan = {
+    planner(sqlConf, sparkConf).planPythonMapInPandas(func, child, isBarrier, profile)
+  }
+
+  private[sql] def planPythonMapInArrow(
+      sqlConf: SQLConf,
+      sparkConf: SparkConf,
+      func: Expression,
+      child: LogicalPlan,
+      isBarrier: Boolean,
+      profile: Option[ResourceProfile]): LogicalPlan = {
+    planner(sqlConf, sparkConf).planPythonMapInArrow(func, child, isBarrier, profile)
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExtractExternalUDFFromWindow.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExtractExternalUDFFromWindow.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.externalUDF
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, ExprId,
+  ExternalUserDefinedFunction, NamedExpression, WindowExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Window}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{EXTERNAL_UDF, WINDOW}
+
+/**
+ * Extracts external UDFs that are parents of window expressions from a [[Window]] operator.
+ * The window expressions are evaluated by the [[Window]], and [[PlanExternalUDFs]] subsequently
+ * converts the external UDFs in the new [[Project]] into evaluation nodes above it.
+ */
+private[sql] object ExtractExternalUDFFromWindow extends Rule[LogicalPlan] {
+
+  private def containsExternalUDFOverWindowExpression(expression: Expression): Boolean = {
+    expression.exists {
+      case udf: ExternalUserDefinedFunction =>
+        udf.exists(_.isInstanceOf[WindowExpression])
+      case _ => false
+    }
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.transformWithPruning(
+      _.containsAllPatterns(EXTERNAL_UDF, WINDOW)) {
+      case window: Window
+          if window.windowExpressions.exists(containsExternalUDFOverWindowExpression) =>
+        val windowProjectExprIds = mutable.Set.empty[ExprId]
+        val windowProjectList = mutable.ArrayBuffer.empty[NamedExpression]
+        val externalUdfProjectList = window.windowExpressions.map { expression =>
+          if (containsExternalUDFOverWindowExpression(expression)) {
+            expression.transformDown {
+              case windowExpression: WindowExpression =>
+                val alias = Alias(windowExpression, s"w_${windowProjectList.size}")()
+                windowProjectList += alias
+                alias.toAttribute
+              case attribute: Attribute if !windowProjectExprIds.contains(attribute.exprId) =>
+                windowProjectList += attribute
+                windowProjectExprIds += attribute.exprId
+                attribute
+            }.asInstanceOf[NamedExpression]
+          } else {
+            if (!windowProjectExprIds.contains(expression.exprId)) {
+              windowProjectList += expression
+              windowProjectExprIds += expression.exprId
+            }
+            expression.toAttribute
+          }
+        }
+        Project(
+          externalUdfProjectList,
+          window.copy(windowExpressions = windowProjectList.toSeq))
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExtractExternalUDFFromWindow.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExtractExternalUDFFromWindow.scala
@@ -64,7 +64,7 @@ private[sql] object ExtractExternalUDFFromWindow extends Rule[LogicalPlan] {
           }
         }
         Project(
-          externalUdfProjectList,
+          window.child.output ++ externalUdfProjectList,
           window.copy(windowExpressions = windowProjectList.toSeq))
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExtractExternalUDFFromWindow.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExtractExternalUDFFromWindow.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.externalUDF
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, ExprId,
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, ExprId,
   ExternalUserDefinedFunction, NamedExpression, WindowExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Window}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -54,10 +54,6 @@ private[sql] object ExtractExternalUDFFromWindow extends Rule[LogicalPlan] {
                 val alias = Alias(windowExpression, s"w_${windowProjectList.size}")()
                 windowProjectList += alias
                 alias.toAttribute
-              case attribute: Attribute if !windowProjectExprIds.contains(attribute.exprId) =>
-                windowProjectList += attribute
-                windowProjectExprIds += attribute.exprId
-                attribute
             }.asInstanceOf[NamedExpression]
           } else {
             if (!windowProjectExprIds.contains(expression.exprId)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/MapPartitionsExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/MapPartitionsExternalUDFExec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.externalUDF
 
-import org.apache.spark.TaskContext
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.rdd.RDD
 import org.apache.spark.resource.ResourceProfile
@@ -58,15 +57,9 @@ case class MapPartitionsExternalUDFExec(
   )
 
   override protected def doExecute(): RDD[InternalRow] = {
-    child.execute().mapPartitionsInternal { rows =>
-      withUDFWorkerSession(TaskContext.get(), securityScope = None) {
-        session =>
-          // TODO [SPARK-55278]: Stream rows to/from the worker
-          // via session.process().
-          throw QueryExecutionErrors.methodNotImplementedError(
-            "MapPartitionsExternalUDFExec.doExecute")
-      }
-    }
+    // TODO(SPARK-55278): Stream rows to and from the worker through session.process().
+    throw QueryExecutionErrors.methodNotImplementedError(
+      "MapPartitionsExternalUDFExec.doExecute")
   }
 
   override protected def withNewChildInternal(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFs.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.{AGGREGATE, EXTERNAL_UDF, JOIN}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf
 
 /**
  * Converts each scalar external UDF expression into a separate logical evaluation node.
@@ -44,10 +44,10 @@ private[sql] object PlanExternalUDFs
   override def apply(plan: LogicalPlan): LogicalPlan = plan match {
     // A correlated subquery is rewritten as a join and revisits this rule later.
     case subquery: Subquery if subquery.correlated => plan
-    case _ if !conf.getConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED) =>
+    case _ if !conf.getConf(StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED) =>
       if (plan.containsPattern(EXTERNAL_UDF)) {
         throw QueryCompilationErrors.externalUDFsDisabledError(
-          SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key)
+          StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key)
       }
       plan
     case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFs.scala
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.externalUDF
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.LogKeys.JOIN_CONDITION
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.plans.InnerLike
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{AGGREGATE, EXTERNAL_UDF, JOIN}
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Converts each scalar external UDF expression into a separate logical evaluation node.
+ * Join-condition handling mirrors `ExtractPythonUDFFromJoinCondition`.
+ *
+ * TODO(SPARK-55278): Add an external UDF equivalent of `ExtractPythonUDFFromLambda`.
+ * TODO(SPARK-55278): Revisit sharing placement logic with the Python UDF extractors after
+ * external UDF planning semantics stabilize.
+ */
+private[sql] object PlanExternalUDFs
+    extends Rule[LogicalPlan] with Logging with PredicateHelper {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan match {
+    // A correlated subquery is rewritten as a join and revisits this rule later.
+    case subquery: Subquery if subquery.correlated => plan
+    case _ if !conf.getConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED) =>
+      if (plan.containsPattern(EXTERNAL_UDF)) {
+        throw new SparkUnsupportedOperationException(
+          errorClass = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
+          messageParameters = Map(
+            "config" -> SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key))
+      }
+      plan
+    case _ =>
+      val joinPlan = extractExternalUDFFromJoinCondition(plan)
+      val aggregatePlan = extractExternalUDFFromAggregate(joinPlan)
+      val groupingPlan = extractGroupingExternalUDFFromAggregate(aggregatePlan)
+      groupingPlan.transformUpWithPruning(_.containsPattern(EXTERNAL_UDF)) {
+        // These nodes already own their external UDF expressions.
+        case udfPlan: ExternalUDF => udfPlan
+        case other => extract(other)
+      }
+  }
+
+  private def hasUnevaluableExternalUDF(expression: Expression, join: Join): Boolean = {
+    expression.exists {
+      case udf: ExternalUserDefinedFunction =>
+        !canEvaluate(udf, join.left) && !canEvaluate(udf, join.right)
+      case _ => false
+    }
+  }
+
+  private def extractExternalUDFFromJoinCondition(plan: LogicalPlan): LogicalPlan = {
+    plan.transformUpWithPruning(_.containsAllPatterns(EXTERNAL_UDF, JOIN)) {
+      case join @ Join(_, _, joinType, Some(condition), _)
+          if hasUnevaluableExternalUDF(condition, join) =>
+        if (!joinType.isInstanceOf[InnerLike]) {
+          // Match `PYTHON_UDF_IN_ON_CLAUSE`: moving a cross-side UDF to a post-join filter
+          // changes the semantics of non-inner joins.
+          throw QueryCompilationErrors.useExternalUDFInJoinConditionUnsupportedError(joinType)
+        }
+
+        val (udfConditions, otherConditions) = splitConjunctivePredicates(condition)
+          .partition(hasUnevaluableExternalUDF(_, join))
+        val newCondition = if (otherConditions.isEmpty) {
+          logWarning(log"The join condition:${MDC(JOIN_CONDITION, condition)} " +
+            log"of the join plan contains external UDFs only, " +
+            log"so it will be moved out and the join plan will become a cross join.")
+          None
+        } else {
+          Some(otherConditions.reduceLeft(And))
+        }
+        Filter(udfConditions.reduceLeft(And), join.copy(condition = newCondition))
+    }
+  }
+
+  private def belongsToAggregate(
+      expression: Expression,
+      groupingExpressions: ExpressionSet): Boolean = {
+    expression.isInstanceOf[AggregateExpression] ||
+      groupingExpressions.contains(expression)
+  }
+
+  private def hasExternalUDFOverAggregate(
+      expression: Expression,
+      groupingExpressions: ExpressionSet): Boolean = {
+    expression.exists {
+      case udf: ExternalUserDefinedFunction =>
+        udf.references.isEmpty || udf.exists(belongsToAggregate(_, groupingExpressions))
+      case _ => false
+    }
+  }
+
+  private def extractExternalUDFFromAggregate(plan: LogicalPlan): LogicalPlan = {
+    plan.transformUpWithPruning(_.containsAllPatterns(EXTERNAL_UDF, AGGREGATE)) {
+      case aggregate: Aggregate =>
+        val groupingExpressions = ExpressionSet(aggregate.groupingExpressions)
+        if (!aggregate.aggregateExpressions.exists(
+            hasExternalUDFOverAggregate(_, groupingExpressions))) {
+          aggregate
+        } else {
+          val projectExpressions = ArrayBuffer.empty[NamedExpression]
+          val aggregateExpressions = ArrayBuffer.empty[NamedExpression]
+          aggregate.aggregateExpressions.foreach { expression =>
+            if (hasExternalUDFOverAggregate(expression, groupingExpressions)) {
+              val newExpression = expression.transformDown {
+                case child: Expression if belongsToAggregate(child, groupingExpressions) =>
+                  val alias = child match {
+                    case named: NamedExpression => named
+                    case other => Alias(other, "agg")()
+                  }
+                  aggregateExpressions += alias
+                  alias.toAttribute
+              }
+              projectExpressions += newExpression.asInstanceOf[NamedExpression]
+            } else {
+              aggregateExpressions += expression
+              projectExpressions += expression.toAttribute
+            }
+          }
+          Project(
+            projectExpressions.toSeq,
+            aggregate.copy(aggregateExpressions = aggregateExpressions.toSeq))
+        }
+    }
+  }
+
+  private def hasExternalUDF(expression: Expression): Boolean = {
+    expression.exists(_.isInstanceOf[ExternalUserDefinedFunction])
+  }
+
+  private def extractGroupingExternalUDFFromAggregate(plan: LogicalPlan): LogicalPlan = {
+    plan.transformUpWithPruning(_.containsAllPatterns(EXTERNAL_UDF, AGGREGATE)) {
+      case aggregate: Aggregate if aggregate.groupingExpressions.exists(hasExternalUDF) =>
+        val projectExpressions = ArrayBuffer.empty[NamedExpression]
+        val groupingExpressions = ArrayBuffer.empty[Expression]
+        val attributeMap = ArrayBuffer.empty[
+          (ExternalUserDefinedFunction, NamedExpression)]
+
+        def mappedAttribute(udf: ExternalUserDefinedFunction): Option[NamedExpression] = {
+          attributeMap.collectFirst {
+            case (candidate, attribute) if sameUDF(candidate, udf) => attribute
+          }
+        }
+
+        aggregate.groupingExpressions.foreach { expression =>
+          if (hasExternalUDF(expression)) {
+            val newExpression = expression.transformDown {
+              case udf: ExternalUserDefinedFunction =>
+                assert(udf.udfDeterministic,
+                  "Non-deterministic external UDFs should not appear in grouping expressions")
+                mappedAttribute(udf).getOrElse {
+                  val alias = Alias(udf, "groupingExternalUDF")()
+                  projectExpressions += alias
+                  attributeMap += ((udf, alias.toAttribute))
+                  alias.toAttribute
+                }
+            }
+            groupingExpressions += newExpression
+          } else {
+            groupingExpressions += expression
+          }
+        }
+
+        val aggregateExpressions = aggregate.aggregateExpressions.map { expression =>
+          expression.transformUp {
+            case udf: ExternalUserDefinedFunction if udf.udfDeterministic =>
+              mappedAttribute(udf).getOrElse(udf)
+          }.asInstanceOf[NamedExpression]
+        }
+        aggregate.copy(
+          groupingExpressions = groupingExpressions.toSeq,
+          aggregateExpressions = aggregateExpressions,
+          child = Project((projectExpressions ++ aggregate.child.output).toSeq, aggregate.child))
+    }
+  }
+
+  private def containsExternalUDF(expression: Expression): Boolean = {
+    expression.exists(_.isInstanceOf[ExternalUserDefinedFunction])
+  }
+
+  private def isEvaluable(udf: ExternalUserDefinedFunction): Boolean = {
+    !udf.children.exists(containsExternalUDF)
+  }
+
+  private def sameUDF(
+      left: ExternalUserDefinedFunction,
+      right: ExternalUserDefinedFunction): Boolean = {
+    if (left.deterministic && right.deterministic) {
+      val normalizedPayload = Array.emptyByteArray
+      left.payload.sameElements(right.payload) &&
+        left.copy(payload = normalizedPayload).semanticEquals(
+          right.copy(payload = normalizedPayload))
+    } else {
+      left.resultId == right.resultId
+    }
+  }
+
+  private def collectEvaluableUDFs(
+      expression: Expression): Iterator[ExternalUserDefinedFunction] = {
+    expression match {
+      case udf: ExternalUserDefinedFunction if isEvaluable(udf) => Iterator.single(udf)
+      case other => other.children.iterator.flatMap(collectEvaluableUDFs)
+    }
+  }
+
+  private def collectEvaluableUDF(plan: LogicalPlan): Option[ExternalUserDefinedFunction] = {
+    val inputSet = plan.inputSet
+    plan.expressions.iterator
+      .flatMap(collectEvaluableUDFs)
+      .find(_.references.subsetOf(inputSet))
+  }
+
+  /** Converts one UDF expression to a node and recursively converts the remaining UDFs. */
+  private def extract(plan: LogicalPlan): LogicalPlan = {
+    collectEvaluableUDF(plan) match {
+      case None => plan
+      case Some(udf) =>
+        val childIndex = plan.children.indexWhere { child =>
+          udf.references.subsetOf(child.outputSet)
+        }
+        if (childIndex < 0) {
+          throw QueryCompilationErrors.externalUDFWithMultipleChildrenUnsupportedError()
+        }
+
+        val resultAttr = AttributeReference("externalUDF", udf.dataType, udf.nullable)()
+        val newChildren = plan.children.zipWithIndex.map { case (child, index) =>
+          if (index == childIndex) {
+            ExecuteExternalUDF(udf, resultAttr, child)
+          } else {
+            child
+          }
+        }
+        val rewritten = plan.withNewChildren(newChildren).transformExpressions {
+          case candidate: ExternalUserDefinedFunction if candidate.resultId == udf.resultId =>
+            resultAttr
+        }
+
+        val newPlan = extract(rewritten)
+        if (newPlan.output != plan.output) {
+          Project(plan.output, newPlan)
+        } else {
+          newPlan
+        }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFs.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.externalUDF
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.JOIN_CONDITION
 import org.apache.spark.sql.catalyst.expressions._
@@ -47,17 +46,15 @@ private[sql] object PlanExternalUDFs
     case subquery: Subquery if subquery.correlated => plan
     case _ if !conf.getConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED) =>
       if (plan.containsPattern(EXTERNAL_UDF)) {
-        throw new SparkUnsupportedOperationException(
-          errorClass = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
-          messageParameters = Map(
-            "config" -> SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key))
+        throw QueryCompilationErrors.externalUDFsDisabledError(
+          SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key)
       }
       plan
     case _ =>
-      val joinPlan = extractExternalUDFFromJoinCondition(plan)
-      val aggregatePlan = extractExternalUDFFromAggregate(joinPlan)
-      val groupingPlan = extractGroupingExternalUDFFromAggregate(aggregatePlan)
-      groupingPlan.transformUpWithPruning(_.containsPattern(EXTERNAL_UDF)) {
+      var preparedPlan = extractExternalUDFFromJoinCondition(plan)
+      preparedPlan = extractExternalUDFFromAggregate(preparedPlan)
+      preparedPlan = extractGroupingExternalUDFFromAggregate(preparedPlan)
+      preparedPlan.transformUpWithPruning(_.containsPattern(EXTERNAL_UDF)) {
         // These nodes already own their external UDF expressions.
         case udfPlan: ExternalUDF => udfPlan
         case other => extract(other)
@@ -242,7 +239,7 @@ private[sql] object PlanExternalUDFs
           udf.references.subsetOf(child.outputSet)
         }
         if (childIndex < 0) {
-          throw QueryCompilationErrors.externalUDFWithMultipleChildrenUnsupportedError()
+          throw QueryCompilationErrors.externalUDFWithMultipleChildrenUnsupportedError(udf)
         }
 
         val resultAttr = AttributeReference("externalUDF", udf.dataType, udf.nullable)()

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -38,8 +38,6 @@ import org.apache.spark.sql.execution.analysis.DetectAmbiguousSelfJoin
 import org.apache.spark.sql.execution.command.{CheckViewReferences, CommandCheck}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.{TableCapabilityCheck, V2SessionCatalog}
-import org.apache.spark.sql.execution.externalUDF.{ClassicExternalUDFPlanner,
-  ExternalUDFPlanner, UnifiedExternalUDFPlanner}
 import org.apache.spark.sql.execution.streaming.runtime.ResolveWriteToStream
 import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
 import org.apache.spark.sql.util.ExecutionListenerManager
@@ -415,19 +413,6 @@ abstract class BaseSessionStateBuilder(
       extensions.buildQueryPostPlannerStrategyRules(session))
   }
 
-  /**
-   * Strategy for converting (Python) UDF calls into logical plan
-   * nodes. Uses the unified external UDF worker framework when
-   * the config is enabled, otherwise the classic Python runner.
-   */
-  protected def externalUDFPlanner: ExternalUDFPlanner = {
-    if (conf.getConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED)) {
-      new UnifiedExternalUDFPlanner(session.sparkContext.conf)
-    } else {
-      new ClassicExternalUDFPlanner()
-    }
-  }
-
   protected def planNormalizationRules: Seq[Rule[LogicalPlan]] = {
     NormalizeCTEIds +:
     extensions.buildPlanNormalizationRules(session)
@@ -509,8 +494,7 @@ abstract class BaseSessionStateBuilder(
       columnarRules,
       adaptiveRulesHolder,
       planNormalizationRules,
-      () => artifactManager,
-      externalUDFPlanner)
+      () => artifactManager)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -37,7 +37,6 @@ import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveRulesHolder
 import org.apache.spark.sql.execution.datasources.DataSourceManager
-import org.apache.spark.sql.execution.externalUDF.ExternalUDFPlanner
 import org.apache.spark.sql.util.ExecutionListenerManager
 import org.apache.spark.util.{DependencyUtils, Utils}
 
@@ -93,8 +92,7 @@ private[sql] class SessionState(
     val columnarRules: Seq[ColumnarRule],
     val adaptiveRulesHolder: AdaptiveRulesHolder,
     val planNormalizationRules: Seq[Rule[LogicalPlan]],
-    val artifactManagerBuilder: () => ArtifactManager,
-    val externalUDFPlanner: ExternalUDFPlanner) {
+    val artifactManagerBuilder: () => ArtifactManager) {
 
   // The following fields are lazy to avoid creating the Hive client when creating SessionState.
   lazy val catalog: SessionCatalog = catalogBuilder()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanningSuite.scala
@@ -22,14 +22,14 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.SparkConf
 import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan,
   MapInPandas, MapPartitionsExternalUDF}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.{MapInPandasExec,
   UserDefinedPythonFunction}
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType,
   StructField, StructType}
@@ -107,6 +107,17 @@ class ClassicUDFPlanningSuite
     val result = applyMapInPandas()
     assertPhysicalNode[MapInPandasExec](result)
   }
+
+  test("unified UDF execution cannot be enabled after session construction") {
+    val config = StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED
+    assert(!spark.sessionState.conf.getConf(config))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.conf.set(config.key, true)
+      },
+      condition = "CANNOT_MODIFY_STATIC_CONFIG",
+      parameters = Map("key" -> s"\"${config.key}\""))
+  }
 }
 
 /**
@@ -118,7 +129,7 @@ class UnifiedUDFPlanningSuite
 
   override def sparkConf: SparkConf =
     super.sparkConf.set(
-      SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key, "true")
+      StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key, "true")
 
   test("mapInPandas uses MapPartitionsExternalUDF logical node") {
     val result = applyMapInPandas()
@@ -129,5 +140,16 @@ class UnifiedUDFPlanningSuite
       " physical node") {
     val result = applyMapInPandas()
     assertPhysicalNode[MapPartitionsExternalUDFExec](result)
+  }
+
+  test("unified UDF execution cannot be disabled after session construction") {
+    val config = StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED
+    assert(spark.sessionState.conf.getConf(config))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.conf.set(config.key, false)
+      },
+      condition = "CANNOT_MODIFY_STATIC_CONFIG",
+      parameters = Map("key" -> s"\"${config.key}\""))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -23,16 +23,17 @@ import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.expressions.{Add, Alias, And, ArrayTransform, Attribute,
-  AttributeReference, CreateArray, EqualTo, Expression, ExternalUserDefinedFunction, GreaterThan,
-  Lag, LambdaFunction, Literal, NamedLambdaVariable, UnspecifiedFrame, WindowExpression,
-  WindowSpecDefinition}
+  AttributeReference, AttributeSet, CreateArray, EqualTo, Expression,
+  ExternalUserDefinedFunction, GreaterThan, Lag, LambdaFunction, Literal, NamedLambdaVariable,
+  UnspecifiedFrame, WindowExpression, WindowSpecDefinition}
 import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
 import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, BinaryNode, ExecuteExternalUDF,
-  Filter, Join, JoinHint, LocalLimit, LocalRelation, LogicalPlan, Project, Range, Window}
+  Filter, Join, JoinHint, LocalLimit, LocalRelation, LogicalPlan, MapPartitionsExternalUDF, Project,
+  Range, Window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType}
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, StructField, StructType}
 import org.apache.spark.udf.worker.{DirectWorker, ProcessCallable, UDFWorkerProperties,
   UDFWorkerSpecification, WorkerEnvironment}
 
@@ -52,9 +53,15 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
 
   private val input = AttributeReference("input", IntegerType, nullable = false)()
   private val relation = LocalRelation(Seq(input))
-  private def workerSpec(name: String): UDFWorkerSpecification = {
+  private def workerSpec(
+      name: String,
+      environmentVariables: Map[String, String] = Map.empty): UDFWorkerSpecification = {
+    val runner = ProcessCallable.newBuilder().addCommand(name)
+    environmentVariables.foreach { case (key, value) =>
+      runner.putEnvironmentVariables(key, value)
+    }
     val direct = DirectWorker.newBuilder()
-      .setRunner(ProcessCallable.newBuilder().addCommand(name))
+      .setRunner(runner)
       .setProperties(UDFWorkerProperties.newBuilder())
 
     UDFWorkerSpecification.newBuilder()
@@ -88,7 +95,10 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
   }
 
   private def extract(expression: Expression): LogicalPlan = {
-    extract(Project(Seq(Alias(expression, "result")()), relation))
+    val plan = Project(Seq(Alias(expression, "result")()), relation)
+    val extracted = extract(plan)
+    assert(extracted.output == plan.output)
+    extracted
   }
 
   private def optimize(plan: LogicalPlan): LogicalPlan = {
@@ -101,6 +111,27 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     plan.collect { case eval: ExecuteExternalUDF => eval }
   }
 
+  private def singleEvalNode(plan: LogicalPlan): ExecuteExternalUDF = {
+    evalNodes(plan) match {
+      case Seq(node) => node
+      case nodes => fail(s"Expected one ExecuteExternalUDF node, found ${nodes.size}:\n$plan")
+    }
+  }
+
+  private def singleOutput(plan: LogicalPlan): Attribute = {
+    plan.output match {
+      case Seq(attribute) => attribute
+      case output => fail(s"Expected one output attribute, found ${output.size}: $output")
+    }
+  }
+
+  private def singleProjectExpression(plan: LogicalPlan): Expression = {
+    plan match {
+      case Project(Seq(alias: Alias), _) => alias.child
+      case other => fail(s"Expected a Project with one Alias, found:\n$other")
+    }
+  }
+
   private def callCount(expression: Expression): Int = {
     expression.collect { case _: ExternalUserDefinedFunction => 1 }.size
   }
@@ -110,18 +141,38 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val expression = udf("outer", spec,
       Seq(udf("middle", spec, Seq(udf("inner", spec, Seq(input))))))
 
-    val nodes = evalNodes(extract(expression))
-    assert(nodes.size == 3)
-    assert(nodes.forall(node => callCount(node.udf) == 1))
+    val extracted = extract(expression)
+    val nodes = evalNodes(extracted)
+    nodes match {
+      case Seq(outer, middle, inner) =>
+        assert(outer.udf.children == Seq(middle.resultAttr))
+        assert(middle.udf.children == Seq(inner.resultAttr))
+        assert(inner.udf.children == Seq(input))
+        assert(inner.child == relation)
+        assert(singleProjectExpression(extracted).semanticEquals(outer.resultAttr))
+        assert(Seq(outer, middle, inner).forall(node => callCount(node.udf) == 1))
+      case _ =>
+        fail(
+          s"Expected outer, middle, and inner evaluation nodes, found:\n${nodes.mkString("\n")}")
+    }
   }
 
   test("independent UDF expressions use separate nodes") {
     val spec = workerSpec("independent")
     val expression = Add(udf("left", spec, Seq(input)), udf("right", spec, Seq(input)))
 
-    val nodes = evalNodes(extract(expression))
-    assert(nodes.size == 2)
-    assert(nodes.forall(node => callCount(node.udf) == 1))
+    val extracted = extract(expression)
+    val nodes = evalNodes(extracted)
+    nodes match {
+      case Seq(upper, lower) =>
+        assert(upper.child == lower)
+        assert(lower.child == relation)
+        assert(nodes.forall(_.udf.children == Seq(input)))
+        assert(nodes.forall(node => callCount(node.udf) == 1))
+        val projectExpression = singleProjectExpression(extracted)
+        assert(nodes.forall(node => projectExpression.references.contains(node.resultAttr)))
+      case _ => fail(s"Expected two independent evaluation nodes, found:\n${nodes.mkString("\n")}")
+    }
   }
 
   test("equivalent deterministic UDF expressions use separate nodes") {
@@ -150,9 +201,19 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val right = udf("right", spec, Seq(input))
     val expression = udf("outer", spec, Seq(Add(left, right)))
 
-    val nodes = evalNodes(extract(expression))
-    assert(nodes.size == 3)
-    assert(nodes.forall(node => callCount(node.udf) == 1))
+    val extracted = extract(expression)
+    val nodes = evalNodes(extracted)
+    nodes match {
+      case Seq(outer, upperBranch, lowerBranch) =>
+        assert(outer.child == upperBranch)
+        assert(upperBranch.child == lowerBranch)
+        assert(lowerBranch.child == relation)
+        assert(outer.udf.references ==
+          AttributeSet(Seq(upperBranch.resultAttr, lowerBranch.resultAttr)))
+        assert(singleProjectExpression(extracted).semanticEquals(outer.resultAttr))
+        assert(nodes.forall(node => callCount(node.udf) == 1))
+      case _ => fail(s"Expected three branched evaluation nodes, found:\n${nodes.mkString("\n")}")
+    }
   }
 
   test("UDFs with different worker specifications use separate nodes") {
@@ -164,6 +225,33 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     assert(nodes.size == 2)
     assert(nodes.map(_.workerSpec).toSet == Set(outerSpec, innerSpec))
     assert(nodes.forall(node => callCount(node.udf) == 1))
+  }
+
+  test("external UDF rendering hides worker execution details") {
+    val sensitiveValue = "sensitive-worker-value"
+    val spec = workerSpec("safe-rendering", Map("UDF_SECRET" -> sensitiveValue))
+    val function = udf("safeRendering", spec, Seq(input))
+    val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
+    val logicalPlan = ExecuteExternalUDF(function, resultAttr, relation)
+    // Structured logging renders MDC values with toString, including join conditions.
+    val loggedCondition = EqualTo(function, Literal(1)).toString
+    val physicalPlan = spark.sessionState.planner.plan(logicalPlan).toSeq match {
+      case Seq(node: ExecuteExternalUDFExec) => node
+      case other =>
+        fail(s"Expected one ExecuteExternalUDFExec node, found:\n${other.mkString("\n")}")
+    }
+
+    assert(function.sql == "safeRendering(input)")
+    Seq(
+      function.toString,
+      loggedCondition,
+      logicalPlan.treeString,
+      physicalPlan.treeString).foreach { display =>
+      // Plan rendering includes expression IDs on attributes, unlike Expression.sql.
+      assert(display.contains("safeRendering(input"))
+      assert(!display.contains(sensitiveValue))
+      assert(!display.contains("environment_variables"))
+    }
   }
 
   test("external UDF input types are validated during analysis") {
@@ -180,21 +268,72 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     assert(exception.getCondition == "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE")
   }
 
+  test("external UDF input types reject fewer declarations than arguments") {
+    val spec = workerSpec("too-few-input-types")
+    val plan = Project(Seq(Alias(
+      udf(
+        "tooFewInputTypes",
+        spec,
+        Seq(input, input),
+        inputTypes = Some(Seq(IntegerType))),
+      "result")()), relation)
+
+    val exception = intercept[AnalysisException] {
+      spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
+    }
+    checkError(
+      exception = exception,
+      condition = "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
+      parameters = Map(
+        "functionName" -> "`tooFewInputTypes`",
+        "expectedNum" -> "1",
+        "actualNum" -> "2",
+        "docroot" -> "https://spark.apache.org/docs/latest"))
+  }
+
+  test("external UDF input types reject more declarations than arguments") {
+    val spec = workerSpec("too-many-input-types")
+    val plan = Project(Seq(Alias(
+      udf(
+        "tooManyInputTypes",
+        spec,
+        Seq(input),
+        inputTypes = Some(Seq(IntegerType, IntegerType))),
+      "result")()), relation)
+
+    val exception = intercept[AnalysisException] {
+      spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
+    }
+    checkError(
+      exception = exception,
+      condition = "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
+      parameters = Map(
+        "functionName" -> "`tooManyInputTypes`",
+        "expectedNum" -> "2",
+        "actualNum" -> "1",
+        "docroot" -> "https://spark.apache.org/docs/latest"))
+  }
+
   test("an external UDF in a higher-order function lambda is rejected") {
-    val spec = workerSpec("lambda")
+    val sensitiveValue = "sensitive-lambda-value"
+    val spec = workerSpec("lambda", Map("UDF_SECRET" -> sensitiveValue))
     val lambdaVariable = NamedLambdaVariable("x", IntegerType, nullable = false)
+    val function = udf("lambda", spec, Seq(lambdaVariable))
     val transform = ArrayTransform(
       CreateArray(Seq(input)),
       LambdaFunction(
-        udf("lambda", spec, Seq(lambdaVariable)),
+        function,
         Seq(lambdaVariable)))
     val plan = Project(Seq(Alias(transform, "result")()), relation)
 
     val exception = intercept[AnalysisException] {
       spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
     }
-    assert(exception.getCondition ==
-      "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF")
+    checkError(
+      exception = exception,
+      condition = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF",
+      parameters = Map("funcName" -> ("\"" + function.sql + "\"")))
+    assert(!exception.getMessage.contains(sensitiveValue))
   }
 
   test("an external UDF over an aggregate expression is evaluated after aggregate") {
@@ -205,9 +344,10 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       aggregateExpressions = Seq(Alias(udf("aggregate", spec, Seq(sum)), "result")()),
       child = relation)
 
-    val nodes = evalNodes(extract(plan))
-    assert(nodes.size == 1)
-    assert(nodes.head.child.isInstanceOf[Aggregate])
+    val evaluation = singleEvalNode(extract(plan))
+    assert(evaluation.child.isInstanceOf[Aggregate])
+    assert(evaluation.udf.references.subsetOf(evaluation.child.outputSet))
+    assert(!evaluation.udf.exists(_.isInstanceOf[Sum]))
   }
 
   test("a zero-argument non-deterministic UDF is evaluated after aggregate") {
@@ -219,9 +359,8 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       child = relation)
 
     val extracted = extract(plan)
-    val nodes = evalNodes(extracted)
-    assert(nodes.size == 1)
-    assert(nodes.head.child.isInstanceOf[Aggregate])
+    val evaluation = singleEvalNode(extracted)
+    assert(evaluation.child.isInstanceOf[Aggregate])
     assert(extracted.output == plan.output)
   }
 
@@ -233,8 +372,22 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       child = relation)
 
     val extracted = extract(plan)
-    val aggregate = extracted.collectFirst { case node: Aggregate => node }.get
-    assert(aggregate.child.collect { case node: ExecuteExternalUDF => node }.size == 1)
+    val aggregate = extracted.collectFirst { case node: Aggregate => node }.getOrElse {
+      fail(s"Expected an Aggregate node, found:\n$extracted")
+    }
+    val projectedGrouping = aggregate.child match {
+      case Project(projectList, evaluation: ExecuteExternalUDF) =>
+        projectList.collectFirst {
+          case alias: Alias if alias.child.semanticEquals(evaluation.resultAttr) =>
+            alias.toAttribute
+        }.getOrElse {
+          fail(s"Expected the grouping UDF result in the Project, found:\n$aggregate")
+        }
+      case other => fail(s"Expected Project and ExecuteExternalUDF below Aggregate, found:\n$other")
+    }
+    assert(aggregate.groupingExpressions.exists(_.semanticEquals(projectedGrouping)))
+    assert(!aggregate.aggregateExpressions.exists(
+      _.exists(_.isInstanceOf[ExternalUserDefinedFunction])))
   }
 
   test("an external UDF over a window expression is evaluated after window") {
@@ -248,7 +401,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       child = relation)
 
     val extracted = extract(plan)
-    val evaluation = evalNodes(extracted).head
+    val evaluation = singleEvalNode(extracted)
     assert(evaluation.child.isInstanceOf[Window])
     assert(!evaluation.udf.exists(_.isInstanceOf[WindowExpression]))
     assert(evaluation.udf.references.subsetOf(evaluation.child.outputSet))
@@ -267,8 +420,13 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       child = relation)
 
     val extracted = extract(plan)
-    val window = extracted.collectFirst { case node: Window => node }.get
-    val evaluation = window.child.asInstanceOf[ExecuteExternalUDF]
+    val window = extracted.collectFirst { case node: Window => node }.getOrElse {
+      fail(s"Expected a Window node, found:\n$extracted")
+    }
+    val evaluation = window.child match {
+      case node: ExecuteExternalUDF => node
+      case other => fail(s"Expected ExecuteExternalUDF below Window, found:\n$other")
+    }
     assert(evaluation.child == relation)
   }
 
@@ -280,10 +438,19 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val plan = Join(relation, right, Inner, Some(condition), JoinHint.NONE)
 
     val extracted = extract(plan)
-    val filter = extracted.collectFirst { case node: Filter => node }.get
-    val evaluation = filter.child.asInstanceOf[ExecuteExternalUDF]
-    val join = evaluation.child.asInstanceOf[Join]
+    val filter = extracted.collectFirst { case node: Filter => node }.getOrElse {
+      fail(s"Expected a Filter node, found:\n$extracted")
+    }
+    val evaluation = filter.child match {
+      case node: ExecuteExternalUDF => node
+      case other => fail(s"Expected ExecuteExternalUDF below Filter, found:\n$other")
+    }
+    val join = evaluation.child match {
+      case node: Join => node
+      case other => fail(s"Expected Join below ExecuteExternalUDF, found:\n$other")
+    }
     assert(join.condition.isEmpty)
+    assert(filter.condition.semanticEquals(evaluation.resultAttr))
   }
 
   test("an external UDF join condition rejects unsupported join types") {
@@ -317,7 +484,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = exception,
       condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF_WITH_MULTIPLE_CHILDREN",
-      parameters = Map.empty)
+      parameters = Map("funcName" -> "\"multiple-children(input, right)\""))
   }
 
   test("external UDF expressions are rejected when unified execution is disabled") {
@@ -332,51 +499,107 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = exception,
       condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
-      parameters = Map("config" -> SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key))
+      parameters = Map(
+        "config" -> s"\"${SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key}\""))
   }
 
   test("optimizer pushes a local limit through an external UDF node") {
     val spec = workerSpec("limit")
     val range = Range(0, 10, 1, 1)
-    val function = udf("limit", spec, Seq(range.output.head))
+    val function = udf("limit", spec, Seq(singleOutput(range)))
     val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
     val plan = LocalLimit(Literal(1), ExecuteExternalUDF(function, resultAttr, range))
 
     val optimized = optimize(plan)
-    val evaluation = optimized.collectFirst { case node: ExecuteExternalUDF => node }.get
+    val evaluation = singleEvalNode(optimized)
     assert(evaluation.child.isInstanceOf[LocalLimit])
   }
 
   test("strategy plans an external UDF execution node") {
     val spec = workerSpec("physical-planning")
     val range = Range(0, 10, 1, 1)
-    val function = udf("physical-planning", spec, Seq(range.output.head))
+    val function = udf("physical-planning", spec, Seq(singleOutput(range)))
     val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
     val logicalPlan = ExecuteExternalUDF(function, resultAttr, range)
 
-    val physicalPlan = spark.sessionState.planner.plan(logicalPlan).next()
-    val execution = physicalPlan.asInstanceOf[ExecuteExternalUDFExec]
+    val execution = spark.sessionState.planner.plan(logicalPlan).toSeq match {
+      case Seq(node: ExecuteExternalUDFExec) => node
+      case other =>
+        fail(s"Expected one ExecuteExternalUDFExec node, found:\n${other.mkString("\n")}")
+    }
     assert(execution.udf == function)
     assert(execution.resultAttr == resultAttr)
     assert(execution.workerSpec == spec)
   }
 
+  test("scalar external UDF execution reports unimplemented before worker startup") {
+    val spec = workerSpec("unimplemented-scalar")
+    val range = Range(0, 10, 1, 1)
+    val function = udf("unimplemented-scalar", spec, Seq(singleOutput(range)))
+    val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
+    val logicalPlan = ExecuteExternalUDF(function, resultAttr, range)
+    val execution = spark.sessionState.planner.plan(logicalPlan).toSeq match {
+      case Seq(node: ExecuteExternalUDFExec) => node
+      case other =>
+        fail(s"Expected one ExecuteExternalUDFExec node, found:\n${other.mkString("\n")}")
+    }
+
+    val exception = intercept[SparkUnsupportedOperationException] {
+      execution.execute()
+    }
+    checkError(
+      exception = exception,
+      condition = "_LEGACY_ERROR_TEMP_2041",
+      parameters = Map("methodName" -> "ExecuteExternalUDFExec.doExecute"))
+  }
+
+  test("map partitions external UDF execution reports unimplemented before worker startup") {
+    val spec = workerSpec("unimplemented-map-partitions")
+    val range = Range(0, 10, 1, 1)
+    val outputType = StructType(Seq(StructField("result", IntegerType)))
+    val function = udf(
+      "unimplemented-map-partitions",
+      spec,
+      Seq.empty,
+      dataType = outputType)
+    val logicalPlan = MapPartitionsExternalUDF(
+      function,
+      isBarrier = false,
+      profile = None,
+      child = range)
+    val execution = spark.sessionState.planner.plan(logicalPlan).toSeq match {
+      case Seq(node: MapPartitionsExternalUDFExec) => node
+      case other =>
+        fail(s"Expected one MapPartitionsExternalUDFExec node, found:\n${other.mkString("\n")}")
+    }
+
+    val exception = intercept[SparkUnsupportedOperationException] {
+      execution.execute()
+    }
+    checkError(
+      exception = exception,
+      condition = "_LEGACY_ERROR_TEMP_2041",
+      parameters = Map("methodName" -> "MapPartitionsExternalUDFExec.doExecute"))
+  }
+
   test("optimizer pushes child-only predicates through an external UDF node") {
     val spec = workerSpec("predicate")
     val range = Range(0, 10, 1, 1)
-    val function = udf("predicate", spec, Seq(range.output.head))
+    val inputAttribute = singleOutput(range)
+    val function = udf("predicate", spec, Seq(inputAttribute))
     val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
-    val childPredicate = GreaterThan(range.output.head, Literal(0L))
+    val childPredicate = GreaterThan(inputAttribute, Literal(0L))
     val resultPredicate = EqualTo(resultAttr, Literal(1))
     val plan = Filter(
       And(childPredicate, resultPredicate),
       ExecuteExternalUDF(function, resultAttr, range))
 
     val optimized = optimize(plan)
-    val evaluation = optimized.collectFirst { case node: ExecuteExternalUDF => node }.get
-    val pushedPredicate = evaluation.child.collectFirst {
+    val evaluation = singleEvalNode(optimized)
+    val pushedPredicate = evaluation.child match {
       case Filter(condition, _) => condition
-    }.get
+      case other => fail(s"Expected Filter below ExecuteExternalUDF, found:\n$other")
+    }
     assert(pushedPredicate.semanticEquals(childPredicate))
   }
 
@@ -387,7 +610,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val condition = udf(
       "cartesian",
       spec,
-      Seq(left.output.head, right.output.head),
+      Seq(singleOutput(left), singleOutput(right)),
       dataType = BooleanType)
     val plan = Join(left, right, Inner, Some(condition), JoinHint.NONE)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.externalUDF
 
 import java.nio.charset.StandardCharsets
 
-import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.{SparkConf, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.expressions.{Add, Alias, And, ArrayTransform, Attribute,
@@ -31,13 +31,16 @@ import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, BinaryNode, ExecuteExternalUDF,
   Filter, Join, JoinHint, LocalLimit, LocalRelation, LogicalPlan, MapPartitionsExternalUDF, Project,
   Range, Window}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, StructField, StructType}
 import org.apache.spark.udf.worker.{DirectWorker, ProcessCallable, UDFWorkerProperties,
   UDFWorkerSpecification, WorkerEnvironment}
 
 class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
+
+  override def sparkConf: SparkConf = super.sparkConf.set(
+    StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key, true)
 
   private case class TestBinaryPlan(
       expression: Expression,
@@ -89,9 +92,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
   }
 
   private def extract(plan: LogicalPlan): LogicalPlan = {
-    withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true") {
-      PlanExternalUDFs(ExtractExternalUDFFromWindow(plan))
-    }
+    PlanExternalUDFs(ExtractExternalUDFFromWindow(plan))
   }
 
   private def extract(expression: Expression): LogicalPlan = {
@@ -102,9 +103,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
   }
 
   private def optimize(plan: LogicalPlan): LogicalPlan = {
-    withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true") {
-      spark.sessionState.optimizer.execute(plan)
-    }
+    spark.sessionState.optimizer.execute(plan)
   }
 
   private def evalNodes(plan: LogicalPlan): Seq[ExecuteExternalUDF] = {
@@ -232,9 +231,11 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("external UDF rendering hides worker execution details") {
-    val sensitiveValue = "sensitive-worker-value"
-    val spec = workerSpec("safe-rendering", Map("UDF_SECRET" -> sensitiveValue))
-    val function = udf("safeRendering", spec, Seq(input))
+    val sensitiveWorkerValue = "sensitive-worker-value"
+    val sensitivePayloadValue = "sensitive-payload-value"
+    val spec = workerSpec("safe-rendering", Map("UDF_SECRET" -> sensitiveWorkerValue))
+    val function = udf("safeRendering", spec, Seq(input)).copy(
+      payload = sensitivePayloadValue.getBytes(StandardCharsets.UTF_8))
     val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
     val logicalPlan = ExecuteExternalUDF(function, resultAttr, relation)
     // Structured logging renders MDC values with toString, including join conditions.
@@ -245,16 +246,26 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
         fail(s"Expected one ExecuteExternalUDFExec node, found:\n${other.mkString("\n")}")
     }
 
-    assert(function.sql == "safeRendering(input)")
-    assert(normalizeRenderedExpressionIds(function.toString) ==
+    val renderedSql = function.sql
+    val renderedFunction = function.toString
+    val renderedLogicalPlan = logicalPlan.treeString
+    val renderedPhysicalPlan = physicalPlan.treeString
+    Seq(renderedSql, renderedFunction, loggedCondition, renderedLogicalPlan, renderedPhysicalPlan)
+      .foreach { rendered =>
+        assert(!rendered.contains(sensitiveWorkerValue))
+        assert(!rendered.contains(sensitivePayloadValue))
+      }
+
+    assert(renderedSql == "safeRendering(input)")
+    assert(normalizeRenderedExpressionIds(renderedFunction) ==
       "safeRendering(input#x)#x")
     assert(normalizeRenderedExpressionIds(loggedCondition) ==
       "(safeRendering(input#x)#x = 1)")
-    assert(normalizeRenderedExpressionIds(logicalPlan.treeString) ==
+    assert(normalizeRenderedExpressionIds(renderedLogicalPlan) ==
       """ExecuteExternalUDF safeRendering(input#x)#x, externalUDF#x: int
         |+- LocalRelation <empty>, [input#x]
         |""".stripMargin)
-    assert(normalizeRenderedExpressionIds(physicalPlan.treeString) ==
+    assert(normalizeRenderedExpressionIds(renderedPhysicalPlan) ==
       """ExecuteExternalUDF safeRendering(input#x)#x, externalUDF#x: int
         |+- LocalTableScan <empty>, [input#x]
         |""".stripMargin)
@@ -396,6 +407,44 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       _.exists(_.isInstanceOf[ExternalUserDefinedFunction])))
   }
 
+  test("grouping UDFs with different worker specifications are not deduplicated") {
+    val groupingSpec = workerSpec("grouping-worker")
+    val resultSpec = workerSpec("result-worker")
+    val groupingFunction = udf("worker-identity", groupingSpec, Seq(input))
+    val resultFunction = udf("worker-identity", resultSpec, Seq(input))
+    val plan = Aggregate(
+      groupingExpressions = Seq(groupingFunction),
+      aggregateExpressions = Seq(Alias(resultFunction, "result")()),
+      child = relation)
+
+    val extracted = extract(plan)
+    val aggregate = extracted.collectFirst { case node: Aggregate => node }.getOrElse {
+      fail(s"Expected an Aggregate node, found:\n$extracted")
+    }
+    val resultEvaluation = aggregate.child match {
+      case node: ExecuteExternalUDF => node
+      case other => fail(s"Expected ExecuteExternalUDF below Aggregate, found:\n$other")
+    }
+    val groupingProjection = resultEvaluation.child match {
+      case project: Project => project
+      case other => fail(s"Expected a Project below ExecuteExternalUDF, found:\n$other")
+    }
+    val groupingEvaluation = singleEvalNode(groupingProjection)
+
+    assert(evalNodes(extracted).size == 2)
+    assert(resultEvaluation.workerSpec == resultSpec)
+    assert(groupingEvaluation.workerSpec == groupingSpec)
+    assert(groupingEvaluation.child == relation)
+    assert(aggregate.aggregateExpressions.exists(
+      _.references.contains(resultEvaluation.resultAttr)))
+    assert(groupingProjection.projectList.exists {
+      case alias: Alias =>
+        aggregate.groupingExpressions.exists(_.semanticEquals(alias.toAttribute)) &&
+          alias.child.semanticEquals(groupingEvaluation.resultAttr)
+      case _ => false
+    })
+  }
+
   test("a non-deterministic external UDF grouping key is evaluated before aggregate") {
     val spec = workerSpec("non-deterministic-grouping")
     val function = udf("non-deterministic-grouping", spec, Seq(input), deterministic = false)
@@ -404,9 +453,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       aggregateExpressions = Seq(Alias(function, "result")()),
       child = relation)
 
-    val analyzed = withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true") {
-      spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
-    }
+    val analyzed = spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
     val analyzedAggregate = analyzed.collectFirst { case node: Aggregate => node }.getOrElse {
       fail(s"Expected an Aggregate node, found:\n$analyzed")
     }
@@ -436,6 +483,8 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       child = relation)
 
     val extracted = extract(plan)
+    assert(extracted.output.map(_.name) == Seq(input.name, "result"))
+    assert(extracted.output.head.semanticEquals(input))
     val evaluation = singleEvalNode(extracted)
     val window = evaluation.child match {
       case node: Window => node
@@ -536,6 +585,27 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       parameters = Map("joinType" -> LeftOuter.sql))
   }
 
+  test("an external UDF referencing the left child is allowed in a left outer join") {
+    val spec = workerSpec("left-outer")
+    val rightInput = AttributeReference("right", IntegerType, nullable = false)()
+    val right = LocalRelation(Seq(rightInput))
+    val condition = udf("left-outer", spec, Seq(input), dataType = BooleanType)
+    val plan = Join(relation, right, LeftOuter, Some(condition), JoinHint.NONE)
+
+    val extracted = extract(plan)
+    val join = extracted.collectFirst { case node: Join => node }.getOrElse {
+      fail(s"Expected a Join node, found:\n$extracted")
+    }
+    val evaluation = join.left match {
+      case node: ExecuteExternalUDF => node
+      case other => fail(s"Expected ExecuteExternalUDF on the left, found:\n$other")
+    }
+    assert(evaluation.child == relation)
+    assert(join.right == right)
+    assert(join.condition.exists(_.semanticEquals(evaluation.resultAttr)))
+    assert(extracted.output == plan.output)
+  }
+
   test("an external UDF referencing multiple children reports an unsupported feature") {
     val spec = workerSpec("multiple-children")
     val rightInput = AttributeReference("right", IntegerType, nullable = false)()
@@ -558,7 +628,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val spec = workerSpec("disabled")
     val plan = Project(Seq(Alias(udf("external", spec, Seq(input)), "result")()), relation)
 
-    val exception = withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "false") {
+    val exception = SQLConf.withExistingConf(new SQLConf) {
       intercept[SparkUnsupportedOperationException] {
         PlanExternalUDFs(plan)
       }
@@ -567,7 +637,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       exception = exception,
       condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
       parameters = Map(
-        "config" -> ("\"" + SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key + "\"")))
+        "config" -> ("\"" + StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key + "\"")))
   }
 
   test("optimizer pushes a local limit through an external UDF node") {
@@ -662,11 +732,15 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       ExecuteExternalUDF(function, resultAttr, range))
 
     val optimized = optimize(plan)
-    val evaluation = singleEvalNode(optimized)
+    val (retainedPredicate, evaluation) = optimized match {
+      case Filter(condition, node: ExecuteExternalUDF) => (condition, node)
+      case other => fail(s"Expected Filter above ExecuteExternalUDF, found:\n$other")
+    }
     val pushedPredicate = evaluation.child match {
       case Filter(condition, _) => condition
       case other => fail(s"Expected Filter below ExecuteExternalUDF, found:\n$other")
     }
+    assert(retainedPredicate.semanticEquals(resultPredicate))
     assert(pushedPredicate.semanticEquals(childPredicate))
   }
 
@@ -681,9 +755,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       dataType = BooleanType)
     val plan = Join(left, right, Inner, Some(condition), JoinHint.NONE)
 
-    val exception = withSQLConf(
-        SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true",
-        SQLConf.CROSS_JOINS_ENABLED.key -> "false") {
+    val exception = withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "false") {
       intercept[AnalysisException] {
         spark.sessionState.optimizer.execute(plan)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -396,19 +396,54 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       _.exists(_.isInstanceOf[ExternalUserDefinedFunction])))
   }
 
+  test("a non-deterministic external UDF grouping key is evaluated before aggregate") {
+    val spec = workerSpec("non-deterministic-grouping")
+    val function = udf("non-deterministic-grouping", spec, Seq(input), deterministic = false)
+    val plan = Aggregate(
+      groupingExpressions = Seq(function),
+      aggregateExpressions = Seq(Alias(function, "result")()),
+      child = relation)
+
+    val analyzed = withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true") {
+      spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
+    }
+    val analyzedAggregate = analyzed.collectFirst { case node: Aggregate => node }.getOrElse {
+      fail(s"Expected an Aggregate node, found:\n$analyzed")
+    }
+    assert(analyzedAggregate.groupingExpressions.forall(_.deterministic))
+
+    val extracted = extract(analyzed)
+    val aggregate = extracted.collectFirst { case node: Aggregate => node }.getOrElse {
+      fail(s"Expected an Aggregate node, found:\n$extracted")
+    }
+    val evaluation = singleEvalNode(aggregate.child)
+    assert(!evaluation.udf.deterministic)
+    assert(evaluation.child == relation)
+    assert(aggregate.groupingExpressions.forall(_.deterministic))
+    assert(!aggregate.expressions.exists(
+      _.exists(_.isInstanceOf[ExternalUserDefinedFunction])))
+  }
+
   test("an external UDF over a window expression is evaluated after window") {
     val spec = workerSpec("over-window")
     val windowSpec = WindowSpecDefinition(Seq.empty, Seq.empty, UnspecifiedFrame)
     val windowExpression = WindowExpression(new Lag(input), windowSpec)
     val plan = Window(
-      windowExpressions = Seq(Alias(udf("over-window", spec, Seq(windowExpression)), "result")()),
+      windowExpressions = Seq(Alias(
+        udf("over-window", spec, Seq(windowExpression, input)), "result")()),
       partitionSpec = Seq.empty,
       orderSpec = Seq.empty,
       child = relation)
 
     val extracted = extract(plan)
     val evaluation = singleEvalNode(extracted)
-    assert(evaluation.child.isInstanceOf[Window])
+    val window = evaluation.child match {
+      case node: Window => node
+      case other => fail(s"Expected a Window node, found:\n$other")
+    }
+    assert(window.output.map(_.exprId).distinct.size == window.output.size)
+    assert(evaluation.udf.children.size == 2)
+    assert(evaluation.udf.children.last.semanticEquals(input))
     assert(!evaluation.udf.exists(_.isInstanceOf[WindowExpression]))
     assert(evaluation.udf.references.subsetOf(evaluation.child.outputSet))
   }
@@ -456,6 +491,30 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       case other => fail(s"Expected Join below ExecuteExternalUDF, found:\n$other")
     }
     assert(join.condition.isEmpty)
+    assert(filter.condition.semanticEquals(evaluation.resultAttr))
+  }
+
+  test("an external UDF is moved out of a mixed join condition") {
+    val spec = workerSpec("mixed-join")
+    val rightInput = AttributeReference("right", IntegerType, nullable = false)()
+    val right = LocalRelation(Seq(rightInput))
+    val equality = EqualTo(input, rightInput)
+    val function = udf("mixed-join", spec, Seq(input, rightInput), dataType = BooleanType)
+    val plan = Join(relation, right, Inner, Some(And(equality, function)), JoinHint.NONE)
+
+    val extracted = extract(plan)
+    val filter = extracted.collectFirst { case node: Filter => node }.getOrElse {
+      fail(s"Expected a Filter node, found:\n$extracted")
+    }
+    val evaluation = filter.child match {
+      case node: ExecuteExternalUDF => node
+      case other => fail(s"Expected ExecuteExternalUDF below Filter, found:\n$other")
+    }
+    val join = evaluation.child match {
+      case node: Join => node
+      case other => fail(s"Expected Join below ExecuteExternalUDF, found:\n$other")
+    }
+    assert(join.condition.exists(_.semanticEquals(equality)))
     assert(filter.condition.semanticEquals(evaluation.resultAttr))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -318,21 +318,20 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val sensitiveValue = "sensitive-lambda-value"
     val spec = workerSpec("lambda", Map("UDF_SECRET" -> sensitiveValue))
     val lambdaVariable = NamedLambdaVariable("x", IntegerType, nullable = false)
-    val function = udf("lambda", spec, Seq(lambdaVariable))
     val transform = ArrayTransform(
       CreateArray(Seq(input)),
       LambdaFunction(
-        function,
+        udf("lambda", spec, Seq(lambdaVariable)),
         Seq(lambdaVariable)))
     val plan = Project(Seq(Alias(transform, "result")()), relation)
 
     val exception = intercept[AnalysisException] {
       spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
     }
-    checkError(
+    checkErrorMatchPVals(
       exception = exception,
       condition = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF",
-      parameters = Map("funcName" -> ("\"" + function.sql + "\"")))
+      parameters = Map("funcName" -> "\"lambda\\(lambda x#[0-9]+\\)\""))
     assert(!exception.getMessage.contains(sensitiveValue))
   }
 
@@ -375,17 +374,17 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val aggregate = extracted.collectFirst { case node: Aggregate => node }.getOrElse {
       fail(s"Expected an Aggregate node, found:\n$extracted")
     }
-    val projectedGrouping = aggregate.child match {
-      case Project(projectList, evaluation: ExecuteExternalUDF) =>
-        projectList.collectFirst {
-          case alias: Alias if alias.child.semanticEquals(evaluation.resultAttr) =>
-            alias.toAttribute
-        }.getOrElse {
-          fail(s"Expected the grouping UDF result in the Project, found:\n$aggregate")
-        }
-      case other => fail(s"Expected Project and ExecuteExternalUDF below Aggregate, found:\n$other")
+    val groupingProjection = aggregate.child match {
+      case project: Project => project
+      case other => fail(s"Expected a Project below Aggregate, found:\n$other")
     }
-    assert(aggregate.groupingExpressions.exists(_.semanticEquals(projectedGrouping)))
+    val evaluation = singleEvalNode(groupingProjection)
+    assert(groupingProjection.projectList.exists {
+      case alias: Alias =>
+        aggregate.groupingExpressions.exists(_.semanticEquals(alias.toAttribute)) &&
+          alias.child.semanticEquals(evaluation.resultAttr)
+      case _ => false
+    })
     assert(!aggregate.aggregateExpressions.exists(
       _.exists(_.isInstanceOf[ExternalUserDefinedFunction])))
   }
@@ -500,7 +499,7 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       exception = exception,
       condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
       parameters = Map(
-        "config" -> s"\"${SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key}\""))
+        "config" -> ("\"" + SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key + "\"")))
   }
 
   test("optimizer pushes a local limit through an external UDF node") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -132,6 +132,10 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  private def normalizeRenderedExpressionIds(rendered: String): String = {
+    rendered.replaceAll("#[0-9]+", "#x")
+  }
+
   private def callCount(expression: Expression): Int = {
     expression.collect { case _: ExternalUserDefinedFunction => 1 }.size
   }
@@ -242,16 +246,18 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     }
 
     assert(function.sql == "safeRendering(input)")
-    Seq(
-      function.toString,
-      loggedCondition,
-      logicalPlan.treeString,
-      physicalPlan.treeString).foreach { display =>
-      // Plan rendering includes expression IDs on attributes, unlike Expression.sql.
-      assert(display.contains("safeRendering(input"))
-      assert(!display.contains(sensitiveValue))
-      assert(!display.contains("environment_variables"))
-    }
+    assert(normalizeRenderedExpressionIds(function.toString) ==
+      "safeRendering(input#x)#x")
+    assert(normalizeRenderedExpressionIds(loggedCondition) ==
+      "(safeRendering(input#x)#x = 1)")
+    assert(normalizeRenderedExpressionIds(logicalPlan.treeString) ==
+      """ExecuteExternalUDF safeRendering(input#x)#x, externalUDF#x: int
+        |+- LocalRelation <empty>, [input#x]
+        |""".stripMargin)
+    assert(normalizeRenderedExpressionIds(physicalPlan.treeString) ==
+      """ExecuteExternalUDF safeRendering(input#x)#x, externalUDF#x: int
+        |+- LocalTableScan <empty>, [input#x]
+        |""".stripMargin)
   }
 
   test("external UDF input types are validated during analysis") {
@@ -318,20 +324,21 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
     val sensitiveValue = "sensitive-lambda-value"
     val spec = workerSpec("lambda", Map("UDF_SECRET" -> sensitiveValue))
     val lambdaVariable = NamedLambdaVariable("x", IntegerType, nullable = false)
+    val function = udf("lambda", spec, Seq(lambdaVariable))
     val transform = ArrayTransform(
       CreateArray(Seq(input)),
       LambdaFunction(
-        udf("lambda", spec, Seq(lambdaVariable)),
+        function,
         Seq(lambdaVariable)))
     val plan = Project(Seq(Alias(transform, "result")()), relation)
 
     val exception = intercept[AnalysisException] {
       spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
     }
-    checkErrorMatchPVals(
+    checkError(
       exception = exception,
       condition = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF",
-      parameters = Map("funcName" -> "\"lambda\\(lambda x#[0-9]+\\)\""))
+      parameters = Map("funcName" -> ("\"" + function.sql + "\"")))
     assert(!exception.getMessage.contains(sensitiveValue))
   }
 
@@ -620,6 +627,12 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
         spark.sessionState.optimizer.execute(plan)
       }
     }
-    assert(exception.getMessage.startsWith("Detected implicit cartesian product"))
+    checkError(
+      exception = exception,
+      condition = "_LEGACY_ERROR_TEMP_1211",
+      parameters = Map(
+        "joinType" -> Inner.sql,
+        "leftPlan" -> "Range (0, 10, step=1, splits=Some(1))",
+        "rightPlan" -> "Range (0, 10, step=1, splits=Some(1))"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.udf.worker.{DirectWorker, ProcessCallable, UDFWorkerProp
 class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
 
   override def sparkConf: SparkConf = super.sparkConf.set(
-    StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key, true)
+    StaticSQLConf.UNIFIED_UDF_EXECUTION_ENABLED, true)
 
   private case class TestBinaryPlan(
       expression: Expression,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.externalUDF
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, And, ArrayTransform, Attribute,
+  AttributeReference, CreateArray, EqualTo, Expression, ExternalUserDefinedFunction, GreaterThan,
+  Lag, LambdaFunction, Literal, NamedLambdaVariable, UnspecifiedFrame, WindowExpression,
+  WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
+import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, BinaryNode, ExecuteExternalUDF,
+  Filter, Join, JoinHint, LocalLimit, LocalRelation, LogicalPlan, Project, Range, Window}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType}
+import org.apache.spark.udf.worker.{DirectWorker, ProcessCallable, UDFWorkerProperties,
+  UDFWorkerSpecification, WorkerEnvironment}
+
+class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
+
+  private case class TestBinaryPlan(
+      expression: Expression,
+      left: LogicalPlan,
+      right: LogicalPlan) extends BinaryNode {
+
+    override def output: Seq[Attribute] = left.output ++ right.output
+
+    override protected def withNewChildrenInternal(
+        newLeft: LogicalPlan,
+        newRight: LogicalPlan): TestBinaryPlan = copy(left = newLeft, right = newRight)
+  }
+
+  private val input = AttributeReference("input", IntegerType, nullable = false)()
+  private val relation = LocalRelation(Seq(input))
+  private def workerSpec(name: String): UDFWorkerSpecification = {
+    val direct = DirectWorker.newBuilder()
+      .setRunner(ProcessCallable.newBuilder().addCommand(name))
+      .setProperties(UDFWorkerProperties.newBuilder())
+
+    UDFWorkerSpecification.newBuilder()
+      .setEnvironment(WorkerEnvironment.newBuilder())
+      .setDirect(direct)
+      .build()
+  }
+
+  private def udf(
+      name: String,
+      spec: UDFWorkerSpecification,
+      children: Seq[Expression],
+      dataType: DataType = IntegerType,
+      deterministic: Boolean = true,
+      inputTypes: Option[Seq[DataType]] = None): ExternalUserDefinedFunction = {
+    ExternalUserDefinedFunction(
+      name = Some(name),
+      workerSpec = spec,
+      payload = name.getBytes(StandardCharsets.UTF_8),
+      dataType = dataType,
+      children = children,
+      inputTypes = inputTypes,
+      udfDeterministic = deterministic,
+      udfNullable = false)
+  }
+
+  private def extract(plan: LogicalPlan): LogicalPlan = {
+    withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true") {
+      PlanExternalUDFs(ExtractExternalUDFFromWindow(plan))
+    }
+  }
+
+  private def extract(expression: Expression): LogicalPlan = {
+    extract(Project(Seq(Alias(expression, "result")()), relation))
+  }
+
+  private def optimize(plan: LogicalPlan): LogicalPlan = {
+    withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true") {
+      spark.sessionState.optimizer.execute(plan)
+    }
+  }
+
+  private def evalNodes(plan: LogicalPlan): Seq[ExecuteExternalUDF] = {
+    plan.collect { case eval: ExecuteExternalUDF => eval }
+  }
+
+  private def callCount(expression: Expression): Int = {
+    expression.collect { case _: ExternalUserDefinedFunction => 1 }.size
+  }
+
+  test("nested UDF expressions use separate nodes") {
+    val spec = workerSpec("nested")
+    val expression = udf("outer", spec,
+      Seq(udf("middle", spec, Seq(udf("inner", spec, Seq(input))))))
+
+    val nodes = evalNodes(extract(expression))
+    assert(nodes.size == 3)
+    assert(nodes.forall(node => callCount(node.udf) == 1))
+  }
+
+  test("independent UDF expressions use separate nodes") {
+    val spec = workerSpec("independent")
+    val expression = Add(udf("left", spec, Seq(input)), udf("right", spec, Seq(input)))
+
+    val nodes = evalNodes(extract(expression))
+    assert(nodes.size == 2)
+    assert(nodes.forall(node => callCount(node.udf) == 1))
+  }
+
+  test("equivalent deterministic UDF expressions use separate nodes") {
+    val spec = workerSpec("deterministic")
+    val expression = Add(
+      udf("duplicate", spec, Seq(input)),
+      udf("duplicate", spec, Seq(input)))
+
+    val nodes = evalNodes(extract(expression))
+    assert(nodes.size == 2)
+  }
+
+  test("equivalent non-deterministic UDF roots remain separate") {
+    val spec = workerSpec("non-deterministic")
+    val expression = Add(
+      udf("duplicate", spec, Seq(input), deterministic = false),
+      udf("duplicate", spec, Seq(input), deterministic = false))
+
+    val nodes = evalNodes(extract(expression))
+    assert(nodes.size == 2)
+  }
+
+  test("dependent branches use separate nodes") {
+    val spec = workerSpec("branched")
+    val left = udf("left", spec, Seq(input))
+    val right = udf("right", spec, Seq(input))
+    val expression = udf("outer", spec, Seq(Add(left, right)))
+
+    val nodes = evalNodes(extract(expression))
+    assert(nodes.size == 3)
+    assert(nodes.forall(node => callCount(node.udf) == 1))
+  }
+
+  test("UDFs with different worker specifications use separate nodes") {
+    val outerSpec = workerSpec("outer-worker")
+    val innerSpec = workerSpec("inner-worker")
+    val expression = udf("outer", outerSpec, Seq(udf("inner", innerSpec, Seq(input))))
+
+    val nodes = evalNodes(extract(expression))
+    assert(nodes.size == 2)
+    assert(nodes.map(_.workerSpec).toSet == Set(outerSpec, innerSpec))
+    assert(nodes.forall(node => callCount(node.udf) == 1))
+  }
+
+  test("external UDF input types are validated during analysis") {
+    val spec = workerSpec("input-types")
+    val validPlan = Project(Seq(Alias(
+      udf("valid", spec, Seq(input), inputTypes = Some(Seq(IntegerType))), "result")()), relation)
+    spark.sessionState.analyzer.executeAndCheck(validPlan, new QueryPlanningTracker)
+
+    val invalidPlan = Project(Seq(Alias(
+      udf("invalid", spec, Seq(input), inputTypes = Some(Seq(BooleanType))), "result")()), relation)
+    val exception = intercept[AnalysisException] {
+      spark.sessionState.analyzer.executeAndCheck(invalidPlan, new QueryPlanningTracker)
+    }
+    assert(exception.getCondition == "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE")
+  }
+
+  test("an external UDF in a higher-order function lambda is rejected") {
+    val spec = workerSpec("lambda")
+    val lambdaVariable = NamedLambdaVariable("x", IntegerType, nullable = false)
+    val transform = ArrayTransform(
+      CreateArray(Seq(input)),
+      LambdaFunction(
+        udf("lambda", spec, Seq(lambdaVariable)),
+        Seq(lambdaVariable)))
+    val plan = Project(Seq(Alias(transform, "result")()), relation)
+
+    val exception = intercept[AnalysisException] {
+      spark.sessionState.analyzer.executeAndCheck(plan, new QueryPlanningTracker)
+    }
+    assert(exception.getCondition ==
+      "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_EXTERNAL_UDF")
+  }
+
+  test("an external UDF over an aggregate expression is evaluated after aggregate") {
+    val spec = workerSpec("aggregate")
+    val sum = Sum(input).toAggregateExpression()
+    val plan = Aggregate(
+      groupingExpressions = Seq.empty,
+      aggregateExpressions = Seq(Alias(udf("aggregate", spec, Seq(sum)), "result")()),
+      child = relation)
+
+    val nodes = evalNodes(extract(plan))
+    assert(nodes.size == 1)
+    assert(nodes.head.child.isInstanceOf[Aggregate])
+  }
+
+  test("a zero-argument non-deterministic UDF is evaluated after aggregate") {
+    val spec = workerSpec("zero-argument")
+    val plan = Aggregate(
+      groupingExpressions = Seq.empty,
+      aggregateExpressions = Seq(Alias(
+        udf("zero-argument", spec, Seq.empty, deterministic = false), "result")()),
+      child = relation)
+
+    val extracted = extract(plan)
+    val nodes = evalNodes(extracted)
+    assert(nodes.size == 1)
+    assert(nodes.head.child.isInstanceOf[Aggregate])
+    assert(extracted.output == plan.output)
+  }
+
+  test("an external UDF used as a grouping key is evaluated before aggregate") {
+    val spec = workerSpec("grouping")
+    val plan = Aggregate(
+      groupingExpressions = Seq(udf("grouping", spec, Seq(input))),
+      aggregateExpressions = Seq(Alias(udf("grouping", spec, Seq(input)), "result")()),
+      child = relation)
+
+    val extracted = extract(plan)
+    val aggregate = extracted.collectFirst { case node: Aggregate => node }.get
+    assert(aggregate.child.collect { case node: ExecuteExternalUDF => node }.size == 1)
+  }
+
+  test("an external UDF over a window expression is evaluated after window") {
+    val spec = workerSpec("over-window")
+    val windowSpec = WindowSpecDefinition(Seq.empty, Seq.empty, UnspecifiedFrame)
+    val windowExpression = WindowExpression(new Lag(input), windowSpec)
+    val plan = Window(
+      windowExpressions = Seq(Alias(udf("over-window", spec, Seq(windowExpression)), "result")()),
+      partitionSpec = Seq.empty,
+      orderSpec = Seq.empty,
+      child = relation)
+
+    val extracted = extract(plan)
+    val evaluation = evalNodes(extracted).head
+    assert(evaluation.child.isInstanceOf[Window])
+    assert(!evaluation.udf.exists(_.isInstanceOf[WindowExpression]))
+    assert(evaluation.udf.references.subsetOf(evaluation.child.outputSet))
+  }
+
+  test("an external UDF used by a window expression is evaluated before window") {
+    val spec = workerSpec("under-window")
+    val windowSpec = WindowSpecDefinition(Seq.empty, Seq.empty, UnspecifiedFrame)
+    val windowExpression = WindowExpression(
+      new Lag(udf("under-window", spec, Seq(input))),
+      windowSpec)
+    val plan = Window(
+      windowExpressions = Seq(Alias(windowExpression, "result")()),
+      partitionSpec = Seq.empty,
+      orderSpec = Seq.empty,
+      child = relation)
+
+    val extracted = extract(plan)
+    val window = extracted.collectFirst { case node: Window => node }.get
+    val evaluation = window.child.asInstanceOf[ExecuteExternalUDF]
+    assert(evaluation.child == relation)
+  }
+
+  test("an external UDF join condition referencing both sides is evaluated after join") {
+    val spec = workerSpec("join")
+    val rightInput = AttributeReference("right", IntegerType, nullable = false)()
+    val right = LocalRelation(Seq(rightInput))
+    val condition = udf("join", spec, Seq(input, rightInput), dataType = BooleanType)
+    val plan = Join(relation, right, Inner, Some(condition), JoinHint.NONE)
+
+    val extracted = extract(plan)
+    val filter = extracted.collectFirst { case node: Filter => node }.get
+    val evaluation = filter.child.asInstanceOf[ExecuteExternalUDF]
+    val join = evaluation.child.asInstanceOf[Join]
+    assert(join.condition.isEmpty)
+  }
+
+  test("an external UDF join condition rejects unsupported join types") {
+    val spec = workerSpec("join")
+    val rightInput = AttributeReference("right", IntegerType, nullable = false)()
+    val right = LocalRelation(Seq(rightInput))
+    val condition = udf("join", spec, Seq(input, rightInput), dataType = BooleanType)
+    val plan = Join(relation, right, LeftOuter, Some(condition), JoinHint.NONE)
+
+    val exception = intercept[AnalysisException] {
+      extract(plan)
+    }
+    checkError(
+      exception = exception,
+      condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF_IN_ON_CLAUSE",
+      parameters = Map("joinType" -> LeftOuter.sql))
+  }
+
+  test("an external UDF referencing multiple children reports an unsupported feature") {
+    val spec = workerSpec("multiple-children")
+    val rightInput = AttributeReference("right", IntegerType, nullable = false)()
+    val right = LocalRelation(Seq(rightInput))
+    val plan = TestBinaryPlan(
+      udf("multiple-children", spec, Seq(input, rightInput)),
+      relation,
+      right)
+
+    val exception = intercept[AnalysisException] {
+      extract(plan)
+    }
+    checkError(
+      exception = exception,
+      condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF_WITH_MULTIPLE_CHILDREN",
+      parameters = Map.empty)
+  }
+
+  test("external UDF expressions are rejected when unified execution is disabled") {
+    val spec = workerSpec("disabled")
+    val plan = Project(Seq(Alias(udf("external", spec, Seq(input)), "result")()), relation)
+
+    val exception = withSQLConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "false") {
+      intercept[SparkUnsupportedOperationException] {
+        PlanExternalUDFs(plan)
+      }
+    }
+    checkError(
+      exception = exception,
+      condition = "UNSUPPORTED_FEATURE.EXTERNAL_UDF",
+      parameters = Map("config" -> SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key))
+  }
+
+  test("optimizer pushes a local limit through an external UDF node") {
+    val spec = workerSpec("limit")
+    val range = Range(0, 10, 1, 1)
+    val function = udf("limit", spec, Seq(range.output.head))
+    val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
+    val plan = LocalLimit(Literal(1), ExecuteExternalUDF(function, resultAttr, range))
+
+    val optimized = optimize(plan)
+    val evaluation = optimized.collectFirst { case node: ExecuteExternalUDF => node }.get
+    assert(evaluation.child.isInstanceOf[LocalLimit])
+  }
+
+  test("strategy plans an external UDF execution node") {
+    val spec = workerSpec("physical-planning")
+    val range = Range(0, 10, 1, 1)
+    val function = udf("physical-planning", spec, Seq(range.output.head))
+    val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
+    val logicalPlan = ExecuteExternalUDF(function, resultAttr, range)
+
+    val physicalPlan = spark.sessionState.planner.plan(logicalPlan).next()
+    val execution = physicalPlan.asInstanceOf[ExecuteExternalUDFExec]
+    assert(execution.udf == function)
+    assert(execution.resultAttr == resultAttr)
+    assert(execution.workerSpec == spec)
+  }
+
+  test("optimizer pushes child-only predicates through an external UDF node") {
+    val spec = workerSpec("predicate")
+    val range = Range(0, 10, 1, 1)
+    val function = udf("predicate", spec, Seq(range.output.head))
+    val resultAttr = AttributeReference("externalUDF", IntegerType, nullable = false)()
+    val childPredicate = GreaterThan(range.output.head, Literal(0L))
+    val resultPredicate = EqualTo(resultAttr, Literal(1))
+    val plan = Filter(
+      And(childPredicate, resultPredicate),
+      ExecuteExternalUDF(function, resultAttr, range))
+
+    val optimized = optimize(plan)
+    val evaluation = optimized.collectFirst { case node: ExecuteExternalUDF => node }.get
+    val pushedPredicate = evaluation.child.collectFirst {
+      case Filter(condition, _) => condition
+    }.get
+    assert(pushedPredicate.semanticEquals(childPredicate))
+  }
+
+  test("optimizer checks cartesian products after external UDF extraction") {
+    val spec = workerSpec("cartesian")
+    val left = Range(0, 10, 1, 1)
+    val right = Range(0, 10, 1, 1)
+    val condition = udf(
+      "cartesian",
+      spec,
+      Seq(left.output.head, right.output.head),
+      dataType = BooleanType)
+    val plan = Join(left, right, Inner, Some(condition), JoinHint.NONE)
+
+    val exception = withSQLConf(
+        SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> "true",
+        SQLConf.CROSS_JOINS_ENABLED.key -> "false") {
+      intercept[AnalysisException] {
+        spark.sessionState.optimizer.execute(plan)
+      }
+    }
+    assert(exception.getMessage.startsWith("Detected implicit cartesian product"))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/PlanExternalUDFsSuite.scala
@@ -441,7 +441,9 @@ class PlanExternalUDFsSuite extends QueryTest with SharedSparkSession {
       case node: Window => node
       case other => fail(s"Expected a Window node, found:\n$other")
     }
-    assert(window.output.map(_.exprId).distinct.size == window.output.size)
+    val windowOutputExprIds =
+      window.child.output.map(_.exprId) ++ window.windowExpressions.map(_.exprId)
+    assert(windowOutputExprIds.distinct.size == windowOutputExprIds.size)
     assert(evaluation.udf.children.size == 2)
     assert(evaluation.udf.children.last.semanticEquals(input))
     assert(!evaluation.udf.exists(_.isInstanceOf[WindowExpression]))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds planning support for scalar `ExternalUserDefinedFunction` expressions.

It:

- Introduces logical and physical scalar external UDF evaluation nodes.
- Extracts each UDF into a separate evaluation node. Dependent and nested UDFs become ordered, stacked nodes, so an evaluation node never contains a nested UDF call.
- Handles UDF placement around aggregates, grouping expressions, windows, and joins.
- Preserves predicate and local-limit pushdown through external UDF nodes.
- Gates planning with `spark.sql.execution.udf.unified.execution.enabled`. When disabled, external UDF expressions are rejected with a structured unsupported-feature error.
- Carries the worker specification with the UDF expression.
- Validates declared input arity and improves structured errors.
- Prevents worker specifications, payloads, and environment variables from leaking through expression, plan, error, or log rendering.
- Fails immediately for unimplemented physical execution, before starting a worker.

This PR intentionally does not implement scalar UDF execution or UDF chaining and fusing. Each UDF is currently planned as an individual evaluation node. Chaining support is tracked separately by SPARK-59049.

### Why are the changes needed?

The language-agnostic external UDF framework can represent external UDFs, but Spark did not have optimizer and planner support for scalar external UDF expressions.

The new rules provide the required placement behavior for joins, aggregates, grouping expressions, and windows while ensuring that nested UDFs do not require nested worker sessions within one evaluation node.

### Does this PR introduce _any_ user-facing change?

No. `ExternalUserDefinedFunction` currently has no public scalar entry point, and scalar execution remains unimplemented.

### How was this patch tested?

Added `PlanExternalUDFsSuite` coverage for:

- Independent, nested, deterministic, and non-deterministic UDFs.
- Aggregates, grouping expressions, windows, and joins.
- Configuration gating and unsupported placements.
- Input type and arity validation.
- Optimizer and physical planner integration.
- Safe rendering of worker specifications and environment variables.
- Fail-fast behavior for unimplemented execution.

Executed:

```bash
build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 \
  'sql/testOnly org.apache.spark.sql.execution.externalUDF.PlanExternalUDFsSuite' \
  sql/scalastyle \
  sql/Test/scalastyle
```

All 26 tests passed, and both Scala style checks completed without errors.

### Was this patch authored or co-authored using generative AI tooling?

Yes.