### PR TITLE
[SPARK-58533][PS] Use native Spark function for NumPy float_power

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -98,9 +98,7 @@ binary_np_spark_mappings = {
     "copysign": pandas_udf(  # type: ignore[call-overload]
         lambda s1, s2: np.copysign(s1, s2), DoubleType()
     ),
-    "float_power": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.float_power(s1, s2), DoubleType()
-    ),
+    "float_power": lambda c1, c2: F.pow(c1.cast("double"), c2.cast("double")),
     "floor_divide": pandas_udf(  # type: ignore[call-overload]
         lambda s1, s2: np.floor_divide(s1, s2), DoubleType()
     ),

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -159,13 +159,12 @@ class NumPyCompatTestsMixin:
                 }
             ),
         ):
-            with self.subTest(base=pdf.base.tolist(), exponent=pdf.exponent.tolist()):
-                psdf = ps.from_pandas(pdf)
-                self.assert_eq(
-                    np.float_power(psdf.base, psdf.exponent),
-                    np.float_power(pdf.base, pdf.exponent),
-                    almost=True,
-                )
+            psdf = ps.from_pandas(pdf)
+            self.assert_eq(
+                np.float_power(psdf.base, psdf.exponent),
+                np.float_power(pdf.base, pdf.exponent),
+                almost=True,
+            )
 
     def test_np_spark_compat_series(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -149,6 +149,24 @@ class NumPyCompatTestsMixin:
                     np_func(psdf.value, psdf.bits), np_func(pdf.value, pdf.bits), almost=True
                 )
 
+    def test_np_float_power(self):
+        for pdf in (
+            pd.DataFrame({"base": [-64, -2, -1, 0, 1, 2, 64], "exponent": [-2, -1, 0, 1, 2, 3, 2]}),
+            pd.DataFrame(
+                {
+                    "base": [-np.inf, -64.0, -2.0, -0.0, 0.0, 2.0, 64.0, np.inf, np.nan],
+                    "exponent": [2.0, 3.0, -2.0, -3.0, -3.0, 0.5, -2.0, 2.0, 2.0],
+                }
+            ),
+        ):
+            with self.subTest(base=pdf.base.tolist(), exponent=pdf.exponent.tolist()):
+                psdf = ps.from_pandas(pdf)
+                self.assert_eq(
+                    np.float_power(psdf.base, psdf.exponent),
+                    np.float_power(pdf.base, pdf.exponent),
+                    almost=True,
+                )
+
     def test_np_spark_compat_series(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the pandas UDF implementation of `np.float_power` in pandas API on Spark with native Spark `pow`, casting both operands to `double`. It also adds compatibility coverage for integral inputs and floating-point special values.

### Why are the changes needed?

Using a native Spark expression avoids pandas UDF and Arrow overhead while preserving NumPy `float_power` floating-point semantics.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `test_np_float_power`, covering integral inputs, signed zero, infinities, and NaN.

- `ruff check python/pyspark/pandas/numpy_compat.py python/pyspark/pandas/tests/test_numpy_compat.py`
- `ruff format --check python/pyspark/pandas/numpy_compat.py python/pyspark/pandas/tests/test_numpy_compat.py`
- `python/run-tests --testnames pyspark.pandas.tests.test_numpy_compat` (`test_np_float_power` passed; the module has two unrelated existing reciprocal pandas-UDF failures due to a local Python/JVM class-signature mismatch.)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5