### PR TITLE
[SPARK-58580][PS] Use native Spark function for NumPy ldexp

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -123,9 +123,7 @@ binary_np_spark_mappings = {
     ),
     "hypot": F.hypot,
     "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "ldexp": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.ldexp(s1, s2), DoubleType()
-    ),
+    "ldexp": lambda c1, c2: c1.cast("double") * F.pow(F.lit(2.0), c2),
     # F.shiftleft accepts literal counts only; call_function also accepts a column.
     # NumPy returns zero for counts outside an int64's bit width, unlike JVM shifts.
     "left_shift": lambda c1, c2: F.when((c2 < 0) | (c2 >= 64), F.lit(0)).otherwise(

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -171,6 +171,31 @@ class NumPyCompatTestsMixin:
                 almost=True,
             )
 
+    def test_np_ldexp(self):
+        pdf = pd.DataFrame(
+            {
+                "x": [
+                    -np.inf,
+                    -64.0,
+                    -2.0,
+                    -0.0,
+                    0.0,
+                    1.0,
+                    2.0,
+                    64.0,
+                    np.inf,
+                    np.nan,
+                    1.0,
+                    1.0,
+                    1.0,
+                ],
+                "exp": [2, 3, -2, -3, -3, 0, -2, 2, 2, 2, -1074, -1075, 1024],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(np.ldexp(psdf.x, psdf.exp), np.ldexp(pdf.x, pdf.exp), almost=True)
+
     def test_np_fmax_fmin(self):
         for pdf in (
             pd.DataFrame({"x1": [-2, -1, 0, 1, 2], "x2": [2, 1, 0, -1, -2]}),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces the pandas UDF used for `np.ldexp` in the pandas API on Spark with the native Spark SQL expression `x * pow(2.0, exp)`.

Adds coverage for finite values, infinities, NaN, signed zero, and exponent overflow and underflow.

### Why are the changes needed?

Using native Spark expressions avoids pandas UDF serialization and lets Spark optimize and code-generate this operation while preserving NumPy-compatible behavior.

### Does this PR introduce _any_ user-facing change?

No. This is a behavior-preserving implementation change.

### How was this patch tested?

`source ~/.zshrc && conda run -n spark-dev-313 python/run-tests --testnames pyspark.pandas.tests.test_numpy_compat.NumPyCompatTests.test_np_ldexp`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)