### PR TITLE
[SPARK-58534][BUILD][FOLLOWUP] Add 4.4 MiMa excludes section to master

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -33,8 +33,11 @@ import com.typesafe.tools.mima.core.*
  */
 object MimaExcludes {
 
-  // Exclude rules for 5.0.x from 4.3.0 (add 5.0-specific filters below as needed).
-  lazy val v50excludes: Seq[Problem => Boolean] = v43excludes
+  // Exclude rules for 5.0.x from 4.4.0 (add 5.0-specific filters below as needed).
+  lazy val v50excludes: Seq[Problem => Boolean] = v44excludes
+
+  // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
+  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes
 
   // Exclude rules for 4.3.x from 4.2.0 (add 4.3-specific filters below as needed).
   lazy val v43excludes: Seq[Problem => Boolean] = v42excludes ++ Seq(
@@ -198,6 +201,7 @@ object MimaExcludes {
 
   def excludes(version: String): Seq[Problem => Boolean] = version match {
     case v if v.startsWith("5.0") => v50excludes
+    case v if v.startsWith("4.4") => v44excludes
     case v if v.startsWith("4.3") => v43excludes
     case v if v.startsWith("4.2") => v42excludes
     case v if v.startsWith("4.1") => v41excludes


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to the `branch-4.x` version bump to 4.4.0, applied to `master`'s `MimaExcludes`:

- add `v44excludes` (built from `v43excludes`);
- re-point `v50excludes` to build on `v44excludes` instead of `v43excludes`, so the chain is `... -> v43excludes -> v44excludes -> v50excludes`;
- add the `case v if v.startsWith("4.4") => v44excludes` arm to `excludes(version)`.

Mirrors SPARK-56740's follow-up (#56510), which added the 4.3 section to `master` after `branch-4.x` was bumped to 4.3.0 by SPARK-57443.

### Why are the changes needed?

Without this, `master`'s exclude chain skips 4.4 and `excludes("4.4.0")` falls through to `case _ => Seq()`, returning no excludes at all.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI will test this out.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5