### PR TITLE
[SPARK-58614][SQL] Support DISTINCT aggregates in unbounded preceding window frames

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2308,7 +2308,7 @@
   },
   "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED" : {
     "message" : [
-      "Distinct window functions are not supported: <windowExpr>."
+      "Unsupported DISTINCT window function: <windowExpr>. DISTINCT aggregate window functions require a lower frame bound of UNBOUNDED PRECEDING and orderable arguments, and do not support Python UDAFs."
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -127,7 +127,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     UnsafeExternalSorter sorter = new UnsafeExternalSorter(taskMemoryManager, blockManager,
       serializerManager, taskContext, recordComparatorSupplier, prefixComparator, initialSize,
         pageSizeBytes, numElementsForSpillThreshold, sizeInBytesForSpillThreshold,
-        spillMergeFactor, inMemorySorter, false /* ignored */);
+        spillMergeFactor, inMemorySorter, false /* ignored */, true);
     sorter.spill(Long.MAX_VALUE, sorter);
     taskContext.taskMetrics().incMemoryBytesSpilled(existingMemoryConsumption);
     sorter.totalSpillBytes += existingMemoryConsumption;
@@ -152,7 +152,30 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     return new UnsafeExternalSorter(taskMemoryManager, blockManager, serializerManager,
       taskContext, recordComparatorSupplier, prefixComparator, initialSize, pageSizeBytes,
       numElementsForSpillThreshold, sizeInBytesForSpillThreshold, spillMergeFactor,
-      null, canUseRadixSort);
+      null, canUseRadixSort, true);
+  }
+
+  /**
+   * Creates a sorter whose caller owns its lifecycle and guarantees that
+   * {@link #cleanupResources()} is invoked.
+   */
+  public static UnsafeExternalSorter createWithCallerOwnedLifecycle(
+      TaskMemoryManager taskMemoryManager,
+      BlockManager blockManager,
+      SerializerManager serializerManager,
+      TaskContext taskContext,
+      Supplier<RecordComparator> recordComparatorSupplier,
+      PrefixComparator prefixComparator,
+      int initialSize,
+      long pageSizeBytes,
+      int numElementsForSpillThreshold,
+      long sizeInBytesForSpillThreshold,
+      int spillMergeFactor,
+      boolean canUseRadixSort) {
+    return new UnsafeExternalSorter(taskMemoryManager, blockManager, serializerManager,
+      taskContext, recordComparatorSupplier, prefixComparator, initialSize, pageSizeBytes,
+      numElementsForSpillThreshold, sizeInBytesForSpillThreshold, spillMergeFactor,
+      null, canUseRadixSort, false);
   }
 
   private UnsafeExternalSorter(
@@ -168,7 +191,8 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       long sizeInBytesForSpillThreshold,
       int spillMergeFactor,
       @Nullable UnsafeInMemorySorter existingInMemorySorter,
-      boolean canUseRadixSort) {
+      boolean canUseRadixSort,
+      boolean registerTaskCompletionListener) {
     super(taskMemoryManager, pageSizeBytes, taskMemoryManager.getTungstenMemoryMode());
     this.taskMemoryManager = taskMemoryManager;
     this.blockManager = blockManager;
@@ -200,12 +224,14 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     this.sizeInBytesForSpillThreshold = sizeInBytesForSpillThreshold;
     this.numElementsForSpillThreshold = numElementsForSpillThreshold;
 
-    // Register a cleanup task with TaskContext to ensure that memory is guaranteed to be freed at
-    // the end of the task. This is necessary to avoid memory leaks in when the downstream operator
-    // does not fully consume the sorter's output (e.g. sort followed by limit).
-    taskContext.addTaskCompletionListener(context -> {
-      cleanupResources();
-    });
+    if (registerTaskCompletionListener) {
+      // Register a cleanup task with TaskContext to ensure that memory is guaranteed to be freed
+      // at the end of the task. This is necessary to avoid memory leaks when the downstream
+      // operator does not fully consume the sorter's output (e.g. sort followed by limit).
+      taskContext.addTaskCompletionListener(context -> {
+        cleanupResources();
+      });
+    }
   }
 
   /**
@@ -375,6 +401,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     try {
       synchronized (this) {
         deleteSpillFiles();
+        spillWriters.clear();
         if (boundedMerger != null) {
           boundedMerger.cleanupIntermediateFiles();
           boundedMerger = null;
@@ -494,13 +521,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     growPointerArrayIfNecessary();
   }
 
-  /**
-   * Write a record to the sorter.
-   */
-  public void insertRecord(
-      Object recordBase, long recordOffset, int length, long prefix, boolean prefixIsNull)
-    throws IOException {
-
+  private void spillIfThresholdReached() throws IOException {
     assert(inMemSorter != null);
     if (inMemSorter.numRecords() >= numElementsForSpillThreshold) {
       logger.info("Spilling data because number of spilledRecords ({}) crossed the threshold {}",
@@ -520,6 +541,16 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
         MDC.of(LogKeys.SPILL_RECORDS_SIZE_THRESHOLD, sizeInBytesForSpillThreshold));
       spill();
     }
+  }
+
+  /**
+   * Write a record to the sorter.
+   */
+  public void insertRecord(
+      Object recordBase, long recordOffset, int length, long prefix, boolean prefixIsNull)
+    throws IOException {
+
+    spillIfThresholdReached();
 
     final int uaoSize = UnsafeAlignedOffset.getUaoSize();
     // Need 4 or 8 bytes to store the record length.
@@ -546,6 +577,8 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
   public void insertKVRecord(Object keyBase, long keyOffset, int keyLen,
       Object valueBase, long valueOffset, int valueLen, long prefix, boolean prefixIsNull)
     throws IOException {
+
+    spillIfThresholdReached();
 
     final int uaoSize = UnsafeAlignedOffset.getUaoSize();
     final int required = keyLen + valueLen + (2 * uaoSize);
@@ -585,7 +618,7 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
   public UnsafeSorterIterator getSortedIterator() throws IOException {
     assert(recordComparatorSupplier != null);
     if (spillWriters.isEmpty()) {
-      // No spills — return in-memory sorted iterator
+      // No spills - return in-memory sorted iterator
       assert(inMemSorter != null);
       readingIterator = new SpillableIterator(inMemSorter.getSortedIterator());
       return readingIterator;

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -401,7 +401,6 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     try {
       synchronized (this) {
         deleteSpillFiles();
-        spillWriters.clear();
         if (boundedMerger != null) {
           boundedMerger.cleanupIntermediateFiles();
           boundedMerger = null;

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -54,6 +54,24 @@ import static org.mockito.Mockito.*;
 
 public class UnsafeExternalSorterSuite {
 
+  private static final class DeleteFailsOnceFile extends File {
+    private int deleteAttempts;
+
+    DeleteFailsOnceFile(File file) {
+      super(file.getAbsolutePath());
+    }
+
+    @Override
+    public boolean delete() {
+      deleteAttempts++;
+      return deleteAttempts > 1 && super.delete();
+    }
+
+    int deleteAttempts() {
+      return deleteAttempts;
+    }
+  }
+
   private final SparkConf conf = new SparkConf();
 
   final LinkedList<File> spillFilesCreated = new LinkedList<>();
@@ -174,6 +192,30 @@ public class UnsafeExternalSorterSuite {
       spillSizeThreshold,
       /* spillMergeFactor */ -1,
       shouldUseRadixSort());
+  }
+
+  @Test
+  public void cleanupResourcesRetriesFailedSpillFileDeletion() throws Exception {
+    DeleteFailsOnceFile[] spillFile = new DeleteFailsOnceFile[1];
+    when(diskBlockManager.createTempLocalBlock()).thenAnswer(invocationOnMock -> {
+      TempLocalBlockId blockId = new TempLocalBlockId(UUID.randomUUID());
+      File file = File.createTempFile("spillFile", ".spill", tempDir);
+      spillFile[0] = new DeleteFailsOnceFile(file);
+      spillFilesCreated.add(spillFile[0]);
+      return Tuple2$.MODULE$.apply(blockId, spillFile[0]);
+    });
+
+    UnsafeExternalSorter sorter = newSorter();
+    insertNumber(sorter, 1);
+    sorter.spill();
+
+    sorter.cleanupResources();
+    assertTrue(spillFile[0].exists());
+    assertEquals(1, spillFile[0].deleteAttempts());
+
+    sorter.cleanupResources();
+    assertFalse(spillFile[0].exists());
+    assertEquals(2, spillFile[0].deleteAttempts());
   }
 
   @Test

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -54,24 +54,6 @@ import static org.mockito.Mockito.*;
 
 public class UnsafeExternalSorterSuite {
 
-  private static final class DeleteFailsOnceFile extends File {
-    private int deleteAttempts;
-
-    DeleteFailsOnceFile(File file) {
-      super(file.getAbsolutePath());
-    }
-
-    @Override
-    public boolean delete() {
-      deleteAttempts++;
-      return deleteAttempts > 1 && super.delete();
-    }
-
-    int deleteAttempts() {
-      return deleteAttempts;
-    }
-  }
-
   private final SparkConf conf = new SparkConf();
 
   final LinkedList<File> spillFilesCreated = new LinkedList<>();
@@ -192,30 +174,6 @@ public class UnsafeExternalSorterSuite {
       spillSizeThreshold,
       /* spillMergeFactor */ -1,
       shouldUseRadixSort());
-  }
-
-  @Test
-  public void cleanupResourcesRetriesFailedSpillFileDeletion() throws Exception {
-    DeleteFailsOnceFile[] spillFile = new DeleteFailsOnceFile[1];
-    when(diskBlockManager.createTempLocalBlock()).thenAnswer(invocationOnMock -> {
-      TempLocalBlockId blockId = new TempLocalBlockId(UUID.randomUUID());
-      File file = File.createTempFile("spillFile", ".spill", tempDir);
-      spillFile[0] = new DeleteFailsOnceFile(file);
-      spillFilesCreated.add(spillFile[0]);
-      return Tuple2$.MODULE$.apply(blockId, spillFile[0]);
-    });
-
-    UnsafeExternalSorter sorter = newSorter();
-    insertNumber(sorter, 1);
-    sorter.spill();
-
-    sorter.cleanupResources();
-    assertTrue(spillFile[0].exists());
-    assertEquals(1, spillFile[0].deleteAttempts());
-
-    sorter.cleanupResources();
-    assertFalse(spillFile[0].exists());
-    assertEquals(2, spillFile[0].deleteAttempts());
   }
 
   @Test

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -50,6 +50,10 @@ window_function [ nulls_option ] OVER
 
       Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for a complete list of Spark aggregate functions.
 
+      `DISTINCT` aggregate window functions require an `UNBOUNDED PRECEDING` lower frame bound
+      and orderable arguments. This includes `OVER ()` and the default frame of an ordered window.
+      Python UDAFs and bounded or sliding lower frame bounds are not supported.
+
 * **nulls_option**
 
     Specifies whether or not to skip null values when evaluating the window function. `RESPECT NULLS` means not skipping null values, while `IGNORE NULLS` means skipping. If not specified, the default is `RESPECT NULLS`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
@@ -21,9 +21,12 @@ import org.apache.spark.sql.catalyst.expressions.{
   AggregateWindowFunction,
   CurrentRow,
   FrameLessOffsetWindowFunction,
+  PythonUDAF,
   RangeFrame,
   RankLike,
   RowFrame,
+  RowOrdering,
+  SortOrder,
   SpecifiedWindowFrame,
   UnboundedFollowing,
   UnboundedPreceding,
@@ -109,11 +112,12 @@ object WindowResolution {
    * - Disallows [[FrameLessOffsetWindowFunction]] (e.g. [[Lag]]) without defined ordering or
    *   one with a frame which is defined as something other than an offset frame (e.g.
    *   `ROWS BETWEEN` is logically incompatible with offset functions).
-   * - Disallows distinct aggregate expressions in window functions.
+   * - Allows distinct aggregate expressions with an unbounded preceding frame.
+   * - Disallows other distinct aggregate expressions in window functions.
    * - Disallows use of certain aggregate functions - [[ListAgg]], [[PercentileCont]],
    *   [[PercentileDisc]], [[Median]]
    * - Allows only window functions of following types:
-   *   - [[AggregateExpression]] (non-distinct)
+   *   - [[AggregateExpression]] (non-distinct, or supported distinct aggregate)
    *   - [[FrameLessOffsetWindowFunction]]
    *   - [[AggregateWindowFunction]]
    */
@@ -141,11 +145,6 @@ object WindowResolution {
 
   def checkWindowFunction(windowExpression: WindowExpression): Unit = {
     windowExpression.windowFunction match {
-      case AggregateExpression(_, _, true, _, _) =>
-        windowExpression.failAnalysis(
-          errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
-          messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
-        )
       case agg @ AggregateExpression(fun: ListAgg, _, _, _, _)
         // listagg(...) WITHIN GROUP (ORDER BY ...) OVER (ORDER BY ...) is unsupported
         if fun.orderingFilled && (windowExpression.windowSpec.orderSpec.nonEmpty ||
@@ -162,6 +161,26 @@ object WindowResolution {
         agg.failAnalysis(
           errorClass = "INVALID_WINDOW_SPEC_FOR_AGGREGATION_FUNC",
           messageParameters = Map("aggFunc" -> toSQLExpr(agg.aggregateFunction))
+        )
+      case AggregateExpression(_: PythonUDAF, _, true, _, _) =>
+        windowExpression.failAnalysis(
+          errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
+          messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
+        )
+      case AggregateExpression(function, _, true, _, _)
+          if (windowExpression.windowSpec.frameSpecification match {
+            case SpecifiedWindowFrame(_, UnboundedPreceding, _) =>
+              val distinctExpressions = function.children.filterNot(_.foldable).map {
+                case sortOrder: SortOrder => sortOrder.child
+                case expression => expression
+              }
+              RowOrdering.isOrderable(distinctExpressions)
+            case _ => false
+          }) => ()
+      case AggregateExpression(_, _, true, _, _) =>
+        windowExpression.failAnalysis(
+          errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
+          messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
         )
       case _: AggregateExpression | _: FrameLessOffsetWindowFunction | _: AggregateWindowFunction =>
       case other =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.catalyst.expressions.{
   AggregateWindowFunction,
   CurrentRow,
   FrameLessOffsetWindowFunction,
-  PythonUDAF,
   RangeFrame,
   RankLike,
   RowFrame,
@@ -160,11 +159,6 @@ object WindowResolution {
         agg.failAnalysis(
           errorClass = "INVALID_WINDOW_SPEC_FOR_AGGREGATION_FUNC",
           messageParameters = Map("aggFunc" -> toSQLExpr(agg.aggregateFunction))
-        )
-      case AggregateExpression(_: PythonUDAF, _, true, _, _) =>
-        windowExpression.failAnalysis(
-          errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
-          messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
         )
       case AggregateExpression(function, _, true, _, _)
           if WindowExpression.isSupportedDistinctAggregate(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
@@ -112,7 +112,8 @@ object WindowResolution {
    * - Disallows [[FrameLessOffsetWindowFunction]] (e.g. [[Lag]]) without defined ordering or
    *   one with a frame which is defined as something other than an offset frame (e.g.
    *   `ROWS BETWEEN` is logically incompatible with offset functions).
-   * - Allows distinct aggregate expressions with an unbounded preceding frame.
+   * - Allows supported distinct aggregate expressions with orderable inputs and an unbounded
+   *   preceding frame.
    * - Disallows other distinct aggregate expressions in window functions.
    * - Disallows use of certain aggregate functions - [[ListAgg]], [[PercentileCont]],
    *   [[PercentileDisc]], [[Median]]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/WindowResolution.scala
@@ -25,8 +25,6 @@ import org.apache.spark.sql.catalyst.expressions.{
   RangeFrame,
   RankLike,
   RowFrame,
-  RowOrdering,
-  SortOrder,
   SpecifiedWindowFrame,
   UnboundedFollowing,
   UnboundedPreceding,
@@ -169,15 +167,8 @@ object WindowResolution {
           messageParameters = Map("windowExpr" -> toSQLExpr(windowExpression))
         )
       case AggregateExpression(function, _, true, _, _)
-          if (windowExpression.windowSpec.frameSpecification match {
-            case SpecifiedWindowFrame(_, UnboundedPreceding, _) =>
-              val distinctExpressions = function.children.filterNot(_.foldable).map {
-                case sortOrder: SortOrder => sortOrder.child
-                case expression => expression
-              }
-              RowOrdering.isOrderable(distinctExpressions)
-            case _ => false
-          }) => ()
+          if WindowExpression.isSupportedDistinctAggregate(
+            function, windowExpression.windowSpec.frameSpecification) => ()
       case AggregateExpression(_, _, true, _, _) =>
         windowExpression.failAnalysis(
           errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -337,6 +337,23 @@ object WindowExpression {
     e.find(_.isInstanceOf[WindowExpression]).isDefined
   }
 
+  private[sql] def distinctAggregateChildren(function: AggregateFunction): Seq[Expression] = {
+    function.children.filterNot(_.foldable).map {
+      case sortOrder: SortOrder => sortOrder.child
+      case expression => expression
+    }.distinctBy(_.canonicalized)
+  }
+
+  private[sql] def isSupportedDistinctAggregate(
+      function: AggregateFunction,
+      frame: WindowFrame): Boolean = {
+    !function.isInstanceOf[PythonUDAF] && (frame match {
+      case SpecifiedWindowFrame(_, UnboundedPreceding, _) =>
+        RowOrdering.isOrderable(distinctAggregateChildren(function))
+      case _ => false
+    })
+  }
+
   def expressionToIngnoreNulls(e: Expression, source: String): Boolean = e match {
     case BooleanLiteral(ignoreNulls) => ignoreNulls
     case _ => throw QueryCompilationErrors.invalidIgnoreNullsParameter(source, e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4678,6 +4678,14 @@ object SQLConf {
       .version("4.1.0")
       .fallbackConf(SHUFFLE_SPILL_MAX_SIZE_FORCE_SPILL_THRESHOLD)
 
+  val WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD =
+    buildConf("spark.sql.windowExec.distinct.hash.fallbackThreshold")
+      .internal()
+      .doc("Threshold for number of distinct keys in the in-memory hash map before a window " +
+        "DISTINCT aggregate falls back to external sorting")
+      .version("4.4.0")
+      .fallbackConf(WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD)
+
   val WINDOW_GROUP_LIMIT_THRESHOLD =
     buildConf("spark.sql.optimizer.windowGroupLimitThreshold")
       .internal()
@@ -9119,6 +9127,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def windowExecBufferSpillThreshold: Int = getConf(WINDOW_EXEC_BUFFER_SPILL_THRESHOLD)
 
   def windowExecBufferSpillSizeThreshold: Long = getConf(WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD)
+
+  def windowExecDistinctHashFallbackThreshold: Int =
+    getConf(WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD)
 
   def windowGroupLimitThreshold: Int = getConf(WINDOW_GROUP_LIMIT_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4681,8 +4681,8 @@ object SQLConf {
   val WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD =
     buildConf("spark.sql.windowExec.distinct.hash.fallbackThreshold")
       .internal()
-      .doc("Threshold for number of distinct keys in the in-memory hash map before a window " +
-        "DISTINCT aggregate falls back to external sorting")
+      .doc("Maximum number of distinct keys kept in the in-memory hash map. A new key after " +
+        "this threshold makes a window DISTINCT aggregate fall back to external sorting")
       .version("4.4.0")
       .fallbackConf(WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4681,6 +4681,7 @@ object SQLConf {
   val WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD =
     buildConf("spark.sql.windowExec.distinct.hash.fallbackThreshold")
       .internal()
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .doc("Maximum number of distinct keys kept in the in-memory hash map. A new key after " +
         "this threshold makes a window DISTINCT aggregate fall back to external sorting")
       .version("4.4.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4685,7 +4685,8 @@ object SQLConf {
       .doc("Maximum number of distinct keys kept in the in-memory hash map. A new key after " +
         "this threshold makes a window DISTINCT aggregate fall back to external sorting")
       .version("4.4.0")
-      .fallbackConf(WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD)
+      .intConf
+      .createWithDefault(Int.MaxValue)
 
   val WINDOW_GROUP_LIMIT_THRESHOLD =
     buildConf("spark.sql.optimizer.windowGroupLimitThreshold")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -208,6 +208,25 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
          | ROWS BETWEEN CURRENT ROW AND CURRENT ROW)"
          |""".stripMargin.replaceAll("\n", "")))
 
+  errorConditionTest(
+    "distinct Python UDAF in window",
+    testRelation2.select(
+      WindowExpression(
+        PythonUDAF(
+          "python_udaf",
+          null,
+          LongType,
+          UnresolvedAttribute("b") :: Nil,
+          udfDeterministic = true).toAggregateExpression(isDistinct = true),
+        WindowSpecDefinition(
+          UnresolvedAttribute("a") :: Nil,
+          Nil,
+          SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))).as("window")),
+    condition = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
+    messageParameters = Map("windowExpr" -> (
+      "\"python_udaf(DISTINCT b) OVER (PARTITION BY a " +
+        "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\"")))
+
   test("distinct function") {
     assertAnalysisErrorCondition(
       CatalystSqlParser.parsePlan("SELECT hex(DISTINCT a) FROM TaBlE"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -200,12 +200,12 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
         WindowSpecDefinition(
           UnresolvedAttribute("a") :: Nil,
           SortOrder(UnresolvedAttribute("b"), Ascending) :: Nil,
-          UnspecifiedFrame)).as("window")),
+          SpecifiedWindowFrame(RowFrame, CurrentRow, CurrentRow))).as("window")),
     condition = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
     messageParameters = Map("windowExpr" ->
       s"""
          |"count(DISTINCT b) OVER (PARTITION BY a ORDER BY b ASC NULLS FIRST
-         | RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+         | ROWS BETWEEN CURRENT ROW AND CURRENT ROW)"
          |""".stripMargin.replaceAll("\n", "")))
 
   test("distinct function") {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
@@ -75,6 +75,36 @@ public final class UnsafeKVExternalSorter {
       int numElementsForSpillThreshold,
       long sizeInBytesForSpillThreshold,
       @Nullable BytesToBytesMap map) throws IOException {
+    this(keySchema, valueSchema, blockManager, serializerManager, pageSizeBytes,
+      numElementsForSpillThreshold, sizeInBytesForSpillThreshold, map, true);
+  }
+
+  /**
+   * Creates a sorter whose caller owns its lifecycle and guarantees that
+   * {@link #cleanupResources()} is invoked.
+   */
+  public static UnsafeKVExternalSorter createWithCallerOwnedLifecycle(
+      StructType keySchema,
+      StructType valueSchema,
+      BlockManager blockManager,
+      SerializerManager serializerManager,
+      long pageSizeBytes,
+      int numElementsForSpillThreshold,
+      long sizeInBytesForSpillThreshold) throws IOException {
+    return new UnsafeKVExternalSorter(keySchema, valueSchema, blockManager, serializerManager,
+      pageSizeBytes, numElementsForSpillThreshold, sizeInBytesForSpillThreshold, null, false);
+  }
+
+  private UnsafeKVExternalSorter(
+      StructType keySchema,
+      StructType valueSchema,
+      BlockManager blockManager,
+      SerializerManager serializerManager,
+      long pageSizeBytes,
+      int numElementsForSpillThreshold,
+      long sizeInBytesForSpillThreshold,
+      @Nullable BytesToBytesMap map,
+      boolean registerTaskCompletionListener) throws IOException {
     this.keySchema = keySchema;
     this.valueSchema = valueSchema;
     final TaskContext taskContext = TaskContext.get();
@@ -90,20 +120,41 @@ public final class UnsafeKVExternalSorter {
     TaskMemoryManager taskMemoryManager = taskContext.taskMemoryManager();
 
     if (map == null) {
-      sorter = UnsafeExternalSorter.create(
-        taskMemoryManager,
-        blockManager,
-        serializerManager,
-        taskContext,
-        comparatorSupplier,
-        prefixComparator,
-        (int) (long) SparkEnv.get().conf().get(package$.MODULE$.SHUFFLE_SORT_INIT_BUFFER_SIZE()),
-        pageSizeBytes,
-        numElementsForSpillThreshold,
-        sizeInBytesForSpillThreshold,
-        (int) SparkEnv.get().conf().get(package$.MODULE$.UNSAFE_SORTER_SPILL_MERGE_FACTOR()),
-        canUseRadixSort);
+      final int initialSize =
+        (int) (long) SparkEnv.get().conf().get(package$.MODULE$.SHUFFLE_SORT_INIT_BUFFER_SIZE());
+      final int spillMergeFactor =
+        (int) SparkEnv.get().conf().get(package$.MODULE$.UNSAFE_SORTER_SPILL_MERGE_FACTOR());
+      if (registerTaskCompletionListener) {
+        sorter = UnsafeExternalSorter.create(
+          taskMemoryManager,
+          blockManager,
+          serializerManager,
+          taskContext,
+          comparatorSupplier,
+          prefixComparator,
+          initialSize,
+          pageSizeBytes,
+          numElementsForSpillThreshold,
+          sizeInBytesForSpillThreshold,
+          spillMergeFactor,
+          canUseRadixSort);
+      } else {
+        sorter = UnsafeExternalSorter.createWithCallerOwnedLifecycle(
+          taskMemoryManager,
+          blockManager,
+          serializerManager,
+          taskContext,
+          comparatorSupplier,
+          prefixComparator,
+          initialSize,
+          pageSizeBytes,
+          numElementsForSpillThreshold,
+          sizeInBytesForSpillThreshold,
+          spillMergeFactor,
+          canUseRadixSort);
+      }
     } else {
+      assert registerTaskCompletionListener;
       // During spilling, the pointer array in `BytesToBytesMap` will not be used, so we can borrow
       // that and use it as the pointer array for `UnsafeInMemorySorter`.
       LongArray pointerArray = map.getArray();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/AggregateProcessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/AggregateProcessor.scala
@@ -36,7 +36,7 @@ import org.apache.spark.util.ArrayImplicits._
  * require the size of the partition processed and this value is exposed to them when
  * the processor is constructed.
  *
- * Processing of distinct aggregates is currently not supported.
+ * DISTINCT input de-duplication is handled by the caller before rows reach this processor.
  *
  * The implementation is split into an object which takes care of construction, and the actual
  * processor class.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -35,8 +35,8 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
  * contains it. A bounded BytesToBytesMap removes duplicates up to the hash fallback threshold. If
  * another new key arrives, the frame permanently falls back to an external sorter for the rest of
  * the window partition. That sorter finds the earliest event for every key, then a second external
- * sorter orders those events by index. `write` feeds each unique, normalized DISTINCT input to the
- * aggregate processor when its event becomes visible.
+ * sorter orders those events by index. The frame feeds each unique, normalized DISTINCT input to
+ * the aggregate processor when its event becomes visible.
  */
 private[window] abstract class DistinctWindowFunctionFrame(
     target: InternalRow,
@@ -102,16 +102,14 @@ private[window] abstract class DistinctWindowFunctionFrame(
         newEventSorter.cleanupResources()
       }
     }
-    prepareUpperBound(rows)
+    prepareFrame(rows)
   }
 
   protected def populateFirstVisibleRows(
       rows: ExternalAppendOnlyUnsafeRowArray,
       firstVisibleRows: FirstVisibleRowsBuilder): Unit
 
-  protected def prepareUpperBound(rows: ExternalAppendOnlyUnsafeRowArray): Unit
-
-  protected def updateUpperBound(index: Int, current: InternalRow): Unit
+  protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit
 
   protected final def addCandidate(
       row: InternalRow,
@@ -327,7 +325,7 @@ private[window] abstract class DistinctWindowFunctionFrame(
     }
   }
 
-  override final def write(index: Int, current: InternalRow): Unit = {
+  protected final def updateProcessor(index: Int): Unit = {
     var bufferUpdated = index == 0
     while (nextEventIndex <= index) {
       processor.update(eventIterator.getValue)
@@ -337,7 +335,14 @@ private[window] abstract class DistinctWindowFunctionFrame(
     if (bufferUpdated) {
       processor.evaluate(target)
     }
-    updateUpperBound(index, current)
+  }
+
+  protected final def evaluateEntirePartition(): Unit = {
+    try {
+      updateProcessor(0)
+    } finally {
+      closeEventResources()
+    }
   }
 
   override final def currentLowerBound(): Int = 0
@@ -393,11 +398,12 @@ private[window] final class UnboundedDistinctWindowFunctionFrame(
     }
   }
 
-  override protected def prepareUpperBound(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+  override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     partitionSize = rows.length
+    evaluateEntirePartition()
   }
 
-  override protected def updateUpperBound(index: Int, current: InternalRow): Unit = {}
+  override def write(index: Int, current: InternalRow): Unit = {}
 
   override def currentUpperBound(): Int = partitionSize
 }
@@ -452,13 +458,14 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
     }
   }
 
-  override protected def prepareUpperBound(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+  override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     boundaryInputIndex = 0
     boundaryIterator = rows.generateIterator()
     nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
   }
 
-  override protected def updateUpperBound(index: Int, current: InternalRow): Unit = {
+  override def write(index: Int, current: InternalRow): Unit = {
+    updateProcessor(index)
     while (nextBoundaryRow != null &&
         upperBound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
       boundaryInputIndex += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -90,7 +90,6 @@ private[window] abstract class DistinctWindowFunctionFrame(
       populateFirstVisibleRows(rows, firstVisibleRows)
       newEventSorter = firstVisibleRows.buildEvents()
       spillSize.add(firstVisibleRows.getSpillSize)
-      spillSize.add(newEventSorter.getSpillSize)
 
       eventSorter = newEventSorter
       newEventSorter = null
@@ -348,6 +347,9 @@ private[window] abstract class DistinctWindowFunctionFrame(
   override final def currentLowerBound(): Int = 0
 
   private def closeEventResources(): Unit = {
+    if (eventSorter != null) {
+      spillSize.add(eventSorter.getSpillSize)
+    }
     if (eventIterator != null) {
       eventIterator.close()
       eventIterator = null
@@ -433,6 +435,12 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
     spillThreshold,
     spillSizeThreshold) {
 
+  private val rowOffset = upperBound match {
+    case RowBoundOrdering(offset) => Some(offset)
+    case _ => None
+  }
+
+  private var partitionSize = 0
   private var boundaryIterator: Iterator[UnsafeRow] = Iterator.empty
   private var nextBoundaryRow: UnsafeRow = _
   private var boundaryInputIndex = 0
@@ -440,36 +448,71 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
   override protected def populateFirstVisibleRows(
       rows: ExternalAppendOnlyUnsafeRowArray,
       firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
-    val inputIterator = rows.generateIterator()
-    val outputIterator = rows.generateIterator()
-    var nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
-    var inputIndex = 0
-    var outputIndex = 0
+    rowOffset match {
+      case Some(offset) =>
+        // A ROWS bound depends only on row indexes. Calculate the first visible output row
+        // directly instead of scanning the partition again as output rows.
+        val inputIterator = rows.generateIterator()
+        var inputIndex = 0
+        while (inputIterator.hasNext) {
+          val input = inputIterator.next()
+          val firstVisibleIndex = inputIndex.toLong - offset.toLong
+          if (firstVisibleIndex < rows.length) {
+            addCandidate(
+              input,
+              math.max(firstVisibleIndex, 0L).toInt,
+              inputIndex,
+              firstVisibleRows)
+          }
+          inputIndex += 1
+        }
 
-    while (outputIterator.hasNext && nextInput != null) {
-      val currentOutput = outputIterator.next()
-      while (nextInput != null &&
-          upperBound.compare(nextInput, inputIndex, currentOutput, outputIndex) <= 0) {
-        addCandidate(nextInput, outputIndex, inputIndex, firstVisibleRows)
-        inputIndex += 1
-        nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
-      }
-      outputIndex += 1
+      case None =>
+        val inputIterator = rows.generateIterator()
+        val outputIterator = rows.generateIterator()
+        var nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
+        var inputIndex = 0
+        var outputIndex = 0
+
+        while (outputIterator.hasNext && nextInput != null) {
+          val currentOutput = outputIterator.next()
+          while (nextInput != null &&
+              upperBound.compare(nextInput, inputIndex, currentOutput, outputIndex) <= 0) {
+            addCandidate(nextInput, outputIndex, inputIndex, firstVisibleRows)
+            inputIndex += 1
+            nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
+          }
+          outputIndex += 1
+        }
     }
   }
 
   override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+    partitionSize = rows.length
     boundaryInputIndex = 0
-    boundaryIterator = rows.generateIterator()
-    nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+    if (rowOffset.isEmpty) {
+      boundaryIterator = rows.generateIterator()
+      nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+    } else {
+      boundaryIterator = Iterator.empty
+      nextBoundaryRow = null
+    }
   }
 
   override def write(index: Int, current: InternalRow): Unit = {
     updateProcessor(index)
-    while (nextBoundaryRow != null &&
-        upperBound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
-      boundaryInputIndex += 1
-      nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+    rowOffset match {
+      case Some(offset) =>
+        // The upper bound is exclusive, hence the extra one after applying the ROWS offset.
+        val upperBoundIndex = index.toLong + offset.toLong + 1L
+        boundaryInputIndex = math.max(0L, math.min(upperBoundIndex, partitionSize.toLong)).toInt
+
+      case None =>
+        while (nextBoundaryRow != null &&
+            upperBound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
+          boundaryInputIndex += 1
+          nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+        }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -34,9 +34,10 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
  * advances. For each qualifying input row this frame finds the first output row whose upper bound
  * contains it. A bounded BytesToBytesMap removes duplicates up to the hash fallback threshold. If
  * another new key arrives, the frame permanently falls back to an external sorter for the rest of
- * the window partition. That sorter finds the earliest event for every key, then a second external
- * sorter orders those events by index. The frame feeds each unique, normalized DISTINCT input to
- * the aggregate processor when its event becomes visible.
+ * the window partition. For a growing frame, that sorter finds the earliest event for every key,
+ * then a second external sorter orders those events by index. The frame feeds each unique,
+ * normalized DISTINCT input to the aggregate processor when its event becomes visible. A frame
+ * covering the entire partition consumes unique inputs directly because their order is undefined.
  */
 private[window] abstract class DistinctWindowFunctionFrame(
     target: InternalRow,
@@ -386,7 +387,9 @@ private[window] abstract class DistinctWindowFunctionFrame(
 }
 
 /**
- * Computes DISTINCT aggregates over the entire window partition.
+ * Computes DISTINCT aggregates over the entire window partition. Since every output row has the
+ * same set of unique inputs, their consumption order is undefined and is not restored after hash
+ * deduplication or sorting by the DISTINCT key.
  */
 private[window] final class UnboundedDistinctWindowFunctionFrame(
     target: InternalRow,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -32,12 +32,14 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
  *
  * Such a frame never removes rows: it either covers the entire partition or only grows as output
  * advances. For each qualifying input row this frame finds the first output row whose upper bound
- * contains it. A bounded BytesToBytesMap removes duplicates up to the hash fallback threshold. If
- * another new key arrives, the frame permanently falls back to an external sorter for the rest of
- * the window partition. For a growing frame, that sorter finds the earliest event for every key,
- * then a second external sorter orders those events by index. The frame feeds each unique,
- * normalized DISTINCT input to the aggregate processor when its event becomes visible. A frame
- * covering the entire partition consumes unique inputs directly because their order is undefined.
+ * contains it. A BytesToBytesMap removes duplicates while it remains below configurable key-count
+ * and memory-size soft limits. When another new key arrives after either limit has been reached, or
+ * an append fails, the frame permanently falls back to an external sorter for the rest of the
+ * window partition. For a growing frame, that sorter finds the earliest event for every key, then
+ * a second external sorter orders those events by (firstVisibleIndex, inputIndex). The frame feeds
+ * each unique, normalized DISTINCT input to the aggregate processor when its event becomes visible.
+ * A frame covering the entire partition consumes unique inputs directly because their order is
+ * undefined.
  */
 private[window] abstract class DistinctWindowFunctionFrame(
     target: InternalRow,
@@ -56,9 +58,6 @@ private[window] abstract class DistinctWindowFunctionFrame(
   }
   private val distinctKeySchema = StructType(distinctFields)
   private val distinctTypes = distinctKeySchema.map(_.dataType)
-  private val eventValueSchema = StructType(distinctFields.map { field =>
-    field.copy(name = s"value${field.name.stripPrefix("key")}")
-  })
   private val positionSchema = StructType(Seq(
     StructField("firstVisibleIndex", IntegerType, nullable = false),
     StructField("inputIndex", IntegerType, nullable = false)))
@@ -119,11 +118,6 @@ private[window] abstract class DistinctWindowFunctionFrame(
     }
   }
 
-  protected final def updateProcessorWithDistinctRows(
-      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
-    firstVisibleRows.foreachDistinctRow((key, _) => processor.update(key))
-  }
-
   protected final def addCandidate(
       row: InternalRow,
       firstVisibleIndex: Int,
@@ -143,9 +137,10 @@ private[window] abstract class DistinctWindowFunctionFrame(
    * in non-decreasing (firstVisibleIndex, inputIndex) order.
    *
    * BytesToBytesMap compares raw UnsafeRow bytes, so binary-unstable keys use the sorter directly.
-   * Once the map is at the hash fallback threshold and another new key arrives, or it cannot append
-   * a record, all map entries are transferred to one external sorter. The rest of this window
-   * partition goes directly to that sorter and never returns to hash-based deduplication.
+   * Once the map reaches either its key-count or memory-size soft limit and another new key
+   * arrives, or it cannot append a record, all map entries are transferred to one external sorter.
+   * The rest of this window partition goes directly to that sorter and never returns to hash-based
+   * deduplication.
    */
   protected final class FirstVisibleRowsBuilder extends AutoCloseable {
     private val map = if (canUseHashDedup) {
@@ -194,10 +189,10 @@ private[window] abstract class DistinctWindowFunctionFrame(
           // Make the map spillable before allocating the event sorter. The destructive iterator
           // releases the hash array immediately and lets memory pressure spill remaining pages.
           val iterator = destructiveMapIterator()
-          events = newSorter(positionSchema, eventValueSchema)
+          events = newSorter(positionSchema, distinctKeySchema)
           drainMap(iterator, (key, position) => emitEvent(events, position, key))
         } else {
-          events = newSorter(positionSchema, eventValueSchema)
+          events = newSorter(positionSchema, distinctKeySchema)
           if (sorter != null) {
             consumeDistinctRows(
               sorter, (key, position) => emitEvent(events, position, key))
@@ -221,6 +216,12 @@ private[window] abstract class DistinctWindowFunctionFrame(
       }
     }
 
+    /**
+     * Returns bytes spilled by the first, distinct-key sorter. The frame accounts for the second,
+     * event-order sorter separately when closing its event resources. Spill files created while a
+     * destructive BytesToBytesMap iterator releases the map's data pages are not included in the
+     * window spill metric.
+     */
     def getSpillSize: Long = if (sorter == null) 0L else sorter.getSpillSize
 
     private def insertIntoSorter(key: UnsafeRow, value: UnsafeRow): Unit = {
@@ -359,14 +360,6 @@ private[window] abstract class DistinctWindowFunctionFrame(
     }
   }
 
-  protected final def evaluateEntirePartition(): Unit = {
-    try {
-      updateProcessor(0)
-    } finally {
-      closeEventResources()
-    }
-  }
-
   override final def currentLowerBound(): Int = 0
 
   private def closeEventResources(): Unit = {
@@ -427,12 +420,12 @@ private[window] final class UnboundedDistinctWindowFunctionFrame(
 
   override protected def processDistinctRows(
       firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
-    updateProcessorWithDistinctRows(firstVisibleRows)
+    firstVisibleRows.foreachDistinctRow((key, _) => processor.update(key))
   }
 
   override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     partitionSize = rows.length
-    evaluateEntirePartition()
+    processor.evaluate(target)
   }
 
   override def write(index: Int, current: InternalRow): Unit = {}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -30,20 +30,20 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
  * Computes one or more equivalent DISTINCT aggregate expressions for a frame whose lower bound is
  * UNBOUNDED PRECEDING.
  *
- * Such a frame only grows as output advances. For each qualifying input row this frame finds the
- * first output row whose upper bound contains it. A bounded BytesToBytesMap removes duplicates
- * up to the hash fallback threshold. If another new key arrives, the frame permanently falls back
- * to an external sorter for the rest of the window partition. That sorter finds the earliest event
- * for every key, then a second external sorter orders those events by index. `write` feeds each
- * unique, normalized DISTINCT input to the aggregate processor when its event becomes visible.
+ * Such a frame never removes rows: it either covers the entire partition or only grows as output
+ * advances. For each qualifying input row this frame finds the first output row whose upper bound
+ * contains it. A bounded BytesToBytesMap removes duplicates up to the hash fallback threshold. If
+ * another new key arrives, the frame permanently falls back to an external sorter for the rest of
+ * the window partition. That sorter finds the earliest event for every key, then a second external
+ * sorter orders those events by index. `write` feeds each unique, normalized DISTINCT input to the
+ * aggregate processor when its event becomes visible.
  */
-private[window] final class DistinctWindowFunctionFrame(
+private[window] abstract class DistinctWindowFunctionFrame(
     target: InternalRow,
     processor: AggregateProcessor,
     distinctExpressions: Seq[Expression],
     filter: Option[Expression],
     inputSchema: Seq[Attribute],
-    upperBound: Option[BoundOrdering],
     spillSize: SQLMetric,
     hashFallbackThreshold: Int,
     spillThreshold: Int,
@@ -73,20 +73,14 @@ private[window] final class DistinctWindowFunctionFrame(
 
   private var eventSorter: UnsafeKVExternalSorter = _
   private var eventIterator: UnsafeKVExternalSorter#KVSorterIterator = _
-  private var boundaryIterator: Iterator[UnsafeRow] = Iterator.empty
-  private var nextBoundaryRow: UnsafeRow = _
-  private var boundaryInputIndex = 0
-  private var partitionSize = 0
   private var nextEventIndex = Int.MaxValue
 
   Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
 
-  override def prepare(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+  override final def prepare(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     closeEventResources()
     nextEventIndex = Int.MaxValue
-    partitionSize = rows.length
-    boundaryInputIndex = 0
-    processor.initialize(partitionSize)
+    processor.initialize(rows.length)
     val partitionIndex = Option(TaskContext.get()).map(_.partitionId()).getOrElse(0)
     boundFilter.foreach(_.initialize(partitionIndex))
 
@@ -108,51 +102,18 @@ private[window] final class DistinctWindowFunctionFrame(
         newEventSorter.cleanupResources()
       }
     }
-
-    upperBound match {
-      case Some(_) =>
-        boundaryIterator = rows.generateIterator()
-        nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
-      case None =>
-        boundaryIterator = Iterator.empty
-        nextBoundaryRow = null
-        boundaryInputIndex = partitionSize
-    }
+    prepareUpperBound(rows)
   }
 
-  private def populateFirstVisibleRows(
+  protected def populateFirstVisibleRows(
       rows: ExternalAppendOnlyUnsafeRowArray,
-      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
-    upperBound match {
-      case None =>
-        val iterator = rows.generateIterator()
-        var inputIndex = 0
-        while (iterator.hasNext) {
-          addCandidate(iterator.next(), 0, inputIndex, firstVisibleRows)
-          inputIndex += 1
-        }
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit
 
-      case Some(bound) =>
-        val inputIterator = rows.generateIterator()
-        val outputIterator = rows.generateIterator()
-        var nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
-        var inputIndex = 0
-        var outputIndex = 0
+  protected def prepareUpperBound(rows: ExternalAppendOnlyUnsafeRowArray): Unit
 
-        while (outputIterator.hasNext && nextInput != null) {
-          val currentOutput = outputIterator.next()
-          while (nextInput != null &&
-              bound.compare(nextInput, inputIndex, currentOutput, outputIndex) <= 0) {
-            addCandidate(nextInput, outputIndex, inputIndex, firstVisibleRows)
-            inputIndex += 1
-            nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
-          }
-          outputIndex += 1
-        }
-    }
-  }
+  protected def updateUpperBound(index: Int, current: InternalRow): Unit
 
-  private def addCandidate(
+  protected final def addCandidate(
       row: InternalRow,
       firstVisibleIndex: Int,
       inputIndex: Int,
@@ -175,7 +136,7 @@ private[window] final class DistinctWindowFunctionFrame(
    * a record, all map entries are transferred to one external sorter. The rest of this window
    * partition goes directly to that sorter and never returns to hash-based deduplication.
    */
-  private final class FirstVisibleRowsBuilder extends AutoCloseable {
+  protected final class FirstVisibleRowsBuilder extends AutoCloseable {
     private val map = if (canUseHashDedup) {
       val taskMemoryManager = TaskContext.get().taskMemoryManager()
       new BytesToBytesMap(taskMemoryManager, 64, taskMemoryManager.pageSizeBytes())
@@ -366,7 +327,7 @@ private[window] final class DistinctWindowFunctionFrame(
     }
   }
 
-  override def write(index: Int, current: InternalRow): Unit = {
+  override final def write(index: Int, current: InternalRow): Unit = {
     var bufferUpdated = index == 0
     while (nextEventIndex <= index) {
       processor.update(eventIterator.getValue)
@@ -376,19 +337,10 @@ private[window] final class DistinctWindowFunctionFrame(
     if (bufferUpdated) {
       processor.evaluate(target)
     }
-
-    upperBound.foreach { bound =>
-      while (nextBoundaryRow != null &&
-          bound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
-        boundaryInputIndex += 1
-        nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
-      }
-    }
+    updateUpperBound(index, current)
   }
 
-  override def currentLowerBound(): Int = 0
-
-  override def currentUpperBound(): Int = boundaryInputIndex
+  override final def currentLowerBound(): Int = 0
 
   private def closeEventResources(): Unit = {
     if (eventIterator != null) {
@@ -401,5 +353,118 @@ private[window] final class DistinctWindowFunctionFrame(
     }
   }
 
-  override def close(): Unit = closeEventResources()
+  override final def close(): Unit = closeEventResources()
+}
+
+/**
+ * Computes DISTINCT aggregates over the entire window partition.
+ */
+private[window] final class UnboundedDistinctWindowFunctionFrame(
+    target: InternalRow,
+    processor: AggregateProcessor,
+    distinctExpressions: Seq[Expression],
+    filter: Option[Expression],
+    inputSchema: Seq[Attribute],
+    spillSize: SQLMetric,
+    hashFallbackThreshold: Int,
+    spillThreshold: Int,
+    spillSizeThreshold: Long)
+  extends DistinctWindowFunctionFrame(
+    target,
+    processor,
+    distinctExpressions,
+    filter,
+    inputSchema,
+    spillSize,
+    hashFallbackThreshold,
+    spillThreshold,
+    spillSizeThreshold) {
+
+  private var partitionSize = 0
+
+  override protected def populateFirstVisibleRows(
+      rows: ExternalAppendOnlyUnsafeRowArray,
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    val iterator = rows.generateIterator()
+    var inputIndex = 0
+    while (iterator.hasNext) {
+      addCandidate(iterator.next(), 0, inputIndex, firstVisibleRows)
+      inputIndex += 1
+    }
+  }
+
+  override protected def prepareUpperBound(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+    partitionSize = rows.length
+  }
+
+  override protected def updateUpperBound(index: Int, current: InternalRow): Unit = {}
+
+  override def currentUpperBound(): Int = partitionSize
+}
+
+/**
+ * Computes DISTINCT aggregates for a growing frame with an UNBOUNDED PRECEDING lower bound.
+ */
+private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
+    target: InternalRow,
+    processor: AggregateProcessor,
+    distinctExpressions: Seq[Expression],
+    filter: Option[Expression],
+    inputSchema: Seq[Attribute],
+    upperBound: BoundOrdering,
+    spillSize: SQLMetric,
+    hashFallbackThreshold: Int,
+    spillThreshold: Int,
+    spillSizeThreshold: Long)
+  extends DistinctWindowFunctionFrame(
+    target,
+    processor,
+    distinctExpressions,
+    filter,
+    inputSchema,
+    spillSize,
+    hashFallbackThreshold,
+    spillThreshold,
+    spillSizeThreshold) {
+
+  private var boundaryIterator: Iterator[UnsafeRow] = Iterator.empty
+  private var nextBoundaryRow: UnsafeRow = _
+  private var boundaryInputIndex = 0
+
+  override protected def populateFirstVisibleRows(
+      rows: ExternalAppendOnlyUnsafeRowArray,
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    val inputIterator = rows.generateIterator()
+    val outputIterator = rows.generateIterator()
+    var nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
+    var inputIndex = 0
+    var outputIndex = 0
+
+    while (outputIterator.hasNext && nextInput != null) {
+      val currentOutput = outputIterator.next()
+      while (nextInput != null &&
+          upperBound.compare(nextInput, inputIndex, currentOutput, outputIndex) <= 0) {
+        addCandidate(nextInput, outputIndex, inputIndex, firstVisibleRows)
+        inputIndex += 1
+        nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
+      }
+      outputIndex += 1
+    }
+  }
+
+  override protected def prepareUpperBound(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+    boundaryInputIndex = 0
+    boundaryIterator = rows.generateIterator()
+    nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+  }
+
+  override protected def updateUpperBound(index: Int, current: InternalRow): Unit = {
+    while (nextBoundaryRow != null &&
+        upperBound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
+      boundaryInputIndex += 1
+      nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+    }
+  }
+
+  override def currentUpperBound(): Int = boundaryInputIndex
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -85,21 +85,12 @@ private[window] abstract class DistinctWindowFunctionFrame(
     boundFilter.foreach(_.initialize(partitionIndex))
 
     val firstVisibleRows = new FirstVisibleRowsBuilder
-    var newEventSorter: UnsafeKVExternalSorter = null
     try {
       populateFirstVisibleRows(rows, firstVisibleRows)
-      newEventSorter = firstVisibleRows.buildEvents()
+      processDistinctRows(firstVisibleRows)
       spillSize.add(firstVisibleRows.getSpillSize)
-
-      eventSorter = newEventSorter
-      newEventSorter = null
-      eventIterator = eventSorter.sortedIterator()
-      loadNextEvent()
     } finally {
       firstVisibleRows.close()
-      if (newEventSorter != null) {
-        newEventSorter.cleanupResources()
-      }
     }
     prepareFrame(rows)
   }
@@ -108,7 +99,29 @@ private[window] abstract class DistinctWindowFunctionFrame(
       rows: ExternalAppendOnlyUnsafeRowArray,
       firstVisibleRows: FirstVisibleRowsBuilder): Unit
 
+  protected def processDistinctRows(firstVisibleRows: FirstVisibleRowsBuilder): Unit
+
   protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit
+
+  protected final def prepareOrderedEvents(firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    var newEventSorter: UnsafeKVExternalSorter = null
+    try {
+      newEventSorter = firstVisibleRows.buildEvents()
+      eventSorter = newEventSorter
+      newEventSorter = null
+      eventIterator = eventSorter.sortedIterator()
+      loadNextEvent()
+    } finally {
+      if (newEventSorter != null) {
+        newEventSorter.cleanupResources()
+      }
+    }
+  }
+
+  protected final def updateProcessorWithDistinctRows(
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    firstVisibleRows.foreachDistinctRow((key, _) => processor.update(key))
+  }
 
   protected final def addCandidate(
       row: InternalRow,
@@ -185,7 +198,8 @@ private[window] abstract class DistinctWindowFunctionFrame(
         } else {
           events = newSorter(positionSchema, eventValueSchema)
           if (sorter != null) {
-            DistinctWindowFunctionFrame.this.buildEvents(sorter, events)
+            consumeDistinctRows(
+              sorter, (key, position) => emitEvent(events, position, key))
           }
         }
         val result = events
@@ -195,6 +209,14 @@ private[window] abstract class DistinctWindowFunctionFrame(
         if (events != null) {
           events.cleanupResources()
         }
+      }
+    }
+
+    def foreachDistinctRow(consume: (UnsafeRow, UnsafeRow) => Unit): Unit = {
+      if (usingMap) {
+        drainMap(destructiveMapIterator(), consume)
+      } else if (sorter != null) {
+        consumeDistinctRows(sorter, consume)
       }
     }
 
@@ -252,9 +274,9 @@ private[window] abstract class DistinctWindowFunctionFrame(
     }
   }
 
-  private def buildEvents(
+  private def consumeDistinctRows(
       firstSorter: UnsafeKVExternalSorter,
-      events: UnsafeKVExternalSorter): Unit = {
+      consume: (UnsafeRow, UnsafeRow) => Unit): Unit = {
     val iterator = firstSorter.sortedIterator()
     var groupKey: UnsafeRow = null
     var selectedKey: UnsafeRow = null
@@ -273,14 +295,14 @@ private[window] abstract class DistinctWindowFunctionFrame(
             selectedPosition = position.copy()
           }
         } else {
-          emitEvent(events, selectedPosition, selectedKey)
+          consume(selectedKey, selectedPosition)
           groupKey = key.copy()
           selectedKey = groupKey
           selectedPosition = position.copy()
         }
       }
       if (groupKey != null) {
-        emitEvent(events, selectedPosition, selectedKey)
+        consume(selectedKey, selectedPosition)
       }
     } finally {
       iterator.close()
@@ -400,6 +422,11 @@ private[window] final class UnboundedDistinctWindowFunctionFrame(
     }
   }
 
+  override protected def processDistinctRows(
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    updateProcessorWithDistinctRows(firstVisibleRows)
+  }
+
   override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     partitionSize = rows.length
     evaluateEntirePartition()
@@ -485,6 +512,11 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
           outputIndex += 1
         }
     }
+  }
+
+  override protected def processDistinctRows(
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    prepareOrderedEvents(firstVisibleRows)
   }
 
   override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -469,9 +469,12 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
   }
 
   private var partitionSize = 0
+  private var boundaryRows: ExternalAppendOnlyUnsafeRowArray = _
   private var boundaryIterator: Iterator[UnsafeRow] = Iterator.empty
   private var nextBoundaryRow: UnsafeRow = _
   private var boundaryInputIndex = 0
+  private var currentOutput: InternalRow = _
+  private var currentOutputIndex = 0
 
   override protected def populateFirstVisibleRows(
       rows: ExternalAppendOnlyUnsafeRowArray,
@@ -523,10 +526,14 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
   override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     partitionSize = rows.length
     boundaryInputIndex = 0
+    currentOutput = null
+    currentOutputIndex = 0
     if (rowOffset.isEmpty) {
-      boundaryIterator = rows.generateIterator()
-      nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+      boundaryRows = rows
+      boundaryIterator = Iterator.empty
+      nextBoundaryRow = null
     } else {
+      boundaryRows = null
       boundaryIterator = Iterator.empty
       nextBoundaryRow = null
     }
@@ -541,13 +548,29 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
         boundaryInputIndex = math.max(0L, math.min(upperBoundIndex, partitionSize.toLong)).toInt
 
       case None =>
-        while (nextBoundaryRow != null &&
-            upperBound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
-          boundaryInputIndex += 1
-          nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
-        }
+        currentOutput = current
+        currentOutputIndex = index
     }
   }
 
-  override def currentUpperBound(): Int = boundaryInputIndex
+  override def currentUpperBound(): Int = {
+    if (rowOffset.isEmpty && currentOutput != null) {
+      // Only the Arrow Python evaluator reads frame bounds. Avoid this extra partition scan for
+      // ordinary SQL evaluation, where DISTINCT aggregate frames never need the bounds.
+      if (boundaryRows != null) {
+        boundaryIterator = boundaryRows.generateIterator()
+        nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+        boundaryRows = null
+      }
+      while (nextBoundaryRow != null && upperBound.compare(
+          nextBoundaryRow,
+          boundaryInputIndex,
+          currentOutput,
+          currentOutputIndex) <= 0) {
+        boundaryInputIndex += 1
+        nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+      }
+    }
+    boundaryInputIndex
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.window
 
 import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.memory.SparkOutOfMemoryError
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
@@ -33,13 +34,13 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
  * Such a frame never removes rows: it either covers the entire partition or only grows as output
  * advances. For each qualifying input row this frame finds the first output row whose upper bound
  * contains it. A BytesToBytesMap removes duplicates while it remains below configurable key-count
- * and memory-size soft limits. When another new key arrives after either limit has been reached, or
- * an append fails, the frame permanently falls back to an external sorter for the rest of the
- * window partition. For a growing frame, that sorter finds the earliest event for every key, then
- * a second external sorter orders those events by (firstVisibleIndex, inputIndex). The frame feeds
- * each unique, normalized DISTINCT input to the aggregate processor when its event becomes visible.
- * A frame covering the entire partition consumes unique inputs directly because their order is
- * undefined.
+ * and memory-size soft limits. If the map cannot be allocated, or if another new key arrives after
+ * either limit has been reached or an append fails, the frame permanently falls back to an
+ * external sorter for the rest of the window partition. For a growing frame, that sorter finds the
+ * earliest event for every key, then a second external sorter orders those events by
+ * (firstVisibleIndex, inputIndex). The frame feeds each unique, normalized DISTINCT input to the
+ * aggregate processor when its event becomes visible. A frame covering the entire partition
+ * consumes unique inputs directly because their order is undefined.
  */
 private[window] abstract class DistinctWindowFunctionFrame(
     target: InternalRow,
@@ -137,15 +138,19 @@ private[window] abstract class DistinctWindowFunctionFrame(
    * in non-decreasing (firstVisibleIndex, inputIndex) order.
    *
    * BytesToBytesMap compares raw UnsafeRow bytes, so binary-unstable keys use the sorter directly.
-   * Once the map reaches either its key-count or memory-size soft limit and another new key
-   * arrives, or it cannot append a record, all map entries are transferred to one external sorter.
-   * The rest of this window partition goes directly to that sorter and never returns to hash-based
-   * deduplication.
+   * If map construction fails, inputs go directly to the sorter. Once the map reaches either its
+   * key-count or memory-size soft limit and another new key arrives, or it cannot append a record,
+   * all map entries are transferred to one external sorter. The rest of this window partition goes
+   * directly to that sorter and never returns to hash-based deduplication.
    */
   protected final class FirstVisibleRowsBuilder extends AutoCloseable {
     private val map = if (canUseHashDedup) {
       val taskMemoryManager = TaskContext.get().taskMemoryManager()
-      new BytesToBytesMap(taskMemoryManager, 64, taskMemoryManager.pageSizeBytes())
+      try {
+        new BytesToBytesMap(taskMemoryManager, 64, taskMemoryManager.pageSizeBytes())
+      } catch {
+        case _: SparkOutOfMemoryError => null
+      }
     } else {
       null
     }
@@ -474,7 +479,7 @@ private[window] final class UnboundedPrecedingDistinctWindowFunctionFrame(
     rowOffset match {
       case Some(offset) =>
         // A ROWS bound depends only on row indexes. Calculate the first visible output row
-        // directly instead of scanning the partition again as output rows.
+        // directly instead of scanning the partition again as output rows advance.
         val inputIterator = rows.generateIterator()
         var inputIndex = 0
         while (inputIterator.hasNext) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.window
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
+import org.apache.spark.sql.execution.{ExternalAppendOnlyUnsafeRowArray, UnsafeKVExternalSorter}
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.types.{DataType, IntegerType, StructField, StructType}
+import org.apache.spark.unsafe.map.BytesToBytesMap
+
+/**
+ * Computes one or more equivalent DISTINCT aggregate expressions for a frame whose lower bound is
+ * UNBOUNDED PRECEDING.
+ *
+ * Such a frame only grows as output advances. For each qualifying input row this frame finds the
+ * first output row whose upper bound contains it. A bounded BytesToBytesMap removes duplicates
+ * until it reaches the hash fallback threshold, then the frame permanently falls back to an
+ * external sorter for the rest of the window partition. That sorter finds the earliest event for
+ * every key, then a second external sorter orders those events by index. `write` feeds each unique,
+ * normalized DISTINCT input to the aggregate processor when its event becomes visible.
+ */
+private[window] final class DistinctWindowFunctionFrame(
+    target: InternalRow,
+    processor: AggregateProcessor,
+    distinctExpressions: Seq[Expression],
+    filter: Option[Expression],
+    inputSchema: Seq[Attribute],
+    upperBound: Option[BoundOrdering],
+    spillSize: SQLMetric,
+    hashFallbackThreshold: Int,
+    spillThreshold: Int,
+    spillSizeThreshold: Long)
+  extends WindowFunctionFrame with AutoCloseable {
+
+  private val distinctFields = distinctExpressions.zipWithIndex.map { case (expression, index) =>
+    StructField(s"key$index", expression.dataType, expression.nullable)
+  }
+  private val distinctKeySchema = StructType(distinctFields)
+  private val distinctTypes = distinctKeySchema.map(_.dataType)
+  private val eventValueSchema = StructType(distinctFields.map { field =>
+    field.copy(name = s"value${field.name.stripPrefix("key")}")
+  })
+  private val positionSchema = StructType(Seq(
+    StructField("firstVisibleIndex", IntegerType, nullable = false),
+    StructField("inputIndex", IntegerType, nullable = false)))
+
+  private val distinctProjection = UnsafeProjection.create(distinctExpressions, inputSchema)
+  private val distinctOrdering = RowOrdering.createNaturalAscendingOrdering(distinctTypes)
+  private val canUseHashDedup = distinctTypes.forall(UnsafeRowUtils.isBinaryStable)
+  private val boundFilter = filter.map(Predicate.create(_, inputSchema))
+  private val positionInput =
+    new SpecificInternalRow(Seq(IntegerType, IntegerType))
+  private val positionProjection =
+    UnsafeProjection.create(Array[DataType](IntegerType, IntegerType))
+
+  private var eventSorter: UnsafeKVExternalSorter = _
+  private var eventIterator: UnsafeKVExternalSorter#KVSorterIterator = _
+  private var boundaryIterator: Iterator[UnsafeRow] = Iterator.empty
+  private var nextBoundaryRow: UnsafeRow = _
+  private var boundaryInputIndex = 0
+  private var partitionSize = 0
+  private var nextEventIndex = Int.MaxValue
+
+  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+
+  override def prepare(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
+    closeEventResources()
+    nextEventIndex = Int.MaxValue
+    partitionSize = rows.length
+    boundaryInputIndex = 0
+    processor.initialize(partitionSize)
+    val partitionIndex = Option(TaskContext.get()).map(_.partitionId()).getOrElse(0)
+    boundFilter.foreach(_.initialize(partitionIndex))
+
+    val firstVisibleRows = new FirstVisibleRowsBuilder
+    var newEventSorter: UnsafeKVExternalSorter = null
+    try {
+      populateFirstVisibleRows(rows, firstVisibleRows)
+      newEventSorter = firstVisibleRows.buildEvents()
+      spillSize.add(firstVisibleRows.getSpillSize)
+      spillSize.add(newEventSorter.getSpillSize)
+
+      eventSorter = newEventSorter
+      newEventSorter = null
+      eventIterator = eventSorter.sortedIterator()
+      loadNextEvent()
+    } finally {
+      firstVisibleRows.close()
+      if (newEventSorter != null) {
+        newEventSorter.cleanupResources()
+      }
+    }
+
+    upperBound match {
+      case Some(_) =>
+        boundaryIterator = rows.generateIterator()
+        nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+      case None =>
+        boundaryIterator = Iterator.empty
+        nextBoundaryRow = null
+        boundaryInputIndex = partitionSize
+    }
+  }
+
+  private def populateFirstVisibleRows(
+      rows: ExternalAppendOnlyUnsafeRowArray,
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    upperBound match {
+      case None =>
+        val iterator = rows.generateIterator()
+        var inputIndex = 0
+        while (iterator.hasNext) {
+          addCandidate(iterator.next(), 0, inputIndex, firstVisibleRows)
+          inputIndex += 1
+        }
+
+      case Some(bound) =>
+        val inputIterator = rows.generateIterator()
+        val outputIterator = rows.generateIterator()
+        var nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
+        var inputIndex = 0
+        var outputIndex = 0
+
+        while (outputIterator.hasNext && nextInput != null) {
+          val currentOutput = outputIterator.next()
+          while (nextInput != null &&
+              bound.compare(nextInput, inputIndex, currentOutput, outputIndex) <= 0) {
+            addCandidate(nextInput, outputIndex, inputIndex, firstVisibleRows)
+            inputIndex += 1
+            nextInput = WindowFunctionFrame.getNextOrNull(inputIterator)
+          }
+          outputIndex += 1
+        }
+    }
+  }
+
+  private def addCandidate(
+      row: InternalRow,
+      firstVisibleIndex: Int,
+      inputIndex: Int,
+      firstVisibleRows: FirstVisibleRowsBuilder): Unit = {
+    if (boundFilter.forall(_.eval(row))) {
+      positionInput.setInt(0, firstVisibleIndex)
+      positionInput.setInt(1, inputIndex)
+      val distinctRow = distinctProjection(row)
+      firstVisibleRows.add(distinctRow, positionProjection(positionInput))
+    }
+  }
+
+  /**
+   * Uses a bounded BytesToBytesMap to remove duplicates before they reach the first external
+   * sorter. The map contains only the earliest row for each distinct key because candidates arrive
+   * in non-decreasing (firstVisibleIndex, inputIndex) order.
+   *
+   * BytesToBytesMap compares raw UnsafeRow bytes, so binary-unstable keys use the sorter directly.
+   * Once the map reaches the hash fallback threshold or cannot append a record, all map entries
+   * are transferred to one external sorter. The rest of this window partition goes directly to
+   * that sorter and never returns to hash-based deduplication.
+   */
+  private final class FirstVisibleRowsBuilder extends AutoCloseable {
+    private val map = if (canUseHashDedup) {
+      val taskMemoryManager = TaskContext.get().taskMemoryManager()
+      new BytesToBytesMap(taskMemoryManager, 64, taskMemoryManager.pageSizeBytes())
+    } else {
+      null
+    }
+    private var usingMap = map != null
+    private var sorter: UnsafeKVExternalSorter = _
+
+    def add(key: UnsafeRow, value: UnsafeRow): Unit = {
+      if (!usingMap) {
+        insertIntoSorter(key, value)
+        return
+      }
+
+      val location = map.lookup(
+        key.getBaseObject,
+        key.getBaseOffset,
+        key.getSizeInBytes)
+      if (location.isDefined) {
+        return
+      }
+
+      if (!location.append(
+          key.getBaseObject,
+          key.getBaseOffset,
+          key.getSizeInBytes,
+          value.getBaseObject,
+          value.getBaseOffset,
+          value.getSizeInBytes)) {
+        switchToSorter()
+        insertIntoSorter(key, value)
+      } else if (map.numKeys() >= hashFallbackThreshold ||
+          map.getTotalMemoryConsumption >= spillSizeThreshold) {
+        switchToSorter()
+      }
+    }
+
+    def buildEvents(): UnsafeKVExternalSorter = {
+      var events: UnsafeKVExternalSorter = null
+      try {
+        if (usingMap) {
+          // Make the map spillable before allocating the event sorter. The destructive iterator
+          // releases the hash array immediately and lets memory pressure spill remaining pages.
+          val iterator = destructiveMapIterator()
+          events = newSorter(positionSchema, eventValueSchema)
+          drainMap(iterator, (key, position) => emitEvent(events, position, key))
+        } else {
+          events = newSorter(positionSchema, eventValueSchema)
+          if (sorter != null) {
+            DistinctWindowFunctionFrame.this.buildEvents(sorter, events)
+          }
+        }
+        val result = events
+        events = null
+        result
+      } finally {
+        if (events != null) {
+          events.cleanupResources()
+        }
+      }
+    }
+
+    def getSpillSize: Long = if (sorter == null) 0L else sorter.getSpillSize
+
+    private def insertIntoSorter(key: UnsafeRow, value: UnsafeRow): Unit = {
+      if (sorter == null) {
+        sorter = newSorter(distinctKeySchema, positionSchema)
+      }
+      sorter.insertKV(key, value)
+    }
+
+    private def switchToSorter(): Unit = {
+      assert(sorter == null)
+      val iterator = destructiveMapIterator()
+      sorter = newSorter(distinctKeySchema, positionSchema)
+      drainMap(iterator, (key, position) => sorter.insertKV(key, position))
+    }
+
+    private def destructiveMapIterator(): BytesToBytesMap#MapIterator = {
+      assert(usingMap)
+      val iterator = map.destructiveIterator()
+      usingMap = false
+      iterator
+    }
+
+    private def drainMap(
+        iterator: BytesToBytesMap#MapIterator,
+        consume: (UnsafeRow, UnsafeRow) => Unit): Unit = {
+      val key = new UnsafeRow(distinctKeySchema.length)
+      val position = new UnsafeRow(positionSchema.length)
+      while (iterator.hasNext) {
+        val location = iterator.next()
+        key.pointTo(
+          location.getKeyBase,
+          location.getKeyOffset,
+          location.getKeyLength)
+        position.pointTo(
+          location.getValueBase,
+          location.getValueOffset,
+          location.getValueLength)
+        consume(key, position)
+      }
+    }
+
+    override def close(): Unit = {
+      if (sorter != null) {
+        sorter.cleanupResources()
+        sorter = null
+      }
+      if (map != null) {
+        map.free()
+        usingMap = false
+      }
+    }
+  }
+
+  private def buildEvents(
+      firstSorter: UnsafeKVExternalSorter,
+      events: UnsafeKVExternalSorter): Unit = {
+    val iterator = firstSorter.sortedIterator()
+    var groupKey: UnsafeRow = null
+    var selectedKey: UnsafeRow = null
+    var selectedPosition: UnsafeRow = null
+    try {
+      while (iterator.next()) {
+        val key = iterator.getKey
+        val position = iterator.getValue
+        if (groupKey == null) {
+          groupKey = key.copy()
+          selectedKey = groupKey
+          selectedPosition = position.copy()
+        } else if (distinctOrdering.compare(groupKey, key) == 0) {
+          if (isEarlier(position, selectedPosition)) {
+            selectedKey = key.copy()
+            selectedPosition = position.copy()
+          }
+        } else {
+          emitEvent(events, selectedPosition, selectedKey)
+          groupKey = key.copy()
+          selectedKey = groupKey
+          selectedPosition = position.copy()
+        }
+      }
+      if (groupKey != null) {
+        emitEvent(events, selectedPosition, selectedKey)
+      }
+    } finally {
+      iterator.close()
+    }
+  }
+
+  private def isEarlier(left: InternalRow, right: InternalRow): Boolean = {
+    val leftVisibleIndex = left.getInt(0)
+    val rightVisibleIndex = right.getInt(0)
+    leftVisibleIndex < rightVisibleIndex ||
+      leftVisibleIndex == rightVisibleIndex && left.getInt(1) < right.getInt(1)
+  }
+
+  private def emitEvent(
+      events: UnsafeKVExternalSorter,
+      position: UnsafeRow,
+      distinctValue: UnsafeRow): Unit = {
+    events.insertKV(position, distinctValue)
+  }
+
+  private def newSorter(
+      keySchema: StructType,
+      valueSchema: StructType): UnsafeKVExternalSorter = {
+    val taskContext = TaskContext.get()
+    // The frame owns all of its sorters and registers one task completion listener at construction.
+    UnsafeKVExternalSorter.createWithCallerOwnedLifecycle(
+      keySchema,
+      valueSchema,
+      SparkEnv.get.blockManager,
+      SparkEnv.get.serializerManager,
+      taskContext.taskMemoryManager().pageSizeBytes,
+      spillThreshold,
+      spillSizeThreshold)
+  }
+
+  private def loadNextEvent(): Unit = {
+    if (eventIterator != null && eventIterator.next()) {
+      nextEventIndex = eventIterator.getKey.getInt(0)
+    } else {
+      nextEventIndex = Int.MaxValue
+    }
+  }
+
+  override def write(index: Int, current: InternalRow): Unit = {
+    var bufferUpdated = index == 0
+    while (nextEventIndex <= index) {
+      processor.update(eventIterator.getValue)
+      bufferUpdated = true
+      loadNextEvent()
+    }
+    if (bufferUpdated) {
+      processor.evaluate(target)
+    }
+
+    upperBound.foreach { bound =>
+      while (nextBoundaryRow != null &&
+          bound.compare(nextBoundaryRow, boundaryInputIndex, current, index) <= 0) {
+        boundaryInputIndex += 1
+        nextBoundaryRow = WindowFunctionFrame.getNextOrNull(boundaryIterator)
+      }
+    }
+  }
+
+  override def currentLowerBound(): Int = 0
+
+  override def currentUpperBound(): Int = boundaryInputIndex
+
+  private def closeEventResources(): Unit = {
+    if (eventIterator != null) {
+      eventIterator.close()
+      eventIterator = null
+    }
+    if (eventSorter != null) {
+      eventSorter.cleanupResources()
+      eventSorter = null
+    }
+  }
+
+  override def close(): Unit = closeEventResources()
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrame.scala
@@ -32,10 +32,10 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
  *
  * Such a frame only grows as output advances. For each qualifying input row this frame finds the
  * first output row whose upper bound contains it. A bounded BytesToBytesMap removes duplicates
- * until it reaches the hash fallback threshold, then the frame permanently falls back to an
- * external sorter for the rest of the window partition. That sorter finds the earliest event for
- * every key, then a second external sorter orders those events by index. `write` feeds each unique,
- * normalized DISTINCT input to the aggregate processor when its event becomes visible.
+ * up to the hash fallback threshold. If another new key arrives, the frame permanently falls back
+ * to an external sorter for the rest of the window partition. That sorter finds the earliest event
+ * for every key, then a second external sorter orders those events by index. `write` feeds each
+ * unique, normalized DISTINCT input to the aggregate processor when its event becomes visible.
  */
 private[window] final class DistinctWindowFunctionFrame(
     target: InternalRow,
@@ -171,9 +171,9 @@ private[window] final class DistinctWindowFunctionFrame(
    * in non-decreasing (firstVisibleIndex, inputIndex) order.
    *
    * BytesToBytesMap compares raw UnsafeRow bytes, so binary-unstable keys use the sorter directly.
-   * Once the map reaches the hash fallback threshold or cannot append a record, all map entries
-   * are transferred to one external sorter. The rest of this window partition goes directly to
-   * that sorter and never returns to hash-based deduplication.
+   * Once the map is at the hash fallback threshold and another new key arrives, or it cannot append
+   * a record, all map entries are transferred to one external sorter. The rest of this window
+   * partition goes directly to that sorter and never returns to hash-based deduplication.
    */
   private final class FirstVisibleRowsBuilder extends AutoCloseable {
     private val map = if (canUseHashDedup) {
@@ -199,7 +199,11 @@ private[window] final class DistinctWindowFunctionFrame(
         return
       }
 
-      if (!location.append(
+      if (map.numKeys() >= hashFallbackThreshold ||
+          map.getTotalMemoryConsumption >= spillSizeThreshold) {
+        switchToSorter()
+        insertIntoSorter(key, value)
+      } else if (!location.append(
           key.getBaseObject,
           key.getBaseOffset,
           key.getSizeInBytes,
@@ -208,9 +212,6 @@ private[window] final class DistinctWindowFunctionFrame(
           value.getSizeInBytes)) {
         switchToSorter()
         insertIntoSorter(key, value)
-      } else if (map.numKeys() >= hashFallbackThreshold ||
-          map.getTotalMemoryConsumption >= spillSizeThreshold) {
-        switchToSorter()
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
@@ -148,10 +148,7 @@ trait WindowEvaluatorFactoryBase {
     val framedFunctions = mutable.Map.empty[FrameKey, (ExpressionBuffer, ExpressionBuffer)]
 
     def distinctChildren(ae: AggregateExpression): Seq[Expression] = {
-      ae.aggregateFunction.children.filterNot(_.foldable).map {
-        case sortOrder: SortOrder => sortOrder.child
-        case expression => expression
-      }.distinctBy(_.canonicalized)
+      WindowExpression.distinctAggregateChildren(ae.aggregateFunction)
     }
 
     // Add a function and its function to the map for a given frame.
@@ -184,8 +181,11 @@ trait WindowEvaluatorFactoryBase {
           val frame = spec.frameSpecification.asInstanceOf[SpecifiedWindowFrame]
           function match {
             case ae @ AggregateExpression(_, _, true, _, _)
-                if frame.lower == UnboundedPreceding =>
+                if WindowExpression.isSupportedDistinctAggregate(ae.aggregateFunction, frame) =>
               collect("DISTINCT_AGGREGATE", frame, e, ae)
+            case AggregateExpression(_, _, true, _, _) =>
+              throw SparkException.internalError(
+                s"Unsupported DISTINCT window expression reached physical planning: ${e.sql}")
             case AggregateExpression(f, _, _, _, _) => collect("AGGREGATE", frame, e, f)
             case f: FrameLessOffsetWindowFunction =>
               collect("FRAME_LESS_OFFSET", f.fakeFrame, e, f)
@@ -255,9 +255,8 @@ trait WindowEvaluatorFactoryBase {
               distinctChildren(ae).map(_.canonicalized),
               distinctInputAttributes)
             ae.aggregateFunction.transformDown {
-              case expression: Expression
-                  if distinctColumnAttributeLookup.contains(expression.canonicalized) =>
-                distinctColumnAttributeLookup(expression.canonicalized)
+              case expression =>
+                distinctColumnAttributeLookup.getOrElse(expression.canonicalized, expression)
             }.asInstanceOf[AggregateFunction]
           }
         lazy val distinctProcessor = AggregateProcessor(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
@@ -273,13 +273,12 @@ trait WindowEvaluatorFactoryBase {
         val factory = key match {
           case ("DISTINCT_AGGREGATE", _, UnboundedPreceding, UnboundedFollowing, _, _) =>
             target: InternalRow =>
-              new DistinctWindowFunctionFrame(
+              new UnboundedDistinctWindowFunctionFrame(
                 target,
                 distinctProcessor,
                 normalizedDistinctExpressions,
                 distinctAggregateExpressions.head.filter,
                 childOutput,
-                upperBound = None,
                 spillSize,
                 conf.windowExecDistinctHashFallbackThreshold,
                 conf.windowExecBufferSpillThreshold,
@@ -287,13 +286,13 @@ trait WindowEvaluatorFactoryBase {
 
           case ("DISTINCT_AGGREGATE", frameType, UnboundedPreceding, upper, _, _) =>
             target: InternalRow =>
-              new DistinctWindowFunctionFrame(
+              new UnboundedPrecedingDistinctWindowFunctionFrame(
                 target,
                 distinctProcessor,
                 normalizedDistinctExpressions,
                 distinctAggregateExpressions.head.filter,
                 childOutput,
-                Some(createBoundOrdering(frameType, upper, timeZone)),
+                createBoundOrdering(frameType, upper, timeZone),
                 spillSize,
                 conf.windowExecDistinctHashFallbackThreshold,
                 conf.windowExecBufferSpillThreshold,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
@@ -22,8 +22,9 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Add, AggregateWindowFunction, Ascending, Attribute, BoundReference, CurrentRow, DateAdd, DateAddYMInterval, DecimalAddNoOverflowCheck, Descending, Expression, ExtractANSIIntervalDays, FrameLessOffsetWindowFunction, FrameType, IdentityProjection, IntegerLiteral, MutableProjection, NamedExpression, OffsetWindowFunction, PythonFuncExpression, RangeFrame, RowFrame, RowOrdering, SortOrder, SpecifiedWindowFrame, TimestampAddInterval, TimestampAddYMInterval, UnaryMinus, UnboundedFollowing, UnboundedPreceding, UnsafeProjection, WindowExpression}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, DeclarativeAggregate}
+import org.apache.spark.sql.catalyst.expressions.{Add, AggregateWindowFunction, Ascending, Attribute, AttributeReference, BoundReference, CurrentRow, DateAdd, DateAddYMInterval, DecimalAddNoOverflowCheck, Descending, Expression, ExtractANSIIntervalDays, FrameLessOffsetWindowFunction, FrameType, IdentityProjection, IntegerLiteral, MutableProjection, NamedExpression, OffsetWindowFunction, PythonFuncExpression, RangeFrame, RowFrame, RowOrdering, SortOrder, SpecifiedWindowFrame, TimestampAddInterval, TimestampAddYMInterval, UnaryMinus, UnboundedFollowing, UnboundedPreceding, UnsafeProjection, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, DeclarativeAggregate}
+import org.apache.spark.sql.catalyst.optimizer.NormalizeFloatingNumbers
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{CalendarIntervalType, DateType, DayTimeIntervalType, DecimalType, IntegerType, TimestampNTZType, TimestampType, YearMonthIntervalType}
@@ -141,21 +142,34 @@ trait WindowEvaluatorFactoryBase {
    * [[WindowExpression]]s and factory function for the [[WindowFunctionFrame]].
    */
   protected lazy val windowFrameExpressionFactoryPairs = {
-    type FrameKey = (String, FrameType, Expression, Expression, Seq[Expression])
+    type FrameKey =
+      (String, FrameType, Expression, Expression, Seq[Expression], Option[Expression])
     type ExpressionBuffer = mutable.Buffer[Expression]
     val framedFunctions = mutable.Map.empty[FrameKey, (ExpressionBuffer, ExpressionBuffer)]
+
+    def distinctChildren(ae: AggregateExpression): Seq[Expression] = {
+      ae.aggregateFunction.children.filterNot(_.foldable).map {
+        case sortOrder: SortOrder => sortOrder.child
+        case expression => expression
+      }
+    }
 
     // Add a function and its function to the map for a given frame.
     def collect(tpe: String, fr: SpecifiedWindowFrame, e: Expression, fn: Expression): Unit = {
       val key = fn match {
+        case ae: AggregateExpression if ae.isDistinct =>
+          val normalizedChildren =
+            distinctChildren(ae).map(NormalizeFloatingNumbers.normalize).map(_.canonicalized)
+          (tpe, fr.frameType, fr.lower, fr.upper, normalizedChildren,
+            ae.filter.map(_.canonicalized))
         // This branch is used for Lead/Lag to support ignoring null and optimize the performance
         // for NthValue ignoring null.
         // All window frames move in rows. If there are multiple Leads, Lags or NthValues acting on
         // a row and operating on different input expressions, they should not be moved uniformly
         // by row. Therefore, we put these functions in different window frames.
         case f: OffsetWindowFunction if f.ignoreNulls =>
-          (tpe, fr.frameType, fr.lower, fr.upper, f.children.map(_.canonicalized))
-        case _ => (tpe, fr.frameType, fr.lower, fr.upper, Nil)
+          (tpe, fr.frameType, fr.lower, fr.upper, f.children.map(_.canonicalized), None)
+        case _ => (tpe, fr.frameType, fr.lower, fr.upper, Nil, None)
       }
       val (es, fns) = framedFunctions.getOrElseUpdate(
         key, (ArrayBuffer.empty[Expression], ArrayBuffer.empty[Expression]))
@@ -169,6 +183,9 @@ trait WindowEvaluatorFactoryBase {
         case e@WindowExpression(function, spec) =>
           val frame = spec.frameSpecification.asInstanceOf[SpecifiedWindowFrame]
           function match {
+            case ae @ AggregateExpression(_, _, true, _, _)
+                if frame.lower == UnboundedPreceding =>
+              collect("DISTINCT_AGGREGATE", frame, e, ae)
             case AggregateExpression(f, _, _, _, _) => collect("AGGREGATE", frame, e, f)
             case f: FrameLessOffsetWindowFunction =>
               collect("FRAME_LESS_OFFSET", f.fakeFrame, e, f)
@@ -219,13 +236,71 @@ trait WindowEvaluatorFactoryBase {
               MutableProjection.create(expressions, schema),
             aggFilters)
         }
+        lazy val distinctAggregateExpressions =
+          functions.map(_.asInstanceOf[AggregateExpression])
+        lazy val originalDistinctExpressions =
+          distinctChildren(distinctAggregateExpressions.head)
+        lazy val normalizedDistinctExpressions =
+          originalDistinctExpressions.map(NormalizeFloatingNumbers.normalize)
+        lazy val distinctInputAttributes =
+          normalizedDistinctExpressions.zipWithIndex.map { case (expression, index) =>
+            AttributeReference(
+              s"windowDistinctValue$index",
+              expression.dataType,
+              expression.nullable)()
+          }
+        lazy val rewrittenDistinctFunctions: Array[Expression] =
+          distinctAggregateExpressions.map { ae =>
+            val distinctColumnAttributeLookup = Utils.toMap(
+              distinctChildren(ae).map(_.canonicalized),
+              distinctInputAttributes)
+            ae.aggregateFunction.transformDown {
+              case expression: Expression
+                  if distinctColumnAttributeLookup.contains(expression.canonicalized) =>
+                distinctColumnAttributeLookup(expression.canonicalized)
+            }.asInstanceOf[AggregateFunction]
+          }
+        lazy val distinctProcessor = AggregateProcessor(
+          rewrittenDistinctFunctions,
+          ordinal,
+          distinctInputAttributes,
+          (expressions, schema) => MutableProjection.create(expressions, schema),
+          Array.fill[Option[Expression]](functions.length)(None))
         val conf = SQLConf.get
         val blockSize = conf.windowSegmentTreeBlockSize
 
         // Create the factory to produce WindowFunctionFrame.
         val factory = key match {
+          case ("DISTINCT_AGGREGATE", _, UnboundedPreceding, UnboundedFollowing, _, _) =>
+            target: InternalRow =>
+              new DistinctWindowFunctionFrame(
+                target,
+                distinctProcessor,
+                normalizedDistinctExpressions,
+                distinctAggregateExpressions.head.filter,
+                childOutput,
+                upperBound = None,
+                spillSize,
+                conf.windowExecDistinctHashFallbackThreshold,
+                conf.windowExecBufferSpillThreshold,
+                conf.windowExecBufferSpillSizeThreshold)
+
+          case ("DISTINCT_AGGREGATE", frameType, UnboundedPreceding, upper, _, _) =>
+            target: InternalRow =>
+              new DistinctWindowFunctionFrame(
+                target,
+                distinctProcessor,
+                normalizedDistinctExpressions,
+                distinctAggregateExpressions.head.filter,
+                childOutput,
+                Some(createBoundOrdering(frameType, upper, timeZone)),
+                spillSize,
+                conf.windowExecDistinctHashFallbackThreshold,
+                conf.windowExecBufferSpillThreshold,
+                conf.windowExecBufferSpillSizeThreshold)
+
           // Frameless offset Frame
-          case ("FRAME_LESS_OFFSET", _, IntegerLiteral(offset), _, expr) =>
+          case ("FRAME_LESS_OFFSET", _, IntegerLiteral(offset), _, expr, _) =>
             target: InternalRow =>
               new FrameLessOffsetWindowFunctionFrame(
                 target,
@@ -237,7 +312,7 @@ trait WindowEvaluatorFactoryBase {
                   MutableProjection.create(expressions, schema),
                 offset,
                 expr.nonEmpty)
-          case ("UNBOUNDED_OFFSET", _, IntegerLiteral(offset), _, expr) =>
+          case ("UNBOUNDED_OFFSET", _, IntegerLiteral(offset), _, expr, _) =>
             target: InternalRow => {
               new UnboundedOffsetWindowFunctionFrame(
                 target,
@@ -250,7 +325,7 @@ trait WindowEvaluatorFactoryBase {
                 offset,
                 expr.nonEmpty)
             }
-          case ("UNBOUNDED_PRECEDING_OFFSET", _, IntegerLiteral(offset), _, expr) =>
+          case ("UNBOUNDED_PRECEDING_OFFSET", _, IntegerLiteral(offset), _, expr, _) =>
             target: InternalRow => {
               new UnboundedPrecedingOffsetWindowFunctionFrame(
                 target,
@@ -265,13 +340,13 @@ trait WindowEvaluatorFactoryBase {
             }
 
           // Entire Partition Frame.
-          case ("AGGREGATE", _, UnboundedPreceding, UnboundedFollowing, _) =>
+          case ("AGGREGATE", _, UnboundedPreceding, UnboundedFollowing, _, _) =>
             target: InternalRow => {
               new UnboundedWindowFunctionFrame(target, processor)
             }
 
           // Growing Frame.
-          case ("AGGREGATE", frameType, UnboundedPreceding, upper, _) =>
+          case ("AGGREGATE", frameType, UnboundedPreceding, upper, _, _) =>
             target: InternalRow => {
               new UnboundedPrecedingWindowFunctionFrame(
                 target,
@@ -280,7 +355,7 @@ trait WindowEvaluatorFactoryBase {
             }
 
           // Shrinking Frame.
-          case ("AGGREGATE", frameType, lower, UnboundedFollowing, _) =>
+          case ("AGGREGATE", frameType, lower, UnboundedFollowing, _, _) =>
             if (eligibleForSegTree(functions, aggFilters, frameType, conf)) {
               val segFns = functions.map(_.asInstanceOf[DeclarativeAggregate])
               // Shrinking-frame queries `[lower, n)` on `WindowSegmentTree` touch the LRU
@@ -333,7 +408,7 @@ trait WindowEvaluatorFactoryBase {
             }
 
           // Moving Frame.
-          case ("AGGREGATE", frameType, lower, upper, _) =>
+          case ("AGGREGATE", frameType, lower, upper, _, _) =>
             if (eligibleForSegTree(functions, aggFilters, frameType, conf)) {
               val segFns = functions.map(_.asInstanceOf[DeclarativeAggregate])
               val cacheHint = estimateMaxCachedBlocks(lower, upper, frameType, blockSize)
@@ -399,10 +474,8 @@ trait WindowEvaluatorFactoryBase {
    * code as the inner DeclarativeAggregate unwrapped from
    * [[AggregateExpression]] (see `windowFrameExpressionFactoryPairs.collect`).
    *
-   * DISTINCT aggregate window expressions are already rejected earlier in
-   * analysis by `WindowResolution.checkWindowFunction`
-   * (error class `DISTINCT_WINDOW_FUNCTION_UNSUPPORTED`), so no explicit
-   * `isDistinct` gate is needed here.
+   * DISTINCT aggregate window expressions use a separate frame factory and never reach this
+   * eligibility check, so no explicit `isDistinct` gate is needed here.
    */
   private def eligibleForSegTree(
       functions: Array[Expression],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactoryBase.scala
@@ -151,7 +151,7 @@ trait WindowEvaluatorFactoryBase {
       ae.aggregateFunction.children.filterNot(_.foldable).map {
         case sortOrder: SortOrder => sortOrder.child
         case expression => expression
-      }
+      }.distinctBy(_.canonicalized)
     }
 
     // Add a function and its function to the map for a given frame.

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/listagg.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/listagg.sql.out
@@ -486,6 +486,21 @@ Aggregate [grp#x], [grp#x, hex(listagg(distinct col#x, 0x2C, col#x ASC NULLS FIR
 
 
 -- !query
+SELECT listagg(DISTINCT col1) OVER (ORDER BY col1) FROM df
+-- !query analysis
+Project [listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)#x]
++- Project [col1#x, listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)#x, listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)#x]
+   +- Window [listagg(distinct col1#x, null, 0, 0) windowspecdefinition(col1#x ASC NULLS FIRST, specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())) AS listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)#x], [col1#x ASC NULLS FIRST]
+      +- Project [col1#x]
+         +- SubqueryAlias df
+            +- View (`df`, [col1#x, col2#x])
+               +- Project [cast(col1#x as string) AS col1#x, cast(col2#x as string) AS col2#x]
+                  +- Project [col1#x, col2#x]
+                     +- SubqueryAlias __auto_generated_subquery_name
+                        +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
 SELECT listagg(c1) FROM (VALUES (ARRAY('a', 'b'))) AS t(c1)
 -- !query analysis
 org.apache.spark.sql.catalyst.ExtendedAnalysisException
@@ -605,26 +620,6 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "startIndex" : 8,
     "stopIndex" : 73,
     "fragment" : "string_agg(col1) WITHIN GROUP (ORDER BY col1) OVER (ORDER BY col1)"
-  } ]
-}
-
-
--- !query
-SELECT listagg(DISTINCT col1) OVER (ORDER BY col1) FROM df
--- !query analysis
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
-  "sqlState" : "0A000",
-  "messageParameters" : {
-    "windowExpr" : "\"listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 8,
-    "stopIndex" : 50,
-    "fragment" : "listagg(DISTINCT col1) OVER (ORDER BY col1)"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/inputs/listagg.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/listagg.sql
@@ -47,6 +47,7 @@ SELECT grp, listagg(DISTINCT col) WITHIN GROUP (ORDER BY col) FROM VALUES (1, 'a
 WITH t(col) AS (SELECT listagg(DISTINCT col1, X'2C') WITHIN GROUP (ORDER BY col1) FROM (VALUES (X'DEAD'), (X'BEEF'), (X'DEAD'), (X'CAFE'))) SELECT len(col), regexp_count(hex(col), hex(X'DEAD')), regexp_count(hex(col), hex(X'BEEF')), regexp_count(hex(col), hex(X'CAFE')) FROM t;
 WITH t(col) AS (SELECT listagg(DISTINCT col1, X'7C') WITHIN GROUP (ORDER BY col1) FROM (VALUES (X'BB'), (X'AA'), (NULL), (X'BB'))) SELECT len(col), regexp_count(hex(col), hex(X'AA')), regexp_count(hex(col), hex(X'BB')) FROM t;
 SELECT grp, hex(listagg(DISTINCT col, X'2C') WITHIN GROUP (ORDER BY col)) FROM VALUES (1, X'AA'), (1, X'BB'), (1, X'AA'), (2, X'CC'), (2, X'CC') AS t(grp, col) GROUP BY grp;
+SELECT listagg(DISTINCT col1) OVER (ORDER BY col1) FROM df;
 
 -- Error cases
 SELECT listagg(c1) FROM (VALUES (ARRAY('a', 'b'))) AS t(c1);
@@ -55,7 +56,6 @@ SELECT listagg(col2, col1) FROM df GROUP BY col1;
 SELECT listagg(col1) OVER (ORDER BY col1) FROM df;
 SELECT listagg(col1) WITHIN GROUP (ORDER BY col1) OVER (ORDER BY col1) FROM df;
 SELECT string_agg(col1) WITHIN GROUP (ORDER BY col1) OVER (ORDER BY col1) FROM df;
-SELECT listagg(DISTINCT col1) OVER (ORDER BY col1) FROM df;
 SELECT listagg(DISTINCT col1) WITHIN GROUP (ORDER BY col2) FROM df;
 SELECT listagg(DISTINCT col1) WITHIN GROUP (ORDER BY col1, col2) FROM df;
 SELECT listagg(DISTINCT col, ',') WITHIN GROUP (ORDER BY col) FROM VALUES (cast(1.1 as double)), (cast(2.2 as double)), (cast(2.2 as double)), (cast(3.3 as double)) AS t(col);

--- a/sql/core/src/test/resources/sql-tests/results/listagg.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/listagg.sql.out
@@ -328,6 +328,18 @@ struct<grp:int,hex(listagg(DISTINCT col, X'2C') WITHIN GROUP (ORDER BY col ASC N
 
 
 -- !query
+SELECT listagg(DISTINCT col1) OVER (ORDER BY col1) FROM df
+-- !query schema
+struct<listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):string>
+-- !query output
+NULL
+a
+a
+ab
+ab
+
+
+-- !query
 SELECT listagg(c1) FROM (VALUES (ARRAY('a', 'b'))) AS t(c1)
 -- !query schema
 struct<>
@@ -454,28 +466,6 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "startIndex" : 8,
     "stopIndex" : 73,
     "fragment" : "string_agg(col1) WITHIN GROUP (ORDER BY col1) OVER (ORDER BY col1)"
-  } ]
-}
-
-
--- !query
-SELECT listagg(DISTINCT col1) OVER (ORDER BY col1) FROM df
--- !query schema
-struct<>
--- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
-  "sqlState" : "0A000",
-  "messageParameters" : {
-    "windowExpr" : "\"listagg(DISTINCT col1, NULL) OVER (ORDER BY col1 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 8,
-    "stopIndex" : 50,
-    "fragment" : "listagg(DISTINCT col1) OVER (ORDER BY col1)"
   } ]
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.TestUtils.assertSpilled
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.internal.SQLConf.{WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD, WINDOW_EXEC_BUFFER_SPILL_THRESHOLD}
+import org.apache.spark.sql.internal.SQLConf.{WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD, WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD, WINDOW_EXEC_BUFFER_SPILL_THRESHOLD, WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD}
 import org.apache.spark.sql.test.SharedSparkSession
 
 case class WindowData(month: Int, area: String, product: Int)
@@ -196,11 +196,283 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
       val e = intercept[AnalysisException] {
         sql(
           """
-            |select month, area, product, sum(distinct product + 1) over (partition by 1 order by 2)
+            |select month, area, product, sum(distinct product + 1) over (
+            |  partition by 1 order by 2 rows between current row and current row)
             |from windowData
           """.stripMargin)
       }
       assert(e.getMessage.contains("Distinct window functions are not supported"))
+    }
+  }
+
+  test("window function: distinct aggregates with an unbounded preceding frame") {
+    val data = Seq(
+      (1, 0, 10, "a", 10),
+      (1, 1, 20, "a", 10),
+      (1, 2, 20, "b", 20),
+      (1, 3, 20, null.asInstanceOf[String], 30),
+      (1, 4, 30, "c", 30),
+      (2, 5, 5, "b", 5),
+      (2, 6, 5, "b", 5),
+      (2, 7, 6, "a", 6)
+    ).toDF("k", "id", "v", "x", "amount")
+
+    withTempView("distinctWindowData") {
+      data.createOrReplaceTempView("distinctWindowData")
+
+      checkAnswer(
+        sql(
+          """
+            |SELECT k, id,
+            |  count(DISTINCT x) OVER (PARTITION BY k ORDER BY v) AS range_count,
+            |  count(DISTINCT x) OVER (
+            |    PARTITION BY k ORDER BY v, id
+            |    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rows_count,
+            |  count(DISTINCT x) OVER (
+            |    PARTITION BY k ORDER BY v, id
+            |    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS preceding_count,
+            |  count(DISTINCT x) OVER (
+            |    PARTITION BY k ORDER BY v, id
+            |    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) AS following_count,
+            |  count(DISTINCT x) OVER (PARTITION BY k) AS partition_count,
+            |  sum(DISTINCT amount) OVER (PARTITION BY k ORDER BY v) AS range_sum,
+            |  avg(DISTINCT amount) OVER (PARTITION BY k ORDER BY v) AS range_avg,
+            |  sort_array(collect_list(DISTINCT amount) OVER (
+            |    PARTITION BY k ORDER BY v)) AS range_values
+            |FROM distinctWindowData
+          """.stripMargin),
+        Seq(
+          Row(1, 0, 1L, 1L, 0L, 1L, 3L, 10L, 10.0, Seq(10)),
+          Row(1, 1, 2L, 1L, 1L, 2L, 3L, 60L, 20.0, Seq(10, 20, 30)),
+          Row(1, 2, 2L, 2L, 1L, 2L, 3L, 60L, 20.0, Seq(10, 20, 30)),
+          Row(1, 3, 2L, 2L, 2L, 3L, 3L, 60L, 20.0, Seq(10, 20, 30)),
+          Row(1, 4, 3L, 3L, 2L, 3L, 3L, 60L, 20.0, Seq(10, 20, 30)),
+          Row(2, 5, 1L, 1L, 0L, 1L, 2L, 5L, 5.0, Seq(5)),
+          Row(2, 6, 1L, 1L, 1L, 2L, 2L, 5L, 5.0, Seq(5)),
+          Row(2, 7, 2L, 2L, 1L, 2L, 2L, 11L, 5.5, Seq(5, 6))
+        ))
+    }
+  }
+
+  test("window function: count distinct with a range offset, filter, and multiple columns") {
+    val data = Seq(
+      (0, 10, "a", 1, true),
+      (1, 20, "a", 1, true),
+      (2, 20, "b", 1, false),
+      (3, 20, "b", 2, true),
+      (4, 30, "c", 3, true)
+    ).toDF("id", "v", "x", "y", "selected")
+
+    withTempView("distinctWindowData") {
+      data.createOrReplaceTempView("distinctWindowData")
+
+      checkAnswer(
+        sql(
+          """
+            |SELECT id,
+            |  count(DISTINCT x) OVER (
+            |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND 5 PRECEDING) AS preceding_count,
+            |  count(DISTINCT x) FILTER (WHERE selected) OVER (
+            |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS filtered_count,
+            |  count(DISTINCT x, y) OVER (
+            |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS tuple_count
+            |FROM distinctWindowData
+          """.stripMargin),
+        Seq(
+          Row(0, 0L, 1L, 1L),
+          Row(1, 1L, 2L, 3L),
+          Row(2, 1L, 2L, 3L),
+          Row(3, 1L, 2L, 3L),
+          Row(4, 2L, 3L, 4L)
+        ))
+    }
+  }
+
+  test("window function: count distinct falls back from hash and sorter spills") {
+    withSQLConf(
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "5",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "2") {
+      val result = sql(
+        """
+          |SELECT max(distinct_count)
+          |FROM (
+          |  SELECT count(DISTINCT id % 3) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS distinct_count
+          |  FROM range(100)
+          |)
+        """.stripMargin)
+      assertSpilled(sparkContext, "count distinct window hash fallback") {
+        checkAnswer(result, Row(3L))
+      }
+    }
+  }
+
+  test("window function: count distinct with a binary-unstable collation") {
+    checkAnswer(
+      sql(
+        """
+          |SELECT id, count(DISTINCT value COLLATE UTF8_LCASE) OVER (
+          |  ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+          |FROM VALUES (0, 'a'), (1, 'A'), (2, 'b'), (3, 'B') AS data(id, value)
+          |ORDER BY id
+        """.stripMargin),
+      Seq(
+        Row(0, 1L),
+        Row(1, 1L),
+        Row(2, 2L),
+        Row(3, 2L)))
+  }
+
+  test("window function: distinct preserves the first collated value across spills") {
+    withSQLConf(WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "1") {
+      checkAnswer(
+        sql(
+          """
+            |SELECT id, collect_list(DISTINCT value COLLATE UTF8_LCASE) OVER (
+            |  ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+            |FROM VALUES (0, 'a'), (1, 'A'), (2, 'b'), (3, 'B') AS data(id, value)
+            |ORDER BY id
+          """.stripMargin),
+        Seq(
+          Row(0, Seq("a")),
+          Row(1, Seq("a")),
+          Row(2, Seq("a", "b")),
+          Row(3, Seq("a", "b"))))
+    }
+  }
+
+  test("window function: distinct aggregates use normalized floating-point inputs") {
+    val rows = sql(
+      """
+        |SELECT id, collect_list(DISTINCT value) OVER (
+        |  ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS values
+        |FROM VALUES
+        |  (0, CAST('-0.0' AS DOUBLE)),
+        |  (1, CAST('0.0' AS DOUBLE)) AS data(id, value)
+        |ORDER BY id
+      """.stripMargin).collect()
+
+    val rawBits = rows.map { row =>
+      row.getSeq[Double](1).map(java.lang.Double.doubleToRawLongBits)
+    }
+    assert(rawBits === Seq(Seq(0L), Seq(0L)))
+  }
+
+  test("window function: distinct aggregates share frames by key and filter") {
+    checkAnswer(
+      sql(
+        """
+          |SELECT id,
+          |  count(DISTINCT value) FILTER (WHERE selected) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS count_value,
+          |  sum(DISTINCT value) FILTER (WHERE selected) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum_value,
+          |  avg(DISTINCT value) FILTER (WHERE selected) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS avg_value,
+          |  sort_array(collect_list(DISTINCT value) FILTER (WHERE selected) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)) AS values,
+          |  count(DISTINCT value) FILTER (WHERE NOT selected) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS other_count
+          |FROM VALUES
+          |  (0, 1, true),
+          |  (1, 1, true),
+          |  (2, 2, false),
+          |  (3, 3, true) AS data(id, value, selected)
+          |ORDER BY id
+        """.stripMargin),
+      Seq(
+        Row(0, 1L, 1L, 1.0, Seq(1), 0L),
+        Row(1, 1L, 1L, 1.0, Seq(1), 0L),
+        Row(2, 1L, 1L, 1.0, Seq(1), 1L),
+        Row(3, 2L, 4L, 2.0, Seq(1, 3), 1L)))
+  }
+
+  test("window function: distinct imperative aggregates share a frame") {
+    checkAnswer(
+      sql(
+        """
+          |SELECT id,
+          |  listagg(DISTINCT value, ',') OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS concatenated,
+          |  sort_array(collect_list(DISTINCT value) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)) AS values
+          |FROM VALUES
+          |  (0, 'a'),
+          |  (1, 'a'),
+          |  (2, 'b') AS data(id, value)
+          |ORDER BY id
+        """.stripMargin),
+      Seq(
+        Row(0, "a", Seq("a")),
+        Row(1, "a", Seq("a")),
+        Row(2, "a,b", Seq("a", "b"))))
+  }
+
+  test("window function: distinct hash fallback honors the size spill threshold") {
+    withSQLConf(
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> Int.MaxValue.toString,
+      WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD.key -> "1",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> Int.MaxValue.toString) {
+      val result = sql(
+        """
+          |SELECT max(distinct_count)
+          |FROM (
+          |  SELECT count(DISTINCT id % 5) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS distinct_count
+          |  FROM range(20)
+          |)
+        """.stripMargin)
+      assertSpilled(sparkContext, "count distinct window hash fallback by size") {
+        checkAnswer(result, Row(5L))
+      }
+    }
+  }
+
+  test("window function: distinct foldable inputs share an empty-key frame") {
+    withSQLConf(
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "1",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "1") {
+      val result = sql(
+        """
+          |SELECT id,
+          |  count(DISTINCT 1) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS count_one,
+          |  count(DISTINCT CAST(NULL AS INT)) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS count_null,
+          |  sum(DISTINCT 2) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum_two
+          |FROM range(3)
+          |ORDER BY id
+        """.stripMargin)
+      assertSpilled(sparkContext, "distinct window with an empty key") {
+        checkAnswer(
+          result,
+          Seq(
+            Row(0L, 1L, 0L, 2L),
+            Row(1L, 1L, 0L, 2L),
+            Row(2L, 1L, 0L, 2L)))
+      }
+    }
+  }
+
+  test("window function: distinct works when the window input buffer spills") {
+    withSQLConf(
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1",
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "2") {
+      val result = sql(
+        """
+          |SELECT max(distinct_count)
+          |FROM (
+          |  SELECT count(DISTINCT 1) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS distinct_count
+          |  FROM range(100)
+          |)
+        """.stripMargin)
+      assertSpilled(sparkContext, "distinct window with spilled input buffer") {
+        checkAnswer(result, Row(1L))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -333,20 +333,27 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
     }
   }
 
-  test("window function: unbounded distinct frame evaluates sorter output directly") {
+  test("window function: unbounded distinct frame falls back by size") {
     withSQLConf(
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
       WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> Int.MaxValue.toString,
-      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "2") {
-      checkAnswer(
-        sql(
-          """
-            |SELECT id,
-            |  count(DISTINCT value) OVER () AS distinct_count,
-            |  sum(DISTINCT value) OVER () AS distinct_sum,
-            |  sort_array(collect_list(DISTINCT value) OVER ()) AS distinct_values
-            |FROM VALUES (0, 3), (1, 1), (2, 3), (3, 2), (4, 1) AS data(id, value)
-          """.stripMargin),
-        Seq.tabulate(5)(id => Row(id, 3L, 6L, Seq(1, 2, 3))))
+      WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD.key -> "1",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> Int.MaxValue.toString) {
+      val result = sql(
+        """
+          |SELECT id,
+          |  count(DISTINCT id % 3) OVER () AS distinct_count,
+          |  sum(DISTINCT id % 3) OVER () AS distinct_sum,
+          |  sort_array(collect_list(DISTINCT id % 3) OVER ()) AS distinct_values
+          |FROM range(20)
+        """.stripMargin)
+      // An entire-partition frame has no event sorter, and the input buffer stays in memory, so
+      // this spill can only come from the distinct-key sorter created by the size fallback.
+      assertSpilled(sparkContext, "unbounded distinct window hash fallback by size") {
+        checkAnswer(
+          result,
+          Seq.tabulate(20)(id => Row(id.toLong, 3L, 3L, Seq(0L, 1L, 2L))))
+      }
     }
   }
 
@@ -393,37 +400,24 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
     }
   }
 
-  test("window function: count distinct with a binary-unstable collation") {
-    checkAnswer(
-      sql(
-        """
-          |SELECT id, count(DISTINCT value COLLATE UTF8_LCASE) OVER (
-          |  ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-          |FROM VALUES (0, 'a'), (1, 'A'), (2, 'b'), (3, 'B') AS data(id, value)
-          |ORDER BY id
-        """.stripMargin),
-      Seq(
-        Row(0, 1L),
-        Row(1, 1L),
-        Row(2, 2L),
-        Row(3, 2L)))
-  }
-
-  test("window function: distinct preserves the first collated value across spills") {
+  test("window function: distinct handles binary-unstable collation across spills") {
     withSQLConf(WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "1") {
       checkAnswer(
         sql(
           """
-            |SELECT id, collect_list(DISTINCT value COLLATE UTF8_LCASE) OVER (
-            |  ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+            |SELECT id,
+            |  count(DISTINCT value COLLATE UTF8_LCASE) OVER (
+            |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+            |  collect_list(DISTINCT value COLLATE UTF8_LCASE) OVER (
+            |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
             |FROM VALUES (0, 'a'), (1, 'A'), (2, 'b'), (3, 'B') AS data(id, value)
             |ORDER BY id
           """.stripMargin),
         Seq(
-          Row(0, Seq("a")),
-          Row(1, Seq("a")),
-          Row(2, Seq("a", "b")),
-          Row(3, Seq("a", "b"))))
+          Row(0, 1L, Seq("a")),
+          Row(1, 1L, Seq("a")),
+          Row(2, 2L, Seq("a", "b")),
+          Row(3, 2L, Seq("a", "b"))))
     }
   }
 
@@ -492,27 +486,6 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
         Row(0, "a", Seq("a")),
         Row(1, "a", Seq("a")),
         Row(2, "a,b", Seq("a", "b"))))
-  }
-
-  test("window function: distinct hash fallback honors the size spill threshold") {
-    withSQLConf(
-      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
-      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> Int.MaxValue.toString,
-      WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD.key -> "1",
-      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> Int.MaxValue.toString) {
-      val result = sql(
-        """
-          |SELECT max(distinct_count)
-          |FROM (
-          |  SELECT count(DISTINCT id % 5) OVER (
-          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS distinct_count
-          |  FROM range(20)
-          |)
-        """.stripMargin)
-      assertSpilled(sparkContext, "count distinct window hash fallback by size") {
-        checkAnswer(result, Row(5L))
-      }
-    }
   }
 
   test("window function: distinct foldable inputs share an empty-key frame") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.TestUtils.{assertNotSpilled, assertSpilled}
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.internal.SQLConf.{WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD, WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD, WINDOW_EXEC_BUFFER_SPILL_THRESHOLD, WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD}
+import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.internal.SQLConf.{ADAPTIVE_EXECUTION_ENABLED, WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD, WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD, WINDOW_EXEC_BUFFER_SPILL_THRESHOLD, WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD}
 import org.apache.spark.sql.test.SharedSparkSession
 
 case class WindowData(month: Int, area: String, product: Int)
@@ -305,6 +306,29 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
       assertSpilled(sparkContext, "count distinct window hash fallback") {
         checkAnswer(result, Row(3L))
       }
+    }
+  }
+
+  test("window function: distinct event sorter spill size is reported") {
+    withSQLConf(
+      ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "5",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> Int.MaxValue.toString) {
+      val result = sql(
+        """
+          |SELECT max(distinct_count)
+          |FROM (
+          |  SELECT count(DISTINCT id) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS distinct_count
+          |  FROM range(100)
+          |)
+        """.stripMargin)
+      checkAnswer(result, Row(100L))
+      val window = result.queryExecution.executedPlan.collectFirst {
+        case window: WindowExec => window
+      }.get
+      assert(window.metrics("spillSize").value > 0)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -309,6 +309,47 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
     }
   }
 
+  test("window function: unbounded distinct frame skips the event sorter") {
+    withSQLConf(
+      ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "5",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> Int.MaxValue.toString) {
+      val result = sql(
+        """
+          |SELECT max(distinct_count)
+          |FROM (
+          |  SELECT count(DISTINCT id) OVER () AS distinct_count
+          |  FROM range(100)
+          |)
+        """.stripMargin)
+      assertNotSpilled(sparkContext, "unbounded distinct window without an event sorter") {
+        checkAnswer(result, Row(100L))
+      }
+      val window = result.queryExecution.executedPlan.collectFirst {
+        case window: WindowExec => window
+      }.get
+      assert(window.metrics("spillSize").value == 0)
+    }
+  }
+
+  test("window function: unbounded distinct frame evaluates sorter output directly") {
+    withSQLConf(
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> Int.MaxValue.toString,
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "2") {
+      checkAnswer(
+        sql(
+          """
+            |SELECT id,
+            |  count(DISTINCT value) OVER () AS distinct_count,
+            |  sum(DISTINCT value) OVER () AS distinct_sum,
+            |  sort_array(collect_list(DISTINCT value) OVER ()) AS distinct_values
+            |FROM VALUES (0, 3), (1, 1), (2, 3), (3, 2), (4, 1) AS data(id, value)
+          """.stripMargin),
+        Seq.tabulate(5)(id => Row(id, 3L, 6L, Seq(1, 2, 3))))
+    }
+  }
+
   test("window function: distinct event sorter spill size is reported") {
     withSQLConf(
       ADAPTIVE_EXECUTION_ENABLED.key -> "false",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -202,8 +202,15 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
             |from windowData
           """.stripMargin)
       }
-      assert(e.getMessage.contains("Distinct window functions are not supported"))
+      assert(e.getMessage.contains("Unsupported DISTINCT window function"))
     }
+  }
+
+  test("window function: distinct rejects unorderable inputs") {
+    val e = intercept[AnalysisException] {
+      sql("SELECT count(DISTINCT map('key', id)) OVER () FROM range(1)")
+    }
+    assert(e.getCondition === "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED")
   }
 
   test("window function: distinct aggregates with an unbounded preceding frame") {
@@ -421,6 +428,27 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
     }
   }
 
+  test("window function: distinct keeps variable-length inputs across row reuse") {
+    withSQLConf(WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "1") {
+      checkAnswer(
+        sql(
+          """
+            |SELECT id,
+            |  max(DISTINCT value) OVER (
+            |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING),
+            |  first(DISTINCT value) OVER (
+            |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING),
+            |  max(DISTINCT value) OVER ()
+            |FROM VALUES (0, 'z'), (1, 'a'), (2, 'b') AS data(id, value)
+            |ORDER BY id
+          """.stripMargin),
+        Seq(
+          Row(0, "z", "z", "z"),
+          Row(1, "z", "z", "z"),
+          Row(2, "z", "z", "z")))
+    }
+  }
+
   test("window function: distinct aggregates use normalized floating-point inputs") {
     val rows = sql(
       """
@@ -486,6 +514,18 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
         Row(0, "a", Seq("a")),
         Row(1, "a", Seq("a")),
         Row(2, "a,b", Seq("a", "b"))))
+  }
+
+  test("window function: listagg distinct reuses its ordering argument as a key") {
+    checkAnswer(
+      sql(
+        """
+          |SELECT id,
+          |  listagg(DISTINCT value) WITHIN GROUP (ORDER BY value) OVER () AS concatenated
+          |FROM VALUES (0, 'b'), (1, 'a'), (2, 'b') AS data(id, value)
+          |ORDER BY id
+        """.stripMargin),
+      Seq(Row(0, "ab"), Row(1, "ab"), Row(2, "ab")))
   }
 
   test("window function: distinct foldable inputs share an empty-key frame") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.TestUtils.assertSpilled
+import org.apache.spark.TestUtils.{assertNotSpilled, assertSpilled}
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.internal.SQLConf.{WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD, WINDOW_EXEC_BUFFER_SIZE_SPILL_THRESHOLD, WINDOW_EXEC_BUFFER_SPILL_THRESHOLD, WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -308,6 +308,26 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
     }
   }
 
+  test("window function: count distinct stays in hash at the fallback threshold") {
+    withSQLConf(
+      WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1000",
+      WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "5",
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "2") {
+      val result = sql(
+        """
+          |SELECT max(distinct_count)
+          |FROM (
+          |  SELECT count(DISTINCT id % 2) OVER (
+          |    ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS distinct_count
+          |  FROM range(100)
+          |)
+        """.stripMargin)
+      assertNotSpilled(sparkContext, "count distinct window at hash fallback threshold") {
+        checkAnswer(result, Row(2L))
+      }
+    }
+  }
+
   test("window function: count distinct with a binary-unstable collation") {
     checkAnswer(
       sql(
@@ -433,7 +453,7 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
   test("window function: distinct foldable inputs share an empty-key frame") {
     withSQLConf(
       WINDOW_EXEC_BUFFER_SPILL_THRESHOLD.key -> "1",
-      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "1") {
+      WINDOW_EXEC_DISTINCT_HASH_FALLBACK_THRESHOLD.key -> "0") {
       val result = sql(
         """
           |SELECT id,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -263,36 +263,40 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
   }
 
   test("window function: count distinct with a range offset, filter, and multiple columns") {
-    val data = Seq(
-      (0, 10, "a", 1, true),
-      (1, 20, "a", 1, true),
-      (2, 20, "b", 1, false),
-      (3, 20, "b", 2, true),
-      (4, 30, "c", 3, true)
-    ).toDF("id", "v", "x", "y", "selected")
+    withSQLConf(WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "1") {
+      val data = Seq(
+        (0, 10, "a", 1, true),
+        (1, 20, "a", 1, true),
+        (2, 20, "b", 1, false),
+        (3, 20, "b", 2, true),
+        (4, 30, "c", 3, true)
+      ).toDF("id", "v", "x", "y", "selected")
 
-    withTempView("distinctWindowData") {
-      data.createOrReplaceTempView("distinctWindowData")
+      withTempView("distinctWindowData") {
+        data.createOrReplaceTempView("distinctWindowData")
 
-      checkAnswer(
-        sql(
-          """
-            |SELECT id,
-            |  count(DISTINCT x) OVER (
-            |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND 5 PRECEDING) AS preceding_count,
-            |  count(DISTINCT x) FILTER (WHERE selected) OVER (
-            |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS filtered_count,
-            |  count(DISTINCT x, y) OVER (
-            |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS tuple_count
-            |FROM distinctWindowData
-          """.stripMargin),
-        Seq(
-          Row(0, 0L, 1L, 1L),
-          Row(1, 1L, 2L, 3L),
-          Row(2, 1L, 2L, 3L),
-          Row(3, 1L, 2L, 3L),
-          Row(4, 2L, 3L, 4L)
-        ))
+        checkAnswer(
+          sql(
+            """
+              |SELECT id,
+              |  count(DISTINCT x) OVER (
+              |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND 5 PRECEDING)
+              |      AS preceding_count,
+              |  count(DISTINCT x) FILTER (WHERE selected) OVER (
+              |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+              |      AS filtered_count,
+              |  count(DISTINCT x, y) OVER (
+              |    ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS tuple_count
+              |FROM distinctWindowData
+            """.stripMargin),
+          Seq(
+            Row(0, 0L, 1L, 1L),
+            Row(1, 1L, 2L, 3L),
+            Row(2, 1L, 2L, 3L),
+            Row(3, 1L, 2L, 3L),
+            Row(4, 2L, 3L, 4L)
+          ))
+      }
     }
   }
 
@@ -354,13 +358,9 @@ class SQLWindowFunctionSuite extends SharedSparkSession {
           |  sort_array(collect_list(DISTINCT id % 3) OVER ()) AS distinct_values
           |FROM range(20)
         """.stripMargin)
-      // An entire-partition frame has no event sorter, and the input buffer stays in memory, so
-      // this spill can only come from the distinct-key sorter created by the size fallback.
-      assertSpilled(sparkContext, "unbounded distinct window hash fallback by size") {
-        checkAnswer(
-          result,
-          Seq.tabulate(20)(id => Row(id.toLong, 3L, 3L, Seq(0L, 1L, 2L))))
-      }
+      checkAnswer(
+        result,
+        Seq.tabulate(20)(id => Row(id.toLong, 3L, 3L, Seq(0L, 1L, 2L))))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala
@@ -21,6 +21,9 @@ import java.util.Properties
 
 import scala.util.Random
 
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, never, verify, when}
+
 import org.apache.spark._
 import org.apache.spark.internal.config._
 import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
@@ -30,6 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{InterpretedOrdering, UnsafePro
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.map.BytesToBytesMap
+import org.apache.spark.util.TaskCompletionListener
 
 /**
  * Test suite for [[UnsafeKVExternalSorter]], with randomly generated test data.
@@ -49,6 +53,42 @@ class UnsafeKVExternalSorterSuite extends SharedSparkSession {
     testKVSorter(keySchema, valueSchema, spill = i > 3)
   }
 
+  test("kv insertion honors the record-count spill threshold") {
+    assertKVInsertionSpills(numElementsForSpillThreshold = 1, Long.MaxValue)
+  }
+
+  test("kv insertion honors the size spill threshold") {
+    assertKVInsertionSpills(Int.MaxValue, sizeInBytesForSpillThreshold = 1L)
+  }
+
+  test("kv sorter can use a caller-owned lifecycle") {
+    val memoryManager = new TestMemoryManager(new SparkConf())
+    val taskMemoryManager = new TaskMemoryManager(memoryManager, 0)
+    val context = mock(classOf[TaskContext])
+    when(context.taskMemoryManager()).thenReturn(taskMemoryManager)
+    TaskContext.setTaskContext(context)
+
+    var sorter: UnsafeKVExternalSorter = null
+    try {
+      val schema = new StructType().add("i", IntegerType)
+      sorter = UnsafeKVExternalSorter.createWithCallerOwnedLifecycle(
+        schema,
+        schema,
+        SparkEnv.get.blockManager,
+        SparkEnv.get.serializerManager,
+        taskMemoryManager.pageSizeBytes(),
+        Int.MaxValue,
+        Long.MaxValue)
+
+      verify(context, never()).addTaskCompletionListener(any[TaskCompletionListener]())
+    } finally {
+      if (sorter != null) {
+        sorter.cleanupResources()
+      }
+      assert(taskMemoryManager.cleanUpAllAllocatedMemory === 0L)
+      TaskContext.unset()
+    }
+  }
 
   /**
    * Create a test case using randomly generated data for the given key and value schema.
@@ -293,6 +333,58 @@ class UnsafeKVExternalSorterSuite extends SharedSparkSession {
       sorter1.merge(sorter2)
       assert(sorter1.getSpillSize === expectedSpillSize)
     } finally {
+      TaskContext.unset()
+    }
+  }
+
+  private def assertKVInsertionSpills(
+      numElementsForSpillThreshold: Int,
+      sizeInBytesForSpillThreshold: Long): Unit = {
+    val memoryManager = new TestMemoryManager(new SparkConf())
+    val taskMemoryManager = new TaskMemoryManager(memoryManager, 0)
+    val context = new TaskContextImpl(
+      stageId = 0,
+      stageAttemptNumber = 0,
+      partitionId = 0,
+      taskAttemptId = 0,
+      attemptNumber = 0,
+      numPartitions = 1,
+      taskMemoryManager = taskMemoryManager,
+      localProperties = new Properties,
+      metricsSystem = null)
+    TaskContext.setTaskContext(context)
+
+    var sorter: UnsafeKVExternalSorter = null
+    try {
+      val schema = new StructType().add("i", IntegerType)
+      val projection = UnsafeProjection.create(schema)
+      val keys = Seq(1, 2).map(i => projection(InternalRow(i)).copy())
+      val value = projection(InternalRow(0)).copy()
+      sorter = new UnsafeKVExternalSorter(
+        schema,
+        schema,
+        SparkEnv.get.blockManager,
+        SparkEnv.get.serializerManager,
+        taskMemoryManager.pageSizeBytes(),
+        numElementsForSpillThreshold,
+        sizeInBytesForSpillThreshold)
+
+      sorter.insertKV(keys.head, value)
+      assert(sorter.getSpillSize === 0L)
+      sorter.insertKV(keys.last, value)
+      assert(sorter.getSpillSize > 0L)
+
+      val iterator = sorter.sortedIterator()
+      var count = 0
+      while (iterator.next()) {
+        count += 1
+      }
+      assert(count === 2)
+    } finally {
+      if (sorter != null) {
+        sorter.cleanupResources()
+      }
+      assert(taskMemoryManager.cleanUpAllAllocatedMemory === 0L)
       TaskContext.unset()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrameSuite.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.window
+
+import java.util.Properties
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{SparkConf, TaskContext, TaskContextImpl}
+import org.apache.spark.memory.{SparkOutOfMemoryError, TaskMemoryManager, TestMemoryManager}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, GenericInternalRow}
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{DataType, IntegerType}
+
+class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession {
+
+  private final class TestDistinctWindowFunctionFrame(
+      inputAttribute: Attribute,
+      spillSize: SQLMetric)
+    extends DistinctWindowFunctionFrame(
+      target = new GenericInternalRow(1),
+      processor = null,
+      distinctExpressions = Seq(inputAttribute),
+      filter = None,
+      inputSchema = Seq(inputAttribute),
+      spillSize = spillSize,
+      hashFallbackThreshold = Int.MaxValue,
+      spillThreshold = Int.MaxValue,
+      spillSizeThreshold = Long.MaxValue) {
+
+    def deduplicate(rows: Seq[(UnsafeRow, UnsafeRow)]): Seq[(Int, Int)] = {
+      val builder = new FirstVisibleRowsBuilder
+      try {
+        rows.foreach { case (key, position) => builder.add(key, position) }
+        val result = ArrayBuffer.empty[(Int, Int)]
+        builder.foreachDistinctRow { (key, position) =>
+          result.append((key.getInt(0), position.getInt(1)))
+        }
+        result.toSeq
+      } finally {
+        builder.close()
+      }
+    }
+
+    override protected def populateFirstVisibleRows(
+        rows: ExternalAppendOnlyUnsafeRowArray,
+        firstVisibleRows: FirstVisibleRowsBuilder): Unit = {}
+
+    override protected def processDistinctRows(
+        firstVisibleRows: FirstVisibleRowsBuilder): Unit = {}
+
+    override protected def prepareFrame(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {}
+
+    override def write(index: Int, current: InternalRow): Unit = {}
+
+    override def currentUpperBound(): Int = 0
+  }
+
+  private def withAllocationFailures[T](numFailures: Int)(
+      body: (TestDistinctWindowFunctionFrame, Seq[(UnsafeRow, UnsafeRow)]) => T): T = {
+    val memoryManager = new TestMemoryManager(
+      new SparkConf(false).set("spark.buffer.pageSize", "1m"))
+    val taskMemoryManager = new TaskMemoryManager(memoryManager, 0)
+    val previousContext = TaskContext.get()
+    TaskContext.setTaskContext(new TaskContextImpl(
+      stageId = 0,
+      stageAttemptNumber = 0,
+      partitionId = 0,
+      taskAttemptId = 0,
+      attemptNumber = 0,
+      numPartitions = 1,
+      taskMemoryManager = taskMemoryManager,
+      localProperties = new Properties,
+      metricsSystem = null))
+
+    var frame: TestDistinctWindowFunctionFrame = null
+    try {
+      val inputAttribute = AttributeReference("key", IntegerType, nullable = false)()
+      frame = new TestDistinctWindowFunctionFrame(
+        inputAttribute,
+        SQLMetrics.createSizeMetric(sparkContext, "spill size"))
+      val keyProjection = UnsafeProjection.create(Array[DataType](IntegerType))
+      val positionProjection =
+        UnsafeProjection.create(Array[DataType](IntegerType, IntegerType))
+      def key(value: Int): UnsafeRow =
+        keyProjection(new GenericInternalRow(Array[Any](value))).copy()
+      def position(firstVisibleIndex: Int, inputIndex: Int): UnsafeRow =
+        positionProjection(
+          new GenericInternalRow(Array[Any](firstVisibleIndex, inputIndex))).copy()
+      val rows = Seq(
+        key(1) -> position(0, 0),
+        key(1) -> position(1, 1),
+        key(2) -> position(2, 2))
+
+      memoryManager.markConsequentOOM(numFailures)
+      body(frame, rows)
+    } finally {
+      if (frame != null) {
+        frame.close()
+      }
+      assert(taskMemoryManager.cleanUpAllAllocatedMemory() === 0L)
+      if (previousContext != null) {
+        TaskContext.setTaskContext(previousContext)
+      } else {
+        TaskContext.unset()
+      }
+    }
+  }
+
+  test("fall back to the sorter when BytesToBytesMap construction runs out of memory") {
+    withAllocationFailures(1) { (frame, rows) =>
+      assert(frame.deduplicate(rows) === Seq(1 -> 0, 2 -> 2))
+    }
+  }
+
+  test("propagate an OOM when the fallback sorter also cannot allocate memory") {
+    withAllocationFailures(2) { (frame, rows) =>
+      intercept[SparkOutOfMemoryError] {
+        frame.deduplicate(rows)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrameSuite.scala
@@ -38,7 +38,8 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
 
   private final class TestDistinctWindowFunctionFrame(
       inputAttribute: Attribute,
-      spillSize: SQLMetric)
+      spillSize: SQLMetric,
+      spillSizeThreshold: Long = Long.MaxValue)
     extends DistinctWindowFunctionFrame(
       target = new GenericInternalRow(1),
       processor = null,
@@ -48,9 +49,14 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
       spillSize = spillSize,
       hashFallbackThreshold = Int.MaxValue,
       spillThreshold = Int.MaxValue,
-      spillSizeThreshold = Long.MaxValue) {
+      spillSizeThreshold = spillSizeThreshold) {
 
     def deduplicate(rows: Seq[(UnsafeRow, UnsafeRow)]): Seq[(Int, Int)] = {
+      deduplicateAndGetSpillSize(rows)._1
+    }
+
+    def deduplicateAndGetSpillSize(
+        rows: Seq[(UnsafeRow, UnsafeRow)]): (Seq[(Int, Int)], Long) = {
       val builder = new FirstVisibleRowsBuilder
       try {
         rows.foreach { case (key, position) => builder.add(key, position) }
@@ -58,7 +64,7 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
         builder.foreachDistinctRow { (key, position) =>
           result.append((key.getInt(0), position.getInt(1)))
         }
-        result.toSeq
+        result.toSeq -> builder.getSpillSize
       } finally {
         builder.close()
       }
@@ -130,25 +136,26 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
         inputAttribute,
         SQLMetrics.createSizeMetric(sparkContext, "spill size"))
       try {
-        val keyProjection = UnsafeProjection.create(Array[DataType](IntegerType))
-        val positionProjection =
-          UnsafeProjection.create(Array[DataType](IntegerType, IntegerType))
-        def key(value: Int): UnsafeRow =
-          keyProjection(new GenericInternalRow(Array[Any](value))).copy()
-        def position(firstVisibleIndex: Int, inputIndex: Int): UnsafeRow =
-          positionProjection(
-            new GenericInternalRow(Array[Any](firstVisibleIndex, inputIndex))).copy()
-        val rows = Seq(
-          key(1) -> position(0, 0),
-          key(1) -> position(1, 1),
-          key(2) -> position(2, 2))
-
         memoryManager.markConsequentOOM(numFailures)
-        body(frame, rows)
+        body(frame, distinctRows())
       } finally {
         frame.close()
       }
     }
+  }
+
+  private def distinctRows(): Seq[(UnsafeRow, UnsafeRow)] = {
+    val keyProjection = UnsafeProjection.create(Array[DataType](IntegerType))
+    val positionProjection = UnsafeProjection.create(Array[DataType](IntegerType, IntegerType))
+    def key(value: Int): UnsafeRow =
+      keyProjection(new GenericInternalRow(Array[Any](value))).copy()
+    def position(firstVisibleIndex: Int, inputIndex: Int): UnsafeRow =
+      positionProjection(
+        new GenericInternalRow(Array[Any](firstVisibleIndex, inputIndex))).copy()
+    Seq(
+      key(1) -> position(0, 0),
+      key(1) -> position(1, 1),
+      key(2) -> position(2, 2))
   }
 
   test("fall back to the sorter when BytesToBytesMap construction runs out of memory") {
@@ -161,6 +168,23 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
     withAllocationFailures(2) { (frame, rows) =>
       intercept[SparkOutOfMemoryError] {
         frame.deduplicate(rows)
+      }
+    }
+  }
+
+  test("spill the distinct-key sorter after size-based fallback") {
+    withTaskMemoryManager { (_, _) =>
+      val inputAttribute = AttributeReference("key", IntegerType, nullable = false)()
+      val frame = new TestDistinctWindowFunctionFrame(
+        inputAttribute,
+        SQLMetrics.createSizeMetric(sparkContext, "spill size"),
+        spillSizeThreshold = 1L)
+      try {
+        val (result, spillSize) = frame.deduplicateAndGetSpillSize(distinctRows())
+        assert(result === Seq(1 -> 0, 2 -> 2))
+        assert(spillSize > 0L)
+      } finally {
+        frame.close()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/DistinctWindowFunctionFrameSuite.scala
@@ -25,8 +25,10 @@ import org.apache.spark.{SparkConf, TaskContext, TaskContextImpl}
 import org.apache.spark.memory.{SparkOutOfMemoryError, TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, GenericInternalRow}
+import org.apache.spark.sql.catalyst.expressions.{
+  Attribute, AttributeReference, Expression, GenericInternalRow, MutableProjection}
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Count
 import org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -76,8 +78,23 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
     override def currentUpperBound(): Int = 0
   }
 
-  private def withAllocationFailures[T](numFailures: Int)(
-      body: (TestDistinctWindowFunctionFrame, Seq[(UnsafeRow, UnsafeRow)]) => T): T = {
+  private final class CountingCurrentRowBoundOrdering extends BoundOrdering {
+    var numComparisons: Int = 0
+
+    def reset(): Unit = numComparisons = 0
+
+    override def compare(
+        inputRow: InternalRow,
+        inputIndex: Int,
+        outputRow: InternalRow,
+        outputIndex: Int): Int = {
+      numComparisons += 1
+      Integer.compare(inputRow.getInt(0), outputRow.getInt(0))
+    }
+  }
+
+  private def withTaskMemoryManager[T](
+      body: (TestMemoryManager, TaskMemoryManager) => T): T = {
     val memoryManager = new TestMemoryManager(
       new SparkConf(false).set("spark.buffer.pageSize", "1m"))
     val taskMemoryManager = new TaskMemoryManager(memoryManager, 0)
@@ -93,36 +110,43 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
       localProperties = new Properties,
       metricsSystem = null))
 
-    var frame: TestDistinctWindowFunctionFrame = null
     try {
-      val inputAttribute = AttributeReference("key", IntegerType, nullable = false)()
-      frame = new TestDistinctWindowFunctionFrame(
-        inputAttribute,
-        SQLMetrics.createSizeMetric(sparkContext, "spill size"))
-      val keyProjection = UnsafeProjection.create(Array[DataType](IntegerType))
-      val positionProjection =
-        UnsafeProjection.create(Array[DataType](IntegerType, IntegerType))
-      def key(value: Int): UnsafeRow =
-        keyProjection(new GenericInternalRow(Array[Any](value))).copy()
-      def position(firstVisibleIndex: Int, inputIndex: Int): UnsafeRow =
-        positionProjection(
-          new GenericInternalRow(Array[Any](firstVisibleIndex, inputIndex))).copy()
-      val rows = Seq(
-        key(1) -> position(0, 0),
-        key(1) -> position(1, 1),
-        key(2) -> position(2, 2))
-
-      memoryManager.markConsequentOOM(numFailures)
-      body(frame, rows)
+      body(memoryManager, taskMemoryManager)
     } finally {
-      if (frame != null) {
-        frame.close()
-      }
       assert(taskMemoryManager.cleanUpAllAllocatedMemory() === 0L)
       if (previousContext != null) {
         TaskContext.setTaskContext(previousContext)
       } else {
         TaskContext.unset()
+      }
+    }
+  }
+
+  private def withAllocationFailures[T](numFailures: Int)(
+      body: (TestDistinctWindowFunctionFrame, Seq[(UnsafeRow, UnsafeRow)]) => T): T = {
+    withTaskMemoryManager { (memoryManager, _) =>
+      val inputAttribute = AttributeReference("key", IntegerType, nullable = false)()
+      val frame = new TestDistinctWindowFunctionFrame(
+        inputAttribute,
+        SQLMetrics.createSizeMetric(sparkContext, "spill size"))
+      try {
+        val keyProjection = UnsafeProjection.create(Array[DataType](IntegerType))
+        val positionProjection =
+          UnsafeProjection.create(Array[DataType](IntegerType, IntegerType))
+        def key(value: Int): UnsafeRow =
+          keyProjection(new GenericInternalRow(Array[Any](value))).copy()
+        def position(firstVisibleIndex: Int, inputIndex: Int): UnsafeRow =
+          positionProjection(
+            new GenericInternalRow(Array[Any](firstVisibleIndex, inputIndex))).copy()
+        val rows = Seq(
+          key(1) -> position(0, 0),
+          key(1) -> position(1, 1),
+          key(2) -> position(2, 2))
+
+        memoryManager.markConsequentOOM(numFailures)
+        body(frame, rows)
+      } finally {
+        frame.close()
       }
     }
   }
@@ -137,6 +161,89 @@ class DistinctWindowFunctionFrameSuite extends QueryTest with SharedSparkSession
     withAllocationFailures(2) { (frame, rows) =>
       intercept[SparkOutOfMemoryError] {
         frame.deduplicate(rows)
+      }
+    }
+  }
+
+  test("track range upper bounds lazily across partitions") {
+    withTaskMemoryManager { (_, _) =>
+      val inputAttribute = AttributeReference("value", IntegerType, nullable = false)()
+      val target = new GenericInternalRow(1)
+      val processor = AggregateProcessor(
+        Array[Expression](Count(Seq(inputAttribute))),
+        ordinal = 0,
+        inputAttributes = Seq(inputAttribute),
+        (expressions, schema) => MutableProjection.create(expressions, schema),
+        filters = Array[Option[Expression]](None))
+      val upperBound = new CountingCurrentRowBoundOrdering
+      val frame = new UnboundedPrecedingDistinctWindowFunctionFrame(
+        target,
+        processor,
+        distinctExpressions = Seq(inputAttribute),
+        filter = None,
+        inputSchema = Seq(inputAttribute),
+        upperBound,
+        SQLMetrics.createSizeMetric(sparkContext, "spill size"),
+        hashFallbackThreshold = Int.MaxValue,
+        spillThreshold = Int.MaxValue,
+        spillSizeThreshold = Long.MaxValue)
+      val rows = new ExternalAppendOnlyUnsafeRowArray(
+        Int.MaxValue,
+        Long.MaxValue,
+        Int.MaxValue,
+        Long.MaxValue)
+      val projection = UnsafeProjection.create(Array[DataType](IntegerType))
+
+      def addRows(values: Seq[Int]): Unit = {
+        values.foreach { value =>
+          rows.add(projection(new GenericInternalRow(Array[Any](value))))
+        }
+      }
+
+      try {
+        addRows(Seq(1, 1, 3))
+        frame.prepare(rows)
+        upperBound.reset()
+
+        val firstPartition = rows.generateIterator()
+        frame.write(0, firstPartition.next())
+        assert(target.getLong(0) === 1L)
+        assert(upperBound.numComparisons === 0)
+        assert(frame.currentUpperBound() === 2)
+        assert(upperBound.numComparisons === 3)
+
+        frame.write(1, firstPartition.next())
+        assert(target.getLong(0) === 1L)
+        assert(upperBound.numComparisons === 3)
+        assert(frame.currentUpperBound() === 2)
+        assert(upperBound.numComparisons === 4)
+
+        frame.write(2, firstPartition.next())
+        assert(target.getLong(0) === 2L)
+        assert(upperBound.numComparisons === 4)
+        assert(frame.currentUpperBound() === 3)
+        assert(upperBound.numComparisons === 5)
+
+        rows.clear()
+        addRows(Seq(2, 4))
+        frame.prepare(rows)
+        upperBound.reset()
+
+        val secondPartition = rows.generateIterator()
+        frame.write(0, secondPartition.next())
+        assert(target.getLong(0) === 1L)
+        assert(upperBound.numComparisons === 0)
+        assert(frame.currentUpperBound() === 1)
+        assert(upperBound.numComparisons === 2)
+
+        frame.write(1, secondPartition.next())
+        assert(target.getLong(0) === 2L)
+        assert(upperBound.numComparisons === 2)
+        assert(frame.currentUpperBound() === 2)
+        assert(upperBound.numComparisons === 3)
+      } finally {
+        frame.close()
+        rows.clear()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowFunctionSuite.scala
@@ -403,9 +403,9 @@ class SegmentTreeWindowFunctionSuite extends SharedSparkSession {
         collect_list($"v").over(winSpec(-2, 2)).as("lst")))
   }
 
-  test("DISTINCT window aggregate is rejected by analyzer regardless of seg-tree flag") {
-    // Analyzer throws DISTINCT_WINDOW_FUNCTION_UNSUPPORTED before frame
-    // construction; seg-tree flag must not alter this behavior.
+  test("DISTINCT moving-frame aggregate is rejected regardless of seg-tree flag") {
+    // The analyzer rejects this bounded frame before frame construction; the seg-tree flag must
+    // not alter this behavior.
     def run(): Unit = {
       baseDF.select($"id", $"pk",
         count_distinct($"v").over(winSpec(-3, 3)).as("cd")).collect()


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR adds support for distinct aggregate window functions whose lower frame bound is
`UNBOUNDED PRECEDING`, including:

- Full-partition frames ending at `UNBOUNDED FOLLOWING`.
- Growing `ROWS` and `RANGE` frames.
- General distinct aggregate functions, not only `COUNT(DISTINCT ...)`.
- Multiple distinct arguments, aggregate filters, and order-sensitive aggregates such as
  `LISTAGG(DISTINCT ...)`.

The implementation:

- Uses `BytesToBytesMap` to deduplicate binary-stable keys in memory.
- Permanently falls back to `UnsafeKVExternalSorter` when the hash threshold is reached or
  memory allocation fails.
- Uses first-occurrence events to incrementally update growing window frames.
- Evaluates full-partition frames once without retaining or restoring the input row order.
- Adds caller-owned sorter lifecycle support and spill metrics.
- Introduces the internal
  `spark.sql.windowExec.distinct.hash.fallbackThreshold` configuration.

Bounded and sliding distinct window frames remain unsupported.

### Why are the changes needed?
Spark currently rejects all distinct aggregate window functions, including common expressions
such as:

```sql
COUNT(DISTINCT value) OVER (
  PARTITION BY key
  ORDER BY id
  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
```
A simple in-memory hash set can consume unbounded memory for partitions with many distinct
values. This implementation combines hash-based deduplication with an external-sort fallback,
providing fast execution for normal workloads while allowing large partitions to spill to disk.


### Does this PR introduce _any_ user-facing change?
Yes.

- DISTINCT aggregate window functions are supported when the window frame has an
  `UNBOUNDED PRECEDING` lower bound and the DISTINCT arguments are orderable.
  Python UDAFs and bounded or sliding lower frame bounds are not supported.
- `UnsafeExternalSorter.insertKVRecord` now honors the existing force-spill thresholds.
  The default behavior is unchanged, but users who lower
  `spark.shuffle.spill.numElementsForceSpillThreshold` or
  `spark.shuffle.spill.maxSizeInBytesForSpillThreshold` may observe additional spills
  in `ObjectHashAggregateExec`.


### How was this patch tested?
The test coverage includes:
Growing ROWS and RANGE frames.
Full-partition frames.
COUNT, SUM, AVG, COLLECT_LIST, and LISTAGG with DISTINCT.
Multiple distinct arguments, filters, and null values.
Hash fallback triggered by entry-count and memory thresholds.
External sorter spills and spill metric reporting.
Binary-unstable collations, normalized floating-point values, and empty distinct keys.
Negative tests for unsupported bounded frames.
The relevant targeted SQL window tests and scalastyle checks pass locally. The LISTAGG
SQL golden results were regenerated to cover the newly supported behavior.


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex (GPT-5)
