### PR TITLE
[SPARK-58580][PS][FOLLOWUP] Preserve ldexp zero and infinity inputs

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -127,7 +127,10 @@ binary_np_spark_mappings = {
     .otherwise(F.lit(1.0)),
     "hypot": F.hypot,
     "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "ldexp": lambda c1, c2: c1.cast("double") * F.pow(F.lit(2.0), c2),
+    "ldexp": lambda c1, c2: F.when(
+        c1.cast("double").isin(0.0, float("-inf"), float("inf")),
+        c1.cast("double"),
+    ).otherwise(c1.cast("double") * F.pow(F.lit(2.0), c2)),
     # F.shiftleft accepts literal counts only; call_function also accepts a column.
     # NumPy returns zero for counts outside an int64's bit width, unlike JVM shifts.
     "left_shift": lambda c1, c2: F.when((c2 < 0) | (c2 >= 64), F.lit(0)).otherwise(

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -188,13 +188,38 @@ class NumPyCompatTestsMixin:
                     1.0,
                     1.0,
                     1.0,
+                    0.0,
+                    -0.0,
+                    np.inf,
+                    -np.inf,
                 ],
-                "exp": [2, 3, -2, -3, -3, 0, -2, 2, 2, 2, -1074, -1075, 1024],
+                "exp": [
+                    2,
+                    3,
+                    -2,
+                    -3,
+                    -3,
+                    0,
+                    -2,
+                    2,
+                    2,
+                    2,
+                    -1074,
+                    -1075,
+                    1024,
+                    1024,
+                    1024,
+                    -1075,
+                    -1075,
+                ],
             }
         )
         psdf = ps.from_pandas(pdf)
 
-        self.assert_eq(np.ldexp(psdf.x, psdf.exp), np.ldexp(pdf.x, pdf.exp), almost=True)
+        result = np.ldexp(psdf.x, psdf.exp)
+        expected = np.ldexp(pdf.x, pdf.exp)
+        self.assert_eq(result, expected, almost=True)
+        self.assert_eq(np.signbit(result.to_pandas()), np.signbit(expected))
 
     def test_np_fmax_fmin(self):
         for pdf in (


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up updates the native `np.ldexp` mapping to return a zero or infinite significand directly before evaluating `pow(2.0, exp)`. This avoids the invalid intermediate products `0.0 * Infinity` and `Infinity * 0.0`.

### Why are the changes needed?

For extreme exponents, the standalone power expression can overflow or underflow before multiplication. The prior native mapping therefore returned `NaN` for valid inputs such as `np.ldexp(0.0, 1024)` and `np.ldexp(np.inf, -1075)`, instead of preserving zero or infinity as NumPy does.

### Does this PR introduce _any_ user-facing change?

Yes. It corrects `np.ldexp` results for zero and infinite significands with exponents that overflow or underflow the power intermediate.

### How was this patch tested?

Added cases for positive and negative zero with exponent `1024`, plus positive and negative infinity with exponent `-1075`. The test also checks result sign bits.

- `python/run-tests --testnames pyspark.pandas.tests.test_numpy_compat.NumPyCompatTests.test_np_ldexp`
- `python/run-tests --testnames pyspark.pandas.tests.connect.test_parity_numpy_compat.NumPyCompatParityTests.test_np_ldexp`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5