### PR TITLE
[SPARK-58632][CONNECT] Send Spark Connect operation ID in gRPC metadata

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1690,7 +1690,6 @@ class SparkConnectClient(object):
         for hook in self._session_hooks:
             req = hook.on_execute_plan(req)
             req.operation_id = operation_id
-        metadata = self._execute_plan_metadata(req.operation_id)
 
         def handle_response(b: pb2.ExecutePlanResponse) -> None:
             self._verify_response_integrity(b)
@@ -1702,7 +1701,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    metadata,
+                    self._execute_plan_metadata(req.operation_id),
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )
@@ -1716,7 +1715,9 @@ class SparkConnectClient(object):
                 for attempt in self._retrying():
                     with attempt:
                         with disable_gc():
-                            for b in self._stub.ExecutePlan(req, metadata=metadata):
+                            for b in self._stub.ExecutePlan(
+                                req, metadata=self._execute_plan_metadata(req.operation_id)
+                            ):
                                 handle_response(b)
         except Exception as error:
             self._handle_error(error, req.operation_id)
@@ -1756,8 +1757,6 @@ class SparkConnectClient(object):
         for hook in self._session_hooks:
             req = hook.on_execute_plan(req)
             req.operation_id = operation_id
-        metadata = self._execute_plan_metadata(req.operation_id)
-
         num_records = 0
         arrow_batch_chunks_to_assemble: List[bytes] = []
 
@@ -1932,7 +1931,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    metadata,
+                    self._execute_plan_metadata(req.operation_id),
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )
@@ -1946,7 +1945,11 @@ class SparkConnectClient(object):
                 for attempt in self._retrying():
                     with attempt:
                         with disable_gc():
-                            it = iter(self._stub.ExecutePlan(req, metadata=metadata))
+                            it = iter(
+                                self._stub.ExecutePlan(
+                                    req, metadata=self._execute_plan_metadata(req.operation_id)
+                                )
+                            )
                         while True:
                             try:
                                 with disable_gc():

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -888,14 +888,14 @@ class SparkConnectClient(object):
             if isinstance(connection, ChannelBuilder)
             else DefaultChannelBuilder(connection, channel_options)
         )
-        metadata = self._builder.metadata()
+        metadata = list(self._builder.metadata())
         if any(key.lower() == _OPERATION_ID_METADATA_KEY for key, _ in metadata):
             logger.warning(
                 "Connection option %s is ignored because Spark Connect sets it for each "
                 "ExecutePlan request.",
                 _OPERATION_ID_METADATA_KEY,
             )
-        self._metadata = [
+        artifact_manager_metadata = [
             (key, value) for key, value in metadata if key.lower() != _OPERATION_ID_METADATA_KEY
         ]
         self._user_id = None
@@ -938,7 +938,7 @@ class SparkConnectClient(object):
             self._user_id,
             self._session_id,
             self._channel,
-            self._metadata,
+            artifact_manager_metadata,
             add_artifacts_timeout=self._rpc_deadlines.add_artifacts,
             artifact_status_timeout=self._rpc_deadlines.artifact_status,
         )
@@ -1665,7 +1665,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.AnalyzePlan(
                         req,
-                        metadata=self._metadata,
+                        metadata=self._builder_metadata(),
                         timeout=self._rpc_deadlines.analyze_plan,
                     )
                     self._verify_response_integrity(resp)
@@ -1721,8 +1721,15 @@ class SparkConnectClient(object):
         except Exception as error:
             self._handle_error(error, req.operation_id)
 
+    def _builder_metadata(self) -> List[Tuple[str, str]]:
+        return [
+            (key, value)
+            for key, value in self._builder.metadata()
+            if key.lower() != _OPERATION_ID_METADATA_KEY
+        ]
+
     def _execute_plan_metadata(self, operation_id: str) -> List[Tuple[str, str]]:
-        metadata = list(self._metadata)
+        metadata = self._builder_metadata()
         metadata.append((_OPERATION_ID_METADATA_KEY, operation_id))
         return metadata
 
@@ -2080,7 +2087,7 @@ class SparkConnectClient(object):
                     with disable_gc():
                         resp = self._stub.Config(
                             req,
-                            metadata=self._metadata,
+                            metadata=self._builder_metadata(),
                             timeout=self._rpc_deadlines.config,
                         )
                     self._verify_response_integrity(resp)
@@ -2126,7 +2133,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.Interrupt(
                         req,
-                        metadata=self._metadata,
+                        metadata=self._builder_metadata(),
                         timeout=self._rpc_deadlines.interrupt,
                     )
                     self._verify_response_integrity(resp)
@@ -2142,7 +2149,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.Interrupt(
                         req,
-                        metadata=self._metadata,
+                        metadata=self._builder_metadata(),
                         timeout=self._rpc_deadlines.interrupt,
                     )
                     self._verify_response_integrity(resp)
@@ -2158,7 +2165,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.Interrupt(
                         req,
-                        metadata=self._metadata,
+                        metadata=self._builder_metadata(),
                         timeout=self._rpc_deadlines.interrupt,
                     )
                     self._verify_response_integrity(resp)
@@ -2178,7 +2185,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.ReleaseSession(
                         req,
-                        metadata=self._metadata,
+                        metadata=self._builder_metadata(),
                         timeout=self._rpc_deadlines.release_session,
                     )
                     self._verify_response_integrity(resp)
@@ -2234,7 +2241,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.GetStatus(
                         req,
-                        metadata=self._metadata,
+                        metadata=self._builder_metadata(),
                         timeout=self._rpc_deadlines.get_status,
                     )
                     self._verify_response_integrity(resp)
@@ -2368,7 +2375,7 @@ class SparkConnectClient(object):
         try:
             return self._stub.FetchErrorDetails(
                 req,
-                metadata=self._metadata,
+                metadata=self._builder_metadata(),
                 timeout=self._rpc_deadlines.fetch_error_details,
             )
         except grpc.RpcError:
@@ -2787,7 +2794,7 @@ class SparkConnectClient(object):
             with attempt:
                 response: pb2.CloneSessionResponse = self._stub.CloneSession(
                     request,
-                    metadata=self._metadata,
+                    metadata=self._builder_metadata(),
                     timeout=self._rpc_deadlines.clone_session,
                 )
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -888,6 +888,12 @@ class SparkConnectClient(object):
             if isinstance(connection, ChannelBuilder)
             else DefaultChannelBuilder(connection, channel_options)
         )
+        if any(key.lower() == _OPERATION_ID_METADATA_KEY for key, _ in self._builder.metadata()):
+            logger.warning(
+                "Connection option %s is ignored because Spark Connect sets it for each "
+                "ExecutePlan request.",
+                _OPERATION_ID_METADATA_KEY,
+            )
         self._user_id = None
         self._retry_policies: List[RetryPolicy] = []
 
@@ -1933,9 +1939,7 @@ class SparkConnectClient(object):
                 for attempt in self._retrying():
                     with attempt:
                         with disable_gc():
-                            it = iter(
-                                self._stub.ExecutePlan(req, metadata=metadata)
-                            )
+                            it = iter(self._stub.ExecutePlan(req, metadata=metadata))
                         while True:
                             try:
                                 with disable_gc():

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -888,12 +888,16 @@ class SparkConnectClient(object):
             if isinstance(connection, ChannelBuilder)
             else DefaultChannelBuilder(connection, channel_options)
         )
-        if any(key.lower() == _OPERATION_ID_METADATA_KEY for key, _ in self._builder.metadata()):
+        metadata = self._builder.metadata()
+        if any(key.lower() == _OPERATION_ID_METADATA_KEY for key, _ in metadata):
             logger.warning(
                 "Connection option %s is ignored because Spark Connect sets it for each "
                 "ExecutePlan request.",
                 _OPERATION_ID_METADATA_KEY,
             )
+        self._metadata = [
+            (key, value) for key, value in metadata if key.lower() != _OPERATION_ID_METADATA_KEY
+        ]
         self._user_id = None
         self._retry_policies: List[RetryPolicy] = []
 
@@ -934,7 +938,7 @@ class SparkConnectClient(object):
             self._user_id,
             self._session_id,
             self._channel,
-            self._builder.metadata(),
+            self._metadata,
             add_artifacts_timeout=self._rpc_deadlines.add_artifacts,
             artifact_status_timeout=self._rpc_deadlines.artifact_status,
         )
@@ -1661,7 +1665,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.AnalyzePlan(
                         req,
-                        metadata=self._builder.metadata(),
+                        metadata=self._metadata,
                         timeout=self._rpc_deadlines.analyze_plan,
                     )
                     self._verify_response_integrity(resp)
@@ -1718,11 +1722,7 @@ class SparkConnectClient(object):
             self._handle_error(error, req.operation_id)
 
     def _execute_plan_metadata(self, operation_id: str) -> List[Tuple[str, str]]:
-        metadata = [
-            (key, value)
-            for key, value in self._builder.metadata()
-            if key.lower() != _OPERATION_ID_METADATA_KEY
-        ]
+        metadata = list(self._metadata)
         metadata.append((_OPERATION_ID_METADATA_KEY, operation_id))
         return metadata
 
@@ -2080,7 +2080,7 @@ class SparkConnectClient(object):
                     with disable_gc():
                         resp = self._stub.Config(
                             req,
-                            metadata=self._builder.metadata(),
+                            metadata=self._metadata,
                             timeout=self._rpc_deadlines.config,
                         )
                     self._verify_response_integrity(resp)
@@ -2126,7 +2126,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.Interrupt(
                         req,
-                        metadata=self._builder.metadata(),
+                        metadata=self._metadata,
                         timeout=self._rpc_deadlines.interrupt,
                     )
                     self._verify_response_integrity(resp)
@@ -2142,7 +2142,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.Interrupt(
                         req,
-                        metadata=self._builder.metadata(),
+                        metadata=self._metadata,
                         timeout=self._rpc_deadlines.interrupt,
                     )
                     self._verify_response_integrity(resp)
@@ -2158,7 +2158,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.Interrupt(
                         req,
-                        metadata=self._builder.metadata(),
+                        metadata=self._metadata,
                         timeout=self._rpc_deadlines.interrupt,
                     )
                     self._verify_response_integrity(resp)
@@ -2178,7 +2178,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.ReleaseSession(
                         req,
-                        metadata=self._builder.metadata(),
+                        metadata=self._metadata,
                         timeout=self._rpc_deadlines.release_session,
                     )
                     self._verify_response_integrity(resp)
@@ -2234,7 +2234,7 @@ class SparkConnectClient(object):
                 with attempt:
                     resp = self._stub.GetStatus(
                         req,
-                        metadata=self._builder.metadata(),
+                        metadata=self._metadata,
                         timeout=self._rpc_deadlines.get_status,
                     )
                     self._verify_response_integrity(resp)
@@ -2368,7 +2368,7 @@ class SparkConnectClient(object):
         try:
             return self._stub.FetchErrorDetails(
                 req,
-                metadata=self._builder.metadata(),
+                metadata=self._metadata,
                 timeout=self._rpc_deadlines.fetch_error_details,
             )
         except grpc.RpcError:
@@ -2787,7 +2787,7 @@ class SparkConnectClient(object):
             with attempt:
                 response: pb2.CloneSessionResponse = self._stub.CloneSession(
                     request,
-                    metadata=self._builder.metadata(),
+                    metadata=self._metadata,
                     timeout=self._rpc_deadlines.clone_session,
                 )
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
 
 
 PYSPARK_ROOT = os.path.dirname(pyspark.__file__)
+_OPERATION_ID_METADATA_KEY = "spark-connect-operation-id"
 
 
 @dataclass(frozen=True)
@@ -1679,6 +1680,7 @@ class SparkConnectClient(object):
         for hook in self._session_hooks:
             req = hook.on_execute_plan(req)
             req.operation_id = operation_id
+        metadata = self._execute_plan_metadata(req.operation_id)
 
         def handle_response(b: pb2.ExecutePlanResponse) -> None:
             self._verify_response_integrity(b)
@@ -1690,7 +1692,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    self._builder.metadata(),
+                    metadata,
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )
@@ -1704,10 +1706,19 @@ class SparkConnectClient(object):
                 for attempt in self._retrying():
                     with attempt:
                         with disable_gc():
-                            for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
+                            for b in self._stub.ExecutePlan(req, metadata=metadata):
                                 handle_response(b)
         except Exception as error:
             self._handle_error(error, req.operation_id)
+
+    def _execute_plan_metadata(self, operation_id: str) -> List[Tuple[str, str]]:
+        metadata = [
+            (key, value)
+            for key, value in self._builder.metadata()
+            if key.lower() != _OPERATION_ID_METADATA_KEY
+        ]
+        metadata.append((_OPERATION_ID_METADATA_KEY, operation_id))
+        return metadata
 
     def _execute_and_fetch_as_iterator(
         self,
@@ -1732,6 +1743,7 @@ class SparkConnectClient(object):
         for hook in self._session_hooks:
             req = hook.on_execute_plan(req)
             req.operation_id = operation_id
+        metadata = self._execute_plan_metadata(req.operation_id)
 
         num_records = 0
         arrow_batch_chunks_to_assemble: List[bytes] = []
@@ -1907,7 +1919,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    self._builder.metadata(),
+                    metadata,
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )
@@ -1922,7 +1934,7 @@ class SparkConnectClient(object):
                     with attempt:
                         with disable_gc():
                             it = iter(
-                                self._stub.ExecutePlan(req, metadata=self._builder.metadata())
+                                self._stub.ExecutePlan(req, metadata=metadata)
                             )
                         while True:
                             try:

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -784,7 +784,7 @@ class CachedRemoteRelation(LogicalPlan):
                             request_serializer=request_serializer,
                             response_deserializer=response_deserializer,
                         )
-                        metadata = session.client._builder.metadata()
+                        metadata = session.client._execute_plan_metadata(req.operation_id)
                         channel(req, metadata=metadata)  # type: ignore[arg-type]
             except Exception as e:
                 logger.warning(f"RemoveRemoteCachedRelation failed with exception: {e}.")

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -299,6 +299,32 @@ class SparkConnectClientTestCase(unittest.TestCase):
 
         self.assertEqual(client._user_id, "abc")
 
+    def test_channel_builder_metadata_is_filtered_per_call(self):
+        class CustomChannelBuilder(DefaultChannelBuilder):
+            def __init__(self):
+                super().__init__("sc://foo/")
+                self.metadata_calls = 0
+
+            def metadata(self):
+                self.metadata_calls += 1
+                return iter(
+                    [
+                        ("authorization", f"token-{self.metadata_calls}"),
+                        ("spark-connect-operation-id", "ignored"),
+                    ]
+                )
+
+        builder = CustomChannelBuilder()
+        client = SparkConnectClient(builder, use_reattachable_execute=False)
+        try:
+            self.assertEqual(
+                client._artifact_manager._metadata, [("authorization", "token-1")]
+            )
+            self.assertEqual(client._builder_metadata(), [("authorization", "token-2")])
+            self.assertEqual(client._builder_metadata(), [("authorization", "token-3")])
+        finally:
+            client.close()
+
     def test_user_context_extension(self):
         client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         mock = MockService(client._session_id)

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -566,7 +566,8 @@ class SparkConnectClientTestCase(unittest.TestCase):
             req = client._execute_plan_request_with_metadata()
             client._execute(req)
             self.assertIsNotNone(mock.metadata)
-            self.assertEqual(dict(mock.metadata)["spark-connect-operation-id"], req.operation_id)
+            values = [v for k, v in mock.metadata if k == "spark-connect-operation-id"]
+            self.assertEqual(values, [req.operation_id])
         finally:
             client.close()
 

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -113,16 +113,22 @@ if should_test_connect:
             self.release_calls = 0
             self.release_until_calls = 0
             self.attach_calls = 0
+            self.execute_metadata = []
+            self.attach_metadata = []
+            self.release_metadata = []
 
         def ExecutePlan(self, *args, **kwargs):
             self.execute_calls += 1
+            self.execute_metadata.append(kwargs.get("metadata"))
             return self._execute_ops
 
         def ReattachExecute(self, *args, **kwargs):
             self.attach_calls += 1
+            self.attach_metadata.append(kwargs.get("metadata"))
             return self._attach_ops
 
         def ReleaseExecute(self, req: proto.ReleaseExecuteRequest, *args, **kwargs):
+            self.release_metadata.append(kwargs.get("metadata"))
             if req.HasField("release_all"):
                 self.release_calls += 1
             elif req.HasField("release_until"):
@@ -317,9 +323,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         builder = CustomChannelBuilder()
         client = SparkConnectClient(builder, use_reattachable_execute=False)
         try:
-            self.assertEqual(
-                client._artifact_manager._metadata, [("authorization", "token-1")]
-            )
+            self.assertEqual(client._artifact_manager._metadata, [("authorization", "token-1")])
             self.assertEqual(client._builder_metadata(), [("authorization", "token-2")])
             self.assertEqual(client._builder_metadata(), [("authorization", "token-3")])
         finally:
@@ -994,6 +998,21 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
             self.assertEqual(1, stub.release_until_calls)
             self.assertEqual(1, stub.release_calls)
             self.assertEqual(1, stub.execute_calls)
+
+        eventually(timeout=1, catch_assertions=True)(check_all)()
+
+    def test_operation_id_metadata_is_sent_on_all_rpcs(self):
+        metadata = [("spark-connect-operation-id", "operation-id")]
+        stub = self._stub_with([self.response], [self.finished])
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, metadata)
+        for _ in ite:
+            pass
+
+        def check_all():
+            self.assertEqual(stub.execute_metadata, [metadata])
+            self.assertEqual(stub.attach_metadata, [metadata])
+            self.assertTrue(stub.release_metadata)
+            self.assertTrue(all(value == metadata for value in stub.release_metadata))
 
         eventually(timeout=1, catch_assertions=True)(check_all)()
 

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -149,6 +149,7 @@ if should_test_connect:
         def __init__(self, session_id: str, operation_statuses=None):
             self._session_id = session_id
             self.req = None
+            self.metadata = None
             self.client_user_context_extensions = []
             if operation_statuses is None:
                 operation_statuses = self.DEFAULT_OPERATION_STATUSES
@@ -156,6 +157,7 @@ if should_test_connect:
 
         def ExecutePlan(self, req: proto.ExecutePlanRequest, metadata, timeout=None):
             self.req = req
+            self.metadata = metadata
             self.client_user_context_extensions = list(req.user_context.extensions)
             resp = proto.ExecutePlanResponse()
             resp.session_id = self._session_id
@@ -551,6 +553,20 @@ class SparkConnectClientTestCase(unittest.TestCase):
         try:
             req = client._execute_plan_request_with_metadata()
             uuid.UUID(req.operation_id)
+        finally:
+            client.close()
+
+    def test_execute_plan_sends_operation_id_metadata(self):
+        client = SparkConnectClient(
+            "sc://foo/;spark-connect-operation-id=ignored", use_reattachable_execute=False
+        )
+        mock = MockService(client._session_id)
+        client._stub = mock
+        try:
+            req = client._execute_plan_request_with_metadata()
+            client._execute(req)
+            self.assertIsNotNone(mock.metadata)
+            self.assertEqual(dict(mock.metadata)["spark-connect-operation-id"], req.operation_id)
         finally:
             client.close()
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -78,19 +78,37 @@ class SparkConnectClientSuite extends ConnectFunSuite {
     assert(client.userId == System.getProperty("user.name"))
   }
 
-  test("client generates an operation ID for ExecutePlan requests") {
-    startDummyServer(0)
-    client = SparkConnectClient
-      .builder()
-      .connectionString(s"sc://localhost:${server.getPort}")
-      .disableReattachableExecute()
-      .build()
+  Seq(false, true).foreach { reattachable =>
+    test(s"client generates an operation ID for ExecutePlan requests ($reattachable)") {
+      var operationIdHeader: Option[String] = None
+      val interceptor = new ServerInterceptor {
+        override def interceptCall[ReqT, RespT](
+            call: ServerCall[ReqT, RespT],
+            headers: Metadata,
+            next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+          val key = Metadata.Key.of(
+            SparkConnectClient.OPERATION_ID_HEADER,
+            Metadata.ASCII_STRING_MARSHALLER)
+          operationIdHeader = Option(headers.get(key))
+          next.startCall(call, headers)
+        }
+      }
+      startDummyServer(0, Seq(interceptor))
+      val builder = SparkConnectClient
+        .builder()
+        .connectionString(s"sc://localhost:${server.getPort}")
+        .option(SparkConnectClient.OPERATION_ID_HEADER, "ignored")
+      if (reattachable) builder.enableReattachableExecute()
+      else builder.disableReattachableExecute()
+      client = builder.build()
 
-    val responses = client.execute(buildPlan("select 1")).toSeq
-    val operationId = responses.head.getOperationId
+      val responses = client.execute(buildPlan("select 1")).toSeq
+      val operationId = responses.head.getOperationId
 
-    UUID.fromString(operationId)
-    assert(responses.forall(_.getOperationId == operationId))
+      UUID.fromString(operationId)
+      assert(responses.forall(_.getOperationId == operationId))
+      assert(operationIdHeader.contains(operationId))
+    }
   }
 
   test("ExecutePlan exceptions expose the client-generated operation ID") {

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -45,8 +45,11 @@ class SparkConnectClientSuite extends ConnectFunSuite {
   private var service: DummySparkConnectService = _
   private var server: Server = _
 
-  private def startDummyServer(port: Int, interceptors: Seq[ServerInterceptor] = Seq()): Unit = {
-    service = new DummySparkConnectService
+  private def startDummyServer(
+      port: Int,
+      interceptors: Seq[ServerInterceptor] = Seq(),
+      dummyService: DummySparkConnectService = new DummySparkConnectService): Unit = {
+    service = dummyService
     val serverBuilder = NettyServerBuilder
       .forPort(port)
       .addService(service)
@@ -80,7 +83,7 @@ class SparkConnectClientSuite extends ConnectFunSuite {
 
   Seq(false, true).foreach { reattachable =>
     test(s"client generates an operation ID for ExecutePlan requests ($reattachable)") {
-      var operationIdHeader: Option[String] = None
+      val operationIdHeaders = mutable.Map.empty[String, Option[String]]
       val interceptor = new ServerInterceptor {
         override def interceptCall[ReqT, RespT](
             call: ServerCall[ReqT, RespT],
@@ -89,11 +92,46 @@ class SparkConnectClientSuite extends ConnectFunSuite {
           val key = Metadata.Key.of(
             SparkConnectClient.OPERATION_ID_HEADER,
             Metadata.ASCII_STRING_MARSHALLER)
-          operationIdHeader = Option(headers.get(key))
+          operationIdHeaders.synchronized {
+            operationIdHeaders(call.getMethodDescriptor.getBareMethodName) =
+              Option(headers.get(key))
+          }
           next.startCall(call, headers)
         }
       }
-      startDummyServer(0, Seq(interceptor))
+      val dummyService = if (reattachable) {
+        new DummySparkConnectService {
+          override def executePlan(
+              request: ExecutePlanRequest,
+              responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
+            responseObserver.onNext(
+              ExecutePlanResponse
+                .newBuilder()
+                .setSessionId(request.getSessionId)
+                .setOperationId(request.getOperationId)
+                .setResponseId("initial-response")
+                .build())
+            responseObserver.onCompleted()
+          }
+
+          override def reattachExecute(
+              request: proto.ReattachExecuteRequest,
+              responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
+            responseObserver.onNext(
+              ExecutePlanResponse
+                .newBuilder()
+                .setSessionId(request.getSessionId)
+                .setOperationId(request.getOperationId)
+                .setResponseId("result-complete")
+                .setResultComplete(proto.ExecutePlanResponse.ResultComplete.newBuilder().build())
+                .build())
+            responseObserver.onCompleted()
+          }
+        }
+      } else {
+        new DummySparkConnectService
+      }
+      startDummyServer(0, Seq(interceptor), dummyService)
       val builder = SparkConnectClient
         .builder()
         .connectionString(s"sc://localhost:${server.getPort}")
@@ -107,7 +145,19 @@ class SparkConnectClientSuite extends ConnectFunSuite {
 
       UUID.fromString(operationId)
       assert(responses.forall(_.getOperationId == operationId))
-      assert(operationIdHeader.contains(operationId))
+      assert(operationIdHeaders.synchronized {
+        operationIdHeaders("ExecutePlan").contains(operationId)
+      })
+      if (reattachable) {
+        assert(operationIdHeaders.synchronized {
+          operationIdHeaders("ReattachExecute").contains(operationId)
+        })
+        Eventually.eventually(timeout(5.seconds)) {
+          assert(operationIdHeaders.synchronized {
+            operationIdHeaders("ReleaseExecute").contains(operationId)
+          })
+        }
+      }
     }
   }
 

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -48,8 +48,9 @@ private[connect] class CustomSparkConnectBlockingStub(
   private def executePlanStub(operationId: String) =
     SparkConnectServiceGrpc
       .newBlockingStub(channel)
-      .withInterceptors(new SparkConnectClient.MetadataHeaderClientInterceptor(
-        Map(SparkConnectClient.OPERATION_ID_HEADER -> operationId)))
+      .withInterceptors(
+        new SparkConnectClient.MetadataHeaderClientInterceptor(
+          Map(SparkConnectClient.OPERATION_ID_HEADER -> operationId)))
 
   // Non-reattachable executePlan intentionally has no deadline: a timeout here would kill the
   // server-side execution with no way to recover (there is no ReattachExecute for this path).

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -56,7 +56,7 @@ private[connect] class CustomSparkConnectBlockingStub(
   // server-side execution with no way to recover (there is no ReattachExecute for this path).
   // Use reattachable execution for long-running queries that need deadline protection.
   def executePlan(request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {
-    val stub = executePlanStub(request.getOperationId)
+    val stubWithOperationId = executePlanStub(request.getOperationId)
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -70,7 +70,7 @@ private[connect] class CustomSparkConnectBlockingStub(
           request,
           r => {
             stubState.responseValidator.wrapIterator(
-              CloseableIterator(stub.executePlan(r).asScala))
+              CloseableIterator(stubWithOperationId.executePlan(r).asScala))
           }),
         Option(request.getOperationId).filter(_.nonEmpty))
     }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -45,12 +45,13 @@ private[connect] class CustomSparkConnectBlockingStub(
   // GrpcExceptionConverter with a GRPC stub for fetching error details from server.
   private val grpcExceptionConverter = stubState.exceptionConverter
 
-  private def executePlanStub(operationId: String) =
-    SparkConnectServiceGrpc
-      .newBlockingStub(channel)
-      .withInterceptors(
+  private def executePlanStub(operationId: String) = {
+    Option(operationId).filter(_.nonEmpty).map { id =>
+      stub.withInterceptors(
         new SparkConnectClient.MetadataHeaderClientInterceptor(
-          Map(SparkConnectClient.OPERATION_ID_HEADER -> operationId)))
+          Map(SparkConnectClient.OPERATION_ID_HEADER -> id)))
+    }.getOrElse(stub)
+  }
 
   // Non-reattachable executePlan intentionally has no deadline: a timeout here would kill the
   // server-side execution with no way to recover (there is no ReattachExecute for this path).

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -46,11 +46,14 @@ private[connect] class CustomSparkConnectBlockingStub(
   private val grpcExceptionConverter = stubState.exceptionConverter
 
   private def executePlanStub(operationId: String) = {
-    Option(operationId).filter(_.nonEmpty).map { id =>
-      stub.withInterceptors(
-        new SparkConnectClient.MetadataHeaderClientInterceptor(
-          Map(SparkConnectClient.OPERATION_ID_HEADER -> id)))
-    }.getOrElse(stub)
+    Option(operationId)
+      .filter(_.nonEmpty)
+      .map { id =>
+        stub.withInterceptors(
+          new SparkConnectClient.MetadataHeaderClientInterceptor(
+            Map(SparkConnectClient.OPERATION_ID_HEADER -> id)))
+      }
+      .getOrElse(stub)
   }
 
   // Non-reattachable executePlan intentionally has no deadline: a timeout here would kill the

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -45,10 +45,17 @@ private[connect] class CustomSparkConnectBlockingStub(
   // GrpcExceptionConverter with a GRPC stub for fetching error details from server.
   private val grpcExceptionConverter = stubState.exceptionConverter
 
+  private def executePlanStub(operationId: String) =
+    SparkConnectServiceGrpc
+      .newBlockingStub(channel)
+      .withInterceptors(new SparkConnectClient.MetadataHeaderClientInterceptor(
+        Map(SparkConnectClient.OPERATION_ID_HEADER -> operationId)))
+
   // Non-reattachable executePlan intentionally has no deadline: a timeout here would kill the
   // server-side execution with no way to recover (there is no ReattachExecute for this path).
   // Use reattachable execution for long-running queries that need deadline protection.
   def executePlan(request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {
+    val stub = executePlanStub(request.getOperationId)
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
@@ -84,7 +84,9 @@ class ExecutePlanResponseReattachableIterator(
   private val operationIdInterceptor = new SparkConnectClient.MetadataHeaderClientInterceptor(
     Map(SparkConnectClient.OPERATION_ID_HEADER -> operationId))
   private val rawBlockingStub =
-    proto.SparkConnectServiceGrpc.newBlockingStub(channel).withInterceptors(operationIdInterceptor)
+    proto.SparkConnectServiceGrpc
+      .newBlockingStub(channel)
+      .withInterceptors(operationIdInterceptor)
   private val rawAsyncStub =
     proto.SparkConnectServiceGrpc.newStub(channel).withInterceptors(operationIdInterceptor)
 

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
@@ -81,8 +81,12 @@ class ExecutePlanResponseReattachableIterator(
   // - this does it's own custom retry handling
   // - error conversion is wrapped around this in CustomSparkConnectBlockingStub,
   //   this needs raw GRPC errors for retries.
-  private val rawBlockingStub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
-  private val rawAsyncStub = proto.SparkConnectServiceGrpc.newStub(channel)
+  private val operationIdInterceptor = new SparkConnectClient.MetadataHeaderClientInterceptor(
+    Map(SparkConnectClient.OPERATION_ID_HEADER -> operationId))
+  private val rawBlockingStub =
+    proto.SparkConnectServiceGrpc.newBlockingStub(channel).withInterceptors(operationIdInterceptor)
+  private val rawAsyncStub =
+    proto.SparkConnectServiceGrpc.newStub(channel).withInterceptors(operationIdInterceptor)
 
   private def stubWithDeadline(deadline: Option[FiniteDuration])
       : proto.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub =

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -56,6 +56,14 @@ private[sql] class SparkConnectClient(
   private val userContext: UserContext = configuration.userContext
 
   private[this] val stubState = new SparkConnectStubState(channel, configuration)
+
+  if (configuration.metadata.keys.exists(
+      _.equalsIgnoreCase(SparkConnectClient.OPERATION_ID_HEADER))) {
+    logWarning(
+      s"Connection option ${SparkConnectClient.OPERATION_ID_HEADER} is ignored because " +
+        "Spark Connect sets it for each ExecutePlan request.")
+  }
+
   private[this] val bstub =
     new CustomSparkConnectBlockingStub(channel, stubState)
   private[this] val stub =

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -703,6 +703,8 @@ private final class SparkConnectOperationIdException(val operationId: String)
 
 object SparkConnectClient {
 
+  private[connect] val OPERATION_ID_HEADER = "spark-connect-operation-id"
+
   /**
    * Returns the ExecutePlan operation ID attached to a Spark Connect failure, when available.
    *
@@ -1178,9 +1180,11 @@ object SparkConnectClient {
 
       // Workaround LocalChannelCredentials are added in
       // https://github.com/grpc/grpc-java/issues/9900
-      var metadataWithOptionalToken = metadata
+      var metadataWithOptionalToken = metadata.filterNot { case (key, _) =>
+        key.equalsIgnoreCase(OPERATION_ID_HEADER)
+      }
       if (!isSslEnabled.contains(true) && isLocal && token.isDefined) {
-        metadataWithOptionalToken = metadata + (("Authorization", s"Bearer ${token.get}"))
+        metadataWithOptionalToken += (("Authorization", s"Bearer ${token.get}"))
       }
 
       if (metadataWithOptionalToken.nonEmpty) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Spark Connect's Scala and Python clients now send the `ExecutePlan` operation ID in the
`spark-connect-operation-id` gRPC metadata header. The same operation ID is used for initial,
reattach, and release RPCs. Client connection options cannot override this per-operation value.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Gateways and other intermediaries cannot reliably correlate an `ExecutePlan` request by inspecting
the protobuf body, especially when a request fails before the server returns a response. A stable,
vendor-neutral metadata header makes the client-generated operation ID available throughout the
request path without decoding the payload.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Spark Connect clients now include `spark-connect-operation-id` in gRPC metadata for operation
RPCs. The value matches `ExecutePlanRequest.operation_id`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added Scala tests for reattachable and non-reattachable clients and a Python test that verifies
connection metadata cannot override the operation ID.

Attempted to run:

`build/sbt 'connect-client-jvm/testOnly org.apache.spark.sql.connect.client.SparkConnectClientSuite'`

The test could not start because Maven Central DNS resolution was unavailable in the local
environment.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: OpenAI Codex (GPT-5)
