### PR TITLE
[SPARK-58567][SQL] Use nonEmpty/isEmpty instead of length comparisons in StateDataSource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
@@ -320,7 +320,7 @@ class StateDataSource extends TableProvider with DataSourceRegister with Logging
 
       // Read the schema file path from operator metadata version v2 onwards
       // for the transformWithState operator
-      val oldSchemaFilePaths = if (storeMetadata.length > 0 && storeMetadata.head.version == 2) {
+      val oldSchemaFilePaths = if (storeMetadata.nonEmpty && storeMetadata.head.version == 2) {
         val opName = storeMetadata.head.operatorName
         if (StatefulOperatorsUtils.TRANSFORM_WITH_STATE_OP_NAMES.exists(opName.contains)) {
           val storeMetadataEntry = storeMetadata.head
@@ -442,7 +442,7 @@ class StateDataSource extends TableProvider with DataSourceRegister with Logging
       storeMetadata: Array[StateMetadataTableEntry]): KeyStateEncoderSpec = {
     // If operator metadata is not found, then log a warning and continue with using the no-prefix
     // key state encoder
-    val keyStateEncoderSpec = if (storeMetadata.length == 0) {
+    val keyStateEncoderSpec = if (storeMetadata.isEmpty) {
       logWarning("Metadata for state store not found, possible cause is this checkpoint " +
         "is created by older version of spark. If the query has session window aggregation, " +
         "the state can't be read correctly and runtime exception will be thrown. " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
Aligns two emptiness checks on the `storeMetadata` array in `StateDataSource` to `.nonEmpty`/`.isEmpty`, matching how the same variable is tested elsewhere in the file.

### Why are the changes needed?
For a Scala `Array` these are exact equivalents of the `length` comparisons; the nearby `require(... == 1)` count-check is left unchanged.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Stylistic, behavior-identical change. No new tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)