### PR TITLE
[SPARK-58502] [SQL] Add order by for in-limit tests to make it deterministic 

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
@@ -68,6 +68,7 @@ FROM   t1
 WHERE  t1a IN (SELECT t2a
                FROM   t2
                WHERE  t1d = t2d
+               ORDER BY date ASC
                LIMIT 10)
 LIMIT  2;
 
@@ -88,6 +89,7 @@ FROM   t1
 WHERE  t1a IN (SELECT t2a
                FROM   t2
                WHERE  t1d = t2d
+               ORDER BY date DESC
                LIMIT 10
                OFFSET 2)
 LIMIT  2
@@ -200,6 +202,7 @@ FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
                WHERE  t2b >= 8
+               ORDER BY t2c DESC
                LIMIT  2
                OFFSET 2)
 LIMIT 4
@@ -233,6 +236,7 @@ FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
                    WHERE  t2b <= t1d
+                   ORDER BY t2b DESC
                    LIMIT  2);
 
 SELECT *
@@ -355,6 +359,7 @@ FROM t1
 WHERE t1d IN (SELECT t2d
               FROM   t2
               WHERE t1a IS NOT NULL
+              ORDER BY t2c
               LIMIT 10);
 
 SELECT COUNT(DISTINCT(t1a))
@@ -362,6 +367,7 @@ FROM t1
 WHERE t1d IN (SELECT MAX(t2d)
               FROM   t2
               WHERE t1a IS NOT NULL
+              ORDER BY t2c DESC
               LIMIT 10);
 
 SELECT COUNT(DISTINCT(t1a))
@@ -369,6 +375,7 @@ FROM t1
 WHERE t1d IN (SELECT DISTINCT t2d
               FROM   t2
               WHERE t1a IS NOT NULL
+              ORDER BY t2d ASC
               LIMIT 10);
 
 set spark.sql.optimizer.decorrelateExistsIn.enabled = false;
@@ -379,6 +386,7 @@ FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
                    WHERE  t2b = t1b
+                   ORDER BY t2b DESC
                    LIMIT  2
                    OFFSET 2);
 set spark.sql.optimizer.decorrelateExistsIn.enabled = true;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add ORDER BY to in-limit test cases and change the testdata such that without order by it will be non deterministic


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To ensure limits are tested deterministically and change the data to make it indeterministic if order by is not added to the sql

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Running the tests


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No