### PR TITLE
[SPARK-58618][BUILD] Fix duplicated path in lint-scala scalafmt failure message

### DIFF
--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -39,7 +39,7 @@ ERRORS=$(./build/mvn \
 )
 
 if test ! -z "$ERRORS"; then
-  echo -e "The scalafmt check failed on sql/connect or sql/connect at following occurrences:\n\n$ERRORS\n"
+  echo -e "The scalafmt check failed on sql/api or sql/connect at following occurrences:\n\n$ERRORS\n"
   echo "Before submitting your change, please make sure to format your code using the following command:"
   echo "./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl sql/api -pl sql/connect/common -pl sql/connect/server -pl sql/connect/shims -pl sql/connect/client/jvm"
   exit 1


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the scalafmt failure message in `dev/lint-scala`, which names the same path twice:

```
The scalafmt check failed on sql/connect or sql/connect at following occurrences:
```

The first path is corrected to `sql/api`, so the message reads `sql/api or sql/connect`.

### Why are the changes needed?

The check runs over `sql/api` plus four modules under `sql/connect` (`common`, `server`, `shims`, `client/jvm`), so `sql/connect or sql/connect` is a tautology that tells the reader nothing about the first module. The corrected wording matches the `-pl` module list printed on the very next line of the same script.

The duplication is a leftover of the module rename in SPARK-49428: the message previously read `sql/connect or connector/connect`, and applying the `connector/connect` to `sql/connect` rename to the message text collapsed both halves to the same path. The `sql/api` module had been added to the check earlier, in SPARK-49511, without the message being updated.

### Does this PR introduce _any_ user-facing change?

No. Developer-facing message text in a lint script only.

### How was this patch tested?

No functional change. The edited string is inside an existing `echo -e` and no test, CI workflow, or doc matches on this message text, so nothing consumes it programmatically.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
