### PR TITLE
[SPARK-58586][DOCS] Use a supported Python version in the RDD guide PYSPARK_PYTHON example

### DIFF
--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -70,7 +70,7 @@ PySpark requires the same minor version of Python in both driver and workers. It
 you can specify which version of Python you want to use by `PYSPARK_PYTHON`, for example:
 
 {% highlight bash %}
-$ PYSPARK_PYTHON=python3.8 bin/pyspark
+$ PYSPARK_PYTHON=python3.11 bin/pyspark
 {% endhighlight %}
 
 </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Updates the `PYSPARK_PYTHON=python3.8` example in `docs/rdd-programming-guide.md` to `python3.11`.

### Why are the changes needed?
The same page states that Spark works with Python 3.11+ about thirty lines above this example, and the build pins `python_requires>=3.11`, so the python3.8 example is stale and internally inconsistent.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Documentation only. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)