### PR TITLE
[SPARK-58612][SQL] Recurse into archives nested inside archives

### DIFF
--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,0 +1,3 @@
+{
+  "sync_reminder_last_shown": "2026-08-06"
+}

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5733,7 +5733,7 @@
   },
   "MAX_ARCHIVE_DEPTH_EXCEEDED" : {
     "message" : [
-      "Cannot read archive entry <entry>: it is nested more than <maxDepth> archives deep."
+      "Cannot read archive entry <entry> in archive <path>: it is nested more than <maxDepth> archives deep."
     ],
     "sqlState" : "KD003"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5731,6 +5731,12 @@
     ],
     "sqlState" : "42000"
   },
+  "MAX_ARCHIVE_DEPTH_EXCEEDED" : {
+    "message" : [
+      "Cannot read archive entry <entry>: it is nested more than <maxDepth> archives deep."
+    ],
+    "sqlState" : "KD003"
+  },
   "MERGE_CARDINALITY_VIOLATION" : {
     "message" : [
       "The ON search condition of the MERGE statement matched a single row from the target table with multiple rows of the source table.",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -942,10 +942,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map("entry" -> entry, "path" -> path))
   }
 
-  def maxArchiveDepthExceeded(entry: String, maxDepth: Int): SparkRuntimeException = {
+  def maxArchiveDepthExceeded(entry: String, path: String, maxDepth: Int): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "MAX_ARCHIVE_DEPTH_EXCEEDED",
-      messageParameters = Map("entry" -> entry, "maxDepth" -> maxDepth.toString))
+      messageParameters =
+        Map("entry" -> entry, "path" -> path, "maxDepth" -> maxDepth.toString))
   }
 
   def cannotCreateColumnarReaderError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -942,6 +942,12 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map("entry" -> entry, "path" -> path))
   }
 
+  def maxArchiveDepthExceeded(entry: String, maxDepth: Int): SparkRuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "MAX_ARCHIVE_DEPTH_EXCEEDED",
+      messageParameters = Map("entry" -> entry, "maxDepth" -> maxDepth.toString))
+  }
+
   def cannotCreateColumnarReaderError(): Throwable = {
     new SparkException(
       errorClass = "_LEGACY_ERROR_TEMP_2065",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3052,6 +3052,17 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val ARCHIVE_READER_MAX_NESTING_DEPTH =
+    buildConf("spark.sql.files.archive.reader.maxNestingDepth")
+      .doc("Maximum number of archive levels an archive reader opens. The top-level archive is " +
+        "depth 1, so 1 reads no nested archives and 2 reads one level of nesting. Recursing past " +
+        "this limit fails the read, guarding against zip bombs and cyclic archives.")
+      .version("5.0.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .intConf
+      .checkValue(_ >= 1, "The max archive nesting depth must be at least 1.")
+      .createWithDefault(10)
+
   val FILES_OPEN_COST_IN_BYTES = buildConf("spark.sql.files.openCostInBytes")
     .internal()
     .doc("The estimated cost to open a file, measured by the number of bytes could be scanned in" +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3055,8 +3055,8 @@ object SQLConf {
   val ARCHIVE_READER_MAX_NESTING_DEPTH =
     buildConf("spark.sql.files.archive.reader.maxNestingDepth")
       .doc("Maximum number of archive levels an archive reader opens. The top-level archive is " +
-        "depth 1, so 1 reads no nested archives and 2 reads one level of nesting. Recursing past " +
-        "this limit fails the read, guarding against zip bombs and cyclic archives.")
+        "depth 1, so 2 admits one level of nesting. Reading an archive nested deeper than " +
+        "this limit fails, guarding against zip bombs and cyclic archives.")
       .version("5.0.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .intConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hdfs.BlockMissingException
 import org.apache.hadoop.security.AccessControlException
 
-import org.apache.spark.{Partition => RDDPartition, TaskContext}
+import org.apache.spark.{Partition => RDDPartition, SparkRuntimeException, TaskContext}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.LogKeys.{CURRENT_FILE, PATH}
 import org.apache.spark.memory.MemoryMode
@@ -281,6 +281,10 @@ class FileScanRDD(
                   // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
                   case e: FileNotFoundException if !ignoreMissingFiles => throw e
                   case e @ (_ : AccessControlException | _ : BlockMissingException) => throw e
+                  // A resource-safety limit is not a corrupt file: skipping the rest of the archive
+                  // would return partial data with no signal that the limit stopped the read.
+                  case e: SparkRuntimeException
+                      if e.getCondition == "MAX_ARCHIVE_DEPTH_EXCEEDED" => throw e
                   case e if ignoreCorruptFiles &&
                       DataSourceUtils.shouldIgnoreCorruptFileException(e) =>
                     logWarning(log"Skipped the rest of the content in the corrupted file: " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormat.scala
@@ -280,7 +280,9 @@ object SupportsArchiveFormat {
       conf: Configuration): ArchiveEntries = {
     val n = name.toLowerCase(Locale.ROOT)
     if (n.endsWith(".tar") || n.endsWith(".tar.gz") || n.endsWith(".tgz")) {
-      val gzipped = n.endsWith(".gz") || n.endsWith(".tgz")
+      // No codec layer decompresses `in` here, unlike the path-based tar open, so unwrap gzip
+      // directly. `in` belongs to the enclosing container and is not this method's to close.
+      val gzipped = n.endsWith(".tar.gz") || n.endsWith(".tgz")
       val tar = new TarArchiveInputStream(if (gzipped) new GZIPInputStream(in) else in)
       val entries = Iterator.continually(tar.getNextEntry).takeWhile(_ != null)
         .map((_, tar: InputStream))
@@ -421,20 +423,24 @@ object SupportsArchiveFormat {
       parseEntry: (ArchiveEntry, InputStream) => Iterator[T]): Iterator[T] = {
     val maxDepth = SQLConf.get.getConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH)
     streamEntries(
-      openArchiveStream(path, conf), conf, "", 1, maxDepth, ignoredPathSegmentRegex)(parseEntry)
+      openArchiveStream(path, conf), path, conf, "", 1, maxDepth,
+      ignoredPathSegmentRegex)(parseEntry)
   }
 
   /**
    * Streams one open `archive`, applying `parseEntry` to each non-skipped entry. An entry that is
    * itself an archive recurses instead, bounded by `maxDepth`.
    *
-   * @param namePrefix nested-entry name prefix ("" at the top, `inner!/` under a nested archive),
-   *                   composing the full `outer!/inner!/leaf` name each entry reports
+   * @param path       the top-level archive path, reported when the depth limit stops a read
+   * @param namePrefix nested-entry name prefix ("" at the top, `outer!/` inside the first nested
+   *                   archive and `outer!/inner!/` one level deeper), composing the full
+   *                   `outer!/inner!/leaf` name each entry reports
    * @param depth      1 for the top-level archive, incremented on each recursion
    * @param maxDepth   recursion ceiling; exceeding it fails the read (zip-bomb / cycle guard)
    */
   private def streamEntries[T](
       archive: ArchiveEntries,
+      path: Path,
       conf: Configuration,
       namePrefix: String,
       depth: Int,
@@ -479,11 +485,12 @@ object SupportsArchiveFormat {
             val stream = CloseShieldInputStream.wrap(next._2)
             currentIter = if (isArchiveFileName(next._1.getName)) {
               if (depth >= maxDepth) {
-                throw QueryExecutionErrors.maxArchiveDepthExceeded(entry.getName, maxDepth)
+                throw QueryExecutionErrors.maxArchiveDepthExceeded(
+                  entry.getName, path.toString, maxDepth)
               }
               streamEntries(
                 openNestedArchiveStream(next._1.getName, stream, conf),
-                conf, s"${entry.getName}!/", depth + 1, maxDepth,
+                path, conf, s"${entry.getName}!/", depth + 1, maxDepth,
                 ignoredPathSegmentRegex)(parseEntry)
             } else {
               parseEntry(entry, stream)
@@ -504,6 +511,12 @@ object SupportsArchiveFormat {
 
       override def close(): Unit = {
         done = true
+        // A nested archive's iterator owns its own container and spill directory, so releasing it
+        // is not covered by this level's cleanup.
+        currentIter match {
+          case c: Closeable => try c.close() catch { case NonFatal(_) => }
+          case _ =>
+        }
         currentIter = Iterator.empty
         cleanup()
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormat.scala
@@ -43,6 +43,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{HadoopFSUtils, Utils}
 
 /**
@@ -199,10 +200,20 @@ object SupportsArchiveFormat {
   /**
    * Whether the file path is a supported archive format.
    */
-  def isArchivePath(path: Path): Boolean = {
-    val name = path.getName.toLowerCase(Locale.ROOT)
-    name.endsWith(".tar") || name.endsWith(".tar.gz") || name.endsWith(".tgz") ||
-      name.endsWith(".zip") || name.endsWith(".7z")
+  def isArchivePath(path: Path): Boolean = isArchiveFileName(path.getName)
+
+  /**
+   * Whether a file name is a supported archive format. Takes the name rather than a [[Path]] so it
+   * can be called on an archive entry's name, which is an arbitrary string that [[Path]] would
+   * misparse (e.g. a colon reads as a URI scheme).
+   *
+   * @param name the file name to test, with or without leading directories
+   * @return true if the name ends in a supported archive extension
+   */
+  def isArchiveFileName(name: String): Boolean = {
+    val lower = name.toLowerCase(Locale.ROOT)
+    lower.endsWith(".tar") || lower.endsWith(".tar.gz") || lower.endsWith(".tgz") ||
+      lower.endsWith(".zip") || lower.endsWith(".7z")
   }
 
   /** An archive's entries as lazy `(entry, stream)` pairs; closing releases the container. */
@@ -254,6 +265,47 @@ object SupportsArchiveFormat {
       override def next(): (ArchiveEntry, InputStream) = entries.next()
       override def close(): Unit = closeFn()
     }
+
+  /**
+   * Opens an archive nested inside an already-open entry, reading from that entry's stream.
+   *
+   * @param name the entry's name, which selects the container by extension
+   * @param in   the entry's byte stream, positioned at the entry start
+   * @param conf Hadoop configuration used to open a spilled container
+   * @return the nested archive's entries; closing it releases the container and any spilled file
+   */
+  private def openNestedArchiveStream(
+      name: String,
+      in: InputStream,
+      conf: Configuration): ArchiveEntries = {
+    val n = name.toLowerCase(Locale.ROOT)
+    if (n.endsWith(".tar") || n.endsWith(".tar.gz") || n.endsWith(".tgz")) {
+      val gzipped = n.endsWith(".gz") || n.endsWith(".tgz")
+      val tar = new TarArchiveInputStream(if (gzipped) new GZIPInputStream(in) else in)
+      val entries = Iterator.continually(tar.getNextEntry).takeWhile(_ != null)
+        .map((_, tar: InputStream))
+      closeable(entries, () => tar.close())
+    } else {
+      // Unlike tar, zip and 7z read their index by seeking, which an entry stream cannot do, so the
+      // entry is spilled to a local file and opened from there.
+      val localDir = Utils.createTempDir(Utils.getLocalDir(SparkEnv.get.conf), "nested-archive")
+      try {
+        val local = copyEntryToLocalFile(in, localDir, name)
+        val nested = openArchiveStream(new Path(local.toURI), conf)
+        closeable(nested, () => {
+          try {
+            nested.close()
+          } finally {
+            Utils.deleteRecursively(localDir)
+          }
+        })
+      } catch {
+        case NonFatal(e) =>
+          Utils.deleteRecursively(localDir)
+          throw e
+      }
+    }
+  }
 
   /** Opens a `.7z` archive by seeking. */
   private def openSevenZStream(path: Path, conf: Configuration): ArchiveEntries = {
@@ -367,7 +419,28 @@ object SupportsArchiveFormat {
       conf: Configuration,
       ignoredPathSegmentRegex: Pattern = HadoopFSUtils.defaultIgnoredPathSegmentRegexPattern)(
       parseEntry: (ArchiveEntry, InputStream) => Iterator[T]): Iterator[T] = {
-    val archive = openArchiveStream(path, conf)
+    val maxDepth = SQLConf.get.getConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH)
+    streamEntries(
+      openArchiveStream(path, conf), conf, "", 1, maxDepth, ignoredPathSegmentRegex)(parseEntry)
+  }
+
+  /**
+   * Streams one open `archive`, applying `parseEntry` to each non-skipped entry. An entry that is
+   * itself an archive recurses instead, bounded by `maxDepth`.
+   *
+   * @param namePrefix nested-entry name prefix ("" at the top, `inner!/` under a nested archive),
+   *                   composing the full `outer!/inner!/leaf` name each entry reports
+   * @param depth      1 for the top-level archive, incremented on each recursion
+   * @param maxDepth   recursion ceiling; exceeding it fails the read (zip-bomb / cycle guard)
+   */
+  private def streamEntries[T](
+      archive: ArchiveEntries,
+      conf: Configuration,
+      namePrefix: String,
+      depth: Int,
+      maxDepth: Int,
+      ignoredPathSegmentRegex: Pattern)(
+      parseEntry: (ArchiveEntry, InputStream) => Iterator[T]): Iterator[T] = {
     var closed = false
 
     def cleanup(): Unit = {
@@ -401,8 +474,20 @@ object SupportsArchiveFormat {
             done = true
             cleanup()
           } else {
+            val entry = new PrefixedArchiveEntry(next._1, namePrefix)
             // Parse the entry stream; any unread remainder is skipped when the archive advances.
-            currentIter = parseEntry(next._1, CloseShieldInputStream.wrap(next._2))
+            val stream = CloseShieldInputStream.wrap(next._2)
+            currentIter = if (isArchiveFileName(next._1.getName)) {
+              if (depth >= maxDepth) {
+                throw QueryExecutionErrors.maxArchiveDepthExceeded(entry.getName, maxDepth)
+              }
+              streamEntries(
+                openNestedArchiveStream(next._1.getName, stream, conf),
+                conf, s"${entry.getName}!/", depth + 1, maxDepth,
+                ignoredPathSegmentRegex)(parseEntry)
+            } else {
+              parseEntry(entry, stream)
+            }
           }
         }
       }
@@ -479,6 +564,19 @@ object SupportsArchiveFormat {
       }
     }
 
+}
+
+/**
+ * An entry reported under a nested archive, whose name carries the full `outer!/inner!/leaf` path.
+ *
+ * @param entry  the underlying entry, delegated to for everything but the name
+ * @param prefix the composed prefix of the archives this entry is nested inside
+ */
+private class PrefixedArchiveEntry(entry: ArchiveEntry, prefix: String) extends ArchiveEntry {
+  override def getName: String = prefix + entry.getName
+  override def getSize: Long = entry.getSize
+  override def isDirectory: Boolean = entry.isDirectory
+  override def getLastModifiedDate: java.util.Date = entry.getLastModifiedDate
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
@@ -215,6 +215,33 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
     spark.read.options(readOptions ++ inferenceOptions ++ extraOptions)
       .format(format).load(paths: _*).schema
 
+  /** Bytes of an archive (of `extension`) containing `entries`, produced via [[writeArchive]]. */
+  protected def archiveBytes(
+      entries: Seq[(String, Array[Byte])],
+      extension: String = archiveExtensions.head): Array[Byte] =
+    withArchiveFile(extension) { inner =>
+      writeArchive(inner, entries)
+      Files.readAllBytes(inner.toPath)
+    }
+
+  /** Bytes of a corrupt archive of [[corruptArchiveExtension]], via [[writeCorruptArchive]]. */
+  protected def corruptArchiveBytes(): Array[Byte] =
+    withArchiveFile(corruptArchiveExtension) { inner =>
+      writeCorruptArchive(inner)
+      Files.readAllBytes(inner.toPath)
+    }
+
+  /**
+   * Writes an outer archive at `dest` whose single entry (`nested.<ext>`) is itself an archive of
+   * `entries`, so a correct read must recurse into it. Nesting uses the same container as the outer
+   * archive (this base mixes in one container); cross-container nesting is covered by the
+   * unit-level [[SupportsArchiveFormatSuite]].
+   */
+  protected def writeNestedArchive(dest: File, entries: Seq[(String, Array[Byte])]): Unit = {
+    val ext = archiveExtensions.head
+    writeArchive(dest, Seq(s"nested.$ext" -> archiveBytes(entries, ext)))
+  }
+
   /**
    * Writes `entries` both into an archive and as loose files in a directory, then asserts the
    * archive read produces exactly the same rows as the directory read.
@@ -353,6 +380,99 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
       // archive is skipped in its entirety while the good archive's rows are still returned.
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
         checkAnswer(read(dir.getCanonicalPath), good)
+      }
+    }
+  }
+
+  // ----- nested-archive tests ------------------------------------------------
+
+  test("a nested archive is recursed into and reads like a directory of its entries") {
+    val parts = Seq(sampleDf((1, "Alice"), (2, "Bob")), sampleDf((3, "Carol")))
+    val entries = parts.zipWithIndex.map { case (p, i) => entryName(i) -> encodeFile(p) }
+    withArchiveFile() { archive =>
+      writeNestedArchive(archive, entries)
+      checkAnswer(read(archive.getCanonicalPath), parts.reduce(_ union _))
+    }
+  }
+
+  test("a nested archive alongside plain entries contributes both") {
+    val nested = sampleDf((1, "Alice"), (2, "Bob"))
+    val plain = sampleDf((3, "Carol"))
+    val ext = archiveExtensions.head
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(
+        entryName(0) -> encodeFile(plain),
+        s"nested.$ext" -> archiveBytes(Seq(entryName(1) -> encodeFile(nested)), ext)))
+      checkAnswer(read(archive.getCanonicalPath), plain.union(nested))
+    }
+  }
+
+  test("three levels of nested archives are recursed into") {
+    val data = sampleDf((1, "Alice"), (2, "Bob"))
+    val ext = archiveExtensions.head
+    // archive -> level2.<ext> -> level3.<ext> -> the data file.
+    val level3 = archiveBytes(Seq(entryName(0) -> encodeFile(data)), ext)
+    val level2 = archiveBytes(Seq(s"level3.$ext" -> level3), ext)
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(s"level2.$ext" -> level2))
+      checkAnswer(read(archive.getCanonicalPath), data)
+    }
+  }
+
+  test("an empty nested archive contributes no rows") {
+    withArchiveFile() { archive =>
+      writeNestedArchive(archive, Seq.empty)
+      checkAnswer(read(archive.getCanonicalPath), Seq.empty[Row])
+    }
+  }
+
+  test("hidden entries inside a nested archive are skipped") {
+    val kept = sampleDf((1, "Alice"), (2, "Bob"))
+    val ext = archiveExtensions.head
+    val innerBytes = archiveBytes(
+      Seq("_SUCCESS" -> "marker".getBytes, entryName(0) -> encodeFile(kept)), ext)
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(s"nested.$ext" -> innerBytes))
+      checkAnswer(read(archive.getCanonicalPath), kept)
+    }
+  }
+
+  test("the depth limit bounds how deeply nested archives are read") {
+    val data = sampleDf((1, "Alice"), (2, "Bob"))
+    val ext = archiveExtensions.head
+    // Three archive levels: the top archive plus two nested ones.
+    val level3 = archiveBytes(Seq(entryName(0) -> encodeFile(data)), ext)
+    val level2 = archiveBytes(Seq(s"level3.$ext" -> level3), ext)
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(s"level2.$ext" -> level2))
+      // 3 admits exactly these three levels.
+      withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "3") {
+        checkAnswer(read(archive.getCanonicalPath), data)
+      }
+      // 2 stops before the innermost archive is opened.
+      withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "2") {
+        intercept[SparkException](read(archive.getCanonicalPath).collect())
+      }
+      // 1 admits only the top archive, so even the first nested archive is too deep.
+      withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "1") {
+        intercept[SparkException](read(archive.getCanonicalPath).collect())
+      }
+    }
+  }
+
+  Seq(true, false).foreach { ignoreCorrupt =>
+    test(s"ignoreCorruptFiles=$ignoreCorrupt controls skipping a corrupt nested archive") {
+      // The nested entry is a corrupt archive of corruptArchiveExtension, so recursing into it
+      // fails; the whole top archive is skipped or errors, matching the top-level contract.
+      withArchiveFile() { archive =>
+        writeArchive(archive, Seq(s"nested.$corruptArchiveExtension" -> corruptArchiveBytes()))
+        withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> ignoreCorrupt.toString) {
+          if (ignoreCorrupt) {
+            checkAnswer(read(archive.getCanonicalPath), Seq.empty[Row])
+          } else {
+            intercept[SparkException](read(archive.getCanonicalPath).collect())
+          }
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
@@ -22,7 +22,7 @@ import java.nio.file.Files
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException}
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.functions.{col, input_file_name, struct}
 import org.apache.spark.sql.internal.SQLConf
@@ -445,17 +445,79 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
     val level2 = archiveBytes(Seq(s"level3.$ext" -> level3), ext)
     withArchiveFile() { archive =>
       writeArchive(archive, Seq(s"level2.$ext" -> level2))
+      val path = new Path(archive.toURI).toString
+
+      def readAtMaxDepth(maxDepth: Int): Unit =
+        withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> maxDepth.toString) {
+          read(archive.getCanonicalPath).collect()
+        }
+
       // 3 admits exactly these three levels.
       withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "3") {
         checkAnswer(read(archive.getCanonicalPath), data)
       }
       // 2 stops before the innermost archive is opened.
-      withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "2") {
-        intercept[SparkException](read(archive.getCanonicalPath).collect())
-      }
+      checkError(
+        exception = intercept[SparkException](readAtMaxDepth(2)).getCause
+          .asInstanceOf[SparkRuntimeException],
+        condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
+        parameters = Map(
+          "entry" -> s"level2.$ext!/level3.$ext", "path" -> path, "maxDepth" -> "2"))
       // 1 admits only the top archive, so even the first nested archive is too deep.
-      withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "1") {
-        intercept[SparkException](read(archive.getCanonicalPath).collect())
+      checkError(
+        exception = intercept[SparkException](readAtMaxDepth(1)).getCause
+          .asInstanceOf[SparkRuntimeException],
+        condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
+        parameters = Map("entry" -> s"level2.$ext", "path" -> path, "maxDepth" -> "1"))
+    }
+  }
+
+  test("closing a partially-read nested archive releases its spilled temp dir") {
+    // A nested zip or 7z spills to a temp dir owned by the nested iterator, so closing the outer
+    // iterator early has to close that one too. A driver-side reader (Avro header inference) takes
+    // one entry and closes, with no task completion to fall back on.
+    val ext = archiveExtensions.head
+    val nestedDirs = () => {
+      val localDir = new File(Utils.getLocalDir(spark.sparkContext.getConf))
+      Option(localDir.listFiles()).getOrElse(Array.empty)
+        .filter(_.getName.startsWith("nested-archive")).map(_.getName).toSet
+    }
+    withArchiveFile() { archive =>
+      writeNestedArchive(archive, Seq(
+        entryName(0) -> encodeFile(sampleDf((1, "Alice"))),
+        entryName(1) -> encodeFile(sampleDf((2, "Bob")))))
+      val before = nestedDirs()
+      val entries = SupportsArchiveFormat.readArchiveEntries(
+        new Path(archive.toURI), spark.sessionState.newHadoopConf()) { (entry, _) =>
+        Iterator.single(entry.getName)
+      }
+      assert(entries.hasNext)
+      entries.next()
+      entries.asInstanceOf[java.io.Closeable].close()
+      assert((nestedDirs() -- before).isEmpty,
+        s"closing early leaked the nested archive's spill dir (ext=$ext)")
+    }
+  }
+
+  test("the depth limit still fails the read under ignoreCorruptFiles") {
+    // The depth limit is a resource-safety bound, not a corrupt file, so ignoreCorruptFiles must
+    // not turn it into a skip that returns partial data.
+    val ext = archiveExtensions.head
+    val level3 = archiveBytes(Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice")))), ext)
+    val level2 = archiveBytes(Seq(s"level3.$ext" -> level3), ext)
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(s"level2.$ext" -> level2))
+      withSQLConf(
+          SQLConf.IGNORE_CORRUPT_FILES.key -> "true",
+          SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "1") {
+        checkError(
+          exception = intercept[SparkException](read(archive.getCanonicalPath).collect())
+            .getCause.asInstanceOf[SparkRuntimeException],
+          condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
+          parameters = Map(
+            "entry" -> s"level2.$ext",
+            "path" -> new Path(archive.toURI).toString,
+            "maxDepth" -> "1"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
@@ -458,15 +458,13 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
       }
       // 2 stops before the innermost archive is opened.
       checkError(
-        exception = intercept[SparkException](readAtMaxDepth(2)).getCause
-          .asInstanceOf[SparkRuntimeException],
+        exception = intercept[SparkRuntimeException](readAtMaxDepth(2)),
         condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
         parameters = Map(
           "entry" -> s"level2.$ext!/level3.$ext", "path" -> path, "maxDepth" -> "2"))
       // 1 admits only the top archive, so even the first nested archive is too deep.
       checkError(
-        exception = intercept[SparkException](readAtMaxDepth(1)).getCause
-          .asInstanceOf[SparkRuntimeException],
+        exception = intercept[SparkRuntimeException](readAtMaxDepth(1)),
         condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
         parameters = Map("entry" -> s"level2.$ext", "path" -> path, "maxDepth" -> "1"))
     }
@@ -511,8 +509,8 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
           SQLConf.IGNORE_CORRUPT_FILES.key -> "true",
           SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> "1") {
         checkError(
-          exception = intercept[SparkException](read(archive.getCanonicalPath).collect())
-            .getCause.asInstanceOf[SparkRuntimeException],
+          exception =
+            intercept[SparkRuntimeException](read(archive.getCanonicalPath).collect()),
           condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
           parameters = Map(
             "entry" -> s"level2.$ext",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormatSuite.scala
@@ -32,14 +32,17 @@ import org.apache.commons.compress.archivers.zip.{ZipArchiveEntry, ZipArchiveOut
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkFunSuite, SparkRuntimeException, TaskContext, TaskContextImpl}
+import org.apache.spark.{SparkRuntimeException, TaskContext, TaskContextImpl}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * Unit tests for the streaming [[SupportsArchiveFormat]] engine: `isArchivePath` dispatch and
  * `readArchiveEntries` (entry ordering, gzip handling, dir/dotfile skipping, lazy advance, the
  * non-closing entry stream, and cleanup). Nothing here touches local disk -- entries are streams.
  */
-class SupportsArchiveFormatSuite extends SparkFunSuite {
+class SupportsArchiveFormatSuite extends QueryTest with SharedSparkSession {
 
   private case class Entry(name: String, data: Array[Byte], isDir: Boolean = false)
 
@@ -194,6 +197,17 @@ class SupportsArchiveFormatSuite extends SparkFunSuite {
   private def textEntry(name: String, body: String): Entry =
     Entry(name, body.getBytes(StandardCharsets.UTF_8))
 
+  /** Bytes of a `writer`-produced archive of `entries`, for embedding as a nested-archive entry. */
+  private def archiveBytes(
+      dir: File,
+      name: String,
+      writer: (File, Seq[Entry]) => Unit,
+      entries: Seq[Entry]): Array[Byte] = {
+    val f = new File(dir, name)
+    writer(f, entries)
+    Files.readAllBytes(f.toPath)
+  }
+
   private def readAll(in: InputStream): Array[Byte] = {
     val out = new ByteArrayOutputStream()
     val buf = new Array[Byte](4096)
@@ -229,6 +243,17 @@ class SupportsArchiveFormatSuite extends SparkFunSuite {
     Seq("foo.csv", "foo.gz", "foo", "dir/", "foo.tarball",
         "foo.tar.bz2", "foo.targz", "foo.zipx", "foo.gzip").foreach { p =>
       assert(!SupportsArchiveFormat.isArchivePath(new Path(p)), s"expected non-match for $p")
+    }
+  }
+
+  test("isArchiveFileName: matches names Path cannot parse") {
+    // An entry name is an arbitrary string, so it may hold characters Path reads as URI syntax --
+    // a colon most notably, which Path takes for a scheme.
+    Seq("data:2026.tar", "dir/data:2026.zip", "a:b:c.7z", "100%.tgz", "a b.tar.gz").foreach { n =>
+      assert(SupportsArchiveFormat.isArchiveFileName(n), s"expected archive match for $n")
+    }
+    Seq("data:2026.csv", "a:b.txt").foreach { n =>
+      assert(!SupportsArchiveFormat.isArchiveFileName(n), s"expected non-match for $n")
     }
   }
 
@@ -605,6 +630,57 @@ class SupportsArchiveFormatSuite extends SparkFunSuite {
         textEntry("real.csv", "kept"),
         textEntry("nested/._sidecar", "junk2")))   // dotfile in a subdir
       assert(collect(sevenZ) == Seq("real.csv" -> "kept"))
+    }
+  }
+
+  // ----- nested archives ----------------------------------------------------
+  // Per-container nested reads are covered by the ArchiveReadSuiteBase suites; these cases cover
+  // what only the engine sees: mixing container types across levels, and the depth limit.
+
+  test("readArchiveEntries: recursion nests tar, zip, and 7z inside each other") {
+    withTempDir { dir =>
+      val level4 = archiveBytes(dir, "l4.tgz", writeTarGz, Seq(textEntry("leaf.csv", "deep")))
+      val level3 = archiveBytes(dir, "l3.7z", writeSevenZ, Seq(Entry("l4.tgz", level4)))
+      val level2 = archiveBytes(dir, "l2.tar", writeTar, Seq(Entry("l3.7z", level3)))
+      val outer = new File(dir, "outer.zip")
+      writeZip(outer, Seq(textEntry("top.csv", "top"), Entry("l2.tar", level2)))
+      assert(collect(outer) ==
+        Seq("top.csv" -> "top", "l2.tar!/l3.7z!/l4.tgz!/leaf.csv" -> "deep"))
+    }
+  }
+
+  test("readArchiveEntries: a nested archive whose name holds a colon is recursed into") {
+    withTempDir { dir =>
+      // A colon in the entry name would read as a URI scheme if the name were parsed as a Path.
+      val inner = archiveBytes(dir, "inner.tar", writeTar, Seq(textEntry("a:1.csv", "a")))
+      val outer = new File(dir, "outer.tar")
+      writeTar(outer, Seq(Entry("data:2026.tar", inner)))
+      assert(collect(outer) == Seq("data:2026.tar!/a:1.csv" -> "a"))
+    }
+  }
+
+  test("readArchiveEntries: recursion past the depth limit throws a clear error") {
+    withTempDir { dir =>
+      val level3 = archiveBytes(dir, "l3.tar", writeTar, Seq(textEntry("leaf.csv", "deep")))
+      val level2 = archiveBytes(dir, "l2.tar", writeTar, Seq(Entry("l3.tar", level3)))
+      val outer = new File(dir, "outer.tar")
+      writeTar(outer, Seq(Entry("l2.tar", level2)))
+
+      def collectWithMaxDepth(maxDepth: Int): Seq[(String, String)] =
+        withSQLConf(SQLConf.ARCHIVE_READER_MAX_NESTING_DEPTH.key -> maxDepth.toString) {
+          collect(outer)
+        }
+
+      // Three levels are readable at the limit, and the innermost is refused one below it.
+      assert(collectWithMaxDepth(3) == Seq("l2.tar!/l3.tar!/leaf.csv" -> "deep"))
+      checkError(
+        exception = intercept[SparkRuntimeException](collectWithMaxDepth(2)),
+        condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
+        parameters = Map("entry" -> "l2.tar!/l3.tar", "maxDepth" -> "2"))
+      checkError(
+        exception = intercept[SparkRuntimeException](collectWithMaxDepth(1)),
+        condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
+        parameters = Map("entry" -> "l2.tar", "maxDepth" -> "1"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SupportsArchiveFormatSuite.scala
@@ -40,7 +40,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * Unit tests for the streaming [[SupportsArchiveFormat]] engine: `isArchivePath` dispatch and
  * `readArchiveEntries` (entry ordering, gzip handling, dir/dotfile skipping, lazy advance, the
- * non-closing entry stream, and cleanup). Nothing here touches local disk -- entries are streams.
+ * non-closing entry stream, and cleanup). Entries are read as streams, except a nested zip or 7z,
+ * which needs random access and so is spilled to a temp file before it is opened.
  */
 class SupportsArchiveFormatSuite extends QueryTest with SharedSparkSession {
 
@@ -671,16 +672,17 @@ class SupportsArchiveFormatSuite extends QueryTest with SharedSparkSession {
           collect(outer)
         }
 
+      val path = new Path(outer.toURI).toString
       // Three levels are readable at the limit, and the innermost is refused one below it.
       assert(collectWithMaxDepth(3) == Seq("l2.tar!/l3.tar!/leaf.csv" -> "deep"))
       checkError(
         exception = intercept[SparkRuntimeException](collectWithMaxDepth(2)),
         condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
-        parameters = Map("entry" -> "l2.tar!/l3.tar", "maxDepth" -> "2"))
+        parameters = Map("entry" -> "l2.tar!/l3.tar", "path" -> path, "maxDepth" -> "2"))
       checkError(
         exception = intercept[SparkRuntimeException](collectWithMaxDepth(1)),
         condition = "MAX_ARCHIVE_DEPTH_EXCEEDED",
-        parameters = Map("entry" -> "l2.tar", "maxDepth" -> "1"))
+        parameters = Map("entry" -> "l2.tar", "path" -> path, "maxDepth" -> "1"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When an archive entry is itself an archive (`.tar`/`.tar.gz`/`.tgz`/`.zip`/`.7z`), recurse
into it and stream its entries, instead of handing the nested archive's raw bytes to the
format parser. Nested entries report the full `outer!/inner!/leaf` logical name.

- `readArchiveEntries` delegates to a depth-aware `streamEntries` that recurses when an
  entry is an archive.
- A new `openNestedArchiveStream` opens a container from an already-open entry stream. Tar
  reads the stream directly; zip and 7z read their index by seeking, which an entry stream
  cannot do, so the entry is spilled to a local file and opened from there.
- New config `spark.sql.files.archive.reader.maxNestingDepth` (default 10) bounds the
  recursion; exceeding it fails the read with `MAX_ARCHIVE_DEPTH_EXCEEDED`, guarding
  against zip bombs and cyclic archives.
- `isArchiveFileName` is factored out of `isArchivePath` so an entry name is matched as a
  plain string: an entry name is arbitrary, and `Path` would misparse one containing a
  colon as a URI scheme.

### Why are the changes needed?

Archives commonly contain other archives, and today those inner archives are handed to the
format parser as opaque bytes, so their contents are unreadable. Recursing makes an archive
of archives behave like a directory tree of the data files it ultimately holds.

### Does this PR introduce any user-facing change?

Yes, gated by `spark.sql.files.archive.reader.enabled` (default false). With archive reading
enabled, a nested archive's entries are now read instead of its raw bytes, and the new
`spark.sql.files.archive.reader.maxNestingDepth` config (default 10) bounds recursion depth.

### How was this patch tested?

`ArchiveReadSuiteBase` gains nested-archive tests that run for every container (recursion
reads like a directory, a nested archive alongside plain entries, three levels of nesting,
empty nested, hidden entries in nested, the depth limit, and corrupt-nested under
`ignoreCorruptFiles`), plus a `writeNestedArchive` helper. `SupportsArchiveFormatSuite`
covers what only the engine sees: one archive nesting tar, zip, and 7z inside each other, a
nested archive whose name contains a colon, and the depth-limit boundary.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

