### PR TITLE
[MINOR][PYTHON][TESTS] Add TaskContext tests for scalar Arrow UDFs

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -1267,6 +1267,33 @@ class ScalarArrowUDFTestsMixin:
             result = df.select(return_one("id").alias("one")).collect()
             self.assertEqual(expected, result)
 
+    def test_arrow_udf_task_context(self):
+        import pyarrow as pa
+
+        from pyspark import TaskContext
+
+        def partition_ids(size):
+            task_context = TaskContext.get()
+            assert task_context is not None
+            return pa.array([task_context.partitionId()] * size, type=pa.int32())
+
+        @arrow_udf("int")
+        def scalar_task_context(values):
+            return partition_ids(len(values))
+
+        @arrow_udf("int", ArrowUDFType.SCALAR_ITER)
+        def scalar_iter_task_context(iterator):
+            for values in iterator:
+                yield partition_ids(len(values))
+
+        for task_context_udf in [scalar_task_context, scalar_iter_task_context]:
+            rows = (
+                self.spark.range(10, numPartitions=2)
+                .select(task_context_udf("id").alias("partition_id"))
+                .collect()
+            )
+            self.assertEqual({0, 1}, {row.partition_id for row in rows})
+
 
 class ScalarArrowUDFTests(ScalarArrowUDFTestsMixin, ReusedSQLTestCase):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a test to ScalarArrowUDFTestsMixin that verifies TaskContext is initialized in both scalar and scalar-iterator Arrow UDFs. The test checks the partition IDs returned by TaskContext and is also inherited by the Spark Connect parity suite.

### Why are the changes needed?

TaskContext is covered for Pandas UDFs and mapInArrow, but scalar Arrow UDFs did not have equivalent coverage. This test closes that gap and guards classic and Spark Connect execution against regressions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

    build/sbt -Phive package
    conda run -n spark-dev-313 --no-capture-output python/run-tests --testnames "pyspark.sql.tests.arrow.test_arrow_udf_scalar ScalarArrowUDFTests.test_arrow_udf_task_context"
    conda run -n spark-dev-313 --no-capture-output python/run-tests --testnames "pyspark.sql.tests.connect.arrow.test_parity_arrow_udf_scalar ScalarArrowPythonUDFParityTests.test_arrow_udf_task_context"
    conda run -n spark-dev-313 ruff check python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
    conda run -n spark-dev-313 ruff format --check python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)