### PR TITLE
[SPARK-58566][SQL][TESTS] Add tests for QuotingUtils.quoteIdentifier and escapeSingleQuotedString

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuotingUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuotingUtilsSuite.scala
@@ -40,4 +40,17 @@ class QuotingUtilsSuite extends SparkFunSuite {
     assert(quoteIfNeeded("0d") == "`0d`")
     assert(quoteIfNeeded("") === "``")
   }
+
+  test("quoteIdentifier escapes back-ticks and always wraps") {
+    assert(QuotingUtils.quoteIdentifier("a") === "`a`")
+    assert(QuotingUtils.quoteIdentifier("") === "``")
+    assert(QuotingUtils.quoteIdentifier("a`b") === "`a``b`")
+    assert(QuotingUtils.quoteIdentifier("`") === "````")
+  }
+
+  test("escapeSingleQuotedString escapes single quotes only") {
+    assert(QuotingUtils.escapeSingleQuotedString("abc") === "abc")
+    assert(QuotingUtils.escapeSingleQuotedString("a'b") === "a\\'b")
+    assert(QuotingUtils.escapeSingleQuotedString("''") === "\\'\\'")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds unit tests for `QuotingUtils.quoteIdentifier` and `escapeSingleQuotedString`, which had no direct coverage.

### Why are the changes needed?
These pure string helpers back-tick-escape identifiers and backslash-escape single quotes; the tests pin their contract (wrapping, doubling, escaping, empty input).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
This PR is the test. `build/sbt "catalyst/testOnly *QuotingUtilsSuite"`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)