### PR TITLE
[MINOR][INFRA] Clarify JIRA reuse for follow-up PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,17 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-Use `[FOLLOWUP]` only when a PR directly modifies or corrects unreleased work from one or more specific earlier PRs, such as addressing post-merge review feedback or fixing a regression introduced by those changes. A separately planned PR that implements another part of a JIRA's original scope is a continuation: reuse the JIRA and use the normal title format without `[FOLLOWUP]`. If the work falls outside the original scope, or if any earlier change has been released, create a new JIRA ticket and do not use `[FOLLOWUP]`. Otherwise, reuse the earlier PRs' JIRA ticket(s) and insert `[FOLLOWUP]` after the component tag, for example `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
+Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased work from
+one or more specific earlier PRs, such as addressing post-merge review feedback or fixing
+a regression introduced by those changes. Reuse the earlier PRs' JIRA ticket(s) and insert
+`[FOLLOWUP]` after the component tag, for example
+`[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
+
+Do not treat a separately planned PR as a follow-up just because it shares a JIRA with an
+earlier PR. If the existing JIRA still covers the work, use the normal title format with
+that JIRA and without `[FOLLOWUP]`. If the work falls outside the existing JIRA's scope, or
+if any earlier change has been released, create a new JIRA ticket and do not use
+`[FOLLOWUP]`.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-If a PR follows up on one or more earlier PRs, reuse their existing JIRA ticket(s). Do not create a new JIRA ticket for the follow-up PR.
+If a PR follows up on one or more earlier PRs whose changes have not been released, reuse their existing JIRA ticket(s) and add `[FOLLOWUP]` to the PR title. If any earlier change has been released, create a new JIRA ticket and do not use `[FOLLOWUP]`.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-If a PR follows up on one or more earlier PRs whose changes have not been released, reuse their existing JIRA ticket(s) and add `[FOLLOWUP]` to the PR title. If any earlier change has been released, create a new JIRA ticket and do not use `[FOLLOWUP]`.
+Use `[FOLLOWUP]` only when a PR directly modifies or corrects unreleased work from one or more specific earlier PRs, such as addressing post-merge review feedback or fixing a regression introduced by those changes. A separately planned PR that implements another part of a JIRA's original scope is a continuation: reuse the JIRA and use the normal title format without `[FOLLOWUP]`. If the work falls outside the original scope, or if any earlier change has been released, create a new JIRA ticket and do not use `[FOLLOWUP]`. Otherwise, reuse the earlier PRs' JIRA ticket(s) and insert `[FOLLOWUP]` after the component tag, for example `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,7 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased earlier PRs.
-For separately planned work, non-trivial changes, or work outside the earlier JIRA's scope, create a separate JIRA ticket for each PR and use the normal title format without `[FOLLOWUP]`.
+Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased earlier PRs. For separately planned work, non-trivial changes, or work outside the earlier JIRA's scope, create a separate JIRA ticket for each PR and use the normal title format without `[FOLLOWUP]`.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,9 +204,7 @@ PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVI
 
 Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased work from
 one or more specific earlier PRs, such as addressing post-merge review feedback or fixing
-a regression introduced by those changes. Reuse the earlier PRs' JIRA ticket(s) and insert
-`[FOLLOWUP]` after the component tag, for example
-`[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
+a regression introduced by those changes.
 
 Do not use `[FOLLOWUP]` for a separately planned PR that implements a distinct part of a
 larger effort. For separately planned non-trivial PRs, create a separate JIRA ticket for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,8 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-If a PR follows up on one or more earlier PRs, reuse their existing JIRA ticket or tickets. Do not
-create a new JIRA ticket for the follow-up PR.
+If a PR follows up on one or more earlier PRs, reuse their existing JIRA ticket(s). Do not create a
+new JIRA ticket for the follow-up PR.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,8 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-If a PR follows up on an earlier PR, reuse the earlier PR's JIRA ticket. Do not create a new JIRA
-ticket for the follow-up PR.
+If a PR follows up on one or more earlier PRs, reuse their existing JIRA ticket or tickets. Do not
+create a new JIRA ticket for the follow-up PR.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,15 +202,8 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased work from
-one or more specific earlier PRs, such as addressing post-merge review feedback or fixing
-a regression introduced by those changes.
-
-Do not use `[FOLLOWUP]` for a separately planned PR that implements a distinct part of a
-larger effort. For separately planned non-trivial PRs, create a separate JIRA ticket for
-each PR and use the normal title format without `[FOLLOWUP]`. Also create a new JIRA ticket
-if the work falls outside the earlier JIRA's scope, or if any earlier change has been
-released.
+Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased earlier PRs.
+For separately planned non-trivial work, create a separate JIRA and use the normal title format.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,9 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
+If a PR follows up on an earlier PR, reuse the earlier PR's JIRA ticket. Do not create a new JIRA
+ticket for the follow-up PR.
+
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 
     python3 dev/create_spark_jira.py "<title>" -c <component> { -t <type> | -p <parent-jira-id> }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,11 +208,11 @@ a regression introduced by those changes. Reuse the earlier PRs' JIRA ticket(s) 
 `[FOLLOWUP]` after the component tag, for example
 `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
 
-Do not treat a separately planned PR as a follow-up just because it shares a JIRA with an
-earlier PR. If the existing JIRA still covers the work, use the normal title format with
-that JIRA and without `[FOLLOWUP]`. If the work falls outside the existing JIRA's scope, or
-if any earlier change has been released, create a new JIRA ticket and do not use
-`[FOLLOWUP]`.
+Do not use `[FOLLOWUP]` for a separately planned PR that implements a distinct part of a
+larger effort. For separately planned non-trivial PRs, create a separate JIRA ticket for
+each PR and use the normal title format without `[FOLLOWUP]`. Also create a new JIRA ticket
+if the work falls outside the earlier JIRA's scope, or if any earlier change has been
+released.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,7 @@ It lists `master` and the latest major's release branches the commit reached (e.
 
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
-If a PR follows up on one or more earlier PRs, reuse their existing JIRA ticket(s). Do not create a
-new JIRA ticket for the follow-up PR.
+If a PR follows up on one or more earlier PRs, reuse their existing JIRA ticket(s). Do not create a new JIRA ticket for the follow-up PR.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ It lists `master` and the latest major's release branches the commit reached (e.
 PR title format is `[SPARK-xxxx][COMPONENT] Title`. Draft, WIP, MINOR, and TRIVIAL PRs may omit the JIRA ID. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
 
 Use `[FOLLOWUP]` only for small PRs that directly modify or correct unreleased earlier PRs.
-For separately planned non-trivial work, create a separate JIRA and use the normal title format.
+For separately planned work, non-trivial changes, or work outside the earlier JIRA's scope, create a separate JIRA ticket for each PR and use the normal title format without `[FOLLOWUP]`.
 
 Infer the PR title from the changes. If no ticket ID is given and the PR is not draft, WIP, MINOR, or TRIVIAL, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clarify the pull request workflow in `AGENTS.md`: follow-up PRs reuse the JIRA ticket from the earlier PR and must not create a new ticket.

### Why are the changes needed?

This avoids duplicate JIRA tickets for work that is already tracked by an existing issue.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`git diff --check` passed. No runtime tests were run because this only updates contributor instructions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex CLI 0.146.1