### PR TITLE
[SPARK-58513][CORE] UnifiedMemoryManager wrongly reports INVALID_DRIVER_MEMORY on the executor side

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3909,9 +3909,16 @@
   },
   "INVALID_DRIVER_MEMORY" : {
     "message" : [
-      "System memory <systemMemory> must be at least <minSystemMemory>.",
-      "Please increase heap size using the --driver-memory option or \"<config>\" in Spark configuration."
+      "Insufficient driver memory:"
     ],
+    "subClass" : {
+      "SYSTEM_MEMORY" : {
+        "message" : [
+          "System memory <systemMemory> must be at least <minSystemMemory>.",
+          "Please increase heap size using the --driver-memory option or \"<config>\" in Spark configuration."
+        ]
+      }
+    },
     "sqlState" : "F0000"
   },
   "INVALID_EMPTY_LOCATION" : {
@@ -3957,16 +3964,22 @@
   },
   "INVALID_EXECUTOR_MEMORY" : {
     "message" : [
-      "Executor memory <executorMemory> must be at least <minSystemMemory>.",
-      "Please increase executor memory using the --executor-memory option or \"<config>\" in Spark configuration."
+      "Insufficient executor memory:"
     ],
-    "sqlState" : "F0000"
-  },
-  "INVALID_EXECUTOR_SYSTEM_MEMORY" : {
-    "message" : [
-      "System memory <systemMemory> must be at least <minSystemMemory>.",
-      "Please increase heap size using the --executor-memory option or \"<config>\" in Spark configuration."
-    ],
+    "subClass" : {
+      "CONFIG_MEMORY" : {
+        "message" : [
+          "Executor memory <executorMemory> must be at least <minSystemMemory>.",
+          "Please increase executor memory using the --executor-memory option or \"<config>\" in Spark configuration."
+        ]
+      },
+      "SYSTEM_MEMORY" : {
+        "message" : [
+          "System memory <systemMemory> must be at least <minSystemMemory>.",
+          "Please increase heap size using the --executor-memory option or \"<config>\" in Spark configuration."
+        ]
+      }
+    },
     "sqlState" : "F0000"
   },
   "INVALID_EXPLODE_EMBEDDED_ARRAY_SCHEMA" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3962,6 +3962,13 @@
     ],
     "sqlState" : "F0000"
   },
+  "INVALID_EXECUTOR_SYSTEM_MEMORY" : {
+    "message" : [
+      "System memory <systemMemory> must be at least <minSystemMemory>.",
+      "Please increase heap size using the --executor-memory option or \"<config>\" in Spark configuration."
+    ],
+    "sqlState" : "F0000"
+  },
   "INVALID_EXPLODE_EMBEDDED_ARRAY_SCHEMA" : {
     "message" : [
       "User specified schema <schema> is invalid when the `explodeEmbeddedArray` option is enabled. The schema must either be a variant field, or a variant field plus a corrupt column field."

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -501,7 +501,7 @@ class SparkEnv (
     _memoryManager = UnifiedMemoryManager(
       memoryManagerConf,
       numUsableCores,
-      isDriver = SparkContext.isDriver(executorId))
+      isDriver = Some(SparkContext.isDriver(executorId)))
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -498,7 +498,10 @@ class SparkEnv (
     } else {
       conf.clone.set(MEMORY_OFFHEAP_ENABLED, false).set(MEMORY_OFFHEAP_SIZE, 0L)
     }
-    _memoryManager = UnifiedMemoryManager(memoryManagerConf, numUsableCores)
+    _memoryManager = UnifiedMemoryManager(
+      memoryManagerConf,
+      numUsableCores,
+      isDriver = SparkContext.isDriver(executorId))
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -501,7 +501,7 @@ class SparkEnv (
     _memoryManager = UnifiedMemoryManager(
       memoryManagerConf,
       numUsableCores,
-      isDriver = Some(SparkContext.isDriver(executorId)))
+      isDriver = SparkContext.isDriver(executorId))
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -471,14 +471,14 @@ object UnifiedMemoryManager extends Logging {
     if (systemMemory < minSystemMemory) {
       if (isDriver) {
         throw new SparkIllegalArgumentException(
-          errorClass = "INVALID_DRIVER_MEMORY",
+          errorClass = "INVALID_DRIVER_MEMORY.SYSTEM_MEMORY",
           messageParameters = Map(
             "systemMemory" -> systemMemory.toString,
             "minSystemMemory" -> minSystemMemory.toString,
             "config" -> config.DRIVER_MEMORY.key))
       } else {
         throw new SparkIllegalArgumentException(
-          errorClass = "INVALID_EXECUTOR_SYSTEM_MEMORY",
+          errorClass = "INVALID_EXECUTOR_MEMORY.SYSTEM_MEMORY",
           messageParameters = Map(
             "systemMemory" -> systemMemory.toString,
             "minSystemMemory" -> minSystemMemory.toString,
@@ -490,7 +490,7 @@ object UnifiedMemoryManager extends Logging {
       val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
         throw new SparkIllegalArgumentException(
-          errorClass = "INVALID_EXECUTOR_MEMORY",
+          errorClass = "INVALID_EXECUTOR_MEMORY.CONFIG_MEMORY",
           messageParameters = Map(
             "executorMemory" -> executorMemory.toString,
             "minSystemMemory" -> minSystemMemory.toString,

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -447,13 +447,13 @@ object UnifiedMemoryManager extends Logging {
   }
 
   def apply(conf: SparkConf, numCores: Int): UnifiedMemoryManager = {
-    apply(conf, numCores, isDriver = true)
+    apply(conf, numCores, isDriver = None)
   }
 
   def apply(
       conf: SparkConf,
       numCores: Int,
-      isDriver: Boolean): UnifiedMemoryManager = {
+      isDriver: Option[Boolean]): UnifiedMemoryManager = {
     val maxMemory = getMaxMemory(conf, isDriver)
     new UnifiedMemoryManager(
       conf,
@@ -466,12 +466,14 @@ object UnifiedMemoryManager extends Logging {
   /**
    * Return the total amount of memory shared between execution and storage, in bytes.
    */
-  private def getMaxMemory(conf: SparkConf, isDriver: Boolean): Long = {
+  private def getMaxMemory(conf: SparkConf, isDriver: Option[Boolean]): Long = {
     val systemMemory = conf.get(TEST_MEMORY)
     val reservedMemory = conf.getLong(TEST_RESERVED_MEMORY.key,
       if (conf.contains(IS_TESTING)) 0 else RESERVED_SYSTEM_MEMORY_BYTES)
     val minSystemMemory = (reservedMemory * 1.5).ceil.toLong
-    if (isDriver && systemMemory < minSystemMemory) {
+    val checkDriverMemory = isDriver.isEmpty || isDriver.contains(true)
+    val checkExecutorMemory = isDriver.isEmpty || isDriver.contains(false)
+    if (checkDriverMemory && systemMemory < minSystemMemory) {
       throw new SparkIllegalArgumentException(
         errorClass = "INVALID_DRIVER_MEMORY",
         messageParameters = Map(
@@ -480,7 +482,7 @@ object UnifiedMemoryManager extends Logging {
           "config" -> config.DRIVER_MEMORY.key))
     }
     // SPARK-12759 Check executor memory to fail fast if memory is insufficient
-    if (!isDriver && conf.contains(config.EXECUTOR_MEMORY)) {
+    if (checkExecutorMemory && conf.contains(config.EXECUTOR_MEMORY)) {
       val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
         throw new SparkIllegalArgumentException(

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -447,13 +447,13 @@ object UnifiedMemoryManager extends Logging {
   }
 
   def apply(conf: SparkConf, numCores: Int): UnifiedMemoryManager = {
-    apply(conf, numCores, isDriver = None)
+    apply(conf, numCores, isDriver = true)
   }
 
   def apply(
       conf: SparkConf,
       numCores: Int,
-      isDriver: Option[Boolean]): UnifiedMemoryManager = {
+      isDriver: Boolean): UnifiedMemoryManager = {
     val maxMemory = getMaxMemory(conf, isDriver)
     new UnifiedMemoryManager(
       conf,
@@ -466,19 +466,27 @@ object UnifiedMemoryManager extends Logging {
   /**
    * Return the total amount of memory shared between execution and storage, in bytes.
    */
-  private def getMaxMemory(conf: SparkConf, isDriver: Option[Boolean]): Long = {
+  private def getMaxMemory(conf: SparkConf, isDriver: Boolean): Long = {
     val systemMemory = conf.get(TEST_MEMORY)
     val reservedMemory = conf.getLong(TEST_RESERVED_MEMORY.key,
       if (conf.contains(IS_TESTING)) 0 else RESERVED_SYSTEM_MEMORY_BYTES)
     val minSystemMemory = (reservedMemory * 1.5).ceil.toLong
-    val checkDriverMemory = isDriver.isEmpty || isDriver.contains(true)
-    if (checkDriverMemory && systemMemory < minSystemMemory) {
-      throw new SparkIllegalArgumentException(
-        errorClass = "INVALID_DRIVER_MEMORY",
-        messageParameters = Map(
-          "systemMemory" -> systemMemory.toString,
-          "minSystemMemory" -> minSystemMemory.toString,
-          "config" -> config.DRIVER_MEMORY.key))
+    if (systemMemory < minSystemMemory) {
+      if (isDriver) {
+        throw new SparkIllegalArgumentException(
+          errorClass = "INVALID_DRIVER_MEMORY",
+          messageParameters = Map(
+            "systemMemory" -> systemMemory.toString,
+            "minSystemMemory" -> minSystemMemory.toString,
+            "config" -> config.DRIVER_MEMORY.key))
+      } else {
+        throw new SparkIllegalArgumentException(
+          errorClass = "INVALID_EXECUTOR_MEMORY",
+          messageParameters = Map(
+            "executorMemory" -> systemMemory.toString,
+            "minSystemMemory" -> minSystemMemory.toString,
+            "config" -> config.EXECUTOR_MEMORY.key))
+      }
     }
     // SPARK-12759 Check executor memory to fail fast if memory is insufficient
     if (conf.contains(config.EXECUTOR_MEMORY)) {

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -446,10 +446,14 @@ object UnifiedMemoryManager extends Logging {
     }
   }
 
+  def apply(conf: SparkConf, numCores: Int): UnifiedMemoryManager = {
+    apply(conf, numCores, isDriver = true)
+  }
+
   def apply(
       conf: SparkConf,
       numCores: Int,
-      isDriver: Boolean = true): UnifiedMemoryManager = {
+      isDriver: Boolean): UnifiedMemoryManager = {
     val maxMemory = getMaxMemory(conf, isDriver)
     new UnifiedMemoryManager(
       conf,

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -478,9 +478,9 @@ object UnifiedMemoryManager extends Logging {
             "config" -> config.DRIVER_MEMORY.key))
       } else {
         throw new SparkIllegalArgumentException(
-          errorClass = "INVALID_EXECUTOR_MEMORY",
+          errorClass = "INVALID_EXECUTOR_SYSTEM_MEMORY",
           messageParameters = Map(
-            "executorMemory" -> systemMemory.toString,
+            "systemMemory" -> systemMemory.toString,
             "minSystemMemory" -> minSystemMemory.toString,
             "config" -> config.EXECUTOR_MEMORY.key))
       }

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -472,7 +472,6 @@ object UnifiedMemoryManager extends Logging {
       if (conf.contains(IS_TESTING)) 0 else RESERVED_SYSTEM_MEMORY_BYTES)
     val minSystemMemory = (reservedMemory * 1.5).ceil.toLong
     val checkDriverMemory = isDriver.isEmpty || isDriver.contains(true)
-    val checkExecutorMemory = isDriver.isEmpty || isDriver.contains(false)
     if (checkDriverMemory && systemMemory < minSystemMemory) {
       throw new SparkIllegalArgumentException(
         errorClass = "INVALID_DRIVER_MEMORY",
@@ -482,7 +481,7 @@ object UnifiedMemoryManager extends Logging {
           "config" -> config.DRIVER_MEMORY.key))
     }
     // SPARK-12759 Check executor memory to fail fast if memory is insufficient
-    if (checkExecutorMemory && conf.contains(config.EXECUTOR_MEMORY)) {
+    if (conf.contains(config.EXECUTOR_MEMORY)) {
       val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
         throw new SparkIllegalArgumentException(

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -446,8 +446,11 @@ object UnifiedMemoryManager extends Logging {
     }
   }
 
-  def apply(conf: SparkConf, numCores: Int): UnifiedMemoryManager = {
-    val maxMemory = getMaxMemory(conf)
+  def apply(
+      conf: SparkConf,
+      numCores: Int,
+      isDriver: Boolean = true): UnifiedMemoryManager = {
+    val maxMemory = getMaxMemory(conf, isDriver)
     new UnifiedMemoryManager(
       conf,
       maxHeapMemory = maxMemory,
@@ -459,12 +462,12 @@ object UnifiedMemoryManager extends Logging {
   /**
    * Return the total amount of memory shared between execution and storage, in bytes.
    */
-  private def getMaxMemory(conf: SparkConf): Long = {
+  private def getMaxMemory(conf: SparkConf, isDriver: Boolean): Long = {
     val systemMemory = conf.get(TEST_MEMORY)
     val reservedMemory = conf.getLong(TEST_RESERVED_MEMORY.key,
       if (conf.contains(IS_TESTING)) 0 else RESERVED_SYSTEM_MEMORY_BYTES)
     val minSystemMemory = (reservedMemory * 1.5).ceil.toLong
-    if (systemMemory < minSystemMemory) {
+    if (isDriver && systemMemory < minSystemMemory) {
       throw new SparkIllegalArgumentException(
         errorClass = "INVALID_DRIVER_MEMORY",
         messageParameters = Map(
@@ -473,7 +476,7 @@ object UnifiedMemoryManager extends Logging {
           "config" -> config.DRIVER_MEMORY.key))
     }
     // SPARK-12759 Check executor memory to fail fast if memory is insufficient
-    if (conf.contains(config.EXECUTOR_MEMORY)) {
+    if (!isDriver && conf.contains(config.EXECUTOR_MEMORY)) {
       val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
         throw new SparkIllegalArgumentException(

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -450,10 +450,7 @@ object UnifiedMemoryManager extends Logging {
     apply(conf, numCores, isDriver = true)
   }
 
-  def apply(
-      conf: SparkConf,
-      numCores: Int,
-      isDriver: Boolean): UnifiedMemoryManager = {
+  def apply(conf: SparkConf, numCores: Int, isDriver: Boolean): UnifiedMemoryManager = {
     val maxMemory = getMaxMemory(conf, isDriver)
     new UnifiedMemoryManager(
       conf,

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -259,7 +259,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     assert(exception.getMessage.contains("increase executor memory"))
   }
 
-  test("executor does not validate driver heap") {
+  test("SPARK-58513: executor does not validate driver heap") {
     val systemMemory = 400L * 1024
     val reservedMemory = 300L * 1024
     val memoryFraction = 0.8
@@ -274,7 +274,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     assert(mm.maxHeapMemory === expectedMaxMemory)
   }
 
-  test("driver does not validate executor memory") {
+  test("SPARK-58513: driver does not validate executor memory") {
     val systemMemory = 1024L * 1024
     val reservedMemory = 300L * 1024
     val memoryFraction = 0.8

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -274,7 +274,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     assert(mm.maxHeapMemory === expectedMaxMemory)
   }
 
-  test("SPARK-58513: driver does not validate executor memory") {
+  test("SPARK-58513: driver validates executor memory") {
     val systemMemory = 1024L * 1024
     val reservedMemory = 300L * 1024
     val memoryFraction = 0.8
@@ -284,9 +284,10 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_RESERVED_MEMORY, reservedMemory)
       .set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
 
-    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = Some(true))
-    val expectedMaxMemory = ((systemMemory - reservedMemory) * memoryFraction).toLong
-    assert(mm.maxHeapMemory === expectedMaxMemory)
+    val exception = intercept[IllegalArgumentException] {
+      UnifiedMemoryManager(conf, numCores = 1, isDriver = Some(true))
+    }
+    assert(exception.getMessage.contains("increase executor memory"))
   }
 
   test("execution can evict cached blocks when there are multiple active tasks (SPARK-12155)") {

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.memory
 
 import org.scalatest.PrivateMethodTester
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkIllegalArgumentException}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests._
 import org.apache.spark.storage.TestBlockId
@@ -269,26 +269,16 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_RESERVED_MEMORY, reservedMemory)
       .set(EXECUTOR_MEMORY.key, (500L * 1024).toString)
 
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[SparkIllegalArgumentException] {
       UnifiedMemoryManager(conf, numCores = 1, isDriver = false)
     }
-    assert(exception.getMessage.contains("increase executor memory"))
-  }
-
-  test("SPARK-58513: driver validates executor memory") {
-    val systemMemory = 1024L * 1024
-    val reservedMemory = 300L * 1024
-    val memoryFraction = 0.8
-    val conf = new SparkConf()
-      .set(MEMORY_FRACTION, memoryFraction)
-      .set(TEST_MEMORY, systemMemory)
-      .set(TEST_RESERVED_MEMORY, reservedMemory)
-      .set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
-
-    val exception = intercept[IllegalArgumentException] {
-      UnifiedMemoryManager(conf, numCores = 1, isDriver = true)
-    }
-    assert(exception.getMessage.contains("increase executor memory"))
+    checkError(
+      exception,
+      condition = "INVALID_EXECUTOR_SYSTEM_MEMORY",
+      parameters = Map(
+        "systemMemory" -> systemMemory.toString,
+        "minSystemMemory" -> ((reservedMemory * 1.5).ceil.toLong).toString,
+        "config" -> EXECUTOR_MEMORY.key))
   }
 
   test("execution can evict cached blocks when there are multiple active tasks (SPARK-12155)") {

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -249,12 +249,12 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_MEMORY, systemMemory)
       .set(TEST_RESERVED_MEMORY, reservedMemory)
 
-    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = false)
+    val mm = UnifiedMemoryManager(conf, numCores = 1)
 
     // Try using an executor memory that's too small
     val conf2 = conf.clone().set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
     val exception = intercept[IllegalArgumentException] {
-      UnifiedMemoryManager(conf2, numCores = 1, isDriver = false)
+      UnifiedMemoryManager(conf2, numCores = 1)
     }
     assert(exception.getMessage.contains("increase executor memory"))
   }
@@ -269,7 +269,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_RESERVED_MEMORY, reservedMemory)
       .set(EXECUTOR_MEMORY.key, (500L * 1024).toString)
 
-    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = false)
+    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = Some(false))
     val expectedMaxMemory = ((systemMemory - reservedMemory) * memoryFraction).toLong
     assert(mm.maxHeapMemory === expectedMaxMemory)
   }
@@ -284,7 +284,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_RESERVED_MEMORY, reservedMemory)
       .set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
 
-    val mm = UnifiedMemoryManager(conf, numCores = 1)
+    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = Some(true))
     val expectedMaxMemory = ((systemMemory - reservedMemory) * memoryFraction).toLong
     assert(mm.maxHeapMemory === expectedMaxMemory)
   }

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -234,10 +234,16 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
 
     // Try using a system memory that's too small
     val conf2 = conf.clone().set(TEST_MEMORY, reservedMemory / 2)
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[SparkIllegalArgumentException] {
       UnifiedMemoryManager(conf2, numCores = 1)
     }
-    assert(exception.getMessage.contains("increase heap size"))
+    checkError(
+      exception,
+      condition = "INVALID_DRIVER_MEMORY.SYSTEM_MEMORY",
+      parameters = Map(
+        "systemMemory" -> (reservedMemory / 2).toString,
+        "minSystemMemory" -> (reservedMemory * 1.5).ceil.toLong.toString,
+        "config" -> DRIVER_MEMORY.key))
   }
 
   test("insufficient executor memory") {
@@ -253,10 +259,16 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
 
     // Try using an executor memory that's too small
     val conf2 = conf.clone().set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[SparkIllegalArgumentException] {
       UnifiedMemoryManager(conf2, numCores = 1)
     }
-    assert(exception.getMessage.contains("increase executor memory"))
+    checkError(
+      exception,
+      condition = "INVALID_EXECUTOR_MEMORY.CONFIG_MEMORY",
+      parameters = Map(
+        "executorMemory" -> (reservedMemory / 2).toString,
+        "minSystemMemory" -> (reservedMemory * 1.5).ceil.toLong.toString,
+        "config" -> EXECUTOR_MEMORY.key))
   }
 
   test("SPARK-58513: executor validates executor heap") {
@@ -274,10 +286,10 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     }
     checkError(
       exception,
-      condition = "INVALID_EXECUTOR_SYSTEM_MEMORY",
+      condition = "INVALID_EXECUTOR_MEMORY.SYSTEM_MEMORY",
       parameters = Map(
         "systemMemory" -> systemMemory.toString,
-        "minSystemMemory" -> ((reservedMemory * 1.5).ceil.toLong).toString,
+        "minSystemMemory" -> (reservedMemory * 1.5).ceil.toLong.toString,
         "config" -> EXECUTOR_MEMORY.key))
   }
 

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -259,7 +259,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
     assert(exception.getMessage.contains("increase executor memory"))
   }
 
-  test("SPARK-58513: executor does not validate driver heap") {
+  test("SPARK-58513: executor validates executor heap") {
     val systemMemory = 400L * 1024
     val reservedMemory = 300L * 1024
     val memoryFraction = 0.8
@@ -269,9 +269,10 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_RESERVED_MEMORY, reservedMemory)
       .set(EXECUTOR_MEMORY.key, (500L * 1024).toString)
 
-    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = Some(false))
-    val expectedMaxMemory = ((systemMemory - reservedMemory) * memoryFraction).toLong
-    assert(mm.maxHeapMemory === expectedMaxMemory)
+    val exception = intercept[IllegalArgumentException] {
+      UnifiedMemoryManager(conf, numCores = 1, isDriver = false)
+    }
+    assert(exception.getMessage.contains("increase executor memory"))
   }
 
   test("SPARK-58513: driver validates executor memory") {
@@ -285,7 +286,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
 
     val exception = intercept[IllegalArgumentException] {
-      UnifiedMemoryManager(conf, numCores = 1, isDriver = Some(true))
+      UnifiedMemoryManager(conf, numCores = 1, isDriver = true)
     }
     assert(exception.getMessage.contains("increase executor memory"))
   }

--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -249,14 +249,44 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
       .set(TEST_MEMORY, systemMemory)
       .set(TEST_RESERVED_MEMORY, reservedMemory)
 
-    val mm = UnifiedMemoryManager(conf, numCores = 1)
+    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = false)
 
     // Try using an executor memory that's too small
     val conf2 = conf.clone().set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
     val exception = intercept[IllegalArgumentException] {
-      UnifiedMemoryManager(conf2, numCores = 1)
+      UnifiedMemoryManager(conf2, numCores = 1, isDriver = false)
     }
     assert(exception.getMessage.contains("increase executor memory"))
+  }
+
+  test("executor does not validate driver heap") {
+    val systemMemory = 400L * 1024
+    val reservedMemory = 300L * 1024
+    val memoryFraction = 0.8
+    val conf = new SparkConf()
+      .set(MEMORY_FRACTION, memoryFraction)
+      .set(TEST_MEMORY, systemMemory)
+      .set(TEST_RESERVED_MEMORY, reservedMemory)
+      .set(EXECUTOR_MEMORY.key, (500L * 1024).toString)
+
+    val mm = UnifiedMemoryManager(conf, numCores = 1, isDriver = false)
+    val expectedMaxMemory = ((systemMemory - reservedMemory) * memoryFraction).toLong
+    assert(mm.maxHeapMemory === expectedMaxMemory)
+  }
+
+  test("driver does not validate executor memory") {
+    val systemMemory = 1024L * 1024
+    val reservedMemory = 300L * 1024
+    val memoryFraction = 0.8
+    val conf = new SparkConf()
+      .set(MEMORY_FRACTION, memoryFraction)
+      .set(TEST_MEMORY, systemMemory)
+      .set(TEST_RESERVED_MEMORY, reservedMemory)
+      .set(EXECUTOR_MEMORY.key, (reservedMemory / 2).toString)
+
+    val mm = UnifiedMemoryManager(conf, numCores = 1)
+    val expectedMaxMemory = ((systemMemory - reservedMemory) * memoryFraction).toLong
+    assert(mm.maxHeapMemory === expectedMaxMemory)
   }
 
   test("execution can evict cached blocks when there are multiple active tasks (SPARK-12155)") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `UnifiedMemoryManager` report role-appropriate errors when the JVM heap is too small:

- `SparkEnv` passes the process role (`isDriver`) to `UnifiedMemoryManager`.
- The system memory check throws `INVALID_DRIVER_MEMORY.SYSTEM_MEMORY` on the driver and the new `INVALID_EXECUTOR_MEMORY.SYSTEM_MEMORY` on executors, each pointing to its own memory option.
- The SPARK-12759 fail-fast check of `spark.executor.memory` is unchanged and runs on both roles, now as `INVALID_EXECUTOR_MEMORY.CONFIG_MEMORY`.
- The two error conditions are restructured with sub-conditions: `INVALID_DRIVER_MEMORY.SYSTEM_MEMORY`, `INVALID_EXECUTOR_MEMORY.{CONFIG_MEMORY, SYSTEM_MEMORY}`.

### Why are the changes needed?

When `spark.executor.memory` is set to 500m, the executor may fail with:

```
Exception in thread "main" java.lang.IllegalArgumentException: System memory 466092032 must be at least 471859200. Please increase heap size using the --driver-memory option or spark.driver.memory in Spark configuration.
```

The message is misleading: the check runs in the executor, whose heap is controlled by `spark.executor.memory`, but it reports driver configuration guidance.

### Does this PR introduce _any_ user-facing change?

Yes, error reporting only; no pass/fail behavior change.

- An executor with insufficient heap now fails with `INVALID_EXECUTOR_MEMORY.SYSTEM_MEMORY`, pointing to `--executor-memory` / `spark.executor.memory`, instead of `INVALID_DRIVER_MEMORY`.
- Existing conditions become sub-conditions: `INVALID_DRIVER_MEMORY` -> `INVALID_DRIVER_MEMORY.SYSTEM_MEMORY`, `INVALID_EXECUTOR_MEMORY` -> `INVALID_EXECUTOR_MEMORY.CONFIG_MEMORY`; messages gain an "Insufficient driver/executor memory:" prefix.

### How was this patch tested?

Added and updated UTs in `UnifiedMemoryManagerSuite`; error definitions are validated by `SparkThrowableSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Yes.
Generated-by: Claude Code (Claude Fable 5)
