### PR TITLE
[SPARK-58621][ML] Add descriptive messages to SummarizerBuffer metric accessor require checks

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -648,7 +648,7 @@ private[spark] class SummarizerBuffer(
    * Sample mean of each dimension.
    */
   def mean: Vector = {
-    require(requestedMetrics.contains(Mean))
+    require(requestedMetrics.contains(Mean), "mean was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     val realMean = Array.ofDim[Double](n)
@@ -664,7 +664,7 @@ private[spark] class SummarizerBuffer(
    * Sum of each dimension.
    */
   def sum: Vector = {
-    require(requestedMetrics.contains(Sum))
+    require(requestedMetrics.contains(Sum), "sum was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     val realSum = Array.ofDim[Double](n)
@@ -680,7 +680,7 @@ private[spark] class SummarizerBuffer(
    * Unbiased estimate of sample variance of each dimension.
    */
   def variance: Vector = {
-    require(requestedMetrics.contains(Variance))
+    require(requestedMetrics.contains(Variance), "variance was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     val realVariance = computeVariance
@@ -691,7 +691,7 @@ private[spark] class SummarizerBuffer(
    * Unbiased estimate of standard deviation of each dimension.
    */
   def std: Vector = {
-    require(requestedMetrics.contains(Std))
+    require(requestedMetrics.contains(Std), "std was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     val realVariance = computeVariance
@@ -732,7 +732,7 @@ private[spark] class SummarizerBuffer(
    *
    */
   def numNonzeros: Vector = {
-    require(requestedMetrics.contains(NumNonZeros))
+    require(requestedMetrics.contains(NumNonZeros), "numNonZeros was not a requested metric.")
     require(totalCnt > 0, s"Nothing has been added to this summarizer.")
 
     Vectors.dense(nnz.map(_.toDouble))
@@ -742,7 +742,7 @@ private[spark] class SummarizerBuffer(
    * Maximum value of each dimension.
    */
   def max: Vector = {
-    require(requestedMetrics.contains(Max))
+    require(requestedMetrics.contains(Max), "max was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     var i = 0
@@ -757,7 +757,7 @@ private[spark] class SummarizerBuffer(
    * Minimum value of each dimension.
    */
   def min: Vector = {
-    require(requestedMetrics.contains(Min))
+    require(requestedMetrics.contains(Min), "min was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     var i = 0
@@ -772,7 +772,7 @@ private[spark] class SummarizerBuffer(
    * L2 (Euclidean) norm of each dimension.
    */
   def normL2: Vector = {
-    require(requestedMetrics.contains(NormL2))
+    require(requestedMetrics.contains(NormL2), "normL2 was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     val realMagnitude = Array.ofDim[Double](n)
@@ -790,7 +790,7 @@ private[spark] class SummarizerBuffer(
    * L1 norm of each dimension.
    */
   def normL1: Vector = {
-    require(requestedMetrics.contains(NormL1))
+    require(requestedMetrics.contains(NormL1), "normL1 was not a requested metric.")
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     Vectors.dense(currL1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a short descriptive message to the nine bare `require(requestedMetrics.contains(X))` guards in `SummarizerBuffer`, so that reading a metric that was not requested fails with a message naming the metric:

```scala
require(requestedMetrics.contains(Mean), "mean was not a requested metric.")
```

### Why are the changes needed?

These guards currently produce a bare `requirement failed`, which does not indicate which metric was involved. The quoted names match the user-facing metric names accepted by `Summarizer.metrics(...)` per the `allMetrics` table, including `numNonZeros` (the metric string differs in casing from the `numNonzeros` accessor, so the message quotes the name a caller actually passes).

These are plain `require` calls rather than part of the structured error-condition framework, and the adjacent `require(totalWeightSum > 0, ...)` check in each of the same methods already carries a message, so this brings the metric guards in line with their immediate neighbours.

### Does this PR introduce _any_ user-facing change?

No. `SummarizerBuffer` is `private[spark]`, and only the message text of an existing check is added.

### How was this patch tested?

Conditions and exception types are unchanged, so existing tests continue to apply; the error-handling tests in `SummarizerSuite` assert only the exception type and do not match on message text.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
