### PR TITLE
[SPARK-58468][CORE] Support on-demand loading for single event logs in SHS

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -257,6 +257,15 @@ class SingleEventLogFileWriter(
 }
 
 object SingleEventLogFileWriter {
+  /** Returns names for completed and in-progress single event logs. */
+  private[history] def getLogFileNames(appId: String, appAttemptId: Option[String]): Seq[String] = {
+    val logBaseName = EventLogFileWriter.nameForAppAndAttempt(appId, appAttemptId)
+    val names = logBaseName +: CompressionCodec.shortCompressionCodecNames.keys.toSeq.map {
+      codec => s"$logBaseName.$codec"
+    }
+    names ++ names.map(_ + EventLogFileWriter.IN_PROGRESS)
+  }
+
   /**
    * Return a file-system-safe path to the log file for the given application.
    *

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -412,16 +412,11 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   override def getLastUpdatedTime(): Long = lastScanTime.get()
 
   override def getAppUI(appId: String, attemptId: Option[String]): Option[LoadedAppUI] = {
-    val logPath = RollingEventLogFilesWriter.EVENT_LOG_DIR_NAME_PREFIX +
-        EventLogFileWriter.nameForAppAndAttempt(appId, attemptId)
     val app = try {
       load(appId)
      } catch {
-      case _: NoSuchElementException if this.conf.get(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED) =>
-        loadFromFallbackLocation(appId, attemptId, logPath) match {
-          case Some(wrapper) => wrapper
-          case None => return None
-        }
+      case _: NoSuchElementException if isOnDemandLogLoadEnabled =>
+        loadFromFallbackLocations(appId, attemptId).getOrElse(return None)
       case _: NoSuchElementException =>
         return None
     }
@@ -460,6 +455,27 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     }
 
     Some(loadedUI)
+  }
+
+  private def loadFromFallbackLocations(
+      appId: String,
+      attemptId: Option[String]): Option[ApplicationInfoWrapper] = {
+    val logPaths = mutable.ArrayBuffer.empty[String]
+    if (conf.get(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED)) {
+      logPaths += RollingEventLogFilesWriter.EVENT_LOG_DIR_NAME_PREFIX +
+        EventLogFileWriter.nameForAppAndAttempt(appId, attemptId)
+    }
+    if (conf.get(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED)) {
+      logPaths ++= SingleEventLogFileWriter.getLogFileNames(appId, attemptId)
+    }
+    logPaths.iterator.map(loadFromFallbackLocation(appId, attemptId, _)).collectFirst {
+      case Some(app) => app
+    }
+  }
+
+  private def isOnDemandLogLoadEnabled: Boolean = {
+    conf.get(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED) ||
+      conf.get(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED)
   }
 
   private def loadFromFallbackLocation(appId: String, attemptId: Option[String], logPath: String)

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -465,7 +465,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       logPaths += RollingEventLogFilesWriter.EVENT_LOG_DIR_NAME_PREFIX +
         EventLogFileWriter.nameForAppAndAttempt(appId, attemptId)
     }
-    if (conf.get(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED)) {
+    if (conf.get(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED)) {
       logPaths ++= SingleEventLogFileWriter.getLogFileNames(appId, attemptId)
     }
     logPaths.iterator.map(loadFromFallbackLocation(appId, attemptId, _)).collectFirst {
@@ -475,7 +475,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   private def isOnDemandLogLoadEnabled: Boolean = {
     conf.get(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED) ||
-      conf.get(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED)
+      conf.get(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED)
   }
 
   private def loadFromFallbackLocation(appId: String, attemptId: Option[String], logPath: String)

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -188,8 +188,16 @@ private[spark] object History {
 
   val EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED =
     ConfigBuilder("spark.history.fs.eventLog.rolling.onDemandLoadEnabled")
-      .doc("Whether to look up rolling event log locations on demand manner before listing files.")
+      .doc("Whether to look up rolling event log locations on demand before listing files.")
       .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED =
+    ConfigBuilder("spark.history.fs.eventLog.v1.onDemandLoadEnabled")
+      .doc("Whether to look up V1 event log locations on demand before listing files.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(true)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -194,7 +194,7 @@ private[spark] object History {
       .createWithDefault(true)
 
   val EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED =
-    ConfigBuilder("spark.history.fs.eventLog.single.onDemandLoadEnabled")
+    ConfigBuilder("spark.history.fs.eventLog.onDemandLoadEnabled")
       .doc("Whether to look up single event log locations on demand manner before listing files.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -188,14 +188,14 @@ private[spark] object History {
 
   val EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED =
     ConfigBuilder("spark.history.fs.eventLog.rolling.onDemandLoadEnabled")
-      .doc("Whether to look up rolling event log locations on demand before listing files.")
+      .doc("Whether to look up rolling event log locations on demand manner before listing files.")
       .version("4.1.0")
       .booleanConf
       .createWithDefault(true)
 
-  val EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED =
-    ConfigBuilder("spark.history.fs.eventLog.v1.onDemandLoadEnabled")
-      .doc("Whether to look up V1 event log locations on demand before listing files.")
+  val EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED =
+    ConfigBuilder("spark.history.fs.eventLog.single.onDemandLoadEnabled")
+      .doc("Whether to look up single event log locations on demand manner before listing files.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
@@ -352,6 +352,17 @@ class SingleEventLogFileWriterSuite extends EventLogFileWritersSuite {
         "a fine:mind$dollar{bills}.1", None, Some(CompressionCodec.LZ4)))
   }
 
+  test("Event log file names") {
+    val names = SingleEventLogFileWriter.getLogFileNames("app1", Some("attempt1"))
+    assert(names.head === "app1_attempt1")
+    assert(names.contains("app1_attempt1.inprogress"))
+    assert(names.size === (1 + CompressionCodec.shortCompressionCodecNames.size) * 2)
+    CompressionCodec.shortCompressionCodecNames.keys.foreach { codec =>
+      assert(names.contains(s"app1_attempt1.$codec"))
+      assert(names.contains(s"app1_attempt1.$codec.inprogress"))
+    }
+  }
+
   override protected def createWriter(
       appId: String,
       appAttemptId: Option[String],

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
@@ -353,13 +353,16 @@ class SingleEventLogFileWriterSuite extends EventLogFileWritersSuite {
   }
 
   test("Event log file names") {
-    val names = SingleEventLogFileWriter.getLogFileNames("app1", Some("attempt1"))
-    assert(names.head === "app1_attempt1")
-    assert(names.contains("app1_attempt1.inprogress"))
-    assert(names.size === (1 + CompressionCodec.shortCompressionCodecNames.size) * 2)
-    CompressionCodec.shortCompressionCodecNames.keys.foreach { codec =>
-      assert(names.contains(s"app1_attempt1.$codec"))
-      assert(names.contains(s"app1_attempt1.$codec.inprogress"))
+    Seq(None, Some("attempt1")).foreach { attemptId =>
+      val baseName = attemptId.map(id => s"app1_$id").getOrElse("app1")
+      val names = SingleEventLogFileWriter.getLogFileNames("app1", attemptId)
+      assert(names.head === baseName)
+      assert(names.contains(s"$baseName.inprogress"))
+      assert(names.size === (1 + CompressionCodec.shortCompressionCodecNames.size) * 2)
+      CompressionCodec.shortCompressionCodecNames.keys.foreach { codec =>
+        assert(names.contains(s"$baseName.$codec"))
+        assert(names.contains(s"$baseName.$codec.inprogress"))
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -83,9 +83,10 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       appId: String,
       appAttemptId: Option[String],
       inProgress: Boolean,
-      codec: Option[String] = None): File = {
+      codec: Option[String] = None,
+      logDir: File = testDir): File = {
     val ip = if (inProgress) EventLogFileWriter.IN_PROGRESS else ""
-    val logUri = SingleEventLogFileWriter.getLogPath(testDir.toURI, appId, appAttemptId, codec)
+    val logUri = SingleEventLogFileWriter.getLogPath(logDir.toURI, appId, appAttemptId, codec)
     val logPath = new Path(logUri).toUri.getPath + ip
     new File(logPath)
   }
@@ -1756,6 +1757,147 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
 
         provider.stop()
       }
+    }
+  }
+
+  test("Support spark.history.fs.eventLog.v1.onDemandLoadEnabled") {
+    Seq(true, false).foreach { onDemandEnabled =>
+      Seq(None, Some(CompressionCodec.LZF)).foreach { codecName =>
+        withTempDir { dir =>
+          val conf = createTestConf(true)
+          conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+          conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, onDemandEnabled)
+          val provider = new FsHistoryProvider(conf)
+          val appId = s"app1-${codecName.getOrElse("none")}"
+          val logFile = newLogFile(appId, None, inProgress = false, codecName, dir)
+          val codec = codecName.map(CompressionCodec.createCodec(conf, _))
+          writeFile(logFile, codec,
+            SparkListenerApplicationStart(appId, Some(appId), 1000, "testuser", None),
+            SparkListenerApplicationEnd(5000))
+
+          assert(provider.getListing().isEmpty)
+          assert(provider.getAppUI(appId, None).isDefined == onDemandEnabled)
+          assert(provider.getListing().length === (if (onDemandEnabled) 1 else 0))
+
+          if (onDemandEnabled) {
+            val appInfo = provider.getListing().next()
+            assert(appInfo.name === appId)
+            assert(appInfo.attempts.head.sparkUser === "testuser")
+            assert(appInfo.attempts.head.completed)
+            assert(appInfo.attempts.head.duration === 4000)
+          }
+
+          provider.stop()
+        }
+      }
+    }
+  }
+
+  test("Support on-demand loading for in-progress V1 event logs") {
+    Seq(None, Some(CompressionCodec.LZF)).foreach { codecName =>
+      withTempDir { dir =>
+        val conf = createTestConf(true)
+        conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+        conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+        val provider = new FsHistoryProvider(conf)
+        val appId = s"app1-${codecName.getOrElse("none")}"
+        val logFile = newLogFile(appId, None, inProgress = true, codecName, dir)
+        val codec = codecName.map(CompressionCodec.createCodec(conf, _))
+        writeFile(logFile, codec,
+          SparkListenerApplicationStart(appId, Some(appId), 1000, "testuser", None))
+
+        assert(provider.getAppUI(appId, None).isDefined)
+        assert(!provider.getListing().next().attempts.head.completed)
+
+        provider.stop()
+      }
+    }
+  }
+
+  test("On-demand loading preserves in-progress V1 event logs during cleanup") {
+    withTempDir { dir =>
+      val clock = new ManualClock(0)
+      val conf = createTestConf(true)
+        .set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+        .set(CLEANER_ENABLED, true)
+        .set(MAX_LOG_AGE_S, 0L)
+        .set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
+        .set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      val provider = new FsHistoryProvider(conf, clock)
+      val logFile = newLogFile("app1", None, inProgress = true, logDir = dir)
+      writeFile(logFile, None,
+        SparkListenerApplicationStart("app1", Some("app1"), 0, "testuser", None))
+
+      assert(provider.getAppUI("app1", None).isDefined)
+      assert(provider.getListing().next().attempts.head.appSparkVersion === SPARK_VERSION)
+      assert(logFile.exists())
+
+      provider.cleanLogs()
+      assert(logFile.exists())
+
+      provider.stop()
+    }
+  }
+
+  test("On-demand loading respects V1 event log attempts") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      val provider = new FsHistoryProvider(conf)
+      val logFile = newLogFile("app1", Some("attempt1"), inProgress = false, logDir = dir)
+      writeFile(logFile, None,
+        SparkListenerApplicationStart("app1", Some("app1"), 1000, "testuser", Some("attempt1")),
+        SparkListenerApplicationEnd(5000))
+
+      assert(provider.getAppUI("app1", None).isEmpty)
+      assert(provider.getListing().isEmpty)
+      assert(provider.getAppUI("app1", Some("attempt1")).isDefined)
+
+      provider.stop()
+    }
+  }
+
+  test("On-demand loading finds V1 event logs in all directories") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, s"${testDir.getAbsolutePath},${dir.getAbsolutePath}")
+      conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      val provider = new FsHistoryProvider(conf)
+      val logFile = newLogFile("app1", None, inProgress = false, logDir = dir)
+      writeFile(logFile, None,
+        SparkListenerApplicationStart("app1", Some("app1"), 1000, "testuser", None),
+        SparkListenerApplicationEnd(5000))
+
+      assert(provider.getAppUI("app1", None).isDefined)
+      assert(provider.getListing().next().attempts.head.logSourceFullPath ===
+        Some(dir.getAbsolutePath))
+
+      provider.stop()
+    }
+  }
+
+  test("On-demand loading supports V1 event logs when scanning is disabled") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq("file:.*"))
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
+      conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      val provider = new FsHistoryProvider(conf)
+      val logFile = newLogFile("app1", None, inProgress = false, logDir = dir)
+      writeFile(logFile, None,
+        SparkListenerApplicationStart("app1", Some("app1"), 1000, "testuser", None),
+        SparkListenerApplicationEnd(5000))
+
+      provider.checkForLogs()
+      assert(provider.getListing().isEmpty)
+      assert(provider.getAppUI("app1", None).isDefined)
+
+      provider.checkForLogs()
+      assert(provider.getListing().length === 1)
+
+      provider.stop()
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1761,7 +1761,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("Support spark.history.fs.eventLog.single.onDemandLoadEnabled") {
+  test("Support spark.history.fs.eventLog.onDemandLoadEnabled") {
     Seq(true, false).foreach { onDemandEnabled =>
       Seq(None, Some(CompressionCodec.LZF)).foreach { codecName =>
         withTempDir { dir =>

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1732,6 +1732,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
         val conf = createTestConf(true)
         conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
         conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, onDemandEnabled)
+        conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, false)
         val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
         val provider = new FsHistoryProvider(conf)
 
@@ -1760,13 +1761,14 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("Support spark.history.fs.eventLog.v1.onDemandLoadEnabled") {
+  test("Support spark.history.fs.eventLog.single.onDemandLoadEnabled") {
     Seq(true, false).foreach { onDemandEnabled =>
       Seq(None, Some(CompressionCodec.LZF)).foreach { codecName =>
         withTempDir { dir =>
           val conf = createTestConf(true)
           conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
-          conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, onDemandEnabled)
+          conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
+          conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, onDemandEnabled)
           val provider = new FsHistoryProvider(conf)
           val appId = s"app1-${codecName.getOrElse("none")}"
           val logFile = newLogFile(appId, None, inProgress = false, codecName, dir)
@@ -1793,12 +1795,13 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("Support on-demand loading for in-progress V1 event logs") {
+  test("Support on-demand loading for in-progress single event logs") {
     Seq(None, Some(CompressionCodec.LZF)).foreach { codecName =>
       withTempDir { dir =>
         val conf = createTestConf(true)
         conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
-        conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+        conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
+        conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, true)
         val provider = new FsHistoryProvider(conf)
         val appId = s"app1-${codecName.getOrElse("none")}"
         val logFile = newLogFile(appId, None, inProgress = true, codecName, dir)
@@ -1814,7 +1817,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("On-demand loading preserves in-progress V1 event logs during cleanup") {
+  test("On-demand loading preserves in-progress single event logs during cleanup") {
     withTempDir { dir =>
       val clock = new ManualClock(0)
       val conf = createTestConf(true)
@@ -1822,7 +1825,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
         .set(CLEANER_ENABLED, true)
         .set(MAX_LOG_AGE_S, 0L)
         .set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
-        .set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+        .set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, true)
       val provider = new FsHistoryProvider(conf, clock)
       val logFile = newLogFile("app1", None, inProgress = true, logDir = dir)
       writeFile(logFile, None,
@@ -1839,11 +1842,12 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("On-demand loading respects V1 event log attempts") {
+  test("On-demand loading respects single event log attempts") {
     withTempDir { dir =>
       val conf = createTestConf(true)
       conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
-      conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
+      conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, true)
       val provider = new FsHistoryProvider(conf)
       val logFile = newLogFile("app1", Some("attempt1"), inProgress = false, logDir = dir)
       writeFile(logFile, None,
@@ -1858,11 +1862,12 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("On-demand loading finds V1 event logs in all directories") {
+  test("On-demand loading finds single event logs in all directories") {
     withTempDir { dir =>
       val conf = createTestConf(true)
       conf.set(HISTORY_LOG_DIR, s"${testDir.getAbsolutePath},${dir.getAbsolutePath}")
-      conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
+      conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, true)
       val provider = new FsHistoryProvider(conf)
       val logFile = newLogFile("app1", None, inProgress = false, logDir = dir)
       writeFile(logFile, None,
@@ -1877,13 +1882,13 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("On-demand loading supports V1 event logs when scanning is disabled") {
+  test("On-demand loading supports single event logs when scanning is disabled") {
     withTempDir { dir =>
       val conf = createTestConf(true)
       conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
       conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq("file:.*"))
       conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, false)
-      conf.set(EVENT_LOG_V1_ON_DEMAND_LOAD_ENABLED, true)
+      conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, true)
       val provider = new FsHistoryProvider(conf)
       val logFile = newLogFile("app1", None, inProgress = false, logDir = dir)
       writeFile(logFile, None,

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1789,6 +1789,9 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
             assert(appInfo.attempts.head.duration === 4000)
           }
 
+          assert(provider.getAppUI("nonexist", None).isEmpty)
+          assert(provider.getListing().length === (if (onDemandEnabled) 1 else 0))
+
           provider.stop()
         }
       }
@@ -1901,6 +1904,38 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
 
       provider.checkForLogs()
       assert(provider.getListing().length === 1)
+
+      provider.stop()
+    }
+  }
+
+  test("On-demand loading supports rolling and single event logs together") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, true)
+      conf.set(EVENT_LOG_SINGLE_ON_DEMAND_LOAD_ENABLED, true)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+      val provider = new FsHistoryProvider(conf)
+
+      val rollingWriter = new RollingEventLogFilesWriter(
+        "app-rolling", None, dir.toURI, conf, hadoopConf)
+      rollingWriter.start()
+      writeEventsToRollingWriter(rollingWriter, Seq(
+        SparkListenerApplicationStart("app-rolling", Some("app-rolling"), 0, "user", None),
+        SparkListenerJobStart(1, 0, Seq.empty)), rollFile = false)
+      rollingWriter.stop()
+
+      val singleLog = newLogFile("app-single", None, inProgress = false, logDir = dir)
+      writeFile(singleLog, None,
+        SparkListenerApplicationStart("app-single", Some("app-single"), 0, "user", None),
+        SparkListenerApplicationEnd(1))
+
+      assert(provider.getAppUI("app-rolling", None).isDefined)
+      assert(provider.getAppUI("app-single", None).isDefined)
+      assert(provider.getListing().length === 2)
+      assert(provider.getAppUI("nonexist", None).isEmpty)
+      assert(provider.getListing().length === 2)
 
       provider.stop()
     }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -454,15 +454,15 @@ Security options for the Spark History Server are covered more detail in the
     <td>spark.history.fs.eventLog.rolling.onDemandLoadEnabled</td>
     <td>true</td>
     <td>
-      Whether to look up rolling event log locations on demand before listing files.
+      Whether to look up rolling event log locations on demand manner before listing files.
     </td>
     <td>4.1.0</td>
   </tr>
   <tr>
-    <td>spark.history.fs.eventLog.v1.onDemandLoadEnabled</td>
+    <td>spark.history.fs.eventLog.single.onDemandLoadEnabled</td>
     <td>true</td>
     <td>
-      Whether to look up V1 event log locations on demand before listing files.
+      Whether to look up single event log locations on demand manner before listing files.
     </td>
     <td>4.3.0</td>
   </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -459,7 +459,7 @@ Security options for the Spark History Server are covered more detail in the
     <td>4.1.0</td>
   </tr>
   <tr>
-    <td>spark.history.fs.eventLog.single.onDemandLoadEnabled</td>
+    <td>spark.history.fs.eventLog.onDemandLoadEnabled</td>
     <td>true</td>
     <td>
       Whether to look up single event log locations on demand manner before listing files.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -454,9 +454,17 @@ Security options for the Spark History Server are covered more detail in the
     <td>spark.history.fs.eventLog.rolling.onDemandLoadEnabled</td>
     <td>true</td>
     <td>
-      Whether to look up rolling event log locations on demand manner before listing files.
+      Whether to look up rolling event log locations on demand before listing files.
     </td>
     <td>4.1.0</td>
+  </tr>
+  <tr>
+    <td>spark.history.fs.eventLog.v1.onDemandLoadEnabled</td>
+    <td>true</td>
+    <td>
+      Whether to look up V1 event log locations on demand before listing files.
+    </td>
+    <td>4.3.0</td>
   </tr>
   <tr>
     <td>spark.history.store.hybridStore.enabled</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends History Server on-demand event-log loading to single event logs.

It adds `spark.history.fs.eventLog.onDemandLoadEnabled`, which is independent from the existing rolling event-log configuration. When enabled, the History Server probes completed, compressed, and in-progress single event-log names after a requested application is absent from the listing.

### Why are the changes needed?

Single event logs remain supported, but on-demand loading currently only supports rolling event logs. A requested application with a single event log can therefore return Not Found until periodic scanning discovers its log.

### Does this PR introduce _any_ user-facing change?

Yes. History Server can load single event logs on demand. The new `spark.history.fs.eventLog.onDemandLoadEnabled` configuration defaults to `true`.

### How was this patch tested?

Added tests for:
- enabled and disabled single event-log on-demand loading
- uncompressed and LZF-compressed logs
- in-progress logs and cleaner safety
- attempt IDs
- multiple log directories
- scan-disabled directories

Ran the focused `FsHistoryProviderSuite` and `SingleEventLogFileWriterSuite` tests. Also ran `SparkConfigBindingPolicySuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: gpt-5.6-terra