### PR TITLE
[SPARK-58500][PYTHON] Accept tuple in DataFrame.describe and selectExpr

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1033,9 +1033,15 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 _cols.append(c)  # type: ignore[arg-type]
         return self._jseq(_cols, _to_java_column)
 
-    def describe(self, *cols: Union[str, List[str]]) -> ParentDataFrame:
-        if len(cols) == 1 and isinstance(cols[0], list):
-            cols = cols[0]  # type: ignore[assignment]
+    @overload
+    def describe(self, *cols: str) -> ParentDataFrame: ...
+
+    @overload
+    def describe(self, __cols: Sequence[str]) -> ParentDataFrame: ...
+
+    def describe(self, *cols: Union[str, Sequence[str]]) -> ParentDataFrame:
+        if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
+            cols = tuple(cols[0])
         jdf = self._jdf.describe(self._jseq(cols))
         return DataFrame(jdf, self.sparkSession)
 
@@ -1116,11 +1122,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def selectExpr(self, *expr: str) -> ParentDataFrame: ...
 
     @overload
-    def selectExpr(self, *expr: List[str]) -> ParentDataFrame: ...
+    def selectExpr(self, __expr: Sequence[str]) -> ParentDataFrame: ...
 
-    def selectExpr(self, *expr: Union[str, List[str]]) -> ParentDataFrame:
-        if len(expr) == 1 and isinstance(expr[0], list):
-            expr = expr[0]  # type: ignore[assignment]
+    def selectExpr(self, *expr: Union[str, Sequence[str]]) -> ParentDataFrame:
+        if len(expr) == 1 and not isinstance(expr[0], str) and isinstance(expr[0], Sequence):
+            expr = tuple(expr[0])
         jdf = self._jdf.selectExpr(self._jseq(expr))
         return DataFrame(jdf, self.sparkSession)
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -300,10 +300,16 @@ class DataFrame(ParentDataFrame):
             session=self._session,
         )
 
-    def selectExpr(self, *expr: Union[str, List[str]]) -> ParentDataFrame:
+    @overload
+    def selectExpr(self, *expr: str) -> ParentDataFrame: ...
+
+    @overload
+    def selectExpr(self, __expr: Sequence[str]) -> ParentDataFrame: ...
+
+    def selectExpr(self, *expr: Union[str, Sequence[str]]) -> ParentDataFrame:
         sql_expr = []
-        if len(expr) == 1 and isinstance(expr[0], list):
-            expr = expr[0]  # type: ignore[assignment]
+        if len(expr) == 1 and not isinstance(expr[0], str) and isinstance(expr[0], Sequence):
+            expr = tuple(expr[0])
         for element in expr:
             if isinstance(element, str):
                 sql_expr.append(F.expr(element))
@@ -1601,9 +1607,15 @@ class DataFrame(ParentDataFrame):
             session=self._session,
         )
 
-    def describe(self, *cols: Union[str, List[str]]) -> ParentDataFrame:
-        if len(cols) == 1 and isinstance(cols[0], list):
-            cols = cols[0]  # type: ignore[assignment]
+    @overload
+    def describe(self, *cols: str) -> ParentDataFrame: ...
+
+    @overload
+    def describe(self, __cols: Sequence[str]) -> ParentDataFrame: ...
+
+    def describe(self, *cols: Union[str, Sequence[str]]) -> ParentDataFrame:
+        if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
+            cols = tuple(cols[0])
 
         _cols = []
         for column in cols:

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3360,8 +3360,14 @@ class DataFrame:
 
     orderBy = sort
 
+    @overload
+    def describe(self, *cols: str) -> "DataFrame": ...
+
+    @overload
+    def describe(self, __cols: Sequence[str]) -> "DataFrame": ...
+
     @dispatch_df_method
-    def describe(self, *cols: Union[str, List[str]]) -> "DataFrame":
+    def describe(self, *cols: Union[str, Sequence[str]]) -> "DataFrame":
         """Computes basic statistics for numeric and string columns.
 
         .. versionadded:: 1.3.1
@@ -3777,10 +3783,10 @@ class DataFrame:
     def selectExpr(self, *expr: str) -> "DataFrame": ...
 
     @overload
-    def selectExpr(self, *expr: List[str]) -> "DataFrame": ...
+    def selectExpr(self, __expr: Sequence[str]) -> "DataFrame": ...
 
     @dispatch_df_method
-    def selectExpr(self, *expr: Union[str, List[str]]) -> "DataFrame":
+    def selectExpr(self, *expr: Union[str, Sequence[str]]) -> "DataFrame":
         """Projects a set of SQL expressions and returns a new :class:`DataFrame`.
 
         This is a variant of :func:`select` that accepts SQL expressions.

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -842,6 +842,15 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             .toPandas(),
         )
 
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name)
+            .selectExpr(("id * 2", "cast(name as long) as name"))
+            .toPandas(),
+            self.spark.read.table(self.tbl_name)
+            .selectExpr(("id * 2", "cast(name as long) as name"))
+            .toPandas(),
+        )
+
     def test_select_star(self):
         data = [Row(a=1, b=Row(c=2, d=Row(e=3)))]
 

--- a/python/pyspark/sql/tests/connect/test_connect_stat.py
+++ b/python/pyspark/sql/tests/connect/test_connect_stat.py
@@ -169,6 +169,10 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
             self.connect.read.table(self.tbl_name).describe(["id", "name"]).toPandas(),
             self.spark.read.table(self.tbl_name).describe(["id", "name"]).toPandas(),
         )
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name).describe(("id", "name")).toPandas(),
+            self.spark.read.table(self.tbl_name).describe(("id", "name")).toPandas(),
+        )
 
     def test_stat_cov(self):
         # SPARK-41067: Test the stat.cov method


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DataFrame.describe` and `DataFrame.selectExpr` accept their column names / SQL expressions as varargs, and also allow a single sequence to be passed in place of the varargs (e.g. `df.describe(["a", "b"])`). Today that single-sequence form is unwrapped only when it is a `list` — the runtime check is `isinstance(x[0], list)` — so passing a tuple such as `df.describe(("a", "b"))` is not unwrapped and is instead treated as a single, invalid column argument.

This PR:
- Widens the `describe` and `selectExpr` type annotations from `Union[str, List[str]]` to `Union[str, Sequence[str]]` (overloads + implementation) across the base (`sql/dataframe.py`), classic (`sql/classic/dataframe.py`), and connect (`sql/connect/dataframe.py`) layers.
- Changes the runtime unwrap check from `isinstance(x[0], list)` to `not isinstance(x[0], str) and isinstance(x[0], Sequence)`, and unwraps with `x = tuple(x[0])`, so a single tuple is unpacked the same way a list is.
- Normalizes the overload shape: `describe` had no overloads in any layer (added the 2-overload shape `*x: str` / `__x: Sequence[str]`); `selectExpr` had a `*expr: List[str]` overload in base + classic (fixed to a single-arg `__expr: Sequence[str]`) and none in connect (added). Drops the now-unnecessary `# type: ignore[assignment]` on the unwrap.

This is a follow-up to the SPARK-58488 cleanup (#57693). Unlike the writer methods (`partitionBy`/`clusterBy`/`bucketBy`/`sortBy`), which already accepted a list or a tuple, `describe`/`selectExpr` accepted a `list` only, so this adds tuple/sequence support.

### Related PRs

This is one of a series of PRs cleaning up the "varargs that also accept a single sequence" typing pattern across PySpark (following SPARK-55967). They are intentionally kept separate:

- #57693 (SPARK-58488) -- `DataFrameWriter` / `DataStreamWriter` `partitionBy` / `clusterBy` / `bucketBy` / `sortBy`, plus the `partitionBy=` keyword argument. Those already accepted a list or a tuple, so that PR only corrects the annotations.
- This PR (SPARK-58500) -- `DataFrame.describe` / `selectExpr`, which accepted a `list` only, so widening them adds tuple support.
- #57726 (SPARK-58522) -- `Window` / `WindowSpec` / `TableArg` `partitionBy` / `orderBy`, the column-typed members of the same family.
- Still to come: the column functions `struct` / `create_map` / `array` / `map_concat`, which check `(list, set)` in classic but `(list, set, tuple)` in connect. The honest type there is not simply `Sequence` (it must also cover `set`), so that one needs a separate discussion.

### Why are the changes needed?

The runtime already intends to accept "a name or a sequence of names", but the check and the annotation only admitted `list`. Passing a tuple silently did the wrong thing (treated the whole tuple as one column/expression) rather than being unpacked. Accepting any non-str `Sequence` makes the behavior consistent with the writer methods and with the general varargs-or-sequence convention in the DataFrame API, and makes the type annotation honest about what is accepted.

### Does this PR introduce _any_ user-facing change?

Yes. Previously `df.describe(("a", "b"))` / `df.selectExpr(("e1", "e2"))` (a single tuple) was not unpacked and did not behave like the list form; now a single tuple of column names / expressions is accepted and unpacked just like a list. This is a backward-compatible addition — the existing str-varargs and single-list forms are unchanged.

### How was this patch tested?

- Added tuple-form cases to the existing connect-vs-classic parity tests `test_connect_stat.py::test_describe` and `test_connect_basic.py::test_select_expr` (these assert the same call on the classic and connect sessions produce equal results, so they cover both layers). Both pass.
- Full-scope `mypy` over `python/pyspark` is clean.
- `ruff format --check` and `ruff check` pass on the changed files.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
