### PR TITLE
[SPARK-58463][INFRA][FOLLOWUP] Format merge summary output

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -458,8 +458,13 @@ def post_merge_comment(pr_num, merged_commits):
         "- merged into %s %s/%s" % (ref, GITHUB_COMMIT_BASE, commit_hash)
         for ref, commit_hash in merged_commits
     ]
-    body = "**Merge Summary:**\n" + "\n".join(lines) + "\n\n*Posted by `merge_spark_pr.py`*"
-    print("\n%s\n\n%s" % (bold("Posting merge comment on PR #%s:" % pr_num), body))
+    summary = "**Merge Summary:**\n" + "\n".join(lines)
+    attribution = "*Posted by `merge_spark_pr.py`*"
+    body = "%s\n%s" % (summary, attribution)
+    print(
+        "\n%s\n\n%s\n%s"
+        % (bold("Posting merge comment on PR #%s:" % pr_num), bold(summary), attribution)
+    )
     if not GITHUB_OAUTH_KEY:
         print_error("GITHUB_OAUTH_KEY is not set; skipping the merge comment.")
         return


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up to SPARK-58463 updates dev/merge_spark_pr.py to render the terminal merge-summary block and its branch lines in bold. The attribution remains unbolded and directly follows the final merge line in the PR comment.

### Why are the changes needed?

The merge summary should be easy to scan without emphasizing the attribution, and the extra blank line before the attribution is unnecessary.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran a no-post dry run of post_merge_comment with master and branch-4.x merge records, with the GitHub token cleared. Also ran git diff --check.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)