### PR TITLE
[SPARK-58471][ML][CONNECT] Improve TrainValidationSplitModel size estimation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -38,8 +38,8 @@ import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.{SizeEstimator, ThreadUtils}
 import org.apache.spark.util.ArrayImplicits._
-import org.apache.spark.util.ThreadUtils
 
 /**
  * Params for [[TrainValidationSplit]] and [[TrainValidationSplitModel]].
@@ -292,6 +292,29 @@ class TrainValidationSplitModel private[ml] (
 
   @Since("2.3.0")
   def hasSubModels: Boolean = _subModels.isDefined
+
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize(excluded = Seq(
+      // estimator: Param[Estimator[_]]
+      estimator,
+      // estimatorParamMaps: Param[Array[ParamMap]]
+      estimatorParamMaps,
+      // evaluator: Param[Evaluator]
+      evaluator))
+    // bestModel: Model[_]
+    size += bestModel.estimatedSize
+    // validationMetrics: Array[Double]
+    size += SizeEstimator.estimate(validationMetrics)
+    // _subModels: Option[Array[Model[_]]]
+    _subModels.foreach { modelArray =>
+      modelArray.foreach { model =>
+        if (model != null) {
+          size += model.estimatedSize
+        }
+      }
+    }
+    size
+  }
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
@@ -73,6 +73,21 @@ class TrainValidationSplitSuite
     }
   }
 
+  test("TrainValidationSplitModel estimated size") {
+    val estimator = new LogisticRegression().setMaxIter(1)
+    // Initialize the estimator's logger before retaining it in the TrainValidationSplitModel.
+    estimator.fit(dataset)
+    val model = new TrainValidationSplit()
+      .setEstimator(estimator)
+      .setEstimatorParamMaps(Array(ParamMap.empty))
+      .setEvaluator(new BinaryClassificationEvaluator())
+      .fit(dataset)
+
+    val maxSize = 16 * 1024
+    assert(model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should not include shared runtime state")
+  }
+
   test("train validation with linear regression") {
     val dataset = sc.parallelize(
       LinearDataGenerator.generateLinearInput(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This subtask of [SPARK-58181](https://issues.apache.org/jira/browse/SPARK-58181), and follow-up to #57665, applies parameter-aware size estimation to `TrainValidationSplitModel`.

It excludes the `estimator`, `estimatorParamMaps`, and `evaluator` params from metadata sizing, then explicitly accounts for the best model, validation metrics, and collected submodels. A regression test confirms that logger-initialized estimator state is not counted.

### Why are the changes needed?

TrainValidationSplitModel retains the same kinds of tuning params as CrossValidatorModel. Their params and values may retain shared runtime state, such as SparkSession, which must not contribute to Spark Connect ML model-cache accounting.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Static checks: `git diff --check`, non-ASCII scan, and changed-Scala line-length scan.

The targeted Scala suite was not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5