### PR TITLE
[MINOR][DOC] Check both AGENTS.md and CLAUDE.md for nested project instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,13 @@ When exploring or working in any directory, always check for nested `AGENTS.md` 
 directory and its ancestors. Read and follow every applicable file; instructions in a more specific
 directory take precedence for that directory's scope.
 
+A directory may carry these instructions as `CLAUDE.md` rather than `AGENTS.md`, so check **both**
+names — a directory with only a `CLAUDE.md` has project instructions you must read too. Where both
+exist, `AGENTS.md` is the real file and `CLAUDE.md` is a symlink to it, as at the repository root,
+so reading either one is enough. When adding instructions to a directory that has neither, name the
+new file `AGENTS.md` and add a `CLAUDE.md` symlink beside it (`ln -s AGENTS.md CLAUDE.md`) to keep
+one source of truth readable under both names.
+
 ## Versioning and Branch Policy
 
 When a change needs a version — `@since` annotations, config `.version("...")` (`SQLConf` / `*Conf`), new `MimaExcludes` sections, etc. — use the version of the branch it first ships in, with `-SNAPSHOT` stripped. Determine that branch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,12 +241,7 @@ When exploring or working in any directory, always check for nested `AGENTS.md` 
 directory and its ancestors. Read and follow every applicable file; instructions in a more specific
 directory take precedence for that directory's scope.
 
-A directory may carry these instructions as `CLAUDE.md` rather than `AGENTS.md`, so check **both**
-names — a directory with only a `CLAUDE.md` has project instructions you must read too. Where both
-exist, `AGENTS.md` is the real file and `CLAUDE.md` is a symlink to it, as at the repository root,
-so reading either one is enough. When adding instructions to a directory that has neither, name the
-new file `AGENTS.md` and add a `CLAUDE.md` symlink beside it (`ln -s AGENTS.md CLAUDE.md`) to keep
-one source of truth readable under both names.
+A directory may carry these instructions as `CLAUDE.md` rather than `AGENTS.md`, so check **both** names — a directory with only a `CLAUDE.md` has project instructions you must read too. Where both files exist, one is typically the real file and the other is a symlink to it, although either name may be the real file. Reading either one is sufficient. When adding instructions to a directory that has neither file, create AGENTS.md as the real file and add a CLAUDE.md symlink beside it (ln -s AGENTS.md CLAUDE.md). This keeps a single source of truth accessible under both names.
 
 ## Versioning and Branch Policy
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extends the "Project Instructions Discovery" section of the root `AGENTS.md` to cover `CLAUDE.md` as
well as `AGENTS.md`.

The section currently tells agents to look for nested `AGENTS.md` files only. That wording arrived in
160b6193ee3 (`[MINOR][DOC] Use AGENTS.md for nested project instructions`), which replaced the
previous `CLAUDE.md` wording. This PR:

- says to check **both** names, and notes that a directory with only a `CLAUDE.md` still has
  instructions that must be read;
- documents the convention this repository already follows at the root (`AGENTS.md` is the real file,
  `CLAUDE.md` is a symlink to it), so a reader knows either name resolves to the same content and
  there is nothing to reconcile;
- states which name to use when adding instructions to a directory that has neither.

Docs only -- no code, no build files.

### Why are the changes needed?

`CLAUDE.md` is the filename Claude Code discovers by convention, and contributors add project
instructions under that name. An agent that follows the current instruction literally looks for
`AGENTS.md` only and skips a directory whose instructions live in a `CLAUDE.md`. Spelling out the
symlink convention also keeps the two names from drifting into two separate documents.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests; this changes prose in a markdown file.

### Was this patch authored or co-authored using generative AI tooling?

Yes
