### PR TITLE
[SPARK-58590][PS] Remove obsolete pandas 0.24.0 version notes from datetime accessor docstrings

### DIFF
--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -688,8 +688,6 @@ class DatetimeMethods:
             - 'raise' will raise an NonExistentTimeError if there are
               nonexistent times
 
-            .. note:: this option only works with pandas 0.24.0+
-
         Returns
         -------
         Series
@@ -748,8 +746,6 @@ class DatetimeMethods:
             - 'raise' will raise an NonExistentTimeError if there are
               nonexistent times
 
-            .. note:: this option only works with pandas 0.24.0+
-
         Returns
         -------
         Series
@@ -807,8 +803,6 @@ class DatetimeMethods:
             - timedelta objects will shift nonexistent times by the timedelta
             - 'raise' will raise an NonExistentTimeError if there are
               nonexistent times
-
-            .. note:: this option only works with pandas 0.24.0+
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removes three identical obsolete notes from the `DatetimeMethods.round`, `floor` and `ceil` docstrings in pandas-on-Spark:

```
.. note:: this option only works with pandas 0.24.0+
```

### Why are the changes needed?
PySpark requires pandas 2.2.0 or newer (`require_minimum_pandas_version` in `python/pyspark/sql/pandas/utils.py`, and `pandas>=2.2.0` in the packaging setup files), so the 0.24.0 condition can never be false. The note is dead and slightly misleading to readers of the API docs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Docstring-only change; no code paths are touched. No tests needed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 4.8)
