### PR TITLE
[SPARK-58429][SQL] Uncorrelated IN-subquery selected with a global aggregate returns false/NULL instead of true when the input is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -140,6 +140,12 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     }
   }
 
+  private def exprsContainUncorrelatedInSubquery(exprs: Seq[Expression]): Boolean = {
+    exprs.exists(_.exists {
+      case in: InSubquery => !in.query.isCorrelated
+      case _ => false
+    })
+  }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
     _.containsAnyPattern(EXISTS_SUBQUERY, LIST_SUBQUERY)) {
@@ -311,9 +317,12 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     // pulled up into the Project node. These expressions use attributes
     // (_aggregateexpression#20L and _aggregateexpression#21L) to refer to the aggregations
     // which are still performed in the Aggregate node (sum(col2#18) and sum(col3#19)).
+    // Also split global aggregates with uncorrelated INs: first(exists) is NULL on empty input.
     case p @ PhysicalAggregation(
         groupingExpressions, aggregateExpressions, resultExpressions, child)
-        if exprsContainsAggregateInSubquery(p.expressions) =>
+        if exprsContainsAggregateInSubquery(p.expressions) ||
+          (groupingExpressions.isEmpty &&
+            exprsContainUncorrelatedInSubquery(resultExpressions)) =>
       val aggExprs = aggregateExpressions.map(
         ae => Alias(ae, "_aggregateexpression")(ae.resultId))
       val aggExprIds = aggExprs.map(_.exprId).toSet

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Cast, EqualTo, Exists, InSubquery, IsNull, ListQuery, Literal, Not, Or}
+import org.apache.spark.sql.catalyst.expressions.{CaseWhen, Cast, EqualTo, Exists, InSubquery, IsNull, ListQuery, Literal, Not, Or}
+import org.apache.spark.sql.catalyst.expressions.aggregate.First
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, LeftSemi, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types.LongType
 
@@ -122,6 +123,35 @@ class RewriteSubquerySuite extends PlanTest {
         Some($"_aggregateexpression" === $"c3"))
       .select($"exists".as("(sum(col2) IN (listquery()))")).analyze
     comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-58429: rewrite uncorrelated IN above a global aggregate over empty input") {
+    val outer = LocalRelation($"a".int)
+    val inner = LocalRelation($"b".int)
+    val query = outer.groupBy()(
+      count(1).as("cnt"),
+      Literal(1).in(ListQuery(inner.select($"b"))).as("in"))
+
+    val optimized = Optimize.execute(query.analyze)
+    val join = optimized.collectFirst { case j: Join => j }.get
+
+    assert(join.left.isInstanceOf[Aggregate])
+    assert(!optimized.exists { plan =>
+      plan.expressions.exists(_.exists(_.isInstanceOf[First]))
+    })
+  }
+
+  test("SPARK-58429: uncorrelated IN inside an aggregate function stays below the aggregate") {
+    val outer = LocalRelation($"a".int)
+    val inner = LocalRelation($"b".int)
+    val in = Literal(1).in(ListQuery(inner.select($"b")))
+    val query = outer.groupBy()(
+      count(CaseWhen(Seq((in, Literal(1))), None)).as("cnt"))
+
+    val optimized = Optimize.execute(query.analyze)
+    val agg = optimized.collectFirst { case a: Aggregate => a }.get
+
+    assert(agg.exists(_.isInstanceOf[Join]))
   }
 
   test("SPARK-57005: No None.get when correlated predicates are eliminated") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2629,6 +2629,21 @@ class SubquerySuite extends SharedSparkSession
     }
   }
 
+  test("SPARK-58429: uncorrelated IN subquery with global aggregate over empty input") {
+    checkAnswer(
+      sql("SELECT count(*), 1 IN (SELECT id FROM range(1, 2)) FROM range(0)"),
+      Row(0L, true))
+    checkAnswer(
+      sql("SELECT count(*), 2 IN (SELECT id FROM range(1, 2)) FROM range(0)"),
+      Row(0L, false))
+    checkAnswer(
+      sql("SELECT count(*), 1 IN (SELECT id FROM range(0)) FROM range(0)"),
+      Row(0L, false))
+    checkAnswer(
+      sql("SELECT count(*), 1 IN (SELECT id FROM range(1, 2)) FROM range(2)"),
+      Row(2L, true))
+  }
+
   test("SPARK-51738: IN subquery with struct type") {
     checkAnswer(
       sql("SELECT foo IN (SELECT struct(1 a)) FROM (SELECT struct(1 b) foo)"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR rewrites an uncorrelated `IN` subquery in the result expressions of a global aggregate above the `Aggregate`.

This avoids wrapping the introduced `exists` attribute in `First`, which does not preserve the subquery result when the aggregate input is empty.

The rewrite only inspects `resultExpressions`, so subqueries inside aggregate functions remain below the aggregate and are not repeatedly rewritten.

### Why are the changes needed?

A global aggregate produces one output row even when its input is empty. Currently, `RewritePredicateSubquery` places the `ExistenceJoin` below the aggregate and wraps its result in `First(exists)`.

For example:

```sql
SELECT count(*), 1 IN (SELECT id FROM range(1, 2))
FROM range(0);
```

Previously, this returned:

```text
0, false
```

The expected result is:

```text
0, true
```

The `IN` predicate is uncorrelated and should be evaluated on the single row produced by the global aggregate.

### Does this PR introduce _any_ user-facing change?

Yes. Uncorrelated `IN` subqueries projected alongside a global aggregate over empty input now return the correct result. There is no public API change.

### How was this patch tested?

Added regression coverage that verifies:

- the `ExistenceJoin` is placed above the global aggregate;
- `First(exists)` is not introduced for this case;
- subqueries inside aggregate functions remain below the aggregate;
- true and false `IN` results over empty input;
- empty subquery behavior;
- existing behavior over non-empty input.

`RewriteSubquerySuite` passed with 8 tests. The modified source and test files compile successfully, and Scalastyle reports no errors or warnings.

### Was this patch authored or co-authored using generative AI tooling?

co-authored by Codex (GPT-5)