### PR TITLE
[SPARK-58469][PS] Use native expressions for NumPy rint

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -68,7 +68,7 @@ unary_np_spark_mappings = {
     "reciprocal": pandas_udf(  # type: ignore[call-overload]
         lambda s: np.reciprocal(s), DoubleType()
     ),
-    "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore[call-overload]
+    "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),
     "sin": F.sin,

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -104,6 +104,7 @@ class NumPyCompatTestsMixin:
             (np.negative, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.positive, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.rad2deg, [-np.inf, -64.0, -np.pi, 0.0, np.pi, 64.0, np.inf, np.nan]),
+            (np.rint, [-np.inf, -2.5, -1.5, -0.5, -0.0, 0.0, 0.5, 1.5, 2.5, np.inf, np.nan]),
             (np.sign, [-np.inf, -64.0, -2.0, -0.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.sinh, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.square, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the pandas UDF mapping for NumPy rint on pandas-on-Spark objects with the native Spark `rint` expression after casting the input to `double`. Add coverage for halfway values, signed zero, NaN, and infinities.

### Why are the changes needed?

The operation can be evaluated by Spark without crossing the Python worker boundary while preserving the existing double result type.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added parity coverage in `NumPyCompatTests.test_np_math_functions`.
- Passed Ruff format and lint checks for the changed Python files.
- Focused PySpark tests were not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)