### PR TITLE
[SPARK-58529][PYTHON][4.2] Relax RESULT_ROWS_MISMATCH assertion for cross-version old-client compatibility

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -677,8 +677,13 @@ class ScalarPandasUDFTestsMixin:
     def check_vectorized_udf_invalid_length(self):
         df = self.spark.range(10)
         raise_exception = pandas_udf(lambda _: pd.Series(1), LongType())
+        # Accept both this branch's SCHEMA_MISMATCH_FOR_PANDAS_UDF message and the
+        # RESULT_ROWS_MISMATCH message a newer server raises (SPARK-58529), so the
+        # cross-version old-client job passes against a master server.
         with self.assertRaisesRegex(
-            Exception, "Result vector from pandas_udf was not the required length"
+            Exception,
+            "Result vector from pandas_udf was not the required length"
+            "|The number of output rows.*must match the number of input rows",
         ):
             df.select(raise_exception(col("id"))).collect()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This backports the test-side change of SPARK-58529 to this maintenance branch. It relaxes the `test_vectorized_udf_invalid_length` assertion in `test_pandas_udf_scalar.py` to accept both this branch's `SCHEMA_MISMATCH_FOR_PANDAS_UDF` message (`Result vector from pandas_udf was not the required length`) and the `RESULT_ROWS_MISMATCH` message a newer server raises (`The number of output rows ... must match the number of input rows`).

No production code changes -- this branch continues to raise its existing message.

### Why are the changes needed?

The `pyspark-connect-old-client` cross-version job clones a maintenance branch's tests and runs them against a newer (master) server. It currently pins `branch-4.0`, but the base is expected to advance to `branch-4.1` / `branch-4.2`. When it does, an assertion pinned to the old pandas-specific substring would fail against a master server that no longer emits it (after SPARK-58529). Relaxing the assertion now -- to match both messages -- keeps this branch's own CI green today and prevents the cross-version job from breaking when its base advances.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The relaxed regex was verified to match both this branch's message and the newer `RESULT_ROWS_MISMATCH` message. Existing `test_vectorized_udf_invalid_length` continues to run.

### Was this patch authored or co-authored using generative AI tooling?

No.
