### PR TITLE
[SPARK-58620][EXAMPLES] Fix incorrect comments and stale usage docs in the custom receiver examples

### DIFF
--- a/docs/streaming-custom-receivers.md
+++ b/docs/streaming-custom-receivers.md
@@ -75,7 +75,7 @@ class CustomReceiver(host: String, port: Int)
 
   def onStop() {
     // There is nothing much to do as the thread calling receive()
-    // is designed to stop by itself if isStopped() returns false
+    // is designed to stop by itself when isStopped() returns true
   }
 
   /** Create a socket connection and receive data until receiver is stopped */
@@ -137,7 +137,7 @@ public class JavaCustomReceiver extends Receiver<String> {
   @Override
   public void onStop() {
     // There is nothing much to do as the thread calling receive()
-    // is designed to stop by itself if isStopped() returns false
+    // is designed to stop by itself when isStopped() returns true
   }
 
   /** Create a socket connection and receive data until receiver is stopped */

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaCustomReceiver.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaCustomReceiver.java
@@ -38,12 +38,12 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 
 /**
- * Custom Receiver that receives data over a socket. Received bytes is interpreted as
+ * Custom Receiver that receives data over a socket. Received bytes are interpreted as
  * text and \n delimited lines are considered as records. They are then counted and printed.
  *
- * Usage: JavaCustomReceiver <master> <hostname> <port>
- *   <master> is the Spark master URL. In local mode, <master> should be 'local[n]' with n > 1.
- *   <hostname> and <port> of the TCP server that Spark Streaming would connect to receive data.
+ * Usage: JavaCustomReceiver <hostname> <port>
+ *   <hostname> and <port> describe the TCP server that Spark Streaming would connect to receive
+ *   data.
  *
  * To run this on your local machine, you need to first run a Netcat server
  *    `$ nc -lk 9999`
@@ -99,7 +99,7 @@ public class JavaCustomReceiver extends Receiver<String> {
   @Override
   public void onStop() {
     // There is nothing much to do as the thread calling receive()
-    // is designed to stop by itself isStopped() returns false
+    // is designed to stop by itself when isStopped() returns true
   }
 
   /** Create a socket connection and receive data until receiver is stopped */

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/CustomReceiver.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/CustomReceiver.scala
@@ -73,7 +73,7 @@ class CustomReceiver(host: String, port: Int)
 
   def onStop(): Unit = {
    // There is nothing much to do as the thread calling receive()
-   // is designed to stop by itself isStopped() returns false
+   // is designed to stop by itself when isStopped() returns true
   }
 
   /** Create a socket connection and receive data until receiver is stopped */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes documentation defects in the custom receiver examples:

1. `JavaCustomReceiver` documents a `<master>` argument the example does not accept. The class comment is corrected to `Usage: JavaCustomReceiver <hostname> <port>` and the stale `<master>` explanation is dropped. The `<hostname>`/`<port>` line, which had no verb, is reworded to "describe the TCP server ...".
2. The `onStop()` comment described the loop continuation condition instead of the stop condition. Corrected to "is designed to stop by itself when `isStopped()` returns true" in `JavaCustomReceiver.java`, `CustomReceiver.scala`, and both snippets in `docs/streaming-custom-receivers.md`.
3. `Received bytes is interpreted as` becomes `are` in `JavaCustomReceiver.java`.

### Why are the changes needed?

Each defect is verifiable against the code in the same file:

- `main()` gates on `args.length < 2` and reads only `args[0]` as hostname and `args[1]` as port; `SparkConf` is built with `setAppName` only, and `setMaster` has never appeared in this file. The in-code `System.err.println` already prints the two-argument usage, so only the class comment disagreed. The stale text is a leftover of SPARK-1826, which removed the positional master argument but left the comment block partly updated. This is the last remaining `<master>` usage text under `examples/`.
- The receive loop is `while (!isStopped() && ...)` in both the Java and Scala examples, so the thread exits when `isStopped()` returns **true**. The old comment stated the opposite, and also lacked a conjunction. The docs page hand-inlines these snippets rather than using `include_example`, so it had drifted the same way and is fixed alongside.
- "Received bytes" is plural. SPARK-15645 fixed this in `CustomReceiver.scala` but missed the Java counterpart.

The `onStop()` fix is applied to all four occurrences so the Java example, its Scala twin, and the docs snippets stay consistent.

### Does this PR introduce _any_ user-facing change?

No. Comments, example usage text, and documentation snippets only.

### How was this patch tested?

No functional change; nothing executable is modified. The corrected statements were each checked against the surrounding code (argument parsing and the `while (!isStopped())` loop).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
