### PR TITLE
[SPARK-58615][ML] Avoid FPGrowthModel temporary column conflicts

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/fpm/FPGrowth.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/fpm/FPGrowth.scala
@@ -280,6 +280,7 @@ class FPGrowthModel private[ml] (
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
     val dt = dataset.schema($(itemsCol)).dataType
+    val rulesCol = Identifiable.randomUID("rules")
     // For each rule, examine the input items and summarize the consequents.
     val predictFunc = (items: Seq[Any], rules: Seq[Row]) => {
       if (items != null) {
@@ -293,9 +294,9 @@ class FPGrowthModel private[ml] (
     val predictUDF = SparkUserDefinedFunction(predictFunc, dt, Nil)
     dataset.join(
       associationRules.select("antecedent", "consequent")
-        .agg(collect_set(struct("antecedent", "consequent")).as("rules")))
-      .withColumn($(predictionCol), predictUDF(col($(itemsCol)), col("rules")))
-      .drop("rules")
+        .agg(collect_set(struct("antecedent", "consequent")).as(rulesCol)))
+      .withColumn($(predictionCol), predictUDF(col($(itemsCol)), col(rulesCol)))
+      .drop(rulesCol)
   }
 
   @Since("2.2.0")

--- a/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
@@ -126,13 +126,6 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     assert(prediction === Seq("3"))
   }
 
-  test("FPGrowth transform should preserve an input rules column") {
-    val data = dataset.withColumn("rules", lit("input"))
-    val transformed = new FPGrowth().setMinSupport(0.5).fit(data).transform(data)
-
-    assert(transformed.select("rules").collect().forall(_.getString(0) == "input"))
-  }
-
   test("FPGrowthModel setMinConfidence should affect rules generation and transform") {
     val model = new FPGrowth().setMinSupport(0.1).setMinConfidence(0.1).fit(dataset)
     val oldRulesNum = model.associationRules.count()

--- a/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/fpm/FPGrowthSuite.scala
@@ -126,6 +126,13 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext with Defaul
     assert(prediction === Seq("3"))
   }
 
+  test("FPGrowth transform should preserve an input rules column") {
+    val data = dataset.withColumn("rules", lit("input"))
+    val transformed = new FPGrowth().setMinSupport(0.5).fit(data).transform(data)
+
+    assert(transformed.select("rules").collect().forall(_.getString(0) == "input"))
+  }
+
   test("FPGrowthModel setMinConfidence should affect rules generation and transform") {
     val model = new FPGrowth().setMinSupport(0.1).setMinConfidence(0.1).fit(dataset)
     val oldRulesNum = model.associationRules.count()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up to #57806 gives the transient association-rules column in `FPGrowthModel.transform` a generated name instead of the fixed name `rules`. It also adds regression coverage for an input dataset that already contains a `rules` column.

### Why are the changes needed?

The fixed temporary column can conflict with an input column of the same name after the join, causing ambiguous-column analysis failures or dropping the user's column.

### Does this PR introduce _any_ user-facing change?

Yes. `FPGrowthModel.transform` now supports and preserves an input column named `rules`.

### How was this patch tested?

- `build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 mllib/Test/compile`
- Added `FPGrowthSuite` coverage for an input `rules` column. The focused suite has not been run locally yet.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)