### PR TITLE
[SPARK-58559][PYTHON] Package all of sbin in PySpark classic distribution

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -19,7 +19,7 @@
 recursive-include pyspark *.pyi py.typed *.json
 recursive-include deps/jars *.jar
 graft deps/bin
-recursive-include deps/sbin spark-config.sh spark-daemon.sh start-history-server.sh stop-history-server.sh
+graft deps/sbin
 recursive-include deps/data *.data *.txt
 graft deps/licenses
 recursive-include deps/examples *.py

--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -342,14 +342,7 @@ try:
         package_data={
             "pyspark.jars": ["*.jar"],
             "pyspark.bin": ["*"],
-            "pyspark.sbin": [
-                "spark-config.sh",
-                "spark-daemon.sh",
-                "start-connect-server.sh",
-                "start-history-server.sh",
-                "stop-connect-server.sh",
-                "stop-history-server.sh",
-            ],
+            "pyspark.sbin": ["*"],
             "pyspark.python.lib": ["*.zip"],
             "pyspark.data": ["*.txt", "*.data"],
             "pyspark.licenses": ["*"],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Package everything in `sbin/` when building a PySpark Classic distribution.

Rely on a clear project support policy -- clarified in https://github.com/apache/spark/pull/57452 -- rather than micro-managing what gets packaged to communicate to users that PySpark is not meant to launch "real" clusters.

### Why are the changes needed?

Some `sbin` scripts were first added to PySpark in #23715. There was some disagreement then about whether PySpark should include these scripts, mainly because some committers at the time thought PySpark should be a client-only distribution.

In the intervening years, the Spark Connect effort has created a true client-only distribution of Spark in contrast to the "heavier" PySpark Classic which includes all of Spark's assembly JARs.

PySpark Classic has included some `sbin` scripts since 3.0.0, and #56907 recently [added the Connect server scripts][1]. #56907, however, neglected to add the corresponding directives to `MANIFEST.in`.

[1]: https://github.com/apache/spark/pull/56907/changes#diff-dd3c4e1caaf1748872bda7e102f7287d434044236e3996835008600c070ad43a

Since #57452 clarifies the intended use of the Python distributions of Spark -- specifically, that starting a full cluster is [not supported][2], regardless of whether it's possible -- I believe it's conceptually simpler to just package all of `sbin`. That would, for example, prevent the kind of gap identified in #56907.

[2]: https://github.com/apache/spark/pull/57452#discussion_r3635301417

### Does this PR introduce _any_ user-facing change?

Yes, it packages additional `sbin` scripts in the PySpark classic distribution.

### How was this patch tested?

Distributions are not tested thoroughly. #57645 adds a dedicated distribution validation script. I think we should discuss there any testing we would like to add for this.

### Was this patch authored or co-authored using generative AI tooling?

No.