### PR TITLE
[WIP][ML] Avoid duplicate StringIndexer skip lookups

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -344,36 +344,36 @@ class StringIndexerModel (
 
   private def getKeepInvalidIndexer(
       labels: Array[String],
-      labelToIndex: OpenHashMap[String, Double]): UserDefinedFunction = {
+      labelToIndex: OpenHashMap[String, Int]): UserDefinedFunction = {
     val unknownIndex = labels.length.toDouble
     udf { label: String =>
       if (label == null) {
         unknownIndex
       } else {
-        labelToIndex.get(label).getOrElse(unknownIndex)
+        labelToIndex.get(label).map(_.toDouble).getOrElse(unknownIndex)
       }
     }.asNondeterministic()
   }
 
   private def getSkipInvalidIndexer(
-      labelToIndex: OpenHashMap[String, Double]): UserDefinedFunction = {
+      labelToIndex: OpenHashMap[String, Int]): UserDefinedFunction = {
     udf { label: String =>
       if (label == null) {
         null
       } else {
-        labelToIndex.get(label).map(index => java.lang.Double.valueOf(index)).orNull
+        labelToIndex.get(label).map(index => java.lang.Double.valueOf(index.toDouble)).orNull
       }
     }.asNondeterministic()
   }
 
   private def getErrorInvalidIndexer(
-      labelToIndex: OpenHashMap[String, Double]): UserDefinedFunction = {
+      labelToIndex: OpenHashMap[String, Int]): UserDefinedFunction = {
     udf { label: String =>
       if (label == null) {
         throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
           "NULLS, try setting StringIndexer.handleInvalid.")
       } else {
-        labelToIndex.get(label).getOrElse {
+        labelToIndex.get(label).map(_.toDouble).getOrElse {
           throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
             s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
         }
@@ -385,7 +385,7 @@ class StringIndexerModel (
       dataset: Dataset[_],
       inputColNames: Array[String],
       outputColNames: Array[String],
-      labelsToIndexArray: Array[OpenHashMap[String, Double]]): DataFrame = {
+      labelsToIndexArray: Array[OpenHashMap[String, Int]]): DataFrame = {
     val (transformedDataset, _) = transformWithIndexers(
       dataset,
       inputColNames,
@@ -400,14 +400,14 @@ class StringIndexerModel (
       dataset: Dataset[_],
       inputColNames: Array[String],
       outputColNames: Array[String],
-      labelsToIndexArray: Array[OpenHashMap[String, Double]]): DataFrame = {
+      labelsToIndexArray: Array[OpenHashMap[String, Int]]): DataFrame = {
     val (transformedDataset, filteredOutputColNames) = transformWithIndexers(
       dataset,
       inputColNames,
       outputColNames,
       labelsToIndexArray,
       keepInvalid = false,
-      (_: Array[String], labelToIndex: OpenHashMap[String, Double]) =>
+      (_: Array[String], labelToIndex: OpenHashMap[String, Int]) =>
         getSkipInvalidIndexer(labelToIndex))
     if (filteredOutputColNames.length > 0) {
       // The skip indexers return null for invalid labels. Their nondeterminism keeps this filter
@@ -422,14 +422,14 @@ class StringIndexerModel (
       dataset: Dataset[_],
       inputColNames: Array[String],
       outputColNames: Array[String],
-      labelsToIndexArray: Array[OpenHashMap[String, Double]]): DataFrame = {
+      labelsToIndexArray: Array[OpenHashMap[String, Int]]): DataFrame = {
     val (transformedDataset, _) = transformWithIndexers(
       dataset,
       inputColNames,
       outputColNames,
       labelsToIndexArray,
       keepInvalid = false,
-      (_: Array[String], labelToIndex: OpenHashMap[String, Double]) =>
+      (_: Array[String], labelToIndex: OpenHashMap[String, Int]) =>
         getErrorInvalidIndexer(labelToIndex))
     transformedDataset
   }
@@ -438,9 +438,9 @@ class StringIndexerModel (
       dataset: Dataset[_],
       inputColNames: Array[String],
       outputColNames: Array[String],
-      labelsToIndexArray: Array[OpenHashMap[String, Double]],
+      labelsToIndexArray: Array[OpenHashMap[String, Int]],
       keepInvalid: Boolean,
-      getIndexer: (Array[String], OpenHashMap[String, Double]) => UserDefinedFunction):
+      getIndexer: (Array[String], OpenHashMap[String, Int]) => UserDefinedFunction):
       (DataFrame, Array[String]) = {
     val filteredOutputColNames = ArrayBuffer.empty[String]
     val filteredOutputColumns = ArrayBuffer.empty[Column]
@@ -494,7 +494,7 @@ class StringIndexerModel (
 
     val (inputColNames, outputColNames) = getInOutCols()
     val labelsToIndexArray = labelsArray.map { labels =>
-      val map = new OpenHashMap[String, Double](labels.length)
+      val map = new OpenHashMap[String, Int](labels.length)
       labels.zipWithIndex.foreach { case (label, idx) =>
         map.update(label, idx)
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -339,41 +339,26 @@ class StringIndexerModel (
   @Since("3.0.0")
   def setOutputCols(value: Array[String]): this.type = set(outputCols, value)
 
-  // This filters out any null values and also the input labels which are not in
-  // the dataset used for fitting.
-  private def filterInvalidData(
-      dataset: Dataset[_],
-      inputColNames: Seq[String],
-      labelsToIndexArray: Array[OpenHashMap[String, Int]]): Dataset[_] = {
-    val conditions: Seq[Column] = inputColNames.indices.map { i =>
-      val inputColName = inputColNames(i)
-      val labelToIndex = labelsToIndexArray(i)
-      // We have this additional lookup at `labelToIndex` when `handleInvalid` is set to
-      // `StringIndexer.SKIP_INVALID`. Another idea is to do this lookup natively by SQL
-      // expression, however, lookup for a key in a map is not efficient in SparkSQL now.
-      // See `ElementAt` and `GetMapValue` expressions. If SQL's map lookup is improved,
-      // we can consider to change this.
-      val filter = udf { label: String =>
-        labelToIndex.contains(label)
-      }
-      filter(dataset(inputColName))
-    }
-
-    dataset.na.drop(inputColNames.filter(dataset.schema.fieldNames.contains(_)))
-      .where(conditions.reduce(_ and _))
-  }
-
   private def getIndexer(
       labels: Seq[String],
-      labelToIndex: OpenHashMap[String, Int],
-      keepInvalid: Boolean) = {
-    val unknownIndex = labels.length
+      labelToIndex: OpenHashMap[String, Double],
+      keepInvalid: Boolean,
+      skipInvalid: Boolean) = {
+    val unknownIndex = labels.length.toDouble
     if (keepInvalid) {
       udf { label: String =>
         if (label == null) {
           unknownIndex
         } else {
           labelToIndex.get(label).getOrElse(unknownIndex)
+        }
+      }.asNondeterministic()
+    } else if (skipInvalid) {
+      udf { label: String =>
+        if (label == null) {
+          null
+        } else {
+          labelToIndex.get(label).map(index => java.lang.Double.valueOf(index)).orNull
         }
       }.asNondeterministic()
     } else {
@@ -397,7 +382,7 @@ class StringIndexerModel (
 
     val (inputColNames, outputColNames) = getInOutCols()
     val labelsToIndexArray = labelsArray.map { labels =>
-      val map = new OpenHashMap[String, Int](labels.length)
+      val map = new OpenHashMap[String, Double](labels.length)
       labels.zipWithIndex.foreach { case (label, idx) =>
         map.update(label, idx)
       }
@@ -405,13 +390,7 @@ class StringIndexerModel (
     }
     val outputColumns = new Array[Column](outputColNames.length)
     val keepInvalid = getHandleInvalid == StringIndexer.KEEP_INVALID
-
-    // Skips invalid rows if `handleInvalid` is set to `StringIndexer.SKIP_INVALID`.
-    val filteredDataset = if (getHandleInvalid == StringIndexer.SKIP_INVALID) {
-      filterInvalidData(dataset, inputColNames.toImmutableArraySeq, labelsToIndexArray)
-    } else {
-      dataset
-    }
+    val skipInvalid = getHandleInvalid == StringIndexer.SKIP_INVALID
 
     for (i <- outputColNames.indices) {
       val inputColName = inputColNames(i)
@@ -427,9 +406,10 @@ class StringIndexerModel (
           .withValues(filteredLabels)
           .toMetadata()
 
-        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, keepInvalid)
+        val indexer =
+          getIndexer(labels.toImmutableArraySeq, labelToIndex, keepInvalid, skipInvalid)
 
-        outputColumns(i) = indexer(dataset(inputColName).cast(StringType)).cast(DoubleType)
+        outputColumns(i) = indexer(dataset(inputColName).cast(StringType))
           .as(outputColName, metadata)
       } catch {
         case _: AnalysisException =>
@@ -443,10 +423,17 @@ class StringIndexerModel (
 
     require(filteredOutputColNames.length == filteredOutputColumns.length)
     if (filteredOutputColNames.length > 0) {
-      filteredDataset.withColumns(
+      val transformedDataset = dataset.withColumns(
         filteredOutputColNames.toImmutableArraySeq, filteredOutputColumns.toImmutableArraySeq)
+      if (skipInvalid) {
+        // The skip indexers return null for invalid labels. Their nondeterminism keeps this filter
+        // above the projection, so each label is looked up only once.
+        transformedDataset.na.drop(filteredOutputColNames)
+      } else {
+        transformedDataset
+      }
     } else {
-      filteredDataset.toDF()
+      dataset.toDF()
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -19,6 +19,8 @@ package org.apache.spark.ml.feature
 
 import java.io.{DataInputStream, DataOutputStream}
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkException, SparkIllegalArgumentException}
@@ -30,6 +32,7 @@ import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Dataset}
+import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{get => fget, printf => fprintf, _}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ArrayImplicits._
@@ -339,40 +342,149 @@ class StringIndexerModel (
   @Since("3.0.0")
   def setOutputCols(value: Array[String]): this.type = set(outputCols, value)
 
-  private def getIndexer(
-      labels: Seq[String],
-      labelToIndex: OpenHashMap[String, Double],
-      handleInvalid: String) = {
-    handleInvalid match {
-      case StringIndexer.KEEP_INVALID =>
-        val unknownIndex = labels.length.toDouble
-        udf { label: String =>
-          if (label == null) {
-            unknownIndex
-          } else {
-            labelToIndex.get(label).getOrElse(unknownIndex)
-          }
-        }.asNondeterministic()
-      case StringIndexer.SKIP_INVALID =>
-        udf { label: String =>
-          if (label == null) {
-            null
-          } else {
-            labelToIndex.get(label).map(index => java.lang.Double.valueOf(index)).orNull
-          }
-        }.asNondeterministic()
-      case _ =>
-        udf { label: String =>
-          if (label == null) {
-            throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
-              "NULLS, try setting StringIndexer.handleInvalid.")
-          } else {
-            labelToIndex.get(label).getOrElse {
-              throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
-                s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
-            }
-          }
-        }.asNondeterministic()
+  private def getKeepInvalidIndexer(
+      labels: Array[String],
+      labelToIndex: OpenHashMap[String, Double]): UserDefinedFunction = {
+    val unknownIndex = labels.length.toDouble
+    udf { label: String =>
+      if (label == null) {
+        unknownIndex
+      } else {
+        labelToIndex.get(label).getOrElse(unknownIndex)
+      }
+    }.asNondeterministic()
+  }
+
+  private def getSkipInvalidIndexer(
+      labelToIndex: OpenHashMap[String, Double]): UserDefinedFunction = {
+    udf { label: String =>
+      if (label == null) {
+        null
+      } else {
+        labelToIndex.get(label).map(index => java.lang.Double.valueOf(index)).orNull
+      }
+    }.asNondeterministic()
+  }
+
+  private def getErrorInvalidIndexer(
+      labelToIndex: OpenHashMap[String, Double]): UserDefinedFunction = {
+    udf { label: String =>
+      if (label == null) {
+        throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
+          "NULLS, try setting StringIndexer.handleInvalid.")
+      } else {
+        labelToIndex.get(label).getOrElse {
+          throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
+            s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
+        }
+      }
+    }.asNondeterministic()
+  }
+
+  private def transformWithKeepInvalid(
+      dataset: Dataset[_],
+      inputColNames: Array[String],
+      outputColNames: Array[String],
+      labelsToIndexArray: Array[OpenHashMap[String, Double]]): DataFrame = {
+    val (transformedDataset, _) = transformWithIndexers(
+      dataset,
+      inputColNames,
+      outputColNames,
+      labelsToIndexArray,
+      keepInvalid = true,
+      getKeepInvalidIndexer)
+    transformedDataset
+  }
+
+  private def transformWithSkipInvalid(
+      dataset: Dataset[_],
+      inputColNames: Array[String],
+      outputColNames: Array[String],
+      labelsToIndexArray: Array[OpenHashMap[String, Double]]): DataFrame = {
+    val (transformedDataset, filteredOutputColNames) = transformWithIndexers(
+      dataset,
+      inputColNames,
+      outputColNames,
+      labelsToIndexArray,
+      keepInvalid = false,
+      (_: Array[String], labelToIndex: OpenHashMap[String, Double]) =>
+        getSkipInvalidIndexer(labelToIndex))
+    if (filteredOutputColNames.length > 0) {
+      // The skip indexers return null for invalid labels. Their nondeterminism keeps this filter
+      // above the projection, so each label is looked up only once.
+      transformedDataset.na.drop(filteredOutputColNames)
+    } else {
+      transformedDataset
+    }
+  }
+
+  private def transformWithErrorInvalid(
+      dataset: Dataset[_],
+      inputColNames: Array[String],
+      outputColNames: Array[String],
+      labelsToIndexArray: Array[OpenHashMap[String, Double]]): DataFrame = {
+    val (transformedDataset, _) = transformWithIndexers(
+      dataset,
+      inputColNames,
+      outputColNames,
+      labelsToIndexArray,
+      keepInvalid = false,
+      (_: Array[String], labelToIndex: OpenHashMap[String, Double]) =>
+        getErrorInvalidIndexer(labelToIndex))
+    transformedDataset
+  }
+
+  private def transformWithIndexers(
+      dataset: Dataset[_],
+      inputColNames: Array[String],
+      outputColNames: Array[String],
+      labelsToIndexArray: Array[OpenHashMap[String, Double]],
+      keepInvalid: Boolean,
+      getIndexer: (Array[String], OpenHashMap[String, Double]) => UserDefinedFunction):
+      (DataFrame, Array[String]) = {
+    val filteredOutputColNames = ArrayBuffer.empty[String]
+    val filteredOutputColumns = ArrayBuffer.empty[Column]
+
+    for (i <- outputColNames.indices) {
+      val inputColName = inputColNames(i)
+      val outputColName = outputColNames(i)
+      val labelToIndex = labelsToIndexArray(i)
+      val labels = labelsArray(i)
+
+      try {
+        dataset.col(inputColName)
+        val filteredLabels = if (keepInvalid) {
+          labels :+ "__unknown"
+        } else {
+          labels
+        }
+        val metadata = NominalAttribute.defaultAttr
+          .withName(outputColName)
+          .withValues(filteredLabels)
+          .toMetadata()
+
+        val indexer = getIndexer(labels, labelToIndex)
+
+        filteredOutputColNames += outputColName
+        filteredOutputColumns += indexer(dataset(inputColName).cast(StringType))
+          .as(outputColName, metadata)
+      } catch {
+        case _: AnalysisException =>
+          logWarning(log"Input column ${MDC(LogKeys.COLUMN_NAME, inputColName)} does not exist " +
+            log"during transformation. Skip StringIndexerModel for this column.")
+      }
+    }
+
+    require(filteredOutputColNames.length == filteredOutputColumns.length)
+    if (filteredOutputColNames.length > 0) {
+      val filteredOutputColNamesArray = filteredOutputColNames.toArray
+      val filteredOutputColumnsArray = filteredOutputColumns.toArray
+      val transformedDataset = dataset.withColumns(
+        filteredOutputColNamesArray.toImmutableArraySeq,
+        filteredOutputColumnsArray.toImmutableArraySeq)
+      (transformedDataset, filteredOutputColNamesArray)
+    } else {
+      (dataset.toDF(), filteredOutputColNames.toArray)
     }
   }
 
@@ -388,53 +500,14 @@ class StringIndexerModel (
       }
       map
     }
-    val outputColumns = new Array[Column](outputColNames.length)
 
-    for (i <- outputColNames.indices) {
-      val inputColName = inputColNames(i)
-      val outputColName = outputColNames(i)
-      val labelToIndex = labelsToIndexArray(i)
-      val labels = labelsArray(i)
-
-      try {
-        dataset.col(inputColName)
-        val filteredLabels = if (getHandleInvalid == StringIndexer.KEEP_INVALID) {
-          labels :+ "__unknown"
-        } else {
-          labels
-        }
-        val metadata = NominalAttribute.defaultAttr
-          .withName(outputColName)
-          .withValues(filteredLabels)
-          .toMetadata()
-
-        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, getHandleInvalid)
-
-        outputColumns(i) = indexer(dataset(inputColName).cast(StringType))
-          .as(outputColName, metadata)
-      } catch {
-        case _: AnalysisException =>
-          logWarning(log"Input column ${MDC(LogKeys.COLUMN_NAME, inputColName)} does not exist " +
-            log"during transformation. Skip StringIndexerModel for this column.")
-          outputColNames(i) = null
-      }
-    }
-    val filteredOutputColNames = outputColNames.filter(_ != null)
-    val filteredOutputColumns = outputColumns.filter(_ != null)
-
-    require(filteredOutputColNames.length == filteredOutputColumns.length)
-    if (filteredOutputColNames.length > 0) {
-      val transformedDataset = dataset.withColumns(
-        filteredOutputColNames.toImmutableArraySeq, filteredOutputColumns.toImmutableArraySeq)
-      if (getHandleInvalid == StringIndexer.SKIP_INVALID) {
-        // The skip indexers return null for invalid labels. Their nondeterminism keeps this filter
-        // above the projection, so each label is looked up only once.
-        transformedDataset.na.drop(filteredOutputColNames)
-      } else {
-        transformedDataset
-      }
-    } else {
-      dataset.toDF()
+    getHandleInvalid match {
+      case StringIndexer.KEEP_INVALID =>
+        transformWithKeepInvalid(dataset, inputColNames, outputColNames, labelsToIndexArray)
+      case StringIndexer.SKIP_INVALID =>
+        transformWithSkipInvalid(dataset, inputColNames, outputColNames, labelsToIndexArray)
+      case StringIndexer.ERROR_INVALID =>
+        transformWithErrorInvalid(dataset, inputColNames, outputColNames, labelsToIndexArray)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -343,9 +343,9 @@ class StringIndexerModel (
       labels: Seq[String],
       labelToIndex: OpenHashMap[String, Double],
       handleInvalid: String) = {
-    val unknownIndex = labels.length.toDouble
     handleInvalid match {
       case StringIndexer.KEEP_INVALID =>
+        val unknownIndex = labels.length.toDouble
         udf { label: String =>
           if (label == null) {
             unknownIndex

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -389,9 +389,6 @@ class StringIndexerModel (
       map
     }
     val outputColumns = new Array[Column](outputColNames.length)
-    val handleInvalid = getHandleInvalid
-    val keepInvalid = handleInvalid == StringIndexer.KEEP_INVALID
-    val skipInvalid = handleInvalid == StringIndexer.SKIP_INVALID
 
     for (i <- outputColNames.indices) {
       val inputColName = inputColNames(i)
@@ -401,13 +398,17 @@ class StringIndexerModel (
 
       try {
         dataset.col(inputColName)
-        val filteredLabels = if (keepInvalid) labels :+ "__unknown" else labels
+        val filteredLabels = if (getHandleInvalid == StringIndexer.KEEP_INVALID) {
+          labels :+ "__unknown"
+        } else {
+          labels
+        }
         val metadata = NominalAttribute.defaultAttr
           .withName(outputColName)
           .withValues(filteredLabels)
           .toMetadata()
 
-        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, handleInvalid)
+        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, getHandleInvalid)
 
         outputColumns(i) = indexer(dataset(inputColName).cast(StringType))
           .as(outputColName, metadata)
@@ -425,7 +426,7 @@ class StringIndexerModel (
     if (filteredOutputColNames.length > 0) {
       val transformedDataset = dataset.withColumns(
         filteredOutputColNames.toImmutableArraySeq, filteredOutputColumns.toImmutableArraySeq)
-      if (skipInvalid) {
+      if (getHandleInvalid == StringIndexer.SKIP_INVALID) {
         // The skip indexers return null for invalid labels. Their nondeterminism keeps this filter
         // above the projection, so each label is looked up only once.
         transformedDataset.na.drop(filteredOutputColNames)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -342,10 +342,9 @@ class StringIndexerModel (
   private def getIndexer(
       labels: Seq[String],
       labelToIndex: OpenHashMap[String, Double],
-      keepInvalid: Boolean,
-      skipInvalid: Boolean) = {
+      handleInvalid: String) = {
     val unknownIndex = labels.length.toDouble
-    if (keepInvalid) {
+    if (handleInvalid == StringIndexer.KEEP_INVALID) {
       udf { label: String =>
         if (label == null) {
           unknownIndex
@@ -353,7 +352,7 @@ class StringIndexerModel (
           labelToIndex.get(label).getOrElse(unknownIndex)
         }
       }.asNondeterministic()
-    } else if (skipInvalid) {
+    } else if (handleInvalid == StringIndexer.SKIP_INVALID) {
       udf { label: String =>
         if (label == null) {
           null
@@ -389,8 +388,9 @@ class StringIndexerModel (
       map
     }
     val outputColumns = new Array[Column](outputColNames.length)
-    val keepInvalid = getHandleInvalid == StringIndexer.KEEP_INVALID
-    val skipInvalid = getHandleInvalid == StringIndexer.SKIP_INVALID
+    val handleInvalid = getHandleInvalid
+    val keepInvalid = handleInvalid == StringIndexer.KEEP_INVALID
+    val skipInvalid = handleInvalid == StringIndexer.SKIP_INVALID
 
     for (i <- outputColNames.indices) {
       val inputColName = inputColNames(i)
@@ -406,8 +406,7 @@ class StringIndexerModel (
           .withValues(filteredLabels)
           .toMetadata()
 
-        val indexer =
-          getIndexer(labels.toImmutableArraySeq, labelToIndex, keepInvalid, skipInvalid)
+        val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, handleInvalid)
 
         outputColumns(i) = indexer(dataset(inputColName).cast(StringType))
           .as(outputColName, metadata)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -344,34 +344,35 @@ class StringIndexerModel (
       labelToIndex: OpenHashMap[String, Double],
       handleInvalid: String) = {
     val unknownIndex = labels.length.toDouble
-    if (handleInvalid == StringIndexer.KEEP_INVALID) {
-      udf { label: String =>
-        if (label == null) {
-          unknownIndex
-        } else {
-          labelToIndex.get(label).getOrElse(unknownIndex)
-        }
-      }.asNondeterministic()
-    } else if (handleInvalid == StringIndexer.SKIP_INVALID) {
-      udf { label: String =>
-        if (label == null) {
-          null
-        } else {
-          labelToIndex.get(label).map(index => java.lang.Double.valueOf(index)).orNull
-        }
-      }.asNondeterministic()
-    } else {
-      udf { label: String =>
-        if (label == null) {
-          throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
-            "NULLS, try setting StringIndexer.handleInvalid.")
-        } else {
-          labelToIndex.get(label).getOrElse {
-            throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
-              s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
+    handleInvalid match {
+      case StringIndexer.KEEP_INVALID =>
+        udf { label: String =>
+          if (label == null) {
+            unknownIndex
+          } else {
+            labelToIndex.get(label).getOrElse(unknownIndex)
           }
-        }
-      }.asNondeterministic()
+        }.asNondeterministic()
+      case StringIndexer.SKIP_INVALID =>
+        udf { label: String =>
+          if (label == null) {
+            null
+          } else {
+            labelToIndex.get(label).map(index => java.lang.Double.valueOf(index)).orNull
+          }
+        }.asNondeterministic()
+      case _ =>
+        udf { label: String =>
+          if (label == null) {
+            throw new SparkException("StringIndexer encountered NULL value. To handle or skip " +
+              "NULLS, try setting StringIndexer.handleInvalid.")
+          } else {
+            labelToIndex.get(label).getOrElse {
+              throw new SparkException(s"Unseen label: $label. To handle unseen labels, " +
+                s"set Param handleInvalid to ${StringIndexer.KEEP_INVALID}.")
+            }
+          }
+        }.asNondeterministic()
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -519,6 +519,26 @@ class StringIndexerSuite extends MLTest with DefaultReadWriteTest {
     }
   }
 
+  test("StringIndexer skips rows with invalid multiple input columns") {
+    val training = Seq(("a", "e"), ("b", "f")).toDF("label1", "label2")
+    val data = Seq(
+      (0, "a", "e"),
+      (1, "c", "e"),
+      (2, "a", "g"),
+      (3, null, "e"),
+      (4, "b", "f")
+    ).toDF("id", "label1", "label2")
+
+    val model = new StringIndexer()
+      .setInputCols(Array("label1", "label2"))
+      .setOutputCols(Array("labelIndex1", "labelIndex2"))
+      .setHandleInvalid("skip")
+      .fit(training)
+
+    val transformed = model.transform(data).select("id", "labelIndex1", "labelIndex2")
+    checkAnswer(transformed, Seq(Row(0, 0.0, 0.0), Row(4, 1.0, 1.0)))
+  }
+
   test("Correctly skipping NULL and NaN values") {
     val df = Seq(("a", Double.NaN), (null, 1.0), ("b", 2.0), (null, 3.0)).toDF("str", "double")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This draft changes the `StringIndexerModel` `handleInvalid = "skip"` path to produce a nullable index in the existing indexing UDF, then drop rows with null generated indexes. It removes the separate membership-filter UDF.

### Why are the changes needed?

Previously, every valid label was probed once by `OpenHashMap.contains` during filtering and again by `OpenHashMap.get` during indexing. The new plan evaluates one lookup per input label while preserving the existing skip behavior.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added multi-column coverage for unseen and null labels with `handleInvalid = "skip"`. `build/sbt mllib/Test/compile` completed successfully. The test suite was not run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)