### PR TITLE
[SPARK-58575][PYTHON] Inline redundant error_class parameter in worker.py verify helpers

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -704,6 +704,18 @@ class ScalarPandasUDFTestsMixin:
             with self.assertRaisesRegex(Exception, "The input iterator must be fully consumed"):
                 df1.select(iter_udf_not_reading_all_input(col("id"))).collect()
 
+        @pandas_udf(LongType(), PandasUDFType.SCALAR_ITER)
+        def iter_udf_too_many_output_rows(it):
+            for batch in it:
+                yield pd.Series([1] * (len(batch) + 1))
+
+        with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": 3}):
+            df1 = self.spark.range(10).repartition(1)
+            with self.assertRaisesRegex(
+                Exception, "The number of output rows must not exceed the number of input rows"
+            ):
+                df1.select(iter_udf_too_many_output_rows(col("id"))).collect()
+
     def test_vectorized_udf_chained(self):
         df = self.spark.range(10)
         scalar_f = pandas_udf(lambda x: x + 1, LongType())

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -329,27 +329,26 @@ def verify_scalar_result(result: Any, num_rows: int) -> Any:
     return result
 
 
-def verify_iterator_exhausted(iterator: Iterator, error_class: str) -> None:
+def verify_iterator_exhausted(iterator: Iterator) -> None:
     """Verify that an iterator has been fully consumed."""
     try:
         next(iterator)
     except StopIteration:
         pass
     else:
-        raise PySparkRuntimeError(errorClass=error_class, messageParameters={})
+        raise PySparkRuntimeError(errorClass="INPUT_NOT_FULLY_CONSUMED", messageParameters={})
 
 
 def verify_output_row_limit(
     iterator: Iterator,
     max_rows: Union[int, Callable[[], int]],
-    error_class: str,
 ) -> Iterator:
     """Yield elements while verifying total rows do not exceed a limit (fail-fast)."""
     total_rows = 0
     for element in iterator:
         total_rows += len(element)
         if total_rows > (max_rows() if callable(max_rows) else max_rows):
-            raise PySparkRuntimeError(errorClass=error_class, messageParameters={})
+            raise PySparkRuntimeError(errorClass="OUTPUT_EXCEEDS_INPUT_ROWS", messageParameters={})
         yield element
 
 
@@ -2013,7 +2012,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             limited = verify_output_row_limit(
                 process_results(),
                 lambda: num_input_rows,
-                error_class="OUTPUT_EXCEEDS_INPUT_ROWS",
             )
 
             # Apply row count match check (final)
@@ -2026,10 +2024,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             yield from matched
 
             # Verify iterator consumed
-            verify_iterator_exhausted(
-                args_iter,
-                error_class="INPUT_NOT_FULLY_CONSUMED",
-            )
+            verify_iterator_exhausted(args_iter)
 
         # profiling is not supported for UDF
         return func, None, ser, ser
@@ -3129,7 +3124,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             limited = verify_output_row_limit(
                 process_results(),
                 lambda: num_input_rows,
-                error_class="OUTPUT_EXCEEDS_INPUT_ROWS",
             )
 
             # Apply row count match check (final)
@@ -3142,10 +3136,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             yield from matched
 
             # Verify iterator consumed
-            verify_iterator_exhausted(
-                args_iter,
-                error_class="INPUT_NOT_FULLY_CONSUMED",
-            )
+            verify_iterator_exhausted(args_iter)
 
         # profiling is not supported for UDF
         return func, None, ser, ser


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to SPARK-58529, which consolidated the row-count verification helpers in `python/pyspark/worker.py` but left two of them over-parameterized with an `error_class` argument that is always passed the same constant. This PR inlines the constant and drops the parameter:

- `verify_output_row_limit`: both call sites (`SQL_SCALAR_ARROW_ITER_UDF` and `SQL_SCALAR_PANDAS_ITER_UDF`) pass `error_class="OUTPUT_EXCEEDS_INPUT_ROWS"`. The constant is inlined into the `raise` and the parameter is removed from the signature and both call sites.
- `verify_iterator_exhausted`: both call sites pass `error_class="INPUT_NOT_FULLY_CONSUMED"`. Same treatment.

Both error classes are semantically bound to these two helpers, which together enforce the iterator-UDF contract that the number of output rows equals the number of input rows. No other code path can reuse them: for example, UDTFs have no such contract (one input row may produce many output rows) and use a different set of verifiers, so parameterizing the error class buys no reuse.

### Why are the changes needed?

Addresses a non-blocking review comment on SPARK-58529. Removing the always-constant parameter makes the helpers read more clearly: the helper name states the contract and the inlined error class is the fixed violation signal, with no indirection to trace through.

### Does this PR introduce _any_ user-facing change?

No. The raised error class and message are unchanged, so there is no behavior change, no `error-conditions.json` change, and no change to existing test assertions.

### How was this patch tested?

Existing test `ScalarPandasUDFTests.test_vectorized_udf_invalid_length` already exercises the `INPUT_NOT_FULLY_CONSUMED` path through `verify_iterator_exhausted`. This PR additionally adds a case to that test covering an iterator UDF that emits more output rows than input rows, which exercises the `OUTPUT_EXCEEDS_INPUT_ROWS` fail-fast path through `verify_output_row_limit` (previously untested).

### Was this patch authored or co-authored using generative AI tooling?

No.
