### PR TITLE
[SPARK-58733][PYTHON][ML][TEST] Revert test_cv_io_pipeline.py parallelization

### DIFF
--- a/python/pyspark/ml/tests/tuning/test_cv_io_pipeline.py
+++ b/python/pyspark/ml/tests/tuning/test_cv_io_pipeline.py
@@ -16,7 +16,6 @@
 #
 
 import tempfile
-from concurrent.futures import ThreadPoolExecutor
 
 from pyspark.ml.feature import HashingTF, Tokenizer
 from pyspark.ml import Pipeline
@@ -55,7 +54,7 @@ class CrossValidatorIOPipelineTests(SparkSessionTestCase, ValidatorTestUtilsMixi
         tokenizer = Tokenizer(inputCol="text", outputCol="words")
         hashingTF = HashingTF(inputCol=tokenizer.getOutputCol(), outputCol="features")
 
-        ova = OneVsRest(classifier=LogisticRegressionCls(), parallelism=2)
+        ova = OneVsRest(classifier=LogisticRegressionCls())
         lr1 = LogisticRegressionCls().setMaxIter(5)
         lr2 = LogisticRegressionCls().setMaxIter(10)
 
@@ -73,7 +72,6 @@ class CrossValidatorIOPipelineTests(SparkSessionTestCase, ValidatorTestUtilsMixi
             estimatorParamMaps=paramGrid,
             evaluator=MulticlassClassificationEvaluator(),
             numFolds=2,
-            parallelism=4,
         )  # use 3+ folds in practice
         cvPath = temp_path + "/cv"
         crossval.save(cvPath)
@@ -102,7 +100,6 @@ class CrossValidatorIOPipelineTests(SparkSessionTestCase, ValidatorTestUtilsMixi
             estimatorParamMaps=paramGrid,
             evaluator=MulticlassClassificationEvaluator(),
             numFolds=2,
-            parallelism=4,
         )  # use 3+ folds in practice
         cv2Path = temp_path + "/cv2"
         crossval2.save(cv2Path)
@@ -129,13 +126,8 @@ class CrossValidatorIOPipelineTests(SparkSessionTestCase, ValidatorTestUtilsMixi
             self.assertEqual(loadedStage.uid, originalStage.uid)
 
     def test_save_load_pipeline_estimator(self):
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            list(
-                executor.map(
-                    self._run_test_save_load_pipeline_estimator,
-                    [LogisticRegression, DummyLogisticRegression],
-                )
-            )
+        self._run_test_save_load_pipeline_estimator(LogisticRegression)
+        self._run_test_save_load_pipeline_estimator(DummyLogisticRegression)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This reverts the test parallelization introduced by #53725. It runs the real and dummy
logistic-regression variants sequentially and restores the default parallelism for
`CrossValidator` and `OneVsRest`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The test combines an outer two-worker thread pool with `CrossValidator(parallelism=4)` and
`OneVsRest(parallelism=2)`. This is flaky in resource-sensitive cases: the nested concurrency can
exhaust the available JVM heap and fail with `java.lang.OutOfMemoryError: Java heap space` while
Spark is serializing a broadcast. The persistence coverage does not require concurrent model
training, so sequential execution is more reliable.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Syntax and formatting checks:

```
git diff --check
conda run -n spark-dev-313 python -m py_compile \
  python/pyspark/ml/tests/tuning/test_cv_io_pipeline.py
```

The focused PySpark test was not run locally because this checkout did not have assembled Spark
artifacts. It will be covered by the PySpark ML GitHub Actions job.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: OpenAI Codex (GPT-5)
