### PR TITLE
[SPARK-58520][SQL] Document dynamic table options in SQL reference

### DIFF
--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -26,10 +26,14 @@ The `INSERT` statement inserts new rows into a table or overwrites the existing 
 ### Syntax
 
 ```sql
-INSERT [ WITH SCHEMA EVOLUTION ] [ INTO | OVERWRITE ] [ TABLE ] table_identifier [ partition_spec ] [ ( column_list ) | [BY NAME] ]
+INSERT [ WITH SCHEMA EVOLUTION ] [ INTO | OVERWRITE ] [ TABLE ] table_identifier
+    [ WITH ( option_key = option_value [ , ... ] ) ] [ partition_spec ]
+    [ ( column_list ) | [BY NAME] ]
     { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 
-INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier [ BY NAME ] REPLACE WHERE boolean_expression query
+INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier
+    [ WITH ( option_key = option_value [ , ... ] ) ] [ BY NAME ]
+    REPLACE WHERE boolean_expression query
 ```
 
 ### Parameters
@@ -45,6 +49,11 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier [ BY NAME ] REP
     Specifies a table name, which may be optionally qualified with a database name.
 
     **Syntax:** `[ database_name. ] table_name`
+
+* **WITH ( option_key = option_value [ , ... ] )**
+
+    Specifies dynamic table options for this `INSERT` operation. These options are passed to the
+    data source connector when writing to the table. The supported options depend on the connector.
 
 * **partition_spec**
 
@@ -87,6 +96,14 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier [ BY NAME ] REP
 ### Examples
 
 #### Insert Into
+
+##### Insert Using Dynamic Table Options
+
+```sql
+-- Option names and values are specific to the table's data source connector.
+INSERT INTO students WITH (`write.split-size` = 10)
+    VALUES ('Amy Smith', '123 Park Ave, San Jose', 111111);
+```
 
 ##### Single Row Insert Using a VALUES Clause
 

--- a/docs/sql-ref-syntax-dml-merge-into.md
+++ b/docs/sql-ref-syntax-dml-merge-into.md
@@ -33,7 +33,9 @@ apply. All of these row-level changes are performed as a single atomic operation
 
 ```sql
 MERGE [ WITH SCHEMA EVOLUTION ] INTO target_table [ [ AS ] target_alias ]
-    USING { source_table | ( source_query ) } [ [ AS ] source_alias ]
+    [ WITH ( target_option_key = target_option_value [ , ... ] ) ]
+    USING { source_table [ WITH ( source_option_key = source_option_value [ , ... ] ) ] |
+        ( source_query ) } [ [ AS ] source_alias ]
     ON merge_condition
     [ WHEN MATCHED [ AND matched_condition ] THEN matched_action ] [ ... ]
     [ WHEN NOT MATCHED [ BY TARGET ] [ AND not_matched_condition ] THEN not_matched_action ] [ ... ]
@@ -68,6 +70,13 @@ not_matched_by_source_action
 
     The source of the merge, specified either as a table or as a parenthesized query. An optional
     alias may be provided with or without the `AS` keyword.
+
+* **WITH ( option_key = option_value [ , ... ] )**
+
+    Specifies dynamic table options for this `MERGE` operation. Options following the target table
+    are passed to the data source connector for the write operation. Options following the source
+    table are passed to the connector when reading the source. The supported options depend on the
+    connector.
 
 * **merge_condition**
 
@@ -147,6 +156,17 @@ SELECT * FROM source;
 | 2|   200|  eng|
 | 3|   120|sales|
 +--+------+-----+
+```
+
+#### Merge Using Dynamic Table Options
+
+```sql
+-- Option names and values are specific to each table's data source connector.
+MERGE INTO target t WITH (`write.split-size` = 10)
+    USING source WITH (`split-size` = 5) s
+    ON t.pk = s.pk
+    WHEN MATCHED THEN UPDATE SET *
+    WHEN NOT MATCHED THEN INSERT *;
 ```
 
 #### Update Matched Rows and Insert New Rows

--- a/docs/sql-ref-syntax-qry-select.md
+++ b/docs/sql-ref-syntax-qry-select.md
@@ -53,6 +53,12 @@ SELECT [ hints , ... ] [ ALL | DISTINCT ] { [ [ named_expression | regex_column_
     [ QUALIFY boolean_expression ]
 ```
 
+A table relation in `from_item` can include dynamic table options:
+
+```sql
+table_identifier [ WITH ( option_key = option_value [ , ... ] ) ] [ [ AS ] table_alias ]
+```
+
 ### Parameters
 
 * **with_query**
@@ -97,6 +103,11 @@ SELECT [ hints , ... ] [ ALL | DISTINCT ] { [ [ named_expression | regex_column_
      * [UNNEST relation](sql-ref-syntax-qry-select-unnest.html)
      * [ [LATERAL](sql-ref-syntax-qry-select-lateral-subquery.html) ] ( Subquery )
      * [File](sql-ref-syntax-qry-select-file.html)
+
+* **WITH ( option_key = option_value [ , ... ] )**
+
+     Specifies dynamic table options for a table relation. These options are passed to the data
+     source connector when reading the table. The supported options depend on the connector.
      
 * **PIVOT**
 
@@ -190,6 +201,16 @@ SELECT [ hints , ... ] [ ALL | DISTINCT ] { [ [ named_expression | regex_column_
 * **TRANSFORM**
 
      Specifies a hive-style transform query specification to transform the input by forking and running user-specified command or script.
+
+### Examples
+
+#### Select Using Dynamic Table Options
+
+```sql
+-- Option names and values are specific to the table's
+-- data source connector.
+SELECT * FROM students WITH (`split-size` = 5);
+```
 
 ### Related Statements
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Document the `WITH (key = value)` dynamic table options clause in the SQL reference pages for:

- `INSERT TABLE`
- `MERGE INTO`
- `SELECT`

Each page now includes the clause in its syntax, explains how the options are passed to the data
source connector, and provides an example. The `MERGE INTO` documentation distinguishes target
write options from source read options.

### Why are the changes needed?

Spark supports dynamic table options for these statements, but their SQL reference pages did not
document the syntax. Users therefore had to discover the feature through implementation code or
tests.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change for existing SQL functionality.

### How was this patch tested?

This is a documentation-only change. The changed files pass `git diff --check`, and their Markdown
code fences were checked for balance. The full Jekyll build was not run because Bundler 2.4.22 is
not installed in the environment.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5) was used for general coding assistance.
