### PR TITLE
[SPARK-58515][SQL] Exclude MySQL permission and limit errors from syntax error classification

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -221,7 +221,25 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
 
   // See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
-    "42000".equals(exception.getSQLState)
+    "42000".equals(exception.getSQLState) &&
+    !isPermissionDeniedErrorBestEffort(exception)
+  }
+
+  // See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+  private def isPermissionDeniedErrorBestEffort(exception: SQLException): Boolean = {
+    val permissionSubstrings = Set(
+      "command denied to user",
+      "access denied",
+      "must have privileges"
+    )
+    val nonSyntaxErrorCodes = Set(
+      1148, // ER_NOT_ALLOWED_COMMAND
+      1203, // ER_TOO_MANY_USER_CONNECTIONS
+      1226 // ER_USER_LIMIT_REACHED
+    )
+    "42000".equals(exception.getSQLState) &&
+    (nonSyntaxErrorCodes.contains(exception.getErrorCode) ||
+      permissionSubstrings.exists(exception.getMessage.toLowerCase(Locale.ROOT).contains))
   }
 
   // See https://dev.mysql.com/doc/refman/8.0/en/alter-table.html

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -222,24 +222,34 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
   // See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
     "42000".equals(exception.getSQLState) &&
-    !isPermissionDeniedErrorBestEffort(exception)
+    !isNonSyntaxErrorBestEffort(exception)
   }
 
   // See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
-  private def isPermissionDeniedErrorBestEffort(exception: SQLException): Boolean = {
-    val permissionSubstrings = Set(
+  // MySQL uses SQLSTATE 42000 for both syntax errors and access/limit failures.
+  private def isNonSyntaxErrorBestEffort(exception: SQLException): Boolean = {
+    val nonSyntaxErrorCodes = Set(
+      1044, // ER_DBACCESS_DENIED_ERROR
+      1142, // ER_TABLEACCESS_DENIED_ERROR
+      1143, // ER_COLUMNACCESS_DENIED_ERROR
+      1148, // ER_NOT_ALLOWED_COMMAND
+      1203, // ER_TOO_MANY_USER_CONNECTIONS
+      1226, // ER_USER_LIMIT_REACHED
+      1227, // ER_SPECIFIC_ACCESS_DENIED_ERROR
+      1370 // ER_PROCACCESS_DENIED_ERROR
+    )
+    // Message matching is a best-effort fallback for drivers that omit error codes.
+    // Prefer error codes above; MySQL messages may be localized.
+    val nonSyntaxSubstrings = Set(
       "command denied to user",
       "access denied",
       "must have privileges"
     )
-    val nonSyntaxErrorCodes = Set(
-      1148, // ER_NOT_ALLOWED_COMMAND
-      1203, // ER_TOO_MANY_USER_CONNECTIONS
-      1226 // ER_USER_LIMIT_REACHED
-    )
-    "42000".equals(exception.getSQLState) &&
-    (nonSyntaxErrorCodes.contains(exception.getErrorCode) ||
-      permissionSubstrings.exists(exception.getMessage.toLowerCase(Locale.ROOT).contains))
+    val message = Option(exception.getMessage)
+      .map(_.toLowerCase(Locale.ROOT))
+      .getOrElse("")
+    nonSyntaxErrorCodes.contains(exception.getErrorCode) ||
+      nonSyntaxSubstrings.exists(message.contains)
   }
 
   // See https://dev.mysql.com/doc/refman/8.0/en/alter-table.html

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2752,7 +2752,50 @@ class JDBCSuite extends SharedSparkSession {
       new SQLException(
         "You have an error in your SQL syntax; check the manual that corresponds to your " +
           "MySQL server version for the right syntax to use near 'SELCT' at line 1",
-        "42000")))
+        "42000",
+        1064)))
+    // Permission / limit failures share SQLSTATE 42000; detect by error code.
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "Access denied for user 'testuser'@'%' to database 'testdb'",
+        "42000",
+        1044)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "SELECT command denied to user 'testuser'@'%' for table 't1'",
+        "42000",
+        1142)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "SELECT command denied to user 'testuser'@'%' for column 'c1' in table 't1'",
+        "42000",
+        1143)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "The used command is not allowed with this MySQL version",
+        "42000",
+        1148)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "User testuser already has more than 'max_user_connections' active connections",
+        "42000",
+        1203)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "User 'testuser' has exceeded the 'max_queries_per_hour' resource (current value: 1000)",
+        "42000",
+        1226)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "Access denied; you need (at least one of) the SUPER privilege(s) for this operation",
+        "42000",
+        1227)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "execute command denied to user 'testuser'@'%' for routine 'p1'",
+        "42000",
+        1370)))
+    // Best-effort message fallback when the vendor error code is absent.
     assert(!dialect.isSyntaxErrorBestEffort(
       new SQLException(
         "execute command denied to user 'testuser'@'%' for table 't1'",
@@ -2767,20 +2810,7 @@ class JDBCSuite extends SharedSparkSession {
         "Access denied for user 'testuser'@'%' to database 'testdb'",
         "42000")))
     assert(!dialect.isSyntaxErrorBestEffort(
-      new SQLException(
-        "User testuser already has more than 'max_user_connections' active connections",
-        "42000",
-        1203)))
-    assert(!dialect.isSyntaxErrorBestEffort(
-      new SQLException(
-        "User 'testuser' has exceeded the 'max_queries_per_hour' resource (current value: 1000)",
-        "42000",
-        1226)))
-    assert(!dialect.isSyntaxErrorBestEffort(
-      new SQLException(
-        "The used command is not allowed with this MySQL version",
-        "42000",
-        1148)))
+      new SQLException(null, "42000", 1142)))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("Connection reset", "08001")))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2746,6 +2746,44 @@ class JDBCSuite extends SharedSparkSession {
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("Connection reset", "08001")))
   }
 
+  test("MySQLDialect syntax error detection") {
+    val dialect = MySQLDialect()
+    assert(dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "You have an error in your SQL syntax; check the manual that corresponds to your " +
+          "MySQL server version for the right syntax to use near 'SELCT' at line 1",
+        "42000")))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "execute command denied to user 'testuser'@'%' for table 't1'",
+        "42000")))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "You must have privileges to update tables in the mysql database to be able to " +
+          "change passwords for others",
+        "42000")))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "Access denied for user 'testuser'@'%' to database 'testdb'",
+        "42000")))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "User testuser already has more than 'max_user_connections' active connections",
+        "42000",
+        1203)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "User 'testuser' has exceeded the 'max_queries_per_hour' resource (current value: 1000)",
+        "42000",
+        1226)))
+    assert(!dialect.isSyntaxErrorBestEffort(
+      new SQLException(
+        "The used command is not allowed with this MySQL version",
+        "42000",
+        1148)))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("Connection reset", "08001")))
+  }
+
   test("SPARK-45425: Mapped TINYINT to ShortType for MsSqlServerDialect") {
     val msSqlServerDialect = JdbcDialects.get("jdbc:sqlserver")
     val metadata = new MetadataBuilder().putLong("scale", 1)


### PR DESCRIPTION

MySQL reports permission-denied and resource-limit failures with SQLState 42000, the same state used for syntax errors. Narrow isSyntaxErrorBestEffort so those cases are not treated as syntax errors.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Improves the syntax error classification to not include some of the errors with sqlState "42000" but which are not syntax errors, rather permission.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix wrongly classified errors.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added a unit test.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Opus 5 

