### PR TITLE
[SPARK-58458][SQL][TESTS] Add coverage for the record split when multiLine is disabled

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -4078,13 +4078,18 @@ abstract class CSVSuite
     // published datasets. In the default non-multiLine mode the input is split on the line
     // separator before the CSV tokenizer runs -- HadoopFileLinesReader feeds
     // UnivocityParser.parseLine one physical line at a time -- so the record cannot be
-    // reassembled. It becomes a NULL-tailed head plus a fragment, which changes the row
-    // count as well as the values. None of that is currently covered by a test.
-    val schema = new StructType()
+    // reassembled: the leading value is truncated and the remainder starts a new record.
+    //
+    // Whether a resulting half is *malformed* is a separate question from the split, and is
+    // decided mainly by token count: univocity's default STOP_AT_DELIMITER does not fail on
+    // an unclosed quote. The two cases below differ in exactly that, they behave differently
+    // under DROPMALFORMED, and the difference is the part worth pinning.
+    val threeCols = new StructType()
       .add("id", StringType)
       .add("nome", StringType)
       .add("uf", StringType)
 
+    // Case 1 -- both halves carry 2 tokens against a 3-column schema, so both are malformed.
     withTempPath { path =>
       Files.write(
         path.toPath,
@@ -4092,41 +4097,82 @@ abstract class CSVSuite
           "2,\"EMPRESA COM\nQUEBRA DE LINHA\",RJ\n" +
           "3,OUTRA EMPRESA,MG\n").getBytes(StandardCharsets.UTF_8))
 
-      // Three records in, four rows out: record 2 is cut at the line break, its trailing
-      // field is nulled, and the remainder of the quoted value starts a new record.
+      // Three records in, four rows out: record 2 is cut at the line break.
       checkAnswer(
-        spark.read.schema(schema).csv(path.getAbsolutePath),
+        spark.read.schema(threeCols).csv(path.getAbsolutePath),
         Row("1", "ACME LTDA", "SP") ::
           Row("2", "EMPRESA COM", null) ::
           Row("QUEBRA DE LINHA\"", "RJ", null) ::
           Row("3", "OUTRA EMPRESA", "MG") :: Nil)
 
-      // multiLine reassembles the record, so the line break survives inside the value.
+      // multiLine reassembles the record, so the break survives inside the value.
       checkAnswer(
-        spark.read.schema(schema).option("multiLine", true).csv(path.getAbsolutePath),
+        spark.read.schema(threeCols).option("multiLine", true).csv(path.getAbsolutePath),
         Row("1", "ACME LTDA", "SP") ::
           Row("2", "EMPRESA COM\nQUEBRA DE LINHA", "RJ") ::
           Row("3", "OUTRA EMPRESA", "MG") :: Nil)
 
-      // Both halves carry unbalanced quotes, so both are malformed and DROPMALFORMED
-      // discards the pair -- the whole source record is lost, not just the damaged half.
+      // Both halves being malformed, DROPMALFORMED discards the pair and the whole source
+      // record is lost -- not just the damaged half.
       checkAnswer(
-        spark.read.schema(schema).option("mode", "DROPMALFORMED").csv(path.getAbsolutePath),
+        spark.read.schema(threeCols).option("mode", "DROPMALFORMED").csv(path.getAbsolutePath),
         Row("1", "ACME LTDA", "SP") ::
           Row("3", "OUTRA EMPRESA", "MG") :: Nil)
 
-      // With columnNameOfCorruptRecord declared, both halves are captured with their raw
-      // text, which is the only configuration in which the split leaves a trace.
-      val withCorrupt = schema.add("_corrupt", StringType)
+      // FAILFAST refuses the file rather than returning a split record.
+      val e = intercept[SparkException] {
+        spark.read
+          .schema(threeCols)
+          .option("mode", "FAILFAST")
+          .csv(path.getAbsolutePath)
+          .collect()
+      }
+      checkErrorMatchPVals(
+        exception = e,
+        condition = "FAILED_READ_FILE.NO_HINT",
+        parameters = Map("path" -> s".*${path.getName}.*"))
+
+      // Only with columnNameOfCorruptRecord declared does the split leave a trace.
       checkAnswer(
         spark.read
-          .schema(withCorrupt)
+          .schema(threeCols.add("_corrupt", StringType))
           .option("columnNameOfCorruptRecord", "_corrupt")
           .csv(path.getAbsolutePath),
         Row("1", "ACME LTDA", "SP", null) ::
           Row("2", "EMPRESA COM", null, "2,\"EMPRESA COM") ::
           Row("QUEBRA DE LINHA\"", "RJ", null, "QUEBRA DE LINHA\",RJ") ::
           Row("3", "OUTRA EMPRESA", "MG", null) :: Nil)
+    }
+
+    // Case 2 -- the leading half's token count matches the schema, so it is NOT malformed.
+    // It is a clean row carrying a silently truncated value, and DROPMALFORMED keeps it,
+    // which is the opposite of what the mode's name suggests for a damaged record.
+    val twoCols = new StructType()
+      .add("id", StringType)
+      .add("valor", StringType)
+
+    withTempPath { path =>
+      Files.write(
+        path.toPath, "1,\"hello\nworld\"\n".getBytes(StandardCharsets.UTF_8))
+
+      checkAnswer(
+        spark.read.schema(twoCols).csv(path.getAbsolutePath),
+        Row("1", "hello") ::
+          Row("world\"", null) :: Nil)
+
+      // The truncated row survives; only the trailing fragment is dropped.
+      checkAnswer(
+        spark.read.schema(twoCols).option("mode", "DROPMALFORMED").csv(path.getAbsolutePath),
+        Row("1", "hello") :: Nil)
+
+      // And nothing flags it: the corrupt-record column stays null on the truncated row.
+      checkAnswer(
+        spark.read
+          .schema(twoCols.add("_corrupt", StringType))
+          .option("columnNameOfCorruptRecord", "_corrupt")
+          .csv(path.getAbsolutePath),
+        Row("1", "hello", null) ::
+          Row("world\"", null, "world\"") :: Nil)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -4072,6 +4072,63 @@ abstract class CSVSuite
       }
     }
   }
+
+  test("SPARK-58458: a quoted line break splits the record when multiLine is disabled") {
+    // A line break inside a quoted value is valid CSV (RFC 4180 section 2.6) and occurs in
+    // published datasets. In the default non-multiLine mode the input is split on the line
+    // separator before the CSV tokenizer runs -- HadoopFileLinesReader feeds
+    // UnivocityParser.parseLine one physical line at a time -- so the record cannot be
+    // reassembled. It becomes a NULL-tailed head plus a fragment, which changes the row
+    // count as well as the values. None of that is currently covered by a test.
+    val schema = new StructType()
+      .add("id", StringType)
+      .add("nome", StringType)
+      .add("uf", StringType)
+
+    withTempPath { path =>
+      Files.write(
+        path.toPath,
+        ("1,ACME LTDA,SP\n" +
+          "2,\"EMPRESA COM\nQUEBRA DE LINHA\",RJ\n" +
+          "3,OUTRA EMPRESA,MG\n").getBytes(StandardCharsets.UTF_8))
+
+      // Three records in, four rows out: record 2 is cut at the line break, its trailing
+      // field is nulled, and the remainder of the quoted value starts a new record.
+      checkAnswer(
+        spark.read.schema(schema).csv(path.getAbsolutePath),
+        Row("1", "ACME LTDA", "SP") ::
+          Row("2", "EMPRESA COM", null) ::
+          Row("QUEBRA DE LINHA\"", "RJ", null) ::
+          Row("3", "OUTRA EMPRESA", "MG") :: Nil)
+
+      // multiLine reassembles the record, so the line break survives inside the value.
+      checkAnswer(
+        spark.read.schema(schema).option("multiLine", true).csv(path.getAbsolutePath),
+        Row("1", "ACME LTDA", "SP") ::
+          Row("2", "EMPRESA COM\nQUEBRA DE LINHA", "RJ") ::
+          Row("3", "OUTRA EMPRESA", "MG") :: Nil)
+
+      // Both halves carry unbalanced quotes, so both are malformed and DROPMALFORMED
+      // discards the pair -- the whole source record is lost, not just the damaged half.
+      checkAnswer(
+        spark.read.schema(schema).option("mode", "DROPMALFORMED").csv(path.getAbsolutePath),
+        Row("1", "ACME LTDA", "SP") ::
+          Row("3", "OUTRA EMPRESA", "MG") :: Nil)
+
+      // With columnNameOfCorruptRecord declared, both halves are captured with their raw
+      // text, which is the only configuration in which the split leaves a trace.
+      val withCorrupt = schema.add("_corrupt", StringType)
+      checkAnswer(
+        spark.read
+          .schema(withCorrupt)
+          .option("columnNameOfCorruptRecord", "_corrupt")
+          .csv(path.getAbsolutePath),
+        Row("1", "ACME LTDA", "SP", null) ::
+          Row("2", "EMPRESA COM", null, "2,\"EMPRESA COM") ::
+          Row("QUEBRA DE LINHA\"", "RJ", null, "QUEBRA DE LINHA\",RJ") ::
+          Row("3", "OUTRA EMPRESA", "MG", null) :: Nil)
+    }
+  }
 }
 
 class CSVv1Suite extends CSVSuite {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a test to `CSVSuite` pinning what the CSV reader does with a line break inside a
quoted value when `multiLine` is left at its default of `false`: the record is cut at
the break into a NULL-tailed head plus a fragment, and the row count rises by one.

The test also pins the three consequences that follow from it — the `multiLine=true`
contrast, `DROPMALFORMED` discarding both halves, and the raw text captured when
`columnNameOfCorruptRecord` is declared.

### Why are the changes needed?

The behaviour is not covered today. `CSVSuite` contains exactly one input literal with
a newline inside quotes, in the `lineSep with 2 chars when multiLine set to ...` test,
and it is confined to the `multiLine = true` branch:

```scala
val inputData = if (multiLine) {
  s"""name,"i am the${newLine} column1"${newLine}jack,30${newLine}tom,18"""
} else {
  s"name,age${newLine}jack,30${newLine}tom,18"
}
```

The `multiLine = false` branch deliberately drops the quoted break, so the default
path is never exercised with the input that distinguishes it. `UnivocityParserSuite`
does not cover it either.

That leaves an untested behaviour that users do meet: a line break inside a quoted
value is valid CSV (RFC 4180 §2.6) and appears in published datasets, so reading such
a file with default options is an ordinary thing to do. The split is a consequence of
the non-multiLine read path being line-oriented by design — `HadoopFileLinesReader`
splits the input on the line separator before the tokenizer sees it, and
`UnivocityParser.parseLine` then receives one physical line at a time — which is what
makes the file splittable. This PR does not propose changing that; it pins what the
current design produces, so a future change to that path cannot alter it silently.

`DROPMALFORMED` losing the whole source record rather than the damaged half is the
part most worth having locked down, since it is the opposite of what the mode's name
suggests for one bad line.

### Does this PR introduce _any_ user-facing change?

No. Test-only.

### How was this patch tested?

This PR *is* the test. It was run in CI against this base before the PR was opened:
`Build modules: sql - slow tests`, `sql - extended tests` and `sql - other tests` all
passed, so the test holds in `CSVv1Suite`, `CSVv2Suite` and `CSVLegacyTimeParserSuite`
alike.

The expected rows were derived before the Scala was written, from `pyspark` 3.5.9 with
the same three-record input and the same explicit three-column schema. 3.5.9 is two
majors behind this base, so those values were treated as a hypothesis to be confirmed
by that CI run rather than as evidence in themselves:

| read | rows |
|---|---|
| default (`multiLine=false`) | 4 — `("1","ACME LTDA","SP")`, `("2","EMPRESA COM",null)`, `("QUEBRA DE LINHA\"","RJ",null)`, `("3","OUTRA EMPRESA","MG")` |
| `multiLine=true` | 3, with the break preserved inside the value |
| `mode=DROPMALFORMED` | 2 — records 1 and 3; record 2 lost entirely |
| `columnNameOfCorruptRecord` declared | 4, both halves carrying raw text `2,"EMPRESA COM` and `QUEBRA DE LINHA",RJ` |

Reproduction script: `docs/evidence/c5_expected_rows.py` in the authoring repo (not
part of this patch).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)

### Related

This is the third of three separate concerns in the same area, filed in order:

1. [#57608](https://github.com/apache/spark/pull/57608) — documents what `multiLine=false`
   does to a line break inside a quoted value (open, reviewed, revision applied).
2. [#57658](https://github.com/apache/spark/pull/57658) — corrects the `PERMISSIVE`
   "drops corrupt records" sentence in the CSV and JSON docs.
3. This PR — pins the behaviour #57608 documents, so it cannot change silently.

Flagging the overlap explicitly since all three touch CSV: this one adds a test and
changes no docs and no `main` code.
