### PR TITLE
[SPARK-58518][SQL] Do not duplicate input paths when globbing is disabled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -825,7 +825,7 @@ object DataSource extends Logging {
           val globResult = if (enableGlobbing) {
             SparkHadoopUtil.get.globPath(fs, globPath)
           } else {
-            qualifiedPaths
+            Seq(globPath)
           }
 
           if (checkEmptyGlobPath && globResult.isEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
@@ -240,6 +240,72 @@ class DataSourceSuite extends SharedSparkSession with PrivateMethodTester {
       parameters = Map("paths" -> "/path1, /path2"))
     )
   }
+
+  test("SPARK-58518: checkAndGlobPathIfNecessary must not duplicate paths " +
+    "when globbing is disabled") {
+    // The lambda runs once per glob-looking path, so returning `qualifiedPaths` -- the whole
+    // input -- multiplies the result: G glob-looking paths and n others give G*(G+n)+n entries
+    // instead of G+n. Those duplicates become the file index's rootPaths.
+    //
+    // checkFilesExist = false keeps this focused on the path arithmetic and avoids depending on
+    // MockFileSystem.exists, which only knows allPathsInFs.
+    val onlyGlobLooking = DataSource.checkAndGlobPathIfNecessary(
+      Seq(path1.toString, path2.toString, globPath1.toString),
+      hadoopConf,
+      checkEmptyGlobPath = true,
+      checkFilesExist = false,
+      enableGlobbing = false
+    )
+
+    // Asserted as a Seq, NOT a Set: `toSet` is what would hide the defect. Order follows
+    // `globbedPaths ++ nonGlobPaths`.
+    assert(onlyGlobLooking === Seq(globPath1, path1, path2))
+
+    // Two glob-looking paths among four is where the multiplication is unmistakable: the buggy
+    // branch yields 2*(2+2)+2 = 10 entries for 4 inputs.
+    val twoGlobLooking = DataSource.checkAndGlobPathIfNecessary(
+      Seq(path1.toString, path2.toString, globPath1.toString, globPath2.toString),
+      hadoopConf,
+      checkEmptyGlobPath = true,
+      checkFilesExist = false,
+      enableGlobbing = false
+    )
+
+    assert(twoGlobLooking === Seq(globPath1, globPath2, path1, path2))
+    assert(twoGlobLooking.length === 4, "globbing is disabled, so each path must appear once")
+  }
+
+  test("SPARK-58518: a filename with a glob metacharacter must not duplicate rows " +
+    "when globbing is disabled") {
+    // isGlobPath is a bare character scan over "{}[]*?\\" with no notion of escaping, so an
+    // ordinary filename takes the branch. Names containing brackets are legal on HDFS and S3,
+    // which is why SPARK-32810 introduced __globPaths__ in the first place.
+    withTempDir { dir =>
+      val plainA = new File(dir, "plain_a.txt")
+      val plainB = new File(dir, "plain_b.txt")
+      val bracketed = new File(dir, "weird_[x].txt")
+      // Files.writeString rather than a PrintWriter: scalastyle bans println, and it is
+      // fully qualified so this test adds no import to the suite.
+      java.nio.file.Files.writeString(plainA.toPath, "row_a\n")
+      java.nio.file.Files.writeString(plainB.toPath, "row_b\n")
+      java.nio.file.Files.writeString(bracketed.toPath, "row_c\n")
+
+      val paths = Seq(plainA, plainB, bracketed).map(_.getCanonicalPath)
+
+      val df = spark.read
+        .option(DataSource.GLOB_PATHS_KEY, "false")
+        .text(paths: _*)
+
+      // Three files, one row each. Before the fix this returned five rows, with the two plain
+      // files duplicated, because the bracketed name made the branch emit all three paths.
+      //
+      // Collected and sorted into an Array rather than compared as a Set, for the same reason
+      // the unit test above avoids toSet: a Set is precisely what would hide duplication. This
+      // also keeps the test free of a `Row` import the suite does not currently carry.
+      assert(df.collect().map(_.getString(0)).sorted === Array("row_a", "row_b", "row_c"))
+      assert(df.count() === 3)
+    }
+  }
 }
 
 object TestPaths {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DataSource.checkAndGlobPathIfNecessary` runs its lambda once per glob-looking path, but the `enableGlobbing == false` branch returned `qualifiedPaths` — the whole input list:

```scala
ThreadUtils.parmap(globPaths, "globPath", numThreads) { globPath =>
  val fs = globPath.getFileSystem(hadoopConf)
  val globResult = if (enableGlobbing) {
    SparkHadoopUtil.get.globPath(fs, globPath)
  } else {
    qualifiedPaths          // <-- the whole list, once per glob-looking path
  }
```

The branch now returns `Seq(globPath)`, the path it was handed.

### Why are the changes needed?

**The query returns duplicate rows.** With `G` paths that look like globs and `n` that do not, the result held `G*(G+n)+n` entries instead of `G+n`. Those duplicates become the file index's `rootPaths`, and for an unpartitioned relation `PartitioningAwareFileIndex.allFiles()` does `rootPaths.flatMap`, so the same `FileStatus` is returned several times and `FileScanRDD` reads the same file repeatedly.

Three single-row files, one of them named `weird_[x].csv`:

```
spark.read.options(**{"__globPaths__": "false"}).csv(paths).count()
# 5      <-- three files, five rows
#   x2  ('0', 'row_from_plain_a.csv')     DUPLICATED
#   x2  ('1', 'row_from_plain_b.csv')     DUPLICATED
#   x1  ('2', 'row_from_weird_[x].csv')
```

"Looks like a glob" is a bare character scan with no notion of escaping (`SparkHadoopUtil.isGlobPath` tests for any of `{}[]*?\`), so the branch is reached by ordinary data. Filenames containing brackets are legal on HDFS and S3 — and SPARK-32810 and SPARK-32815 exist precisely because the project decided such names must work.

**The highest-impact caller is the Structured Streaming file source**, which sets `GLOB_PATHS_KEY -> "false"` unconditionally and hands the whole microbatch's file list to a `DataSource`. So a microbatch containing one file whose *name* holds a metacharacter emits every other file in that batch more than once. `MLUtils.parseLibSVMFile` and the `TextInput*.infer` schema-inference paths pass multiple paths with globbing disabled too.

The diff is one expression, so it is worth being explicit that the *finding* is silent data duplication rather than a style change.

### Does this PR introduce _any_ user-facing change?

Yes, and only in the direction of correctness: affected reads return the right number of rows instead of a larger one, and do less I/O.

No behaviour changes for the case the option was introduced to serve. With a single path, `qualifiedPaths` and `Seq(globPath)` are the same value, so every scenario SPARK-32810 fixed and tested behaves identically. `globResult` stays non-empty, so the `checkEmptyGlobPath` check cannot begin raising `PATH_NOT_FOUND` where it did not before.

### How was this patch tested?

Two tests added to `DataSourceSuite`, and **verified to fail on unmodified `master` before the fix was applied** — the fork CI run of the test alone reported `Tests: succeeded 21345, failed 2`, the two failures being exactly these, with the duplication visible in the messages:

```
- SPARK-58518: checkAndGlobPathIfNecessary must not duplicate paths when globbing is disabled *** FAILED ***
  List(mockFs://mockFs/somepath1, mockFs://mockFs/somepath2, mockFs://mockFs/globpath1*,
       mockFs://mockFs/somepath1, mockFs://mockFs/somepath2)

- SPARK-58518: a filename with a glob metacharacter must not duplicate rows when globbing is disabled *** FAILED ***
  Array("row_a", "row_a", "row_b", "row_b", "row_c") did not equal Array("row_a", "row_b", "row_c")
```

With the fix, the full matrix is green.

**Both tests assert on ordered sequences rather than sets, and that is deliberate.** Every existing assertion in this suite compares `resultPaths.toSet` against a `Set` — and a `Set` is exactly what erases duplication. Together with the fact that all six existing `checkAndGlobPathIfNecessary` tests pass `enableGlobbing = true`, that is why this went unnoticed: the branch was never exercised, and the suite's assertion style could not have caught it if it had been.

The end-to-end test uses `text` rather than CSV, since the defect is in `DataSource` and is format-agnostic. Verified by hand in `text`, `json`, `csv` and `parquet`, all returning five rows for three files.

The predicted count holds exactly, which is what distinguishes a diagnosis from an observation:

| G | n | files | predicted `G*(G+n)+n` | observed |
|---|---|---|---|---|
| 1 | 0 | 1 | 1 | 1 |
| 1 | 2 | 3 | 5 | 5 |
| 2 | 0 | 2 | 4 | 4 |
| 2 | 2 | 4 | 10 | 10 |
| 3 | 1 | 4 | 13 | 13 |

The `G=1, n=0` row is also the answer to why this survived since 2020: every test SPARK-32810 added reads a single path, and that is the one case that comes back correct.

**Scope, stated honestly:** the correctness impact needs an unpartitioned relation. When partition columns are discovered, `allFiles()` takes a branch returning a `Map`'s values, which absorbs the duplicates — measured on the same data, 15 rows without `basePath` against 9 with it. On partitioned relations this remains wasted listing work rather than wrong results.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)

### Related

- SPARK-32810 (#29659) introduced this branch; SPARK-32815 covers LibSVM with such filenames. Neither reports this defect.
- SPARK-28266 also produced duplicate rows, but from a Hive serde `path` property repeating the table LOCATION, and was fixed in #33328 — nowhere near this method. It does establish that duplicated input paths are treated as a correctness bug.
- No JIRA matches this method plus duplication, and no PR mentions `enableGlobbing` apart from #29659.
