### PR TITLE
[SPARK-58516][SQL] Extend AbstractIterator in ColumnarIterator instead of mixing in Iterator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.columnar
 
+import scala.collection.AbstractIterator
+
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
@@ -27,8 +29,16 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
  * An Iterator to walk through the InternalRows from a CachedBatch
+ *
+ * Extends `AbstractIterator` rather than mixing in `Iterator` directly. Mixing a trait into a
+ * class that fixes its type parameter makes scalac copy the trait's forwarders here and emit them
+ * raw, with no `Signature` attribute: the class file grows, and javac cannot subclass it, seeing
+ * `Object minBy(Function1, Ordering)` clash with `IterableOnceOps`'
+ * `<B> A minBy(Function1<A, B>, Ordering<B>)`. `AbstractIterator` keeps its element type generic,
+ * so the forwarders stay in it, with their signatures. The subclass generated below is compiled
+ * as Java source under the javac codegen backend (SPARK-57403); Janino skips this check.
  */
-abstract class ColumnarIterator extends Iterator[InternalRow] {
+abstract class ColumnarIterator extends AbstractIterator[InternalRow] {
   def initialize(input: Iterator[DefaultCachedBatch], columnTypes: Array[DataType],
     columnIndexes: Array[Int]): Unit
 }
@@ -165,7 +175,6 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
       import java.nio.ByteOrder;
       import scala.collection.Iterator;
       import org.apache.spark.sql.types.DataType;
-      import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
       import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
       import org.apache.spark.sql.execution.columnar.MutableUnsafeRow;
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -30,13 +30,10 @@ import org.apache.spark.unsafe.types.CalendarInterval
 /**
  * An Iterator to walk through the InternalRows from a CachedBatch
  *
- * Extends `AbstractIterator` rather than mixing in `Iterator` directly. Mixing a trait into a
+ * Extends `AbstractIterator` rather than mixing in `Iterator` directly. Mixing the trait into a
  * class that fixes its type parameter makes scalac copy the trait's forwarders here and emit them
- * raw, with no `Signature` attribute: the class file grows, and javac cannot subclass it, seeing
- * `Object minBy(Function1, Ordering)` clash with `IterableOnceOps`'
- * `<B> A minBy(Function1<A, B>, Ordering<B>)`. `AbstractIterator` keeps its element type generic,
- * so the forwarders stay in it, with their signatures. The subclass generated below is compiled
- * as Java source under the javac codegen backend (SPARK-57403); Janino skips this check.
+ * raw, with no `Signature` attribute: the class file bloats, and javac rejects any subclass of it,
+ * including the one generated below. Janino does not check this. See SPARK-58516.
  */
 abstract class ColumnarIterator extends AbstractIterator[InternalRow] {
   def initialize(input: Iterator[DefaultCachedBatch], columnTypes: Array[DataType],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -29,11 +29,6 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
  * An Iterator to walk through the InternalRows from a CachedBatch
- *
- * Extends `AbstractIterator` rather than mixing in `Iterator` directly. Mixing the trait into a
- * class that fixes its type parameter makes scalac copy the trait's forwarders here and emit them
- * raw, with no `Signature` attribute: the class file bloats, and javac rejects any subclass of it,
- * including the one generated below. Janino does not check this. See SPARK-58516.
  */
 abstract class ColumnarIterator extends AbstractIterator[InternalRow] {
   def initialize(input: Iterator[DefaultCachedBatch], columnTypes: Array[DataType],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two changes to `GenerateColumnAccessor.scala`, both making the generated `SpecificColumnarIterator` compilable by javac:

- `ColumnarIterator` extends `scala.collection.AbstractIterator[InternalRow]` instead of mixing in `Iterator[InternalRow]` directly.
- The generated source template no longer imports `org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder`.

### Why are the changes needed?

Prerequisite for SPARK-57403, whose javac backend compiles the generated subclass as Java source. Janino performs neither check below, which is why both forms work today.

**The supertype.** Mixing a trait into a class that fixes its type parameter makes scalac copy the trait's forwarders into that class file and emit them raw, with no `Signature` attribute, so javac cannot subclass it. A minimal reproduction, scalac 2.13.18, no Spark:

```scala
abstract class DirectIter extends Iterator[String] { def initialize(): Unit }
abstract class AbsIter extends scala.collection.AbstractIterator[String] { def initialize(): Unit }
```

```java
public class PA extends DirectIter { /* hasNext, next, initialize */ }
public class PB extends AbsIter    { /* hasNext, next, initialize */ }
```

```
$ javac PA.java
PA.java:1: error: minBy(Function1,Ordering) in DirectIter cannot implement
                  <B>minBy(Function1<A,B>,Ordering<B>) in IterableOnceOps
  return type Object is not compatible with String

$ javac PB.java     # no error
```

`AbstractIterator` stays generic in its element type, so its forwarders keep their signatures. Its class file also shrinks from 31,491 to 1,484 bytes, since the forwarders are no longer duplicated here.

**The import.** `BufferHolder` is package-private and the generated class sits in the default package. Java checks accessibility at the import declaration, whether or not the name is used, so javac rejects the template over this line alone. The line is also dead: nothing in the template has referenced `BufferHolder` since a7c19d9c21d (SPARK-23713, 2018), which moved the generated writes to `UnsafeRowWriter` and made `BufferHolder` package-private in the same commit.

### Does this PR introduce _any_ user-facing change?

No. `AbstractIterator[+A] extends Iterator[A]`, so `ColumnarIterator` remains a `scala.collection.Iterator[InternalRow]`.

### How was this patch tested?

`sql/testOnly org.apache.spark.sql.execution.columnar.* org.apache.spark.sql.CachedTableSuite org.apache.spark.sql.DatasetCacheSuite` (593 tests). `InMemoryColumnarQuerySuite`'s "SPARK-14138: Generated SpecificColumnarIterator can exceed JVM size limit for cached DF" exercises the generated subclass.

No test is added: what this guards against is javac rejecting the generated subclass, and the javac backend is not in the tree yet. `CodeCompilerSuite` covers both once SPARK-57403 lands.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code Opus 5
