### PR TITLE
[SPARK-58482][SQL] Fix NaN bounds in cached column statistics

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ArrowCachedBatchSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ArrowCachedBatchSerializer.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.catalyst.util.SQLOrderingUtil
 import org.apache.spark.sql.columnar.{CachedBatch, SimpleMetricsCachedBatchSerializer}
 import org.apache.spark.sql.errors.ExecutionErrors
 import org.apache.spark.sql.execution.arrow.ArrowWriter
@@ -680,24 +681,20 @@ private object ArrowCachedBatchSerializer {
   def calculateMinMaxFloat(
       vector: org.apache.arrow.vector.FieldVector,
       rowCount: Int): (Any, Any) = {
-    var min = Float.MaxValue
-    var max = Float.MinValue
+    var min = 0.0f
+    var max = 0.0f
     var hasValue = false
 
     (0 until rowCount).foreach { i =>
       if (!vector.isNull(i)) {
         val value = vector.asInstanceOf[org.apache.arrow.vector.Float4Vector].get(i)
-        // Skip NaN: IEEE 754 comparisons with NaN are always false, so NaN never
-        // updates min/max in the row-based path (FloatColumnStats.gatherValueStats).
-        if (!value.isNaN) {
-          if (!hasValue) {
-            min = value
-            max = value
-            hasValue = true
-          } else {
-            if (value < min) min = value
-            if (value > max) max = value
-          }
+        if (!hasValue) {
+          min = value
+          max = value
+          hasValue = true
+        } else {
+          if (SQLOrderingUtil.compareFloats(value, min) < 0) min = value
+          if (SQLOrderingUtil.compareFloats(value, max) > 0) max = value
         }
       }
     }
@@ -708,23 +705,20 @@ private object ArrowCachedBatchSerializer {
   def calculateMinMaxDouble(
       vector: org.apache.arrow.vector.FieldVector,
       rowCount: Int): (Any, Any) = {
-    var min = Double.MaxValue
-    var max = Double.MinValue
+    var min = 0.0d
+    var max = 0.0d
     var hasValue = false
 
     (0 until rowCount).foreach { i =>
       if (!vector.isNull(i)) {
         val value = vector.asInstanceOf[org.apache.arrow.vector.Float8Vector].get(i)
-        // Skip NaN to match DoubleColumnStats.gatherValueStats.
-        if (!value.isNaN) {
-          if (!hasValue) {
-            min = value
-            max = value
-            hasValue = true
-          } else {
-            if (value < min) min = value
-            if (value > max) max = value
-          }
+        if (!hasValue) {
+          min = value
+          max = value
+          hasValue = true
+        } else {
+          if (SQLOrderingUtil.compareDoubles(value, min) < 0) min = value
+          if (SQLOrderingUtil.compareDoubles(value, max) > 0) max = value
         }
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnStats.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnStats.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.columnar
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, UnsafeArrayData, UnsafeMapData, UnsafeRow}
+import org.apache.spark.sql.catalyst.util.SQLOrderingUtil
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{BinaryView, TimestampNanosVal, UTF8String}
 
@@ -221,8 +222,13 @@ private[columnar] final class FloatColumnStats extends ColumnStats {
   }
 
   def gatherValueStats(value: Float): Unit = {
-    if (value > upper) upper = value
-    if (value < lower) lower = value
+    if (count == nullCount) {
+      upper = value
+      lower = value
+    } else {
+      if (SQLOrderingUtil.compareFloats(value, upper) > 0) upper = value
+      if (SQLOrderingUtil.compareFloats(value, lower) < 0) lower = value
+    }
     sizeInBytes += FLOAT.defaultSize
     count += 1
   }
@@ -245,8 +251,13 @@ private[columnar] final class DoubleColumnStats extends ColumnStats {
   }
 
   def gatherValueStats(value: Double): Unit = {
-    if (value > upper) upper = value
-    if (value < lower) lower = value
+    if (count == nullCount) {
+      upper = value
+      lower = value
+    } else {
+      if (SQLOrderingUtil.compareDoubles(value, upper) > 0) upper = value
+      if (SQLOrderingUtil.compareDoubles(value, lower) < 0) lower = value
+    }
     sizeInBytes += DOUBLE.defaultSize
     count += 1
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ArrowCachedBatchSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ArrowCachedBatchSerializerSuite.scala
@@ -1317,19 +1317,18 @@ class ArrowCachedBatchSerializerSuite extends QueryTest with SharedSparkSession 
     assert(tsNtzStats.getLong(0) < tsNtzStats.getLong(1))
     tsNtzDf.unpersist()
 
-    // FloatType: NaN is included but IEEE 754 comparisons with NaN are always false,
-    // so NaN never updates min/max; lower=1.0f, upper=10.0f
+    // FloatType: NaN sorts after all finite values; lower=1.0f, upper=NaN
     val floatDf = singlePartDf(Seq(1.0f, Float.NaN, 10.0f), FloatType).cache()
     val floatStats = cachedStats(floatDf)
     assert(!floatStats.isNullAt(0) && !floatStats.isNullAt(1))
-    assert(floatStats.getFloat(0) == 1.0f && floatStats.getFloat(1) == 10.0f)
+    assert(floatStats.getFloat(0) == 1.0f && floatStats.getFloat(1).isNaN)
     floatDf.unpersist()
 
-    // DoubleType: same NaN-exclusion behavior via IEEE 754; lower=1.0, upper=10.0
+    // DoubleType: NaN sorts after all finite values; lower=1.0, upper=NaN
     val doubleDf = singlePartDf(Seq(1.0, Double.NaN, 10.0), DoubleType).cache()
     val doubleStats = cachedStats(doubleDf)
     assert(!doubleStats.isNullAt(0) && !doubleStats.isNullAt(1))
-    assert(doubleStats.getDouble(0) == 1.0 && doubleStats.getDouble(1) == 10.0)
+    assert(doubleStats.getDouble(0) == 1.0 && doubleStats.getDouble(1).isNaN)
     doubleDf.unpersist()
 
     // StringType (UTF8_BINARY): "apple" < "zebra" in binary order
@@ -1441,35 +1440,17 @@ class ArrowCachedBatchSerializerSuite extends QueryTest with SharedSparkSession 
     assertNullBounds(spark.sql("SELECT parse_json('{\"k\":1}') AS v").cache())
   }
 
-  test("row path stats: all-NaN Float/Double column produces inverted sentinel bounds") {
-    // FloatColumnStats and DoubleColumnStats initialize upper=MinValue, lower=MaxValue as
-    // sentinels. IEEE 754 comparisons with NaN are always false, so NaN never beats either
-    // sentinel. When every value is NaN, the sentinels are returned unchanged: lower=MaxValue,
-    // upper=MinValue (lower > upper). This differs from the Arrow path, which returns null bounds
-    // for all-NaN input (because calculateMinMaxFloat/Double explicitly skips NaN with !_.isNaN
-    // and returns (null, null) when hasValue stays false).
+  test("row path stats: all-NaN Float/Double columns produce NaN bounds") {
     val floatDf = singlePartDf(Seq(Float.NaN), FloatType).cache()
     val floatStats = cachedStats(floatDf)
-    assert(!floatStats.isNullAt(0),
-      "FloatType lower should not be null for all-NaN (sentinel used)")
-    assert(!floatStats.isNullAt(1),
-      "FloatType upper should not be null for all-NaN (sentinel used)")
-    assert(floatStats.getFloat(0) == Float.MaxValue,
-      s"FloatType lower expected Float.MaxValue (sentinel), got ${floatStats.getFloat(0)}")
-    assert(floatStats.getFloat(1) == Float.MinValue,
-      s"FloatType upper expected Float.MinValue (sentinel), got ${floatStats.getFloat(1)}")
+    assert(!floatStats.isNullAt(0) && floatStats.getFloat(0).isNaN)
+    assert(!floatStats.isNullAt(1) && floatStats.getFloat(1).isNaN)
     floatDf.unpersist()
 
     val doubleDf = singlePartDf(Seq(Double.NaN), DoubleType).cache()
     val doubleStats = cachedStats(doubleDf)
-    assert(!doubleStats.isNullAt(0),
-      "DoubleType lower should not be null for all-NaN (sentinel used)")
-    assert(!doubleStats.isNullAt(1),
-      "DoubleType upper should not be null for all-NaN (sentinel used)")
-    assert(doubleStats.getDouble(0) == Double.MaxValue,
-      s"DoubleType lower expected Double.MaxValue (sentinel), got ${doubleStats.getDouble(0)}")
-    assert(doubleStats.getDouble(1) == Double.MinValue,
-      s"DoubleType upper expected Double.MinValue (sentinel), got ${doubleStats.getDouble(1)}")
+    assert(!doubleStats.isNullAt(0) && doubleStats.getDouble(0).isNaN)
+    assert(!doubleStats.isNullAt(1) && doubleStats.getDouble(1).isNaN)
     doubleDf.unpersist()
   }
 
@@ -1535,12 +1516,12 @@ class ArrowCachedBatchSerializerSuite extends QueryTest with SharedSparkSession 
       dtiVector.setSafe(0, 86400000000L)       // 1 day in microseconds
       timeVector.setSafe(0, 28800000000000L)   // 08:00:00 in nanoseconds
 
-      // Row 1: mid values -- Float/Double use NaN to verify NaN is excluded from min/max
+      // Row 1: mid values -- Float/Double use NaN to verify Catalyst ordering
       boolVector.setSafe(1, 1)               // true -- becomes the max
       byteVector.setSafe(1, 5.toByte)
       shortVector.setSafe(1, 500.toShort)
-      floatVector.setSafe(1, Float.NaN)      // NaN: must not affect lower=1.0f or upper=10.0f
-      doubleVector.setSafe(1, Double.NaN)    // NaN: must not affect lower=1.0 or upper=10.0
+      floatVector.setSafe(1, Float.NaN)      // NaN becomes the upper bound
+      doubleVector.setSafe(1, Double.NaN)    // NaN becomes the upper bound
       dateVector.setSafe(1, 19000)
       tsVector.setSafe(1, 1700000000000000L)
       tsNtzVector.setSafe(1, 1700000000000000L)
@@ -1584,13 +1565,13 @@ class ArrowCachedBatchSerializerSuite extends QueryTest with SharedSparkSession 
       assert(stats.getShort(10) == 100.toShort, s"ShortType lower=${stats.getShort(10)}")
       assert(stats.getShort(11) == 1000.toShort, s"ShortType upper=${stats.getShort(11)}")
 
-      // col3 FloatType (offset 15): lower=1.0f, upper=10.0f
+      // col3 FloatType (offset 15): lower=1.0f, upper=NaN
       assert(stats.getFloat(15) == 1.0f, s"FloatType lower=${stats.getFloat(15)}")
-      assert(stats.getFloat(16) == 10.0f, s"FloatType upper=${stats.getFloat(16)}")
+      assert(stats.getFloat(16).isNaN, s"FloatType upper=${stats.getFloat(16)}")
 
-      // col4 DoubleType (offset 20): lower=1.0, upper=10.0
+      // col4 DoubleType (offset 20): lower=1.0, upper=NaN
       assert(stats.getDouble(20) == 1.0, s"DoubleType lower=${stats.getDouble(20)}")
-      assert(stats.getDouble(21) == 10.0, s"DoubleType upper=${stats.getDouble(21)}")
+      assert(stats.getDouble(21).isNaN, s"DoubleType upper=${stats.getDouble(21)}")
 
       // col5 DateType (offset 25): lower=18262 (2020-01-01), upper=20000
       assert(stats.getInt(25) == 18262, s"DateType lower=${stats.getInt(25)}")
@@ -1831,11 +1812,7 @@ class ArrowCachedBatchSerializerSuite extends QueryTest with SharedSparkSession 
         "equal sizes mean the configured level is being ignored")
   }
 
-  test("collectStatistics returns null bounds when all Float/Double values are NaN") {
-    // When every non-null value in a Float or Double column is NaN, calculateMinMaxFloat/Double
-    // finds no valid (non-NaN) values. hasValue stays false -> returns (null, null) -> null bounds.
-    // Null bounds disable partition pruning, ensuring NaN-only batches are never incorrectly
-    // pruned.
+  test("collectStatistics returns NaN bounds when all Float/Double values are NaN") {
     val schema = Seq(
       AttributeReference("float_col", FloatType)(),
       AttributeReference("double_col", DoubleType)()
@@ -1857,13 +1834,13 @@ class ArrowCachedBatchSerializerSuite extends QueryTest with SharedSparkSession 
 
       val stats = ArrowCachedBatchSerializer.collectStatistics(root, schema)
 
-      // FloatType (col0, offset 0): no valid values -> null bounds
-      assert(stats.isNullAt(0), "FloatType lower bound should be null when all values are NaN")
-      assert(stats.isNullAt(1), "FloatType upper bound should be null when all values are NaN")
+      // FloatType (col0, offset 0): lower=NaN, upper=NaN
+      assert(!stats.isNullAt(0) && stats.getFloat(0).isNaN)
+      assert(!stats.isNullAt(1) && stats.getFloat(1).isNaN)
 
-      // DoubleType (col1, offset 5): no valid values -> null bounds
-      assert(stats.isNullAt(5), "DoubleType lower bound should be null when all values are NaN")
-      assert(stats.isNullAt(6), "DoubleType upper bound should be null when all values are NaN")
+      // DoubleType (col1, offset 5): lower=NaN, upper=NaN
+      assert(!stats.isNullAt(5) && stats.getDouble(5).isNaN)
+      assert(!stats.isNullAt(6) && stats.getDouble(6).isNaN)
 
       root.close()
     } catch {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnStatsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnStatsSuite.scala
@@ -36,6 +36,34 @@ class ColumnStatsSuite extends SparkFunSuite {
   testTimestampNanosColumnStats(TIMESTAMP_NTZ_NANOS, Array(null, null, 0))
   testTimestampNanosColumnStats(TIMESTAMP_LTZ_NANOS, Array(null, null, 0))
 
+  test("floating-point column stats treat NaN as the upper bound") {
+    val floatStats = new FloatColumnStats
+    floatStats.gatherNullStats()
+    floatStats.gatherValueStats(Float.NaN)
+    assert(floatStats.collectedStatistics(0).asInstanceOf[Float].isNaN)
+    assert(floatStats.collectedStatistics(1).asInstanceOf[Float].isNaN)
+    Seq(1.5f, 0.0f).foreach(floatStats.gatherValueStats)
+    assert(floatStats.collectedStatistics(0) === 0.0f)
+    assert(floatStats.collectedStatistics(1).asInstanceOf[Float].isNaN)
+    val reversedFloatStats = new FloatColumnStats
+    Seq(0.0f, Float.NaN).foreach(reversedFloatStats.gatherValueStats)
+    assert(reversedFloatStats.collectedStatistics(0) === 0.0f)
+    assert(reversedFloatStats.collectedStatistics(1).asInstanceOf[Float].isNaN)
+
+    val doubleStats = new DoubleColumnStats
+    doubleStats.gatherNullStats()
+    doubleStats.gatherValueStats(Double.NaN)
+    assert(doubleStats.collectedStatistics(0).asInstanceOf[Double].isNaN)
+    assert(doubleStats.collectedStatistics(1).asInstanceOf[Double].isNaN)
+    Seq(1.5d, 0.0d).foreach(doubleStats.gatherValueStats)
+    assert(doubleStats.collectedStatistics(0) === 0.0d)
+    assert(doubleStats.collectedStatistics(1).asInstanceOf[Double].isNaN)
+    val reversedDoubleStats = new DoubleColumnStats
+    Seq(0.0d, Double.NaN).foreach(reversedDoubleStats.gatherValueStats)
+    assert(reversedDoubleStats.collectedStatistics(0) === 0.0d)
+    assert(reversedDoubleStats.collectedStatistics(1).asInstanceOf[Double].isNaN)
+  }
+
   def testColumnStats[T <: PhysicalDataType, U <: ColumnStats](
       columnStatsClass: Class[U],
       columnType: NativeColumnType[T],

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -173,12 +173,20 @@ class InMemoryColumnarQuerySuite extends SharedSparkSession with AdaptiveSparkPl
   }
 
   test("SPARK-58482: cached table pruning should retain NaN values") {
-    val df = Seq((1, 1.5d), (2, Double.NaN), (3, 0.0d)).toDF("id", "v").cache()
+    val doubleDf = Seq((1, 1.5d), (2, Double.NaN), (3, 0.0d)).toDF("id", "v").cache()
     try {
-      df.count()
-      checkAnswer(df.filter($"v" === Double.NaN).select("id"), Row(2))
+      doubleDf.count()
+      checkAnswer(doubleDf.filter($"v" === Double.NaN).select("id"), Row(2))
     } finally {
-      df.unpersist(blocking = true)
+      doubleDf.unpersist(blocking = true)
+    }
+
+    val floatDf = Seq((1, 1.5f), (2, Float.NaN), (3, 0.0f)).toDF("id", "v").cache()
+    try {
+      floatDf.count()
+      checkAnswer(floatDf.filter($"v" === Float.NaN).select("id"), Row(2))
+    } finally {
+      floatDf.unpersist(blocking = true)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -172,6 +172,16 @@ class InMemoryColumnarQuerySuite extends SharedSparkSession with AdaptiveSparkPl
     assert(df.filter("f <= 10.0").count() == 9)
   }
 
+  test("SPARK-58482: cached table pruning should retain NaN values") {
+    val df = Seq((1, 1.5d), (2, Double.NaN), (3, 0.0d)).toDF("id", "v").cache()
+    try {
+      df.count()
+      checkAnswer(df.filter($"v" === Double.NaN).select("id"), Row(2))
+    } finally {
+      df.unpersist(blocking = true)
+    }
+  }
+
   test("SPARK-1436 regression: in-memory columns must be able to be accessed multiple times") {
     val plan = spark.sessionState.executePlan(testData.logicalPlan).sparkPlan
     val scan = InMemoryRelation(new TestCachedBatchSerializer(useCompression = true, 5),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes cached `FloatType` and `DoubleType` column statistics use Catalyst's SQL
floating-point ordering when collecting lower and upper bounds. It also initializes both bounds
from the first non-null value.

Unit coverage verifies NaN bounds for both float and double values in either input order, including
leading nulls. An end-to-end regression test verifies that cached table pruning retains rows that
match a NaN filter.

### Why are the changes needed?

The cached column statistics collector previously used JVM `<` and `>` comparisons. Every such
comparison with NaN is false, so NaN could be omitted from a cached batch's upper bound. Cache
pruning uses Catalyst ordering, where NaN sorts after finite values, and could therefore incorrectly
prune a batch containing a matching NaN row.

### Does this PR introduce _any_ user-facing change?

Yes. Queries filtering a cached floating-point column for NaN no longer risk returning an empty or
incomplete result because a matching cached batch was incorrectly pruned.

### How was this patch tested?

Added regression coverage and ran:

```
build/sbt 'sql/testOnly org.apache.spark.sql.execution.columnar.ColumnStatsSuite'
build/sbt 'sql/testOnly org.apache.spark.sql.execution.columnar.InMemoryColumnarQuerySuite'
build/sbt sql/scalastyle sql/Test/scalastyle
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (used for code assistance).
