### PR TITLE
[SPARK-58583][ML] Construct squared Euclidean silhouette stats on executors

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
@@ -330,13 +330,10 @@ private[evaluation] object SquaredEuclideanSilhouette extends Silhouette {
         }
       )
 
-    clustersStatsRDD
-      .collectAsMap()
-      .toMap
-      .transform {
-        case (_, (featureSum: DenseVector, squaredNormSum: Double, weightSum: Double)) =>
-          SquaredEuclideanSilhouette.ClusterStats(featureSum, squaredNormSum, weightSum)
-      }
+    clustersStatsRDD.mapValues {
+      case (featureSum: DenseVector, squaredNormSum: Double, weightSum: Double) =>
+        SquaredEuclideanSilhouette.ClusterStats(featureSum, squaredNormSum, weightSum)
+    }.collectAsMap().toMap
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR constructs `SquaredEuclideanSilhouette.ClusterStats` in the executor-side RDD
transformation before collecting the per-cluster map to the driver.

### Why are the changes needed?

The previous code collected tuple values and then constructed a second map of `ClusterStats`
on the driver. Constructing the values before collection avoids that driver-side conversion and
its temporary map allocation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Static checks completed successfully:

- `git diff --check`
- ASCII scan of the changed Scala file
- changed-line length scan

No test suite was run because it was not requested; this is a behavior-preserving relocation of
a serializable value-object construction.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
