### PR TITLE
[SPARK-58555][SQL] Add new tests for JDBC DS Join pushdown

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -229,8 +229,6 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
 
   protected val supportsColumnPruning: Boolean = true
 
-  protected val supportsJoinPushdown: Boolean = true
-
   // Condition-less joins are not supported in join pushdown
   test("Test that 2-way join without condition should not have join pushed down") {
     val sqlQuery =
@@ -507,48 +505,42 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
          |GROUP BY t1.id, t1.address
          |""".stripMargin
 
-    val rows = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
+    val rowsNoPushdown = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
       sql(sqlQuery).collect().toSeq
     }
 
-    assert(rows.nonEmpty)
+    assert(rowsNoPushdown.nonEmpty)
 
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
-
-      if (supportsJoinPushdown) {
-        checkJoinPushed(df)
-        checkAggregateRemoved(df, supportsAggregatePushdown)
-      }
-      checkAnswer(df, rows)
+      checkJoinPushed(df)
+      checkAggregateRemoved(df, supportsAggregatePushdown)
+      checkAnswer(df, rowsNoPushdown)
     }
   }
 
-  test("Test multi-way left outer join with function in join condition") {
+  test("Test multi-way join with function in join condition") {
     val sqlQuery =
       s"""
          |SELECT a.id, c.address, d.address, a.amount
          |FROM $catalogAndNamespace.$casedJoinTableName1 a
-         |LEFT JOIN $catalogAndNamespace.$casedJoinTableName1 c
+         |JOIN $catalogAndNamespace.$casedJoinTableName1 c
          |  ON a.address = c.address
-         |LEFT JOIN $catalogAndNamespace.$casedJoinTableName1 d
+         |JOIN $catalogAndNamespace.$casedJoinTableName1 d
          |  ON LOWER(a.address) = LOWER(d.address)
          |WHERE a.amount >= 1000
          |""".stripMargin
 
-    val rows = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
+    val rowsNoPushdown = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
       sql(sqlQuery).collect().toSeq
     }
 
-    assert(rows.nonEmpty)
+    assert(rowsNoPushdown.nonEmpty)
 
     withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
       val df = sql(sqlQuery)
-
-      if (supportsJoinPushdown) {
-        checkJoinPushed(df)
-      }
-      checkAnswer(df, rows)
+      checkJoinPushed(df)
+      checkAnswer(df, rowsNoPushdown)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -497,6 +497,61 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
     }
   }
 
+  test("Test aggregate with group by on top of join") {
+    val sqlQuery =
+      s"""
+         |SELECT t1.id, t1.address, min(t2.salary), count(1)
+         |FROM $catalogAndNamespace.$casedJoinTableName1 t1
+         |JOIN $catalogAndNamespace.$casedJoinTableName2 t2 ON t1.id = t2.id
+         |WHERE t1.amount > 1000
+         |GROUP BY t1.id, t1.address
+         |""".stripMargin
+
+    val rows = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
+      sql(sqlQuery).collect().toSeq
+    }
+
+    assert(rows.nonEmpty)
+
+    withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
+      val df = sql(sqlQuery)
+
+      if (supportsJoinPushdown) {
+        checkJoinPushed(df)
+        checkAggregateRemoved(df, supportsAggregatePushdown)
+      }
+      checkAnswer(df, rows)
+    }
+  }
+
+  test("Test multi-way left outer join with function in join condition") {
+    val sqlQuery =
+      s"""
+         |SELECT a.id, c.address, d.address, a.amount
+         |FROM $catalogAndNamespace.$casedJoinTableName1 a
+         |LEFT JOIN $catalogAndNamespace.$casedJoinTableName1 c
+         |  ON a.address = c.address
+         |LEFT JOIN $catalogAndNamespace.$casedJoinTableName1 d
+         |  ON LOWER(a.address) = LOWER(d.address)
+         |WHERE a.amount >= 1000
+         |""".stripMargin
+
+    val rows = withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "false") {
+      sql(sqlQuery).collect().toSeq
+    }
+
+    assert(rows.nonEmpty)
+
+    withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
+      val df = sql(sqlQuery)
+
+      if (supportsJoinPushdown) {
+        checkJoinPushed(df)
+      }
+      checkAnswer(df, rows)
+    }
+  }
+
   test("Test sort limit on top of join is pushed down") {
     val sqlQuery = s"""
       |SELECT min(a.id + b.id), a.id, b.id

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -498,7 +498,7 @@ trait JDBCV2JoinPushdownIntegrationSuiteBase
   test("Test aggregate with group by on top of join") {
     val sqlQuery =
       s"""
-         |SELECT t1.id, t1.address, min(t2.salary), count(1)
+         |SELECT t1.id, t1.address, min(t2.salary)
          |FROM $catalogAndNamespace.$casedJoinTableName1 t1
          |JOIN $catalogAndNamespace.$casedJoinTableName2 t2 ON t1.id = t2.id
          |WHERE t1.amount > 1000


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Add two new tests in suite that verifies behaviour of JDBC Data Source join pushdown

### Why are the changes needed?
- Optimizer rules may be reordered or new rule may be added, so join on top of aggregates may not be pushed down anymore. In this way, we make feature coverage more robust.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test addtion/NA


### Was this patch authored or co-authored using generative AI tooling?
No
