### PR TITLE
[SPARK-58546][ML] Avoid redundant StringIndexer label lookups

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -363,9 +363,10 @@ class StringIndexerModel (
       .where(conditions.reduce(_ and _))
   }
 
-  private def getIndexer(labels: Seq[String], labelToIndex: OpenHashMap[String, Double]) = {
-    val keepInvalid = (getHandleInvalid == StringIndexer.KEEP_INVALID)
-
+  private def getIndexer(
+      labels: Seq[String],
+      labelToIndex: OpenHashMap[String, Double],
+      keepInvalid: Boolean) = {
     udf { label: String =>
       if (label == null) {
         if (keepInvalid) {
@@ -375,13 +376,12 @@ class StringIndexerModel (
             "NULLS, try setting StringIndexer.handleInvalid.")
         }
       } else {
-        if (labelToIndex.contains(label)) {
-          labelToIndex(label)
-        } else if (keepInvalid) {
-          labels.length
-        } else {
-          throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
-            s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
+        labelToIndex.get(label) match {
+          case Some(index) => index
+          case None if keepInvalid => labels.length
+          case None =>
+            throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
+              s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
         }
       }
     }.asNondeterministic()
@@ -400,6 +400,7 @@ class StringIndexerModel (
       map
     }
     val outputColumns = new Array[Column](outputColNames.length)
+    val keepInvalid = getHandleInvalid == StringIndexer.KEEP_INVALID
 
     // Skips invalid rows if `handleInvalid` is set to `StringIndexer.SKIP_INVALID`.
     val filteredDataset = if (getHandleInvalid == StringIndexer.SKIP_INVALID) {
@@ -416,16 +417,13 @@ class StringIndexerModel (
 
       try {
         dataset.col(inputColName)
-        val filteredLabels = getHandleInvalid match {
-          case StringIndexer.KEEP_INVALID => labels :+ "__unknown"
-          case _ => labels
-        }
+        val filteredLabels = if (keepInvalid) labels :+ "__unknown" else labels
         val metadata = NominalAttribute.defaultAttr
           .withName(outputColName)
           .withValues(filteredLabels)
           .toMetadata()
 
-        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex)
+        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, keepInvalid)
 
         outputColumns(i) = indexer(dataset(inputColName).cast(StringType))
           .as(outputColName, metadata)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -367,24 +367,28 @@ class StringIndexerModel (
       labels: Seq[String],
       labelToIndex: OpenHashMap[String, Double],
       keepInvalid: Boolean) = {
-    udf { label: String =>
-      if (label == null) {
-        if (keepInvalid) {
-          labels.length
+    val unknownIndex = labels.length.toDouble
+    if (keepInvalid) {
+      udf { label: String =>
+        if (label == null) {
+          unknownIndex
         } else {
+          labelToIndex.get(label).getOrElse(unknownIndex)
+        }
+      }.asNondeterministic()
+    } else {
+      udf { label: String =>
+        if (label == null) {
           throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
             "NULLS, try setting StringIndexer.handleInvalid.")
-        }
-      } else {
-        labelToIndex.get(label) match {
-          case Some(index) => index
-          case None if keepInvalid => labels.length
-          case None =>
+        } else {
+          labelToIndex.get(label).getOrElse {
             throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
               s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
+          }
         }
-      }
-    }.asNondeterministic()
+      }.asNondeterministic()
+    }
   }
 
   @Since("2.0.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR passes `keepInvalid` into `StringIndexerModel.getIndexer`, computes it once during transformation, and uses one `OpenHashMap.get` lookup for non-null labels.

### Why are the changes needed?

The previous UDF performed `contains` followed by map access for known labels, causing two lookups per value. This removes the redundant lookup while preserving invalid-label behavior.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not run (not requested). Verified with `git diff --check`, ASCII scan, and changed-line length scan.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)