### PR TITLE
[SPARK-58463][INFRA][FOLLOWUP] Restore merge summary comment spacing

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -460,7 +460,7 @@ def post_merge_comment(pr_num, merged_commits):
     ]
     summary = "**Merge Summary:**\n" + "\n".join(lines)
     attribution = "*Posted by `merge_spark_pr.py`*"
-    body = "%s\n%s" % (summary, attribution)
+    body = "%s\n\n%s" % (summary, attribution)
     print(
         "\n%s\n\n%s\n%s"
         % (bold("Posting merge comment on PR #%s:" % pr_num), bold(summary), attribution)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up to SPARK-58463 restores the two newlines between the merge-summary block and its attribution in the PR comment. The terminal output formatting remains unchanged.

### Why are the changes needed?

The merge-summary comment should retain its original readable Markdown spacing. This change limits the earlier formatting work to stdout and stderr.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran git diff --check. No automated test was added because this is a one-line string-formatting correction.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)