### PR TITLE
[SPARK-58486][SQL] Use collation-aware hashes for runtime Bloom filters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.{INVOKE, JSON_TO_STRUCT, LIKE_FAMLIY, PYTHON_UDF, REGEXP_EXTRACT_FAMILY, REGEXP_REPLACE, SCALA_UDF}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.SchemaUtils
 
 /**
  * Insert a runtime filter on one side of the join (we call this side the application side) if
@@ -35,6 +36,14 @@ import org.apache.spark.sql.internal.SQLConf
  * bloom filter but we may add other physical implementations in the future.
  */
 object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with JoinSelectionHelper {
+
+  private def bloomFilterHash(key: Expression): Expression = {
+    if (SchemaUtils.hasNonUTF8BinaryCollation(key.dataType)) {
+      new CollationAwareXxHash64(Seq(key))
+    } else {
+      new XxHash64(Seq(key))
+    }
+  }
 
   private def injectFilter(
       filterApplicationSideKey: Expression,
@@ -61,10 +70,9 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     val rowCount = filterCreationSidePlan.stats.rowCount
     val bloomFilterAgg =
       if (rowCount.isDefined && rowCount.get.longValue > 0L) {
-        new BloomFilterAggregate(
-          new CollationAwareXxHash64(Seq(filterCreationSideKey)), rowCount.get.longValue)
+        new BloomFilterAggregate(bloomFilterHash(filterCreationSideKey), rowCount.get.longValue)
       } else {
-        new BloomFilterAggregate(new CollationAwareXxHash64(Seq(filterCreationSideKey)))
+        new BloomFilterAggregate(bloomFilterHash(filterCreationSideKey))
       }
 
     val alias = Alias(bloomFilterAgg.toAggregateExpression(), "bloomFilter")()
@@ -76,8 +84,8 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       return filterApplicationSidePlan
     }
     val bloomFilterSubquery = ScalarSubquery(aggregate, Nil)
-    val filter = BloomFilterMightContain(bloomFilterSubquery,
-      new CollationAwareXxHash64(Seq(filterApplicationSideKey)))
+    val filter = BloomFilterMightContain(
+      bloomFilterSubquery, bloomFilterHash(filterApplicationSideKey))
     Filter(filter, filterApplicationSidePlan)
   }
 
@@ -276,6 +284,8 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     plan.exists {
       case Filter(condition, _) =>
         splitConjunctivePredicates(condition).exists {
+          case BloomFilterMightContain(_, XxHash64(Seq(valueExpression), _))
+            if valueExpression.fastEquals(key) => true
           case BloomFilterMightContain(_, CollationAwareXxHash64(Seq(valueExpression), _))
             if valueExpression.fastEquals(key) => true
           case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -61,9 +61,10 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     val rowCount = filterCreationSidePlan.stats.rowCount
     val bloomFilterAgg =
       if (rowCount.isDefined && rowCount.get.longValue > 0L) {
-        new BloomFilterAggregate(new XxHash64(Seq(filterCreationSideKey)), rowCount.get.longValue)
+        new BloomFilterAggregate(
+          new CollationAwareXxHash64(Seq(filterCreationSideKey)), rowCount.get.longValue)
       } else {
-        new BloomFilterAggregate(new XxHash64(Seq(filterCreationSideKey)))
+        new BloomFilterAggregate(new CollationAwareXxHash64(Seq(filterCreationSideKey)))
       }
 
     val alias = Alias(bloomFilterAgg.toAggregateExpression(), "bloomFilter")()
@@ -76,7 +77,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     }
     val bloomFilterSubquery = ScalarSubquery(aggregate, Nil)
     val filter = BloomFilterMightContain(bloomFilterSubquery,
-      new XxHash64(Seq(filterApplicationSideKey)))
+      new CollationAwareXxHash64(Seq(filterApplicationSideKey)))
     Filter(filter, filterApplicationSidePlan)
   }
 
@@ -275,7 +276,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     plan.exists {
       case Filter(condition, _) =>
         splitConjunctivePredicates(condition).exists {
-          case BloomFilterMightContain(_, XxHash64(Seq(valueExpression), _))
+          case BloomFilterMightContain(_, CollationAwareXxHash64(Seq(valueExpression), _))
             if valueExpression.fastEquals(key) => true
           case _ => false
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.io.File
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain, CollationAwareXxHash64, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain, CollationAwareXxHash64, Expression, Literal, XxHash64}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, BloomFilterAggregate}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan}
 import org.apache.spark.sql.execution.{ReusedSubqueryExec, SubqueryExec}
@@ -277,6 +277,16 @@ class InjectRuntimeFilterSuite extends SharedSparkSession
     numMightContains
   }
 
+  def getBloomFilterHashes(plan: LogicalPlan): Seq[Expression] = {
+    plan.collectWithSubqueries {
+      case node => node.expressions.flatMap(_.collect {
+        case BloomFilterMightContain(_, hash) => hash
+        case AggregateExpression(
+            BloomFilterAggregate(hash, _, _, _, _), _, _, _, _) => hash
+      })
+    }.flatten
+  }
+
   def columnPruningTakesEffect(plan: LogicalPlan): Boolean = {
     def takesEffect(plan: LogicalPlan): Boolean = {
       val result = org.apache.spark.sql.catalyst.optimizer.ColumnPruning.apply(plan)
@@ -302,8 +312,11 @@ class InjectRuntimeFilterSuite extends SharedSparkSession
   test("Runtime bloom filter join: simple") {
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000") {
-      assertRewroteWithBloomFilter("select * from bf1 join bf2 on bf1.c1 = bf2.c2 " +
-        "where bf2.a2 = 62")
+      val query = "select * from bf1 join bf2 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      assertRewroteWithBloomFilter(query)
+      val bloomFilterHashes = getBloomFilterHashes(sql(query).queryExecution.optimizedPlan)
+      assert(bloomFilterHashes.size == 2)
+      assert(bloomFilterHashes.forall(_.isInstanceOf[XxHash64]))
       assertDidNotRewriteWithBloomFilter("select * from bf1 join bf2 on bf1.c1 = bf2.c2")
     }
   }
@@ -519,44 +532,41 @@ class InjectRuntimeFilterSuite extends SharedSparkSession
     }
   }
 
-  test("SPARK-58486: runtime bloom filters use collation-aware hashing") {
-    withTable("runtime_filter_dim", "runtime_filter_fact") {
-      sql("""
-        |CREATE TABLE runtime_filter_dim(
-        |  key STRING COLLATE UTF8_LCASE,
-        |  category STRING) USING parquet
-        |""".stripMargin)
-      sql("INSERT INTO runtime_filter_dim VALUES ('ABC', 'x')")
-      sql("""
-        |CREATE TABLE runtime_filter_fact USING parquet AS
-        |SELECT concat('abc', CAST(id AS STRING)) COLLATE UTF8_LCASE AS key
-        |FROM range(5000)
-        |""".stripMargin)
+  Seq("UTF8_LCASE", "UNICODE_CI").foreach { collation =>
+    test(s"SPARK-58486: runtime bloom filters use collation-aware hashing ($collation)") {
+      withTable("runtime_filter_dim", "runtime_filter_fact") {
+        sql(s"""
+          |CREATE TABLE runtime_filter_dim(
+          |  key STRING COLLATE $collation,
+          |  category STRING) USING parquet
+          |""".stripMargin)
+        sql("INSERT INTO runtime_filter_dim VALUES ('ABC', 'x')")
+        sql(s"""
+          |CREATE TABLE runtime_filter_fact USING parquet AS
+          |SELECT concat('abc', CAST(id AS STRING)) COLLATE $collation AS key
+          |FROM range(5000)
+          |""".stripMargin)
 
-      val query =
-        """
-          |SELECT count(*)
-          |FROM runtime_filter_fact fact JOIN runtime_filter_dim dim
-          |ON substr(fact.key, 1, 3) = dim.key
-          |WHERE dim.category = 'x'
-          |""".stripMargin
+        val query =
+          """
+            |SELECT count(*)
+            |FROM runtime_filter_fact fact JOIN runtime_filter_dim dim
+            |ON substr(fact.key, 1, 3) = dim.key
+            |WHERE dim.category = 'x'
+            |""".stripMargin
 
-      withSQLConf(
-        SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
-        SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1",
-        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-        assertRewroteWithBloomFilter(query)
+        withSQLConf(
+          SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+          SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+          assertRewroteWithBloomFilter(query)
+          checkAnswer(sql(query), Seq(Row(5000L)))
 
-        val plan = sql(query).queryExecution.optimizedPlan
-        val bloomFilterHashes = plan.collectWithSubqueries {
-          case node => node.expressions.flatMap(_.collect {
-            case BloomFilterMightContain(_, hash) => hash
-            case AggregateExpression(
-                BloomFilterAggregate(hash, _, _, _, _), _, _, _, _) => hash
-          })
-        }.flatten
-        assert(bloomFilterHashes.size == 2)
-        assert(bloomFilterHashes.forall(_.isInstanceOf[CollationAwareXxHash64]))
+          val bloomFilterHashes =
+            getBloomFilterHashes(sql(query).queryExecution.optimizedPlan)
+          assert(bloomFilterHashes.size == 2)
+          assert(bloomFilterHashes.forall(_.isInstanceOf[CollationAwareXxHash64]))
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.io.File
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain, CollationAwareXxHash64, Literal}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, BloomFilterAggregate}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan}
 import org.apache.spark.sql.execution.{ReusedSubqueryExec, SubqueryExec}
@@ -516,6 +516,48 @@ class InjectRuntimeFilterSuite extends SharedSparkSession
         "bf1.c1 = bf2.c2 where square(bf2.a2) = 62" )
       assertDidNotRewriteWithBloomFilter("select * from bf1 join bf2 on " +
         "bf1.c1 = square(bf2.c2) where bf2.a2 = 62" )
+    }
+  }
+
+  test("SPARK-58486: runtime bloom filters use collation-aware hashing") {
+    withTable("runtime_filter_dim", "runtime_filter_fact") {
+      sql("""
+        |CREATE TABLE runtime_filter_dim(
+        |  key STRING COLLATE UTF8_LCASE,
+        |  category STRING) USING parquet
+        |""".stripMargin)
+      sql("INSERT INTO runtime_filter_dim VALUES ('ABC', 'x')")
+      sql("""
+        |CREATE TABLE runtime_filter_fact USING parquet AS
+        |SELECT concat('abc', CAST(id AS STRING)) COLLATE UTF8_LCASE AS key
+        |FROM range(5000)
+        |""".stripMargin)
+
+      val query =
+        """
+          |SELECT count(*)
+          |FROM runtime_filter_fact fact JOIN runtime_filter_dim dim
+          |ON substr(fact.key, 1, 3) = dim.key
+          |WHERE dim.category = 'x'
+          |""".stripMargin
+
+      withSQLConf(
+        SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+        SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        assertRewroteWithBloomFilter(query)
+
+        val plan = sql(query).queryExecution.optimizedPlan
+        val bloomFilterHashes = plan.collectWithSubqueries {
+          case node => node.expressions.flatMap(_.collect {
+            case BloomFilterMightContain(_, hash) => hash
+            case AggregateExpression(
+                BloomFilterAggregate(hash, _, _, _, _), _, _, _, _) => hash
+          })
+        }.flatten
+        assert(bloomFilterHashes.size == 2)
+        assert(bloomFilterHashes.forall(_.isInstanceOf[CollationAwareXxHash64]))
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `InjectRuntimeFilter` to use `CollationAwareXxHash64` when building and
probing runtime Bloom filters. It also updates the existing-filter check to recognize the
collation-aware hash expression.

A regression test covers a `UTF8_LCASE` equi-join whose application-side key is a `substr`
expression. The test verifies both the query result and the hash expressions in the optimized
plan.

### Why are the changes needed?

Runtime Bloom filters currently use the collation-agnostic `XxHash64`. Values that compare equal
under a non-binary collation can therefore produce different hashes. This can cause the Bloom
filter to reject valid join rows before the collation-aware join is evaluated.

For example, the regression query returns 5000 rows with runtime Bloom filters disabled but 0
rows when they are enabled because `"abc"` and `"ABC"` hash differently despite being equal under
`UTF8_LCASE`.

### Does this PR introduce _any_ user-facing change?

Yes. Equi-joins on collated keys, including non-attribute expressions, no longer silently lose
matching rows when a runtime Bloom filter is injected.

### How was this patch tested?

Added `SPARK-58486: runtime bloom filters use collation-aware hashing` to
`InjectRuntimeFilterSuite`.

Ran:

```
build/sbt 'sql/testOnly org.apache.spark.sql.InjectRuntimeFilterSuite'
build/sbt catalyst/scalastyle sql/Test/scalastyle
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (used for code assistance).
