### PR TITLE
[SPARK-58529][PYTHON][4.0] Relax RESULT_ROWS_MISMATCH assertion for cross-version old-client compatibility

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -668,7 +668,7 @@ class ScalarPandasUDFTestsMixin:
         df = self.spark.range(10)
         raise_exception = pandas_udf(lambda _: pd.Series(1), LongType())
         with self.assertRaisesRegex(
-            Exception, "Result vector from pandas_udf was not the required length"
+            Exception, "The number of output rows.*must match the number of input rows"
         ):
             df.select(raise_exception(col("id"))).collect()
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -667,8 +667,13 @@ class ScalarPandasUDFTestsMixin:
     def check_vectorized_udf_invalid_length(self):
         df = self.spark.range(10)
         raise_exception = pandas_udf(lambda _: pd.Series(1), LongType())
+        # Accept both this branch's SCHEMA_MISMATCH_FOR_PANDAS_UDF message and the
+        # RESULT_ROWS_MISMATCH message a newer server raises (SPARK-58529), so the
+        # cross-version old-client job passes against a master server.
         with self.assertRaisesRegex(
-            Exception, "The number of output rows.*must match the number of input rows"
+            Exception,
+            "Result vector from pandas_udf was not the required length"
+            "|The number of output rows.*must match the number of input rows",
         ):
             df.select(raise_exception(col("id"))).collect()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This backports the test-side change of SPARK-58529 to `branch-4.0`. It relaxes the `test_vectorized_udf_invalid_length` assertion in `test_pandas_udf_scalar.py` from the pandas-specific substring `"Result vector from pandas_udf was not the required length"` to the shared `"The number of output rows.*must match the number of input rows"` template text.

No production code changes -- `branch-4.0` continues to raise the message with its trailing `Result vector from pandas_udf ...` clause.

### Why are the changes needed?

The `pyspark-connect-old-client` job on `master` clones `branch-4.0`'s tests and runs them against a `master` server. After SPARK-58529 removed the pandas-specific tail from the `RESULT_ROWS_MISMATCH` message on `master`, `branch-4.0`'s assertion on that removed substring fails against the new server. The relaxed regex matches both the old (`branch-4.0` server) and new (`master` server) messages, so `branch-4.0`'s own CI and the cross-version old-client job both pass.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The relaxed regex was verified to match both the old message (with the pandas tail) and the new message (without it). Existing `test_vectorized_udf_invalid_length` continues to run.

### Was this patch authored or co-authored using generative AI tooling?

No.
