### PR TITLE
[SPARK-57897][BUILD][4.x][FOLLOWUP] Fix branch-4.x project loading

### DIFF
--- a/connector/credential-aws/pom.xml
+++ b/connector/credential-aws/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.13</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/connect/client/jdbc/pom.xml
+++ b/sql/connect/client/jdbc/pom.xml
@@ -53,6 +53,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <version>${io.grpc.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the explicit gRPC API version required on `branch-4.x`, which does not include the gRPC BOM used on master. Also correct the AWS credential module's parent version from `5.0.0-SNAPSHOT` to `4.3.0-SNAPSHOT`.

### Why are the changes needed?

The backports that added these entries left the branch unable to load its Maven/SBT project model, causing all GitHub Actions jobs to fail before tests could run.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran:

```
env JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
  MAVEN_MIRROR_URL=https://maven-proxy.dev.databricks.com \
  build/sbt -Pcredential-aws \
  'connect-client-jdbc/Test/compile' \
  'credential-aws/Test/compile'
```

Both targets passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
