### PR TITLE
[SPARK-58603][PYTHON] Expand DataFrame query context coverage to pyspark.sql.functions

### DIFF
--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -303,6 +303,13 @@ def _with_origin(func: FuncT) -> FuncT:
     """
     A decorator to capture and provide the call site information to the server side
     when PySpark API functions are invoked.
+
+    Notes
+    -----
+    A PySpark API can invoke other decorated APIs internally, for example
+    :meth:`Column.__and__` calls :func:`lit`. Only the outermost call is captured because
+    that is the one closest to the user code, mirroring the JVM side `withOrigin`. Nested
+    calls are skipped entirely, so they neither overwrite nor clear the captured origin.
     """
 
     @functools.wraps(func)
@@ -311,6 +318,10 @@ def _with_origin(func: FuncT) -> FuncT:
         from pyspark.sql.utils import is_remote
 
         if hasattr(func, "__name__") and is_debugging_enabled():
+            if current_origin().fragment is not None:
+                # Already within a decorated API; keep the outermost origin.
+                return func(*args, **kwargs)
+
             if is_remote():
                 # Getting the configuration requires RPC call. Uses the default value for now.
                 depth = 1
@@ -333,13 +344,17 @@ def _with_origin(func: FuncT) -> FuncT:
                         "spark.sql.stackTracesInDataFrameContext"
                     )
                 )
-                # Update call site when the function is called
-                jvm_pyspark_origin.set(func.__name__, _capture_call_site(depth))
+                call_site = _capture_call_site(depth)
+                # Update call site when the function is called. The call site is also kept
+                # on the Python side so that nested calls can detect the outermost one.
+                set_current_origin(func.__name__, call_site)
+                jvm_pyspark_origin.set(func.__name__, call_site)
 
                 try:
                     return func(*args, **kwargs)
                 finally:
                     jvm_pyspark_origin.clear()
+                    set_current_origin(None, None)
         else:
             return func(*args, **kwargs)
 

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -34,6 +34,7 @@ from typing import (
     overload,
     cast,
 )
+import types
 from types import FrameType
 
 import pyspark
@@ -47,6 +48,10 @@ _current_origin = threading.local()
 # Providing DataFrame debugging options to reduce performance slowdown.
 # Default is True.
 _enable_debugging_cache = None
+
+# `spark.sql.stackTracesInDataFrameContext` cached as a (session, value) pair, so that it is
+# not read from the JVM on every decorated API call.
+_stack_traces_in_context_cache: Optional[Any] = None
 
 
 def is_debugging_enabled() -> bool:
@@ -68,6 +73,24 @@ def is_debugging_enabled() -> bool:
             _enable_debugging_cache = False
 
     return _enable_debugging_cache
+
+
+def _get_stack_traces_in_context(spark: Any) -> int:
+    """
+    Return `spark.sql.stackTracesInDataFrameContext`, cached per session.
+
+    Reading it is a JVM call (an RPC with Spark Connect), and it is read on every decorated
+    API call, so the value is cached against the session it was read from.
+    """
+    global _stack_traces_in_context_cache
+
+    cached = _stack_traces_in_context_cache
+    if cached is not None and cached[0] is spark:
+        return cached[1]
+
+    depth = int(spark.conf.get("spark.sql.stackTracesInDataFrameContext"))
+    _stack_traces_in_context_cache = (spark, depth)
+    return depth
 
 
 def current_origin() -> threading.local:
@@ -242,6 +265,24 @@ class ErrorClassesReader:
         return None
 
 
+@functools.lru_cache(maxsize=1)
+def _get_ipython_roots() -> Optional[List[str]]:
+    """
+    Return the package roots to filter out when IPython is available, or None otherwise.
+
+    Python does not cache failed imports, so probing IPython on every call site capture
+    repeats the whole module search. The probe is cached here instead.
+    """
+    try:
+        import IPython
+
+        # ipykernel is required for IPython
+        import ipykernel
+    except ImportError:
+        return None
+    return [os.path.dirname(IPython.__file__), os.path.dirname(ipykernel.__file__)]
+
+
 def _capture_call_site(depth: int) -> str:
     """
     Capture the call site information including file name, line number, and function name.
@@ -266,24 +307,21 @@ def _capture_call_site(depth: int) -> str:
 
     selected_frames: Iterator[FrameType] = itertools.islice(stack, depth)
 
-    # We try import here since IPython is not a required dependency
-    try:
+    # IPython is not a required dependency, so it is probed lazily. A failed import is not
+    # cached by Python, so the probe is done once here and the result reused; otherwise every
+    # call repeats the full module search.
+    ipython_roots = _get_ipython_roots()
+    if ipython_roots is not None:
         import IPython
-
-        # ipykernel is required for IPython
-        import ipykernel
 
         ipython = IPython.get_ipython()
         # Filtering out IPython related frames
-        ipy_root = os.path.dirname(IPython.__file__)
-        ipykernel_root = os.path.dirname(ipykernel.__file__)
         selected_frames = (
             frame
             for frame in selected_frames
-            if (ipy_root not in frame.f_code.co_filename)
-            and (ipykernel_root not in frame.f_code.co_filename)
+            if all(root not in frame.f_code.co_filename for root in ipython_roots)
         )
-    except ImportError:
+    else:
         ipython = None
 
     # Identifying the cell is useful when the error is generated from IPython Notebook
@@ -339,12 +377,7 @@ def _with_origin(func: FuncT) -> FuncT:
                 jvm_pyspark_origin = getattr(
                     spark._jvm, "org.apache.spark.sql.catalyst.trees.PySparkCurrentOrigin"
                 )
-                depth = int(
-                    spark.conf.get(  # type: ignore[arg-type]
-                        "spark.sql.stackTracesInDataFrameContext"
-                    )
-                )
-                call_site = _capture_call_site(depth)
+                call_site = _capture_call_site(_get_stack_traces_in_context(spark))
                 # Update call site when the function is called. The call site is also kept
                 # on the Python side so that nested calls can detect the outermost one.
                 set_current_origin(func.__name__, call_site)
@@ -358,7 +391,21 @@ def _with_origin(func: FuncT) -> FuncT:
         else:
             return func(*args, **kwargs)
 
+    # Marks the wrapper so that the decoration can be asserted on, since `functools.wraps`
+    # makes it otherwise indistinguishable from the function it wraps.
+    wrapper.__origin_wrapped__ = True  # type: ignore[attr-defined]
     return cast(FuncT, wrapper)
+
+
+def _is_origin_wrapped(func: Any) -> bool:
+    """
+    Whether `func` is decorated with `_with_origin`, looking through other decorators.
+    """
+    while func is not None:
+        if getattr(func, "__origin_wrapped__", False):
+            return True
+        func = getattr(func, "__wrapped__", None)
+    return False
 
 
 @overload
@@ -394,3 +441,45 @@ def with_origin_to_class(
                 if callable(method) and name not in skipping:
                     setattr(cls, name, _with_origin(method))
         return cls
+
+
+# Functions that take a user defined callable or an arbitrary expression string. The
+# interesting call site for those is inside the user's own function, or the expression
+# itself, so decorating them only adds overhead.
+_ORIGIN_IGNORED_FUNCTIONS = frozenset(
+    [
+        "udf",
+        "udtf",
+        "arrow_udf",
+        "arrow_udtf",
+        "pandas_udf",
+        "expr",
+        "broadcast",
+        "call_udf",
+        "call_function",
+    ]
+)
+
+
+def with_origin_to_functions(module_name: str) -> None:
+    """
+    Decorate the public functions of a ``pyspark.sql.functions`` module with `_with_origin`
+    to capture call site information.
+
+    Expressions are commonly built from these functions rather than from
+    :class:`Column` methods, so without this a DataFrame query context cannot point at the
+    user code that built a failing expression.
+    """
+    if os.environ.get("PYSPARK_PIN_THREAD", "true").lower() != "true":
+        return
+
+    import sys
+
+    module = sys.modules[module_name]
+    for name, func in list(vars(module).items()):
+        if name.startswith("_") or name in _ORIGIN_IGNORED_FUNCTIONS:
+            continue
+        # Only functions defined in this module; leave imported helpers and classes alone.
+        if not isinstance(func, types.FunctionType) or func.__module__ != module_name:
+            continue
+        setattr(module, name, _with_origin(func))

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -49,9 +49,10 @@ _current_origin = threading.local()
 # Default is True.
 _enable_debugging_cache = None
 
-# `spark.sql.stackTracesInDataFrameContext` cached as a (session, value) pair, so that it is
-# not read from the JVM on every decorated API call.
-_stack_traces_in_context_cache: Optional[Any] = None
+# The active session and the JVM `PySparkCurrentOrigin`, cached as a
+# (SparkContext, (session, origin)) pair, so that they are not resolved through the JVM on
+# every decorated API call.
+_origin_context_cache: Optional[Any] = None
 
 
 def is_debugging_enabled() -> bool:
@@ -75,22 +76,43 @@ def is_debugging_enabled() -> bool:
     return _enable_debugging_cache
 
 
-def _get_stack_traces_in_context(spark: Any) -> int:
+def _get_origin_context() -> Optional[Any]:
     """
-    Return `spark.sql.stackTracesInDataFrameContext`, cached per session.
+    Return the active session and the JVM `PySparkCurrentOrigin`, or None when there is no
+    active session.
 
-    Reading it is a JVM call (an RPC with Spark Connect), and it is read on every decorated
-    API call, so the value is cached against the session it was read from.
+    Resolving the JVM object costs several JVM round trips through
+    `SparkSession.getActiveSession`, and it is needed on every decorated API call, so it is
+    cached against the active `SparkContext`, which is a plain attribute lookup. The class is
+    a JVM singleton, so it stays valid for the lifetime of the context.
+
+    Note that `spark.sql.stackTracesInDataFrameContext` is deliberately not cached here: it
+    is a runtime configuration and can be changed at any point with `spark.conf.set`.
     """
-    global _stack_traces_in_context_cache
+    global _origin_context_cache
 
-    cached = _stack_traces_in_context_cache
-    if cached is not None and cached[0] is spark:
+    from pyspark import SparkContext
+
+    sc = SparkContext._active_spark_context
+    if sc is None:
+        return None
+
+    cached = _origin_context_cache
+    if cached is not None and cached[0] is sc:
         return cached[1]
 
-    depth = int(spark.conf.get("spark.sql.stackTracesInDataFrameContext"))
-    _stack_traces_in_context_cache = (spark, depth)
-    return depth
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.getActiveSession()
+    if spark is None:
+        return None
+    assert spark._jvm is not None
+    context = (
+        spark,
+        getattr(spark._jvm, "org.apache.spark.sql.catalyst.trees.PySparkCurrentOrigin"),
+    )
+    _origin_context_cache = (sc, context)
+    return context
 
 
 def current_origin() -> threading.local:
@@ -352,7 +374,6 @@ def _with_origin(func: FuncT) -> FuncT:
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        from pyspark.sql import SparkSession
         from pyspark.sql.utils import is_remote
 
         if hasattr(func, "__name__") and is_debugging_enabled():
@@ -370,14 +391,13 @@ def _with_origin(func: FuncT) -> FuncT:
                 finally:
                     set_current_origin(None, None)
             else:
-                spark = SparkSession.getActiveSession()
-                if spark is None:
+                context = _get_origin_context()
+                if context is None:
                     return func(*args, **kwargs)
-                assert spark._jvm is not None
-                jvm_pyspark_origin = getattr(
-                    spark._jvm, "org.apache.spark.sql.catalyst.trees.PySparkCurrentOrigin"
-                )
-                call_site = _capture_call_site(_get_stack_traces_in_context(spark))
+                spark, jvm_pyspark_origin = context
+                # Read every time: this is a runtime configuration.
+                depth = int(spark.conf.get("spark.sql.stackTracesInDataFrameContext"))
+                call_site = _capture_call_site(depth)
                 # Update call site when the function is called. The call site is also kept
                 # on the Python side so that nested calls can detect the outermost one.
                 set_current_origin(func.__name__, call_site)

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -476,10 +476,18 @@ def with_origin_to_functions(module_name: str) -> None:
     import sys
 
     module = sys.modules[module_name]
+    decorated: Dict[str, Any] = {}
     for name, func in list(vars(module).items()):
         if name.startswith("_") or name in _ORIGIN_IGNORED_FUNCTIONS:
             continue
         # Only functions defined in this module; leave imported helpers and classes alone.
         if not isinstance(func, types.FunctionType) or func.__module__ != module_name:
             continue
-        setattr(module, name, _with_origin(func))
+        # Aliases such as `negate = negative` must reuse the wrapper of the function they
+        # alias, so that both names keep pointing at the same object and the fragment stays
+        # the aliased name.
+        wrapper = decorated.get(func.__name__)
+        if wrapper is None:
+            wrapper = _with_origin(func)
+            decorated[func.__name__] = wrapper
+        setattr(module, name, wrapper)

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -40,6 +40,7 @@ import numpy as np
 
 from pyspark.errors import PySparkTypeError, PySparkValueError
 from pyspark.errors.utils import _with_origin
+from pyspark.errors.utils import with_origin_to_functions as _with_origin_to_functions
 from pyspark.sql import Column
 from pyspark.sql.connect.expressions import (
     CaseWhen,
@@ -5776,6 +5777,12 @@ def vector_sum(col: "ColumnOrName") -> Column:
 
 
 vector_sum.__doc__ = pysparkfuncs.vector_sum.__doc__
+
+
+# Capture the call site of the public functions above, so that a DataFrame query context can
+# point at the user code that built a failing expression. `col` is already decorated
+# directly; decorating it again here is harmless because `_with_origin` is re-entrant.
+_with_origin_to_functions(__name__)
 
 
 def _test() -> None:

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -42,6 +42,7 @@ from typing import (
 
 from pyspark.errors import PySparkTypeError, PySparkValueError
 from pyspark.errors.utils import _with_origin
+from pyspark.errors.utils import with_origin_to_functions as _with_origin_to_functions
 from pyspark.sql.column import Column
 from pyspark.sql.types import (
     ArrayType,
@@ -33412,6 +33413,12 @@ def vector_sum(col: "ColumnOrName") -> Column:
     [4.0, 6.0]
     """
     return _invoke_function_over_columns("vector_sum", col)
+
+
+# Capture the call site of the public functions above, so that a DataFrame query context can
+# point at the user code that built a failing expression. `col` is already decorated
+# directly; decorating it again here is harmless because `_with_origin` is re-entrant.
+_with_origin_to_functions(__name__)
 
 
 def _test() -> None:

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe_query_context.py
@@ -16,12 +16,19 @@
 #
 
 
+import unittest
+
 from pyspark.sql.tests.test_dataframe_query_context import DataFrameQueryContextTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class DataFrameQueryContextParityTests(DataFrameQueryContextTestsMixin, ReusedConnectTestCase):
-    pass
+    @unittest.skip(
+        "Spark Connect does not read spark.sql.stackTracesInDataFrameContext, since that "
+        "requires an RPC, and captures a single frame instead."
+    )
+    def test_dataframe_query_context_stack_traces_conf(self):
+        super().test_dataframe_query_context_stack_traces_conf()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/test_dataframe_query_context.py
@@ -20,6 +20,7 @@ from pyspark.errors import (
     ArithmeticException,
     QueryContextType,
     NumberFormatException,
+    ArrayIndexOutOfBoundsException,
 )
 from pyspark.sql import functions as sf
 from pyspark.testing.sqlutils import (
@@ -532,6 +533,36 @@ class DataFrameQueryContextTestsMixin:
         # Fully cleared once the outermost call completes.
         self.assertIsNone(current_origin().fragment)
         self.assertIsNone(current_origin().call_site)
+
+    def test_dataframe_query_context_functions(self):
+        # Expressions are commonly built from `pyspark.sql.functions` rather than from
+        # `Column` methods. Those functions used to capture no call site, so the context fell
+        # back to the JVM stack trace, which points at py4j reflection internals.
+        try:
+            self.spark.range(1).select(sf.element_at(sf.array(sf.lit(1)), 5)).collect()
+            self.fail("Expected the query to fail")
+        except ArrayIndexOutOfBoundsException as e:
+            call_site = e.getQueryContext()[0].callSite()
+
+        # A Python `<file>:<line>` call site, rather than the JVM stack trace fallback such
+        # as "java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)".
+        # Note that this test file itself lives under the PySpark package, whose frames are
+        # filtered out of the call site, so the innermost reported frame is its caller.
+        self.assertRegex(call_site, r"\.py:[0-9]+$")
+
+    def test_dataframe_query_context_functions_coverage(self):
+        # Public functions are decorated, while the ones taking a user defined callable or a
+        # raw expression string are deliberately left alone.
+        from pyspark.errors.utils import _ORIGIN_IGNORED_FUNCTIONS, _is_origin_wrapped
+
+        self.assertTrue(_is_origin_wrapped(sf.split))
+        self.assertTrue(_is_origin_wrapped(sf.upper))
+        self.assertTrue(_is_origin_wrapped(sf.to_date))
+
+        for name in _ORIGIN_IGNORED_FUNCTIONS:
+            func = getattr(sf, name, None)
+            if func is not None:
+                self.assertFalse(_is_origin_wrapped(func), name)
 
 
 class DataFrameQueryContextTests(DataFrameQueryContextTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/test_dataframe_query_context.py
@@ -550,6 +550,27 @@ class DataFrameQueryContextTestsMixin:
         # filtered out of the call site, so the innermost reported frame is its caller.
         self.assertRegex(call_site, r"\.py:[0-9]+$")
 
+    def test_dataframe_query_context_stack_traces_conf(self):
+        # `spark.sql.stackTracesInDataFrameContext` is a runtime configuration, so a change
+        # must take effect on the next captured call site rather than being cached.
+        def call_site_frames():
+            def level3():
+                return sf.element_at(sf.array(sf.lit(1)), 5)
+
+            def level2():
+                return level3()
+
+            try:
+                self.spark.range(1).select(level2()).collect()
+                self.fail("Expected the query to fail")
+            except ArrayIndexOutOfBoundsException as e:
+                return len(e.getQueryContext()[0].callSite().splitlines())
+
+        self.assertEqual(call_site_frames(), 1)
+        with self.sql_conf({"spark.sql.stackTracesInDataFrameContext": 3}):
+            self.assertEqual(call_site_frames(), 3)
+        self.assertEqual(call_site_frames(), 1)
+
     def test_dataframe_query_context_functions_coverage(self):
         # Public functions are decorated, while the ones taking a user defined callable or a
         # raw expression string are deliberately left alone.

--- a/python/pyspark/sql/tests/test_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/test_dataframe_query_context.py
@@ -564,6 +564,15 @@ class DataFrameQueryContextTestsMixin:
             if func is not None:
                 self.assertFalse(_is_origin_wrapped(func), name)
 
+        # Aliases stay identical to what they alias, rather than becoming a separate wrapper.
+        for alias, aliased in [
+            ("negate", "negative"),
+            ("column", "col"),
+            ("power", "pow"),
+            ("random", "rand"),
+        ]:
+            self.assertIs(getattr(sf, alias), getattr(sf, aliased), alias)
+
 
 class DataFrameQueryContextTests(DataFrameQueryContextTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/test_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/test_dataframe_query_context.py
@@ -507,6 +507,32 @@ class DataFrameQueryContextTestsMixin:
             fragment="col",
         )
 
+    def test_with_origin_is_reentrant(self):
+        # A PySpark API can invoke another decorated API internally, for example
+        # `Column.__and__` calls `lit`. The nested call must neither overwrite nor clear the
+        # outer origin, so that the outermost call site, the one closest to the user code,
+        # is the one reported. This mirrors the JVM side `withOrigin`.
+        from pyspark.errors.utils import _with_origin, current_origin
+
+        observed = []
+
+        @_with_origin
+        def inner():
+            observed.append(current_origin().fragment)
+
+        @_with_origin
+        def outer():
+            inner()
+            # Still set after the nested call returns, so the expression built here
+            # is still attributed to `outer`.
+            observed.append(current_origin().fragment)
+
+        outer()
+        self.assertEqual(observed, ["outer", "outer"])
+        # Fully cleared once the outermost call completes.
+        self.assertIsNone(current_origin().fragment)
+        self.assertIsNone(current_origin().call_site)
+
 
 class DataFrameQueryContextTests(DataFrameQueryContextTestsMixin, ReusedSQLTestCase):
     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

Expressions are commonly built from `pyspark.sql.functions` (`F.split`, `F.to_date`, ...)
rather than from `Column` methods, but only `col` was decorated with `_with_origin`. Those
expressions therefore carried no Python call site, and the DataFrame query context fell back
to the JVM stack trace, which points at py4j reflection internals.

This PR:

1. Decorates the public functions of both `pyspark.sql.functions.builtin` and
   `pyspark.sql.connect.functions.builtin` via a new `with_origin_to_functions` helper,
   alongside the existing `with_origin_to_class`. Functions taking a user defined callable or
   a raw expression string (`udf`, `pandas_udf`, `expr`, ...) are left out, since the
   interesting call site for those is inside the user's own function. Aliases such as
   `negate = negative` reuse the wrapper of the function they alias, so both names keep
   pointing at the same object.
2. Makes `_with_origin` re-entrant. This is a prerequisite: a decorated function invoked from
   another one (for example `Column.__and__` calls `lit`) used to overwrite the origin and
   then clear it on exit, leaving the outer call with no origin. The guard mirrors the JVM
   side `withOrigin` in `sql/api/.../trees/origin.scala`, keeping the outermost call site
   because that is closest to the user code.
3. Removes two dominant per-call costs, so that the added coverage does not slow anything
   down:
   - `_capture_call_site` probed IPython on every call. Python does not cache failed imports,
     so when IPython or `ipykernel` is absent the probe repeated the whole module search.
   - `_with_origin` called `SparkSession.getActiveSession()` per call, which internally costs
     three JVM round trips, plus a `getattr` on the JVM view to resolve `PySparkCurrentOrigin`.
     Both are now resolved once and cached against the active `SparkContext`, which is a plain
     attribute lookup, and `PySparkCurrentOrigin` is a JVM singleton.

Note that `spark.sql.stackTracesInDataFrameContext` is deliberately still read on every call.
Unlike `spark.python.sql.dataFrameDebugging.enabled`, which is a static conf, it is a runtime
conf and can be changed with `spark.conf.set` at any point.

### Why are the changes needed?

Without this, the error for an expression built from `pyspark.sql.functions` does not point at
the user code that built it, which is the whole purpose of the DataFrame query context. For
example, for an expression built inside a helper function:

```python
def helper():
    return F.element_at(F.array(F.lit(1)), 5)

df.select(helper()).collect()
```

Before:

```
== DataFrame ==
"element_at" was called from
java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

After:

```
== DataFrame ==
"element_at" was called from
/path/to/user_code.py:11
```

### Does this PR introduce _any_ user-facing change?

Yes. Errors raised from expressions built with `pyspark.sql.functions` now report the Python
call site that built the expression, instead of falling back to a JVM internal frame. The
example above shows the difference. No API changes.

### How was this patch tested?

New tests in `python/pyspark/sql/tests/test_dataframe_query_context.py`:

- `test_dataframe_query_context_functions`: the call site for an `element_at` failure is a
  Python `<file>:<line>`, not a JVM frame.
- `test_dataframe_query_context_functions_coverage`: public functions are decorated, the
  ignored ones are not, and aliases stay identical to what they alias.
- `test_dataframe_query_context_stack_traces_conf`: changing
  `spark.sql.stackTracesInDataFrameContext` at runtime takes effect on the next capture. This
  fails if the value is cached. Skipped in the Connect parity suite, which uses a fixed depth
  of 1 because reading the conf there would need an RPC.
- `test_with_origin_is_reentrant`: a nested decorated call neither overwrites nor clears the
  outer origin, and the origin is cleared after the outermost call. Verified this fails
  without the re-entrancy guard.

Ran locally, classic and Connect: `test_dataframe_query_context` (10 tests),
`connect.test_parity_dataframe_query_context` (10 tests), `errors.tests.test_errors`, plus
`test_functions`, `test_column` and the `functions.builtin` doctests of both modules compared
against master to confirm no new failures.

Performance, measured on a real local session, median of 7 rounds. Building an expression from
`Column` methods only (already covered before this PR) and from `pyspark.sql.functions` (newly
covered):

| expression build | before | after |
|---|---|---|
| `Column` methods only, classic | 1.34 ms | **0.72 ms** |
| `pyspark.sql.functions`, classic | 1.47 ms | **1.48 ms** |
| `pyspark.sql.functions`, Connect | 92.4 us | **53.2 us** |

Already covered paths get substantially faster from the two removed per-call costs, and the
newly covered functions land at parity, so the added coverage costs nothing measurable. A
per-call breakdown on the classic path, for reference:

```
getActiveSession()                     158.53 us   (now cached)
getattr(_jvm, PySparkCurrentOrigin)     29.15 us   (now cached)
jvm.set + jvm.clear                    133.32 us   (inherent to carrying the call site)
SparkContext._active_spark_context       0.02 us
```

Import time for `pyspark.sql.functions` is unchanged (123 ms vs 122 ms). Capture remains
disabled by `spark.sql.dataFrameQueryContext.enabled=false`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
