### PR TITLE
[SPARK-58470][PS] Use native expressions for NumPy trunc

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -23,6 +23,20 @@ from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.types import DoubleType, LongType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
+
+# Spark does not provide a numeric trunc function. Subtract the remainder from the absolute value
+# and reapply the sign to truncate toward zero without converting a double to an integral type.
+def _trunc(c):
+    c = c.cast("double")
+    is_non_finite = F.isnan(c) | (c == float("-inf")) | (c == float("inf"))
+    truncated = F.abs(c) - (F.abs(c) % F.lit(1.0))
+    return (
+        F.when(c.isNull() | is_non_finite | (c == 0), c)
+        .when(c < 0, F.negative(truncated))
+        .otherwise(truncated)
+    )
+
+
 unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
@@ -78,7 +92,7 @@ unary_np_spark_mappings = {
     "square": lambda c: c.cast("double") * c,
     "tan": F.tan,
     "tanh": F.tanh,
-    "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore[call-overload]
+    "trunc": _trunc,
 }
 
 binary_np_spark_mappings = {

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -24,19 +24,6 @@ from pyspark.sql.types import DoubleType, LongType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
 
 
-# Spark does not provide a numeric trunc function. Subtract the remainder from the absolute value
-# and reapply the sign to truncate toward zero without converting a double to an integral type.
-def _trunc(c):
-    c = c.cast("double")
-    is_non_finite = F.isnan(c) | (c == float("-inf")) | (c == float("inf"))
-    truncated = F.abs(c) - (F.abs(c) % F.lit(1.0))
-    return (
-        F.when(c.isNull() | is_non_finite | (c == 0), c)
-        .when(c < 0, F.negative(truncated))
-        .otherwise(truncated)
-    )
-
-
 unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
@@ -92,7 +79,15 @@ unary_np_spark_mappings = {
     "square": lambda c: c.cast("double") * c,
     "tan": F.tan,
     "tanh": F.tanh,
-    "trunc": _trunc,
+    "trunc": lambda c: F.when(
+        c.cast("double").isNull()
+        | F.isnan(c.cast("double"))
+        | c.cast("double").isin(float("-inf"), float("inf")),
+        c.cast("double"),
+    ).otherwise(
+        F.signum(c.cast("double"))
+        * (F.abs(c.cast("double")) - (F.abs(c.cast("double")) % F.lit(1.0)))
+    ),
 }
 
 binary_np_spark_mappings = {

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -108,6 +108,24 @@ class NumPyCompatTestsMixin:
             (np.sinh, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.square, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
             (np.tanh, [-np.inf, -64.0, -2.0, 0.0, 2.0, 64.0, np.inf, np.nan]),
+            (
+                np.trunc,
+                [
+                    -np.inf,
+                    -64.0,
+                    -2.0,
+                    -1.5,
+                    -0.5,
+                    -0.0,
+                    0.0,
+                    0.5,
+                    1.5,
+                    2.0,
+                    64.0,
+                    np.inf,
+                    np.nan,
+                ],
+            ),
         ):
             with self.subTest(name=np_func.__name__, values=values):
                 pdf = pd.DataFrame({"a": values})


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the pandas UDF mapping for NumPy trunc on pandas-on-Spark objects with native Spark expressions. The implementation uses the remainder of the absolute double value and reapplies the sign, preserving nulls, NaN, infinities, and signed zero. Add coverage for these values and fractional positive and negative inputs.

### Why are the changes needed?

Spark does not provide a numeric trunc function, but the operation can be evaluated with native expressions without crossing the Python worker boundary.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added parity coverage in `NumPyCompatTests.test_np_math_functions`.
- Manually verified the native expression for signed zero, fractional values, infinities, NaN, and large doubles.
- Passed Ruff format and lint checks for the changed Python files.
- Focused PySpark tests were not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)