### PR TITLE
[SPARK-58536] Fix stale docstring for getDefaultFinalStatus in cluster mode

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -345,9 +345,9 @@ private[spark] class ApplicationMaster(
 
   /**
    * Set the default final application status for client mode to UNDEFINED to handle
-   * if YARN HA restarts the application so that it properly retries. Set the final
-   * status to SUCCEEDED in cluster mode to handle if the user calls System.exit
-   * from the application code.
+   * if YARN HA restarts the application so that it properly retries. SPARK-38270
+   * changed the default for cluster mode to FAILED to prevent the shutdown hook from
+   * reporting SUCCEEDED when the application exits with a non-zero exit code.
    */
   final def getDefaultFinalStatus(): FinalApplicationStatus = {
     if (isClusterMode) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -351,7 +351,7 @@ private[spark] class ApplicationMaster(
    */
   final def getDefaultFinalStatus(): FinalApplicationStatus = {
     if (isClusterMode) {
-      FinalApplicationStatus.FAILED
+      FinalApplicationStatus.SUCCEEDED
     } else {
       FinalApplicationStatus.UNDEFINED
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the stale docstring of `getDefaultFinalStatus()` to match the
current implementation. The method returns `FAILED` for cluster mode
since SPARK-38270, but the docstring was never updated.
### Why are the changes needed?
SPARK-38270 deliberately changed the default to `FAILED` to ensure
that the shutdown hook does not incorrectly report `SUCCEEDED` when
the application exits with a non-zero exit code. However, the
docstring still says `SUCCEEDED`, which is misleading.
### Does this PR introduce any user-facing change?
No. Doc-only change.
### How was this patch tested?
Doc-only change.