### PR TITLE
[SPARK-58511][SQL] Bypass ineffective pre-shuffle partial aggregation at runtime

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -181,6 +181,67 @@ Missing or inaccurate statistics will hinder Spark's ability to select an optima
 - **Query plan estimates**: You can inspect Spark's cost estimates in the optimized query plan via [`EXPLAIN COST`](sql-ref-syntax-qry-explain.html) or `DataFrame.explain(mode="cost")`.
 - **Runtime statistics**: You can inspect these statistics in the [SQL UI](web-ui.html#sql-tab) under the "Details" section as a query is running. Look for `Statistics(..., isRuntime=true)` in the plan.
 
+## Optimizing the Aggregate
+
+### Adaptive Partial Aggregation
+
+A grouping aggregation normally runs in two phases: a partial aggregation before the shuffle and a
+final aggregation after it. The partial aggregation is only worthwhile when it actually reduces the
+number of rows; when the grouping keys are close to unique it maintains -- and possibly spills -- an
+aggregation map roughly as large as its input while emitting almost as many rows as it consumed.
+
+When adaptive partial aggregation is enabled, hash aggregation measures the reduction ratio (the
+number of distinct grouping keys divided by the number of processed rows) at runtime and, if the
+partial aggregation is not reducing rows enough to be worthwhile, stops populating the aggregation
+map and passes the remaining rows through as single-row partial aggregation buffers for the final
+aggregation to merge. Query results are unchanged. The ratio is evaluated periodically, and again
+right before the aggregation map would spill, so a query that only becomes ineffective later in its
+input is still caught.
+
+<table class="spark-config">
+  <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
+  <tr>
+    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.enabled</code></td>
+    <td>true</td>
+    <td>
+      When true, hash aggregation adaptively bypasses the pre-shuffle partial aggregation at runtime
+      when it observes that the partial aggregation is not reducing the number of rows enough to be
+      worthwhile. This applies only to hash aggregation with grouping keys.
+    </td>
+    <td>4.3.0</td>
+  </tr>
+  <tr>
+    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.sampleRows</code></td>
+    <td>100000</td>
+    <td>
+      The number of input rows to sample before evaluating the reduction ratio. When the ratio is
+      below the threshold, the next evaluation happens after twice as many rows, so low-cardinality
+      input is re-checked only rarely.
+    </td>
+    <td>4.3.0</td>
+  </tr>
+  <tr>
+    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.noSpillReductionRatioThreshold</code></td>
+    <td>0.9</td>
+    <td>
+      The reduction ratio threshold applied while the aggregation map is still fully in memory. If
+      the ratio is at least this value the partial aggregation is bypassed. A larger value is more
+      conservative (keeps partial aggregation in more cases).
+    </td>
+    <td>4.3.0</td>
+  </tr>
+  <tr>
+    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.spillReductionRatioThreshold</code></td>
+    <td>(value of <code>noSpillReductionRatioThreshold</code>)</td>
+    <td>
+      The reduction ratio threshold applied when the aggregation map is about to spill. Setting it
+      lower makes the bypass more likely once spilling is imminent, and 0 always bypasses instead of
+      spilling.
+    </td>
+    <td>4.3.0</td>
+  </tr>
+</table>
+
 ## Optimizing the Join Strategy
 
 ### Automatically Broadcasting Joins

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -194,10 +194,12 @@ When adaptive partial aggregation is enabled, hash aggregation measures the comp
 number of processed rows divided by the number of keys held in its aggregation maps) at runtime
 and, if the partial aggregation is not collapsing enough rows to be worthwhile, stops populating
 the aggregation map and passes the remaining rows through as single-row partial aggregation buffers
-for the final aggregation to merge. If the first bypassed row is a duplicate of a key already in the
-frozen map, it is emitted ahead of that key's accumulated rows, so an order-sensitive aggregate
-such as `first`/`last` can return different values. The ratio is evaluated periodically, and again
-right before the aggregation map would spill, in which case the spill is skipped entirely.
+for the final aggregation to merge. Once pass-through is active the map is frozen and its output
+always comes before the passed-through rows: rows that collide with the frozen map are held in a
+queue behind it and flushed only after it drains, so a duplicate of a key already in the map still
+merges after that key's accumulated rows, keeping an order-sensitive aggregate such as
+`first`/`last` consistent with a run that never bypasses. The ratio is evaluated periodically, and
+again right before the aggregation map would spill, in which case the spill is skipped entirely.
 
 Both evaluations use the cumulative rows and keys of the current map epoch and, once triggered,
 pass-through is not reversed for the rest of the task, so a skewed prefix biases the outcome in
@@ -227,7 +229,10 @@ evaluations start later.
     <td>
       The number of rows between periodic compaction-ratio evaluations. Setting this to
       <code>0</code> disables the periodic evaluation. The ratio may still be evaluated when the
-      aggregation map is about to spill.
+      aggregation map is about to spill. A larger value also delays the periodic evaluations, so
+      when one of them trips pass-through the frozen map tends to hold more rows; the frozen map
+      stays resident until its output is drained, so a larger value raises that transient memory
+      peak.
     </td>
     <td>4.4.0</td>
   </tr>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -194,15 +194,20 @@ When adaptive partial aggregation is enabled, hash aggregation measures the comp
 number of processed rows divided by the number of keys held in its aggregation maps) at runtime
 and, if the partial aggregation is not collapsing enough rows to be worthwhile, stops populating
 the aggregation map and passes the remaining rows through as single-row partial aggregation buffers
-for the final aggregation to merge. Query results are unchanged. The ratio is evaluated
-periodically, and again right before the aggregation map would spill, in which case the spill is
-skipped entirely. Periodic evaluations use the cumulative rows and keys of the current map epoch,
-so a favorable prefix can mask a later distinct-heavy tail. A spill restarts the accounting, so a
-query that becomes ineffective only later in its input is then caught. To catch such a turn
-without waiting for a spill, raise `minCompaction` so the cumulative ratio trips the threshold on
-a weaker late turn (a higher threshold also bypasses more readily on other inputs). To avoid
-committing to pass-through on an unfavorable prefix before an aggregatable tail shows up, raise
-`minRows` so the periodic evaluations start later.
+for the final aggregation to merge. If the first bypassed row is a duplicate of a key already in the
+frozen map, it is emitted ahead of that key's accumulated rows, so an order-sensitive aggregate
+such as `first`/`last` can return different values. The ratio is evaluated periodically, and again
+right before the aggregation map would spill, in which case the spill is skipped entirely.
+
+Both evaluations use the cumulative rows and keys of the current map epoch and, once triggered,
+pass-through is not reversed for the rest of the task, so a skewed prefix biases the outcome in
+either direction. A favorable prefix can mask a later distinct-heavy tail, keeping the aggregation
+on until a spill restarts the accounting; conversely, a distinct-heavy prefix can trip the
+pass-through early and keep it tripped even where the rest of the input would aggregate well. To
+catch the former without waiting for a spill, raise `minCompaction` so the cumulative ratio trips
+the threshold on a weaker late turn (a higher threshold also bypasses more readily on other inputs).
+To avoid committing the task to pass-through on the latter, raise `minRows` so the periodic
+evaluations start later.
 
 <table class="spark-config">
   <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -202,7 +202,7 @@ skipped entirely -- so a query that only becomes ineffective later in its input 
   <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
   <tr>
     <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.enabled</code></td>
-    <td>true</td>
+    <td>false</td>
     <td>
       When true, hash aggregation adaptively bypasses the pre-shuffle partial aggregation at runtime
       when it observes that the partial aggregation is not reducing the number of rows enough to be

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -214,21 +214,20 @@ skipped entirely -- so a query that only becomes ineffective later in its input 
     <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.minRows</code></td>
     <td>100000</td>
     <td>
-      The number of rows to process before the compaction ratio is evaluated, so a decision is never
-      made on too few rows. The ratio is re-evaluated every time this many further rows have been
-      processed. Setting this to <code>0</code> disables the periodic evaluation entirely, leaving
-      only the check made when the aggregation map is about to spill.
+      The number of rows between periodic compaction-ratio evaluations. Setting this to
+      <code>0</code> disables the periodic evaluation. The ratio may still be evaluated when the
+      aggregation map is about to spill.
     </td>
     <td>4.4.0</td>
   </tr>
   <tr>
     <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.minCompaction</code></td>
-    <td>1.1</td>
+    <td>1.05</td>
     <td>
       The minimum compaction ratio required to keep the partial aggregation. A ratio of 10 means the
-      partial aggregation collapses ten rows into one key; when the observed ratio is below this
-      value the partial aggregation is bypassed for the rest of the input. A larger value bypasses
-      more aggressively.
+      partial aggregation collapses ten rows into one key; when an evaluation finds the ratio below
+      this value the partial aggregation is bypassed for the rest of the input. A larger value
+      bypasses more aggressively.
     </td>
     <td>4.4.0</td>
   </tr>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -216,7 +216,8 @@ skipped entirely -- so a query that only becomes ineffective later in its input 
     <td>
       The number of rows to process before the compaction ratio is evaluated, so a decision is never
       made on too few rows. The ratio is re-evaluated every time this many further rows have been
-      processed.
+      processed. Setting this to <code>0</code> disables the periodic evaluation entirely, leaving
+      only the check made when the aggregation map is about to spill.
     </td>
     <td>4.4.0</td>
   </tr>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -187,7 +187,7 @@ Missing or inaccurate statistics will hinder Spark's ability to select an optima
 
 A grouping aggregation normally runs in two phases: a partial aggregation before the shuffle and a
 final aggregation after it. The partial aggregation is only worthwhile when it actually reduces the
-number of rows; when the grouping keys are close to unique it maintains -- and possibly spills -- an
+number of rows; when the grouping keys are close to unique it maintains, and possibly spills, an
 aggregation map roughly as large as its input while emitting almost as many rows as it consumed.
 
 When adaptive partial aggregation is enabled, hash aggregation measures the compaction ratio (the
@@ -195,8 +195,14 @@ number of processed rows divided by the number of keys held in its aggregation m
 and, if the partial aggregation is not collapsing enough rows to be worthwhile, stops populating
 the aggregation map and passes the remaining rows through as single-row partial aggregation buffers
 for the final aggregation to merge. Query results are unchanged. The ratio is evaluated
-periodically, and again right before the aggregation map would spill -- in which case the spill is
-skipped entirely -- so a query that only becomes ineffective later in its input is still caught.
+periodically, and again right before the aggregation map would spill, in which case the spill is
+skipped entirely. Periodic evaluations use the cumulative rows and keys of the current map epoch,
+so a favorable prefix can mask a later distinct-heavy tail. A spill restarts the accounting, so a
+query that becomes ineffective only later in its input is then caught. To catch such a turn
+without waiting for a spill, raise `minCompaction` so the cumulative ratio trips the threshold on
+a weaker late turn (a higher threshold also bypasses more readily on other inputs). To avoid
+committing to pass-through on an unfavorable prefix before an aggregatable tail shows up, raise
+`minRows` so the periodic evaluations start later.
 
 <table class="spark-config">
   <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -190,13 +190,13 @@ final aggregation after it. The partial aggregation is only worthwhile when it a
 number of rows; when the grouping keys are close to unique it maintains -- and possibly spills -- an
 aggregation map roughly as large as its input while emitting almost as many rows as it consumed.
 
-When adaptive partial aggregation is enabled, hash aggregation measures the reduction ratio (the
-number of distinct grouping keys divided by the number of processed rows) at runtime and, if the
-partial aggregation is not reducing rows enough to be worthwhile, stops populating the aggregation
-map and passes the remaining rows through as single-row partial aggregation buffers for the final
-aggregation to merge. Query results are unchanged. The ratio is evaluated periodically, and again
-right before the aggregation map would spill, so a query that only becomes ineffective later in its
-input is still caught.
+When adaptive partial aggregation is enabled, hash aggregation measures the compaction ratio (the
+number of processed rows divided by the number of keys held in its aggregation maps) at runtime
+and, if the partial aggregation is not collapsing enough rows to be worthwhile, stops populating
+the aggregation map and passes the remaining rows through as single-row partial aggregation buffers
+for the final aggregation to merge. Query results are unchanged. The ratio is evaluated
+periodically, and again right before the aggregation map would spill -- in which case the spill is
+skipped entirely -- so a query that only becomes ineffective later in its input is still caught.
 
 <table class="spark-config">
   <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
@@ -208,37 +208,28 @@ input is still caught.
       when it observes that the partial aggregation is not reducing the number of rows enough to be
       worthwhile. This applies only to hash aggregation with grouping keys.
     </td>
-    <td>4.3.0</td>
+    <td>4.4.0</td>
   </tr>
   <tr>
-    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.sampleRows</code></td>
+    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.minRows</code></td>
     <td>100000</td>
     <td>
-      The number of input rows to sample before evaluating the reduction ratio. When the ratio is
-      below the threshold, the next evaluation happens after twice as many rows, so low-cardinality
-      input is re-checked only rarely.
+      The number of rows to process before the compaction ratio is evaluated, so a decision is never
+      made on too few rows. The ratio is re-evaluated every time this many further rows have been
+      processed.
     </td>
-    <td>4.3.0</td>
+    <td>4.4.0</td>
   </tr>
   <tr>
-    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.noSpillReductionRatioThreshold</code></td>
-    <td>0.9</td>
+    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.minCompaction</code></td>
+    <td>1.1</td>
     <td>
-      The reduction ratio threshold applied while the aggregation map is still fully in memory. If
-      the ratio is at least this value the partial aggregation is bypassed. A larger value is more
-      conservative (keeps partial aggregation in more cases).
+      The minimum compaction ratio required to keep the partial aggregation. A ratio of 10 means the
+      partial aggregation collapses ten rows into one key; when the observed ratio is below this
+      value the partial aggregation is bypassed for the rest of the input. A larger value bypasses
+      more aggressively.
     </td>
-    <td>4.3.0</td>
-  </tr>
-  <tr>
-    <td><code>spark.sql.execution.aggregate.adaptivePartialAggregation.spillReductionRatioThreshold</code></td>
-    <td>(value of <code>noSpillReductionRatioThreshold</code>)</td>
-    <td>
-      The reduction ratio threshold applied when the aggregation map is about to spill. Setting it
-      lower makes the bypass more likely once spilling is imminent, and 0 always bypasses instead of
-      spilling.
-    </td>
-    <td>4.3.0</td>
+    <td>4.4.0</td>
   </tr>
 </table>
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4171,12 +4171,10 @@ object SQLConf {
 
   val ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS =
     buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.minRows")
-      .doc("The number of rows to process before adaptive partial aggregation (see " +
-        s"'${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}') evaluates the compaction ratio. The " +
-        "ratio is evaluated once this many rows have been processed since the previous " +
-        "evaluation, so a decision is never made on too few rows. A value of 0 disables the " +
-        "periodic evaluation entirely, leaving only the check made when the aggregation map is " +
-        "about to spill.")
+      .doc("The number of rows between periodic compaction-ratio evaluations by adaptive partial " +
+        s"aggregation (see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). Setting this to 0 " +
+        "disables the periodic evaluation. The ratio may still be evaluated when the aggregation " +
+        "map is about to spill.")
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .longConf
@@ -4188,16 +4186,15 @@ object SQLConf {
       .doc("The minimum compaction ratio required to keep the pre-shuffle partial aggregation " +
         s"(see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). The compaction ratio is the " +
         "number of processed rows divided by the number of keys held in the aggregation maps, " +
-        "so a ratio of 10 means the partial aggregation collapses ten rows into one. When the " +
-        s"ratio is below this value after '${ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key}' rows, " +
-        "or when the aggregation map is about to spill, the partial aggregation is bypassed for " +
+        "so a ratio of 10 means the partial aggregation collapses ten rows into one. When an " +
+        "evaluation finds the ratio below this value, the partial aggregation is bypassed for " +
         "the rest of the input. A larger value bypasses more aggressively.")
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .doubleConf
       .checkValue(v => v >= 1.0 && v.isFinite,
         "The minimum compaction ratio must be a finite value of at least 1.0.")
-      .createWithDefault(1.1)
+      .createWithDefault(1.05)
 
   val JSON_GENERATOR_IGNORE_NULL_FIELDS =
     buildConf("spark.sql.jsonGenerator.ignoreNullFields")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4156,6 +4156,66 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val ADAPTIVE_PARTIAL_AGGREGATION_ENABLED =
+    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.enabled")
+      .doc("When true, hash aggregation adaptively bypasses the pre-shuffle partial aggregation " +
+        "at runtime when it observes that the partial aggregation is not reducing the number of " +
+        "rows enough to be worthwhile. Once bypassed, the remaining input rows are passed " +
+        "through as single-row partial aggregation buffers for the final aggregation to merge, " +
+        "which avoids the cost of maintaining and spilling a large aggregation map with little " +
+        "reduction benefit. This applies only to hash aggregation with grouping keys.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
+      .createWithDefault(true)
+
+  val ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS =
+    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.sampleRows")
+      .doc("The number of input rows to sample before evaluating the reduction ratio for the " +
+        s"no-spill tier of adaptive partial aggregation (see " +
+        s"'${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). From this many rows on, if the ratio " +
+        "of distinct grouping keys to processed rows is at least " +
+        s"'spark.sql.execution.aggregate.adaptivePartialAggregation." +
+        "noSpillReductionRatioThreshold', partial aggregation is bypassed for the rest of the " +
+        "input. When the ratio is below the threshold, the next evaluation happens after twice " +
+        "as many rows, so low-cardinality input is re-checked only rarely.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .intConf
+      .checkValue(_ > 0, "The sample row count must be positive.")
+      .createWithDefault(100000)
+
+  val ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD =
+    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation." +
+      "noSpillReductionRatioThreshold")
+      .doc("The reduction ratio threshold used by the no-spill tier of adaptive partial " +
+        s"aggregation (see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). The reduction ratio " +
+        "is the number of distinct grouping keys divided by the number of processed rows. After " +
+        s"sampling '${ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key}' rows without spilling, if " +
+        "the ratio is at least this value the partial aggregation is bypassed. A larger value " +
+        "is more conservative (keeps partial aggregation in more cases).")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .doubleConf
+      .checkValue(v => v > 0.0 && v <= 1.0, "The reduction ratio threshold must be in (0.0, 1.0].")
+      .createWithDefault(0.95)
+
+  val ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD =
+    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation." +
+      "spillReductionRatioThreshold")
+      .doc("The reduction ratio threshold used by the on-spill tier of adaptive partial " +
+        s"aggregation (see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). When the aggregation " +
+        "map is about to spill, if the ratio of distinct grouping keys to processed rows is at " +
+        "least this value the partial aggregation is bypassed for the rest of the input. This " +
+        "threshold is more aggressive (lower) than the no-spill tier because once the map " +
+        "spills, partial aggregation starts paying disk I/O costs, so it is worth bypassing " +
+        "with less reduction benefit.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .doubleConf
+      .checkValue(v => v > 0.0 && v <= 1.0, "The reduction ratio threshold must be in (0.0, 1.0].")
+      .createWithDefault(0.8)
+
   val JSON_GENERATOR_IGNORE_NULL_FIELDS =
     buildConf("spark.sql.jsonGenerator.ignoreNullFields")
       .doc("Whether to ignore null fields when generating JSON objects in JSON data source and " +
@@ -8902,6 +8962,18 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def useHashAggregation: Boolean = getConf(USE_HASH_AGG)
 
   def bypassPartialAggregation: Boolean = getConf(BYPASS_PARTIAL_AGGREGATION)
+
+  def adaptivePartialAggregationEnabled: Boolean =
+    getConf(ADAPTIVE_PARTIAL_AGGREGATION_ENABLED)
+
+  def adaptivePartialAggregationSampleRows: Int =
+    getConf(ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS)
+
+  def adaptivePartialAggregationNoSpillReductionRatioThreshold: Double =
+    getConf(ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD)
+
+  def adaptivePartialAggregationSpillReductionRatioThreshold: Double =
+    getConf(ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD)
 
   def objectAggSortBasedFallbackThreshold: Int = getConf(OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4166,7 +4166,7 @@ object SQLConf {
         "reduction benefit. Disabled by default. This applies only to hash aggregation with " +
         "grouping keys.")
       .version("4.4.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 
@@ -4177,7 +4177,7 @@ object SQLConf {
         "disables the periodic evaluation. The ratio may still be evaluated when the aggregation " +
         "map is about to spill.")
       .version("4.4.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .longConf
       .checkValue(_ >= 0, "The minimum row count must not be negative.")
       .createWithDefault(100000)
@@ -4191,7 +4191,7 @@ object SQLConf {
         "evaluation finds the ratio below this value, the partial aggregation is bypassed for " +
         "the rest of the input. A larger value bypasses more aggressively.")
       .version("4.4.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .doubleConf
       .checkValue(v => v >= 1.0 && v.isFinite,
         "The minimum compaction ratio must be a finite value of at least 1.0.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4195,7 +4195,8 @@ object SQLConf {
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .doubleConf
-      .checkValue(_ >= 1.0, "The minimum compaction ratio must be at least 1.0.")
+      .checkValue(v => v >= 1.0 && v.isFinite,
+        "The minimum compaction ratio must be a finite value of at least 1.0.")
       .createWithDefault(1.1)
 
   val JSON_GENERATOR_IGNORE_NULL_FIELDS =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4197,8 +4197,8 @@ object SQLConf {
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .doubleConf
-      .checkValue(v => v > 0.0 && v <= 1.0, "The reduction ratio threshold must be in (0.0, 1.0].")
-      .createWithDefault(0.95)
+      .checkValue(v => v >= 0.0 && v <= 1.0, "The reduction ratio threshold must be in [0.0, 1.0].")
+      .createWithDefault(0.9)
 
   val ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD =
     buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation." +
@@ -4206,15 +4206,13 @@ object SQLConf {
       .doc("The reduction ratio threshold used by the on-spill tier of adaptive partial " +
         s"aggregation (see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). When the aggregation " +
         "map is about to spill, if the ratio of distinct grouping keys to processed rows is at " +
-        "least this value the partial aggregation is bypassed for the rest of the input. This " +
-        "threshold is more aggressive (lower) than the no-spill tier because once the map " +
-        "spills, partial aggregation starts paying disk I/O costs, so it is worth bypassing " +
-        "with less reduction benefit.")
+        "least this value the partial aggregation is bypassed for the rest of the input. It " +
+        s"falls back to '${ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD.key}' " +
+        "so that both tiers apply one policy by default. Setting it lower makes the bypass more " +
+        "likely once spilling is imminent, and 0 always bypasses instead of spilling.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
-      .doubleConf
-      .checkValue(v => v > 0.0 && v <= 1.0, "The reduction ratio threshold must be in (0.0, 1.0].")
-      .createWithDefault(0.8)
+      .fallbackConf(ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD)
 
   val JSON_GENERATOR_IGNORE_NULL_FIELDS =
     buildConf("spark.sql.jsonGenerator.ignoreNullFields")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4164,55 +4164,37 @@ object SQLConf {
         "through as single-row partial aggregation buffers for the final aggregation to merge, " +
         "which avoids the cost of maintaining and spilling a large aggregation map with little " +
         "reduction benefit. This applies only to hash aggregation with grouping keys.")
-      .version("4.3.0")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
       .createWithDefault(true)
 
-  val ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS =
-    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.sampleRows")
-      .doc("The number of input rows to sample before evaluating the reduction ratio for the " +
-        s"no-spill tier of adaptive partial aggregation (see " +
-        s"'${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). From this many rows on, if the ratio " +
-        "of distinct grouping keys to processed rows is at least " +
-        s"'spark.sql.execution.aggregate.adaptivePartialAggregation." +
-        "noSpillReductionRatioThreshold', partial aggregation is bypassed for the rest of the " +
-        "input. When the ratio is below the threshold, the next evaluation happens after twice " +
-        "as many rows, so low-cardinality input is re-checked only rarely.")
-      .version("4.3.0")
+  val ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS =
+    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.minRows")
+      .doc("The number of rows to process before adaptive partial aggregation (see " +
+        s"'${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}') evaluates the compaction ratio. The " +
+        "ratio is evaluated once this many rows have been processed since the previous " +
+        "evaluation, so a decision is never made on too few rows.")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
-      .intConf
-      .checkValue(_ > 0, "The sample row count must be positive.")
+      .longConf
+      .checkValue(_ > 0, "The minimum row count must be positive.")
       .createWithDefault(100000)
 
-  val ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD =
-    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation." +
-      "noSpillReductionRatioThreshold")
-      .doc("The reduction ratio threshold used by the no-spill tier of adaptive partial " +
-        s"aggregation (see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). The reduction ratio " +
-        "is the number of distinct grouping keys divided by the number of processed rows. After " +
-        s"sampling '${ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key}' rows without spilling, if " +
-        "the ratio is at least this value the partial aggregation is bypassed. A larger value " +
-        "is more conservative (keeps partial aggregation in more cases).")
-      .version("4.3.0")
+  val ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION =
+    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.minCompaction")
+      .doc("The minimum compaction ratio required to keep the pre-shuffle partial aggregation " +
+        s"(see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). The compaction ratio is the " +
+        "number of processed rows divided by the number of keys held in the aggregation maps, " +
+        "so a ratio of 10 means the partial aggregation collapses ten rows into one. When the " +
+        s"ratio is below this value after '${ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key}' rows, " +
+        "or when the aggregation map is about to spill, the partial aggregation is bypassed for " +
+        "the rest of the input. A larger value bypasses more aggressively.")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .doubleConf
-      .checkValue(v => v >= 0.0 && v <= 1.0, "The reduction ratio threshold must be in [0.0, 1.0].")
-      .createWithDefault(0.9)
-
-  val ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD =
-    buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation." +
-      "spillReductionRatioThreshold")
-      .doc("The reduction ratio threshold used by the on-spill tier of adaptive partial " +
-        s"aggregation (see '${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}'). When the aggregation " +
-        "map is about to spill, if the ratio of distinct grouping keys to processed rows is at " +
-        "least this value the partial aggregation is bypassed for the rest of the input. It " +
-        s"falls back to '${ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD.key}' " +
-        "so that both tiers apply one policy by default. Setting it lower makes the bypass more " +
-        "likely once spilling is imminent, and 0 always bypasses instead of spilling.")
-      .version("4.3.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
-      .fallbackConf(ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD)
+      .checkValue(_ >= 1.0, "The minimum compaction ratio must be at least 1.0.")
+      .createWithDefault(1.1)
 
   val JSON_GENERATOR_IGNORE_NULL_FIELDS =
     buildConf("spark.sql.jsonGenerator.ignoreNullFields")
@@ -8964,14 +8946,11 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def adaptivePartialAggregationEnabled: Boolean =
     getConf(ADAPTIVE_PARTIAL_AGGREGATION_ENABLED)
 
-  def adaptivePartialAggregationSampleRows: Int =
-    getConf(ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS)
+  def adaptivePartialAggregationMinRows: Long =
+    getConf(ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS)
 
-  def adaptivePartialAggregationNoSpillReductionRatioThreshold: Double =
-    getConf(ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD)
-
-  def adaptivePartialAggregationSpillReductionRatioThreshold: Double =
-    getConf(ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD)
+  def adaptivePartialAggregationMinCompaction: Double =
+    getConf(ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION)
 
   def objectAggSortBasedFallbackThreshold: Int = getConf(OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4163,11 +4163,12 @@ object SQLConf {
         "rows enough to be worthwhile. Once bypassed, the remaining input rows are passed " +
         "through as single-row partial aggregation buffers for the final aggregation to merge, " +
         "which avoids the cost of maintaining and spilling a large aggregation map with little " +
-        "reduction benefit. This applies only to hash aggregation with grouping keys.")
+        "reduction benefit. Disabled by default. This applies only to hash aggregation with " +
+        "grouping keys.")
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS =
     buildConf("spark.sql.execution.aggregate.adaptivePartialAggregation.minRows")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4174,11 +4174,13 @@ object SQLConf {
       .doc("The number of rows to process before adaptive partial aggregation (see " +
         s"'${ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key}') evaluates the compaction ratio. The " +
         "ratio is evaluated once this many rows have been processed since the previous " +
-        "evaluation, so a decision is never made on too few rows.")
+        "evaluation, so a decision is never made on too few rows. A value of 0 disables the " +
+        "periodic evaluation entirely, leaving only the check made when the aggregation map is " +
+        "about to spill.")
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .longConf
-      .checkValue(_ > 0, "The minimum row count must be positive.")
+      .checkValue(_ >= 0, "The minimum row count must not be negative.")
       .createWithDefault(100000)
 
   val ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION =

--- a/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk21-results.txt
@@ -1,0 +1,56 @@
+================================================================================================
+high-cardinality input, no-spill pass-through (Tier 1)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, high card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        4094           4126          45          2.0         488.0       1.0X
+codegen = true, adaptive = T                        2402           2424          32          3.5         286.3       1.7X
+codegen = false, adaptive = F                       4989           4994           6          1.7         594.8       0.8X
+codegen = false, adaptive = T                       3183           3193          13          2.6         379.5       1.3X
+
+
+================================================================================================
+low-cardinality input, no-spill pass-through (Tier 1)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, low card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        287            299          11         58.4          17.1       1.0X
+codegen = true, adaptive = T                        282            290           5         59.4          16.8       1.0X
+codegen = false, adaptive = F                      1328           1329           2         12.6          79.2       0.2X
+codegen = false, adaptive = T                      1342           1350          12         12.5          80.0       0.2X
+
+
+================================================================================================
+high-cardinality input, on-spill pass-through (Tier 2)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, high card, spill:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                       8850           8911          87          0.9        1055.0       1.0X
+codegen = true, adaptive = T                       4448           4570         173          1.9         530.3       2.0X
+codegen = false, adaptive = F                      9261           9357         136          0.9        1104.0       1.0X
+codegen = false, adaptive = T                      5276           5355         112          1.6         629.0       1.7X
+
+
+================================================================================================
+low-cardinality input, on-spill pass-through (Tier 2)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, low card, spill:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        789            806          16         21.3          47.0       1.0X
+codegen = true, adaptive = T                        813            835          28         20.6          48.5       1.0X
+codegen = false, adaptive = F                      1351           1425         104         12.4          80.5       0.6X
+codegen = false, adaptive = T                      1346           1350           6         12.5          80.2       0.6X
+
+

--- a/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk21-results.txt
@@ -1,56 +1,56 @@
 ================================================================================================
-high-cardinality input, no-spill pass-through (Tier 1)
+high-cardinality input, pass-through at the periodic check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, high card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        4094           4126          45          2.0         488.0       1.0X
-codegen = true, adaptive = T                        2402           2424          32          3.5         286.3       1.7X
-codegen = false, adaptive = F                       4989           4994           6          1.7         594.8       0.8X
-codegen = false, adaptive = T                       3183           3193          13          2.6         379.5       1.3X
+codegen = true, adaptive = F                        4069           4145         108          2.1         485.0       1.0X
+codegen = true, adaptive = T                        2585           2632          67          3.2         308.1       1.6X
+codegen = false, adaptive = F                       4818           4849          44          1.7         574.3       0.8X
+codegen = false, adaptive = T                       2983           3150         236          2.8         355.6       1.4X
 
 
 ================================================================================================
-low-cardinality input, no-spill pass-through (Tier 1)
+low-cardinality input, pass-through at the periodic check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, low card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        287            299          11         58.4          17.1       1.0X
-codegen = true, adaptive = T                        282            290           5         59.4          16.8       1.0X
-codegen = false, adaptive = F                      1328           1329           2         12.6          79.2       0.2X
-codegen = false, adaptive = T                      1342           1350          12         12.5          80.0       0.2X
+codegen = true, adaptive = F                        281            292           7         59.6          16.8       1.0X
+codegen = true, adaptive = T                        291            323          52         57.7          17.3       1.0X
+codegen = false, adaptive = F                      1289           1303          20         13.0          76.8       0.2X
+codegen = false, adaptive = T                      1266           1270           7         13.3          75.4       0.2X
 
 
 ================================================================================================
-high-cardinality input, on-spill pass-through (Tier 2)
+high-cardinality input, pass-through at the spill check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, high card, spill:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                       8850           8911          87          0.9        1055.0       1.0X
-codegen = true, adaptive = T                       4448           4570         173          1.9         530.3       2.0X
-codegen = false, adaptive = F                      9261           9357         136          0.9        1104.0       1.0X
-codegen = false, adaptive = T                      5276           5355         112          1.6         629.0       1.7X
+codegen = true, adaptive = F                       8120           8126           9          1.0         968.0       1.0X
+codegen = true, adaptive = T                       4460           4476          22          1.9         531.7       1.8X
+codegen = false, adaptive = F                      9331           9389          82          0.9        1112.3       0.9X
+codegen = false, adaptive = T                      5369           5382          18          1.6         640.1       1.5X
 
 
 ================================================================================================
-low-cardinality input, on-spill pass-through (Tier 2)
+low-cardinality input, pass-through at the spill check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, low card, spill:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        789            806          16         21.3          47.0       1.0X
-codegen = true, adaptive = T                        813            835          28         20.6          48.5       1.0X
-codegen = false, adaptive = F                      1351           1425         104         12.4          80.5       0.6X
-codegen = false, adaptive = T                      1346           1350           6         12.5          80.2       0.6X
+codegen = true, adaptive = F                        768            782          12         21.8          45.8       1.0X
+codegen = true, adaptive = T                        769            780          13         21.8          45.8       1.0X
+codegen = false, adaptive = F                      1366           1369           4         12.3          81.4       0.6X
+codegen = false, adaptive = T                      1358           1358           0         12.4          80.9       0.6X
 
 

--- a/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk25-results.txt
@@ -1,56 +1,56 @@
 ================================================================================================
-high-cardinality input, no-spill pass-through (Tier 1)
+high-cardinality input, pass-through at the periodic check
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, high card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        4083           4087           6          2.1         486.7       1.0X
-codegen = true, adaptive = T                        2431           2443          17          3.5         289.8       1.7X
-codegen = false, adaptive = F                       4913           4924          14          1.7         585.7       0.8X
-codegen = false, adaptive = T                       3214           3220           9          2.6         383.1       1.3X
+codegen = true, adaptive = F                        4338           4408         100          1.9         517.1       1.0X
+codegen = true, adaptive = T                        2586           2608          30          3.2         308.3       1.7X
+codegen = false, adaptive = F                       5146           5199          76          1.6         613.4       0.8X
+codegen = false, adaptive = T                       3271           3287          22          2.6         390.0       1.3X
 
 
 ================================================================================================
-low-cardinality input, no-spill pass-through (Tier 1)
+low-cardinality input, pass-through at the periodic check
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, low card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        257            267           8         65.3          15.3       1.0X
-codegen = true, adaptive = T                        282            292           7         59.5          16.8       0.9X
-codegen = false, adaptive = F                      1290           1290           0         13.0          76.9       0.2X
-codegen = false, adaptive = T                      1298           1301           4         12.9          77.4       0.2X
+codegen = true, adaptive = F                        269            275           4         62.5          16.0       1.0X
+codegen = true, adaptive = T                        284            294           6         59.1          16.9       0.9X
+codegen = false, adaptive = F                      1317           1321           6         12.7          78.5       0.2X
+codegen = false, adaptive = T                      1309           1382         104         12.8          78.0       0.2X
 
 
 ================================================================================================
-high-cardinality input, on-spill pass-through (Tier 2)
+high-cardinality input, pass-through at the spill check
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, high card, spill:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                       7932           7986          77          1.1         945.5       1.0X
-codegen = true, adaptive = T                       4246           4354         152          2.0         506.2       1.9X
-codegen = false, adaptive = F                      9290           9386         136          0.9        1107.4       0.9X
-codegen = false, adaptive = T                      5244           5298          76          1.6         625.2       1.5X
+codegen = true, adaptive = F                       8332           8462         184          1.0         993.2       1.0X
+codegen = true, adaptive = T                       4677           4683           9          1.8         557.5       1.8X
+codegen = false, adaptive = F                      9932           9966          47          0.8        1184.0       0.8X
+codegen = false, adaptive = T                      5412           5618         291          1.6         645.1       1.5X
 
 
 ================================================================================================
-low-cardinality input, on-spill pass-through (Tier 2)
+low-cardinality input, pass-through at the spill check
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1021-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, low card, spill:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        764            774          17         22.0          45.5       1.0X
-codegen = true, adaptive = T                        786            794           8         21.3          46.9       1.0X
-codegen = false, adaptive = F                      1362           1362           0         12.3          81.2       0.6X
-codegen = false, adaptive = T                      1363           1368           7         12.3          81.2       0.6X
+codegen = true, adaptive = F                        773            786          17         21.7          46.1       1.0X
+codegen = true, adaptive = T                        790            803          20         21.2          47.1       1.0X
+codegen = false, adaptive = F                      1370           1377          10         12.2          81.6       0.6X
+codegen = false, adaptive = T                      1366           1373          11         12.3          81.4       0.6X
 
 

--- a/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-jdk25-results.txt
@@ -1,0 +1,56 @@
+================================================================================================
+high-cardinality input, no-spill pass-through (Tier 1)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, high card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        4083           4087           6          2.1         486.7       1.0X
+codegen = true, adaptive = T                        2431           2443          17          3.5         289.8       1.7X
+codegen = false, adaptive = F                       4913           4924          14          1.7         585.7       0.8X
+codegen = false, adaptive = T                       3214           3220           9          2.6         383.1       1.3X
+
+
+================================================================================================
+low-cardinality input, no-spill pass-through (Tier 1)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, low card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        257            267           8         65.3          15.3       1.0X
+codegen = true, adaptive = T                        282            292           7         59.5          16.8       0.9X
+codegen = false, adaptive = F                      1290           1290           0         13.0          76.9       0.2X
+codegen = false, adaptive = T                      1298           1301           4         12.9          77.4       0.2X
+
+
+================================================================================================
+high-cardinality input, on-spill pass-through (Tier 2)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, high card, spill:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                       7932           7986          77          1.1         945.5       1.0X
+codegen = true, adaptive = T                       4246           4354         152          2.0         506.2       1.9X
+codegen = false, adaptive = F                      9290           9386         136          0.9        1107.4       0.9X
+codegen = false, adaptive = T                      5244           5298          76          1.6         625.2       1.5X
+
+
+================================================================================================
+low-cardinality input, on-spill pass-through (Tier 2)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, low card, spill:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        764            774          17         22.0          45.5       1.0X
+codegen = true, adaptive = T                        786            794           8         21.3          46.9       1.0X
+codegen = false, adaptive = F                      1362           1362           0         12.3          81.2       0.6X
+codegen = false, adaptive = T                      1363           1368           7         12.3          81.2       0.6X
+
+

--- a/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-results.txt
+++ b/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-results.txt
@@ -1,0 +1,56 @@
+================================================================================================
+high-cardinality input, no-spill pass-through (Tier 1)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, high card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        3975           4060         120          2.1         473.8       1.0X
+codegen = true, adaptive = T                        2381           2404          32          3.5         283.8       1.7X
+codegen = false, adaptive = F                       4850           4854           5          1.7         578.2       0.8X
+codegen = false, adaptive = T                       3081           3086           7          2.7         367.3       1.3X
+
+
+================================================================================================
+low-cardinality input, no-spill pass-through (Tier 1)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, low card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        287            318          24         58.4          17.1       1.0X
+codegen = true, adaptive = T                        312            320           7         53.8          18.6       0.9X
+codegen = false, adaptive = F                      1261           1263           3         13.3          75.1       0.2X
+codegen = false, adaptive = T                      1301           1303           3         12.9          77.6       0.2X
+
+
+================================================================================================
+high-cardinality input, on-spill pass-through (Tier 2)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, high card, spill:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                       8319           8410         128          1.0         991.7       1.0X
+codegen = true, adaptive = T                       4421           4464          61          1.9         527.0       1.9X
+codegen = false, adaptive = F                      9254           9314          85          0.9        1103.2       0.9X
+codegen = false, adaptive = T                      5251           5257           8          1.6         626.0       1.6X
+
+
+================================================================================================
+low-cardinality input, on-spill pass-through (Tier 2)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
+AMD EPYC 7763 64-Core Processor
+adaptive partial agg, low card, spill:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+codegen = true, adaptive = F                        808            816          11         20.8          48.1       1.0X
+codegen = true, adaptive = T                        826            842          19         20.3          49.3       1.0X
+codegen = false, adaptive = F                      1332           1343          15         12.6          79.4       0.6X
+codegen = false, adaptive = T                      1303           1304           1         12.9          77.7       0.6X
+
+

--- a/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-results.txt
+++ b/sql/core/benchmarks/AdaptivePartialAggregationBenchmark-results.txt
@@ -1,56 +1,56 @@
 ================================================================================================
-high-cardinality input, no-spill pass-through (Tier 1)
+high-cardinality input, pass-through at the periodic check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, high card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        3975           4060         120          2.1         473.8       1.0X
-codegen = true, adaptive = T                        2381           2404          32          3.5         283.8       1.7X
-codegen = false, adaptive = F                       4850           4854           5          1.7         578.2       0.8X
-codegen = false, adaptive = T                       3081           3086           7          2.7         367.3       1.3X
+codegen = true, adaptive = F                        4118           4125          11          2.0         490.9       1.0X
+codegen = true, adaptive = T                        2411           2427          23          3.5         287.4       1.7X
+codegen = false, adaptive = F                       4846           4861          21          1.7         577.7       0.8X
+codegen = false, adaptive = T                       2991           3009          25          2.8         356.6       1.4X
 
 
 ================================================================================================
-low-cardinality input, no-spill pass-through (Tier 1)
+low-cardinality input, pass-through at the periodic check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, low card, no spill:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        287            318          24         58.4          17.1       1.0X
-codegen = true, adaptive = T                        312            320           7         53.8          18.6       0.9X
-codegen = false, adaptive = F                      1261           1263           3         13.3          75.1       0.2X
-codegen = false, adaptive = T                      1301           1303           3         12.9          77.6       0.2X
+codegen = true, adaptive = F                        270            311          37         62.2          16.1       1.0X
+codegen = true, adaptive = T                        293            318          22         57.3          17.5       0.9X
+codegen = false, adaptive = F                      1305           1312          10         12.9          77.8       0.2X
+codegen = false, adaptive = T                      1329           1435         150         12.6          79.2       0.2X
 
 
 ================================================================================================
-high-cardinality input, on-spill pass-through (Tier 2)
+high-cardinality input, pass-through at the spill check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, high card, spill:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                       8319           8410         128          1.0         991.7       1.0X
-codegen = true, adaptive = T                       4421           4464          61          1.9         527.0       1.9X
-codegen = false, adaptive = F                      9254           9314          85          0.9        1103.2       0.9X
-codegen = false, adaptive = T                      5251           5257           8          1.6         626.0       1.6X
+codegen = true, adaptive = F                       8196           8247          73          1.0         977.0       1.0X
+codegen = true, adaptive = T                       4433           4530         137          1.9         528.5       1.8X
+codegen = false, adaptive = F                      9544           9555          15          0.9        1137.8       0.9X
+codegen = false, adaptive = T                      5243           5395         215          1.6         625.0       1.6X
 
 
 ================================================================================================
-low-cardinality input, on-spill pass-through (Tier 2)
+low-cardinality input, pass-through at the spill check
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 adaptive partial agg, low card, spill:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-codegen = true, adaptive = F                        808            816          11         20.8          48.1       1.0X
-codegen = true, adaptive = T                        826            842          19         20.3          49.3       1.0X
-codegen = false, adaptive = F                      1332           1343          15         12.6          79.4       0.6X
-codegen = false, adaptive = T                      1303           1304           1         12.9          77.7       0.6X
+codegen = true, adaptive = F                        803            813          11         20.9          47.8       1.0X
+codegen = true, adaptive = T                        829            839           9         20.2          49.4       1.0X
+codegen = false, adaptive = F                      1362           1387          35         12.3          81.2       0.6X
+codegen = false, adaptive = T                      1365           1376          15         12.3          81.4       0.6X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -228,6 +228,14 @@ public final class UnsafeFixedWidthAggregationMap {
   }
 
   /**
+   * Returns the number of distinct keys currently stored in the underlying `BytesToBytesMap`.
+   * Used by adaptive partial aggregation to estimate the pre-shuffle reduction ratio.
+   */
+  public int getNumKeys() {
+    return map.numKeys();
+  }
+
+  /**
    * Sorts the map's records in place, spill them to disk, and returns an [[UnsafeKVExternalSorter]]
    *
    * Note that the map will be reset for inserting new records, and the returned sorter can NOT be

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/aggregate/RowBasedAggregateHashMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/aggregate/RowBasedAggregateHashMap.java
@@ -110,6 +110,14 @@ public abstract class RowBasedAggregateHashMap implements AutoCloseable {
     return batch.rowIterator();
   }
 
+  /**
+   * Returns the number of distinct keys currently held by this map. Used by adaptive partial
+   * aggregation to measure the reduction ratio across both aggregation maps.
+   */
+  public final int getNumKeys() {
+    return numRows;
+  }
+
   @Override
   public final void close() {
     batch.close();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -624,8 +624,13 @@ case class HashAggregateExec(
     // After the child input is consumed, finish the build: with adaptive partial aggregation mark
     // that the child is fully consumed (to support re-entry; the map iterators are set up inside
     // the map-output function), otherwise set up the map iterators for the output below.
+    // A child may leave its produce loop early rather than exhausting its input: `UnionExec` runs
+    // each child inside its own helper, so a streamed row that fills the output buffer returns
+    // only as far as here. Reaching the end of `produce` therefore does not by itself mean the
+    // input is consumed -- pending output says the child parked instead, and the build resumes on
+    // re-entry. Without this the rest of that partition is silently dropped.
     val postChildProduce = if (adaptivePartialAggEnabled) {
-      s"$adaptiveChildrenConsumedTerm = true;"
+      s"if (!shouldStop()) { $adaptiveChildrenConsumedTerm = true; }"
     } else {
       finishHashMap
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -204,8 +204,8 @@ case class HashAggregateExec(
   private var processedRowsTerm: String = _
   private var adaptiveChildrenConsumedTerm: String = _
   // Whether the map output has already been emitted (and the maps freed). Once pass-through is
-  // active the maps are frozen, so they are output as soon as pass-through fires to release their
-  // memory before the remaining input is streamed; this flag lets the final output skip them.
+  // active the maps are frozen, so the next re-entry outputs them -- releasing their memory before
+  // the rest of the input is streamed; this flag lets the final output skip them.
   private var adaptiveMapOutputDoneTerm: String = _
   // Whether the map iterators have been set up (`finishHashMap`). The map-output function may be
   // re-entered when its loops return via `shouldStop()` to drain the buffer, and `finishAggregate`

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -154,8 +154,9 @@ case class HashAggregateExec(
    * single-row partial buffers (see [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]). It only
    * applies to a pre-shuffle partial aggregation with grouping keys:
    *   - `Partial` mode only: the downstream `Final` aggregation merges the passed-through
-   *     single-row buffers, so the output contract is unchanged.
-   *     `Final`/`Complete`/`PartialMerge` have no such downstream to fall back on.
+   *     single-row buffers, so the output contract is unchanged. `Final`/`Complete` produce the
+   *     result themselves and have no such downstream. `PartialMerge` does have one and could be
+   *     supported by passing its incoming buffer through unchanged, but that is left for later.
    *   - grouping keys present: a global aggregation produces a single output row, so partial
    *     aggregation achieves the maximum reduction and must never be bypassed.
    *   - DISTINCT aggregate functions are allowed: the intermediate `PartialMerge` phase of the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -214,6 +214,11 @@ case class HashAggregateExec(
   // `minRows` after every check, and the count is reset after a spill so the new in-memory map
   // epoch is judged on its own rows.
   private var adaptiveNextCheckRowTerm: String = _
+  // The fast map's key count as of the last spill. The fast map never spills and is never cleared,
+  // so its keys outlive the epoch the processed-row count is reset for; subtracting this baseline
+  // keeps both sides of the ratio on the same epoch. Once the fast map fills it stops accepting
+  // keys, so the difference settles at zero and the ratio is the regular map's alone.
+  private var adaptiveFastKeysAtSpillTerm: String = _
   // The name of the generated output function, promoted to a field so `doConsumeWithKeys` can emit
   // pass-through rows directly from within the build loop.
   private var outputFunc: String = _
@@ -513,6 +518,8 @@ case class HashAggregateExec(
         ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveMapOutputDone")
       adaptiveMapSetupDoneTerm =
         ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveMapSetupDone")
+      adaptiveFastKeysAtSpillTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_INT, "adaptiveFastKeysAtSpill")
     }
     if (conf.enableTwoLevelAggMap) {
       enableTwoLevelHashMap()
@@ -864,22 +871,12 @@ case class HashAggregateExec(
     // never matches and only the spill check remains.
     val adaptiveIneffective = if (adaptivePartialAggEnabled) {
       val totalKeys = if (isFastHashMapEnabled) {
-        s"($fastHashMapTerm.getNumKeys() + $hashMapTerm.getNumKeys())"
+        s"($fastHashMapTerm.getNumKeys() - $adaptiveFastKeysAtSpillTerm + " +
+          s"$hashMapTerm.getNumKeys())"
       } else {
         s"$hashMapTerm.getNumKeys()"
       }
       s"$processedRowsTerm < (double) $totalKeys * ${adaptiveMinCompaction}D"
-    } else {
-      ""
-    }
-
-    // After a spill the map starts a new in-memory epoch, so the counters restart and the ratio of
-    // that epoch alone decides whether the remaining rows are passed through.
-    val adaptiveResetEpoch = if (adaptivePartialAggEnabled) {
-      s"""
-         |$processedRowsTerm = 0L;
-         |$adaptiveNextCheckRowTerm = ${adaptiveMinRows}L;
-       """.stripMargin
     } else {
       ""
     }
@@ -919,6 +916,23 @@ case class HashAggregateExec(
          """.stripMargin
 
       if (adaptivePartialAggEnabled) {
+        // Spilling starts a new in-memory epoch, so the counters restart and the ratio of that
+        // epoch alone decides the remaining rows. The fast map neither spills nor clears, so its
+        // keys outlive the epoch; snapshotting them here keeps both sides of the ratio on the
+        // same rows. Once the fast map fills it stops accepting keys and the difference settles
+        // at zero, leaving the regular map's keys alone.
+        val snapshotFastKeys = if (isFastHashMapEnabled) {
+          s"$adaptiveFastKeysAtSpillTerm = $fastHashMapTerm.getNumKeys();"
+        } else {
+          ""
+        }
+        val spillAndRestartEpoch =
+          s"""
+             |$spillMap
+             |$processedRowsTerm = 0L;
+             |$adaptiveNextCheckRowTerm = ${adaptiveMinRows}L;
+             |$snapshotFastKeys
+           """.stripMargin
         s"""
            |// generate grouping key
            |${unsafeRowKeyCode.code}
@@ -928,8 +942,7 @@ case class HashAggregateExec(
            |    if ($processedRowsTerm > 0 && $adaptiveIneffective) {
            |      $adaptivePassThroughTerm = true;
            |    } else {
-           |      $spillMap
-           |      $adaptiveResetEpoch
+           |      $spillAndRestartEpoch
            |    }
            |  }
            |}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -72,7 +72,9 @@ case class HashAggregateExec(
     "aggTime" -> SQLMetrics.createTimingMetric(sparkContext, "time in aggregation build"),
     "avgHashProbe" ->
       SQLMetrics.createAverageMetric(sparkContext, "avg hash probes per key"),
-    "numTasksFallBacked" -> SQLMetrics.createMetric(sparkContext, "number of sort fallback tasks"))
+    "numTasksFallBacked" -> SQLMetrics.createMetric(sparkContext, "number of sort fallback tasks"),
+    "numBypassingRows" ->
+      SQLMetrics.createMetric(sparkContext, "number of bypassing rows"))
 
   // This is for testing. We force TungstenAggregationIterator to fall back to the unsafe row hash
   // map and/or the sort-based aggregation once it has processed a given number of input rows.
@@ -94,6 +96,7 @@ case class HashAggregateExec(
     val avgHashProbe = longMetric("avgHashProbe")
     val aggTime = longMetric("aggTime")
     val numTasksFallBacked = longMetric("numTasksFallBacked")
+    val numBypassingRows = longMetric("numBypassingRows")
 
     child.execute().mapPartitionsWithIndex { (partIndex, iter) =>
 
@@ -121,7 +124,9 @@ case class HashAggregateExec(
             peakMemory,
             spillSize,
             avgHashProbe,
-            numTasksFallBacked)
+            numTasksFallBacked,
+            numBypassingRows,
+            adaptivePartialAggConfig)
         if (!hasInput && groupingExpressions.isEmpty) {
           numOutputRows += 1
           Iterator.single[UnsafeRow](aggregationIterator.outputForEmptyGroupingKeyWithoutInput())
@@ -141,6 +146,47 @@ case class HashAggregateExec(
     .map(_.asInstanceOf[DeclarativeAggregate])
   private val bufferSchema = DataTypeUtils.fromAttributes(aggregateBufferAttributes)
 
+  /**
+   * Runtime configuration for adaptive partial aggregation, or `None` when it does not apply to
+   * this operator. When defined, the aggregation may bypass partial aggregation at runtime and
+   * pass the remaining input rows through as single-row partial buffers (see
+   * [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]).
+   *
+   * Adaptive partial aggregation only applies to a pre-shuffle partial aggregation with grouping
+   * keys:
+   *   - `Partial` mode only: the downstream `Final` aggregation merges the passed-through
+   *     single-row buffers, so the output contract is unchanged. `Final`/`Complete`/`PartialMerge`
+   *     have no such downstream to fall back on.
+   *   - grouping keys present: a global aggregation produces a single output row, so partial
+   *     aggregation achieves the maximum reduction and must never be bypassed.
+   *   - DISTINCT aggregate functions are allowed: the intermediate `PartialMerge` phase of the
+   *     multi-phase distinct plan is not `Partial` mode (and requires a distribution), so it always
+   *     aggregates and de-duplicates, and the passed-through rows from the distinct `Partial` phase
+   *     therefore carry exactly one distinct value each.
+   */
+  private val adaptivePartialAggConfig: Option[AdaptivePartialAggregationConfig] = {
+    val applicable = conf.adaptivePartialAggregationEnabled &&
+      groupingExpressions.nonEmpty &&
+      // Only the pre-shuffle partial aggregation has a downstream `Final` to merge passed-through
+      // single-row buffers. `requiredChildDistributionExpressions` is `None` exactly for that
+      // pre-shuffle phase and `Some` for the `Final`/`Complete` phase. This check is what keeps a
+      // group-by-only aggregate (no aggregate functions, so an empty `aggregateExpressions`) from
+      // being admitted vacuously: `aggregateExpressions.forall(_.mode == Partial)` alone is true
+      // for the empty list, which would wrongly make the `Final` phase eligible as well.
+      requiredChildDistributionExpressions.isEmpty &&
+      aggregateExpressions.forall(a => a.mode == Partial)
+    if (applicable) {
+      Some(AdaptivePartialAggregationConfig(
+        sampleRows = conf.adaptivePartialAggregationSampleRows,
+        noSpillReductionRatioThreshold =
+          conf.adaptivePartialAggregationNoSpillReductionRatioThreshold,
+        spillReductionRatioThreshold =
+          conf.adaptivePartialAggregationSpillReductionRatioThreshold))
+    } else {
+      None
+    }
+  }
+
   // The name for Fast HashMap
   private var fastHashMapTerm: String = _
   private var isFastHashMapEnabled: Boolean = false
@@ -153,6 +199,31 @@ case class HashAggregateExec(
   // The name for UnsafeRow HashMap
   private var hashMapTerm: String = _
   private var sorterTerm: String = _
+
+  // Codegen state for adaptive partial aggregation. When the pre-shuffle reduction ratio of the
+  // regular (second-level) hash map is too low, the operator stops populating the map and instead
+  // streams each remaining row through as a single-row partial buffer for the Final aggregate to
+  // merge. Only the regular map is governed: the append-only fast hash map keeps absorbing hot
+  // keys, so pass-through only ever applies to the fast-miss stream and the fast path is never
+  // regressed for high-reduction inputs.
+  private var adaptivePassThroughTerm: String = _
+  private var regularMapRowCountTerm: String = _
+  private var adaptiveChildrenConsumedTerm: String = _
+  // Whether the map output has already been emitted (and the maps freed). Once pass-through is
+  // active the maps are frozen, so they are output as soon as pass-through fires to release their
+  // memory before the remaining input is streamed; this flag lets the final output skip them.
+  private var adaptiveMapOutputDoneTerm: String = _
+  // Whether the map iterators have been set up (`finishHashMap`). The map-output function may be
+  // re-entered when its loops return via `shouldStop()` to drain the buffer, and `finishAggregate`
+  // destructs the map, so the setup must run only once.
+  private var adaptiveMapSetupDoneTerm: String = _
+  // The next regular-map row count at which the no-spill tier re-evaluates the reduction ratio.
+  // It starts at `sampleRows` and doubles after each sub-threshold check, so the ratio is checked
+  // only rarely once the input proves low-cardinality.
+  private var adaptiveNextSampleRowTerm: String = _
+  // The name of the generated output function, promoted to a field so `doConsumeWithKeys` can emit
+  // pass-through rows directly from within the build loop.
+  private var outputFunc: String = _
 
   /**
    * This is called by generated Java class, should be public.
@@ -436,6 +507,20 @@ case class HashAggregateExec(
 
   protected override def doProduceWithKeys(ctx: CodegenContext): String = {
     val initAgg = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "initAgg")
+    if (adaptivePartialAggConfig.isDefined) {
+      adaptivePassThroughTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptivePassThrough")
+      regularMapRowCountTerm = ctx.addMutableState(CodeGenerator.JAVA_LONG, "regularMapRowCount")
+      adaptiveNextSampleRowTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_LONG, "adaptiveNextSampleRow",
+          v => s"$v = ${adaptivePartialAggConfig.get.sampleRows}L;")
+      adaptiveChildrenConsumedTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveChildrenConsumed")
+      adaptiveMapOutputDoneTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveMapOutputDone")
+      adaptiveMapSetupDoneTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveMapSetupDone")
+    }
     if (conf.enableTwoLevelAggMap) {
       enableTwoLevelHashMap()
     } else if (conf.enableVectorizedHashMap) {
@@ -535,18 +620,29 @@ case class HashAggregateExec(
     // `addNewFunction` spills this helper into a nested class (as can happen
     // once the outer class passes the code-size threshold), the bare field
     // reference fails with `IllegalAccessError`.
+
+    // Generate code for output. This must happen before the `doAgg` helper below, because with
+    // adaptive partial aggregation enabled, `doConsumeWithKeys` (invoked from the child's produce
+    // inside `doAgg`) emits pass-through rows by calling this output function directly.
+    val keyTerm = ctx.freshName("aggKey")
+    val bufferTerm = ctx.freshName("aggBuffer")
+    outputFunc = generateResultFunction(ctx)
+
+    // After the child input is consumed, finish the build: with adaptive partial aggregation mark
+    // that the child is fully consumed (to support re-entry; the map iterators are set up inside
+    // the map-output function), otherwise set up the map iterators for the output below.
+    val postChildProduce = if (adaptivePartialAggConfig.isDefined) {
+      s"$adaptiveChildrenConsumedTerm = true;"
+    } else {
+      finishHashMap
+    }
     val doAggFuncName = ctx.addNewFunction(doAgg,
       s"""
          |private void $doAgg(int partitionIndex) throws java.io.IOException {
          |  ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
-         |  $finishHashMap
+         |  $postChildProduce
          |}
        """.stripMargin)
-
-    // generate code for output
-    val keyTerm = ctx.freshName("aggKey")
-    val bufferTerm = ctx.freshName("aggBuffer")
-    val outputFunc = generateResultFunction(ctx)
 
     val limitNotReachedCondition = limitNotReachedCond
 
@@ -615,8 +711,78 @@ case class HashAggregateExec(
        """.stripMargin
     }
 
+    // With adaptive partial aggregation the maps are frozen once pass-through is active, so their
+    // output (which also frees them) can happen as soon as pass-through fires, releasing the memory
+    // before the remaining input is streamed. The output loops are wrapped in a function so the
+    // same code runs either early (once pass-through freezes the maps) or at the end of the build.
+    // The done flag is set inside, after the loops, so a mid-output drain (the loops return via
+    // `shouldStop()`) leaves it unset and the caller resumes the map iterator on re-entry; once it
+    // is set the maps have been fully output and freed and will not be touched again. The iterator
+    // setup (`finishHashMap`, which destructs the map) is guarded to run only once.
+    val outputMapFuncName = if (adaptivePartialAggConfig.isDefined) {
+      val name = ctx.freshName("outputMap")
+      ctx.addNewFunction(name,
+        s"""
+           |private void $name() throws java.io.IOException {
+           |  if (!$adaptiveMapSetupDoneTerm) {
+           |    $finishHashMap
+           |    $adaptiveMapSetupDoneTerm = true;
+           |  }
+           |  $outputFromFastHashMap
+           |  $outputFromRegularHashMap
+           |  $adaptiveMapOutputDoneTerm = true;
+           |}
+         """.stripMargin)
+    } else {
+      ""
+    }
+
     val aggTime = metricTerm(ctx, "aggTime")
     val beforeAgg = ctx.freshName("beforeAgg")
+    // With adaptive partial aggregation, `doAgg` may start appending pass-through rows to the
+    // output buffer mid-build. In that case `shouldStop()` becomes true and we must return so the
+    // buffered rows are drained; the build is resumed on re-entry (guarded by `childrenConsumed`)
+    // until the child input is exhausted, only then falling through to the map output below.
+    val adaptiveStopCheck = if (adaptivePartialAggConfig.isDefined) {
+      "if (shouldStop()) return;"
+    } else {
+      ""
+    }
+    // Once pass-through is active the maps are frozen, so output them (releasing their memory)
+    // exactly once: early in `adaptiveResumeBuild` (resuming the build means it returned because
+    // pass-through filled the buffer, so pass-through is already active) or at the end in
+    // `adaptiveFinalOutput` when they were never output early. The output loops return via
+    // `shouldStop()` when the buffer fills, so the done flag is set inside the output function and
+    // re-entry resumes the map iterator.
+    val adaptiveOutputMap = if (adaptivePartialAggConfig.isDefined) {
+      s"""
+         |if (!$adaptiveMapOutputDoneTerm) {
+         |  $outputMapFuncName();
+         |  if (shouldStop()) return;
+         |}
+       """.stripMargin
+    } else {
+      ""
+    }
+    val adaptiveResumeBuild = if (adaptivePartialAggConfig.isDefined) {
+      s"""
+         |if (!$adaptiveChildrenConsumedTerm) {
+         |  $adaptiveOutputMap
+         |  $doAggFuncName(partitionIndex);
+         |  if (shouldStop()) return;
+         |}
+       """.stripMargin
+    } else {
+      ""
+    }
+    val adaptiveFinalOutput = if (adaptivePartialAggConfig.isDefined) {
+      adaptiveOutputMap
+    } else {
+      s"""
+         |$outputFromFastHashMap
+         |$outputFromRegularHashMap
+       """.stripMargin
+    }
     s"""
        |if (!$initAgg) {
        |  $initAgg = true;
@@ -626,12 +792,26 @@ case class HashAggregateExec(
        |  long $beforeAgg = System.nanoTime();
        |  $doAggFuncName(partitionIndex);
        |  $aggTime.add((System.nanoTime() - $beforeAgg) / $NANOS_PER_MILLIS);
+       |  $adaptiveStopCheck
        |}
-       |// output the result
-       |$outputFromFastHashMap
-       |$outputFromRegularHashMap
+       |$adaptiveResumeBuild
+       |$adaptiveFinalOutput
      """.stripMargin
   }
+
+  // Blocking operators normally suppress the child's `shouldStop()` check because they buffer all
+  // output. With adaptive partial aggregation, pass-through rows are appended to the output buffer
+  // while consuming child input, so the stop check must be re-enabled to keep the buffer bounded.
+  override def needStopCheck: Boolean =
+    adaptivePartialAggConfig.isDefined || super.needStopCheck
+
+  // Blocking operators normally do not copy their result because every output row is drained (via
+  // `shouldStop()`) before the next one is produced. Adaptive pass-through breaks that assumption:
+  // when an `Expand` sits below, one input row fans out into several pass-through rows that are all
+  // appended in the same child loop iteration before any drain, and they all alias the single
+  // result `UnsafeRow`. Copy the result so the buffered rows do not collapse into the last one.
+  override def needCopyResult: Boolean =
+    adaptivePartialAggConfig.isDefined || super.needCopyResult
 
   protected override def doConsumeWithKeys(ctx: CodegenContext, input: Seq[ExprCode]): String = {
     // create grouping key
@@ -643,6 +823,18 @@ case class HashAggregateExec(
     val unsafeRowKeyHash = ctx.freshName("unsafeRowKeyHash")
     val unsafeRowBuffer = ctx.freshName("unsafeRowAggBuffer")
     val fastRowBuffer = ctx.freshName("fastAggBuffer")
+
+    // For adaptive partial aggregation pass-through, each bypassed row is emitted as a single-row
+    // partial buffer: start from the initial aggregation buffer, apply the update expressions once,
+    // and output `key ++ buffer` for the Final aggregate to merge. This projects the initial
+    // buffer.
+    val emptyAggBufferCode = if (adaptivePartialAggConfig.isDefined) {
+      GenerateUnsafeProjection.createCode(ctx, declFunctions.flatMap(f => f.initialValues))
+    } else {
+      null
+    }
+    // Per-row local flag marking that the current row is being streamed through (held by no map).
+    val adaptiveRowBypassedTerm = ctx.freshName("adaptiveRowBypassed")
 
     // To individually generate code for each aggregate function, an element in `updateExprs` holds
     // all the expressions for the buffer of an aggregation function.
@@ -663,46 +855,122 @@ case class HashAggregateExec(
       case _ => ("true", "", "")
     }
 
-    val findOrInsertRegularHashMap: String =
-      s"""
-         |// generate grouping key
-         |${unsafeRowKeyCode.code}
-         |int $unsafeRowKeyHash = ${unsafeRowKeyCode.value}.hashCode();
-         |if ($checkFallbackForBytesToBytesMap) {
-         |  // try to get the buffer from hash map
-         |  $unsafeRowBuffer =
-         |    $hashMapTerm.getAggregationBufferFromUnsafeRow($unsafeRowKeys, $unsafeRowKeyHash);
-         |}
-         |// Can't allocate buffer from the hash map. Spill the map and fallback to sort-based
-         |// aggregation after processing all input rows.
-         |if ($unsafeRowBuffer == null) {
-         |  if ($sorterTerm == null) {
-         |    $sorterTerm = $hashMapTerm.destructAndCreateExternalSorter();
-         |  } else {
-         |    $sorterTerm.merge($hashMapTerm.destructAndCreateExternalSorter());
-         |  }
-         |  $resetCounter
-         |  // the hash map had be spilled, it should have enough memory now,
-         |  // try to allocate buffer again.
-         |  $unsafeRowBuffer = $hashMapTerm.getAggregationBufferFromUnsafeRow(
-         |    $unsafeRowKeys, $unsafeRowKeyHash);
-         |  if ($unsafeRowBuffer == null) {
-         |    // failed to allocate the first page
-         |    throw QueryExecutionErrors.aggregateOutOfMemoryError();
-         |  }
-         |}
-       """.stripMargin
+    val findOrInsertRegularHashMap: String = {
+      // Assumes the grouping key projection (`unsafeRowKeyCode.code`) has already run for this row,
+      // so `unsafeRowKeyCode.value` holds the current key. The projection is emitted exactly once
+      // per regular-map row (see below); emitting it in more than one runtime branch is unsafe
+      // because the projection's subexpression/writer state assigned in one branch would be read
+      // stale from another (e.g. the adaptive pass-through path would reuse the last probed key).
+      val probeRegularMap =
+        s"""
+           |int $unsafeRowKeyHash = ${unsafeRowKeyCode.value}.hashCode();
+           |if ($checkFallbackForBytesToBytesMap) {
+           |  // try to get the buffer from hash map
+           |  $unsafeRowBuffer =
+           |    $hashMapTerm.getAggregationBufferFromUnsafeRow($unsafeRowKeys, $unsafeRowKeyHash);
+           |}
+         """.stripMargin
+
+      val spillMap =
+        s"""
+           |if ($sorterTerm == null) {
+           |  $sorterTerm = $hashMapTerm.destructAndCreateExternalSorter();
+           |} else {
+           |  $sorterTerm.merge($hashMapTerm.destructAndCreateExternalSorter());
+           |}
+           |$resetCounter
+           |// the hash map had be spilled, it should have enough memory now,
+           |// try to allocate buffer again.
+           |$unsafeRowBuffer = $hashMapTerm.getAggregationBufferFromUnsafeRow(
+           |  $unsafeRowKeys, $unsafeRowKeyHash);
+           |if ($unsafeRowBuffer == null) {
+           |  // failed to allocate the first page
+           |  throw QueryExecutionErrors.aggregateOutOfMemoryError();
+           |}
+         """.stripMargin
+
+      if (adaptivePartialAggConfig.isDefined) {
+        val cfg = adaptivePartialAggConfig.get
+        // Adaptive partial aggregation governs only this regular (second-level) map. Count the
+        // rows that enter it (a fast-map miss, or every row when the fast map is off) and use
+        // `regularMap.getNumKeys() / regularRows` as the pre-shuffle reduction ratio.
+        //   - Tier 2 (on-spill): when the map cannot allocate for a new key (it would otherwise
+        //     spill), bypass instead if the ratio is at least `spillReductionRatioThreshold`.
+        //   - Tier 1 (no-spill): from `sampleRows` regular rows on, bypass if the ratio is at
+        //     least `noSpillReductionRatioThreshold`. The sampling window doubles after each
+        //     sub-threshold check, so low-cardinality input is re-evaluated only rarely while a
+        //     late high-cardinality tail can still trigger the bypass.
+        // Both tiers fire only before any spill (`sorter == null`): once the map has spilled, the
+        // reduction-ratio estimate no longer covers the spilled rows, and pass-through must never
+        // coexist with sort-based aggregation. When the map is full after a spill, the map spills
+        // again as usual.
+        // The key projection runs once here so `unsafeRowKeyCode.value` is valid for both the
+        // probe below and the pass-through buffer built by the caller.
+        s"""
+           |// generate grouping key
+           |${unsafeRowKeyCode.code}
+           |if (!$adaptivePassThroughTerm) {
+           |  $regularMapRowCountTerm += 1;
+           |  $probeRegularMap
+           |  if ($unsafeRowBuffer == null) {
+           |    // The map is full and would spill. Pre-spill, decide whether to bypass instead.
+           |    if ($sorterTerm == null &&
+           |        (double) $hashMapTerm.getNumKeys() >=
+           |          $regularMapRowCountTerm * ${cfg.spillReductionRatioThreshold}D) {
+           |      $adaptivePassThroughTerm = true;
+           |    } else {
+           |      $spillMap
+           |    }
+           |  } else if ($sorterTerm == null &&
+           |      $regularMapRowCountTerm == $adaptiveNextSampleRowTerm) {
+           |    if ((double) $hashMapTerm.getNumKeys() >=
+           |        $regularMapRowCountTerm * ${cfg.noSpillReductionRatioThreshold}D) {
+           |      $adaptivePassThroughTerm = true;
+           |    } else {
+           |      $adaptiveNextSampleRowTerm = $adaptiveNextSampleRowTerm * 2;
+           |    }
+           |  }
+           |}
+         """.stripMargin
+      } else {
+        s"""
+           |// generate grouping key
+           |${unsafeRowKeyCode.code}
+           |$probeRegularMap
+           |// Can't allocate buffer from the hash map. Spill the map and fallback to sort-based
+           |// aggregation after processing all input rows.
+           |if ($unsafeRowBuffer == null) {
+           |  $spillMap
+           |}
+         """.stripMargin
+      }
+    }
 
     val findOrInsertHashMap: String = {
-      if (isFastHashMapEnabled) {
+      val findCode = if (isFastHashMapEnabled) {
         // If fast hash map is on, we first generate code to probe and update the fast hash map.
         // If the probe is successful the corresponding fast row buffer will hold the mutable row.
+        // Once adaptive pass-through is active, skip the fast map entirely so the row is streamed
+        // through instead of being inserted anywhere.
+        val fastMapProbe =
+          s"""
+             |${fastRowKeys.map(_.code).mkString("\n")}
+             |if (${fastRowKeys.map("!" + _.isNull).mkString(" && ")}) {
+             |  $fastRowBuffer = $fastHashMapTerm.findOrInsert(
+             |    ${fastRowKeys.map(_.value).mkString(", ")});
+             |}
+           """.stripMargin
+        val guardedFastMapProbe = if (adaptivePartialAggConfig.isDefined) {
+          s"""
+             |if (!$adaptivePassThroughTerm) {
+             |  $fastMapProbe
+             |}
+           """.stripMargin
+        } else {
+          fastMapProbe
+        }
         s"""
-           |${fastRowKeys.map(_.code).mkString("\n")}
-           |if (${fastRowKeys.map("!" + _.isNull).mkString(" && ")}) {
-           |  $fastRowBuffer = $fastHashMapTerm.findOrInsert(
-           |    ${fastRowKeys.map(_.value).mkString(", ")});
-           |}
+           |$guardedFastMapProbe
            |// Cannot find the key in fast hash map, try regular hash map.
            |if ($fastRowBuffer == null) {
            |  $findOrInsertRegularHashMap
@@ -711,6 +979,31 @@ case class HashAggregateExec(
       } else {
         findOrInsertRegularHashMap
       }
+
+      // When pass-through is active, a row that no map holds must be streamed through.
+      // `rowBypassed` marks exactly those rows: the fast map and regular map probes are skipped
+      // (guarded above), so both buffers stay null. The Tier-1 transition row is excluded on
+      // purpose -- its probe already inserted the key into the regular map, so it is aggregated
+      // there and must not be re-emitted.
+      val createPassThroughBuffer = if (adaptivePartialAggConfig.isDefined) {
+        // The grouping key was already projected in `findOrInsertRegularHashMap`
+        // (`unsafeRowKeyCode.code`), so `unsafeRowKeyCode.value` holds this row's key. Only build
+        // the single-row partial buffer here.
+        s"""
+           |if ($adaptivePassThroughTerm && $unsafeRowBuffer == null) {
+           |  $adaptiveRowBypassedTerm = true;
+           |  ${emptyAggBufferCode.code}
+           |  $unsafeRowBuffer = ${emptyAggBufferCode.value};
+           |}
+         """.stripMargin
+      } else {
+        ""
+      }
+
+      s"""
+         |$findCode
+         |$createPassThroughBuffer
+       """.stripMargin
     }
 
     val inputAttrs = aggregateBufferAttributes ++ inputAttributes
@@ -845,29 +1138,56 @@ case class HashAggregateExec(
       }
     }
 
-    val declareRowBuffer: String = if (isFastHashMapEnabled) {
-      val fastRowType = if (isVectorizedHashMapEnabled) {
-        classOf[MutableColumnarRow].getName
+    val declareRowBuffer: String = {
+      val declareBuffers = if (isFastHashMapEnabled) {
+        val fastRowType = if (isVectorizedHashMapEnabled) {
+          classOf[MutableColumnarRow].getName
+        } else {
+          "UnsafeRow"
+        }
+        s"""
+           |UnsafeRow $unsafeRowBuffer = null;
+           |$fastRowType $fastRowBuffer = null;
+         """.stripMargin
       } else {
-        "UnsafeRow"
+        s"UnsafeRow $unsafeRowBuffer = null;"
+      }
+      val declareBypassed = if (adaptivePartialAggConfig.isDefined) {
+        s"boolean $adaptiveRowBypassedTerm = false;"
+      } else {
+        ""
       }
       s"""
-         |UnsafeRow $unsafeRowBuffer = null;
-         |$fastRowType $fastRowBuffer = null;
+         |$declareBuffers
+         |$declareBypassed
        """.stripMargin
-    } else {
-      s"UnsafeRow $unsafeRowBuffer = null;"
     }
 
     // We try to do hash map based in-memory aggregation first. If there is not enough memory (the
     // hash map will return null for new key), we spill the hash map to disk to free memory, then
     // continue to do in-memory aggregation and spilling until all the rows had been processed.
     // Finally, sort the spilled aggregate buffers by key, and merge them together for same key.
+    //
+    // With adaptive partial aggregation, once pass-through is active `updateRowInHashMap` fills the
+    // single-row buffer built above; we then emit `key ++ buffer` straight to the parent so the row
+    // skips both the fast map and the regular map.
+    val emitPassThroughRow = if (adaptivePartialAggConfig.isDefined) {
+      val numBypassingRows = metricTerm(ctx, "numBypassingRows")
+      s"""
+         |if ($adaptiveRowBypassedTerm) {
+         |  $numBypassingRows.add(1);
+         |  $outputFunc(${unsafeRowKeyCode.value}, $unsafeRowBuffer);
+         |}
+       """.stripMargin
+    } else {
+      ""
+    }
     s"""
        |$declareRowBuffer
        |$findOrInsertHashMap
        |$incCounter
        |$updateRowInHashMap
+       |$emitPassThroughRow
      """.stripMargin
   }
 
@@ -897,3 +1217,24 @@ case class HashAggregateExec(
   override protected def withNewChildInternal(newChild: SparkPlan): HashAggregateExec =
     copy(child = newChild)
 }
+
+/**
+ * Runtime parameters that control adaptive partial aggregation for a single [[HashAggregateExec]].
+ *
+ * The aggregation samples the pre-shuffle reduction ratio (distinct grouping keys / processed
+ * rows) and bypasses partial aggregation when the ratio is too high to be worthwhile, using two
+ * tiers:
+ *   - no-spill tier: evaluated from `sampleRows` rows on while the aggregation map is still fully
+ *     in memory; the sampling window doubles after each sub-threshold check, so a low-cardinality
+ *     input is re-evaluated only rarely while a late high-cardinality tail can still be caught.
+ *     In-memory partial aggregation is cheap, so this tier uses the more conservative
+ *     `noSpillReductionRatioThreshold`.
+ *   - on-spill tier: evaluated when the aggregation map is about to spill. Partial aggregation now
+ *     pays disk I/O costs, so this tier uses the more aggressive `spillReductionRatioThreshold`.
+ *
+ * Once either tier triggers, partial aggregation is bypassed for the rest of the input.
+ */
+case class AdaptivePartialAggregationConfig(
+    sampleRows: Int,
+    noSpillReductionRatioThreshold: Double,
+    spillReductionRatioThreshold: Double)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -163,8 +163,8 @@ case class HashAggregateExec(
    * single-row partial buffers (see [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]). It only
    * applies to a pre-shuffle partial aggregation with grouping keys:
    *   - `Partial` mode only: the downstream `Final` aggregation merges the passed-through
-   *     single-row buffers, so the output contract is unchanged. `Final`/`Complete` produce the
-   *     result themselves and have no such downstream. `PartialMerge` does have one and could be
+   *     single-row buffers. `Final`/`Complete` produce the result themselves and have no such
+   *     downstream. `PartialMerge` does have one and could be
    *     supported by passing its incoming buffer through unchanged, but that is left for later.
    *     The mode check is also what excludes the intermediate phase of a DISTINCT plan, whose
    *     modes are `PartialMerge ++ Partial`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -220,8 +220,10 @@ case class HashAggregateExec(
   private var processedRowsTerm: String = _
   private var adaptiveChildrenConsumedTerm: String = _
   // Whether the map output has already been emitted (and the maps freed). Once pass-through is
-  // active the maps are frozen, so the next re-entry outputs them -- releasing their memory before
-  // the rest of the input is streamed; this flag lets the final output skip them.
+  // active the maps are frozen; draining them -- which also frees them -- releases their memory
+  // before the rest of the input is streamed. The drain runs right after the trigger row in a
+  // fused plan, or on the next re-entry when an exchange splits the build from the output (see
+  // `emitPassThroughRow`); either way this flag lets the later output skip the maps.
   private var adaptiveMapOutputDoneTerm: String = _
   // Whether the map iterators have been set up (`finishHashMap`). The map-output function may be
   // re-entered when its loops return via `shouldStop()` to drain the buffer, and `finishAggregate`
@@ -239,6 +241,9 @@ case class HashAggregateExec(
   // The name of the generated output function, promoted to a field so `doConsumeWithKeys` can emit
   // pass-through rows directly from within the build loop.
   private var outputFunc: String = _
+  // The name of the generated map-output function, promoted to a field so `doConsumeWithKeys` can
+  // drain the frozen maps right after the trigger row in a fused plan (see `emitPassThroughRow`).
+  private var adaptiveOutputMapFuncName: String = _
 
   /**
    * This is called by generated Java class, should be public.
@@ -658,14 +663,6 @@ case class HashAggregateExec(
     } else {
       finishHashMap
     }
-    val doAggFuncName = ctx.addNewFunction(doAgg,
-      s"""
-         |private void $doAgg(int partitionIndex) throws java.io.IOException {
-         |  ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
-         |  $postChildProduce
-         |}
-       """.stripMargin)
-
     val limitNotReachedCondition = limitNotReachedCond
 
     def outputFromFastHashMap: String = {
@@ -741,7 +738,7 @@ case class HashAggregateExec(
     // `shouldStop()`) leaves it unset and the caller resumes the map iterator on re-entry; once it
     // is set the maps have been fully output and freed and will not be touched again. The iterator
     // setup (`finishHashMap`, which destructs the map) is guarded to run only once.
-    val outputMapFuncName = if (adaptivePartialAggEnabled) {
+    adaptiveOutputMapFuncName = if (adaptivePartialAggEnabled) {
       val name = ctx.freshName("outputMap")
       ctx.addNewFunction(name,
         s"""
@@ -759,12 +756,22 @@ case class HashAggregateExec(
       ""
     }
 
+    val doAggFuncName = ctx.addNewFunction(doAgg,
+      s"""
+         |private void $doAgg(int partitionIndex) throws java.io.IOException {
+         |  ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
+         |  $postChildProduce
+         |}
+       """.stripMargin)
+
     val aggTime = metricTerm(ctx, "aggTime")
     val beforeAgg = ctx.freshName("beforeAgg")
-    // With adaptive partial aggregation, `doAgg` may start appending pass-through rows to the
-    // output buffer mid-build. In that case `shouldStop()` becomes true and we must return so the
-    // buffered rows are drained; the build is resumed on re-entry (guarded by `childrenConsumed`)
-    // until the child input is exhausted, only then falling through to the map output below.
+    // Split by an exchange, `doAgg` may start appending pass-through rows to the output buffer
+    // mid-build. In that case `shouldStop()` becomes true and we must return so the buffered rows
+    // are drained; the build is resumed on re-entry (guarded by `childrenConsumed`) until the
+    // child input is exhausted, only then falling through to the map output below. Fused with the
+    // Final, nothing is buffered, so `shouldStop()` never fires and the maps are drained inside
+    // the build (see `emitPassThroughRow`).
     val adaptiveStopCheck = if (adaptivePartialAggEnabled) {
       "if (shouldStop()) return;"
     } else {
@@ -773,13 +780,15 @@ case class HashAggregateExec(
     // Once pass-through is active the maps are frozen, so output them (releasing their memory)
     // exactly once: early in `adaptiveResumeBuild` (resuming the build means it returned because
     // pass-through filled the buffer, so pass-through is already active) or at the end in
-    // `adaptiveFinalOutput` when they were never output early. The output loops return via
-    // `shouldStop()` when the buffer fills, so the done flag is set inside the output function and
-    // re-entry resumes the map iterator.
+    // `adaptiveFinalOutput` when they were never output early. A fused plan drains them inside
+    // the build instead, right after the trigger row (see `emitPassThroughRow`); the done flag
+    // set there makes both call sites below a no-op. The output loops return via `shouldStop()`
+    // when the buffer fills, so the done flag is set inside the output function and re-entry
+    // resumes the map iterator.
     val adaptiveOutputMap = if (adaptivePartialAggEnabled) {
       s"""
          |if (!$adaptiveMapOutputDoneTerm) {
-         |  $outputMapFuncName();
+         |  $adaptiveOutputMapFuncName();
          |  if (shouldStop()) return;
          |}
        """.stripMargin
@@ -845,6 +854,13 @@ case class HashAggregateExec(
   // requirement rather than copying for every adaptive aggregate.
   override def needCopyResult: Boolean = adaptivePartialAggEnabled &&
     child.asInstanceOf[CodegenSupport].needCopyResult
+
+  // Whether this partial aggregate is the root of its whole-stage. When an exchange splits the
+  // partial from the Final, the partial is the whole-stage root and its output function appends to
+  // `BufferedRowIterator.currentRows`; fused, the output feeds the Final's `doConsume` directly and
+  // is never buffered. The distinction decides where the frozen maps are drained (see
+  // `emitPassThroughRow`).
+  private def isWholeStageRoot: Boolean = parent.isInstanceOf[WholeStageCodegenExec]
 
   protected override def doConsumeWithKeys(ctx: CodegenContext, input: Seq[ExprCode]): String = {
     // create grouping key
@@ -1234,12 +1250,34 @@ case class HashAggregateExec(
     // With adaptive partial aggregation, once pass-through is active `updateRowInHashMap` fills the
     // single-row buffer built above; we then emit `key ++ buffer` straight to the parent so the row
     // skips both the fast map and the regular map.
+    //
+    // The maps were frozen when pass-through fired, so they are drained to preserve the merge order
+    // -- trigger row, then the maps, then the rest of the input. Where the drain runs depends on
+    // the plan shape. Split by an exchange, the partial is the whole-stage root and its output
+    // function appends a reference to the reusable output row; draining in the same call would
+    // overwrite that row while still buffered and silently drop the trigger, so the drain is left
+    // to `doProduceWithKeys` on the next `processNext` (the buffered trigger is pulled first).
+    // Fused with the Final (no exchange), the output is consumed directly by the Final's
+    // `doConsume` and never buffered, so there is no aliasing hazard; the drain runs here, right
+    // after the trigger, because nothing else would yield the build loop -- with no append there is
+    // no `shouldStop()` -- and the maps would otherwise come out only after all the remaining
+    // streamed rows, flipping the merge order.
     val emitPassThroughRow = if (adaptivePartialAggEnabled) {
       val numBypassingRows = metricTerm(ctx, "numBypassingRows")
+      val drainFused = if (isWholeStageRoot) {
+        ""
+      } else {
+        s"""
+           |if (!$adaptiveMapOutputDoneTerm) {
+           |  $adaptiveOutputMapFuncName();
+           |}
+         """.stripMargin
+      }
       s"""
          |if ($adaptiveRowBypassedTerm) {
          |  $numBypassingRows.add(1);
          |  $outputFunc(${unsafeRowKeyCode.value}, $unsafeRowBuffer);
+         |  $drainFused
          |}
        """.stripMargin
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -857,20 +857,27 @@ case class HashAggregateExec(
     // would spill (in which case the spill is skipped entirely). `minRows = 0` disables the
     // periodic check: the row count is only ever compared after being incremented past 0, so it
     // never matches and only the spill check remains.
-    val adaptiveTotalKeys = if (isFastHashMapEnabled) {
-      s"($fastHashMapTerm.getNumKeys() + $hashMapTerm.getNumKeys())"
+    val adaptiveIneffective = if (adaptivePartialAggEnabled) {
+      val totalKeys = if (isFastHashMapEnabled) {
+        s"($fastHashMapTerm.getNumKeys() + $hashMapTerm.getNumKeys())"
+      } else {
+        s"$hashMapTerm.getNumKeys()"
+      }
+      s"$processedRowsTerm < (double) $totalKeys * ${adaptiveMinCompaction}D"
     } else {
-      s"$hashMapTerm.getNumKeys()"
+      ""
     }
-    val adaptiveIneffective =
-      s"$processedRowsTerm < (double) $adaptiveTotalKeys * ${adaptiveMinCompaction}D"
+
     // After a spill the map starts a new in-memory epoch, so the counters restart and the ratio of
     // that epoch alone decides whether the remaining rows are passed through.
-    val adaptiveResetEpoch =
+    val adaptiveResetEpoch = if (adaptivePartialAggEnabled) {
       s"""
-         |$processedRowsTerm = 0;
+         |$processedRowsTerm = 0L;
          |$adaptiveNextCheckRowTerm = ${adaptiveMinRows}L;
        """.stripMargin
+    } else {
+      ""
+    }
 
     val findOrInsertRegularHashMap: String = {
       // Assumes the grouping key projection (`unsafeRowKeyCode.code`) has already run for this row,
@@ -970,26 +977,40 @@ case class HashAggregateExec(
         findOrInsertRegularHashMap
       }
 
-      // True when an aggregation map accepted this row, from either map. The fast map serves a row
-      // without it ever reaching the regular map, so both buffers have to be consulted to tell an
-      // aggregated row from one that must be streamed through.
-      val heldByAMap = if (isFastHashMapEnabled) {
-        s"($fastRowBuffer != null || $unsafeRowBuffer != null)"
-      } else {
-        s"($unsafeRowBuffer != null)"
-      }
-
-      // When pass-through is active, a row that no map holds must be streamed through.
-      // `rowBypassed` marks exactly those rows: both probes are skipped (guarded above), so
-      // neither buffer is set. A row a map did accept is excluded -- including the row that
-      // flipped pass-through at the periodic check, which is already aggregated in the map that
+      // Every row is either accepted by an aggregation map or streamed through -- the fast map
+      // serves a row without it ever reaching the regular map, so both buffers are consulted to
+      // tell the two apart.
+      //
+      // An accepted row counts toward the compaction ratio, so the numerator matches the
+      // operator-level denominator. Counting inside the regular-map branch alone would drop the
+      // rows the fast map absorbed from the ratio and bypass an aggregation that is in fact
+      // reducing. A row no map holds is streamed once pass-through is active: both probes are
+      // skipped (guarded above), so neither buffer is set, and `rowBypassed` marks exactly those
+      // rows. The row that fails to insert at the spill boundary lands here too, while the row
+      // that merely flipped pass-through at the check point is already aggregated in the map that
       // took it and must not be re-emitted.
-      val createPassThroughBuffer = if (adaptivePartialAggEnabled) {
+      val countOrPassThroughRow = if (adaptivePartialAggEnabled) {
+        val heldByAMap = if (isFastHashMapEnabled) {
+          s"($fastRowBuffer != null || $unsafeRowBuffer != null)"
+        } else {
+          s"($unsafeRowBuffer != null)"
+        }
         // The grouping key was already projected in `findOrInsertRegularHashMap`
         // (`unsafeRowKeyCode.code`), so `unsafeRowKeyCode.value` holds this row's key. Only build
         // the single-row partial buffer here.
         s"""
-           |if ($adaptivePassThroughTerm && !$heldByAMap) {
+           |if ($heldByAMap) {
+           |  if (!$adaptivePassThroughTerm) {
+           |    $processedRowsTerm += 1;
+           |    if ($processedRowsTerm == $adaptiveNextCheckRowTerm) {
+           |      if ($adaptiveIneffective) {
+           |        $adaptivePassThroughTerm = true;
+           |      } else {
+           |        $adaptiveNextCheckRowTerm += ${adaptiveMinRows}L;
+           |      }
+           |    }
+           |  }
+           |} else if ($adaptivePassThroughTerm) {
            |  $adaptiveRowBypassedTerm = true;
            |  ${emptyAggBufferCode.code}
            |  $unsafeRowBuffer = ${emptyAggBufferCode.value};
@@ -999,32 +1020,9 @@ case class HashAggregateExec(
         ""
       }
 
-      // Count every row an aggregation map accepted so the numerator matches the operator-level
-      // denominator. Counting inside the regular-map branch alone would drop the rows the fast map
-      // absorbed from the ratio and bypass an aggregation that is in fact reducing. The row that
-      // fails to insert at the spill boundary sets pass-through and holds no buffer, so it is
-      // excluded here and streamed instead.
-      val adaptivePeriodicCheck = if (adaptivePartialAggEnabled) {
-        s"""
-           |if (!$adaptivePassThroughTerm && $heldByAMap) {
-           |  $processedRowsTerm += 1;
-           |  if ($processedRowsTerm == $adaptiveNextCheckRowTerm) {
-           |    if ($adaptiveIneffective) {
-           |      $adaptivePassThroughTerm = true;
-           |    } else {
-           |      $adaptiveNextCheckRowTerm += ${adaptiveMinRows}L;
-           |    }
-           |  }
-           |}
-         """.stripMargin
-      } else {
-        ""
-      }
-
       s"""
          |$findCode
-         |$adaptivePeriodicCheck
-         |$createPassThroughBuffer
+         |$countOrPassThroughRow
        """.stripMargin
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -879,7 +879,7 @@ case class HashAggregateExec(
            |  $sorterTerm.merge($hashMapTerm.destructAndCreateExternalSorter());
            |}
            |$resetCounter
-           |// the hash map had be spilled, it should have enough memory now,
+           |// the hash map had been spilled, so it should have enough memory now,
            |// try to allocate buffer again.
            |$unsafeRowBuffer = $hashMapTerm.getAggregationBufferFromUnsafeRow(
            |  $unsafeRowKeys, $unsafeRowKeyHash);
@@ -910,24 +910,26 @@ case class HashAggregateExec(
            |// generate grouping key
            |${unsafeRowKeyCode.code}
            |if (!$adaptivePassThroughTerm) {
-           |  $regularMapRowCountTerm += 1;
            |  $probeRegularMap
            |  if ($unsafeRowBuffer == null) {
-           |    // The map is full and would spill. Pre-spill, decide whether to bypass instead.
-           |    if ($sorterTerm == null &&
+           |    if ($sorterTerm == null && $regularMapRowCountTerm > 0 &&
            |        (double) $hashMapTerm.getNumKeys() >=
            |          $regularMapRowCountTerm * ${cfg.spillReductionRatioThreshold}D) {
            |      $adaptivePassThroughTerm = true;
            |    } else {
            |      $spillMap
            |    }
-           |  } else if ($sorterTerm == null &&
-           |      $regularMapRowCountTerm == $adaptiveNextSampleRowTerm) {
-           |    if ((double) $hashMapTerm.getNumKeys() >=
-           |        $regularMapRowCountTerm * ${cfg.noSpillReductionRatioThreshold}D) {
-           |      $adaptivePassThroughTerm = true;
-           |    } else {
-           |      $adaptiveNextSampleRowTerm = $adaptiveNextSampleRowTerm * 2;
+           |  }
+           |  if ($unsafeRowBuffer != null) {
+           |    $regularMapRowCountTerm += 1;
+           |    if ($sorterTerm == null &&
+           |        $regularMapRowCountTerm == $adaptiveNextSampleRowTerm) {
+           |      if ((double) $hashMapTerm.getNumKeys() >=
+           |          $regularMapRowCountTerm * ${cfg.noSpillReductionRatioThreshold}D) {
+           |        $adaptivePassThroughTerm = true;
+           |      } else {
+           |        $adaptiveNextSampleRowTerm = $adaptiveNextSampleRowTerm * 2;
+           |      }
            |    }
            |  }
            |}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -72,9 +72,16 @@ case class HashAggregateExec(
     "aggTime" -> SQLMetrics.createTimingMetric(sparkContext, "time in aggregation build"),
     "avgHashProbe" ->
       SQLMetrics.createAverageMetric(sparkContext, "avg hash probes per key"),
-    "numTasksFallBacked" -> SQLMetrics.createMetric(sparkContext, "number of sort fallback tasks"),
-    "numBypassingRows" ->
-      SQLMetrics.createMetric(sparkContext, "number of bypassing rows"))
+    "numTasksFallBacked" -> SQLMetrics.createMetric(sparkContext, "number of sort fallback tasks")
+  ) ++ {
+    // Only the aggregates that can actually bypass report this, so the rest do not show a
+    // constant 0 in the SQL UI (see `UnionExec.metrics` for the same approach).
+    if (adaptivePartialAggEnabled) {
+      Map("numBypassingRows" -> SQLMetrics.createMetric(sparkContext, "number of bypassing rows"))
+    } else {
+      Map.empty[String, SQLMetric]
+    }
+  }
 
   // This is for testing. We force TungstenAggregationIterator to fall back to the unsafe row hash
   // map and/or the sort-based aggregation once it has processed a given number of input rows.
@@ -96,7 +103,8 @@ case class HashAggregateExec(
     val avgHashProbe = longMetric("avgHashProbe")
     val aggTime = longMetric("aggTime")
     val numTasksFallBacked = longMetric("numTasksFallBacked")
-    val numBypassingRows = longMetric("numBypassingRows")
+    // Registered only when the feature applies, and only read from the pass-through path.
+    val numBypassingRows = if (adaptivePartialAggEnabled) longMetric("numBypassingRows") else null
 
     child.execute().mapPartitionsWithIndex { (partIndex, iter) =>
 
@@ -159,22 +167,30 @@ case class HashAggregateExec(
    *     supported by passing its incoming buffer through unchanged, but that is left for later.
    *   - grouping keys present: a global aggregation produces a single output row, so partial
    *     aggregation achieves the maximum reduction and must never be bypassed.
-   *   - DISTINCT aggregate functions are allowed: the intermediate `PartialMerge` phase of the
-   *     multi-phase distinct plan is not `Partial` mode (and requires a distribution), so it always
-   *     aggregates and de-duplicates, and the passed-through rows from the distinct `Partial` phase
+   *   - DISTINCT aggregate functions are allowed: the intermediate phase of the multi-phase
+   *     distinct plan mixes `PartialMerge` with `Partial`, so the mode check excludes it and it
+   *     always aggregates and de-duplicates. The rows reaching the distinct `Partial` phase
    *     therefore carry exactly one distinct value each.
+   *   - batch only: a streaming partial aggregate keeps state across batches, and it is built
+   *     with all-`Partial` modes and no required distribution, so it would otherwise qualify.
    */
   private val adaptivePartialAggEnabled: Boolean = {
     conf.adaptivePartialAggregationEnabled &&
       groupingExpressions.nonEmpty &&
-      // Only the pre-shuffle partial aggregation has a downstream `Final` to merge passed-through
-      // single-row buffers. `requiredChildDistributionExpressions` is `None` exactly for that
-      // pre-shuffle phase and `Some` for the `Final`/`Complete` phase. This check is what keeps a
-      // group-by-only aggregate (no aggregate functions, so an empty `aggregateExpressions`) from
-      // being admitted vacuously: `aggregateExpressions.forall(_.mode == Partial)` alone is true
-      // for the empty list, which would wrongly make the `Final` phase eligible as well.
-      requiredChildDistributionExpressions.isEmpty &&
-      aggregateExpressions.forall(a => a.mode == Partial)
+      // Streaming aggregation carries state across batches and its partial phase also has no
+      // required distribution, so keep this batch-only. The static sibling
+      // `spark.sql.execution.bypassPartialAggregation` likewise stays away from it.
+      !isStreaming &&
+      // Every aggregate function must be in `Partial` mode, so a downstream `Final` is there to
+      // merge the passed-through single-row buffers. This is also what excludes the intermediate
+      // phase of a DISTINCT plan, whose modes are `PartialMerge ++ Partial`.
+      aggregateExpressions.forall(a => a.mode == Partial) &&
+      // A group-by-only aggregate has no aggregate functions at all, so the `forall` above is
+      // vacuously true for both its phases. `requiredChildDistributionExpressions` tells them
+      // apart: the `Final` phase requires a distribution, the pre-shuffle phase does not. (It is
+      // not a general pre-shuffle test -- `AggUtils.planAggregateWithOneDistinct` leaves it `None`
+      // on an aggregate that sits after a shuffle -- but the mode check covers that case.)
+      requiredChildDistributionExpressions.isEmpty
   }
 
   // The number of rows between two compaction-ratio evaluations, and the ratio below which the
@@ -810,7 +826,15 @@ case class HashAggregateExec(
 
   // Blocking operators normally suppress the child's `shouldStop()` check because they buffer all
   // output. With adaptive partial aggregation, pass-through rows are appended to the output buffer
-  // while consuming child input, so the stop check must be re-enabled to keep the buffer bounded.
+  // while consuming child input, so the stop check is re-enabled to let the child yield between
+  // rows.
+  //
+  // This bounds the buffer only as far as the child honours it. A one-to-many child that does not
+  // check `shouldStop()` inside its fan-out -- `GenerateExec` emits `for (index ...) { consume }`
+  // and `while (iterator.hasNext()) { consume }` with no check -- appends every row produced from
+  // one input row before it can yield. Those rows used to accumulate in the spillable aggregation
+  // map; once pass-through is active they accumulate in `BufferedRowIterator.currentRows`, which
+  // is not spillable, so a very wide expansion trades spill I/O for heap.
   override def needStopCheck: Boolean = adaptivePartialAggEnabled
 
   // Blocking operators normally do not copy their result because every output row is drained (via

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -223,9 +223,9 @@ case class HashAggregateExec(
   private var adaptiveChildrenConsumedTerm: String = _
   // Whether the map output has already been emitted (and the maps freed). Once pass-through is
   // active the maps are frozen; draining them -- which also frees them -- releases their memory
-  // before the rest of the input is streamed. The drain runs right after the trigger row in a
-  // fused plan, or on the next re-entry when an exchange splits the build from the output (see
-  // `emitPassThroughRow`); either way this flag lets the later output skip the maps.
+  // before the rest of the input is streamed. The drain starts as soon as the first passed-through
+  // row queues a copy behind the maps, advancing one map row per queued row (see
+  // `handlePassThroughRow`); this flag lets the later output skip the maps.
   private var adaptiveMapOutputDoneTerm: String = _
   // Whether the map iterators have been set up (`finishHashMap`). The map-output function may be
   // re-entered when its loops return via `shouldStop()` to drain the buffer, and `finishAggregate`
@@ -243,9 +243,16 @@ case class HashAggregateExec(
   // The name of the generated output function, promoted to a field so `doConsumeWithKeys` can emit
   // pass-through rows directly from within the build loop.
   private var outputFunc: String = _
-  // The name of the generated map-output function, promoted to a field so `doConsumeWithKeys` can
-  // drain the frozen maps right after the trigger row in a fused plan (see `emitPassThroughRow`).
-  private var adaptiveOutputMapFuncName: String = _
+  // The name of the generated function that drains the frozen maps and, once they are fully
+  // drained, flushes the queue of passed-through rows held behind them. Promoted to a field so
+  // `doConsumeWithKeys` can advance the maps one row per passed-through row (see
+  // `handlePassThroughRow`).
+  private var adaptiveOutputMapAndFlushFuncName: String = _
+  // The queue of passed-through rows, held behind the frozen maps so the maps are emitted first.
+  // Each queued row advances the map output by one row, so the queue stays bounded by how many
+  // passed-through rows a child emits before it honours `shouldStop()` (see
+  // `handlePassThroughRow`).
+  private var adaptivePendingRowsTerm: String = _
 
   /**
    * This is called by generated Java class, should be public.
@@ -544,6 +551,9 @@ case class HashAggregateExec(
         ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveMapSetupDone")
       adaptiveFastKeysAtSpillTerm =
         ctx.addMutableState(CodeGenerator.JAVA_INT, "adaptiveFastKeysAtSpill")
+      adaptivePendingRowsTerm = ctx.addMutableState(
+        "java.util.LinkedList<UnsafeRow[]>", "adaptivePendingRows",
+        v => s"$v = new java.util.LinkedList<UnsafeRow[]>();", forceInline = true)
     }
     if (conf.enableTwoLevelAggMap) {
       enableTwoLevelHashMap()
@@ -743,9 +753,15 @@ case class HashAggregateExec(
     // The done flag is set inside, after the loops, so a mid-output drain (the loops return via
     // `shouldStop()`) leaves it unset and the caller resumes the map iterator on re-entry; once it
     // is set the maps have been fully output and freed and will not be touched again. The iterator
-    // setup (`finishHashMap`, which destructs the map) is guarded to run only once.
-    adaptiveOutputMapFuncName = if (adaptivePartialAggEnabled) {
-      val name = ctx.freshName("outputMap")
+    // setup (`finishHashMap`, which destructs the map) is guarded to run only once. The queue of
+    // passed-through rows held behind the maps is flushed here, right after the done flag is set:
+    // the maps must precede the held rows so the downstream Final merges a group's map buffer
+    // before its pass-through buffers (a group can straddle the freeze, since the maps only freeze
+    // once pass-through fires), and the copies were made when the row was queued, so emitting them
+    // here cannot corrupt the build's reusable rows.
+    adaptiveOutputMapAndFlushFuncName = if (adaptivePartialAggEnabled) {
+      val name = ctx.freshName("outputMapAndFlush")
+      val pair = ctx.freshName("pendingRow")
       ctx.addNewFunction(name,
         s"""
            |private void $name() throws java.io.IOException {
@@ -756,6 +772,10 @@ case class HashAggregateExec(
            |  $outputFromFastHashMap
            |  $outputFromRegularHashMap
            |  $adaptiveMapOutputDoneTerm = true;
+           |  while (!$adaptivePendingRowsTerm.isEmpty()) {
+           |    UnsafeRow[] $pair = (UnsafeRow[]) $adaptivePendingRowsTerm.poll();
+           |    $outputFunc($pair[0], $pair[1]);
+           |  }
            |}
          """.stripMargin)
     } else {
@@ -780,27 +800,27 @@ case class HashAggregateExec(
     val beforeAgg = ctx.freshName("beforeAgg")
     // Split by an exchange, `doAgg` may start appending pass-through rows to the output buffer
     // mid-build. In that case `shouldStop()` becomes true and we must return so the buffered rows
-    // are drained; the build is resumed on re-entry (guarded by `childrenConsumed`) until the
-    // child input is exhausted, only then falling through to the map output below. Fused with the
-    // Final, nothing is buffered, so `shouldStop()` never fires and the maps are drained inside
-    // the build (see `emitPassThroughRow`).
+    // are drained; on re-entry the frozen maps are output first (`adaptiveOutputMapAndFlush`) and
+    // then the build resumes (guarded by `childrenConsumed`) until the child input is exhausted.
+    // Fused with the Final, nothing is buffered, so `shouldStop()` never fires and the maps are
+    // drained inside the build (see `handlePassThroughRow`).
     val adaptiveStopCheck = if (adaptivePartialAggEnabled) {
       "if (shouldStop()) return;"
     } else {
       ""
     }
     // Once pass-through is active the maps are frozen, so output them (releasing their memory)
-    // exactly once: early in `adaptiveResumeBuild` (resuming the build means it returned because
-    // pass-through filled the buffer, so pass-through is already active) or at the end in
-    // `adaptiveFinalOutput` when they were never output early. A fused plan drains them inside
-    // the build instead, right after the trigger row (see `emitPassThroughRow`); the done flag
-    // set there makes both call sites below a no-op. The output loops return via `shouldStop()`
-    // when the buffer fills, so the done flag is set inside the output function and re-entry
-    // resumes the map iterator.
-    val adaptiveOutputMap = if (adaptivePartialAggEnabled) {
+    // ahead of the passed-through rows. The output starts the moment the first passed-through row
+    // queues behind the maps (`handlePassThroughRow` advances the maps by one row per queued row),
+    // and continues on re-entry here; `adaptiveFinalOutput` covers the case where pass-through
+    // never fired during the build, when the full maps are the result. The output loops return via
+    // `shouldStop()` when the buffer fills, so the done flag is set inside the output function and
+    // re-entry resumes the map iterator. Only once the maps are fully drained are the queued
+    // pass-through rows flushed, so every map buffer precedes the rows that collided with it.
+    val adaptiveOutputMapAndFlush = if (adaptivePartialAggEnabled) {
       s"""
          |if (!$adaptiveMapOutputDoneTerm) {
-         |  $adaptiveOutputMapFuncName();
+         |  $adaptiveOutputMapAndFlushFuncName();
          |  if (shouldStop()) return;
          |}
        """.stripMargin
@@ -811,7 +831,7 @@ case class HashAggregateExec(
       val beforeResumedAgg = ctx.freshName("beforeResumedAgg")
       s"""
          |if (!$adaptiveChildrenConsumedTerm) {
-         |  $adaptiveOutputMap
+         |  $adaptiveOutputMapAndFlush
          |  long $beforeResumedAgg = System.nanoTime();
          |  $doAggFuncName(partitionIndex);
          |  $aggTime.add((System.nanoTime() - $beforeResumedAgg) / $NANOS_PER_MILLIS);
@@ -822,7 +842,7 @@ case class HashAggregateExec(
       ""
     }
     val adaptiveFinalOutput = if (adaptivePartialAggEnabled) {
-      adaptiveOutputMap
+      adaptiveOutputMapAndFlush
     } else {
       s"""
          |$outputFromFastHashMap
@@ -850,12 +870,14 @@ case class HashAggregateExec(
   // while consuming child input, so the stop check is re-enabled to let the child yield between
   // rows.
   //
-  // This bounds the buffer only as far as the child honours it. A one-to-many child that does not
-  // check `shouldStop()` inside its fan-out -- `GenerateExec` emits `for (index ...) { consume }`
-  // and `while (iterator.hasNext()) { consume }` with no check -- appends every row produced from
-  // one input row before it can yield. Those rows used to accumulate in the spillable aggregation
-  // map; once pass-through is active they accumulate in `BufferedRowIterator.currentRows`, which
-  // is not spillable, so a very wide expansion trades spill I/O for heap.
+  // This bounds the buffer only as far as the child honours it. Each passed-through row queues a
+  // copy and advances the frozen-map output by one row, and that one appended map row makes
+  // `shouldStop()` true, so a child that checks between rows never queues more than one row. A
+  // one-to-many child that does not check `shouldStop()` inside its fan-out (`GenerateExec` emits
+  // `for (index ...) { consume }` and `while (iterator.hasNext()) { consume }` with no check)
+  // appends every row produced from one input row before it can yield: the fan-out batch lands in
+  // `BufferedRowIterator.currentRows` (which is not spillable), and the map advances one row per
+  // queued row, so the buffer grows to roughly the batch width rather than `minRows`.
   override def needStopCheck: Boolean = adaptivePartialAggEnabled
 
   // Blocking operators normally do not copy their result because every output row is drained (via
@@ -866,13 +888,6 @@ case class HashAggregateExec(
   // requirement rather than copying for every adaptive aggregate.
   override def needCopyResult: Boolean = adaptivePartialAggEnabled &&
     child.asInstanceOf[CodegenSupport].needCopyResult
-
-  // Whether this partial aggregate is the root of its whole-stage. When an exchange splits the
-  // partial from the Final, the partial is the whole-stage root and its output function appends to
-  // `BufferedRowIterator.currentRows`; fused, the output feeds the Final's `doConsume` directly and
-  // is never buffered. The distinction decides where the frozen maps are drained (see
-  // `emitPassThroughRow`).
-  private def isWholeStageRoot: Boolean = parent.isInstanceOf[WholeStageCodegenExec]
 
   protected override def doConsumeWithKeys(ctx: CodegenContext, input: Seq[ExprCode]): String = {
     // create grouping key
@@ -1263,41 +1278,30 @@ case class HashAggregateExec(
     // single-row buffer built above; we then emit `key ++ buffer` straight to the parent so the row
     // skips both the fast map and the regular map.
     //
-    // The maps were frozen when pass-through fired, so they are drained to preserve the merge order
-    // (trigger row, then the maps, then the rest of the input). Where the drain runs depends on
-    // the plan shape. Split by an exchange, the partial is the whole-stage root and its output
-    // function appends a reference to the reusable output row; draining in the same call would
-    // overwrite that row while still buffered and silently drop the trigger, so the drain is left
-    // to `doProduceWithKeys` on the next `processNext` (the buffered trigger is pulled first).
-    // A one-to-many child that cannot yield mid-fan-out changes the trade: without a stop check
-    // its whole batch is appended before the deferred drain runs, flipping the merge order for a
-    // group that straddles the freeze point. Such children report `needCopyResult`, so every row
-    // is a copy, the aliasing hazard is gone, and the drain runs here right after the trigger,
-    // draining the whole frozen map before the fan-out batch continues. Fused with the Final (no
-    // exchange), the output is consumed directly by the Final's `doConsume` and never buffered, so
-    // there is no aliasing hazard either; the drain runs here too, because nothing else would
-    // yield the build loop (with no append there is no `shouldStop()`), and the maps would
-    // otherwise come out only after all the remaining streamed rows, flipping the merge order.
-    val emitPassThroughRow = if (adaptivePartialAggEnabled) {
+    // The maps were frozen when pass-through fired, so a group can straddle the freeze and hold
+    // both a map buffer and pass-through buffers. The downstream Final merges in emit order, so
+    // every map buffer must precede the pass-through buffers of the same group. We hold each
+    // passed-through row in a queue behind the maps: the row is queued as a copy, and queuing it
+    // advances the map output by one row. That one appended map row is what makes `shouldStop()`
+    // true, so a child that honours the check yields at the end of its batch and never queues more
+    // than one row; a one-to-many child that cannot yield mid-fan-out queues its whole batch at
+    // once, bounding the queue by the batch width. The map drains one row per queued row (the same
+    // cadence the 1:1 shape already uses), and once the maps are fully drained the queue is
+    // flushed, so the maps always precede the held rows. Fused with the Final, nothing is
+    // buffered, `shouldStop()` never fires, and the single output call drains the whole map before
+    // the held row follows.
+    val handlePassThroughRow = if (adaptivePartialAggEnabled) {
       val numBypassingRows = metricTerm(ctx, "numBypassingRows")
-      val drainFused = if (isWholeStageRoot && !needCopyResult) {
-        ""
-      } else {
-        // `outputMap` returns on `shouldStop()`, already true here because the bypassed row was
-        // just appended, so drain in a loop to emit the whole frozen map before the fan-out batch
-        // continues. Fused, nothing is buffered and `shouldStop()` stays false, so the loop runs
-        // once.
-        s"""
-           |while (!$adaptiveMapOutputDoneTerm) {
-           |  $adaptiveOutputMapFuncName();
-           |}
-         """.stripMargin
-      }
       s"""
          |if ($adaptiveRowBypassedTerm) {
          |  $numBypassingRows.add(1);
-         |  $outputFunc(${unsafeRowKeyCode.value}, $unsafeRowBuffer);
-         |  $drainFused
+         |  if ($adaptiveMapOutputDoneTerm) {
+         |    $outputFunc(${unsafeRowKeyCode.value}, $unsafeRowBuffer);
+         |  } else {
+         |    $adaptivePendingRowsTerm.add(new UnsafeRow[] {
+         |      ${unsafeRowKeyCode.value}.copy(), $unsafeRowBuffer.copy() });
+         |    $adaptiveOutputMapAndFlushFuncName();
+         |  }
          |}
        """.stripMargin
     } else {
@@ -1308,7 +1312,7 @@ case class HashAggregateExec(
        |$findOrInsertHashMap
        |$incCounter
        |$updateRowInHashMap
-       |$emitPassThroughRow
+       |$handlePassThroughRow
      """.stripMargin
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -134,6 +134,7 @@ case class HashAggregateExec(
             avgHashProbe,
             numTasksFallBacked,
             numBypassingRows,
+            aggTime,
             adaptivePartialAggEnabled,
             adaptiveMinRows,
             adaptiveMinCompaction)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -126,7 +126,9 @@ case class HashAggregateExec(
             avgHashProbe,
             numTasksFallBacked,
             numBypassingRows,
-            adaptivePartialAggConfig)
+            adaptivePartialAggEnabled,
+            adaptiveMinRows,
+            adaptiveMinCompaction)
         if (!hasInput && groupingExpressions.isEmpty) {
           numOutputRows += 1
           Iterator.single[UnsafeRow](aggregationIterator.outputForEmptyGroupingKeyWithoutInput())
@@ -147,16 +149,13 @@ case class HashAggregateExec(
   private val bufferSchema = DataTypeUtils.fromAttributes(aggregateBufferAttributes)
 
   /**
-   * Runtime configuration for adaptive partial aggregation, or `None` when it does not apply to
-   * this operator. When defined, the aggregation may bypass partial aggregation at runtime and
-   * pass the remaining input rows through as single-row partial buffers (see
-   * [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]).
-   *
-   * Adaptive partial aggregation only applies to a pre-shuffle partial aggregation with grouping
-   * keys:
+   * Whether adaptive partial aggregation applies to this operator. When it does, the aggregation
+   * may bypass partial aggregation at runtime and pass the remaining input rows through as
+   * single-row partial buffers (see [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]). It only
+   * applies to a pre-shuffle partial aggregation with grouping keys:
    *   - `Partial` mode only: the downstream `Final` aggregation merges the passed-through
-   *     single-row buffers, so the output contract is unchanged. `Final`/`Complete`/`PartialMerge`
-   *     have no such downstream to fall back on.
+   *     single-row buffers, so the output contract is unchanged.
+   *     `Final`/`Complete`/`PartialMerge` have no such downstream to fall back on.
    *   - grouping keys present: a global aggregation produces a single output row, so partial
    *     aggregation achieves the maximum reduction and must never be bypassed.
    *   - DISTINCT aggregate functions are allowed: the intermediate `PartialMerge` phase of the
@@ -164,8 +163,8 @@ case class HashAggregateExec(
    *     aggregates and de-duplicates, and the passed-through rows from the distinct `Partial` phase
    *     therefore carry exactly one distinct value each.
    */
-  private val adaptivePartialAggConfig: Option[AdaptivePartialAggregationConfig] = {
-    val applicable = conf.adaptivePartialAggregationEnabled &&
+  private val adaptivePartialAggEnabled: Boolean = {
+    conf.adaptivePartialAggregationEnabled &&
       groupingExpressions.nonEmpty &&
       // Only the pre-shuffle partial aggregation has a downstream `Final` to merge passed-through
       // single-row buffers. `requiredChildDistributionExpressions` is `None` exactly for that
@@ -175,17 +174,12 @@ case class HashAggregateExec(
       // for the empty list, which would wrongly make the `Final` phase eligible as well.
       requiredChildDistributionExpressions.isEmpty &&
       aggregateExpressions.forall(a => a.mode == Partial)
-    if (applicable) {
-      Some(AdaptivePartialAggregationConfig(
-        sampleRows = conf.adaptivePartialAggregationSampleRows,
-        noSpillReductionRatioThreshold =
-          conf.adaptivePartialAggregationNoSpillReductionRatioThreshold,
-        spillReductionRatioThreshold =
-          conf.adaptivePartialAggregationSpillReductionRatioThreshold))
-    } else {
-      None
-    }
   }
+
+  // The number of rows between two compaction-ratio evaluations, and the ratio below which the
+  // partial aggregation is considered ineffective. Only read when the feature applies.
+  private val adaptiveMinRows: Long = conf.adaptivePartialAggregationMinRows
+  private val adaptiveMinCompaction: Double = conf.adaptivePartialAggregationMinCompaction
 
   // The name for Fast HashMap
   private var fastHashMapTerm: String = _
@@ -200,14 +194,13 @@ case class HashAggregateExec(
   private var hashMapTerm: String = _
   private var sorterTerm: String = _
 
-  // Codegen state for adaptive partial aggregation. When the pre-shuffle reduction ratio of the
-  // regular (second-level) hash map is too low, the operator stops populating the map and instead
-  // streams each remaining row through as a single-row partial buffer for the Final aggregate to
-  // merge. Only the regular map is governed: the append-only fast hash map keeps absorbing hot
-  // keys, so pass-through only ever applies to the fast-miss stream and the fast path is never
-  // regressed for high-reduction inputs.
+  // Codegen state for adaptive partial aggregation. When the aggregation maps stop collapsing
+  // enough rows, the operator stops populating them and instead streams each remaining row through
+  // as a single-row partial buffer for the Final aggregate to merge. The compaction ratio is
+  // measured at the operator level: all processed rows against the keys held by both the fast and
+  // the regular map, so two-level-map routing does not change the decision.
   private var adaptivePassThroughTerm: String = _
-  private var regularMapRowCountTerm: String = _
+  private var processedRowsTerm: String = _
   private var adaptiveChildrenConsumedTerm: String = _
   // Whether the map output has already been emitted (and the maps freed). Once pass-through is
   // active the maps are frozen, so they are output as soon as pass-through fires to release their
@@ -217,10 +210,10 @@ case class HashAggregateExec(
   // re-entered when its loops return via `shouldStop()` to drain the buffer, and `finishAggregate`
   // destructs the map, so the setup must run only once.
   private var adaptiveMapSetupDoneTerm: String = _
-  // The next regular-map row count at which the no-spill tier re-evaluates the reduction ratio.
-  // It starts at `sampleRows` and doubles after each sub-threshold check, so the ratio is checked
-  // only rarely once the input proves low-cardinality.
-  private var adaptiveNextSampleRowTerm: String = _
+  // The processed-row count at which the compaction ratio is evaluated next. It advances by
+  // `minRows` after every check, and the count is reset after a spill so the new in-memory map
+  // epoch is judged on its own rows.
+  private var adaptiveNextCheckRowTerm: String = _
   // The name of the generated output function, promoted to a field so `doConsumeWithKeys` can emit
   // pass-through rows directly from within the build loop.
   private var outputFunc: String = _
@@ -507,13 +500,13 @@ case class HashAggregateExec(
 
   protected override def doProduceWithKeys(ctx: CodegenContext): String = {
     val initAgg = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "initAgg")
-    if (adaptivePartialAggConfig.isDefined) {
+    if (adaptivePartialAggEnabled) {
       adaptivePassThroughTerm =
         ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptivePassThrough")
-      regularMapRowCountTerm = ctx.addMutableState(CodeGenerator.JAVA_LONG, "regularMapRowCount")
-      adaptiveNextSampleRowTerm =
-        ctx.addMutableState(CodeGenerator.JAVA_LONG, "adaptiveNextSampleRow",
-          v => s"$v = ${adaptivePartialAggConfig.get.sampleRows}L;")
+      processedRowsTerm = ctx.addMutableState(CodeGenerator.JAVA_LONG, "processedRows")
+      adaptiveNextCheckRowTerm =
+        ctx.addMutableState(CodeGenerator.JAVA_LONG, "adaptiveNextCheckRow",
+          v => s"$v = ${adaptiveMinRows}L;")
       adaptiveChildrenConsumedTerm =
         ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "adaptiveChildrenConsumed")
       adaptiveMapOutputDoneTerm =
@@ -631,7 +624,7 @@ case class HashAggregateExec(
     // After the child input is consumed, finish the build: with adaptive partial aggregation mark
     // that the child is fully consumed (to support re-entry; the map iterators are set up inside
     // the map-output function), otherwise set up the map iterators for the output below.
-    val postChildProduce = if (adaptivePartialAggConfig.isDefined) {
+    val postChildProduce = if (adaptivePartialAggEnabled) {
       s"$adaptiveChildrenConsumedTerm = true;"
     } else {
       finishHashMap
@@ -719,7 +712,7 @@ case class HashAggregateExec(
     // `shouldStop()`) leaves it unset and the caller resumes the map iterator on re-entry; once it
     // is set the maps have been fully output and freed and will not be touched again. The iterator
     // setup (`finishHashMap`, which destructs the map) is guarded to run only once.
-    val outputMapFuncName = if (adaptivePartialAggConfig.isDefined) {
+    val outputMapFuncName = if (adaptivePartialAggEnabled) {
       val name = ctx.freshName("outputMap")
       ctx.addNewFunction(name,
         s"""
@@ -743,7 +736,7 @@ case class HashAggregateExec(
     // output buffer mid-build. In that case `shouldStop()` becomes true and we must return so the
     // buffered rows are drained; the build is resumed on re-entry (guarded by `childrenConsumed`)
     // until the child input is exhausted, only then falling through to the map output below.
-    val adaptiveStopCheck = if (adaptivePartialAggConfig.isDefined) {
+    val adaptiveStopCheck = if (adaptivePartialAggEnabled) {
       "if (shouldStop()) return;"
     } else {
       ""
@@ -754,7 +747,7 @@ case class HashAggregateExec(
     // `adaptiveFinalOutput` when they were never output early. The output loops return via
     // `shouldStop()` when the buffer fills, so the done flag is set inside the output function and
     // re-entry resumes the map iterator.
-    val adaptiveOutputMap = if (adaptivePartialAggConfig.isDefined) {
+    val adaptiveOutputMap = if (adaptivePartialAggEnabled) {
       s"""
          |if (!$adaptiveMapOutputDoneTerm) {
          |  $outputMapFuncName();
@@ -764,18 +757,21 @@ case class HashAggregateExec(
     } else {
       ""
     }
-    val adaptiveResumeBuild = if (adaptivePartialAggConfig.isDefined) {
+    val adaptiveResumeBuild = if (adaptivePartialAggEnabled) {
+      val beforeResumedAgg = ctx.freshName("beforeResumedAgg")
       s"""
          |if (!$adaptiveChildrenConsumedTerm) {
          |  $adaptiveOutputMap
+         |  long $beforeResumedAgg = System.nanoTime();
          |  $doAggFuncName(partitionIndex);
+         |  $aggTime.add((System.nanoTime() - $beforeResumedAgg) / $NANOS_PER_MILLIS);
          |  if (shouldStop()) return;
          |}
        """.stripMargin
     } else {
       ""
     }
-    val adaptiveFinalOutput = if (adaptivePartialAggConfig.isDefined) {
+    val adaptiveFinalOutput = if (adaptivePartialAggEnabled) {
       adaptiveOutputMap
     } else {
       s"""
@@ -802,16 +798,16 @@ case class HashAggregateExec(
   // Blocking operators normally suppress the child's `shouldStop()` check because they buffer all
   // output. With adaptive partial aggregation, pass-through rows are appended to the output buffer
   // while consuming child input, so the stop check must be re-enabled to keep the buffer bounded.
-  override def needStopCheck: Boolean =
-    adaptivePartialAggConfig.isDefined || super.needStopCheck
+  override def needStopCheck: Boolean = adaptivePartialAggEnabled
 
   // Blocking operators normally do not copy their result because every output row is drained (via
   // `shouldStop()`) before the next one is produced. Adaptive pass-through breaks that assumption:
   // when an `Expand` sits below, one input row fans out into several pass-through rows that are all
   // appended in the same child loop iteration before any drain, and they all alias the single
-  // result `UnsafeRow`. Copy the result so the buffered rows do not collapse into the last one.
-  override def needCopyResult: Boolean =
-    adaptivePartialAggConfig.isDefined || super.needCopyResult
+  // result `UnsafeRow`. Such children report `needCopyResult` themselves, so propagate their
+  // requirement rather than copying for every adaptive aggregate.
+  override def needCopyResult: Boolean = adaptivePartialAggEnabled &&
+    child.asInstanceOf[CodegenSupport].needCopyResult
 
   protected override def doConsumeWithKeys(ctx: CodegenContext, input: Seq[ExprCode]): String = {
     // create grouping key
@@ -828,7 +824,7 @@ case class HashAggregateExec(
     // partial buffer: start from the initial aggregation buffer, apply the update expressions once,
     // and output `key ++ buffer` for the Final aggregate to merge. This projects the initial
     // buffer.
-    val emptyAggBufferCode = if (adaptivePartialAggConfig.isDefined) {
+    val emptyAggBufferCode = if (adaptivePartialAggEnabled) {
       GenerateUnsafeProjection.createCode(ctx, declFunctions.flatMap(f => f.initialValues))
     } else {
       null
@@ -889,46 +885,45 @@ case class HashAggregateExec(
            |}
          """.stripMargin
 
-      if (adaptivePartialAggConfig.isDefined) {
-        val cfg = adaptivePartialAggConfig.get
-        // Adaptive partial aggregation governs only this regular (second-level) map. Count the
-        // rows that enter it (a fast-map miss, or every row when the fast map is off) and use
-        // `regularMap.getNumKeys() / regularRows` as the pre-shuffle reduction ratio.
-        //   - Tier 2 (on-spill): when the map cannot allocate for a new key (it would otherwise
-        //     spill), bypass instead if the ratio is at least `spillReductionRatioThreshold`.
-        //   - Tier 1 (no-spill): from `sampleRows` regular rows on, bypass if the ratio is at
-        //     least `noSpillReductionRatioThreshold`. The sampling window doubles after each
-        //     sub-threshold check, so low-cardinality input is re-evaluated only rarely while a
-        //     late high-cardinality tail can still trigger the bypass.
-        // Both tiers fire only before any spill (`sorter == null`): once the map has spilled, the
-        // reduction-ratio estimate no longer covers the spilled rows, and pass-through must never
-        // coexist with sort-based aggregation. When the map is full after a spill, the map spills
-        // again as usual.
-        // The key projection runs once here so `unsafeRowKeyCode.value` is valid for both the
-        // probe below and the pass-through buffer built by the caller.
+      if (adaptivePartialAggEnabled) {
+        // The compaction ratio is measured at the operator level: all processed rows against the
+        // keys held by both maps, so two-level-map routing does not change the decision. The same
+        // predicate decides both check points -- periodically every `minRows` rows, and right
+        // before the map would spill (in which case the spill is skipped entirely).
+        val totalKeys = if (isFastHashMapEnabled) {
+          s"($fastHashMapTerm.getNumKeys() + $hashMapTerm.getNumKeys())"
+        } else {
+          s"$hashMapTerm.getNumKeys()"
+        }
+        // After a spill the map starts a new in-memory epoch, so the counters restart and the
+        // ratio of that epoch alone decides whether the remaining rows are passed through.
+        val resetEpoch =
+          s"""
+             |$processedRowsTerm = 0;
+             |$adaptiveNextCheckRowTerm = ${adaptiveMinRows}L;
+           """.stripMargin
+        val ineffective =
+          s"$processedRowsTerm < (double) $totalKeys * ${adaptiveMinCompaction}D"
         s"""
            |// generate grouping key
            |${unsafeRowKeyCode.code}
            |if (!$adaptivePassThroughTerm) {
            |  $probeRegularMap
            |  if ($unsafeRowBuffer == null) {
-           |    if ($sorterTerm == null && $regularMapRowCountTerm > 0 &&
-           |        (double) $hashMapTerm.getNumKeys() >=
-           |          $regularMapRowCountTerm * ${cfg.spillReductionRatioThreshold}D) {
+           |    if ($processedRowsTerm > 0 && $ineffective) {
            |      $adaptivePassThroughTerm = true;
            |    } else {
            |      $spillMap
+           |      $resetEpoch
            |    }
            |  }
            |  if ($unsafeRowBuffer != null) {
-           |    $regularMapRowCountTerm += 1;
-           |    if ($sorterTerm == null &&
-           |        $regularMapRowCountTerm == $adaptiveNextSampleRowTerm) {
-           |      if ((double) $hashMapTerm.getNumKeys() >=
-           |          $regularMapRowCountTerm * ${cfg.noSpillReductionRatioThreshold}D) {
+           |    $processedRowsTerm += 1;
+           |    if ($processedRowsTerm == $adaptiveNextCheckRowTerm) {
+           |      if ($ineffective) {
            |        $adaptivePassThroughTerm = true;
            |      } else {
-           |        $adaptiveNextSampleRowTerm = $adaptiveNextSampleRowTerm * 2;
+           |        $adaptiveNextCheckRowTerm += ${adaptiveMinRows}L;
            |      }
            |    }
            |  }
@@ -962,7 +957,7 @@ case class HashAggregateExec(
              |    ${fastRowKeys.map(_.value).mkString(", ")});
              |}
            """.stripMargin
-        val guardedFastMapProbe = if (adaptivePartialAggConfig.isDefined) {
+        val guardedFastMapProbe = if (adaptivePartialAggEnabled) {
           s"""
              |if (!$adaptivePassThroughTerm) {
              |  $fastMapProbe
@@ -984,10 +979,10 @@ case class HashAggregateExec(
 
       // When pass-through is active, a row that no map holds must be streamed through.
       // `rowBypassed` marks exactly those rows: the fast map and regular map probes are skipped
-      // (guarded above), so both buffers stay null. The Tier-1 transition row is excluded on
-      // purpose -- its probe already inserted the key into the regular map, so it is aggregated
-      // there and must not be re-emitted.
-      val createPassThroughBuffer = if (adaptivePartialAggConfig.isDefined) {
+      // (guarded above), so both buffers stay null. The periodic-check transition row is excluded
+      // on purpose -- its probe already inserted the key into the regular map, so it is
+      // aggregated there and must not be re-emitted.
+      val createPassThroughBuffer = if (adaptivePartialAggEnabled) {
         // The grouping key was already projected in `findOrInsertRegularHashMap`
         // (`unsafeRowKeyCode.code`), so `unsafeRowKeyCode.value` holds this row's key. Only build
         // the single-row partial buffer here.
@@ -1154,7 +1149,7 @@ case class HashAggregateExec(
       } else {
         s"UnsafeRow $unsafeRowBuffer = null;"
       }
-      val declareBypassed = if (adaptivePartialAggConfig.isDefined) {
+      val declareBypassed = if (adaptivePartialAggEnabled) {
         s"boolean $adaptiveRowBypassedTerm = false;"
       } else {
         ""
@@ -1173,7 +1168,7 @@ case class HashAggregateExec(
     // With adaptive partial aggregation, once pass-through is active `updateRowInHashMap` fills the
     // single-row buffer built above; we then emit `key ++ buffer` straight to the parent so the row
     // skips both the fast map and the regular map.
-    val emitPassThroughRow = if (adaptivePartialAggConfig.isDefined) {
+    val emitPassThroughRow = if (adaptivePartialAggEnabled) {
       val numBypassingRows = metricTerm(ctx, "numBypassingRows")
       s"""
          |if ($adaptiveRowBypassedTerm) {
@@ -1219,24 +1214,3 @@ case class HashAggregateExec(
   override protected def withNewChildInternal(newChild: SparkPlan): HashAggregateExec =
     copy(child = newChild)
 }
-
-/**
- * Runtime parameters that control adaptive partial aggregation for a single [[HashAggregateExec]].
- *
- * The aggregation samples the pre-shuffle reduction ratio (distinct grouping keys / processed
- * rows) and bypasses partial aggregation when the ratio is too high to be worthwhile, using two
- * tiers:
- *   - no-spill tier: evaluated from `sampleRows` rows on while the aggregation map is still fully
- *     in memory; the sampling window doubles after each sub-threshold check, so a low-cardinality
- *     input is re-evaluated only rarely while a late high-cardinality tail can still be caught.
- *     In-memory partial aggregation is cheap, so this tier uses the more conservative
- *     `noSpillReductionRatioThreshold`.
- *   - on-spill tier: evaluated when the aggregation map is about to spill. Partial aggregation now
- *     pays disk I/O costs, so this tier uses the more aggressive `spillReductionRatioThreshold`.
- *
- * Once either tier triggers, partial aggregation is bypassed for the rest of the input.
- */
-case class AdaptivePartialAggregationConfig(
-    sampleRows: Int,
-    noSpillReductionRatioThreshold: Double,
-    spillReductionRatioThreshold: Double)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -1273,18 +1273,22 @@ case class HashAggregateExec(
     // its whole batch is appended before the deferred drain runs, flipping the merge order for a
     // group that straddles the freeze point. Such children report `needCopyResult`, so every row
     // is a copy, the aliasing hazard is gone, and the drain runs here right after the trigger,
-    // between fan-out rows. Fused with the Final (no exchange), the output is consumed directly
-    // by the Final's `doConsume` and never buffered, so there is no aliasing hazard either; the
-    // drain runs here too, because nothing else would yield the build loop (with no append there
-    // is no `shouldStop()`), and the maps would otherwise come out only after all the remaining
-    // streamed rows, flipping the merge order.
+    // draining the whole frozen map before the fan-out batch continues. Fused with the Final (no
+    // exchange), the output is consumed directly by the Final's `doConsume` and never buffered, so
+    // there is no aliasing hazard either; the drain runs here too, because nothing else would
+    // yield the build loop (with no append there is no `shouldStop()`), and the maps would
+    // otherwise come out only after all the remaining streamed rows, flipping the merge order.
     val emitPassThroughRow = if (adaptivePartialAggEnabled) {
       val numBypassingRows = metricTerm(ctx, "numBypassingRows")
       val drainFused = if (isWholeStageRoot && !needCopyResult) {
         ""
       } else {
+        // `outputMap` returns on `shouldStop()`, already true here because the bypassed row was
+        // just appended, so drain in a loop to emit the whole frozen map before the fan-out batch
+        // continues. Fused, nothing is buffered and `shouldStop()` stays false, so the loop runs
+        // once.
         s"""
-           |if (!$adaptiveMapOutputDoneTerm) {
+           |while (!$adaptiveMapOutputDoneTerm) {
            |  $adaptiveOutputMapFuncName();
            |}
          """.stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -851,6 +851,27 @@ case class HashAggregateExec(
       case _ => ("true", "", "")
     }
 
+    // The compaction ratio is measured at the operator level: all processed rows against the keys
+    // held by both maps, so two-level-map routing does not change the decision. The same predicate
+    // decides both check points -- periodically every `minRows` rows, and right before the map
+    // would spill (in which case the spill is skipped entirely). `minRows = 0` disables the
+    // periodic check: the row count is only ever compared after being incremented past 0, so it
+    // never matches and only the spill check remains.
+    val adaptiveTotalKeys = if (isFastHashMapEnabled) {
+      s"($fastHashMapTerm.getNumKeys() + $hashMapTerm.getNumKeys())"
+    } else {
+      s"$hashMapTerm.getNumKeys()"
+    }
+    val adaptiveIneffective =
+      s"$processedRowsTerm < (double) $adaptiveTotalKeys * ${adaptiveMinCompaction}D"
+    // After a spill the map starts a new in-memory epoch, so the counters restart and the ratio of
+    // that epoch alone decides whether the remaining rows are passed through.
+    val adaptiveResetEpoch =
+      s"""
+         |$processedRowsTerm = 0;
+         |$adaptiveNextCheckRowTerm = ${adaptiveMinRows}L;
+       """.stripMargin
+
     val findOrInsertRegularHashMap: String = {
       // Assumes the grouping key projection (`unsafeRowKeyCode.code`) has already run for this row,
       // so `unsafeRowKeyCode.value` holds the current key. The projection is emitted exactly once
@@ -886,45 +907,17 @@ case class HashAggregateExec(
          """.stripMargin
 
       if (adaptivePartialAggEnabled) {
-        // The compaction ratio is measured at the operator level: all processed rows against the
-        // keys held by both maps, so two-level-map routing does not change the decision. The same
-        // predicate decides both check points -- periodically every `minRows` rows, and right
-        // before the map would spill (in which case the spill is skipped entirely).
-        val totalKeys = if (isFastHashMapEnabled) {
-          s"($fastHashMapTerm.getNumKeys() + $hashMapTerm.getNumKeys())"
-        } else {
-          s"$hashMapTerm.getNumKeys()"
-        }
-        // After a spill the map starts a new in-memory epoch, so the counters restart and the
-        // ratio of that epoch alone decides whether the remaining rows are passed through.
-        val resetEpoch =
-          s"""
-             |$processedRowsTerm = 0;
-             |$adaptiveNextCheckRowTerm = ${adaptiveMinRows}L;
-           """.stripMargin
-        val ineffective =
-          s"$processedRowsTerm < (double) $totalKeys * ${adaptiveMinCompaction}D"
         s"""
            |// generate grouping key
            |${unsafeRowKeyCode.code}
            |if (!$adaptivePassThroughTerm) {
            |  $probeRegularMap
            |  if ($unsafeRowBuffer == null) {
-           |    if ($processedRowsTerm > 0 && $ineffective) {
+           |    if ($processedRowsTerm > 0 && $adaptiveIneffective) {
            |      $adaptivePassThroughTerm = true;
            |    } else {
            |      $spillMap
-           |      $resetEpoch
-           |    }
-           |  }
-           |  if ($unsafeRowBuffer != null) {
-           |    $processedRowsTerm += 1;
-           |    if ($processedRowsTerm == $adaptiveNextCheckRowTerm) {
-           |      if ($ineffective) {
-           |        $adaptivePassThroughTerm = true;
-           |      } else {
-           |        $adaptiveNextCheckRowTerm += ${adaptiveMinRows}L;
-           |      }
+           |      $adaptiveResetEpoch
            |    }
            |  }
            |}
@@ -977,17 +970,26 @@ case class HashAggregateExec(
         findOrInsertRegularHashMap
       }
 
+      // True when an aggregation map accepted this row, from either map. The fast map serves a row
+      // without it ever reaching the regular map, so both buffers have to be consulted to tell an
+      // aggregated row from one that must be streamed through.
+      val heldByAMap = if (isFastHashMapEnabled) {
+        s"($fastRowBuffer != null || $unsafeRowBuffer != null)"
+      } else {
+        s"($unsafeRowBuffer != null)"
+      }
+
       // When pass-through is active, a row that no map holds must be streamed through.
-      // `rowBypassed` marks exactly those rows: the fast map and regular map probes are skipped
-      // (guarded above), so both buffers stay null. The periodic-check transition row is excluded
-      // on purpose -- its probe already inserted the key into the regular map, so it is
-      // aggregated there and must not be re-emitted.
+      // `rowBypassed` marks exactly those rows: both probes are skipped (guarded above), so
+      // neither buffer is set. A row a map did accept is excluded -- including the row that
+      // flipped pass-through at the periodic check, which is already aggregated in the map that
+      // took it and must not be re-emitted.
       val createPassThroughBuffer = if (adaptivePartialAggEnabled) {
         // The grouping key was already projected in `findOrInsertRegularHashMap`
         // (`unsafeRowKeyCode.code`), so `unsafeRowKeyCode.value` holds this row's key. Only build
         // the single-row partial buffer here.
         s"""
-           |if ($adaptivePassThroughTerm && $unsafeRowBuffer == null) {
+           |if ($adaptivePassThroughTerm && !$heldByAMap) {
            |  $adaptiveRowBypassedTerm = true;
            |  ${emptyAggBufferCode.code}
            |  $unsafeRowBuffer = ${emptyAggBufferCode.value};
@@ -997,8 +999,31 @@ case class HashAggregateExec(
         ""
       }
 
+      // Count every row an aggregation map accepted so the numerator matches the operator-level
+      // denominator. Counting inside the regular-map branch alone would drop the rows the fast map
+      // absorbed from the ratio and bypass an aggregation that is in fact reducing. The row that
+      // fails to insert at the spill boundary sets pass-through and holds no buffer, so it is
+      // excluded here and streamed instead.
+      val adaptivePeriodicCheck = if (adaptivePartialAggEnabled) {
+        s"""
+           |if (!$adaptivePassThroughTerm && $heldByAMap) {
+           |  $processedRowsTerm += 1;
+           |  if ($processedRowsTerm == $adaptiveNextCheckRowTerm) {
+           |    if ($adaptiveIneffective) {
+           |      $adaptivePassThroughTerm = true;
+           |    } else {
+           |      $adaptiveNextCheckRowTerm += ${adaptiveMinRows}L;
+           |    }
+           |  }
+           |}
+         """.stripMargin
+      } else {
+        ""
+      }
+
       s"""
          |$findCode
+         |$adaptivePeriodicCheck
          |$createPassThroughBuffer
        """.stripMargin
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -166,31 +166,32 @@ case class HashAggregateExec(
    *     single-row buffers, so the output contract is unchanged. `Final`/`Complete` produce the
    *     result themselves and have no such downstream. `PartialMerge` does have one and could be
    *     supported by passing its incoming buffer through unchanged, but that is left for later.
+   *     The mode check is also what excludes the intermediate phase of a DISTINCT plan, whose
+   *     modes are `PartialMerge ++ Partial`.
    *   - grouping keys present: a global aggregation produces a single output row, so partial
    *     aggregation achieves the maximum reduction and must never be bypassed.
-   *   - DISTINCT aggregate functions are allowed: the intermediate phase of the multi-phase
-   *     distinct plan mixes `PartialMerge` with `Partial`, so the mode check excludes it and it
-   *     always aggregates and de-duplicates. The rows reaching the distinct `Partial` phase
-   *     therefore carry exactly one distinct value each.
+   *   - no required distribution: with no aggregate functions (a group-by-only aggregate) the
+   *     mode check is vacuously true for both phases, so `requiredChildDistributionExpressions`
+   *     tells them apart, the `Final` phase requiring a distribution and the pre-shuffle phase
+   *     not. It is not a general pre-shuffle test, because `AggUtils.planAggregateWithOneDistinct`
+   *     leaves it `None` on a post-shuffle aggregate. DISTINCT aggregate functions are allowed:
+   *     the phase that de-duplicates on (keys ++ distinct columns) requires a distribution, so
+   *     this check keeps it out, while the distinct `Partial` phase that groups on the keys
+   *     alone is eligible even though it sits after a shuffle: another `Exchange` and a `Final`
+   *     follow it, so its passed-through buffers are still merged.
    *   - batch only: a streaming partial aggregate keeps state across batches, and it is built
    *     with all-`Partial` modes and no required distribution, so it would otherwise qualify.
+   *     A batch `session_window` grouping likewise qualifies, but its partial aggregate feeds a
+   *     `MergingSessionsExec` that merges overlapping sessions, so it is kept out for now. The
+   *     static sibling `spark.sql.execution.bypassPartialAggregation` likewise stays away from
+   *     streaming and `session_window` groupings.
    */
   private val adaptivePartialAggEnabled: Boolean = {
     conf.adaptivePartialAggregationEnabled &&
       groupingExpressions.nonEmpty &&
-      // Streaming aggregation carries state across batches and its partial phase also has no
-      // required distribution, so keep this batch-only. The static sibling
-      // `spark.sql.execution.bypassPartialAggregation` likewise stays away from it.
       !isStreaming &&
-      // Every aggregate function must be in `Partial` mode, so a downstream `Final` is there to
-      // merge the passed-through single-row buffers. This is also what excludes the intermediate
-      // phase of a DISTINCT plan, whose modes are `PartialMerge ++ Partial`.
+      !groupingExpressions.exists(_.metadata.contains(SessionWindow.marker)) &&
       aggregateExpressions.forall(a => a.mode == Partial) &&
-      // A group-by-only aggregate has no aggregate functions at all, so the `forall` above is
-      // vacuously true for both its phases. `requiredChildDistributionExpressions` tells them
-      // apart: the `Final` phase requires a distribution, the pre-shuffle phase does not. (It is
-      // not a general pre-shuffle test -- `AggUtils.planAggregateWithOneDistinct` leaves it `None`
-      // on an aggregate that sits after a shuffle -- but the mode check covers that case.)
       requiredChildDistributionExpressions.isEmpty
   }
 
@@ -644,12 +645,16 @@ case class HashAggregateExec(
     // once the outer class passes the code-size threshold), the bare field
     // reference fails with `IllegalAccessError`.
 
-    // Generate code for output. This must happen before the `doAgg` helper below, because with
-    // adaptive partial aggregation enabled, `doConsumeWithKeys` (invoked from the child's produce
-    // inside `doAgg`) emits pass-through rows by calling this output function directly.
+    // Generate code for output. With adaptive partial aggregation enabled this must happen before
+    // the `doAgg` helper below, because `doConsumeWithKeys` (invoked from the child's produce
+    // inside `doAgg`) emits pass-through rows by calling this output function directly. Otherwise
+    // the output function is generated after `doAgg`, so the early `consume(...)` inside it cannot
+    // change the codegen layout for plans the feature never touches.
     val keyTerm = ctx.freshName("aggKey")
     val bufferTerm = ctx.freshName("aggBuffer")
-    outputFunc = generateResultFunction(ctx)
+    if (adaptivePartialAggEnabled) {
+      outputFunc = generateResultFunction(ctx)
+    }
 
     // After the child input is consumed, finish the build: with adaptive partial aggregation mark
     // that the child is fully consumed (to support re-entry; the map iterators are set up inside
@@ -764,6 +769,12 @@ case class HashAggregateExec(
          |  $postChildProduce
          |}
        """.stripMargin)
+    // For a non-adaptive plan, generate the output function only after `doAgg` so its
+    // `consume(...)` cannot reorder the codegen layout (see above). It must still land before
+    // `adaptiveFinalOutput` reads it below.
+    if (!adaptivePartialAggEnabled) {
+      outputFunc = generateResultFunction(ctx)
+    }
 
     val aggTime = metricTerm(ctx, "aggTime")
     val beforeAgg = ctx.freshName("beforeAgg")
@@ -1253,19 +1264,23 @@ case class HashAggregateExec(
     // skips both the fast map and the regular map.
     //
     // The maps were frozen when pass-through fired, so they are drained to preserve the merge order
-    // -- trigger row, then the maps, then the rest of the input. Where the drain runs depends on
+    // (trigger row, then the maps, then the rest of the input). Where the drain runs depends on
     // the plan shape. Split by an exchange, the partial is the whole-stage root and its output
     // function appends a reference to the reusable output row; draining in the same call would
     // overwrite that row while still buffered and silently drop the trigger, so the drain is left
     // to `doProduceWithKeys` on the next `processNext` (the buffered trigger is pulled first).
-    // Fused with the Final (no exchange), the output is consumed directly by the Final's
-    // `doConsume` and never buffered, so there is no aliasing hazard; the drain runs here, right
-    // after the trigger, because nothing else would yield the build loop -- with no append there is
-    // no `shouldStop()` -- and the maps would otherwise come out only after all the remaining
+    // A one-to-many child that cannot yield mid-fan-out changes the trade: without a stop check
+    // its whole batch is appended before the deferred drain runs, flipping the merge order for a
+    // group that straddles the freeze point. Such children report `needCopyResult`, so every row
+    // is a copy, the aliasing hazard is gone, and the drain runs here right after the trigger,
+    // between fan-out rows. Fused with the Final (no exchange), the output is consumed directly
+    // by the Final's `doConsume` and never buffered, so there is no aliasing hazard either; the
+    // drain runs here too, because nothing else would yield the build loop (with no append there
+    // is no `shouldStop()`), and the maps would otherwise come out only after all the remaining
     // streamed rows, flipping the merge order.
     val emitPassThroughRow = if (adaptivePartialAggEnabled) {
       val numBypassingRows = metricTerm(ctx, "numBypassingRows")
-      val drainFused = if (isWholeStageRoot) {
+      val drainFused = if (isWholeStageRoot && !needCopyResult) {
         ""
       } else {
         s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -882,10 +882,12 @@ case class HashAggregateExec(
 
   // Blocking operators normally do not copy their result because every output row is drained (via
   // `shouldStop()`) before the next one is produced. Adaptive pass-through breaks that assumption:
-  // when an `Expand` sits below, one input row fans out into several pass-through rows that are all
-  // appended in the same child loop iteration before any drain, and they all alias the single
-  // result `UnsafeRow`. Such children report `needCopyResult` themselves, so propagate their
-  // requirement rather than copying for every adaptive aggregate.
+  // `outputFunc` writes every output row into the same reusable result `UnsafeRow`, and under a
+  // fan-out child several such rows are appended without an intervening drain - the frozen-map
+  // rows, emitted one per queued row inside the child's fan-out loop, and the held pass-through
+  // batch, flushed from `outputMapAndFlush` after the maps drain. Without a copy they would all
+  // alias the single result row. Such children report `needCopyResult` themselves, so propagate
+  // their requirement rather than copying for every adaptive aggregate.
   override def needCopyResult: Boolean = adaptivePartialAggEnabled &&
     child.asInstanceOf[CodegenSupport].needCopyResult
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -57,9 +57,10 @@ import org.apache.spark.util.ArrayImplicits._
  *  - Part 3: Methods and fields used by hash-based aggregation.
  *  - Part 4: Methods and fields used when we switch to sort-based aggregation.
  *  - Part 5: Methods and fields used by sort-based aggregation.
- *  - Part 6: Loads input and process input rows.
- *  - Part 7: Public methods of this iterator.
- *  - Part 8: A utility function used to generate a result when there is no
+ *  - Part 6: Methods and fields used by adaptive partial aggregation pass-through.
+ *  - Part 7: Loads input and process input rows.
+ *  - Part 8: Public methods of this iterator.
+ *  - Part 9: A utility function used to generate a result when there is no
  *            input and there is no grouping expression.
  *
  * @param partIndex
@@ -195,8 +196,9 @@ class TungstenAggregationIterator(
   //     that could not be inserted becomes the first pass-through row.
   // A spill starts a new in-memory map epoch: the row counters restart so that epoch is judged on
   // its own rows, which lets an input whose cardinality only turns unfavorable later still be
-  // passed through. Pass-through may therefore coexist with earlier spills; the output stage
-  // drains the sort-based (or map) output first and streams the remaining rows afterwards.
+  // passed through. Pass-through may therefore coexist with earlier spills. The output order
+  // matches the generated path: the first pass-through row is emitted before the sort-based (or
+  // map) output, and the remaining rows stream afterwards.
   private def processInputs(fallbackStartsAt: (Int, Int)): Unit = {
     if (groupingExpressions.isEmpty) {
       // If there is no grouping expressions, we can just reuse the same buffer over and over again.
@@ -237,6 +239,7 @@ class TungstenAggregationIterator(
             // `newInput` could not be inserted; stash a copy as the first pass-through row so it
             // is not lost when we drain the rest of `inputIter`.
             pendingPassThroughRow = newInput.copy()
+            passThroughTriggerPending = true
           } else {
             val sorter = hashMap.destructAndCreateExternalSorter()
             if (externalSorter == null) {
@@ -265,6 +268,9 @@ class TungstenAggregationIterator(
           if (adaptivePartialAggEnabled && processedRows == nextCheckRow) {
             if (ineffective()) {
               passThrough = true
+              // The first row consumed after the flip becomes the first pass-through row, emitted
+              // before the frozen map (or sort) output to match the generated path.
+              passThroughTriggerPending = true
             } else {
               nextCheckRow += minRows
             }
@@ -411,19 +417,24 @@ class TungstenAggregationIterator(
   }
 
   ///////////////////////////////////////////////////////////////////////////
-  // Part 5b: Methods and fields used by adaptive partial aggregation pass-through.
+  // Part 6: Methods and fields used by adaptive partial aggregation pass-through.
   ///////////////////////////////////////////////////////////////////////////
 
   // Indicates that partial aggregation has been bypassed and the remaining input rows should be
   // passed through as single-row partial buffers. Set in `processInputs` by either check point.
-  // It may coexist with earlier spills, so the output order is: sort-based (or map) output first,
-  // then the pass-through rows -- a group's map buffer holds its earlier rows, so its streamed
-  // rows merge after it.
+  // It may coexist with earlier spills. The output order matches the generated path: the first
+  // pass-through row is emitted before the frozen map (or sort-based) output, and the remaining
+  // rows stream afterwards.
   private[this] var passThrough: Boolean = false
 
   // The row that could not be inserted at the spill check. It is stashed here (as
   // a copy) so it becomes the first pass-through row rather than being lost.
   private[this] var pendingPassThroughRow: InternalRow = null
+
+  // Whether the first pass-through row has not been emitted yet. It is emitted before the frozen
+  // map (or sort) output -- mirroring the generated path, where the first bypassed row is appended
+  // to the output buffer from inside the build loop and the maps only drain afterwards.
+  private[this] var passThroughTriggerPending: Boolean = false
 
   // A reused aggregation buffer for building single-row partial buffers during pass-through. It is
   // re-initialized from `initialAggregationBuffer` for every passed-through row.
@@ -453,7 +464,7 @@ class TungstenAggregationIterator(
   }
 
   ///////////////////////////////////////////////////////////////////////////
-  // Part 6: Loads input rows and setup aggregationBufferMapIterator if we
+  // Part 7: Loads input rows and setup aggregationBufferMapIterator if we
   //         have not switched to sort-based aggregation.
   ///////////////////////////////////////////////////////////////////////////
 
@@ -492,7 +503,7 @@ class TungstenAggregationIterator(
   })
 
   ///////////////////////////////////////////////////////////////////////////
-  // Part 7: Iterator's public methods.
+  // Part 8: Iterator's public methods.
   ///////////////////////////////////////////////////////////////////////////
 
   override final def hasNext: Boolean = {
@@ -502,7 +513,17 @@ class TungstenAggregationIterator(
 
   override final def next(): UnsafeRow = {
     if (hasNext) {
-      val res = if (sortBased && sortedInputHasNewGroup) {
+      val res = if (passThroughTriggerPending &&
+        (pendingPassThroughRow != null || inputIter.hasNext)) {
+        // Adaptive partial aggregation bypassed partial aggregation: emit the first pass-through
+        // row before the frozen map (or sort) output, matching the generated path where the first
+        // bypassed row is appended to the output buffer from inside the build loop and the maps
+        // only drain afterwards. The remaining rows stream after the map output below. When the
+        // flip happens on the last input row there is no such row, and only the map (or sort)
+        // output remains.
+        passThroughTriggerPending = false
+        nextPassThroughOutput()
+      } else if (sortBased && sortedInputHasNewGroup) {
         // Process the current group.
         processCurrentSortedGroup()
         // Generate output row for the current group.
@@ -534,9 +555,7 @@ class TungstenAggregationIterator(
         }
       } else {
         // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
-        // rows as single-row partial buffers. These come last: a group's map buffer holds its
-        // earlier rows, so its streamed rows have to merge after it, which is the order a
-        // non-bypassed run produces.
+        // rows as single-row partial buffers, after the frozen map output above.
         nextPassThroughOutput()
       }
 
@@ -549,7 +568,7 @@ class TungstenAggregationIterator(
   }
 
   ///////////////////////////////////////////////////////////////////////////
-  // Part 8: Utility functions
+  // Part 9: Utility functions
   ///////////////////////////////////////////////////////////////////////////
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -501,7 +501,15 @@ class TungstenAggregationIterator(
 
   override final def next(): UnsafeRow = {
     if (hasNext) {
-      val res = if (sortBased && sortedInputHasNewGroup) {
+      // Pass-through rows come first, matching the generated path, where a bypassed row is emitted
+      // from inside the build loop and the frozen maps are only drained afterwards. The two paths
+      // have to agree: otherwise `spark.sql.codegen.wholeStage` would be observable in the result
+      // of an order-sensitive aggregate such as `first`/`last`.
+      val res = if (passThroughHasNext) {
+        // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
+        // rows as single-row partial buffers.
+        nextPassThroughOutput()
+      } else if (sortBased && sortedInputHasNewGroup) {
         // Process the current group.
         processCurrentSortedGroup()
         // Generate output row for the current group.
@@ -510,8 +518,9 @@ class TungstenAggregationIterator(
         sortBasedAggregationBuffer.copyFrom(initialAggregationBuffer)
 
         outputRow
-      } else if (mapIteratorHasNext) {
-        // We did not fall back to sort-based aggregation.
+      } else {
+        // We did not fall back to sort-based aggregation; `hasNext` guarantees the map iterator
+        // has a row here.
         val result =
           generateOutput(
             aggregationBufferMapIterator.getKey,
@@ -524,17 +533,13 @@ class TungstenAggregationIterator(
         if (!mapIteratorHasNext) {
           // If there is no input from aggregationBufferMapIterator, we copy current result.
           val resultCopy = result.copy()
-          // Then, we free the map. Pass-through (if any) does not use the map.
+          // Then, we free the map. Pass-through, which runs before this, does not use the map.
           hashMap.free()
 
           resultCopy
         } else {
           result
         }
-      } else {
-        // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
-        // rows as single-row partial buffers.
-        nextPassThroughOutput()
       }
 
       numOutputRows += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -201,8 +201,8 @@ class TungstenAggregationIterator(
   // A spill starts a new in-memory map epoch: the row counters restart so that epoch is judged on
   // its own rows, which lets an input whose cardinality only turns unfavorable later still be
   // passed through. Pass-through may therefore coexist with earlier spills. The output order
-  // matches the generated path: the first pass-through row is emitted before the sort-based (or
-  // map) output, and the remaining rows stream afterwards.
+  // matches the generated path: the frozen map (or sort-based) output comes first, and the
+  // pass-through rows stream afterwards.
   private def processInputs(fallbackStartsAt: (Int, Int)): Unit = {
     if (groupingExpressions.isEmpty) {
       // If there is no grouping expressions, we can just reuse the same buffer over and over again.
@@ -243,7 +243,6 @@ class TungstenAggregationIterator(
             // `newInput` could not be inserted; stash a copy as the first pass-through row so it
             // is not lost when we drain the rest of `inputIter`.
             pendingPassThroughRow = newInput.copy()
-            passThroughTriggerPending = true
           } else {
             val sorter = hashMap.destructAndCreateExternalSorter()
             if (externalSorter == null) {
@@ -272,9 +271,6 @@ class TungstenAggregationIterator(
           if (adaptivePartialAggEnabled && processedRows == nextCheckRow) {
             if (ineffective()) {
               passThrough = true
-              // The first row consumed after the flip becomes the first pass-through row, emitted
-              // before the frozen map (or sort) output to match the generated path.
-              passThroughTriggerPending = true
             } else {
               nextCheckRow += minRows
             }
@@ -426,19 +422,13 @@ class TungstenAggregationIterator(
 
   // Indicates that partial aggregation has been bypassed and the remaining input rows should be
   // passed through as single-row partial buffers. Set in `processInputs` by either check point.
-  // It may coexist with earlier spills. The output order matches the generated path: the first
-  // pass-through row is emitted before the frozen map (or sort-based) output, and the remaining
-  // rows stream afterwards.
+  // It may coexist with earlier spills. The output order matches the generated path: the frozen
+  // map (or sort-based) output comes first, and the pass-through rows stream afterwards.
   private[this] var passThrough: Boolean = false
 
   // The row that could not be inserted at the spill check. It is stashed here (as
   // a copy) so it becomes the first pass-through row rather than being lost.
   private[this] var pendingPassThroughRow: InternalRow = null
-
-  // Whether the first pass-through row has not been emitted yet. It is emitted before the frozen
-  // map (or sort) output -- mirroring the generated path, where the first bypassed row is appended
-  // to the output buffer from inside the build loop and the maps only drain afterwards.
-  private[this] var passThroughTriggerPending: Boolean = false
 
   // A reused aggregation buffer for building single-row partial buffers during pass-through. It is
   // re-initialized from `initialAggregationBuffer` for every passed-through row.
@@ -524,21 +514,7 @@ class TungstenAggregationIterator(
 
   override final def next(): UnsafeRow = {
     if (hasNext) {
-      val res = if (passThroughTriggerPending &&
-        (pendingPassThroughRow != null || inputIter.hasNext)) {
-        // Adaptive partial aggregation bypassed partial aggregation: emit the first pass-through
-        // row before the frozen map (or sort) output, matching the generated path where the first
-        // bypassed row is appended to the output buffer from inside the build loop and the maps
-        // only drain afterwards. The remaining rows stream after the map output below. When the
-        // flip happens on the last input row there is no such row, and only the map (or sort)
-        // output remains.
-        passThroughTriggerPending = false
-        passThroughDrainStart = System.nanoTime()
-        val out = nextPassThroughOutput()
-        aggTime += NANOSECONDS.toMillis(System.nanoTime() - passThroughDrainStart)
-        passThroughDrainStart = -1L
-        out
-      } else if (sortBased && sortedInputHasNewGroup) {
+      val res = if (sortBased && sortedInputHasNewGroup) {
         // Process the current group.
         processCurrentSortedGroup()
         // Generate output row for the current group.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -209,6 +209,13 @@ class TungstenAggregationIterator(
     } else {
       var i = 0
       var processedRows = 0L
+      // Eligibility and the thresholds are fixed for the lifetime of this iterator, so unwrap them
+      // once instead of re-checking the `Option` for every row.
+      val adaptiveEnabled = adaptivePartialAggConfig.isDefined
+      val noSpillRatioThreshold =
+        adaptivePartialAggConfig.map(_.noSpillReductionRatioThreshold).getOrElse(0.0)
+      val spillRatioThreshold =
+        adaptivePartialAggConfig.map(_.spillReductionRatioThreshold).getOrElse(0.0)
       // The next row count at which the no-spill tier re-evaluates the reduction ratio. It starts
       // at `sampleRows` and doubles after each sub-threshold check, so the ratio is checked only
       // rarely once the input proves low-cardinality.
@@ -224,9 +231,8 @@ class TungstenAggregationIterator(
           // The map is full and would normally spill. On the first spill, adaptive partial
           // aggregation may instead bypass: keep the in-memory map as-is, pass this row and all
           // remaining rows through, and skip the spill entirely.
-          if (adaptivePartialAggConfig.isDefined && externalSorter == null && processedRows > 0 &&
-              hashMap.getNumKeys().toDouble >=
-                processedRows * adaptivePartialAggConfig.get.spillReductionRatioThreshold) {
+          if (adaptiveEnabled && externalSorter == null && processedRows > 0 &&
+              hashMap.getNumKeys().toDouble >= processedRows * spillRatioThreshold) {
             passThrough = true
             // `newInput` could not be inserted; stash a copy as the first pass-through row so it
             // is not lost when we drain the rest of `inputIter`.
@@ -254,10 +260,8 @@ class TungstenAggregationIterator(
           // the reduction ratio is too high to be worthwhile, bypass partial aggregation for the
           // rest. The window doubles after each sub-threshold check so low-cardinality input is
           // re-evaluated only rarely while a late high-cardinality tail can still be caught.
-          if (adaptivePartialAggConfig.isDefined && externalSorter == null &&
-              processedRows == nextSampleRow) {
-            if (hashMap.getNumKeys().toDouble >=
-                processedRows * adaptivePartialAggConfig.get.noSpillReductionRatioThreshold) {
+          if (adaptiveEnabled && externalSorter == null && processedRows == nextSampleRow) {
+            if (hashMap.getNumKeys().toDouble >= processedRows * noSpillRatioThreshold) {
               passThrough = true
             } else {
               nextSampleRow = nextSampleRow * 2

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -58,7 +58,7 @@ import org.apache.spark.util.ArrayImplicits._
  *  - Part 4: Methods and fields used when we switch to sort-based aggregation.
  *  - Part 5: Methods and fields used by sort-based aggregation.
  *  - Part 6: Methods and fields used by adaptive partial aggregation pass-through.
- *  - Part 7: Loads input and process input rows.
+ *  - Part 7: Loads input and processes input rows.
  *  - Part 8: Public methods of this iterator.
  *  - Part 9: A utility function used to generate a result when there is no
  *            input and there is no grouping expression.
@@ -464,7 +464,7 @@ class TungstenAggregationIterator(
   }
 
   ///////////////////////////////////////////////////////////////////////////
-  // Part 7: Loads input rows and setup aggregationBufferMapIterator if we
+  // Part 7: Loads input rows and sets up aggregationBufferMapIterator if we
   //         have not switched to sort-based aggregation.
   ///////////////////////////////////////////////////////////////////////////
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -417,7 +417,8 @@ class TungstenAggregationIterator(
   // Indicates that partial aggregation has been bypassed and the remaining input rows should be
   // passed through as single-row partial buffers. Set in `processInputs` by either check point.
   // It may coexist with earlier spills, so the output order is: sort-based (or map) output first,
-  // then the pass-through rows.
+  // then the pass-through rows -- a group's map buffer holds its earlier rows, so its streamed
+  // rows merge after it.
   private[this] var passThrough: Boolean = false
 
   // The row that could not be inserted at the spill check. It is stashed here (as
@@ -501,15 +502,7 @@ class TungstenAggregationIterator(
 
   override final def next(): UnsafeRow = {
     if (hasNext) {
-      // Pass-through rows come first, matching the generated path, where a bypassed row is emitted
-      // from inside the build loop and the frozen maps are only drained afterwards. The two paths
-      // have to agree: otherwise `spark.sql.codegen.wholeStage` would be observable in the result
-      // of an order-sensitive aggregate such as `first`/`last`.
-      val res = if (passThroughHasNext) {
-        // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
-        // rows as single-row partial buffers.
-        nextPassThroughOutput()
-      } else if (sortBased && sortedInputHasNewGroup) {
+      val res = if (sortBased && sortedInputHasNewGroup) {
         // Process the current group.
         processCurrentSortedGroup()
         // Generate output row for the current group.
@@ -518,9 +511,8 @@ class TungstenAggregationIterator(
         sortBasedAggregationBuffer.copyFrom(initialAggregationBuffer)
 
         outputRow
-      } else {
-        // We did not fall back to sort-based aggregation; `hasNext` guarantees the map iterator
-        // has a row here.
+      } else if (mapIteratorHasNext) {
+        // We did not fall back to sort-based aggregation.
         val result =
           generateOutput(
             aggregationBufferMapIterator.getKey,
@@ -533,13 +525,19 @@ class TungstenAggregationIterator(
         if (!mapIteratorHasNext) {
           // If there is no input from aggregationBufferMapIterator, we copy current result.
           val resultCopy = result.copy()
-          // Then, we free the map. Pass-through, which runs before this, does not use the map.
+          // Then, we free the map. Pass-through (if any) does not use the map.
           hashMap.free()
 
           resultCopy
         } else {
           result
         }
+      } else {
+        // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
+        // rows as single-row partial buffers. These come last: a group's map buffer holds its
+        // earlier rows, so its streamed rows have to merge after it, which is the order a
+        // non-bypassed run produces.
+        nextPassThroughOutput()
       }
 
       numOutputRows += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -213,7 +213,9 @@ class TungstenAggregationIterator(
       val minRows = adaptiveMinRows
       // The processed-row count at which the compaction ratio is evaluated next. It advances by
       // `minRows` after every check, and restarts after a spill so the new in-memory map epoch is
-      // judged on its own rows.
+      // judged on its own rows. `minRows = 0` disables the periodic check: the count is only ever
+      // compared after being incremented past 0, so it never matches and only the spill check
+      // below remains.
       var nextCheckRow = minRows
       // The partial aggregation is ineffective when it does not collapse `minCompaction` rows into
       // one key. There is no fast map on this path, so the map's keys are all the operator holds.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -95,7 +95,9 @@ class TungstenAggregationIterator(
     peakMemory: SQLMetric,
     spillSize: SQLMetric,
     avgHashProbe: SQLMetric,
-    numTasksFallBacked: SQLMetric)
+    numTasksFallBacked: SQLMetric,
+    numBypassingRows: SQLMetric = null,
+    adaptivePartialAggConfig: Option[AdaptivePartialAggregationConfig] = None)
   extends AggregationIterator(
     partIndex,
     groupingExpressions,
@@ -179,6 +181,21 @@ class TungstenAggregationIterator(
   // hashMap. If there is not enough memory, it will multiple hash-maps, spilling
   // after each becomes full then using sort to merge these spills, finally do sort
   // based aggregation.
+  //
+  // When adaptive partial aggregation is enabled (see [[AdaptivePartialAggregationConfig]]), the
+  // processing may stop early and switch to pass-through mode: the remaining input rows are not
+  // added to the map but are instead emitted as single-row partial buffers by the output stage
+  // (see `passThroughOutput`). Two tiers decide the switch, both evaluated only before any spill
+  // has happened (so `externalSorter == null`), which keeps the reduction-ratio estimate based on
+  // the full set of processed rows and guarantees `passThrough` never coexists with sort-based
+  // aggregation:
+  //   - no-spill tier: from `sampleRows` rows on while the map is in memory, if
+  //     distinctKeys / processedRows >= noSpillReductionRatioThreshold; the sampling window doubles
+  //     after each sub-threshold check, so a low-cardinality input is re-evaluated only rarely.
+  //   - on-spill tier: when the map is about to spill for the first time, if
+  //     distinctKeys / processedRows >= spillReductionRatioThreshold. In this case we do NOT spill;
+  //     the full in-memory map is kept for normal output and the row that could not be inserted
+  //     becomes the first pass-through row.
   private def processInputs(fallbackStartsAt: (Int, Int)): Unit = {
     if (groupingExpressions.isEmpty) {
       // If there is no grouping expressions, we can just reuse the same buffer over and over again.
@@ -191,7 +208,12 @@ class TungstenAggregationIterator(
       }
     } else {
       var i = 0
-      while (inputIter.hasNext) {
+      var processedRows = 0L
+      // The next row count at which the no-spill tier re-evaluates the reduction ratio. It starts
+      // at `sampleRows` and doubles after each sub-threshold check, so the ratio is checked only
+      // rarely once the input proves low-cardinality.
+      var nextSampleRow = adaptivePartialAggConfig.map(_.sampleRows.toLong).getOrElse(0L)
+      while (inputIter.hasNext && !passThrough) {
         val newInput = inputIter.next()
         val groupingKey = groupingProjection.apply(newInput)
         var buffer: UnsafeRow = null
@@ -199,21 +221,49 @@ class TungstenAggregationIterator(
           buffer = hashMap.getAggregationBufferFromUnsafeRow(groupingKey)
         }
         if (buffer == null) {
-          val sorter = hashMap.destructAndCreateExternalSorter()
-          if (externalSorter == null) {
-            externalSorter = sorter
+          // The map is full and would normally spill. On the first spill, adaptive partial
+          // aggregation may instead bypass: keep the in-memory map as-is, pass this row and all
+          // remaining rows through, and skip the spill entirely.
+          if (adaptivePartialAggConfig.isDefined && externalSorter == null && processedRows > 0 &&
+              hashMap.getNumKeys().toDouble >=
+                processedRows * adaptivePartialAggConfig.get.spillReductionRatioThreshold) {
+            passThrough = true
+            // `newInput` could not be inserted; stash a copy as the first pass-through row so it
+            // is not lost when we drain the rest of `inputIter`.
+            pendingPassThroughRow = newInput.copy()
           } else {
-            externalSorter.merge(sorter)
-          }
-          i = 0
-          buffer = hashMap.getAggregationBufferFromUnsafeRow(groupingKey)
-          if (buffer == null) {
-            // failed to allocate the first page
-            throw QueryExecutionErrors.aggregateOutOfMemoryError()
+            val sorter = hashMap.destructAndCreateExternalSorter()
+            if (externalSorter == null) {
+              externalSorter = sorter
+            } else {
+              externalSorter.merge(sorter)
+            }
+            i = 0
+            buffer = hashMap.getAggregationBufferFromUnsafeRow(groupingKey)
+            if (buffer == null) {
+              // failed to allocate the first page
+              throw QueryExecutionErrors.aggregateOutOfMemoryError()
+            }
           }
         }
-        processRow(buffer, newInput)
-        i += 1
+        if (!passThrough) {
+          processRow(buffer, newInput)
+          i += 1
+          processedRows += 1
+          // No-spill tier: from the sampling window on, if the map is still fully in memory and
+          // the reduction ratio is too high to be worthwhile, bypass partial aggregation for the
+          // rest. The window doubles after each sub-threshold check so low-cardinality input is
+          // re-evaluated only rarely while a late high-cardinality tail can still be caught.
+          if (adaptivePartialAggConfig.isDefined && externalSorter == null &&
+              processedRows == nextSampleRow) {
+            if (hashMap.getNumKeys().toDouble >=
+                processedRows * adaptivePartialAggConfig.get.noSpillReductionRatioThreshold) {
+              passThrough = true
+            } else {
+              nextSampleRow = nextSampleRow * 2
+            }
+          }
+        }
       }
 
       if (externalSorter != null) {
@@ -355,6 +405,49 @@ class TungstenAggregationIterator(
   }
 
   ///////////////////////////////////////////////////////////////////////////
+  // Part 5b: Methods and fields used by adaptive partial aggregation pass-through.
+  ///////////////////////////////////////////////////////////////////////////
+
+  // Indicates that partial aggregation has been bypassed and the remaining input rows should be
+  // passed through as single-row partial buffers. Set in `processInputs` by either adaptive tier.
+  // Because both tiers only trigger before any spill, pass-through never coexists with sort-based
+  // aggregation, so the output order is: map entries first, then the pass-through rows.
+  private[this] var passThrough: Boolean = false
+
+  // The row that could not be inserted at the on-spill tier trigger point. It is stashed here (as
+  // a copy) so it becomes the first pass-through row rather than being lost.
+  private[this] var pendingPassThroughRow: InternalRow = null
+
+  // A reused aggregation buffer for building single-row partial buffers during pass-through. It is
+  // re-initialized from `initialAggregationBuffer` for every passed-through row.
+  private[this] lazy val passThroughAggregationBuffer: UnsafeRow = createNewAggregationBuffer()
+
+  // Whether there are remaining pass-through rows to emit.
+  private def passThroughHasNext: Boolean =
+    passThrough && (pendingPassThroughRow != null || inputIter.hasNext)
+
+  // Emits the next input row as a single-row partial aggregation buffer, i.e. a group of size one.
+  // The output (grouping key ++ buffer) is a valid partial buffer that the downstream Final
+  // aggregation merges, so the result is identical to running partial aggregation on this row.
+  private def nextPassThroughOutput(): UnsafeRow = {
+    val row = if (pendingPassThroughRow != null) {
+      val stashed = pendingPassThroughRow
+      pendingPassThroughRow = null
+      stashed
+    } else {
+      inputIter.next()
+    }
+    val groupingKey = groupingProjection.apply(row)
+    // Reset the buffer to initial values, then update it with this single row.
+    passThroughAggregationBuffer.copyFrom(initialAggregationBuffer)
+    processRow(passThroughAggregationBuffer, row)
+    if (numBypassingRows != null) {
+      numBypassingRows += 1
+    }
+    generateOutput(groupingKey, passThroughAggregationBuffer)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
   // Part 6: Loads input rows and setup aggregationBufferMapIterator if we
   //         have not switched to sort-based aggregation.
   ///////////////////////////////////////////////////////////////////////////
@@ -398,7 +491,8 @@ class TungstenAggregationIterator(
   ///////////////////////////////////////////////////////////////////////////
 
   override final def hasNext: Boolean = {
-    (sortBased && sortedInputHasNewGroup) || (!sortBased && mapIteratorHasNext)
+    (sortBased && sortedInputHasNewGroup) || (!sortBased && mapIteratorHasNext) ||
+      passThroughHasNext
   }
 
   override final def next(): UnsafeRow = {
@@ -412,7 +506,7 @@ class TungstenAggregationIterator(
         sortBasedAggregationBuffer.copyFrom(initialAggregationBuffer)
 
         outputRow
-      } else {
+      } else if (mapIteratorHasNext) {
         // We did not fall back to sort-based aggregation.
         val result =
           generateOutput(
@@ -426,13 +520,17 @@ class TungstenAggregationIterator(
         if (!mapIteratorHasNext) {
           // If there is no input from aggregationBufferMapIterator, we copy current result.
           val resultCopy = result.copy()
-          // Then, we free the map.
+          // Then, we free the map. Pass-through (if any) does not use the map.
           hashMap.free()
 
           resultCopy
         } else {
           result
         }
+      } else {
+        // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
+        // rows as single-row partial buffers.
+        nextPassThroughOutput()
       }
 
       numOutputRows += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -129,8 +129,9 @@ class TungstenAggregationIterator(
   ///////////////////////////////////////////////////////////////////////////
 
   // Creates a new aggregation buffer and initializes buffer values.
-  // This function should be only called at most two times (when we create the hash map,
-  // and when we create the re-used buffer for sort-based aggregation).
+  // This function should be called at most three times: when we create the hash map, when we
+  // create the re-used buffer for sort-based aggregation, and when we create the buffer for
+  // pass-through rows.
   private def createNewAggregationBuffer(): UnsafeRow = {
     val bufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
     val buffer: UnsafeRow = UnsafeProjection.create(bufferSchema.map(_.dataType))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -96,8 +96,10 @@ class TungstenAggregationIterator(
     spillSize: SQLMetric,
     avgHashProbe: SQLMetric,
     numTasksFallBacked: SQLMetric,
-    numBypassingRows: SQLMetric = null,
-    adaptivePartialAggConfig: Option[AdaptivePartialAggregationConfig] = None)
+    numBypassingRows: SQLMetric,
+    adaptivePartialAggEnabled: Boolean,
+    adaptiveMinRows: Long,
+    adaptiveMinCompaction: Double)
   extends AggregationIterator(
     partIndex,
     groupingExpressions,
@@ -182,20 +184,19 @@ class TungstenAggregationIterator(
   // after each becomes full then using sort to merge these spills, finally do sort
   // based aggregation.
   //
-  // When adaptive partial aggregation is enabled (see [[AdaptivePartialAggregationConfig]]), the
-  // processing may stop early and switch to pass-through mode: the remaining input rows are not
-  // added to the map but are instead emitted as single-row partial buffers by the output stage
-  // (see `passThroughOutput`). Two tiers decide the switch, both evaluated only before any spill
-  // has happened (so `externalSorter == null`), which keeps the reduction-ratio estimate based on
-  // the full set of processed rows and guarantees `passThrough` never coexists with sort-based
-  // aggregation:
-  //   - no-spill tier: from `sampleRows` rows on while the map is in memory, if
-  //     distinctKeys / processedRows >= noSpillReductionRatioThreshold; the sampling window doubles
-  //     after each sub-threshold check, so a low-cardinality input is re-evaluated only rarely.
-  //   - on-spill tier: when the map is about to spill for the first time, if
-  //     distinctKeys / processedRows >= spillReductionRatioThreshold. In this case we do NOT spill;
-  //     the full in-memory map is kept for normal output and the row that could not be inserted
-  //     becomes the first pass-through row.
+  // When adaptive partial aggregation is enabled (`adaptivePartialAggEnabled`), the processing may
+  // stop early and switch to pass-through mode: the remaining input rows are not added to the map
+  // but are instead emitted as single-row partial buffers by the output stage (see
+  // `nextPassThroughOutput`). One predicate decides both check points -- the aggregation is
+  // ineffective when `processedRows < distinctKeys * minCompaction`, i.e. it does not collapse
+  // `minCompaction` rows into one key:
+  //   - periodically, every `minRows` processed rows;
+  //   - when the map is about to spill, in which case the spill is skipped entirely and the row
+  //     that could not be inserted becomes the first pass-through row.
+  // A spill starts a new in-memory map epoch: the row counters restart so that epoch is judged on
+  // its own rows, which lets an input whose cardinality only turns unfavorable later still be
+  // passed through. Pass-through may therefore coexist with earlier spills; the output stage
+  // drains the sort-based (or map) output first and streams the remaining rows afterwards.
   private def processInputs(fallbackStartsAt: (Int, Int)): Unit = {
     if (groupingExpressions.isEmpty) {
       // If there is no grouping expressions, we can just reuse the same buffer over and over again.
@@ -209,17 +210,15 @@ class TungstenAggregationIterator(
     } else {
       var i = 0
       var processedRows = 0L
-      // Eligibility and the thresholds are fixed for the lifetime of this iterator, so unwrap them
-      // once instead of re-checking the `Option` for every row.
-      val adaptiveEnabled = adaptivePartialAggConfig.isDefined
-      val noSpillRatioThreshold =
-        adaptivePartialAggConfig.map(_.noSpillReductionRatioThreshold).getOrElse(0.0)
-      val spillRatioThreshold =
-        adaptivePartialAggConfig.map(_.spillReductionRatioThreshold).getOrElse(0.0)
-      // The next row count at which the no-spill tier re-evaluates the reduction ratio. It starts
-      // at `sampleRows` and doubles after each sub-threshold check, so the ratio is checked only
-      // rarely once the input proves low-cardinality.
-      var nextSampleRow = adaptivePartialAggConfig.map(_.sampleRows.toLong).getOrElse(0L)
+      val minRows = adaptiveMinRows
+      // The processed-row count at which the compaction ratio is evaluated next. It advances by
+      // `minRows` after every check, and restarts after a spill so the new in-memory map epoch is
+      // judged on its own rows.
+      var nextCheckRow = minRows
+      // The partial aggregation is ineffective when it does not collapse `minCompaction` rows into
+      // one key. There is no fast map on this path, so the map's keys are all the operator holds.
+      def ineffective(): Boolean =
+        processedRows < hashMap.getNumKeys().toDouble * adaptiveMinCompaction
       while (inputIter.hasNext && !passThrough) {
         val newInput = inputIter.next()
         val groupingKey = groupingProjection.apply(newInput)
@@ -228,11 +227,10 @@ class TungstenAggregationIterator(
           buffer = hashMap.getAggregationBufferFromUnsafeRow(groupingKey)
         }
         if (buffer == null) {
-          // The map is full and would normally spill. On the first spill, adaptive partial
-          // aggregation may instead bypass: keep the in-memory map as-is, pass this row and all
-          // remaining rows through, and skip the spill entirely.
-          if (adaptiveEnabled && externalSorter == null && processedRows > 0 &&
-              hashMap.getNumKeys().toDouble >= processedRows * spillRatioThreshold) {
+          // The map is full and would normally spill. Adaptive partial aggregation may instead
+          // bypass: keep the in-memory map as-is, pass this row and all remaining rows through,
+          // and skip the spill entirely.
+          if (adaptivePartialAggEnabled && processedRows > 0 && ineffective()) {
             passThrough = true
             // `newInput` could not be inserted; stash a copy as the first pass-through row so it
             // is not lost when we drain the rest of `inputIter`.
@@ -245,6 +243,10 @@ class TungstenAggregationIterator(
               externalSorter.merge(sorter)
             }
             i = 0
+            // The map starts a new in-memory epoch, so the counters restart and the ratio of that
+            // epoch alone decides whether the remaining rows are passed through.
+            processedRows = 0L
+            nextCheckRow = minRows
             buffer = hashMap.getAggregationBufferFromUnsafeRow(groupingKey)
             if (buffer == null) {
               // failed to allocate the first page
@@ -256,15 +258,13 @@ class TungstenAggregationIterator(
           processRow(buffer, newInput)
           i += 1
           processedRows += 1
-          // No-spill tier: from the sampling window on, if the map is still fully in memory and
-          // the reduction ratio is too high to be worthwhile, bypass partial aggregation for the
-          // rest. The window doubles after each sub-threshold check so low-cardinality input is
-          // re-evaluated only rarely while a late high-cardinality tail can still be caught.
-          if (adaptiveEnabled && externalSorter == null && processedRows == nextSampleRow) {
-            if (hashMap.getNumKeys().toDouble >= processedRows * noSpillRatioThreshold) {
+          // Periodic check: if the aggregation is not collapsing enough rows, bypass it for the
+          // rest of the input.
+          if (adaptivePartialAggEnabled && processedRows == nextCheckRow) {
+            if (ineffective()) {
               passThrough = true
             } else {
-              nextSampleRow = nextSampleRow * 2
+              nextCheckRow += minRows
             }
           }
         }
@@ -413,12 +413,12 @@ class TungstenAggregationIterator(
   ///////////////////////////////////////////////////////////////////////////
 
   // Indicates that partial aggregation has been bypassed and the remaining input rows should be
-  // passed through as single-row partial buffers. Set in `processInputs` by either adaptive tier.
-  // Because both tiers only trigger before any spill, pass-through never coexists with sort-based
-  // aggregation, so the output order is: map entries first, then the pass-through rows.
+  // passed through as single-row partial buffers. Set in `processInputs` by either check point.
+  // It may coexist with earlier spills, so the output order is: sort-based (or map) output first,
+  // then the pass-through rows.
   private[this] var passThrough: Boolean = false
 
-  // The row that could not be inserted at the on-spill tier trigger point. It is stashed here (as
+  // The row that could not be inserted at the spill check. It is stashed here (as
   // a copy) so it becomes the first pass-through row rather than being lost.
   private[this] var pendingPassThroughRow: InternalRow = null
 
@@ -445,9 +445,7 @@ class TungstenAggregationIterator(
     // Reset the buffer to initial values, then update it with this single row.
     passThroughAggregationBuffer.copyFrom(initialAggregationBuffer)
     processRow(passThroughAggregationBuffer, row)
-    if (numBypassingRows != null) {
-      numBypassingRows += 1
-    }
+    numBypassingRows += 1
     generateOutput(groupingKey, passThroughAggregationBuffer)
   }
 
@@ -501,7 +499,7 @@ class TungstenAggregationIterator(
 
   override final def next(): UnsafeRow = {
     if (hasNext) {
-      val res = if (sortBased) {
+      val res = if (sortBased && sortedInputHasNewGroup) {
         // Process the current group.
         processCurrentSortedGroup()
         // Generate output row for the current group.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.aggregate
 
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
@@ -98,6 +100,7 @@ class TungstenAggregationIterator(
     avgHashProbe: SQLMetric,
     numTasksFallBacked: SQLMetric,
     numBypassingRows: SQLMetric,
+    aggTime: SQLMetric,
     adaptivePartialAggEnabled: Boolean,
     adaptiveMinRows: Long,
     adaptiveMinCompaction: Double)
@@ -444,6 +447,13 @@ class TungstenAggregationIterator(
   private def passThroughHasNext: Boolean =
     passThrough && (pendingPassThroughRow != null || inputIter.hasNext)
 
+  // `aggTime` only covers the build, which runs to completion in the constructor before
+  // pass-through is known; the interpreted path consumes the rest of the input lazily through
+  // `next()`. The drain is therefore timed there, bracketed once per drain (not per row) so the
+  // timing call does not distort the per-row work, mirroring the generated path which times the
+  // drain around each resume of the build.
+  private var passThroughDrainStart: Long = -1L
+
   // Emits the next input row as a single-row partial aggregation buffer, i.e. a group of size one.
   // The output (grouping key ++ buffer) is a valid partial buffer that the downstream Final
   // aggregation merges, so the result is identical to running partial aggregation on this row.
@@ -522,7 +532,11 @@ class TungstenAggregationIterator(
         // flip happens on the last input row there is no such row, and only the map (or sort)
         // output remains.
         passThroughTriggerPending = false
-        nextPassThroughOutput()
+        passThroughDrainStart = System.nanoTime()
+        val out = nextPassThroughOutput()
+        aggTime += NANOSECONDS.toMillis(System.nanoTime() - passThroughDrainStart)
+        passThroughDrainStart = -1L
+        out
       } else if (sortBased && sortedInputHasNewGroup) {
         // Process the current group.
         processCurrentSortedGroup()
@@ -556,7 +570,15 @@ class TungstenAggregationIterator(
       } else {
         // Adaptive partial aggregation bypassed partial aggregation: emit the remaining input
         // rows as single-row partial buffers, after the frozen map output above.
-        nextPassThroughOutput()
+        if (passThroughDrainStart == -1L) {
+          passThroughDrainStart = System.nanoTime()
+        }
+        val out = nextPassThroughOutput()
+        if (!passThroughHasNext) {
+          aggTime += NANOSECONDS.toMillis(System.nanoTime() - passThroughDrainStart)
+          passThroughDrainStart = -1L
+        }
+        out
       }
 
       numOutputRows += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/VectorizedHashMapGenerator.scala
@@ -83,6 +83,10 @@ class VectorizedHashMapGenerator(
        |    buckets = new int[numBuckets];
        |    java.util.Arrays.fill(buckets, -1);
        |  }
+       |
+       |  public int getNumKeys() {
+       |    return numRows;
+       |  }
      """.stripMargin
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -142,7 +142,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // A partial aggregate is always present for the grouped queries these tests use.
     assert(partialAggs.nonEmpty, "expected a partial HashAggregateExec in the plan")
     val counters = AggCounters(
-      skipped = partialAggs.map(_.metrics("numBypassingRows").value).sum,
+      // The metric is only registered on aggregates the feature applies to; an aggregate without
+      // it bypassed nothing.
+      skipped = partialAggs.map(_.metrics.get("numBypassingRows").map(_.value).getOrElse(0L)).sum,
       partialOutputRows = partialAggs.map(_.metrics("numOutputRows").value).sum,
       spillBytes = partialAggs.map(_.metrics("spillSize").value).sum,
       tasksFallBacked = partialAggs.map(_.metrics("numTasksFallBacked").value).sum)
@@ -162,7 +164,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     df.collect()
     val byKeyCount = collect(df.queryExecution.executedPlan) {
       case agg: HashAggregateExec if agg.aggregateExpressions.forall(_.mode == Partial) =>
-        agg.groupingExpressions.length -> agg.metrics("numBypassingRows").value
+        agg.groupingExpressions.length ->
+          agg.metrics.get("numBypassingRows").map(_.value).getOrElse(0L)
     }.groupBy(_._1).map { case (n, pairs) => n -> pairs.map(_._2).sum }
     checkAgainstReference(df, build)
     byKeyCount
@@ -264,10 +267,13 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged with nullable grouping keys") {
+    // Nulls are sparse enough (1 in 40) that the keys stay close to unique and the input really
+    // does bypass; a denser null key would lift the compaction ratio above the threshold and the
+    // test would never engage the feature.
     checkAdaptiveMatchesReference { () =>
       spark.range(0, 400, 1, 1)
         .select(
-          when($"id" % 4 === 0, lit(null)).otherwise($"id") as "k",
+          when($"id" % 40 === 0, lit(null)).otherwise($"id") as "k",
           $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s", count(lit(1)) as "c")
@@ -489,6 +495,12 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   // heuristic guarding its *static* row sampling, not a correctness requirement. Our decision is
   // made at runtime from the observed compaction ratio, so we deliberately do not port that
   // exclusion. These tests assert results stay correct with the exclusion absent.
+  //
+  // The ROLLUP and CUBE cases below use two grouping columns, where the grand-total set keeps the
+  // compaction ratio high enough that they decline to bypass -- they cover the eligible-but-
+  // declining side. (Widening the rollup lowers the ratio: with five distinct columns the same
+  // shape does bypass.) The GROUPING SETS and multi-distinct tests, and `pass-through fires for
+  // high-cardinality input below an Expand`, cover an Expand that bypasses.
 
   test("results unchanged for ROLLUP (Expand below partial aggregate)") {
     checkAdaptiveMatchesReference { () =>
@@ -509,15 +521,18 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged for GROUPING SETS (Expand below partial aggregate)") {
+    // No `()` grouping set, and both keys distinct, so every expanded row is a fresh key and the
+    // input genuinely bypasses. A grand-total set would collapse all rows into one group and lift
+    // the compaction ratio above the threshold (see the ROLLUP and CUBE tests below).
     withTempView("t") {
       spark.range(0, 400, 1, 1)
-        .select(($"id" % 180) as "k1", ($"id" % 6) as "k2", $"id" as "v")
+        .select($"id" as "k1", ($"id" + 1000) as "k2", $"id" as "v")
         .createOrReplaceTempView("t")
       checkAdaptiveMatchesReference { () =>
         spark.sql(
           """SELECT k1, k2, sum(v) AS s, count(1) AS c
             |FROM t
-            |GROUP BY k1, k2 GROUPING SETS ((k1, k2), (k1), ())""".stripMargin)
+            |GROUP BY k1, k2 GROUPING SETS ((k1, k2), (k1), (k2))""".stripMargin)
       }
     }
   }
@@ -539,6 +554,45 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     checkAdaptiveMatchesReference { () =>
       spark.range(0, 100, 1, 2).union(spark.range(100, 200, 1, 2)).groupBy("id").count()
     }
+  }
+
+  test("both execution paths agree on an order-sensitive aggregate") {
+    // Bypassing emits a group's streamed rows ahead of the ones its map still holds, so
+    // `first`/`last` see a different merge order than an unbypassed run. Whether that order is
+    // guaranteed is a separate question -- what must hold is that the generated and interpreted
+    // paths agree, or `spark.sql.codegen.wholeStage` would be observable in the result.
+    //
+    // Key -1 takes the first and last input rows; the rest are distinct, so the bypass fires early
+    // and leaves row 0 in the map while row 8 streams past it.
+    val query = () => spark.range(0, 9, 1, 1)
+      .select(
+        when($"id" === 0 || $"id" === 8, lit(-1L)).otherwise($"id") as "k",
+        $"id" as "v")
+      .groupBy($"k")
+      .agg(first($"v") as "f", last($"v") as "l")
+
+    val results = for {
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+      forceSpill <- Seq(true, false)
+    } yield {
+      val spillConf = if (forceSpill) {
+        Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
+      } else {
+        Nil
+      }
+      withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "2") ++
+          spillConf ++ fixedPlanConfs): _*) {
+        query().collect().toSeq.sortBy(_.getLong(0))
+      }
+    }
+    assert(results.distinct.length == 1,
+      s"the execution paths disagree: ${results.map(_.mkString("[", ",", "]")).distinct}")
   }
 
   test("results unchanged below a generator that cannot yield mid-fan-out") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -111,8 +111,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
    *     `tasksFallBacked` otherwise.
    *   - `tasksFallBacked`: the partial aggregate's `numTasksFallBacked`, incremented only when the
    *     regular map actually falls back into sort-based aggregation. When the spill check bypasses
-   *     at the
-   *     spill boundary the sorter is never created, so this stays 0 -- direct, per-operator
+   *     at the spill boundary the sorter is never created, so this stays 0 -- direct, per-operator
    *     evidence the bypass replaced the sort fallback.
    */
   private case class AggCounters(
@@ -652,6 +651,29 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
+  test("rows absorbed by the fast map count toward the compaction ratio") {
+    // The compaction ratio is measured at the operator level, so the rows the fast map absorbs
+    // must count in the numerator just as its keys count in the denominator. This input is
+    // dominated by a hot-key prefix that the fast map serves without ever reaching the regular
+    // map, followed by a short distinct tail that does reach it. Counting only the regular map's
+    // traffic would see the tail alone -- a ratio near 1 -- and bypass an aggregation that is in
+    // fact collapsing rows heavily.
+    forEachCodegenAndMap() { clue =>
+      // With the fast map on it holds 4 keys, so `k < 4` is served there and `k >= 4` falls
+      // through. 400 hot-key rows against 4 hot keys plus 20 tail keys is a ratio of about 17.5,
+      // far above the default 1.1, so nothing may bypass.
+      val df = () => spark.range(0, 420, 1, 1)
+        .select(when($"id" < 400, $"id" % 4).otherwise($"id" - 396) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        assert(numBypassingRows(df) == 0,
+          "an aggregation collapsing ~17 rows per key must not bypass; fast-map hits are " +
+            "missing from the numerator if it does")
+      }
+    }
+  }
+
   test("the periodic check fires when the sample shows no reduction, without spilling") {
     // No forced regular-map spill: only the periodic check can trigger the bypass. Fully
     // distinct keys over a small sample cross `noSpillReductionRatioThreshold`, so rows bypass and
@@ -731,11 +753,10 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("without the feature the same input really does fall back to sort") {
-    // Sanity check for the the spill check assertion above: with adaptive disabled, the identical
+    // Sanity check for the spill check assertion above: with adaptive disabled, the identical
     // high-cardinality input under the same forced fallback genuinely falls back to sort-based
     // aggregation. This proves the spill check's `tasksFallBacked == 0` reflects the bypass and
-    // not merely
-    // an input that never reached the spill boundary.
+    // not merely an input that never reached the spill boundary.
     for {
       wholeStage <- Seq(true, false)
       twoLevelMap <- Seq(true, false)
@@ -810,6 +831,41 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       withClue(clue) {
         assert(numBypassingRows(df) > 0,
           "an unreachable compaction ratio must bypass even a low-cardinality input")
+      }
+    }
+  }
+
+  test("minRows = 0 disables the periodic check but keeps the spill check") {
+    // `minRows = 0` is a sentinel for "never evaluate periodically". Without a forced regular-map
+    // spill there is no check point at all, so fully distinct input -- which the default settings
+    // bypass immediately -- must be aggregated all the way through. This is what proves the
+    // periodic check is genuinely off rather than merely deferred.
+    forEachCodegenAndMap(minRows = 0) { clue =>
+      val df = () => spark.range(0, 200, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        assert(numBypassingRows(df) == 0,
+          "minRows = 0 must disable the periodic check, so nothing may bypass without a spill")
+      }
+    }
+  }
+
+  test("minRows = 0 still bypasses at the spill boundary") {
+    // The other half of the sentinel: with the periodic check off, the spill check alone still
+    // bypasses instead of paying the spill I/O, which is the spill-only operating mode.
+    forEachCodegenAndMap(minRows = 0, regularFallback = 16) { clue =>
+      val df = () => spark.range(0, 200, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        val c = runAndReadCounters(df)
+        assert(c.skipped > 0,
+          "the spill check must still bypass when the periodic check is disabled")
+        assert(c.tasksFallBacked == 0,
+          "the spill check must replace the sort fallback, not trigger it")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -637,16 +637,22 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("both execution paths agree on an order-sensitive aggregate") {
-    // Bypassing merges a group's buffers in a different order than an unbypassed run: the rows
-    // streamed after the flip reach the `Final` aggregate before the ones the maps still hold.
-    // That order is not guaranteed -- what must hold is that the generated and interpreted paths
-    // produce the *same* result, or `spark.sql.codegen.wholeStage` becomes observable.
+    // Bypassing merges a group's buffers in a different order than a run that never bypasses:
+    // the first bypassed row is emitted ahead of the frozen map, and the rows streamed after it
+    // trail the map output. That order is not a promise -- what must hold is that the generated
+    // and interpreted paths produce the *same* result, or `spark.sql.codegen.wholeStage` becomes
+    // observable. The test deliberately does not compare against a non-bypassed run.
     //
-    // Both axes below matter. Splitting the plan by an exchange (or not) changes how the frozen
-    // map output merges with the streamed rows -- the generated path must be told whether its
-    // output is buffered or feeds the `Final`'s `doConsume` directly -- so the two shapes are
-    // exercised separately. And the divergence only shows when the colliding row is not the one
-    // the flip fired on, since that row is emitted from the build loop either way.
+    // The flip fires at the first periodic check: with `minRows=8` it lands on the 8th aggregated
+    // row, when the map already holds 8 distinct keys (id 0 maps to -1, ids 1-7 to keys 1-7), so
+    // the compaction ratio 1.0 is below `minCompaction` (1.05) and every remaining row streams;
+    // id 8 is the first bypassed row. At `dupAt=8` the colliding row is that first bypassed row,
+    // so its buffer reaches the `Final` before the frozen map's and `first`/`last` invert. At
+    // `dupAt=9` the colliding row streams after the map and the group stays in input order.
+    //
+    // Both plan shapes are exercised separately. Splitting the aggregates with an `Exchange` (or
+    // not) changes how the frozen map output merges with the streamed rows -- the generated path
+    // must be told whether its output is buffered or feeds the `Final`'s `doConsume` directly.
     for {
       splits <- Seq(1, 2)
       derivedKey <- Seq(false, true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  *      multi-distinct).
  *   2. Triggering: the `numBypassingRows` metric proves the bypass actually fires when (and only
  *      when) it should -- high-cardinality input bypasses, low-cardinality input keeps aggregating,
- *      the feature switch and eligibility rules are honored, and both decision tiers work.
+ *      the feature switch and eligibility rules are honored, and both check points work.
  */
 class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   with AdaptiveSparkPlanHelper {
@@ -45,7 +45,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   import testImplicits._
 
   // A `testFallbackStartsAt` setting ("fastMapCounter, regularMapCounter") that makes the regular
-  // map fall back (spill) periodically, exercising the on-spill (Tier 2) decision path in both the
+  // map fall back (spill) periodically, exercising the spill-check decision path in both the
   // codegen and interpreted aggregation paths. Kept moderate so low-cardinality inputs (which are
   // never bypassed and therefore really spill) do not open an unbounded number of spill readers.
   private val forceSpillFallback = "4, 16"
@@ -85,8 +85,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
           SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
-          // Small sample so the no-spill (Tier 1) path triggers on modest inputs.
-          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> "8") ++
+          // Small sample so the no-spill (the periodic check) path triggers on modest inputs.
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8") ++
           spillConf ++ fixedPlanConfs): _*) {
         val msg = s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap forceSpill=$forceSpill"
         withClue(msg) {
@@ -106,10 +106,12 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
    *     effective and climbs toward the input row count once the operator bypasses.
    *   - `spillBytes`: the partial aggregate's `spillSize`. Reliable only when no fallback is
    *     forced: on the interpreted path this is derived from the task-cumulative memory-spill
-   *     counter, so a forced fallback (or downstream shuffle-write spill) can inflate it. Asserted
-   *     only by the Tier 1 test, which forces no fallback; use `tasksFallBacked` otherwise.
+   *     counter, so a forced fallback (or downstream shuffle-write spill) can inflate it.
+   *     Asserted only by the periodic check test, which forces no fallback; use
+   *     `tasksFallBacked` otherwise.
    *   - `tasksFallBacked`: the partial aggregate's `numTasksFallBacked`, incremented only when the
-   *     regular map actually falls back into sort-based aggregation. When Tier 2 bypasses at the
+   *     regular map actually falls back into sort-based aggregation. When the spill check bypasses
+   *     at the
    *     spill boundary the sorter is never created, so this stays 0 -- direct, per-operator
    *     evidence the bypass replaced the sort fallback.
    */
@@ -177,12 +179,12 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
    * so nothing could ever bypass. To make the triggering tests meaningful when the two-level map is
    * on, we shrink the fast map via the first field of `testFallbackStartsAt` so rows fall through
    * to the regular map. `regularFallback` optionally sets the second field to also force the
-   * regular map to spill (for the on-spill tier); when 0 the regular map does not spill.
+   * regular map to spill (for the spill check); when 0 the regular map does not spill.
    */
   private def forEachCodegenAndMap(
-      sampleRows: Int = 8,
+      minRows: Long = 8,
       regularFallback: Int = 0,
-      noSpillThreshold: Double = -1.0)(
+      minCompaction: Double = -1.0)(
       body: String => Unit): Unit = {
     for {
       wholeStage <- Seq(true, false)
@@ -198,9 +200,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
         Nil
       }
       // A negative value means "leave the threshold at its default".
-      val thresholdConf = if (noSpillThreshold >= 0.0) {
-        Seq(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD.key ->
-          noSpillThreshold.toString)
+      val thresholdConf = if (minCompaction >= 0.0) {
+        Seq(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION.key -> minCompaction.toString)
       } else {
         Nil
       }
@@ -209,7 +210,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
           SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
-          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> sampleRows.toString) ++
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> minRows.toString) ++
           fallbackConf ++ thresholdConf ++ fixedPlanConfs): _*) {
         body(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap")
       }
@@ -222,7 +223,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   test("results unchanged for high-cardinality input that bypasses partial aggregation") {
     // Every grouping key is distinct, so partial aggregation reduces nothing and should be
-    // bypassed by both tiers.
+    // bypassed by the periodic check.
     checkAdaptiveMatchesReference { () =>
       spark.range(0, 200, 1, 1)
         .select($"id" as "k", ($"id" * 2) as "v")
@@ -359,7 +360,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // modes alone is vacuously true and could wrongly admit the `Final` phase of the two-phase
     // plan. With duplicate keys, a bypassing `Final` would skip its de-duplication and return
     // duplicate rows. The two-level map off variants route the rows to the regular map so the
-    // sampling tier fires and the regression would show up.
+    // periodic check fires and the regression would show up.
     checkAdaptiveMatchesReference { () =>
       spark.range(0, 1000, 1, 1)
         .select(($"id" % 10) as "c")
@@ -368,7 +369,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged when a large frozen map is output before pass-through streaming") {
-    // A larger sample lets the map accumulate many keys before the no-spill tier bypasses, so the
+    // A larger sample lets the map accumulate many keys before the periodic check bypasses, so the
     // early map output (which also frees the map) spans several drain cycles and re-enters the
     // map-output function; the results must still match the feature-off reference.
     val query = () => spark.range(0, 400000, 1, 1)
@@ -378,7 +379,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     withSQLConf(
       (Seq(
         SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
-        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> "200000",
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "200000",
         SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> "false") ++ fixedPlanConfs): _*) {
       val reference = withSQLConf(
         SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") {
@@ -651,8 +652,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("Tier 1 (no-spill) fires when the sample shows no reduction, without spilling") {
-    // No forced regular-map spill: only the no-spill sampling tier can trigger the bypass. Fully
+  test("the periodic check fires when the sample shows no reduction, without spilling") {
+    // No forced regular-map spill: only the periodic check can trigger the bypass. Fully
     // distinct keys over a small sample cross `noSpillReductionRatioThreshold`, so rows bypass and
     // the regular map never spills.
     forEachCodegenAndMap() { clue =>
@@ -662,18 +663,20 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
         .agg(sum($"v") as "s")
       withClue(clue) {
         val c = runAndReadCounters(df)
-        assert(c.skipped > 0, "Tier 1 should bypass fully distinct input under the sample")
-        assert(c.spillBytes == 0, "Tier 1 must decide before any spill happens")
-        assert(c.tasksFallBacked == 0, "Tier 1 must not fall back to sort-based aggregation")
+        assert(c.skipped > 0,
+          "the periodic check should bypass fully distinct input under the sample")
+        assert(c.spillBytes == 0, "the periodic check must decide before any spill happens")
+        assert(c.tasksFallBacked == 0,
+          "the periodic check must not fall back to sort-based aggregation")
       }
     }
   }
 
-  test("Tier 2 (on-spill) fires when the map would spill on high-cardinality input") {
+  test("the spill check fires when the map would spill on high-cardinality input") {
     // Force the regular map to fall back quickly. High-cardinality input that reaches the fallback
-    // point should bypass via the on-spill tier rather than spilling. Use a sample larger than the
-    // input so Tier 1 cannot fire first and the on-spill tier is the one exercised.
-    forEachCodegenAndMap(sampleRows = 100000, regularFallback = 16) { clue =>
+    // point should bypass via the spill check rather than spilling. Use a sample larger than the
+    // input so the periodic check cannot fire first and the spill check is the one exercised.
+    forEachCodegenAndMap(minRows = 100000, regularFallback = 16) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
         .select($"id" as "k", $"id" as "v")
         .groupBy($"k")
@@ -681,21 +684,57 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       withClue(clue) {
         val c = runAndReadCounters(df)
         assert(c.skipped > 0,
-          "Tier 2 should bypass high-cardinality input at the spill boundary")
-        // The whole point of Tier 2 is to bypass *instead of* falling back to sort-based
+          "the spill check should bypass high-cardinality input at the spill boundary")
+        // The whole point of the spill check is to bypass *instead of* falling back to sort-based
         // aggregation, so the sorter is never created. `numTasksFallBacked` is the reliable
         // per-operator signal for that (the `spillSize` metric on the interpreted path is derived
         // from the task-cumulative memory-spill counter and can be inflated by unrelated spilling
         // such as the downstream shuffle write, so it is not asserted here).
-        assert(c.tasksFallBacked == 0, "Tier 2 must replace the sort fallback, not trigger it")
+        assert(c.tasksFallBacked == 0,
+          "the spill check must replace the sort fallback, not trigger it")
+      }
+    }
+  }
+
+  test("a new in-memory map epoch after a spill can still bypass") {
+    // A spill starts a new in-memory map epoch and restarts the row counters, so an input whose
+    // cardinality only turns unfavorable after an early spill is still caught. The first 100 rows
+    // repeat 5 keys and keep the aggregation effective while the forced fallback makes the map
+    // spill; the remaining 300 rows are fully distinct, so the new epoch is judged ineffective and
+    // the rest of the input is passed through. Both the spill and the bypass must be observable.
+    for {
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+    } {
+      val fastCap = if (twoLevelMap) 4 else 1
+      withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8",
+          "spark.sql.TungstenAggregate.testFallbackStartsAt" -> s"$fastCap, 40") ++
+          fixedPlanConfs): _*) {
+        val df = () => spark.range(0, 400, 1, 1)
+          .select(when($"id" < 100, $"id" % 5).otherwise($"id") as "k", $"id" as "v")
+          .groupBy($"k")
+          .agg(sum($"v") as "s")
+        withClue(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap") {
+          val c = runAndReadCounters(df)
+          assert(c.tasksFallBacked > 0,
+            "the low-cardinality prefix should still spill and fall back to sort")
+          assert(c.skipped > 0,
+            "the high-cardinality tail after the spill should be passed through")
+        }
       }
     }
   }
 
   test("without the feature the same input really does fall back to sort") {
-    // Sanity check for the Tier 2 assertion above: with adaptive disabled, the identical
+    // Sanity check for the the spill check assertion above: with adaptive disabled, the identical
     // high-cardinality input under the same forced fallback genuinely falls back to sort-based
-    // aggregation. This proves Tier 2's `tasksFallBacked == 0` reflects the bypass and not merely
+    // aggregation. This proves the spill check's `tasksFallBacked == 0` reflects the bypass and
+    // not merely
     // an input that never reached the spill boundary.
     for {
       wholeStage <- Seq(true, false)
@@ -723,35 +762,34 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("spill tier decides identically at the exact ratio boundary with codegen on and off") {
-    // The on-spill tier evaluates the ratio over the rows already aggregated, excluding the failed
-    // insertion that becomes the first pass-through row, so both execution paths must judge the
-    // same row set and reach the same decision. `id % 40` over 400 rows gives 40 distinct keys
-    // when the map fills at 50 aggregated rows, i.e. a ratio of exactly 0.8: at the threshold the
-    // bypass fires, just above it (0.85) it does not.
-    Seq(0.8 -> true, 0.85 -> false).foreach { case (threshold, shouldBypass) =>
+  test("the spill check decides identically at the exact ratio boundary with codegen on and off") {
+    // The check before a spill evaluates the ratio over the rows already aggregated, excluding the
+    // failed insertion that becomes the first pass-through row, so both execution paths must judge
+    // the same row set and reach the same decision. `id % 40` over 400 rows gives 40 keys when the
+    // map fills at 50 aggregated rows, i.e. a compaction ratio of exactly 1.25: demanding 1.25 the
+    // aggregation is kept (`50 < 40 * 1.25` is false), demanding 1.3 it is bypassed.
+    Seq(1.25 -> false, 1.3 -> true).foreach { case (minCompaction, shouldBypass) =>
       val skippedPerCodegen = Seq(true, false).map { wholeStage =>
         withSQLConf(
           (Seq(
             SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
             SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
             SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> "false",
-            // A sample larger than the input keeps the no-spill tier out of the picture.
-            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> "100000",
-            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD.key ->
-              threshold.toString,
+            // A `minRows` larger than the input keeps the periodic check out of the picture.
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "100000",
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION.key -> minCompaction.toString,
             "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 50") ++
             fixedPlanConfs): _*) {
           val df = () => spark.range(0, 400, 1, 1)
             .select(($"id" % 40) as "k", $"id" as "v")
             .groupBy($"k")
             .agg(sum($"v") as "s")
-          withClue(s"threshold=$threshold wholeStage=$wholeStage") {
+          withClue(s"minCompaction=$minCompaction wholeStage=$wholeStage") {
             numBypassingRows(df)
           }
         }
       }
-      withClue(s"threshold=$threshold skipped=$skippedPerCodegen") {
+      withClue(s"minCompaction=$minCompaction skipped=$skippedPerCodegen") {
         assert(skippedPerCodegen.forall(_ > 0) == shouldBypass,
           s"expected bypass=$shouldBypass at the ratio boundary")
         assert(skippedPerCodegen.map(_ > 0).distinct.length == 1,
@@ -760,26 +798,26 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("a zero threshold always bypasses once the sample has been processed") {
-    // 0 is the most aggressive setting: the ratio check `distinctKeys >= rows * 0` always holds,
-    // so even a low-cardinality input that the default threshold keeps aggregating is bypassed
-    // right after the sample. The results must still match the feature-off reference.
-    forEachCodegenAndMap(noSpillThreshold = 0.0) { clue =>
+  test("a very high minCompaction always bypasses once minRows has been processed") {
+    // Demanding an unreachable compaction ratio is the most aggressive setting: even a
+    // low-cardinality input that the default threshold keeps aggregating is bypassed at the first
+    // check point. The results must still match the feature-off reference.
+    forEachCodegenAndMap(minCompaction = 1000000.0) { clue =>
       val df = () => spark.range(0, 600, 1, 1)
         .select(($"id" % 5) as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
         assert(numBypassingRows(df) > 0,
-          "a zero threshold must bypass even a low-cardinality input")
+          "an unreachable compaction ratio must bypass even a low-cardinality input")
       }
     }
   }
 
   test("larger sample defers the decision so a small high-cardinality input is not bypassed") {
-    // With a sample larger than the whole input and no regular-map spill forced, the Tier 1 check
+    // With a sample larger than the whole input and no regular-map spill forced, the periodic check
     // point is never reached, so nothing bypasses even though the keys are fully distinct.
-    forEachCodegenAndMap(sampleRows = 100000) { clue =>
+    forEachCodegenAndMap(minRows = 100000) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
         .select($"id" as "k", $"id" as "v")
         .groupBy($"k")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -78,8 +78,15 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
    * `ClusteredDistribution`, so `EnsureRequirements` inserts no `Exchange` however many partitions
    * it has. Tests that want the split shape group on a derived key (a cast, say) so the input
    * partitioning no longer satisfies the requirement.
+   *
+   * `expectBypass` ties the correctness guarantee to the triggering guarantee: beyond matching the
+   * reference, every cell must either actually stream rows through (when true) or keep
+   * aggregating (when false). Without it a test could silently stop exercising pass-through if the
+   * input stopped being bypassable, and only this assertion makes that fail loudly.
    */
-  private def checkAdaptiveMatchesReference(build: Int => DataFrame): Unit = {
+  private def checkAdaptiveMatchesReference(
+      build: Int => DataFrame,
+      expectBypass: Boolean = true): Unit = {
     for {
       inputPartitions <- Seq(1, 2)
       wholeStage <- Seq(true, false)
@@ -107,7 +114,23 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
         val msg = s"inputPartitions=$inputPartitions wholeStage=$wholeStage " +
           s"twoLevelMap=$twoLevelMap forceSpill=$forceSpill"
         withClue(msg) {
-          checkAnswer(build(inputPartitions), reference)
+          // Collect once so the metrics are populated, then check whether the bypass fired for
+          // this cell. The metric lives on the `Partial`-mode `HashAggregateExec`, so that is the
+          // operator the assertion reads.
+          val df = build(inputPartitions)
+          df.collect()
+          val skipped = collect(df.queryExecution.executedPlan) {
+            case agg: HashAggregateExec if agg.aggregateExpressions.forall(_.mode == Partial) =>
+              agg.metrics.get("numBypassingRows").map(_.value).getOrElse(0L)
+          }.sum
+          if (expectBypass) {
+            assert(skipped > 0,
+              s"expected rows to bypass partial aggregation, got $skipped bypassed rows")
+          } else {
+            assert(skipped == 0,
+              s"expected no rows to bypass partial aggregation, got $skipped bypassed rows")
+          }
+          checkAnswer(df, reference)
         }
       }
     }
@@ -252,17 +275,22 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged for low-cardinality input that keeps partial aggregation") {
-    // Few distinct keys, high reduction: partial aggregation is effective and should be kept.
-    checkAdaptiveMatchesReference { parts =>
-      spark.range(0, 600, 1, parts)
-        .select(($"id" % 5).cast("string") as "k", $"id" as "v")
-        .groupBy($"k")
-        .agg(sum($"v") as "s", count(lit(1)) as "c", min($"v") as "mn", max($"v") as "mx")
-    }
+    // Few distinct keys, high reduction: partial aggregation is effective and should be kept, so
+    // the bypass metric must stay zero in every cell.
+    checkAdaptiveMatchesReference(
+      expectBypass = false,
+      build = { parts =>
+        spark.range(0, 600, 1, parts)
+          .select(($"id" % 5).cast("string") as "k", $"id" as "v")
+          .groupBy($"k")
+          .agg(sum($"v") as "s", count(lit(1)) as "c", min($"v") as "mn", max($"v") as "mx")
+      })
   }
 
   test("results unchanged for medium-cardinality input near the reduction threshold") {
-    // Roughly half the rows are distinct keys; exercises the boundary of the ratio checks.
+    // Roughly half the rows are distinct keys; exercises the boundary of the ratio checks. The
+    // overall compaction ratio (~2.0) is above the threshold, but the *first* periodic check still
+    // sees the leading distinct keys and fires, so the bypass must be observable too.
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 1000, 1, parts)
         .select(($"id" % 500).cast("string") as "k", $"id" as "v")
@@ -403,11 +431,19 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
         SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
         SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "200000",
         SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> "false") ++ fixedPlanConfs): _*) {
+      val df = query()
+      df.collect()
+      val skipped = collect(df.queryExecution.executedPlan) {
+        case agg: HashAggregateExec if agg.aggregateExpressions.forall(_.mode == Partial) =>
+          agg.metrics.get("numBypassingRows").map(_.value).getOrElse(0L)
+      }.sum
+      assert(skipped > 0,
+        s"expected the large frozen map to eventually bypass, got $skipped bypassed rows")
       val reference = withSQLConf(
         SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") {
         query().collect().toSeq
       }
-      checkAnswer(query(), reference)
+      checkAnswer(df, reference)
     }
   }
 
@@ -498,12 +534,15 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged with an empty input") {
-    checkAdaptiveMatchesReference { parts =>
-      spark.range(0, 0, 1, 1)
-        .select($"id".cast("string") as "k", $"id" as "v")
-        .groupBy($"k")
-        .agg(sum($"v") as "s", count(lit(1)) as "c")
-    }
+    // No rows means the check points never fire; the metric must stay zero.
+    checkAdaptiveMatchesReference(
+      expectBypass = false,
+      build = { parts =>
+        spark.range(0, 0, 1, 1)
+          .select($"id".cast("string") as "k", $"id" as "v")
+          .groupBy($"k")
+          .agg(sum($"v") as "s", count(lit(1)) as "c")
+      })
   }
 
   // The following four tests cover plans where an `ExpandExec` sits below the partial aggregate
@@ -520,21 +559,29 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   // high-cardinality input below an Expand`, cover an Expand that bypasses.
 
   test("results unchanged for ROLLUP (Expand below partial aggregate)") {
-    checkAdaptiveMatchesReference { parts =>
-      spark.range(0, 400, 1, parts)
-        .select(($"id" % 200) as "k1", ($"id" % 7) as "k2", $"id" as "v")
-        .rollup($"k1", $"k2")
-        .agg(sum($"v") as "s", count(lit(1)) as "c")
-    }
+    // The grand-total group repeats on every expanded row, so the compaction ratio stays above the
+    // threshold and the partial aggregate declines to bypass in every cell.
+    checkAdaptiveMatchesReference(
+      expectBypass = false,
+      build = { parts =>
+        spark.range(0, 400, 1, parts)
+          .select(($"id" % 200) as "k1", ($"id" % 7) as "k2", $"id" as "v")
+          .rollup($"k1", $"k2")
+          .agg(sum($"v") as "s", count(lit(1)) as "c")
+      })
   }
 
   test("results unchanged for CUBE (Expand below partial aggregate)") {
-    checkAdaptiveMatchesReference { parts =>
-      spark.range(0, 400, 1, parts)
-        .select(($"id" % 150) as "k1", ($"id" % 5) as "k2", $"id" as "v")
-        .cube($"k1", $"k2")
-        .agg(sum($"v") as "s", count(lit(1)) as "c")
-    }
+    // Same as ROLLUP: the grand-total group keeps the ratio above the threshold, so nothing
+    // bypasses.
+    checkAdaptiveMatchesReference(
+      expectBypass = false,
+      build = { parts =>
+        spark.range(0, 400, 1, parts)
+          .select(($"id" % 150) as "k1", ($"id" % 5) as "k2", $"id" as "v")
+          .cube($"k1", $"k2")
+          .agg(sum($"v") as "s", count(lit(1)) as "c")
+      })
   }
 
   test("results unchanged for GROUPING SETS (Expand below partial aggregate)") {
@@ -595,11 +642,11 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // That order is not guaranteed -- what must hold is that the generated and interpreted paths
     // produce the *same* result, or `spark.sql.codegen.wholeStage` becomes observable.
     //
-    // Both axes below matter. A single input partition, or a key the input is already partitioned
-    // by, fuses the two aggregates into one whole-stage, where streamed rows go straight into the
-    // Final's hash map and never reach the output buffer -- the paths cannot diverge there. And
-    // the divergence only shows when the colliding row is not the one the flip fired on, since
-    // that row is emitted from the build loop either way.
+    // Both axes below matter. Splitting the plan by an exchange (or not) changes how the frozen
+    // map output merges with the streamed rows -- the generated path must be told whether its
+    // output is buffered or feeds the `Final`'s `doConsume` directly -- so the two shapes are
+    // exercised separately. And the divergence only shows when the colliding row is not the one
+    // the flip fired on, since that row is emitted from the build loop either way.
     for {
       splits <- Seq(1, 2)
       derivedKey <- Seq(false, true)
@@ -790,6 +837,29 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
         assert(numBypassingRows(df) == 0,
           "an aggregation collapsing ~17 rows per key must not bypass; fast-map hits are " +
             "missing from the numerator if it does")
+      }
+    }
+  }
+
+  test("a distinct-heavy prefix commits the task even when later rows collapse") {
+    // The flip is one-way, so the decision is made from the rows seen so far, not the partition as
+    // a whole. Here the first `minRows` rows are all distinct, so the periodic check bypasses and
+    // the pass-through stays on permanently: the remaining rows -- which all collapse onto a single
+    // key and would have aggregated well -- stream through as single-row partial buffers. The
+    // overall compaction ratio (40 rows / 8 keys = 5.0) would keep aggregation, but the prefix has
+    // already committed the task. The mirror case (a compacting prefix with a distinct tail) is
+    // covered by the test above; this pins the other side of the same asymmetry.
+    forEachCodegenAndMap() { clue =>
+      val df = () => spark.range(0, 40, 1, 1)
+        .select(when($"id" < 8, $"id").otherwise(lit(0L)) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        val c = runAndReadCounters(df)
+        assert(c.skipped == 32,
+          s"expected the 32 rows after the flip to bypass, got ${c.skipped}")
+        assert(c.partialOutputRows == 40,
+          s"expected every input row to stream through the partial, got ${c.partialOutputRows}")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -85,7 +85,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
           SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
-          // Small sample so the no-spill (the periodic check) path triggers on modest inputs.
+          // Small `minRows` so the periodic check runs on modest inputs.
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8") ++
           spillConf ++ fixedPlanConfs): _*) {
         val msg = s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap forceSpill=$forceSpill"
@@ -170,10 +170,10 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   /**
    * Runs `body` once per (wholeStage, twoLevelMap) combination with the feature enabled and a small
-   * sample, threading a descriptive clue for failure messages.
+   * `minRows`, threading a descriptive clue for failure messages.
    *
-   * The fast (first-level) map is append-only and never spills; adaptive partial aggregation
-   * governs only the regular (second-level) map. With the default fast-map capacity (2^16) a small
+   * The fast (first-level) map is append-only and never spills, so only the regular (second-level)
+   * map can reach a spill boundary. With the default fast-map capacity (2^16) a small
    * high-cardinality input would be fully absorbed by the fast map and never reach the regular map,
    * so nothing could ever bypass. To make the triggering tests meaningful when the two-level map is
    * on, we shrink the fast map via the first field of `testFallbackStartsAt` so rows fall through
@@ -368,9 +368,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged when a large frozen map is output before pass-through streaming") {
-    // A larger sample lets the map accumulate many keys before the periodic check bypasses, so the
-    // early map output (which also frees the map) spans several drain cycles and re-enters the
-    // map-output function; the results must still match the feature-off reference.
+    // A larger `minRows` lets the map accumulate many keys before the periodic check bypasses,
+    // so the early map output (which also frees the map) spans several drain cycles and re-enters
+    // the map-output function; the results must still match the feature-off reference.
     val query = () => spark.range(0, 400000, 1, 1)
       .select($"id" as "k", $"id" as "v")
       .groupBy($"k")
@@ -487,7 +487,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   // (ROLLUP / CUBE / GROUPING SETS / multi-distinct). PR apache/spark#28804 statically disabled its
   // skip-partial-aggregate optimization whenever an Expand was present, but that was a performance
   // heuristic guarding its *static* row sampling, not a correctness requirement. Our decision is
-  // made at runtime from the observed reduction ratio, so we deliberately do not port that
+  // made at runtime from the observed compaction ratio, so we deliberately do not port that
   // exclusion. These tests assert results stay correct with the exclusion absent.
 
   test("results unchanged for ROLLUP (Expand below partial aggregate)") {
@@ -614,7 +614,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // The static PR#28804 heuristic would have refused to skip whenever an Expand was present; our
     // runtime decision skips because the expanded rows genuinely do not reduce. GROUPING SETS over
     // two single-column, fully-distinct sets is used (rather than ROLLUP/CUBE) so there is no
-    // grand-total group dragging the reduction ratio below the threshold: every expanded row is a
+    // grand-total group lifting the compaction ratio above the threshold: every expanded row is a
     // fresh key, so all configurations bypass.
     forEachCodegenAndMap() { clue =>
       withTempView("t") {
@@ -695,9 +695,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("the periodic check fires when the sample shows no reduction, without spilling") {
+  test("the periodic check fires when the ratio shows no reduction, without spilling") {
     // No forced regular-map spill: only the periodic check can trigger the bypass. Fully
-    // distinct keys over a small sample cross `noSpillReductionRatioThreshold`, so rows bypass and
+    // distinct keys give a compaction ratio of 1.0, below `minCompaction`, so rows bypass and
     // the regular map never spills.
     forEachCodegenAndMap() { clue =>
       val df = () => spark.range(0, 200, 1, 1)
@@ -707,7 +707,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       withClue(clue) {
         val c = runAndReadCounters(df)
         assert(c.skipped > 0,
-          "the periodic check should bypass fully distinct input under the sample")
+          "the periodic check should bypass fully distinct input")
         assert(c.spillBytes == 0, "the periodic check must decide before any spill happens")
         assert(c.tasksFallBacked == 0,
           "the periodic check must not fall back to sort-based aggregation")
@@ -717,7 +717,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   test("the spill check fires when the map would spill on high-cardinality input") {
     // Force the regular map to fall back quickly. High-cardinality input that reaches the fallback
-    // point should bypass via the spill check rather than spilling. Use a sample larger than the
+    // point should bypass via the spill check rather than spilling. Use a `minRows` larger than the
     // input so the periodic check cannot fire first and the spill check is the one exercised.
     forEachCodegenAndMap(minRows = 100000, regularFallback = 16) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
@@ -904,9 +904,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     spark.conf.unset(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION.key)
   }
 
-  test("larger sample defers the decision so a small high-cardinality input is not bypassed") {
-    // With a sample larger than the whole input and no regular-map spill forced, the periodic check
-    // point is never reached, so nothing bypasses even though the keys are fully distinct.
+  test("a larger minRows defers the decision so a small high-cardinality input is not bypassed") {
+    // With `minRows` larger than the whole input and no regular-map spill forced, the periodic
+    // check point is never reached, so nothing bypasses even though the keys are fully distinct.
     forEachCodegenAndMap(minRows = 100000) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
         .select($"id" as "k", $"id" as "v")
@@ -914,7 +914,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
         .agg(sum($"v") as "s")
       withClue(clue) {
         assert(numBypassingRows(df) == 0,
-          "no bypass expected before the sample size is reached")
+          "no bypass expected before `minRows` rows have been processed")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -720,13 +720,79 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // a different order than a non-bypassed run, and the generated path disagreed with the
     // interpreted one. The fan-out child reports `needCopyResult`, so the drained maps can run
     // right after the trigger row, restoring the merge order.
+    //
+    // The colliding key must not be the first one the map drains: key 0 is emitted before any
+    // bypassed row can overtake it, so `lit(0L)` cannot expose the interleaving. Key 6 is inserted
+    // early (by id 3) but drained after keys 0-5, so a bypassed row colliding with it lands ahead
+    // of its map buffer unless the drain finishes before the fan-out batch continues.
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 20, 1, parts)
         .select($"id", explode(array(
           $"id" * 2,
-          when($"id" === 4, lit(0L)).otherwise($"id" * 2 + 1))) as "k")
+          when($"id" === 4, lit(6L)).otherwise($"id" * 2 + 1))) as "k")
         .select($"k", ($"id" * 100 + $"k") as "v")
         .groupBy($"k").agg(first($"v") as "f", last($"v") as "l")
+    }
+  }
+
+  test("a wide fan-out drains the whole frozen map before streaming the batch") {
+    // A pass-through row must not carry one map row with it: in the split shape the frozen map
+    // interleaves with the trigger row's fan-out batch, so a colliding key in that batch is safe
+    // only if the drain already finished. This batch is four rows wide and collides twice, so any
+    // drain that stops short of the full map breaks the merge order for at least one collision.
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 20, 1, parts)
+        .select($"id", explode(array(
+          $"id" * 4,
+          when($"id" === 2, lit(3L)).otherwise($"id" * 4 + 1),
+          $"id" * 4 + 2,
+          when($"id" === 2, lit(7L)).otherwise($"id" * 4 + 3))) as "k")
+        .select($"k", ($"id" * 100 + $"k") as "v")
+        .groupBy($"k").agg(first($"v") as "f", last($"v") as "l")
+    }
+  }
+
+  test("a frozen map larger than the fan-out batch preserves the merge order") {
+    // The interleave window is as wide as the trigger row's fan-out batch, so a small map can
+    // finish draining within it; this query grows the map well past the batch width, so a drain
+    // that stops short of the whole map leaves the colliding key's buffer behind it.
+    //
+    // The generated and interpreted paths must agree on the merge order, or `wholeStage` becomes
+    // observable, so each cell compares them directly. There is no feature-off comparison: in the
+    // forced-fallback cells the colliding key's rows straddle the `Final`'s own spill, whose
+    // sort-based re-merge inverts `first`/`last` on both paths alike.
+    for {
+      splits <- Seq(1, 2)
+      twoLevelMap <- Seq(true, false)
+      forceSpill <- Seq(true, false)
+    } {
+      val query = () => {
+        spark.range(0, 100, 1, splits)
+          .select($"id", explode(array(
+            $"id" * 2,
+            when($"id" === 16, lit(5L)).otherwise($"id" * 2 + 1))) as "k")
+          .select($"k", ($"id" * 100 + $"k") as "v")
+          .groupBy($"k").agg(first($"v") as "f", last($"v") as "l")
+      }
+      val spillConf = if (forceSpill) {
+        Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
+      } else {
+        Nil
+      }
+      def run(wholeStage: Boolean): DataFrame = withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "32") ++
+          spillConf ++ fixedPlanConfs): _*) {
+        query()
+      }
+      val generated = run(wholeStage = true)
+      val interpreted = run(wholeStage = false)
+      withClue(s"splits=$splits twoLevelMap=$twoLevelMap forceSpill=$forceSpill: ") {
+        checkAnswer(generated, interpreted)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -28,16 +28,17 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Tests for runtime adaptive partial aggregation
  * (see [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]). When a partial aggregate is not reducing
  * rows, the operator stops aggregating and streams the remaining rows through as single-row partial
- * buffers for the Final aggregate to merge. Ordinary aggregate results stay equivalent; an
- * order-sensitive aggregate such as `first`/`last` can merge its buffers in a different order, so
- * only agreement between the generated and interpreted paths is guaranteed.
+ * buffers for the Final aggregate to merge. Once pass-through is active the map is frozen, and its
+ * output always precedes the passed-through rows: a row that collides with a frozen key is held
+ * behind the map and flushed only after it drains, so every group merges its buffers in the same
+ * order as a run that never bypasses, including order-sensitive aggregates such as `first`/`last`.
  *
  * The suite has two halves:
- *   1. Correctness: ordinary aggregate results are identical to the reference (feature-off) run
- *      across the full matrix of codegen on/off, two-level map on/off, and spill/no-spill, over a
- *      range of aggregate shapes, key types, and `Expand`-bearing plans (ROLLUP / CUBE / GROUPING
- *      SETS / multi-distinct). Order-sensitive aggregates are tested separately for cross-path
- *      agreement rather than against the reference.
+ *   1. Correctness: aggregate results are identical to the reference (feature-off) run across the
+ *      full matrix of codegen on/off, two-level map on/off, and spill/no-spill, over a range of
+ *      aggregate shapes, key types, and `Expand`-bearing plans (ROLLUP / CUBE / GROUPING SETS /
+ *      multi-distinct). Order-sensitive aggregates are tested against the reference too, including
+ *      under a fan-out child that queues its whole batch behind the frozen map.
  *   2. Triggering: the `numBypassingRows` metric proves the bypass actually fires when (and only
  *      when) it should -- high-cardinality input bypasses, low-cardinality input keeps aggregating,
  *      the feature switch and eligibility rules are honored, and both check points work.
@@ -657,26 +658,31 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("both execution paths agree on an order-sensitive aggregate") {
-    // Bypassing merges a group's buffers in a different order than a run that never bypasses:
-    // the first bypassed row is emitted ahead of the frozen map, and the rows streamed after it
-    // trail the map output. That order is not a promise -- what must hold is that the generated
-    // and interpreted paths produce the *same* result, or `spark.sql.codegen.wholeStage` becomes
-    // observable. The test deliberately does not compare against a non-bypassed run.
+    // Bypassing must merge a group's buffers in the same order as a run that never bypasses: a
+    // group can straddle the freeze and hold both a map buffer and pass-through buffers, and the
+    // `Final` merges in emit order. The queue holds each passed-through row behind the frozen map
+    // and flushes it only after the map drains, so the map buffer always precedes the colliding
+    // pass-through buffers on both execution paths -- exactly the merge order of a run that never
+    // bypasses, so every enabled cell must match the feature-off reference and
+    // `spark.sql.codegen.wholeStage` must not be observable.
     //
     // The flip fires at the first periodic check: with `minRows=8` it lands on the 8th aggregated
     // row, when the map already holds 8 distinct keys (id 0 maps to -1, ids 1-7 to keys 1-7), so
     // the compaction ratio 1.0 is below `minCompaction` (1.05) and every remaining row streams;
     // id 8 is the first bypassed row. At `dupAt=8` the colliding row is that first bypassed row,
-    // so its buffer reaches the `Final` before the frozen map's and `first`/`last` invert. At
-    // `dupAt=9` the colliding row streams after the map and the group stays in input order.
-    //
-    // Both plan shapes are exercised separately. Splitting the aggregates with an `Exchange` (or
-    // not) changes how the frozen map output merges with the streamed rows -- the generated path
-    // must be told whether its output is buffered or feeds the `Final`'s `doConsume` directly.
+    // queued behind the frozen map and flushed only after the map drains, so its buffer still
+    // reaches the `Final` after the frozen map's and `first`/`last` match the merge order; at
+    // `dupAt=9` the colliding row streams directly after the map and the group stays in input
+    // order. Both plan shapes are exercised separately: splitting the aggregates with an
+    // `Exchange` (or not) changes whether streamed rows pass through
+    // `BufferedRowIterator.currentRows` or feed the `Final`'s `doConsume` directly.
     for {
       splits <- Seq(1, 2)
       derivedKey <- Seq(false, true)
       dupAt <- Seq(8, 9)
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+      forceSpill <- Seq(true, false)
     } {
       val query = () => {
         val base = when($"id" === 0 || $"id" === dupAt, lit(-1L)).otherwise($"id")
@@ -686,45 +692,40 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           .groupBy($"k")
           .agg(first($"v") as "f", last($"v") as "l")
       }
-      val results = for {
-        wholeStage <- Seq(true, false)
-        twoLevelMap <- Seq(true, false)
-        forceSpill <- Seq(true, false)
-      } yield {
-        val spillConf = if (forceSpill) {
-          Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
-        } else {
-          Nil
-        }
-        withSQLConf(
-          (Seq(
-            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
-            SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
-            SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
-            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8") ++
-            spillConf ++ fixedPlanConfs): _*) {
-          query().collect().toSeq.map(_.toString()).sorted
-        }
+      val spillConf = if (forceSpill) {
+        Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
+      } else {
+        Nil
       }
-      withClue(s"splits=$splits derivedKey=$derivedKey dupAt=$dupAt: ") {
-        assert(results.distinct.length == 1,
-          s"the execution paths disagree: ${results.distinct.map(_.mkString("[", ",", "]"))}")
+      def run(enabled: Boolean): Seq[String] = withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> enabled.toString,
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8") ++
+          spillConf ++ fixedPlanConfs): _*) {
+        query().collect().toSeq.map(_.toString()).sorted
+      }
+      withClue(s"splits=$splits derivedKey=$derivedKey dupAt=$dupAt " +
+        s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap forceSpill=$forceSpill: ") {
+        assert(run(enabled = true) == run(enabled = false),
+          "adaptive partial aggregation changed an order-sensitive result")
       }
     }
   }
 
   test("fan-out below a split aggregate preserves the merge order") {
     // A `GenerateExec` expands a collection without checking `shouldStop()`, so in the
-    // exchange-split shape the whole fan-out batch of the trigger input row used to be appended
-    // before the frozen maps drained. A group whose rows straddle the freeze point then merged in
-    // a different order than a non-bypassed run, and the generated path disagreed with the
-    // interpreted one. The fan-out child reports `needCopyResult`, so the drained maps can run
-    // right after the trigger row, restoring the merge order.
+    // exchange-split shape the whole fan-out batch of the trigger input row is queued at once
+    // rather than one row at a time. Each queued row advances the frozen-map output by one row,
+    // and the queue is flushed only after the map fully drains, so a group whose rows straddle
+    // the freeze point still merges its map buffer before its pass-through buffers, matching a
+    // non-bypassed run.
     //
     // The colliding key must not be the first one the map drains: key 0 is emitted before any
     // bypassed row can overtake it, so `lit(0L)` cannot expose the interleaving. Key 6 is inserted
     // early (by id 3) but drained after keys 0-5, so a bypassed row colliding with it lands ahead
-    // of its map buffer unless the drain finishes before the fan-out batch continues.
+    // of its map buffer unless the map output still precedes the held batch.
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 20, 1, parts)
         .select($"id", explode(array(
@@ -735,11 +736,11 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("a wide fan-out drains the whole frozen map before streaming the batch") {
-    // A pass-through row must not carry one map row with it: in the split shape the frozen map
-    // interleaves with the trigger row's fan-out batch, so a colliding key in that batch is safe
-    // only if the drain already finished. This batch is four rows wide and collides twice, so any
-    // drain that stops short of the full map breaks the merge order for at least one collision.
+  test("a wide fan-out batch stays queued behind the frozen map") {
+    // A colliding key must not merge before its map buffer. This batch is four rows wide and
+    // collides twice, so the colliding pass-through rows must both wait behind the frozen map for
+    // the whole map to drain; a design that let any part of the batch escape ahead of the map
+    // breaks the merge order for at least one collision.
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 20, 1, parts)
         .select($"id", explode(array(
@@ -753,16 +754,14 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("a frozen map larger than the fan-out batch preserves the merge order") {
-    // The interleave window is as wide as the trigger row's fan-out batch, so a small map can
-    // finish draining within it; this query grows the map well past the batch width, so a drain
-    // that stops short of the whole map leaves the colliding key's buffer behind it.
-    //
-    // The generated and interpreted paths must agree on the merge order, or `wholeStage` becomes
-    // observable, so each cell compares them directly. There is no feature-off comparison: in the
-    // forced-fallback cells the colliding key's rows straddle the `Final`'s own spill, whose
-    // sort-based re-merge inverts `first`/`last` on both paths alike.
+    // The queue bounds the held rows to the batch width regardless of the map size, and the flush
+    // waits for the whole map to drain. This query grows the map well past the batch width, so a
+    // design that flushed the held rows early would leave the colliding key's map buffer behind
+    // them. Every enabled cell must match the feature-off reference, so each compares directly
+    // against a non-bypassed run, across both the generated and interpreted paths.
     for {
       splits <- Seq(1, 2)
+      wholeStage <- Seq(true, false)
       twoLevelMap <- Seq(true, false)
       forceSpill <- Seq(true, false)
     } {
@@ -779,27 +778,29 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       } else {
         Nil
       }
-      def run(wholeStage: Boolean): DataFrame = withSQLConf(
+      def run(enabled: Boolean): DataFrame = withSQLConf(
         (Seq(
-          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> enabled.toString,
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
           SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "32") ++
           spillConf ++ fixedPlanConfs): _*) {
         query()
       }
-      val generated = run(wholeStage = true)
-      val interpreted = run(wholeStage = false)
-      withClue(s"splits=$splits twoLevelMap=$twoLevelMap forceSpill=$forceSpill: ") {
-        checkAnswer(generated, interpreted)
+      val reference = run(enabled = false)
+      val adaptive = run(enabled = true)
+      withClue(s"splits=$splits wholeStage=$wholeStage " +
+        s"twoLevelMap=$twoLevelMap forceSpill=$forceSpill: ") {
+        checkAnswer(adaptive, reference)
       }
     }
   }
 
   test("results unchanged below a generator that cannot yield mid-fan-out") {
-    // `GenerateExec` expands a collection without checking `shouldStop()`, so the aggregate cannot
-    // rely on the child to bound the output buffer -- each streamed row has to be able to leave
-    // the build loop on its own.
+    // `GenerateExec` expands a collection without checking `shouldStop()`, so it cannot bound the
+    // output buffer between the rows of one input row. Each passed-through row queues a copy and
+    // advances the frozen-map output by one row, so the whole fan-out batch is held behind the map
+    // and the memory is bounded by the batch width rather than by how many rows the child emits.
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 1, 1, parts)
         .select(explode(sequence(lit(1), lit(500))) as "k")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -657,7 +657,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("both execution paths agree on an order-sensitive aggregate") {
+  test("order-sensitive aggregates match a non-bypassed run") {
     // Bypassing must merge a group's buffers in the same order as a run that never bypasses: a
     // group can straddle the freeze and hold both a map buffer and pass-through buffers, and the
     // `Final` merges in emit order. The queue holds each passed-through row behind the frozen map
@@ -722,15 +722,15 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // the freeze point still merges its map buffer before its pass-through buffers, matching a
     // non-bypassed run.
     //
-    // The colliding key must not be the first one the map drains: key 0 is emitted before any
-    // bypassed row can overtake it, so `lit(0L)` cannot expose the interleaving. Key 6 is inserted
-    // early (by id 3) but drained after keys 0-5, so a bypassed row colliding with it lands ahead
-    // of its map buffer unless the map output still precedes the held batch.
+    // The colliding row is the first row of the trigger batch, so it is the first one queued: a
+    // design that emitted queued rows ahead of the frozen map would put it before its map buffer.
+    // Key 2 is inserted early (by id 1) and drained third, so id 4's first exploded element
+    // collides with it; the other two fan-out tests cover collisions on later batch elements.
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 20, 1, parts)
         .select($"id", explode(array(
-          $"id" * 2,
-          when($"id" === 4, lit(6L)).otherwise($"id" * 2 + 1))) as "k")
+          when($"id" === 4, lit(2L)).otherwise($"id" * 2),
+          $"id" * 2 + 1)) as "k")
         .select($"k", ($"id" * 100 + $"k") as "v")
         .groupBy($"k").agg(first($"v") as "f", last($"v") as "l")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -682,7 +682,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     forEachCodegenAndMap() { clue =>
       // With the fast map on it holds 4 keys, so `k < 4` is served there and `k >= 4` falls
       // through. 400 hot-key rows against 4 hot keys plus 20 tail keys is a ratio of about 17.5,
-      // far above the default 1.1, so nothing may bypass.
+      // far above the default, so nothing may bypass.
       val df = () => spark.range(0, 420, 1, 1)
         .select(when($"id" < 400, $"id" % 4).otherwise($"id" - 396) as "k", $"id" as "v")
         .groupBy($"k")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -179,7 +179,10 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
    * to the regular map. `regularFallback` optionally sets the second field to also force the
    * regular map to spill (for the on-spill tier); when 0 the regular map does not spill.
    */
-  private def forEachCodegenAndMap(sampleRows: Int = 8, regularFallback: Int = 0)(
+  private def forEachCodegenAndMap(
+      sampleRows: Int = 8,
+      regularFallback: Int = 0,
+      noSpillThreshold: Double = -1.0)(
       body: String => Unit): Unit = {
     for {
       wholeStage <- Seq(true, false)
@@ -194,13 +197,20 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       } else {
         Nil
       }
+      // A negative value means "leave the threshold at its default".
+      val thresholdConf = if (noSpillThreshold >= 0.0) {
+        Seq(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_NO_SPILL_REDUCTION_RATIO_THRESHOLD.key ->
+          noSpillThreshold.toString)
+      } else {
+        Nil
+      }
       withSQLConf(
         (Seq(
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
           SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> sampleRows.toString) ++
-          fallbackConf ++ fixedPlanConfs): _*) {
+          fallbackConf ++ thresholdConf ++ fixedPlanConfs): _*) {
         body(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap")
       }
     }
@@ -709,6 +719,59 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           assert(c.tasksFallBacked > 0,
             "feature disabled: the forced fallback should trigger sort-based aggregation")
         }
+      }
+    }
+  }
+
+  test("spill tier decides identically at the exact ratio boundary with codegen on and off") {
+    // The on-spill tier evaluates the ratio over the rows already aggregated, excluding the failed
+    // insertion that becomes the first pass-through row, so both execution paths must judge the
+    // same row set and reach the same decision. `id % 40` over 400 rows gives 40 distinct keys
+    // when the map fills at 50 aggregated rows, i.e. a ratio of exactly 0.8: at the threshold the
+    // bypass fires, just above it (0.85) it does not.
+    Seq(0.8 -> true, 0.85 -> false).foreach { case (threshold, shouldBypass) =>
+      val skippedPerCodegen = Seq(true, false).map { wholeStage =>
+        withSQLConf(
+          (Seq(
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+            SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+            SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> "false",
+            // A sample larger than the input keeps the no-spill tier out of the picture.
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> "100000",
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SPILL_REDUCTION_RATIO_THRESHOLD.key ->
+              threshold.toString,
+            "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 50") ++
+            fixedPlanConfs): _*) {
+          val df = () => spark.range(0, 400, 1, 1)
+            .select(($"id" % 40) as "k", $"id" as "v")
+            .groupBy($"k")
+            .agg(sum($"v") as "s")
+          withClue(s"threshold=$threshold wholeStage=$wholeStage") {
+            numBypassingRows(df)
+          }
+        }
+      }
+      withClue(s"threshold=$threshold skipped=$skippedPerCodegen") {
+        assert(skippedPerCodegen.forall(_ > 0) == shouldBypass,
+          s"expected bypass=$shouldBypass at the ratio boundary")
+        assert(skippedPerCodegen.map(_ > 0).distinct.length == 1,
+          "codegen and interpreted paths must reach the same decision at the boundary")
+      }
+    }
+  }
+
+  test("a zero threshold always bypasses once the sample has been processed") {
+    // 0 is the most aggressive setting: the ratio check `distinctKeys >= rows * 0` always holds,
+    // so even a low-cardinality input that the default threshold keeps aggregating is bypassed
+    // right after the sample. The results must still match the feature-off reference.
+    forEachCodegenAndMap(noSpillThreshold = 0.0) { clue =>
+      val df = () => spark.range(0, 600, 1, 1)
+        .select(($"id" % 5) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        assert(numBypassingRows(df) > 0,
+          "a zero threshold must bypass even a low-cardinality input")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -62,19 +62,35 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     SQLConf.REPLACE_HASH_WITH_SORT_AGG_ENABLED.key -> "false")
 
   /**
-   * Runs `df` with adaptive partial aggregation disabled (the reference) and then across the full
-   * configuration matrix with it enabled, asserting every enabled run matches the reference.
+   * Runs `build` with adaptive partial aggregation disabled (the reference) and then across the
+   * full configuration matrix with it enabled, asserting every enabled run matches the reference.
+   *
+   * `build` takes the number of input partitions, which the matrix varies along with everything
+   * else, because the plan shape decides which parts of the feature run at all. When the two
+   * aggregates end up in one whole-stage -- no `Exchange` between them -- the partial aggregate's
+   * output feeds the Final's `doConsume` directly and never reaches
+   * `BufferedRowIterator.currentRows`, so `shouldStop()` stays false for the whole build and
+   * neither `needStopCheck` nor the resumed-build path is exercised. Splitting them puts the
+   * streamed rows through the output buffer and runs both.
+   *
+   * More than one input partition is necessary but not sufficient for that split: a `Range` keyed
+   * directly on `id` already reports an output partitioning that satisfies the Final aggregate's
+   * `ClusteredDistribution`, so `EnsureRequirements` inserts no `Exchange` however many partitions
+   * it has. Tests that want the split shape group on a derived key (a cast, say) so the input
+   * partitioning no longer satisfies the requirement.
    */
-  private def checkAdaptiveMatchesReference(build: () => DataFrame): Unit = {
-    val reference = withSQLConf(
-      (SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") +: fixedPlanConfs: _*) {
-      build().collect().toSeq
-    }
+  private def checkAdaptiveMatchesReference(build: Int => DataFrame): Unit = {
     for {
+      inputPartitions <- Seq(1, 2)
       wholeStage <- Seq(true, false)
       twoLevelMap <- Seq(true, false)
       forceSpill <- Seq(true, false)
     } {
+      // The reference is built with the same partitioning, so only the feature differs.
+      val reference = withSQLConf(
+        (SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") +: fixedPlanConfs: _*) {
+        build(inputPartitions).collect().toSeq
+      }
       val spillConf = if (forceSpill) {
         Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
       } else {
@@ -88,9 +104,10 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           // Small `minRows` so the periodic check runs on modest inputs.
           SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8") ++
           spillConf ++ fixedPlanConfs): _*) {
-        val msg = s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap forceSpill=$forceSpill"
+        val msg = s"inputPartitions=$inputPartitions wholeStage=$wholeStage " +
+          s"twoLevelMap=$twoLevelMap forceSpill=$forceSpill"
         withClue(msg) {
-          checkAnswer(build(), reference)
+          checkAnswer(build(inputPartitions), reference)
         }
       }
     }
@@ -226,9 +243,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   test("results unchanged for high-cardinality input that bypasses partial aggregation") {
     // Every grouping key is distinct, so partial aggregation reduces nothing and should be
     // bypassed by the periodic check.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 200, 1, 1)
-        .select($"id" as "k", ($"id" * 2) as "v")
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 200, 1, parts)
+        .select($"id".cast("string") as "k", ($"id" * 2) as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s", count(lit(1)) as "c", max($"v") as "m")
     }
@@ -236,9 +253,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   test("results unchanged for low-cardinality input that keeps partial aggregation") {
     // Few distinct keys, high reduction: partial aggregation is effective and should be kept.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 600, 1, 1)
-        .select(($"id" % 5) as "k", $"id" as "v")
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 600, 1, parts)
+        .select(($"id" % 5).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s", count(lit(1)) as "c", min($"v") as "mn", max($"v") as "mx")
     }
@@ -246,17 +263,17 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   test("results unchanged for medium-cardinality input near the reduction threshold") {
     // Roughly half the rows are distinct keys; exercises the boundary of the ratio checks.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 1000, 1, 1)
-        .select(($"id" % 500) as "k", $"id" as "v")
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 1000, 1, parts)
+        .select(($"id" % 500).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s", count(lit(1)) as "c")
     }
   }
 
   test("results unchanged with multiple grouping keys and string keys") {
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 500, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 500, 1, parts)
         .select(
           concat(lit("g"), ($"id" % 300).cast("string")) as "k1",
           ($"id" % 7) as "k2",
@@ -270,10 +287,10 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // Nulls are sparse enough (1 in 40) that the keys stay close to unique and the input really
     // does bypass; a denser null key would lift the compaction ratio above the threshold and the
     // test would never engage the feature.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 400, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 400, 1, parts)
         .select(
-          when($"id" % 40 === 0, lit(null)).otherwise($"id") as "k",
+          when($"id" % 40 === 0, lit(null)).otherwise($"id").cast("string") as "k",
           $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s", count(lit(1)) as "c")
@@ -282,9 +299,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   test("results unchanged with average (multi-slot buffer) aggregate") {
     // avg has a two-slot partial buffer (sum, count); pass-through buffers must carry all slots.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 300, 1, 1)
-        .select($"id" as "k", ($"id" + 1) as "v")
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 300, 1, parts)
+        .select($"id".cast("string") as "k", ($"id" + 1) as "v")
         .groupBy($"k")
         .agg(avg($"v") as "a", sum($"v") as "s")
     }
@@ -293,8 +310,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   test("results unchanged with a mix of many aggregate functions and buffer types") {
     // Exercises a wide pass-through buffer spanning several aggregate buffer layouts at once:
     // sum (decimal), avg (double), count, min/max, first/last, and stddev (imperative buffer).
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 400, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 400, 1, parts)
         .select(
           $"id" as "k",
           ($"id" % 97).cast("decimal(10,2)") as "d",
@@ -322,9 +339,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // filter guard actually runs in the pass-through path.
     withTempView("t") {
       spark.range(0, 400, 1, 1)
-        .select($"id" as "k", ($"id" % 100) as "v")
+        .select($"id".cast("string") as "k", ($"id" % 100) as "v")
         .createOrReplaceTempView("t")
-      checkAdaptiveMatchesReference { () =>
+      checkAdaptiveMatchesReference { parts =>
         spark.sql(
           """SELECT k,
             |       sum(v) FILTER (WHERE v % 2 = 0) AS s_even,
@@ -338,8 +355,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged with decimal and date grouping keys") {
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 300, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 300, 1, parts)
         .select(
           ($"id" % 280).cast("decimal(12,3)") as "k1",
           date_add(lit(java.sql.Date.valueOf("2020-01-01")), ($"id" % 250).cast("int")) as "k2",
@@ -353,8 +370,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // No aggregate functions: the pass-through buffer is a zero-column UnsafeRow, so the output is
     // just the grouping key. High-cardinality keys should bypass, and the de-duplicated result must
     // still match the reference.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 400, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 400, 1, parts)
         .select(($"id" % 350) as "k1", ($"id" % 11) as "k2")
         .distinct()
     }
@@ -366,8 +383,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // plan. With duplicate keys, a bypassing `Final` would skip its de-duplication and return
     // duplicate rows. The two-level map off variants route the rows to the regular map so the
     // periodic check fires and the regression would show up.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 1000, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 1000, 1, parts)
         .select(($"id" % 10) as "c")
         .distinct()
     }
@@ -378,7 +395,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // so the early map output (which also frees the map) spans several drain cycles and re-enters
     // the map-output function; the results must still match the feature-off reference.
     val query = () => spark.range(0, 400000, 1, 1)
-      .select($"id" as "k", $"id" as "v")
+      .select($"id".cast("string") as "k", $"id" as "v")
       .groupBy($"k")
       .agg(sum($"v") as "s")
     withSQLConf(
@@ -395,9 +412,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("distinct aggregation stays correct") {
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 300, 1, 1)
-        .select($"id" as "k", ($"id" % 50) as "v")
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 300, 1, parts)
+        .select($"id".cast("string") as "k", ($"id" % 50) as "v")
         .groupBy($"k")
         .agg(countDistinct($"v") as "cd", sum($"v") as "s")
     }
@@ -409,7 +426,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // phase are de-duplicated and pass-through carries exactly one distinct value each.
     forEachCodegenAndMap() { clue =>
       val df = () => spark.range(0, 1000, 1, 1)
-        .select(($"id" % 100) as "k", $"id" as "v")
+        .select(($"id" % 100).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(countDistinct($"v") as "cd")
       withClue(clue) {
@@ -425,7 +442,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // de-duplication partial (2 grouping keys) reduce nothing, so it must bypass.
     forEachCodegenAndMap() { clue =>
       val df = () => spark.range(0, 400, 1, 1)
-        .select(($"id" % 4) as "k", $"id" as "v")
+        .select(($"id" % 4).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(countDistinct($"v") as "cd")
       withClue(clue) {
@@ -442,7 +459,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // (1 grouping key) sees a fresh key per row and must bypass.
     forEachCodegenAndMap() { clue =>
       val df = () => spark.range(0, 400, 1, 1)
-        .select($"id" as "k", ($"id" % 2) as "v")
+        .select($"id".cast("string") as "k", ($"id" % 2) as "v")
         .groupBy($"k")
         .agg(countDistinct($"v") as "cd")
       withClue(clue) {
@@ -459,7 +476,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // and the distinct partial counts them, so the result must still match the reference.
     forEachCodegenAndMap() { clue =>
       val df = () => spark.range(0, 400, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(countDistinct($"v") as "cd")
       withClue(clue) {
@@ -481,9 +498,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged with an empty input") {
-    checkAdaptiveMatchesReference { () =>
+    checkAdaptiveMatchesReference { parts =>
       spark.range(0, 0, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s", count(lit(1)) as "c")
     }
@@ -503,8 +520,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   // high-cardinality input below an Expand`, cover an Expand that bypasses.
 
   test("results unchanged for ROLLUP (Expand below partial aggregate)") {
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 400, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 400, 1, parts)
         .select(($"id" % 200) as "k1", ($"id" % 7) as "k2", $"id" as "v")
         .rollup($"k1", $"k2")
         .agg(sum($"v") as "s", count(lit(1)) as "c")
@@ -512,8 +529,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged for CUBE (Expand below partial aggregate)") {
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 400, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 400, 1, parts)
         .select(($"id" % 150) as "k1", ($"id" % 5) as "k2", $"id" as "v")
         .cube($"k1", $"k2")
         .agg(sum($"v") as "s", count(lit(1)) as "c")
@@ -528,7 +545,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       spark.range(0, 400, 1, 1)
         .select($"id" as "k1", ($"id" + 1000) as "k2", $"id" as "v")
         .createOrReplaceTempView("t")
-      checkAdaptiveMatchesReference { () =>
+      checkAdaptiveMatchesReference { parts =>
         spark.sql(
           """SELECT k1, k2, sum(v) AS s, count(1) AS c
             |FROM t
@@ -538,9 +555,9 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
   }
 
   test("results unchanged for multi-distinct (Expand below partial aggregate)") {
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 400, 1, 1)
-        .select(($"id" % 100) as "k", ($"id" % 30) as "a", ($"id" % 40) as "b")
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 400, 1, parts)
+        .select(($"id" % 100).cast("string") as "k", ($"id" % 30) as "a", ($"id" % 40) as "b")
         .groupBy($"k")
         .agg(countDistinct($"a") as "da", countDistinct($"b") as "db", sum($"a") as "s")
     }
@@ -551,56 +568,84 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // output buffer returns only as far as the aggregate's build loop. Reaching the end of the
     // child's produce therefore does not mean the input is exhausted, and treating it as such
     // drops the rest of the partition.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 100, 1, 2).union(spark.range(100, 200, 1, 2)).groupBy("id").count()
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 100, 1, parts + 1)
+        .union(spark.range(100, 200, 1, parts + 1))
+        .groupBy("id").count()
+    }
+  }
+
+  test("results unchanged when an Exchange separates the two aggregates") {
+    // Grouping on a derived key stops the `Range`'s output partitioning from satisfying the Final
+    // aggregate's `ClusteredDistribution`, so the plan keeps an `Exchange` and the two aggregates
+    // land in separate whole-stages. That is the shape where streamed rows actually pass through
+    // `BufferedRowIterator.currentRows` -- fused, they go straight into the Final's hash map and
+    // neither `needStopCheck` nor the resumed build is reached.
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 200, 1, parts)
+        .select($"id".cast("string") as "k", ($"id" * 2) as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c", max($"v") as "m")
     }
   }
 
   test("both execution paths agree on an order-sensitive aggregate") {
-    // Bypassing emits a group's streamed rows ahead of the ones its map still holds, so
-    // `first`/`last` see a different merge order than an unbypassed run. Whether that order is
-    // guaranteed is a separate question -- what must hold is that the generated and interpreted
-    // paths agree, or `spark.sql.codegen.wholeStage` would be observable in the result.
+    // Bypassing merges a group's buffers in a different order than an unbypassed run: the rows
+    // streamed after the flip reach the `Final` aggregate before the ones the maps still hold.
+    // That order is not guaranteed -- what must hold is that the generated and interpreted paths
+    // produce the *same* result, or `spark.sql.codegen.wholeStage` becomes observable.
     //
-    // Key -1 takes the first and last input rows; the rest are distinct, so the bypass fires early
-    // and leaves row 0 in the map while row 8 streams past it.
-    val query = () => spark.range(0, 9, 1, 1)
-      .select(
-        when($"id" === 0 || $"id" === 8, lit(-1L)).otherwise($"id") as "k",
-        $"id" as "v")
-      .groupBy($"k")
-      .agg(first($"v") as "f", last($"v") as "l")
-
-    val results = for {
-      wholeStage <- Seq(true, false)
-      twoLevelMap <- Seq(true, false)
-      forceSpill <- Seq(true, false)
-    } yield {
-      val spillConf = if (forceSpill) {
-        Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
-      } else {
-        Nil
+    // Both axes below matter. A single input partition, or a key the input is already partitioned
+    // by, fuses the two aggregates into one whole-stage, where streamed rows go straight into the
+    // Final's hash map and never reach the output buffer -- the paths cannot diverge there. And
+    // the divergence only shows when the colliding row is not the one the flip fired on, since
+    // that row is emitted from the build loop either way.
+    for {
+      splits <- Seq(1, 2)
+      derivedKey <- Seq(false, true)
+      dupAt <- Seq(8, 9)
+    } {
+      val query = () => {
+        val base = when($"id" === 0 || $"id" === dupAt, lit(-1L)).otherwise($"id")
+        spark.range(0, 40, 1, splits)
+          .select(if (derivedKey) base.cast("string") else base as "k", $"id" as "v")
+          .toDF("k", "v")
+          .groupBy($"k")
+          .agg(first($"v") as "f", last($"v") as "l")
       }
-      withSQLConf(
-        (Seq(
-          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
-          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
-          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
-          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "2") ++
-          spillConf ++ fixedPlanConfs): _*) {
-        query().collect().toSeq.sortBy(_.getLong(0))
+      val results = for {
+        wholeStage <- Seq(true, false)
+        twoLevelMap <- Seq(true, false)
+        forceSpill <- Seq(true, false)
+      } yield {
+        val spillConf = if (forceSpill) {
+          Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
+        } else {
+          Nil
+        }
+        withSQLConf(
+          (Seq(
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+            SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+            SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+            SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "8") ++
+            spillConf ++ fixedPlanConfs): _*) {
+          query().collect().toSeq.map(_.toString()).sorted
+        }
+      }
+      withClue(s"splits=$splits derivedKey=$derivedKey dupAt=$dupAt: ") {
+        assert(results.distinct.length == 1,
+          s"the execution paths disagree: ${results.distinct.map(_.mkString("[", ",", "]"))}")
       }
     }
-    assert(results.distinct.length == 1,
-      s"the execution paths disagree: ${results.map(_.mkString("[", ",", "]")).distinct}")
   }
 
   test("results unchanged below a generator that cannot yield mid-fan-out") {
     // `GenerateExec` expands a collection without checking `shouldStop()`, so the aggregate cannot
     // rely on the child to bound the output buffer -- each streamed row has to be able to leave
     // the build loop on its own.
-    checkAdaptiveMatchesReference { () =>
-      spark.range(0, 1, 1, 1)
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 1, 1, parts)
         .select(explode(sequence(lit(1), lit(500))) as "k")
         .groupBy($"k").count()
     }
@@ -614,7 +659,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     forEachCodegenAndMap() { clue =>
       // Fully distinct keys: partial aggregation reduces nothing, so rows must bypass.
       val highCard = () => spark.range(0, 200, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -623,7 +668,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       }
       // Few distinct keys, high reduction: partial aggregation is effective, nothing bypasses.
       val lowCard = () => spark.range(0, 600, 1, 1)
-        .select(($"id" % 5) as "k", $"id" as "v")
+        .select(($"id" % 5).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -650,7 +695,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     forEachCodegenAndMap() { clue =>
       withTempView("t") {
         spark.range(0, 200, 1, 1)
-          .select($"id" as "k", ($"id" % 100) as "v")
+          .select($"id".cast("string") as "k", ($"id" % 100) as "v")
           .createOrReplaceTempView("t")
         val df = () => spark.sql(
           """SELECT k, sum(v) FILTER (WHERE v % 2 = 0) AS s
@@ -701,7 +746,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
           SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString) ++ fixedPlanConfs): _*) {
         val df = () => spark.range(0, 200, 1, 1)
-          .select($"id" as "k", $"id" as "v")
+          .select($"id".cast("string") as "k", $"id" as "v")
           .groupBy($"k")
           .agg(sum($"v") as "s")
         withClue(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap") {
@@ -755,7 +800,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // the regular map never spills.
     forEachCodegenAndMap() { clue =>
       val df = () => spark.range(0, 200, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -775,7 +820,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // input so the periodic check cannot fire first and the spill check is the one exercised.
     forEachCodegenAndMap(minRows = 100000, regularFallback = 16) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -845,7 +890,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           "spark.sql.TungstenAggregate.testFallbackStartsAt" -> s"$fastCap, 16") ++
           fixedPlanConfs): _*) {
         val df = () => spark.range(0, 200, 1, 1)
-          .select($"id" as "k", $"id" as "v")
+          .select($"id".cast("string") as "k", $"id" as "v")
           .groupBy($"k")
           .agg(sum($"v") as "s")
         withClue(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap") {
@@ -877,7 +922,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
             "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 50") ++
             fixedPlanConfs): _*) {
           val df = () => spark.range(0, 400, 1, 1)
-            .select(($"id" % 40) as "k", $"id" as "v")
+            .select(($"id" % 40).cast("string") as "k", $"id" as "v")
             .groupBy($"k")
             .agg(sum($"v") as "s")
           withClue(s"minCompaction=$minCompaction wholeStage=$wholeStage") {
@@ -900,7 +945,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // check point. The results must still match the feature-off reference.
     forEachCodegenAndMap(minCompaction = 1000000.0) { clue =>
       val df = () => spark.range(0, 600, 1, 1)
-        .select(($"id" % 5) as "k", $"id" as "v")
+        .select(($"id" % 5).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -917,7 +962,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // periodic check is genuinely off rather than merely deferred.
     forEachCodegenAndMap(minRows = 0) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -932,7 +977,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // bypasses instead of paying the spill I/O, which is the spill-only operating mode.
     forEachCodegenAndMap(minRows = 0, regularFallback = 16) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -963,7 +1008,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     // check point is never reached, so nothing bypasses even though the keys are fully distinct.
     forEachCodegenAndMap(minRows = 100000) { clue =>
       val df = () => spark.range(0, 200, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -983,7 +1028,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       // partial aggregate emits far more than the handful of keys a real aggregation would. Read
       // all counters from a single execution so the metrics are not double-counted.
       val highCard = () => spark.range(0, numRows, 1, 1)
-        .select($"id" as "k", $"id" as "v")
+        .select($"id".cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {
@@ -1001,7 +1046,7 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
       // Low-cardinality reference: partial aggregation stays effective, so its output equals the
       // small number of distinct keys and nothing is bypassed.
       val lowCard = () => spark.range(0, 600, 1, 1)
-        .select(($"id" % 5) as "k", $"id" as "v")
+        .select(($"id" % 5).cast("string") as "k", $"id" as "v")
         .groupBy($"k")
         .agg(sum($"v") as "s")
       withClue(clue) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -337,7 +337,8 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
 
   test("results unchanged with a mix of many aggregate functions and buffer types") {
     // Exercises a wide pass-through buffer spanning several aggregate buffer layouts at once:
-    // sum (decimal), avg (double), count, min/max, first/last, and stddev (imperative buffer).
+    // sum (decimal), avg (double), count, min/max, first/last, and stddev (declarative buffer).
+    // The imperative-buffer case is covered separately (see the `approx_count_distinct` test).
     checkAdaptiveMatchesReference { parts =>
       spark.range(0, 400, 1, parts)
         .select(
@@ -354,6 +355,22 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           first($"dbl") as "f",
           last($"dbl") as "l",
           stddev($"dbl") as "sd2")
+    }
+  }
+
+  test("results unchanged with an imperative-buffer aggregate") {
+    // `approx_count_distinct` uses `HyperLogLogPlusPlus`, an `ImperativeAggregate` whose buffer
+    // state is written by `initialize(buffer)` rather than by a projection, so a pass-through
+    // single-row buffer has to be re-initialized with `copyFrom(initialAggregationBuffer)` for
+    // every row. No declarative aggregate exercises that reset. It also reports
+    // `supportCodegen = false`, so the operator only ever runs on `TungstenAggregationIterator`;
+    // keep it in its own test rather than folding it into a codegen cell that would quietly
+    // become interpreted.
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 300, 1, parts)
+        .select($"id".cast("string") as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(approx_count_distinct($"v") as "c")
     }
   }
 
@@ -693,6 +710,23 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
+  test("fan-out below a split aggregate preserves the merge order") {
+    // A `GenerateExec` expands a collection without checking `shouldStop()`, so in the
+    // exchange-split shape the whole fan-out batch of the trigger input row used to be appended
+    // before the frozen maps drained. A group whose rows straddle the freeze point then merged in
+    // a different order than a non-bypassed run, and the generated path disagreed with the
+    // interpreted one. The fan-out child reports `needCopyResult`, so the drained maps can run
+    // right after the trigger row, restoring the merge order.
+    checkAdaptiveMatchesReference { parts =>
+      spark.range(0, 20, 1, parts)
+        .select($"id", explode(array(
+          $"id" * 2,
+          when($"id" === 4, lit(0L)).otherwise($"id" * 2 + 1))) as "k")
+        .select($"k", ($"id" * 100 + $"k") as "v")
+        .groupBy($"k").agg(first($"v") as "f", last($"v") as "l")
+    }
+  }
+
   test("results unchanged below a generator that cannot yield mid-fan-out") {
     // `GenerateExec` expands a collection without checking `shouldStop()`, so the aggregate cannot
     // rely on the child to bound the output buffer -- each streamed row has to be able to leave
@@ -822,6 +856,22 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           "a global aggregation is not eligible and must never bypass")
       }
     }
+  }
+
+  test("no pass-through for a session_window grouping key") {
+    // A batch `session_window` grouping is not streaming, but its partial aggregate feeds a
+    // `MergingSessionsExec` that merges overlapping sessions, and passing single-row buffers into
+    // it is untested. It is gated out in `adaptivePartialAggEnabled`. This input has fully
+    // distinct sessions (ratio 1.0) and a small `minRows`, so without the gate the periodic check
+    // would bypass and the `expectBypass = false` assertion would fail.
+    checkAdaptiveMatchesReference(
+      expectBypass = false,
+      build = { parts =>
+        spark.range(0, 40, 1, parts)
+          .select($"id" as "v", timestamp_seconds($"id" * 60) as "time")
+          .groupBy(session_window($"time", "10 seconds"))
+          .agg(sum($"v") as "s")
+      })
   }
 
   test("rows absorbed by the fast map count toward the compaction ratio") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -1,0 +1,770 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.aggregate
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Partial
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests for runtime adaptive partial aggregation
+ * (see [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]). When a partial aggregate is not reducing
+ * rows, the operator stops aggregating and streams the remaining rows through as single-row partial
+ * buffers for the Final aggregate to merge. It must never change results.
+ *
+ * The suite has two halves:
+ *   1. Correctness: output is identical to the reference (feature-off) run across the full matrix
+ *      of codegen on/off, two-level map on/off, and spill/no-spill, over a range of aggregate
+ *      shapes, key types, and `Expand`-bearing plans (ROLLUP / CUBE / GROUPING SETS /
+ *      multi-distinct).
+ *   2. Triggering: the `numBypassingRows` metric proves the bypass actually fires when (and only
+ *      when) it should -- high-cardinality input bypasses, low-cardinality input keeps aggregating,
+ *      the feature switch and eligibility rules are honored, and both decision tiers work.
+ */
+class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+
+  import testImplicits._
+
+  // A `testFallbackStartsAt` setting ("fastMapCounter, regularMapCounter") that makes the regular
+  // map fall back (spill) periodically, exercising the on-spill (Tier 2) decision path in both the
+  // codegen and interpreted aggregation paths. Kept moderate so low-cardinality inputs (which are
+  // never bypassed and therefore really spill) do not open an unbounded number of spill readers.
+  private val forceSpillFallback = "4, 16"
+
+  // The upstream `CombineAdjacentAggregation` and `ReplaceHashWithSortAgg` rules would change the
+  // plan of these small single-partition queries away from a Partial+Final `HashAggregateExec`:
+  // the former merges the two adjacent phases (no shuffle in between) into a single `Complete`
+  // aggregate, and the latter converts a hash aggregate to a sort aggregate when the input is
+  // already sorted by the grouping key (a `Range` over an ascending `id` key). The adaptive
+  // feature lives in the partial hash aggregation, so both rules are disabled to keep that
+  // structure in the tests.
+  private val fixedPlanConfs = Seq(
+    SQLConf.COMBINE_ADJACENT_AGGREGATION_ENABLED.key -> "false",
+    SQLConf.REPLACE_HASH_WITH_SORT_AGG_ENABLED.key -> "false")
+
+  /**
+   * Runs `df` with adaptive partial aggregation disabled (the reference) and then across the full
+   * configuration matrix with it enabled, asserting every enabled run matches the reference.
+   */
+  private def checkAdaptiveMatchesReference(build: () => DataFrame): Unit = {
+    val reference = withSQLConf(
+      (SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") +: fixedPlanConfs: _*) {
+      build().collect().toSeq
+    }
+    for {
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+      forceSpill <- Seq(true, false)
+    } {
+      val spillConf = if (forceSpill) {
+        Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> forceSpillFallback)
+      } else {
+        Nil
+      }
+      withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          // Small sample so the no-spill (Tier 1) path triggers on modest inputs.
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> "8") ++
+          spillConf ++ fixedPlanConfs): _*) {
+        val msg = s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap forceSpill=$forceSpill"
+        withClue(msg) {
+          checkAnswer(build(), reference)
+        }
+      }
+    }
+  }
+
+  /**
+   * The observable per-run counters we assert on, all read from the partial `HashAggregateExec` in
+   * a single execution so the metrics are not double-counted:
+   *   - `skipped`: our self-reported `numBypassingRows` metric.
+   *   - `partialOutputRows`: the partial aggregate's own `numOutputRows`. An independent,
+   *     pre-existing counter driven by the normal output path, so it is the ground truth for
+   *     whether rows were streamed through -- it equals the distinct key count when aggregation is
+   *     effective and climbs toward the input row count once the operator bypasses.
+   *   - `spillBytes`: the partial aggregate's `spillSize`. Reliable only when no fallback is
+   *     forced: on the interpreted path this is derived from the task-cumulative memory-spill
+   *     counter, so a forced fallback (or downstream shuffle-write spill) can inflate it. Asserted
+   *     only by the Tier 1 test, which forces no fallback; use `tasksFallBacked` otherwise.
+   *   - `tasksFallBacked`: the partial aggregate's `numTasksFallBacked`, incremented only when the
+   *     regular map actually falls back into sort-based aggregation. When Tier 2 bypasses at the
+   *     spill boundary the sorter is never created, so this stays 0 -- direct, per-operator
+   *     evidence the bypass replaced the sort fallback.
+   */
+  private case class AggCounters(
+      skipped: Long,
+      partialOutputRows: Long,
+      spillBytes: Long,
+      tasksFallBacked: Long)
+
+  // Verifies `df` (an already-collected bypassing run) produces the same results as the feature-off
+  // reference. `build` is re-run for the reference so it gets a genuinely non-adaptive plan rather
+  // than reusing the bypassing run's cached one.
+  private def checkAgainstReference(df: DataFrame, build: () => DataFrame): Unit = {
+    val reference = withSQLConf(
+      SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") {
+      build().collect().toSeq
+    }
+    checkAnswer(df, reference)
+  }
+
+  private def runAndReadCounters(build: () => DataFrame): AggCounters = {
+    // The triggering tests assert on metrics, so also verify the bypassing run produces the same
+    // results as the feature-off reference.
+    val df = build()
+    df.collect()
+    val partialAggs = collect(df.queryExecution.executedPlan) {
+      case agg: HashAggregateExec if agg.aggregateExpressions.forall(_.mode == Partial) => agg
+    }
+    // A partial aggregate is always present for the grouped queries these tests use.
+    assert(partialAggs.nonEmpty, "expected a partial HashAggregateExec in the plan")
+    val counters = AggCounters(
+      skipped = partialAggs.map(_.metrics("numBypassingRows").value).sum,
+      partialOutputRows = partialAggs.map(_.metrics("numOutputRows").value).sum,
+      spillBytes = partialAggs.map(_.metrics("spillSize").value).sum,
+      tasksFallBacked = partialAggs.map(_.metrics("numTasksFallBacked").value).sum)
+    checkAgainstReference(df, build)
+    counters
+  }
+
+  private def numBypassingRows(build: () => DataFrame): Long = runAndReadCounters(build).skipped
+
+  // Returns the bypassed-row count per Partial-mode `HashAggregateExec`, keyed by the number of
+  // grouping keys, and verifies the run matches the feature-off reference. A `count(DISTINCT ...)`
+  // group-by has two such Partial phases -- the de-duplication partial (grouping on key + distinct
+  // columns) and the distinct partial (grouping on the keys only) -- so their bypasses can be told
+  // apart by the grouping key count.
+  private def bypassRowsByGroupingKeyCount(build: () => DataFrame): Map[Int, Long] = {
+    val df = build()
+    df.collect()
+    val byKeyCount = collect(df.queryExecution.executedPlan) {
+      case agg: HashAggregateExec if agg.aggregateExpressions.forall(_.mode == Partial) =>
+        agg.groupingExpressions.length -> agg.metrics("numBypassingRows").value
+    }.groupBy(_._1).map { case (n, pairs) => n -> pairs.map(_._2).sum }
+    checkAgainstReference(df, build)
+    byKeyCount
+  }
+
+  /**
+   * Runs `body` once per (wholeStage, twoLevelMap) combination with the feature enabled and a small
+   * sample, threading a descriptive clue for failure messages.
+   *
+   * The fast (first-level) map is append-only and never spills; adaptive partial aggregation
+   * governs only the regular (second-level) map. With the default fast-map capacity (2^16) a small
+   * high-cardinality input would be fully absorbed by the fast map and never reach the regular map,
+   * so nothing could ever bypass. To make the triggering tests meaningful when the two-level map is
+   * on, we shrink the fast map via the first field of `testFallbackStartsAt` so rows fall through
+   * to the regular map. `regularFallback` optionally sets the second field to also force the
+   * regular map to spill (for the on-spill tier); when 0 the regular map does not spill.
+   */
+  private def forEachCodegenAndMap(sampleRows: Int = 8, regularFallback: Int = 0)(
+      body: String => Unit): Unit = {
+    for {
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+    } {
+      // Shrink the fast map to 4 keys when it is on so rows reach the regular map. The second field
+      // controls regular-map spilling; 0 means "never" (a large sentinel).
+      val fallbackConf = if (twoLevelMap || regularFallback > 0) {
+        val fastCap = if (twoLevelMap) 4 else 1
+        val regular = if (regularFallback > 0) regularFallback else Int.MaxValue
+        Seq("spark.sql.TungstenAggregate.testFallbackStartsAt" -> s"$fastCap, $regular")
+      } else {
+        Nil
+      }
+      withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> sampleRows.toString) ++
+          fallbackConf ++ fixedPlanConfs): _*) {
+        body(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap")
+      }
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Part 1: Correctness -- results identical to the feature-off reference.
+  /////////////////////////////////////////////////////////////////////////////
+
+  test("results unchanged for high-cardinality input that bypasses partial aggregation") {
+    // Every grouping key is distinct, so partial aggregation reduces nothing and should be
+    // bypassed by both tiers.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 200, 1, 1)
+        .select($"id" as "k", ($"id" * 2) as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c", max($"v") as "m")
+    }
+  }
+
+  test("results unchanged for low-cardinality input that keeps partial aggregation") {
+    // Few distinct keys, high reduction: partial aggregation is effective and should be kept.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 600, 1, 1)
+        .select(($"id" % 5) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c", min($"v") as "mn", max($"v") as "mx")
+    }
+  }
+
+  test("results unchanged for medium-cardinality input near the reduction threshold") {
+    // Roughly half the rows are distinct keys; exercises the boundary of the ratio checks.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 1000, 1, 1)
+        .select(($"id" % 500) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  test("results unchanged with multiple grouping keys and string keys") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 500, 1, 1)
+        .select(
+          concat(lit("g"), ($"id" % 300).cast("string")) as "k1",
+          ($"id" % 7) as "k2",
+          $"id" as "v")
+        .groupBy($"k1", $"k2")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  test("results unchanged with nullable grouping keys") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 400, 1, 1)
+        .select(
+          when($"id" % 4 === 0, lit(null)).otherwise($"id") as "k",
+          $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  test("results unchanged with average (multi-slot buffer) aggregate") {
+    // avg has a two-slot partial buffer (sum, count); pass-through buffers must carry all slots.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 300, 1, 1)
+        .select($"id" as "k", ($"id" + 1) as "v")
+        .groupBy($"k")
+        .agg(avg($"v") as "a", sum($"v") as "s")
+    }
+  }
+
+  test("results unchanged with a mix of many aggregate functions and buffer types") {
+    // Exercises a wide pass-through buffer spanning several aggregate buffer layouts at once:
+    // sum (decimal), avg (double), count, min/max, first/last, and stddev (imperative buffer).
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 400, 1, 1)
+        .select(
+          $"id" as "k",
+          ($"id" % 97).cast("decimal(10,2)") as "d",
+          ($"id" % 13).cast("double") as "dbl")
+        .groupBy($"k")
+        .agg(
+          sum($"d") as "sd",
+          avg($"dbl") as "ad",
+          count(lit(1)) as "c",
+          min($"dbl") as "mn",
+          max($"dbl") as "mx",
+          first($"dbl") as "f",
+          last($"dbl") as "l",
+          stddev($"dbl") as "sd2")
+    }
+  }
+
+  test("results unchanged with filtered aggregate functions") {
+    // A `FILTER (WHERE ...)` aggregate is compiled into a per-row guard around the buffer update
+    // rather than a separate filtering operator: `If(filter, update, buffer)` in the interpreted
+    // path and an `if (!cond) continue` guard in the generated code. Pass-through reuses those
+    // exact update expressions, so a bypassed row whose filter is false contributes nothing to its
+    // single-row buffer. The all-true and all-false filters pin the two extremes, and the fully
+    // distinct grouping keys ensure rows bypass (in the regular-map-only configurations) so the
+    // filter guard actually runs in the pass-through path.
+    withTempView("t") {
+      spark.range(0, 400, 1, 1)
+        .select($"id" as "k", ($"id" % 100) as "v")
+        .createOrReplaceTempView("t")
+      checkAdaptiveMatchesReference { () =>
+        spark.sql(
+          """SELECT k,
+            |       sum(v) FILTER (WHERE v % 2 = 0) AS s_even,
+            |       count(1) FILTER (WHERE v > 50) AS c_gt50,
+            |       avg(v) FILTER (WHERE v > 25) AS a_gt25,
+            |       sum(v) FILTER (WHERE true) AS s_all,
+            |       sum(v) FILTER (WHERE false) AS s_none
+            |FROM t GROUP BY k""".stripMargin)
+      }
+    }
+  }
+
+  test("results unchanged with decimal and date grouping keys") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 300, 1, 1)
+        .select(
+          ($"id" % 280).cast("decimal(12,3)") as "k1",
+          date_add(lit(java.sql.Date.valueOf("2020-01-01")), ($"id" % 250).cast("int")) as "k2",
+          $"id" as "v")
+        .groupBy($"k1", $"k2")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  test("results unchanged for group-by-only (distinct) with no aggregate functions") {
+    // No aggregate functions: the pass-through buffer is a zero-column UnsafeRow, so the output is
+    // just the grouping key. High-cardinality keys should bypass, and the de-duplicated result must
+    // still match the reference.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 400, 1, 1)
+        .select(($"id" % 350) as "k1", ($"id" % 11) as "k2")
+        .distinct()
+    }
+  }
+
+  test("results unchanged for group-by-only with duplicate keys (Final phase must not bypass)") {
+    // A group-by-only aggregate has an empty `aggregateExpressions`, so checking the aggregate
+    // modes alone is vacuously true and could wrongly admit the `Final` phase of the two-phase
+    // plan. With duplicate keys, a bypassing `Final` would skip its de-duplication and return
+    // duplicate rows. The two-level map off variants route the rows to the regular map so the
+    // sampling tier fires and the regression would show up.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 1000, 1, 1)
+        .select(($"id" % 10) as "c")
+        .distinct()
+    }
+  }
+
+  test("results unchanged when a large frozen map is output before pass-through streaming") {
+    // A larger sample lets the map accumulate many keys before the no-spill tier bypasses, so the
+    // early map output (which also frees the map) spans several drain cycles and re-enters the
+    // map-output function; the results must still match the feature-off reference.
+    val query = () => spark.range(0, 400000, 1, 1)
+      .select($"id" as "k", $"id" as "v")
+      .groupBy($"k")
+      .agg(sum($"v") as "s")
+    withSQLConf(
+      (Seq(
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true",
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> "200000",
+        SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> "false") ++ fixedPlanConfs): _*) {
+      val reference = withSQLConf(
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false") {
+        query().collect().toSeq
+      }
+      checkAnswer(query(), reference)
+    }
+  }
+
+  test("distinct aggregation stays correct") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 300, 1, 1)
+        .select($"id" as "k", ($"id" % 50) as "v")
+        .groupBy($"k")
+        .agg(countDistinct($"v") as "cd", sum($"v") as "s")
+    }
+  }
+
+  test("distinct aggregation bypasses on high-cardinality input") {
+    // The `PartialMerge` phase of the multi-phase distinct plan always aggregates (it is not
+    // `Partial` mode and requires a distribution), so the rows reaching the distinct `Partial`
+    // phase are de-duplicated and pass-through carries exactly one distinct value each.
+    forEachCodegenAndMap() { clue =>
+      val df = () => spark.range(0, 1000, 1, 1)
+        .select(($"id" % 100) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(countDistinct($"v") as "cd")
+      withClue(clue) {
+        assert(numBypassingRows(df) > 0,
+          "expected a distinct partial aggregation to bypass for high-cardinality input")
+      }
+    }
+  }
+
+  test("count distinct: the de-duplication partial aggregate bypasses") {
+    // `count(DISTINCT v) GROUP BY k` plans two `Partial` phases: the de-duplication partial groups
+    // on (k, v) and the distinct partial groups on (k). Fully distinct (k, v) pairs make the
+    // de-duplication partial (2 grouping keys) reduce nothing, so it must bypass.
+    forEachCodegenAndMap() { clue =>
+      val df = () => spark.range(0, 400, 1, 1)
+        .select(($"id" % 4) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(countDistinct($"v") as "cd")
+      withClue(clue) {
+        val byKeyCount = bypassRowsByGroupingKeyCount(df)
+        assert(byKeyCount.get(2).exists(_ > 0),
+          s"expected the (k, v) de-duplication partial to bypass, got $byKeyCount")
+      }
+    }
+  }
+
+  test("count distinct: the distinct partial aggregate bypasses") {
+    // Mirror of the test above for the other phase: with many distinct keys but few distinct
+    // values per key, the (k, v) de-duplication partial reduces well while the distinct partial
+    // (1 grouping key) sees a fresh key per row and must bypass.
+    forEachCodegenAndMap() { clue =>
+      val df = () => spark.range(0, 400, 1, 1)
+        .select($"id" as "k", ($"id" % 2) as "v")
+        .groupBy($"k")
+        .agg(countDistinct($"v") as "cd")
+      withClue(clue) {
+        val byKeyCount = bypassRowsByGroupingKeyCount(df)
+        assert(byKeyCount.get(1).exists(_ > 0),
+          s"expected the distinct partial (grouping on k) to bypass, got $byKeyCount")
+      }
+    }
+  }
+
+  test("count distinct: both partial aggregates bypass and results stay correct") {
+    // Fully distinct keys and fully distinct values: neither partial phase reduces anything, so
+    // both bypass in the same execution. The de-duplication partial keeps the (k, v) pairs unique
+    // and the distinct partial counts them, so the result must still match the reference.
+    forEachCodegenAndMap() { clue =>
+      val df = () => spark.range(0, 400, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(countDistinct($"v") as "cd")
+      withClue(clue) {
+        val byKeyCount = bypassRowsByGroupingKeyCount(df)
+        assert(byKeyCount.get(2).exists(_ > 0),
+          s"expected the (k, v) de-duplication partial to bypass, got $byKeyCount")
+        assert(byKeyCount.get(1).exists(_ > 0),
+          s"expected the distinct partial (grouping on k) to bypass, got $byKeyCount")
+      }
+    }
+  }
+
+  test("global aggregation (no grouping keys) is never bypassed and stays correct") {
+    withSQLConf(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "true") {
+      checkAnswer(
+        spark.range(0, 100, 1, 1).agg(sum($"id") as "s", count(lit(1)) as "c"),
+        Row(4950L, 100L))
+    }
+  }
+
+  test("results unchanged with an empty input") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 0, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  // The following four tests cover plans where an `ExpandExec` sits below the partial aggregate
+  // (ROLLUP / CUBE / GROUPING SETS / multi-distinct). PR apache/spark#28804 statically disabled its
+  // skip-partial-aggregate optimization whenever an Expand was present, but that was a performance
+  // heuristic guarding its *static* row sampling, not a correctness requirement. Our decision is
+  // made at runtime from the observed reduction ratio, so we deliberately do not port that
+  // exclusion. These tests assert results stay correct with the exclusion absent.
+
+  test("results unchanged for ROLLUP (Expand below partial aggregate)") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 400, 1, 1)
+        .select(($"id" % 200) as "k1", ($"id" % 7) as "k2", $"id" as "v")
+        .rollup($"k1", $"k2")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  test("results unchanged for CUBE (Expand below partial aggregate)") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 400, 1, 1)
+        .select(($"id" % 150) as "k1", ($"id" % 5) as "k2", $"id" as "v")
+        .cube($"k1", $"k2")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+    }
+  }
+
+  test("results unchanged for GROUPING SETS (Expand below partial aggregate)") {
+    withTempView("t") {
+      spark.range(0, 400, 1, 1)
+        .select(($"id" % 180) as "k1", ($"id" % 6) as "k2", $"id" as "v")
+        .createOrReplaceTempView("t")
+      checkAdaptiveMatchesReference { () =>
+        spark.sql(
+          """SELECT k1, k2, sum(v) AS s, count(1) AS c
+            |FROM t
+            |GROUP BY k1, k2 GROUPING SETS ((k1, k2), (k1), ())""".stripMargin)
+      }
+    }
+  }
+
+  test("results unchanged for multi-distinct (Expand below partial aggregate)") {
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 400, 1, 1)
+        .select(($"id" % 100) as "k", ($"id" % 30) as "a", ($"id" % 40) as "b")
+        .groupBy($"k")
+        .agg(countDistinct($"a") as "da", countDistinct($"b") as "db", sum($"a") as "s")
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Part 2: Triggering -- the bypass fires when, and only when, it should.
+  /////////////////////////////////////////////////////////////////////////////
+
+  test("pass-through fires for high-cardinality input, not for low-cardinality input") {
+    forEachCodegenAndMap() { clue =>
+      // Fully distinct keys: partial aggregation reduces nothing, so rows must bypass.
+      val highCard = () => spark.range(0, 200, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        assert(numBypassingRows(highCard) > 0,
+          "expected some rows to bypass partial aggregation for high-cardinality input")
+      }
+      // Few distinct keys, high reduction: partial aggregation is effective, nothing bypasses.
+      val lowCard = () => spark.range(0, 600, 1, 1)
+        .select(($"id" % 5) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        assert(numBypassingRows(lowCard) == 0,
+          "expected no rows to bypass partial aggregation for low-cardinality input")
+      }
+    }
+  }
+
+  test("group-by-only pass-through fires for high-cardinality input") {
+    forEachCodegenAndMap() { clue =>
+      val distinctKeys = () => spark.range(0, 200, 1, 1).select($"id" as "k").distinct()
+      withClue(clue) {
+        assert(numBypassingRows(distinctKeys) > 0,
+          "expected group-by-only rows to bypass partial aggregation for high-cardinality input")
+      }
+    }
+  }
+
+  test("filtered aggregate functions are eligible for pass-through") {
+    // The filter clause does not change eligibility: a partial aggregate over `FILTER (WHERE ...)`
+    // functions still bypasses on high-cardinality input, and the per-row filter guard runs inside
+    // the pass-through single-row buffer update.
+    forEachCodegenAndMap() { clue =>
+      withTempView("t") {
+        spark.range(0, 200, 1, 1)
+          .select($"id" as "k", ($"id" % 100) as "v")
+          .createOrReplaceTempView("t")
+        val df = () => spark.sql(
+          """SELECT k, sum(v) FILTER (WHERE v % 2 = 0) AS s
+            |FROM t GROUP BY k""".stripMargin)
+        withClue(clue) {
+          assert(numBypassingRows(df) > 0,
+            "expected filtered-aggregate rows to bypass partial aggregation for high-cardinality " +
+              "input")
+        }
+      }
+    }
+  }
+
+  test("pass-through fires for high-cardinality input below an Expand") {
+    // The static PR#28804 heuristic would have refused to skip whenever an Expand was present; our
+    // runtime decision skips because the expanded rows genuinely do not reduce. GROUPING SETS over
+    // two single-column, fully-distinct sets is used (rather than ROLLUP/CUBE) so there is no
+    // grand-total group dragging the reduction ratio below the threshold: every expanded row is a
+    // fresh key, so all configurations bypass.
+    forEachCodegenAndMap() { clue =>
+      withTempView("t") {
+        spark.range(0, 200, 1, 1)
+          .select($"id".as("k1"), ($"id" + 1000).as("k2"), $"id".as("v"))
+          .createOrReplaceTempView("t")
+        val gs = () => spark.sql(
+          """SELECT k1, k2, sum(v) AS s
+            |FROM t
+            |GROUP BY k1, k2 GROUPING SETS ((k1), (k2))""".stripMargin)
+        withClue(clue) {
+          assert(numBypassingRows(gs) > 0,
+            "expected rows below an Expand to bypass partial aggregation for high-cardinality " +
+              "input")
+        }
+      }
+    }
+  }
+
+  test("no pass-through when the feature is disabled") {
+    // The metric must stay zero across the whole matrix when the switch is off, even for input that
+    // would otherwise bypass.
+    for {
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+    } {
+      withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString) ++ fixedPlanConfs): _*) {
+        val df = () => spark.range(0, 200, 1, 1)
+          .select($"id" as "k", $"id" as "v")
+          .groupBy($"k")
+          .agg(sum($"v") as "s")
+        withClue(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap") {
+          assert(numBypassingRows(df) == 0,
+            "no rows should bypass partial aggregation when the feature is disabled")
+        }
+      }
+    }
+  }
+
+  test("no pass-through for a global aggregation with no grouping keys") {
+    // Global aggregation is ineligible (`groupingExpressions` is empty): there is a single group,
+    // so there is nothing to stream through. The partial aggregate must never bypass regardless of
+    // codegen or map settings, even under a forced fallback.
+    forEachCodegenAndMap(regularFallback = 16) { clue =>
+      val df = () => spark.range(0, 200, 1, 1)
+        .agg(sum($"id") as "s", count(lit(1)) as "c")
+      withClue(clue) {
+        assert(numBypassingRows(df) == 0,
+          "a global aggregation is not eligible and must never bypass")
+      }
+    }
+  }
+
+  test("Tier 1 (no-spill) fires when the sample shows no reduction, without spilling") {
+    // No forced regular-map spill: only the no-spill sampling tier can trigger the bypass. Fully
+    // distinct keys over a small sample cross `noSpillReductionRatioThreshold`, so rows bypass and
+    // the regular map never spills.
+    forEachCodegenAndMap() { clue =>
+      val df = () => spark.range(0, 200, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        val c = runAndReadCounters(df)
+        assert(c.skipped > 0, "Tier 1 should bypass fully distinct input under the sample")
+        assert(c.spillBytes == 0, "Tier 1 must decide before any spill happens")
+        assert(c.tasksFallBacked == 0, "Tier 1 must not fall back to sort-based aggregation")
+      }
+    }
+  }
+
+  test("Tier 2 (on-spill) fires when the map would spill on high-cardinality input") {
+    // Force the regular map to fall back quickly. High-cardinality input that reaches the fallback
+    // point should bypass via the on-spill tier rather than spilling. Use a sample larger than the
+    // input so Tier 1 cannot fire first and the on-spill tier is the one exercised.
+    forEachCodegenAndMap(sampleRows = 100000, regularFallback = 16) { clue =>
+      val df = () => spark.range(0, 200, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        val c = runAndReadCounters(df)
+        assert(c.skipped > 0,
+          "Tier 2 should bypass high-cardinality input at the spill boundary")
+        // The whole point of Tier 2 is to bypass *instead of* falling back to sort-based
+        // aggregation, so the sorter is never created. `numTasksFallBacked` is the reliable
+        // per-operator signal for that (the `spillSize` metric on the interpreted path is derived
+        // from the task-cumulative memory-spill counter and can be inflated by unrelated spilling
+        // such as the downstream shuffle write, so it is not asserted here).
+        assert(c.tasksFallBacked == 0, "Tier 2 must replace the sort fallback, not trigger it")
+      }
+    }
+  }
+
+  test("without the feature the same input really does fall back to sort") {
+    // Sanity check for the Tier 2 assertion above: with adaptive disabled, the identical
+    // high-cardinality input under the same forced fallback genuinely falls back to sort-based
+    // aggregation. This proves Tier 2's `tasksFallBacked == 0` reflects the bypass and not merely
+    // an input that never reached the spill boundary.
+    for {
+      wholeStage <- Seq(true, false)
+      twoLevelMap <- Seq(true, false)
+    } {
+      val fastCap = if (twoLevelMap) 4 else 1
+      withSQLConf(
+        (Seq(
+          SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> "false",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> twoLevelMap.toString,
+          "spark.sql.TungstenAggregate.testFallbackStartsAt" -> s"$fastCap, 16") ++
+          fixedPlanConfs): _*) {
+        val df = () => spark.range(0, 200, 1, 1)
+          .select($"id" as "k", $"id" as "v")
+          .groupBy($"k")
+          .agg(sum($"v") as "s")
+        withClue(s"wholeStage=$wholeStage twoLevelMap=$twoLevelMap") {
+          val c = runAndReadCounters(df)
+          assert(c.skipped == 0, "feature disabled: nothing should bypass")
+          assert(c.tasksFallBacked > 0,
+            "feature disabled: the forced fallback should trigger sort-based aggregation")
+        }
+      }
+    }
+  }
+
+  test("larger sample defers the decision so a small high-cardinality input is not bypassed") {
+    // With a sample larger than the whole input and no regular-map spill forced, the Tier 1 check
+    // point is never reached, so nothing bypasses even though the keys are fully distinct.
+    forEachCodegenAndMap(sampleRows = 100000) { clue =>
+      val df = () => spark.range(0, 200, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        assert(numBypassingRows(df) == 0,
+          "no bypass expected before the sample size is reached")
+      }
+    }
+  }
+
+  test("partial aggregate output row count reflects the bypass (independent of the skip metric)") {
+    // `numOutputRows` on the partial aggregate is the ground truth: it is driven by the normal
+    // aggregation output path, not by our self-reported `numBypassingRows` metric. This test cross
+    // checks the two and pins the observable data-side effect of bypassing.
+    val numRows = 200
+    forEachCodegenAndMap() { clue =>
+      // Fully distinct keys: once the bypass fires the operator stops collapsing rows, so the
+      // partial aggregate emits far more than the handful of keys a real aggregation would. Read
+      // all counters from a single execution so the metrics are not double-counted.
+      val highCard = () => spark.range(0, numRows, 1, 1)
+        .select($"id" as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        val c = runAndReadCounters(highCard)
+        assert(c.skipped > 0, "high-cardinality input should bypass")
+        // Every partial output row is either a real (aggregated) group or a bypassed row, so the
+        // partial output count must be at least the number of bypassed rows, and it climbs toward
+        // the input row count -- well above the heavy reduction a kept aggregation would give.
+        assert(c.partialOutputRows >= c.skipped,
+          s"partial output ${c.partialOutputRows} should be >= bypassed rows ${c.skipped}")
+        assert(c.partialOutputRows > numRows / 2,
+          s"partial output (${c.partialOutputRows}) should climb toward the input row count")
+      }
+
+      // Low-cardinality reference: partial aggregation stays effective, so its output equals the
+      // small number of distinct keys and nothing is bypassed.
+      val lowCard = () => spark.range(0, 600, 1, 1)
+        .select(($"id" % 5) as "k", $"id" as "v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s")
+      withClue(clue) {
+        val c = runAndReadCounters(lowCard)
+        assert(c.skipped == 0, "low-cardinality input should not bypass")
+        assert(c.partialOutputRows == 5,
+          "an effective partial aggregate should emit exactly the distinct key count")
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -531,6 +531,27 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
+  test("results unchanged under a fused Union (child yields from a nested helper)") {
+    // `UnionExec` wraps each child's produce in its own helper, so a streamed row that fills the
+    // output buffer returns only as far as the aggregate's build loop. Reaching the end of the
+    // child's produce therefore does not mean the input is exhausted, and treating it as such
+    // drops the rest of the partition.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 100, 1, 2).union(spark.range(100, 200, 1, 2)).groupBy("id").count()
+    }
+  }
+
+  test("results unchanged below a generator that cannot yield mid-fan-out") {
+    // `GenerateExec` expands a collection without checking `shouldStop()`, so the aggregate cannot
+    // rely on the child to bound the output buffer -- each streamed row has to be able to leave
+    // the build loop on its own.
+    checkAdaptiveMatchesReference { () =>
+      spark.range(0, 1, 1, 1)
+        .select(explode(sequence(lit(1), lit(500))) as "k")
+        .groupBy($"k").count()
+    }
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Part 2: Triggering -- the bypass fires when, and only when, it should.
   /////////////////////////////////////////////////////////////////////////////
@@ -868,6 +889,19 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
           "the spill check must replace the sort fallback, not trigger it")
       }
     }
+  }
+
+  test("minCompaction rejects values that cannot be generated as a Java literal") {
+    // The threshold is interpolated straight into the generated source, where a non-finite double
+    // renders as `InfinityD` -- not a valid Java literal. Reject it at configuration time rather
+    // than failing to compile the stage (or silently deoptimizing when codegen falls back).
+    Seq("Infinity", "-Infinity", "NaN", "1e309").foreach { v =>
+      val e = intercept[IllegalArgumentException] {
+        spark.conf.set(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION.key, v)
+      }
+      assert(e.getMessage.contains("finite"), s"expected a finiteness error for '$v': $e")
+    }
+    spark.conf.unset(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_COMPACTION.key)
   }
 
   test("larger sample defers the decision so a small high-cardinality input is not bypassed") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -28,13 +28,16 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Tests for runtime adaptive partial aggregation
  * (see [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]). When a partial aggregate is not reducing
  * rows, the operator stops aggregating and streams the remaining rows through as single-row partial
- * buffers for the Final aggregate to merge. It must never change results.
+ * buffers for the Final aggregate to merge. Ordinary aggregate results stay equivalent; an
+ * order-sensitive aggregate such as `first`/`last` can merge its buffers in a different order, so
+ * only agreement between the generated and interpreted paths is guaranteed.
  *
  * The suite has two halves:
- *   1. Correctness: output is identical to the reference (feature-off) run across the full matrix
- *      of codegen on/off, two-level map on/off, and spill/no-spill, over a range of aggregate
- *      shapes, key types, and `Expand`-bearing plans (ROLLUP / CUBE / GROUPING SETS /
- *      multi-distinct).
+ *   1. Correctness: ordinary aggregate results are identical to the reference (feature-off) run
+ *      across the full matrix of codegen on/off, two-level map on/off, and spill/no-spill, over a
+ *      range of aggregate shapes, key types, and `Expand`-bearing plans (ROLLUP / CUBE / GROUPING
+ *      SETS / multi-distinct). Order-sensitive aggregates are tested separately for cross-path
+ *      agreement rather than against the reference.
  *   2. Triggering: the `numBypassingRows` metric proves the bypass actually fires when (and only
  *      when) it should -- high-cardinality input bypasses, low-cardinality input keeps aggregating,
  *      the feature switch and eligibility rules are honored, and both check points work.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Benchmark comparing runtime adaptive partial aggregation (see
+ * [[SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED]]) against the static pre-shuffle partial
+ * aggregation. When the partial aggregation is not reducing rows, the operator streams the
+ * remaining rows through as single-row partial buffers instead of maintaining (and possibly
+ * spilling) a large aggregation map.
+ *
+ * Each scenario runs the query across the full matrix of whole-stage codegen on/off and the
+ * feature disabled (`adaptive = F`, the pre-change baseline) vs enabled (`adaptive = T`), over a
+ * {high, low}-cardinality x {no-spill, on-spill} grid:
+ *   - high-cardinality, no spill: the no-spill tier bypasses, which should win.
+ *   - low-cardinality, no spill: nothing bypasses, which must not regress.
+ *   - high-cardinality, forced regular-map spill: the on-spill tier bypasses instead of spilling,
+ *     which should win.
+ *   - low-cardinality, forced regular-map spill: the ratio is too low for the on-spill tier to
+ *     bypass, so both runs spill identically (no regression).
+ *
+ * To run this benchmark:
+ * {{{
+ *   1. build/sbt "sql/Test/runMain
+ *        org.apache.spark.sql.execution.benchmark.AdaptivePartialAggregationBenchmark"
+ *   2. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain
+ *        org.apache.spark.sql.execution.benchmark.AdaptivePartialAggregationBenchmark"
+ *      Results will be written to "benchmarks/AdaptivePartialAggregationBenchmark-results.txt".
+ * }}}
+ */
+object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    // The upstream `CombineAdjacentAggregation` and `ReplaceHashWithSortAgg` rules would collapse
+    // or convert these single-partition hash aggregates, so both are disabled to keep the
+    // Partial+Final `HashAggregateExec` structure the adaptive feature governs.
+    val fixedPlanConfs = Seq(
+      SQLConf.COMBINE_ADJACENT_AGGREGATION_ENABLED.key -> "false",
+      SQLConf.REPLACE_HASH_WITH_SORT_AGG_ENABLED.key -> "false")
+
+    // Adds the (whole-stage codegen, adaptive switch) matrix for `query`. `extraConf` is applied
+    // to all four cases so the only differences are the two axes.
+    def addCodegenAdaptiveCases(
+        benchmark: Benchmark,
+        query: () => DataFrame,
+        extraConf: Seq[(String, String)] = Nil): Unit = {
+      for {
+        wholeStage <- Seq(true, false)
+        adaptive <- Seq(false, true)
+      } {
+        val adaptiveLabel = if (adaptive) "T" else "F"
+        val label = s"codegen = $wholeStage, adaptive = $adaptiveLabel"
+        benchmark.addCase(label) { _ =>
+          withSQLConf(
+            (Seq(
+              SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+              SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_ENABLED.key -> adaptive.toString) ++
+              fixedPlanConfs ++ extraConf): _*) {
+            query().noop()
+          }
+        }
+      }
+    }
+
+    // Fully distinct keys make partial aggregation useless, so the no-spill (Tier 1) sampling tier
+    // bypasses: the feature should be faster than the baseline that maintains a map entry per row.
+    runBenchmark("high-cardinality input, no-spill pass-through (Tier 1)") {
+      val N = 8L << 20
+      val benchmark = new Benchmark("adaptive partial agg, high card, no spill", N,
+        output = output)
+      addCodegenAdaptiveCases(benchmark, () => distinctKeyedDf(N))
+      benchmark.run()
+    }
+
+    // 1000 distinct keys over a large input: partial aggregation reduces a lot, the no-spill tier
+    // never fires, and the two runs must match (no regression).
+    runBenchmark("low-cardinality input, no-spill pass-through (Tier 1)") {
+      val N = 16L << 20
+      val benchmark = new Benchmark("adaptive partial agg, low card, no spill", N,
+        output = output)
+      addCodegenAdaptiveCases(benchmark, () =>
+        spark.range(N).selectExpr("id % 1000 as k", "id as v").groupBy("k").agg("v" -> "sum"))
+      benchmark.run()
+    }
+
+    // Force the regular map to spill quickly and disable the no-spill tier (huge sample). With
+    // fully distinct keys the reduction ratio is 1.0, so at the spill boundary the on-spill
+    // (Tier 2) tier bypasses instead of spilling; the baseline spills repeatedly and falls back
+    // to sort-based aggregation.
+    runBenchmark("high-cardinality input, on-spill pass-through (Tier 2)") {
+      val N = 8L << 20
+      val benchmark = new Benchmark("adaptive partial agg, high card, spill", N, output = output)
+      val tier2Conf = Seq(
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> Int.MaxValue.toString,
+        "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 1048576")
+      addCodegenAdaptiveCases(benchmark, () => distinctKeyedDf(N), extraConf = tier2Conf)
+      benchmark.run()
+    }
+
+    // Force the regular map to spill quickly on low-cardinality input. The reduction ratio is tiny
+    // (1000 distinct keys), so even at the spill boundary the on-spill tier correctly does not
+    // bypass: both runs spill and fall back to sort-based aggregation identically (no regression).
+    runBenchmark("low-cardinality input, on-spill pass-through (Tier 2)") {
+      val N = 16L << 20
+      val benchmark = new Benchmark("adaptive partial agg, low card, spill", N, output = output)
+      val tier2Conf = Seq(
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> Int.MaxValue.toString,
+        "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 1048576")
+      addCodegenAdaptiveCases(benchmark, () =>
+        spark.range(N).selectExpr("id % 1000 as k", "id as v").groupBy("k").agg("v" -> "sum"),
+        extraConf = tier2Conf)
+      benchmark.run()
+    }
+  }
+
+  private def distinctKeyedDf(N: Long): DataFrame =
+    spark.range(N).selectExpr("id as k", "id as v").groupBy("k").agg("v" -> "sum")
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
@@ -35,8 +35,8 @@ import org.apache.spark.sql.internal.SQLConf
  *   - low-cardinality, no spill: nothing bypasses, which must not regress.
  *   - high-cardinality, forced regular-map spill: the spill check bypasses instead of spilling,
  *     which should win.
- *   - low-cardinality, forced regular-map spill: the ratio is too low for the spill check to
- *     bypass, so both runs spill identically (no regression).
+ *   - low-cardinality, forced regular-map spill: the compaction ratio is far above the threshold,
+ *     so the spill check keeps aggregating and both runs spill identically (no regression).
  *
  * To run this benchmark:
  * {{{
@@ -103,9 +103,9 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
     }
 
     // Force the regular map to spill quickly and disable the periodic check (huge minRows). With
-    // fully distinct keys the reduction ratio is 1.0, so at the spill boundary the on-spill
-    // spill check bypasses instead of spilling; the baseline spills repeatedly and falls back
-    // to sort-based aggregation.
+    // fully distinct keys the compaction ratio is 1.0, so at the spill boundary the spill check
+    // bypasses instead of spilling; the baseline spills repeatedly and falls back to sort-based
+    // aggregation.
     runBenchmark("high-cardinality input, pass-through at the spill check") {
       val N = 8L << 20
       val benchmark = new Benchmark("adaptive partial agg, high card, spill", N, output = output)
@@ -116,9 +116,10 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       benchmark.run()
     }
 
-    // Force the regular map to spill quickly on low-cardinality input. The reduction ratio is tiny
-    // (1000 distinct keys), so even at the spill boundary the spill check correctly does not
-    // bypass: both runs spill and fall back to sort-based aggregation identically (no regression).
+    // Force the regular map to spill quickly on low-cardinality input. With only 1000 distinct
+    // keys the compaction ratio is far above the threshold, so even at the spill boundary the
+    // spill check correctly keeps aggregating: both runs spill and fall back to sort-based
+    // aggregation identically (no regression).
     runBenchmark("low-cardinality input, pass-through at the spill check") {
       val N = 16L << 20
       val benchmark = new Benchmark("adaptive partial agg, low card, spill", N, output = output)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
@@ -31,11 +31,11 @@ import org.apache.spark.sql.internal.SQLConf
  * Each scenario runs the query across the full matrix of whole-stage codegen on/off and the
  * feature disabled (`adaptive = F`, the pre-change baseline) vs enabled (`adaptive = T`), over a
  * {high, low}-cardinality x {no-spill, on-spill} grid:
- *   - high-cardinality, no spill: the no-spill tier bypasses, which should win.
+ *   - high-cardinality, no spill: the periodic check bypasses, which should win.
  *   - low-cardinality, no spill: nothing bypasses, which must not regress.
- *   - high-cardinality, forced regular-map spill: the on-spill tier bypasses instead of spilling,
+ *   - high-cardinality, forced regular-map spill: the spill check bypasses instead of spilling,
  *     which should win.
- *   - low-cardinality, forced regular-map spill: the ratio is too low for the on-spill tier to
+ *   - low-cardinality, forced regular-map spill: the ratio is too low for the spill check to
  *     bypass, so both runs spill identically (no regression).
  *
  * To run this benchmark:
@@ -81,9 +81,9 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       }
     }
 
-    // Fully distinct keys make partial aggregation useless, so the no-spill (Tier 1) sampling tier
-    // bypasses: the feature should be faster than the baseline that maintains a map entry per row.
-    runBenchmark("high-cardinality input, no-spill pass-through (Tier 1)") {
+    // Fully distinct keys make partial aggregation useless, so the periodic check bypasses: the
+    // feature should be faster than the baseline that maintains a map entry per row.
+    runBenchmark("high-cardinality input, pass-through at the periodic check") {
       val N = 8L << 20
       val benchmark = new Benchmark("adaptive partial agg, high card, no spill", N,
         output = output)
@@ -91,9 +91,9 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       benchmark.run()
     }
 
-    // 1000 distinct keys over a large input: partial aggregation reduces a lot, the no-spill tier
+    // 1000 distinct keys over a large input: partial aggregation reduces a lot, the periodic check
     // never fires, and the two runs must match (no regression).
-    runBenchmark("low-cardinality input, no-spill pass-through (Tier 1)") {
+    runBenchmark("low-cardinality input, pass-through at the periodic check") {
       val N = 16L << 20
       val benchmark = new Benchmark("adaptive partial agg, low card, no spill", N,
         output = output)
@@ -102,32 +102,32 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       benchmark.run()
     }
 
-    // Force the regular map to spill quickly and disable the no-spill tier (huge sample). With
+    // Force the regular map to spill quickly and disable the periodic check (huge minRows). With
     // fully distinct keys the reduction ratio is 1.0, so at the spill boundary the on-spill
-    // tier (Tier 2) bypasses instead of spilling; the baseline spills repeatedly and falls back
+    // spill check bypasses instead of spilling; the baseline spills repeatedly and falls back
     // to sort-based aggregation.
-    runBenchmark("high-cardinality input, on-spill pass-through (Tier 2)") {
+    runBenchmark("high-cardinality input, pass-through at the spill check") {
       val N = 8L << 20
       val benchmark = new Benchmark("adaptive partial agg, high card, spill", N, output = output)
-      val tier2Conf = Seq(
-        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> Int.MaxValue.toString,
+      val spillCheckConf = Seq(
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> Long.MaxValue.toString,
         "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 1048576")
-      addCodegenAdaptiveCases(benchmark, () => distinctKeyedDf(N), extraConf = tier2Conf)
+      addCodegenAdaptiveCases(benchmark, () => distinctKeyedDf(N), extraConf = spillCheckConf)
       benchmark.run()
     }
 
     // Force the regular map to spill quickly on low-cardinality input. The reduction ratio is tiny
-    // (1000 distinct keys), so even at the spill boundary the on-spill tier correctly does not
+    // (1000 distinct keys), so even at the spill boundary the spill check correctly does not
     // bypass: both runs spill and fall back to sort-based aggregation identically (no regression).
-    runBenchmark("low-cardinality input, on-spill pass-through (Tier 2)") {
+    runBenchmark("low-cardinality input, pass-through at the spill check") {
       val N = 16L << 20
       val benchmark = new Benchmark("adaptive partial agg, low card, spill", N, output = output)
-      val tier2Conf = Seq(
-        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_SAMPLE_ROWS.key -> Int.MaxValue.toString,
+      val spillCheckConf = Seq(
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> Long.MaxValue.toString,
         "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 1048576")
       addCodegenAdaptiveCases(benchmark, () =>
         spark.range(N).selectExpr("id % 1000 as k", "id as v").groupBy("k").agg("v" -> "sum"),
-        extraConf = tier2Conf)
+        extraConf = spillCheckConf)
       benchmark.run()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.internal.SQLConf
  * feature disabled (`adaptive = F`, the pre-change baseline) vs enabled (`adaptive = T`), over a
  * {high, low}-cardinality x {no-spill, on-spill} grid:
  *   - high-cardinality, no spill: the periodic check bypasses, which should win.
- *   - low-cardinality, no spill: nothing bypasses, which must not regress.
+ *   - low-cardinality, no spill: nothing bypasses, and the per-row guard the feature still adds
+ *     shows up as a small overhead to quantify.
  *   - high-cardinality, forced regular-map spill: the spill check bypasses instead of spilling,
  *     which should win.
  *   - low-cardinality, forced regular-map spill: the compaction ratio is far above the threshold,
@@ -91,8 +92,11 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       benchmark.run()
     }
 
-    // 1000 distinct keys over a large input: partial aggregation reduces a lot, the periodic check
-    // never activates pass-through, and the two runs must match (no regression).
+    // 1000 distinct keys over a large input: partial aggregation reduces a lot, so the periodic
+    // check never activates pass-through. The two runs still differ: the adaptive path pays a
+    // small per-row overhead (the stop check, the bypass counter and the check-point compare)
+    // even when nothing bypasses. The measured difference is a few percent, not a functional
+    // regression.
     runBenchmark("low-cardinality input, pass-through at the periodic check") {
       val N = 16L << 20
       val benchmark = new Benchmark("adaptive partial agg, low card, no spill", N,
@@ -110,7 +114,7 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       val N = 8L << 20
       val benchmark = new Benchmark("adaptive partial agg, high card, spill", N, output = output)
       val spillCheckConf = Seq(
-        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> Long.MaxValue.toString,
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "0",
         "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 1048576")
       addCodegenAdaptiveCases(benchmark, () => distinctKeyedDf(N), extraConf = spillCheckConf)
       benchmark.run()
@@ -124,7 +128,7 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
       val N = 16L << 20
       val benchmark = new Benchmark("adaptive partial agg, low card, spill", N, output = output)
       val spillCheckConf = Seq(
-        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> Long.MaxValue.toString,
+        SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_MIN_ROWS.key -> "0",
         "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "1, 1048576")
       addCodegenAdaptiveCases(benchmark, () =>
         spark.range(N).selectExpr("id % 1000 as k", "id as v").groupBy("k").agg("v" -> "sum"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
@@ -104,7 +104,7 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
 
     // Force the regular map to spill quickly and disable the no-spill tier (huge sample). With
     // fully distinct keys the reduction ratio is 1.0, so at the spill boundary the on-spill
-    // (Tier 2) tier bypasses instead of spilling; the baseline spills repeatedly and falls back
+    // tier (Tier 2) bypasses instead of spilling; the baseline spills repeatedly and falls back
     // to sort-based aggregation.
     runBenchmark("high-cardinality input, on-spill pass-through (Tier 2)") {
       val N = 8L << 20

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/AdaptivePartialAggregationBenchmark.scala
@@ -92,7 +92,7 @@ object AdaptivePartialAggregationBenchmark extends SqlBasedBenchmark {
     }
 
     // 1000 distinct keys over a large input: partial aggregation reduces a lot, the periodic check
-    // never fires, and the two runs must match (no regression).
+    // never activates pass-through, and the two runs must match (no regression).
     runBenchmark("low-cardinality input, pass-through at the periodic check") {
       val N = 16L << 20
       val benchmark = new Benchmark("adaptive partial agg, low card, no spill", N,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes hash aggregation detect at runtime that a pre-shuffle partial aggregation is not reducing rows, and bypass it: the remaining input rows are passed through as single-row partial buffers that the downstream `Final` aggregation merges, so the output contract is unchanged.

The decision is driven by the **compaction ratio** - processed rows divided by the number of keys the operator holds. A ratio of 10 means the partial aggregation collapses ten rows into one; a ratio near 1 means it is doing bookkeeping for nothing. The partial aggregation is bypassed for the rest of the input when the ratio falls below `minCompaction`, checked at two points:

- **periodically**, every `minRows` processed rows, so a decision is never made on too few rows.
- **on spill**, when the map cannot allocate for a new key and would otherwise spill. Spilling is when an ineffective partial aggregation starts paying disk I/O, so it is worth re-checking off-cycle.

Both checks share the same predicate and the same threshold. The row and key counts are measured at the operator level, over all processed rows and across both maps (`fastMap.getNumKeys() + regularMap.getNumKeys()`), which is what makes a single threshold meaningful on both the two-level and single-map paths.

The counters restart after each spill, so a new in-memory map epoch is judged on its own rows rather than on a ratio diluted by everything already spilled. Pass-through can therefore begin after earlier spills have happened.

Only a pre-shuffle `Partial` hash aggregation with grouping keys is eligible. Streaming partial aggregates are excluded (`!isStreaming`): they keep state across batches. A batch `session_window` grouping is likewise kept out, because its partial aggregate feeds a `MergingSessionsExec` that merges overlapping sessions. `requiredChildDistributionExpressions.isEmpty` identifies that phase and, importantly, keeps a group-by-only aggregate's `Final` phase out - its `aggregateExpressions` is empty, so a mode-only check would admit it vacuously. Both the codegen path (`HashAggregateExec`) and the interpreted path (`TungstenAggregationIterator`) are covered. Two `CodegenSupport` overrides keep the generated path safe under pass-through: `needStopCheck` lets a run of single-row buffers yield between rows instead of accumulating them in the whole-stage's in-memory output list, and `needCopyResult` propagates a fan-out child's copy requirement so the several pass-through rows of one input row do not alias the single result row.

Once pass-through is active the maps are frozen and the remaining input rows stream through as single-row partial buffers. Until the maps have fully drained, each streamed row is held in a small queue behind them: queuing a row advances the map output by one row, and the queue flushes only once the maps are drained, so every frozen-map buffer is emitted before any streamed row that could collide with it. A downstream `Final` merges in emit order, so a group that straddles the freeze still merges its map buffer before its pass-through buffers. The queue is bounded: a child that honours `shouldStop()` yields after every streamed row and never queues more than one; a one-to-many child that cannot yield mid-fan-out (`GenerateExec`) queues its whole fan-out batch at once, bounding the queue by the batch width. Once the maps drain, later streamed rows are emitted directly. The merge order is local to a partition and not a cross-partition promise - the `Partial` output is repartitioned before the `Final` merges it - but the generated and interpreted paths always emit the same order, so `spark.sql.codegen.wholeStage` never changes a result.

`DISTINCT` aggregates are eligible: in the multi-phase distinct plan the intermediate `PartialMerge` phase is not `Partial` mode (and requires a distribution), so it always aggregates and de-duplicates, and the rows reaching the distinct `Partial` phase therefore carry exactly one distinct value each.

New configs, all under `spark.sql.execution.aggregate.adaptivePartialAggregation.*`:

| config | default | meaning |
| --- | --- | --- |
| `enabled` | `false` | the feature switch (opt-in) |
| `minRows` | `100000` | rows between two compaction-ratio evaluations |
| `minCompaction` | `1.05` | the ratio below which the partial aggregation is bypassed |

A `numBypassingRows` SQL metric reports how many rows bypassed, on the eligible operators.

The comparison is strict: a ratio exactly equal to `minCompaction` does not bypass. `minCompaction` is validated to be at least 1.0, because a ratio below 1.0 is impossible for a non-empty map (each key is held by at least one processed row); at exactly 1.0 the strict comparison still never bypasses, so the effective range is above 1.0.

### Why are the changes needed?

For high-cardinality grouping keys the pre-shuffle partial aggregation reduces little or nothing, but still pays for maintaining - and often spilling - an aggregation map as large as the input. Bypassing it at runtime removes that cost while keeping the two-phase plan intact, so the decision needs no planner-side statistics and adapts per task.

This is related to, but independent of, the static `spark.sql.execution.bypassPartialAggregation` (SPARK-57688), which drops the partial aggregation at planning time. The runtime version keeps the partial aggregation when it does reduce rows and only bypasses when the observed ratio says it does not; the two can be used together.

### Does this PR introduce _any_ user-facing change?

Order-sensitive aggregates such as `first`/`last` are unaffected: once pass-through is active the frozen map's output always precedes the passed-through rows, so a group that straddles the freeze merges its map buffer before its pass-through buffers, matching a run that never bypasses. The feature is disabled by default (opt-in) and, when enabled, otherwise changes only how the pre-shuffle partial aggregation is executed, plus the new `numBypassingRows` metric in the SQL UI. The pass-through decision is made once per task and not reversed, which the config documentation covers.

### How was this patch tested?

New `AdaptivePartialAggregationSuite` (51 tests), in two halves:

- **Correctness**: output identical to the feature-off reference across the full matrix of codegen on/off, two-level map on/off, and spill/no-spill, over a range of aggregate shapes (multi-slot buffers, imperative buffers, `FILTER (WHERE ...)`), key types (string, decimal, date, nullable), group-by-only aggregates with duplicate keys, empty input, and `Expand`-bearing plans (ROLLUP / CUBE / GROUPING SETS / multi-distinct).
- **Triggering**: the `numBypassingRows` metric proves the bypass fires when (and only when) it should - high cardinality bypasses, low cardinality does not, the feature switch and eligibility rules are honored, and both check points work. There are tests for the exact ratio boundary, and for a new in-memory map epoch bypassing after an earlier spill. These tests also compare against the feature-off reference so a bypassing run can never pass on metrics alone. For `count(DISTINCT v) GROUP BY k` the bypasses of the two `Partial` phases are told apart by grouping-key count and asserted separately.

Three tests use an order-sensitive `first`/`last` aggregate to pin the merge order under a fan-out child, where the trigger row's whole fan-out batch is queued at once and the map drains inside it. Each compares every enabled cell against the feature-off reference across the split and unsplit plan shapes, whole-stage on/off, two-level map on/off, and spill/no-spill: one splits the aggregates with an `Exchange` so the held batch cannot overtake the map, one widens the fan-out batch to four rows with two collisions so both colliding rows must wait for the whole map to drain, and the third grows the frozen map well past the batch width (and forces a spill) so a design that flushed the held rows early would leave the colliding key's map buffer behind them. The merge order is not a contract, but `spark.sql.codegen.wholeStage` must never change a result.

`AdaptivePartialAggregationBenchmark` covers the {high, low}-cardinality x {no-spill, on-spill} grid, each across codegen on/off and the adaptive switch.

<details>
<summary>Generated code for `select c2, count(*) from t3 group by c2` (partial aggregation stage, two-level map enabled)</summary>

```java
/* 001 */ public Object generate(Object[] references) {
/* 002 */   return new GeneratedIteratorForCodegenStage1(references);
/* 003 */ }
/* 004 */
/* 005 */ // codegenStageId=1
/* 006 */ final class GeneratedIteratorForCodegenStage1 extends org.apache.spark.sql.execution.BufferedRowIterator {
/* 007 */   private Object[] references;
/* 008 */   private scala.collection.Iterator[] inputs;
/* 009 */   private boolean hashAgg_initAgg_0;
/* 010 */   private boolean hashAgg_adaptivePassThrough_0;
/* 011 */   private long hashAgg_processedRows_0;
/* 012 */   private long hashAgg_adaptiveNextCheckRow_0;
/* 013 */   private boolean hashAgg_adaptiveChildrenConsumed_0;
/* 014 */   private boolean hashAgg_adaptiveMapOutputDone_0;
/* 015 */   private boolean hashAgg_adaptiveMapSetupDone_0;
/* 016 */   private int hashAgg_adaptiveFastKeysAtSpill_0;
/* 017 */   private java.util.LinkedList<UnsafeRow[]> hashAgg_adaptivePendingRows_0;
/* 018 */   private boolean hashAgg_bufIsNull_0;
/* 019 */   private long hashAgg_bufValue_0;
/* 020 */   private hashAgg_FastHashMap_0 hashAgg_fastHashMap_0;
/* 021 */   private org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> hashAgg_fastHashMapIter_0;
/* 022 */   private org.apache.spark.unsafe.KVIterator hashAgg_mapIter_0;
/* 023 */   private org.apache.spark.sql.execution.UnsafeFixedWidthAggregationMap hashAgg_hashMap_0;
/* 024 */   private org.apache.spark.sql.execution.UnsafeKVExternalSorter hashAgg_sorter_0;
/* 025 */   private int columnartorow_batchIdx_0;
/* 026 */   private org.apache.spark.sql.vectorized.ColumnarBatch[] columnartorow_mutableStateArray_1 = new org.apache.spark.sql.vectorized.ColumnarBatch[1];
/* 027 */   private org.apache.spark.sql.execution.vectorized.OnHeapColumnVector[] columnartorow_mutableStateArray_2 = new org.apache.spark.sql.execution.vectorized.OnHeapColumnVector[1];
/* 028 */   private scala.collection.Iterator[] columnartorow_mutableStateArray_0 = new scala.collection.Iterator[1];
/* 029 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter[] hashAgg_mutableStateArray_0 = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter[5];
/* 030 */
/* 031 */   public GeneratedIteratorForCodegenStage1(Object[] references) {
/* 032 */     this.references = references;
/* 033 */   }
/* 034 */
/* 035 */   public void init(int index, scala.collection.Iterator[] inputs) {
/* 036 */     partitionIndex = index;
/* 037 */     this.inputs = inputs;
/* 038 */
/* 039 */     hashAgg_adaptiveNextCheckRow_0 = 100000L;
/* 040 */     hashAgg_adaptivePendingRows_0 = new java.util.LinkedList<UnsafeRow[]>();
/* 041 */     hashAgg_mutableStateArray_0[0] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(2, 0);
/* 042 */     columnartorow_mutableStateArray_0[0] = inputs[0];
/* 043 */     hashAgg_mutableStateArray_0[1] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 044 */     hashAgg_mutableStateArray_0[2] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 045 */     hashAgg_mutableStateArray_0[3] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 046 */     hashAgg_mutableStateArray_0[4] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1, 0);
/* 047 */
/* 048 */   }
/* 049 */
/* 050 */   public class hashAgg_FastHashMap_0
/* 051 */   extends org.apache.spark.sql.execution.aggregate.RowBasedAggregateHashMap {
/* 052 */     public hashAgg_FastHashMap_0(
/* 053 */       org.apache.spark.memory.TaskMemoryManager taskMemoryManager,
/* 054 */       InternalRow emptyAggregationBuffer) {
/* 055 */       super(((org.apache.spark.sql.types.StructType) references[1] /* keySchemaTerm */), ((org.apache.spark.sql.types.StructType) references[2] /* valueSchemaTerm */), taskMemoryManager, emptyAggregationBuffer,
/* 056 */         1 << 16, 1, 0);
/* 057 */     }
/* 058 */
/* 059 */     public org.apache.spark.sql.catalyst.expressions.UnsafeRow findOrInsert(long hashAgg_key_0) {
/* 060 */       long h = hash(hashAgg_key_0);
/* 061 */       int step = 0;
/* 062 */       int idx = (int) h & (numBuckets - 1);
/* 063 */       while (step < maxSteps) {
/* 064 */         // Return bucket index if it's either an empty slot or already contains the key
/* 065 */         if (buckets[idx] == -1) {
/* 066 */           if (numRows < capacity && !isBatchFull) {
/* 067 */             rowWriter.reset();
/* 068 */             rowWriter.zeroOutNullBytes();
/* 069 */             rowWriter.write(0, hashAgg_key_0);
/* 070 */             return appendCurrentKey(idx);
/* 071 */           } else {
/* 072 */             // No more space
/* 073 */             return null;
/* 074 */           }
/* 075 */         } else if (equals(idx, hashAgg_key_0)) {
/* 076 */           return batch.getValueRow(buckets[idx]);
/* 077 */         }
/* 078 */         idx = (idx + 1) & (numBuckets - 1);
/* 079 */         step++;
/* 080 */       }
/* 081 */       // Didn't find it
/* 082 */       return null;
/* 083 */     }
/* 084 */
/* 085 */     private boolean equals(int idx, long hashAgg_key_0) {
/* 086 */       UnsafeRow row = batch.getKeyRow(buckets[idx]);
/* 087 */       return (row.getLong(0) == hashAgg_key_0);
/* 088 */     }
/* 089 */
/* 090 */     private long hash(long hashAgg_key_0) {
/* 091 */       long hashAgg_hash_0 = 0;
/* 092 */
/* 093 */       long hashAgg_result_0 = hashAgg_key_0;
/* 094 */       hashAgg_hash_0 = (hashAgg_hash_0 ^ (0x9e3779b9)) + hashAgg_result_0 + (hashAgg_hash_0 << 6) + (hashAgg_hash_0 >>> 2);
/* 095 */
/* 096 */       return hashAgg_hash_0;
/* 097 */     }
/* 098 */
/* 099 */   }
/* 100 */
/* 101 */   private void hashAgg_doAggregateWithKeysOutput_0(UnsafeRow hashAgg_keyTerm_0, UnsafeRow hashAgg_bufferTerm_0)
/* 102 */   throws java.io.IOException {
/* 103 */     ((org.apache.spark.sql.execution.metric.SQLMetric) references[7] /* numOutputRows */).add(1);
/* 104 */
/* 105 */     boolean hashAgg_isNull_1 = hashAgg_keyTerm_0.isNullAt(0);
/* 106 */     long hashAgg_value_2 = hashAgg_isNull_1 ?
/* 107 */     -1L : (hashAgg_keyTerm_0.getLong(0));
/* 108 */     long hashAgg_value_3 = hashAgg_bufferTerm_0.getLong(0);
/* 109 */
/* 110 */     hashAgg_mutableStateArray_0[0].reset();
/* 111 */
/* 112 */     hashAgg_mutableStateArray_0[0].zeroOutNullBytes();
/* 113 */
/* 114 */     hashAgg_mutableStateArray_0[0].writeNullable(0, hashAgg_value_2, hashAgg_isNull_1);
/* 115 */
/* 116 */     hashAgg_mutableStateArray_0[0].write(1, hashAgg_value_3);
/* 117 */     append((hashAgg_mutableStateArray_0[0].getRow()));
/* 118 */
/* 119 */   }
/* 120 */
/* 121 */   private void hashAgg_doAggregateWithKeys_0(int partitionIndex) throws java.io.IOException {
/* 122 */     if (columnartorow_mutableStateArray_1[0] == null) {
/* 123 */       columnartorow_nextBatch_0();
/* 124 */     }
/* 125 */     while ( columnartorow_mutableStateArray_1[0] != null) {
/* 126 */       int columnartorow_numRows_0 = columnartorow_mutableStateArray_1[0].numRows();
/* 127 */       int columnartorow_localEnd_0 = columnartorow_numRows_0 - columnartorow_batchIdx_0;
/* 128 */       for (int columnartorow_localIdx_0 = 0; columnartorow_localIdx_0 < columnartorow_localEnd_0; columnartorow_localIdx_0++) {
/* 129 */         int columnartorow_rowIdx_0 = columnartorow_batchIdx_0 + columnartorow_localIdx_0;
/* 130 */         boolean columnartorow_isNull_0 = columnartorow_mutableStateArray_2[0].isNullAt(columnartorow_rowIdx_0);
/* 131 */         long columnartorow_value_0 = columnartorow_isNull_0 ? -1L : (columnartorow_mutableStateArray_2[0].getLong(columnartorow_rowIdx_0));
/* 132 */
/* 133 */         hashAgg_doConsume_0(columnartorow_value_0, columnartorow_isNull_0);
/* 134 */         if (shouldStop()) { columnartorow_batchIdx_0 = columnartorow_rowIdx_0 + 1; return; }
/* 135 */       }
/* 136 */       columnartorow_batchIdx_0 = columnartorow_numRows_0;
/* 137 */       columnartorow_nextBatch_0();
/* 138 */     }
/* 139 */     // clean up resources
/* 140 */     if (columnartorow_mutableStateArray_1[0] != null) {
/* 141 */       columnartorow_mutableStateArray_1[0].close();
/* 142 */     }
/* 143 */
/* 144 */     if (!shouldStop()) { hashAgg_adaptiveChildrenConsumed_0 = true; }
/* 145 */   }
/* 146 */
/* 147 */   private void wholestagecodegen_outputMapAndFlush_0() throws java.io.IOException {
/* 148 */     if (!hashAgg_adaptiveMapSetupDone_0) {
/* 149 */       hashAgg_fastHashMapIter_0 = hashAgg_fastHashMap_0.rowIterator();
/* 150 */       hashAgg_mapIter_0 = ((org.apache.spark.sql.execution.aggregate.HashAggregateExec) references[0] /* plan */).finishAggregate(hashAgg_hashMap_0, hashAgg_sorter_0, ((org.apache.spark.sql.execution.metric.SQLMetric) references[3] /* peakMemory */), ((org.apache.spark.sql.execution.metric.SQLMetric) references[4] /* spillSize */), ((org.apache.spark.sql.execution.metric.SQLMetric) references[5] /* avgHashProbe */), ((org.apache.spark.sql.execution.metric.SQLMetric) references[6] /* numTasksFallBacked */));
/* 151 */
/* 152 */       hashAgg_adaptiveMapSetupDone_0 = true;
/* 153 */     }
/* 154 */
/* 155 */     while ( hashAgg_fastHashMapIter_0.next()) {
/* 156 */       UnsafeRow hashAgg_aggKey_0 = (UnsafeRow) hashAgg_fastHashMapIter_0.getKey();
/* 157 */       UnsafeRow hashAgg_aggBuffer_0 = (UnsafeRow) hashAgg_fastHashMapIter_0.getValue();
/* 158 */       hashAgg_doAggregateWithKeysOutput_0(hashAgg_aggKey_0, hashAgg_aggBuffer_0);
/* 159 */
/* 160 */       if (shouldStop()) return;
/* 161 */     }
/* 162 */     hashAgg_fastHashMap_0.close();
/* 163 */
/* 164 */     while ( hashAgg_mapIter_0.next()) {
/* 165 */       UnsafeRow hashAgg_aggKey_0 = (UnsafeRow) hashAgg_mapIter_0.getKey();
/* 166 */       UnsafeRow hashAgg_aggBuffer_0 = (UnsafeRow) hashAgg_mapIter_0.getValue();
/* 167 */       hashAgg_doAggregateWithKeysOutput_0(hashAgg_aggKey_0, hashAgg_aggBuffer_0);
/* 168 */       if (shouldStop()) return;
/* 169 */     }
/* 170 */     hashAgg_mapIter_0.close();
/* 171 */     if (hashAgg_sorter_0 == null) {
/* 172 */       hashAgg_hashMap_0.free();
/* 173 */     }
/* 174 */
/* 175 */     hashAgg_adaptiveMapOutputDone_0 = true;
/* 176 */     while (!hashAgg_adaptivePendingRows_0.isEmpty()) {
/* 177 */       UnsafeRow[] wholestagecodegen_pendingRow_0 = (UnsafeRow[]) hashAgg_adaptivePendingRows_0.poll();
/* 178 */       hashAgg_doAggregateWithKeysOutput_0(wholestagecodegen_pendingRow_0[0], wholestagecodegen_pendingRow_0[1]);
/* 179 */     }
/* 180 */   }
/* 181 */
/* 182 */   private void hashAgg_doConsume_0(long hashAgg_expr_0_0, boolean hashAgg_exprIsNull_0_0) throws java.io.IOException {
/* 183 */     UnsafeRow hashAgg_unsafeRowAggBuffer_0 = null;
/* 184 */     UnsafeRow hashAgg_fastAggBuffer_0 = null;
/* 185 */
/* 186 */     boolean hashAgg_adaptiveRowBypassed_0 = false;
/* 187 */
/* 188 */     if (!hashAgg_adaptivePassThrough_0) {
/* 189 */       if (!hashAgg_exprIsNull_0_0) {
/* 190 */         hashAgg_fastAggBuffer_0 = hashAgg_fastHashMap_0.findOrInsert(
/* 191 */           hashAgg_expr_0_0);
/* 192 */       }
/* 193 */
/* 194 */     }
/* 195 */
/* 196 */     // Cannot find the key in fast hash map, try regular hash map.
/* 197 */     if (hashAgg_fastAggBuffer_0 == null) {
/* 198 */       // generate grouping key
/* 199 */       hashAgg_mutableStateArray_0[3].reset();
/* 200 */
/* 201 */       hashAgg_mutableStateArray_0[3].zeroOutNullBytes();
/* 202 */
/* 203 */       hashAgg_mutableStateArray_0[3].writeNullable(0, hashAgg_expr_0_0, hashAgg_exprIsNull_0_0);
/* 204 */       if (!hashAgg_adaptivePassThrough_0) {
/* 205 */         int hashAgg_unsafeRowKeyHash_0 = (hashAgg_mutableStateArray_0[3].getRow()).hashCode();
/* 206 */         if (true) {
/* 207 */           // try to get the buffer from hash map
/* 208 */           hashAgg_unsafeRowAggBuffer_0 =
/* 209 */           hashAgg_hashMap_0.getAggregationBufferFromUnsafeRow((hashAgg_mutableStateArray_0[3].getRow()), hashAgg_unsafeRowKeyHash_0);
/* 210 */         }
/* 211 */
/* 212 */         if (hashAgg_unsafeRowAggBuffer_0 == null) {
/* 213 */           if (hashAgg_processedRows_0 > 0 && hashAgg_processedRows_0 < (double) (hashAgg_fastHashMap_0.getNumKeys() - hashAgg_adaptiveFastKeysAtSpill_0 + hashAgg_hashMap_0.getNumKeys()) * 1.05D) {
/* 214 */             hashAgg_adaptivePassThrough_0 = true;
/* 215 */           } else {
/* 216 */             if (hashAgg_sorter_0 == null) {
/* 217 */               hashAgg_sorter_0 = hashAgg_hashMap_0.destructAndCreateExternalSorter();
/* 218 */             } else {
/* 219 */               hashAgg_sorter_0.merge(hashAgg_hashMap_0.destructAndCreateExternalSorter());
/* 220 */             }
/* 221 */
/* 222 */             // the hash map had been spilled, so it should have enough memory now,
/* 223 */             // try to allocate buffer again.
/* 224 */             hashAgg_unsafeRowAggBuffer_0 = hashAgg_hashMap_0.getAggregationBufferFromUnsafeRow(
/* 225 */               (hashAgg_mutableStateArray_0[3].getRow()), hashAgg_unsafeRowKeyHash_0);
/* 226 */             if (hashAgg_unsafeRowAggBuffer_0 == null) {
/* 227 */               // failed to allocate the first page
/* 228 */               throw QueryExecutionErrors.aggregateOutOfMemoryError();
/* 229 */             }
/* 230 */
/* 231 */             hashAgg_processedRows_0 = 0L;
/* 232 */             hashAgg_adaptiveNextCheckRow_0 = 100000L;
/* 233 */             hashAgg_adaptiveFastKeysAtSpill_0 = hashAgg_fastHashMap_0.getNumKeys();
/* 234 */
/* 235 */           }
/* 236 */         }
/* 237 */       }
/* 238 */
/* 239 */     }
/* 240 */
/* 241 */     if ((hashAgg_fastAggBuffer_0 != null || hashAgg_unsafeRowAggBuffer_0 != null)) {
/* 242 */       if (!hashAgg_adaptivePassThrough_0) {
/* 243 */         hashAgg_processedRows_0 += 1;
/* 244 */         if (hashAgg_processedRows_0 == hashAgg_adaptiveNextCheckRow_0) {
/* 245 */           if (hashAgg_processedRows_0 < (double) (hashAgg_fastHashMap_0.getNumKeys() - hashAgg_adaptiveFastKeysAtSpill_0 + hashAgg_hashMap_0.getNumKeys()) * 1.05D) {
/* 246 */             hashAgg_adaptivePassThrough_0 = true;
/* 247 */           } else {
/* 248 */             hashAgg_adaptiveNextCheckRow_0 += 100000L;
/* 249 */           }
/* 250 */         }
/* 251 */       }
/* 252 */     } else if (hashAgg_adaptivePassThrough_0) {
/* 253 */       hashAgg_adaptiveRowBypassed_0 = true;
/* 254 */       hashAgg_mutableStateArray_0[4].reset();
/* 255 */
/* 256 */       hashAgg_mutableStateArray_0[4].write(0, 0L);
/* 257 */       hashAgg_unsafeRowAggBuffer_0 = (hashAgg_mutableStateArray_0[4].getRow());
/* 258 */     }
/* 259 */
/* 260 */     // Updates the proper row buffer
/* 261 */     if (hashAgg_fastAggBuffer_0 != null) {
/* 262 */       hashAgg_unsafeRowAggBuffer_0 = hashAgg_fastAggBuffer_0;
/* 263 */     }
/* 264 */
/* 265 */     // common sub-expressions
/* 266 */
/* 267 */     // evaluate aggregate functions and update aggregation buffers
/* 268 */
/* 269 */     long hashAgg_value_13 = hashAgg_unsafeRowAggBuffer_0.getLong(0);
/* 270 */
/* 271 */     long hashAgg_value_12 = -1L;
/* 272 */
/* 273 */     hashAgg_value_12 = org.apache.spark.sql.catalyst.util.MathUtils.addExact(hashAgg_value_13, 1L, ((org.apache.spark.sql.catalyst.trees.SQLQueryContext) references[10] /* errCtx */));
/* 274 */
/* 275 */     hashAgg_unsafeRowAggBuffer_0.setLong(0, hashAgg_value_12);
/* 276 */
/* 277 */     if (hashAgg_adaptiveRowBypassed_0) {
/* 278 */       ((org.apache.spark.sql.execution.metric.SQLMetric) references[11] /* numBypassingRows */).add(1);
/* 279 */       if (hashAgg_adaptiveMapOutputDone_0) {
/* 280 */         hashAgg_doAggregateWithKeysOutput_0((hashAgg_mutableStateArray_0[3].getRow()), hashAgg_unsafeRowAggBuffer_0);
/* 281 */       } else {
/* 282 */         hashAgg_adaptivePendingRows_0.add(new UnsafeRow[] {
/* 283 */             (hashAgg_mutableStateArray_0[3].getRow()).copy(), hashAgg_unsafeRowAggBuffer_0.copy() });
/* 284 */         wholestagecodegen_outputMapAndFlush_0();
/* 285 */       }
/* 286 */     }
/* 287 */
/* 288 */   }
/* 289 */
/* 290 */   protected void processNext() throws java.io.IOException {
/* 291 */     if (!hashAgg_initAgg_0) {
/* 292 */       hashAgg_initAgg_0 = true;
/* 293 */       hashAgg_fastHashMap_0 = new hashAgg_FastHashMap_0(((org.apache.spark.sql.execution.aggregate.HashAggregateExec) references[0] /* plan */).getTaskContext().taskMemoryManager(), ((org.apache.spark.sql.execution.aggregate.HashAggregateExec) references[0] /* plan */).getEmptyAggregationBuffer());
/* 294 */
/* 295 */       ((org.apache.spark.sql.execution.aggregate.HashAggregateExec) references[0] /* plan */).addFastHashMapCloseHook(hashAgg_fastHashMap_0);
/* 296 */
/* 297 */       hashAgg_hashMap_0 = ((org.apache.spark.sql.execution.aggregate.HashAggregateExec) references[0] /* plan */).createHashMap();
/* 298 */       long hashAgg_beforeAgg_0 = System.nanoTime();
/* 299 */       hashAgg_doAggregateWithKeys_0(partitionIndex);
/* 300 */       ((org.apache.spark.sql.execution.metric.SQLMetric) references[12] /* aggTime */).add((System.nanoTime() - hashAgg_beforeAgg_0) / 1000000);
/* 301 */       if (shouldStop()) return;
/* 302 */     }
/* 303 */
/* 304 */     if (!hashAgg_adaptiveChildrenConsumed_0) {
/* 305 */       if (!hashAgg_adaptiveMapOutputDone_0) {
/* 306 */         wholestagecodegen_outputMapAndFlush_0();
/* 307 */         if (shouldStop()) return;
/* 308 */       }
/* 309 */
/* 310 */       long hashAgg_beforeResumedAgg_0 = System.nanoTime();
/* 311 */       hashAgg_doAggregateWithKeys_0(partitionIndex);
/* 312 */       ((org.apache.spark.sql.execution.metric.SQLMetric) references[12] /* aggTime */).add((System.nanoTime() - hashAgg_beforeResumedAgg_0) / 1000000);
/* 313 */       if (shouldStop()) return;
/* 314 */     }
/* 315 */
/* 316 */     if (!hashAgg_adaptiveMapOutputDone_0) {
/* 317 */       wholestagecodegen_outputMapAndFlush_0();
/* 318 */       if (shouldStop()) return;
/* 319 */     }
/* 320 */   }
/* 321 */
/* 322 */   private void columnartorow_nextBatch_0() throws java.io.IOException {
/* 323 */     columnartorow_mutableStateArray_1[0] = org.apache.spark.sql.execution.ColumnarToRowExec.advanceBatch(
/* 324 */       columnartorow_mutableStateArray_0[0], columnartorow_mutableStateArray_1[0], ((org.apache.spark.sql.execution.metric.SQLMetric) references[9] /* numInputBatches */), ((org.apache.spark.sql.execution.metric.SQLMetric) references[8] /* numOutputRows */));
/* 325 */     if (columnartorow_mutableStateArray_1[0] != null) {
/* 326 */       columnartorow_batchIdx_0 = 0;
/* 327 */       columnartorow_mutableStateArray_2[0] = (org.apache.spark.sql.execution.vectorized.OnHeapColumnVector) columnartorow_mutableStateArray_1[0].column(0);
/* 328 */
/* 329 */     }
/* 330 */   }
/* 331 */ }
```

</details>


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.5)






