### PR TITLE
Correct terminology from 'uber jar' to 'user jar'

### DIFF
--- a/docs/cluster-overview.md
+++ b/docs/cluster-overview.md
@@ -102,7 +102,7 @@ The following table summarizes terms you'll see used to refer to cluster concept
       <td>Application jar</td>
       <td>
         A jar containing the user's Spark application. In some cases users will want to create
-        an "uber jar" containing their application along with its dependencies. The user's jar
+        an "user jar" containing their application along with its dependencies. The user's jar
         should never include Hadoop or Spark libraries, however, these will be added at runtime.
       </td>
     </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a typo in the Apache Spark documentation by replacing **"uber jar"** with **"user jar"** in the relevant README file.

### Why are the changes needed?

The existing text contains a typo that could confuse readers. This change improves the accuracy and readability of the documentation.

### Does this PR introduce *any* user-facing change?

No.

### How was this patch tested?

Documentation-only change. No code changes or tests were required.

### Was this patch authored or co-authored using generative AI tooling?
