### PR TITLE
[SPARK-58522][PYTHON] Accept a single tuple of columns in Window and TableArg partitionBy/orderBy

### DIFF
--- a/python/pyspark/sql/classic/table_arg.py
+++ b/python/pyspark/sql/classic/table_arg.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING
+from typing import cast, Iterable, overload, Sequence, TYPE_CHECKING, Union
 
 from pyspark.sql.classic.column import _to_java_column, _to_seq
 from pyspark.sql.table_arg import TableArg as ParentTableArg
@@ -30,19 +30,31 @@ class TableArg(ParentTableArg):
     def __init__(self, j_table_arg: "JavaObject"):
         self._j_table_arg = j_table_arg
 
-    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
+    @overload
+    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg": ...
+
+    @overload
+    def partitionBy(self, __cols: Sequence["ColumnOrName"]) -> "TableArg": ...
+
+    def partitionBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "TableArg":
         sc = get_active_spark_context()
-        if len(cols) == 1 and isinstance(cols[0], list):
-            cols = cols[0]
-        j_cols = _to_seq(sc, cols, _to_java_column)
+        if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
+            cols = tuple(cols[0])
+        j_cols = _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
         new_j_table_arg = self._j_table_arg.partitionBy(j_cols)
         return TableArg(new_j_table_arg)
 
-    def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
+    @overload
+    def orderBy(self, *cols: "ColumnOrName") -> "TableArg": ...
+
+    @overload
+    def orderBy(self, __cols: Sequence["ColumnOrName"]) -> "TableArg": ...
+
+    def orderBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "TableArg":
         sc = get_active_spark_context()
-        if len(cols) == 1 and isinstance(cols[0], list):
-            cols = cols[0]
-        j_cols = _to_seq(sc, cols, _to_java_column)
+        if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
+            cols = tuple(cols[0])
+        j_cols = _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
         new_j_table_arg = self._j_table_arg.orderBy(j_cols)
         return TableArg(new_j_table_arg)
 

--- a/python/pyspark/sql/classic/window.py
+++ b/python/pyspark/sql/classic/window.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 import sys
-from typing import cast, Iterable, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import cast, Iterable, overload, Sequence, Tuple, TYPE_CHECKING, Union
 
 from pyspark.sql.window import (
     Window as ParentWindow,
@@ -36,13 +36,21 @@ def _to_java_cols(
 ) -> "JavaObject":
     from pyspark.sql.classic.column import _to_seq, _to_java_column
 
-    if len(cols) == 1 and isinstance(cols[0], list):
+    if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
         cols = tuple(cols[0])
     sc = get_active_spark_context()
     return _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
 
 
 class Window(ParentWindow):
+    @overload
+    @staticmethod
+    def partitionBy(*cols: "ColumnOrName") -> ParentWindowSpec: ...
+
+    @overload
+    @staticmethod
+    def partitionBy(__cols: Sequence["ColumnOrName"]) -> ParentWindowSpec: ...
+
     @staticmethod
     def partitionBy(*cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> ParentWindowSpec:
         from py4j.java_gateway import JVMView
@@ -52,6 +60,14 @@ class Window(ParentWindow):
             cast(JVMView, sc._jvm), "org.apache.spark.sql.expressions.Window"
         ).partitionBy(_to_java_cols(cols))
         return WindowSpec(jspec)
+
+    @overload
+    @staticmethod
+    def orderBy(*cols: "ColumnOrName") -> ParentWindowSpec: ...
+
+    @overload
+    @staticmethod
+    def orderBy(__cols: Sequence["ColumnOrName"]) -> ParentWindowSpec: ...
 
     @staticmethod
     def orderBy(*cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> ParentWindowSpec:
@@ -100,10 +116,22 @@ class WindowSpec(ParentWindowSpec):
     def __init__(self, jspec: "JavaObject") -> None:
         self._jspec = jspec
 
+    @overload
+    def partitionBy(self, *cols: "ColumnOrName") -> ParentWindowSpec: ...
+
+    @overload
+    def partitionBy(self, __cols: Sequence["ColumnOrName"]) -> ParentWindowSpec: ...
+
     def partitionBy(
         self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]
     ) -> ParentWindowSpec:
         return WindowSpec(self._jspec.partitionBy(_to_java_cols(cols)))
+
+    @overload
+    def orderBy(self, *cols: "ColumnOrName") -> ParentWindowSpec: ...
+
+    @overload
+    def orderBy(self, __cols: Sequence["ColumnOrName"]) -> ParentWindowSpec: ...
 
     def orderBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> ParentWindowSpec:
         return WindowSpec(self._jspec.orderBy(_to_java_cols(cols)))

--- a/python/pyspark/sql/classic/window.py
+++ b/python/pyspark/sql/classic/window.py
@@ -37,7 +37,7 @@ def _to_java_cols(
     from pyspark.sql.classic.column import _to_seq, _to_java_column
 
     if len(cols) == 1 and isinstance(cols[0], list):
-        cols = cols[0]  # type: ignore[assignment]
+        cols = tuple(cols[0])
     sc = get_active_spark_context()
     return _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
 

--- a/python/pyspark/sql/connect/table_arg.py
+++ b/python/pyspark/sql/connect/table_arg.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 def _to_cols(cols: Tuple[Union["ColumnOrName", Sequence["ColumnOrName"]], ...]) -> List[Column]:
     if len(cols) == 1 and isinstance(cols[0], list):
-        cols = cols[0]  # type: ignore[assignment]
+        cols = tuple(cols[0])
     return [F._to_col(c) for c in cast(Iterable["ColumnOrName"], cols)]
 
 

--- a/python/pyspark/sql/connect/table_arg.py
+++ b/python/pyspark/sql/connect/table_arg.py
@@ -17,6 +17,7 @@
 
 from typing import (
     Iterable,
+    overload,
     TYPE_CHECKING,
     Union,
     Sequence,
@@ -39,7 +40,7 @@ if TYPE_CHECKING:
 
 
 def _to_cols(cols: Tuple[Union["ColumnOrName", Sequence["ColumnOrName"]], ...]) -> List[Column]:
-    if len(cols) == 1 and isinstance(cols[0], list):
+    if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
         cols = tuple(cols[0])
     return [F._to_col(c) for c in cast(Iterable["ColumnOrName"], cols)]
 
@@ -54,7 +55,13 @@ class TableArg(ParentTableArg):
             self._subquery_expr._with_single_partition
         )
 
-    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
+    @overload
+    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg": ...
+
+    @overload
+    def partitionBy(self, __cols: Sequence["ColumnOrName"]) -> "TableArg": ...
+
+    def partitionBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "TableArg":
         if self._is_partitioned():
             raise IllegalArgumentException(
                 "Cannot call partitionBy() after partitionBy() or "
@@ -72,7 +79,13 @@ class TableArg(ParentTableArg):
         )
         return TableArg(new_expr)
 
-    def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
+    @overload
+    def orderBy(self, *cols: "ColumnOrName") -> "TableArg": ...
+
+    @overload
+    def orderBy(self, __cols: Sequence["ColumnOrName"]) -> "TableArg": ...
+
+    def orderBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "TableArg":
         if not self._is_partitioned():
             raise IllegalArgumentException(
                 "Please call partitionBy() or withSinglePartition() before orderBy()."

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -14,7 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import TYPE_CHECKING, Any, Union, Sequence, List, Optional, Tuple, cast, Iterable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Union,
+    Sequence,
+    List,
+    Optional,
+    Tuple,
+    cast,
+    Iterable,
+    overload,
+)
 
 from pyspark.sql.column import Column
 from pyspark.sql.window import (
@@ -31,7 +42,7 @@ __all__ = ["Window", "WindowSpec"]
 
 
 def _to_cols(cols: Tuple[Union["ColumnOrName", Sequence["ColumnOrName"]], ...]) -> List[Column]:
-    if len(cols) == 1 and isinstance(cols[0], list):
+    if len(cols) == 1 and not isinstance(cols[0], str) and isinstance(cols[0], Sequence):
         cols = tuple(cols[0])
     return [F._to_col(c) for c in cast(Iterable["ColumnOrName"], cols)]
 
@@ -82,12 +93,24 @@ class WindowSpec(ParentWindowSpec):
         self._orderSpec = orderSpec
         self._frame = frame
 
+    @overload
+    def partitionBy(self, *cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    def partitionBy(self, __cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
+
     def partitionBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "WindowSpec":
         return WindowSpec(
             partitionSpec=[c._expr for c in _to_cols(cols)],  # type: ignore[misc]
             orderSpec=self._orderSpec,
             frame=self._frame,
         )
+
+    @overload
+    def orderBy(self, *cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    def orderBy(self, __cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
 
     def orderBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "WindowSpec":
         return WindowSpec(
@@ -136,13 +159,29 @@ class WindowSpec(ParentWindowSpec):
 class Window(ParentWindow):
     _spec = WindowSpec(partitionSpec=[], orderSpec=[], frame=None)
 
+    @overload
+    @staticmethod
+    def partitionBy(*cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    @staticmethod
+    def partitionBy(__cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
+
     @staticmethod
     def partitionBy(*cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "WindowSpec":
-        return Window._spec.partitionBy(*cols)
+        return Window._spec.partitionBy(*cols)  # type: ignore[arg-type]
+
+    @overload
+    @staticmethod
+    def orderBy(*cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    @staticmethod
+    def orderBy(__cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
 
     @staticmethod
     def orderBy(*cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "WindowSpec":
-        return Window._spec.orderBy(*cols)
+        return Window._spec.orderBy(*cols)  # type: ignore[arg-type]
 
     @staticmethod
     def rowsBetween(start: int, end: int) -> "WindowSpec":

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -32,7 +32,7 @@ __all__ = ["Window", "WindowSpec"]
 
 def _to_cols(cols: Tuple[Union["ColumnOrName", Sequence["ColumnOrName"]], ...]) -> List[Column]:
     if len(cols) == 1 and isinstance(cols[0], list):
-        cols = cols[0]  # type: ignore[assignment]
+        cols = tuple(cols[0])
     return [F._to_col(c) for c in cast(Iterable["ColumnOrName"], cols)]
 
 

--- a/python/pyspark/sql/table_arg.py
+++ b/python/pyspark/sql/table_arg.py
@@ -17,7 +17,7 @@
 
 # mypy: disable-error-code="empty-body"
 
-from typing import TYPE_CHECKING
+from typing import overload, Sequence, TYPE_CHECKING, Union
 
 from pyspark.sql.tvf_argument import TableValuedFunctionArgument
 from pyspark.sql.utils import dispatch_table_arg_method
@@ -35,8 +35,14 @@ class TableArg(TableValuedFunctionArgument):
     to TVF(Table-Valued Function)s including UDTF(User-Defined Table Function)s.
     """
 
+    @overload
+    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg": ...
+
+    @overload
+    def partitionBy(self, __cols: Sequence["ColumnOrName"]) -> "TableArg": ...
+
     @dispatch_table_arg_method
-    def partitionBy(self, *cols: "ColumnOrName") -> "TableArg":
+    def partitionBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "TableArg":
         """
         Partitions the data based on the specified columns.
 
@@ -95,8 +101,14 @@ class TableArg(TableValuedFunctionArgument):
         """
         ...
 
+    @overload
+    def orderBy(self, *cols: "ColumnOrName") -> "TableArg": ...
+
+    @overload
+    def orderBy(self, __cols: Sequence["ColumnOrName"]) -> "TableArg": ...
+
     @dispatch_table_arg_method
-    def orderBy(self, *cols: "ColumnOrName") -> "TableArg":
+    def orderBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "TableArg":
         """
         Orders the data within each partition by the specified columns.
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -2059,6 +2059,24 @@ class FunctionsTestsMixin:
         for r, ex in zip(rs, expected):
             self.assertEqual(tuple(r), ex[: len(r)])
 
+    def test_window_partitionBy_orderBy_with_sequence(self):
+        # partitionBy/orderBy accept the columns either spread out as varargs or
+        # passed as a single list/tuple; all forms should be equivalent.
+        df = self.spark.createDataFrame(
+            [(1, "a", 3), (1, "b", 3), (2, "c", 4), (2, "d", 4)], ["key", "value", "number"]
+        )
+
+        def row_numbers(w):
+            return [r[0] for r in df.select(F.row_number().over(w)).orderBy("value").collect()]
+
+        # Window.partitionBy is the static method; the chained .orderBy exercises
+        # WindowSpec.orderBy. Both accept a single list or tuple of columns.
+        varargs = Window.partitionBy("key", "number").orderBy("value", "key")
+        as_list = Window.partitionBy(["key", "number"]).orderBy(["value", "key"])
+        as_tuple = Window.partitionBy(("key", "number")).orderBy(("value", "key"))
+        self.assertEqual(row_numbers(varargs), row_numbers(as_list))
+        self.assertEqual(row_numbers(varargs), row_numbers(as_tuple))
+
     def test_window_functions_cumulative_sum(self):
         df = self.spark.createDataFrame([("one", 1), ("two", 2)], ["key", "value"])
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1311,6 +1311,16 @@ class BaseUDTFTestsMixin:
             checkRowOrder=True,
         )
         assertDataFrameEqual(
+            func(df.asTable().partitionBy(("key", "number")).orderBy(df.value)),
+            [
+                Row(key=1, value="a"),
+                Row(key=1, value="b"),
+                Row(key=2, value="c"),
+                Row(key=2, value="d"),
+            ],
+            checkRowOrder=True,
+        )
+        assertDataFrameEqual(
             func(df.asTable().partitionBy("key").orderBy(df.value.desc())),
             [
                 Row(key=1, value="b"),
@@ -1322,6 +1332,16 @@ class BaseUDTFTestsMixin:
         )
         assertDataFrameEqual(
             func(df.asTable().partitionBy("key").orderBy(["number", "value"])),
+            [
+                Row(key=1, value="a"),
+                Row(key=1, value="b"),
+                Row(key=2, value="c"),
+                Row(key=2, value="d"),
+            ],
+            checkRowOrder=True,
+        )
+        assertDataFrameEqual(
+            func(df.asTable().partitionBy("key").orderBy(("number", "value"))),
             [
                 Row(key=1, value="a"),
                 Row(key=1, value="b"),

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -18,7 +18,7 @@
 # mypy: disable-error-code="empty-body"
 
 import sys
-from typing import Sequence, TYPE_CHECKING, Union
+from typing import overload, Sequence, TYPE_CHECKING, Union
 
 from pyspark.sql.utils import dispatch_window_method
 from pyspark.util import (
@@ -65,6 +65,14 @@ class Window:
     unboundedFollowing: int = JVM_LONG_MAX
 
     currentRow: int = 0
+
+    @overload
+    @staticmethod
+    def partitionBy(*cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    @staticmethod
+    def partitionBy(__cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
 
     @staticmethod
     @dispatch_window_method
@@ -117,6 +125,14 @@ class Window:
         +---+--------+----------+
         """
         ...
+
+    @overload
+    @staticmethod
+    def orderBy(*cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    @staticmethod
+    def orderBy(__cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
 
     @staticmethod
     @dispatch_window_method
@@ -344,6 +360,12 @@ class WindowSpec:
 
         return WindowSpec.__new__(WindowSpec, jspec)
 
+    @overload
+    def partitionBy(self, *cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    def partitionBy(self, __cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
+
     def partitionBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "WindowSpec":
         """
         Defines the partitioning columns in a :class:`WindowSpec`.
@@ -356,6 +378,12 @@ class WindowSpec:
             names of columns or expressions
         """
         ...
+
+    @overload
+    def orderBy(self, *cols: "ColumnOrName") -> "WindowSpec": ...
+
+    @overload
+    def orderBy(self, __cols: Sequence["ColumnOrName"]) -> "WindowSpec": ...
 
     def orderBy(self, *cols: Union["ColumnOrName", Sequence["ColumnOrName"]]) -> "WindowSpec":
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Window.partitionBy`/`orderBy` (on both `Window` and `WindowSpec`) and `TableArg.partitionBy`/`orderBy` accept their columns as varargs, and also allow a single sequence to be passed in place of the varargs (e.g. `Window.partitionBy(["a", "b"])`). That single-sequence form was unwrapped only when it was a list, so a tuple was not unwrapped and was instead treated as a single, invalid column argument.

This PR:

1. Widens the runtime unwrap check from `isinstance(cols[0], list)` to any non-`str` `Sequence`, so a single tuple is unpacked the same way a list already is. (`Column` is not a `Sequence`, so it is excluded by the check itself.)
2. Widens the implementation signatures to `Union[ColumnOrName, Sequence[ColumnOrName]]` across the base, classic and connect layers, and adds the standard two-overload public signature (a spread of columns, or a single sequence of columns) which neither `Window` nor `TableArg` had.
3. Removes the three `# type: ignore[assignment]` comments on the single-sequence unwrap in the `_to_cols` and `_to_java_cols` helpers, by assigning `tuple(cols[0])` rather than reusing the tuple-typed variable to hold a list.

Two `# type: ignore[arg-type]` comments are added in the connect `Window` static methods. They forward their varargs into `WindowSpec.partitionBy`/`orderBy`, which are now overloaded, and a spread of the wide union matches neither overload. This follows the existing precedent for the same pattern in `DataFrame.agg`, which forwards to `self.groupBy().agg(*exprs)  # type: ignore[arg-type]`. Classic does not need this because it forwards to the plain `_to_java_cols` helper instead.

### Related PRs

This is one of a series of PRs cleaning up the "varargs that also accept a single sequence" typing pattern across PySpark (following SPARK-55967). They are intentionally kept separate:

- #57693 (SPARK-58488) -- `DataFrameWriter` / `DataStreamWriter` `partitionBy` / `clusterBy` / `bucketBy` / `sortBy`, plus the `partitionBy=` keyword argument on `save` / `saveAsTable`. Those already accepted a list or a tuple, so that PR only corrects the annotations.
- #57702 (SPARK-58500) -- `DataFrame.describe` / `selectExpr`. Those accepted a `list` only, so widening them adds tuple support (a small, backward-compatible behavior change).
- This PR (SPARK-58522) -- `Window` / `WindowSpec` / `TableArg` `partitionBy` / `orderBy`, the column-typed members of the same family.
- Still to come: the column functions `struct` / `create_map` / `array` / `map_concat`, which check `(list, set)` in classic but `(list, set, tuple)` in connect. The honest type there is not simply `Sequence` (it must also cover `set`), so that one needs a separate discussion.

### Why are the changes needed?

The annotations were inaccurate today, in opposite directions:

- `Window.partitionBy`/`orderBy` were annotated `*cols: Union[ColumnOrName, Sequence[ColumnOrName]]`, so passing a tuple type-checked even though the runtime did not unwrap it — the annotation promised more than the implementation delivered.
- `TableArg.partitionBy`/`orderBy` were annotated `*cols: ColumnOrName`, which admits no sequence at all, even though the runtime unwrapped a single list and the docstrings document `str, Column, or list`. Because the declared element type had no sequence member, the list-handling branch was dead code as far as the type checker was concerned (confirmed with `mypy --warn-unreachable`), so the annotation forbade a call that is supported, documented, and already covered by an existing test.

This also makes these methods consistent with the other column-collecting varargs methods on `DataFrame` (`select`, `groupBy`, `rollup`, `cube`), which already accept any non-`str` `Sequence` and declare it with a two-overload signature, and with `describe`/`selectExpr`, which were widened the same way in SPARK-58500.

### Does this PR introduce _any_ user-facing change?

Yes, and it is backward compatible. Calls that work today keep working; a single tuple (or any other sequence) is now accepted in addition to a list.

Before:

```python
>>> Window.partitionBy(("dept", "team"))   # tuple not unwrapped -> invalid column argument
>>> df.asTable().partitionBy(("key", "number"))
```

After, these behave the same as the already-supported list form:

```python
>>> Window.partitionBy(["dept", "team"])   # unchanged
>>> Window.partitionBy(("dept", "team"))   # now equivalent
```

Docstrings are left as-is (`str`, `Column` or `list`), matching the convention followed in SPARK-58488 and SPARK-58500.

### How was this patch tested?

Added tuple-form cases alongside the existing list-form cases, in mixins that run under both classic and Spark Connect:

- `test_udtf.py` `test_df_asTable_chaining_methods` (`BaseUDTFTestsMixin`): `partitionBy(("key", "number"))` and `orderBy(("number", "value"))`.
- `test_functions.py` `test_window_partitionBy_orderBy_with_sequence` (`FunctionsTestsMixin`): asserts the varargs, list and tuple forms produce identical results.

Also verified `mypy --namespace-packages --config-file python/mypy.ini python/pyspark` is clean over the full scope (1290 files), and `ruff format --check` / `ruff check` pass on all changed files. No typing `.yml` cases reference these methods, so none needed updating.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

