### PR TITLE
[SPARK-58537][INFRA][4.x] Make maven_test.yml default to branch-4.x on branch-4.x

### DIFF
--- a/.github/workflows/build_maven_java21_arm.yml
+++ b/.github/workflows/build_maven_java21_arm.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, ARM)"
+name: "Build / Maven (branch-4.x, Scala 2.13, Hadoop 3, JDK 21, ARM)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven_java21_macos26.yml
+++ b/.github/workflows/build_maven_java21_macos26.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, MacOS-26)"
+name: "Build / Maven (branch-4.x, Scala 2.13, Hadoop 3, JDK 21, MacOS-26)"
 
 on:
   schedule:

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -30,7 +30,7 @@ on:
         description: Branch to run the build against
         required: false
         type: string
-        default: master
+        default: branch-4.x
       hadoop:
         description: Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.
         required: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

The scheduled Maven workflows on `branch-4.x` were building `master`, not the branch. They call the reusable `maven_test.yml` without passing a `branch` input, and that workflow declared `default: master`, which it then uses as the checkout ref. Five workflows on this branch rely on the default: `build_maven.yml`, `build_maven_java21.yml`, `build_maven_java25.yml`, `build_maven_java21_arm.yml` and `build_maven_java21_macos26.yml`.

Point the default at `branch-4.x`, matching `build_and_test.yml` on this branch (already `branch-4.x`) and both reusable workflows on `branch-4.2` and `branch-4.1` (each defaulting to their own branch, which is why their callers correctly pass no input).

Also retitle `build_maven_java21_arm.yml` and `build_maven_java21_macos26.yml`, which still said `master` in their names — a stale artifact of being copied from `master` (the same two are stale on `branch-4.2`). They ran against `master` only because of the default this commit fixes, so the names would otherwise become actively wrong.

Callers that target another branch pass `branch:` explicitly (e.g. `build_branch41_maven.yml` passes `branch-4.1`) and are unaffected.

This misreporting masked SPARK-57897, where `branch-4.x` could not load its Maven project model at all, yet the branch's Maven workflow kept reporting success.

### Why are the changes needed?

branch-4.x refers to master branch on CI which ended up with missing Maven build failure.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

scheduled CI will confirm with it.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5