### PR TITLE
[SPARK-58519][SQL] Document UPDATE and DELETE FROM statements

### DIFF
--- a/docs/sql-ref-syntax-dml-delete-from.md
+++ b/docs/sql-ref-syntax-dml-delete-from.md
@@ -1,0 +1,98 @@
+---
+layout: global
+title: DELETE FROM
+displayTitle: DELETE FROM
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+### Description
+
+The `DELETE FROM` statement removes rows from a table that satisfy an optional condition. When no
+condition is specified, every row is removed.
+
+`DELETE FROM` is supported on tables backed by
+[Data Source V2](sql-v2-data-sources.html#row-level-dml) connectors that support delete operations.
+
+### Syntax
+
+```sql
+DELETE FROM table_identifier [ [ AS ] table_alias ]
+    [ WITH ( option_key = option_value [ , ... ] ) ]
+    [ WHERE boolean_expression ]
+```
+
+### Parameters
+
+* **table_identifier**
+
+    Specifies the table from which rows are deleted. The table name may be optionally qualified
+    with a database name.
+
+    **Syntax:** `[ database_name. ] table_name`
+
+* **table_alias**
+
+    Specifies an optional alias for the target table. The alias may be introduced with or without
+    the `AS` keyword.
+
+* **WITH ( option_key = option_value [ , ... ] )**
+
+    Specifies dynamic table options for this `DELETE FROM` operation. These options are passed to
+    the data source connector when deleting from the table. The supported options depend on the
+    connector.
+
+* **WHERE boolean_expression**
+
+    Specifies an optional condition that selects the rows to delete. If the `WHERE` clause is
+    omitted, all rows are deleted.
+
+### Examples
+
+The following examples assume that an `employees` table has already been created and populated.
+
+#### Delete Rows Matching a Condition
+
+```sql
+DELETE FROM employees WHERE status = 'inactive';
+```
+
+#### Delete Rows Using an Alias
+
+```sql
+DELETE FROM employees AS e
+    WHERE e.department = 'Sales' AND e.last_active_date < DATE '2025-01-01';
+```
+
+#### Delete Using Dynamic Table Options
+
+```sql
+-- Option names and values are specific to the table's data source connector.
+DELETE FROM employees WITH (`write.split-size` = 10)
+    WHERE status = 'inactive';
+```
+
+#### Delete All Rows
+
+```sql
+DELETE FROM employees;
+```
+
+### Related Statements
+
+* [UPDATE statement](sql-ref-syntax-dml-update.html)
+* [MERGE INTO statement](sql-ref-syntax-dml-merge-into.html)
+* [SELECT statement](sql-ref-syntax-qry-select.html)

--- a/docs/sql-ref-syntax-dml-delete-from.md
+++ b/docs/sql-ref-syntax-dml-delete-from.md
@@ -31,7 +31,7 @@ condition is specified, every row is removed.
 
 ```sql
 DELETE FROM table_identifier [ [ AS ] table_alias ]
-    [ WITH ( option_key = option_value [ , ... ] ) ]
+    [ WITH ( key = value [ , ... ] ) ]
     [ WHERE boolean_expression ]
 ```
 
@@ -49,11 +49,13 @@ DELETE FROM table_identifier [ [ AS ] table_alias ]
     Specifies an optional alias for the target table. The alias may be introduced with or without
     the `AS` keyword.
 
-* **WITH ( option_key = option_value [ , ... ] )**
+* **WITH ( key = value [ , ... ] )**
 
-    Specifies dynamic table options for this `DELETE FROM` operation. These options are passed to
-    the data source connector when deleting from the table. The supported options depend on the
-    connector.
+    Specifies an optional list of dynamic table options passed to the Data Source V2 connector for
+    this statement only. The options allow per-statement tuning without changing the table's
+    persistent configuration. Keys and values are treated as strings; a key that is not a valid
+    identifier can be quoted with backticks. Spark passes options through without validating their
+    names, and connectors may ignore options they do not recognize.
 
 * **WHERE boolean_expression**
 
@@ -93,6 +95,7 @@ DELETE FROM employees;
 
 ### Related Statements
 
-* [UPDATE statement](sql-ref-syntax-dml-update.html)
+* [INSERT TABLE statement](sql-ref-syntax-dml-insert-table.html)
 * [MERGE INTO statement](sql-ref-syntax-dml-merge-into.html)
 * [SELECT statement](sql-ref-syntax-qry-select.html)
+* [UPDATE statement](sql-ref-syntax-dml-update.html)

--- a/docs/sql-ref-syntax-dml-merge-into.md
+++ b/docs/sql-ref-syntax-dml-merge-into.md
@@ -487,5 +487,7 @@ SELECT * FROM students;
 
 ### Related Statements
 
+* [DELETE FROM statement](sql-ref-syntax-dml-delete-from.html)
 * [INSERT TABLE statement](sql-ref-syntax-dml-insert-table.html)
 * [SELECT statement](sql-ref-syntax-qry-select.html)
+* [UPDATE statement](sql-ref-syntax-dml-update.html)

--- a/docs/sql-ref-syntax-dml-update.md
+++ b/docs/sql-ref-syntax-dml-update.md
@@ -32,8 +32,8 @@ operations.
 
 ```sql
 UPDATE table_identifier [ [ AS ] table_alias ]
-    [ WITH ( option_key = option_value [ , ... ] ) ]
-    SET column = expression [ , ... ]
+    [ WITH ( key = value [ , ... ] ) ]
+    SET column = value [ , ... ]
     [ WHERE boolean_expression ]
 ```
 
@@ -50,14 +50,19 @@ UPDATE table_identifier [ [ AS ] table_alias ]
     Specifies an optional alias for the target table. The alias may be introduced with or without
     the `AS` keyword.
 
-* **WITH ( option_key = option_value [ , ... ] )**
+* **WITH ( key = value [ , ... ] )**
 
-    Specifies dynamic table options for this `UPDATE` operation. These options are passed to the
-    data source connector when writing to the table. The supported options depend on the connector.
+    Specifies an optional list of dynamic table options passed to the Data Source V2 connector for
+    this statement only. The options allow per-statement tuning without changing the table's
+    persistent configuration. Keys and values are treated as strings; a key that is not a valid
+    identifier can be quoted with backticks. Spark passes options through without validating their
+    names, and connectors may ignore options they do not recognize.
 
-* **SET column = expression [ , ... ]**
+* **SET column = value [ , ... ]**
 
-    Assigns a value to one or more columns. Each value may be an expression or `DEFAULT`. A nested
+    Specifies the columns to update and the values to assign to them. Each `value` is an expression,
+    typically referencing columns of the target table, but it may also be `DEFAULT` or an
+    uncorrelated scalar subquery over another table. A comma separates each assignment. A nested
     field may be targeted by using a qualified column name.
 
 * **WHERE boolean_expression**
@@ -103,5 +108,6 @@ UPDATE employees SET status = 'active';
 ### Related Statements
 
 * [DELETE FROM statement](sql-ref-syntax-dml-delete-from.html)
+* [INSERT TABLE statement](sql-ref-syntax-dml-insert-table.html)
 * [MERGE INTO statement](sql-ref-syntax-dml-merge-into.html)
 * [SELECT statement](sql-ref-syntax-qry-select.html)

--- a/docs/sql-ref-syntax-dml-update.md
+++ b/docs/sql-ref-syntax-dml-update.md
@@ -1,0 +1,107 @@
+---
+layout: global
+title: UPDATE
+displayTitle: UPDATE
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+### Description
+
+The `UPDATE` statement changes the values of columns in rows that satisfy an optional condition.
+When no condition is specified, every row is updated.
+
+`UPDATE` is supported on tables backed by
+[Data Source V2](sql-v2-data-sources.html#row-level-dml) connectors that support row-level
+operations.
+
+### Syntax
+
+```sql
+UPDATE table_identifier [ [ AS ] table_alias ]
+    [ WITH ( option_key = option_value [ , ... ] ) ]
+    SET column = expression [ , ... ]
+    [ WHERE boolean_expression ]
+```
+
+### Parameters
+
+* **table_identifier**
+
+    Specifies the table to update, which may be optionally qualified with a database name.
+
+    **Syntax:** `[ database_name. ] table_name`
+
+* **table_alias**
+
+    Specifies an optional alias for the target table. The alias may be introduced with or without
+    the `AS` keyword.
+
+* **WITH ( option_key = option_value [ , ... ] )**
+
+    Specifies dynamic table options for this `UPDATE` operation. These options are passed to the
+    data source connector when writing to the table. The supported options depend on the connector.
+
+* **SET column = expression [ , ... ]**
+
+    Assigns a value to one or more columns. Each value may be an expression or `DEFAULT`. A nested
+    field may be targeted by using a qualified column name.
+
+* **WHERE boolean_expression**
+
+    Specifies an optional condition that selects the rows to update. If the `WHERE` clause is
+    omitted, all rows are updated.
+
+### Examples
+
+The following examples assume that an `employees` table has already been created and populated.
+
+#### Update Rows Matching a Condition
+
+```sql
+UPDATE employees
+    SET salary = salary + 1000
+    WHERE department = 'Engineering';
+```
+
+#### Update Multiple Columns Using an Alias
+
+```sql
+UPDATE employees AS e
+    SET e.salary = e.salary * 1.05, e.status = 'reviewed'
+    WHERE e.department = 'Sales';
+```
+
+#### Update Using Dynamic Table Options
+
+```sql
+-- Option names and values are specific to the table's data source connector.
+UPDATE employees WITH (`write.split-size` = 10)
+    SET status = 'inactive'
+    WHERE last_active_date < DATE '2025-01-01';
+```
+
+#### Update All Rows
+
+```sql
+UPDATE employees SET status = 'active';
+```
+
+### Related Statements
+
+* [DELETE FROM statement](sql-ref-syntax-dml-delete-from.html)
+* [MERGE INTO statement](sql-ref-syntax-dml-merge-into.html)
+* [SELECT statement](sql-ref-syntax-qry-select.html)

--- a/docs/sql-ref-syntax.md
+++ b/docs/sql-ref-syntax.md
@@ -48,9 +48,11 @@ Data Definition Statements are used to create or modify the structure of databas
 
 Data Manipulation Statements are used to add, change, or delete data. Spark SQL supports the following Data Manipulation Statements:
 
+ * [DELETE FROM](sql-ref-syntax-dml-delete-from.html)
  * [INSERT TABLE](sql-ref-syntax-dml-insert-table.html)
  * [INSERT OVERWRITE DIRECTORY](sql-ref-syntax-dml-insert-overwrite-directory.html)
  * [MERGE INTO](sql-ref-syntax-dml-merge-into.html)
+ * [UPDATE](sql-ref-syntax-dml-update.html)
  * [LOAD](sql-ref-syntax-dml-load.html)
 
 ### Data Retrieval Statements


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add SQL reference pages for the `UPDATE` and `DELETE FROM` statements. Both pages document:

- statement syntax
- table aliases
- dynamic table options
- assignment or filtering parameters
- conditional and whole-table examples

This PR also links the new pages from the SQL syntax index and adds them to the related statements
on the `MERGE INTO` page.

### Why are the changes needed?

Spark supports `UPDATE` and `DELETE FROM` for Data Source V2 tables, but the SQL reference did not
have dedicated pages for either statement. Users therefore could not find their syntax, parameters,
or examples alongside the other DML statements.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change for existing SQL functionality.

### How was this patch tested?

The focused parser tests passed:

```text
build/sbt 'catalyst/testOnly *DDLParserSuite -- -z "delete from table" -z "update table"'
```

The run completed with 10 tests passed and no failures. The staged changes also pass
`git diff --cached --check`, and the new Markdown links and code fences were checked locally.

The full Jekyll build was not run because Bundler 2.4.22 is not installed in the environment.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5) was used for general coding assistance.
