### PR TITLE
[SPARK-58633][ML] Use integer label indexes in StringIndexerModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -344,7 +344,7 @@ class StringIndexerModel (
   private def filterInvalidData(
       dataset: Dataset[_],
       inputColNames: Seq[String],
-      labelsToIndexArray: Array[OpenHashMap[String, Double]]): Dataset[_] = {
+      labelsToIndexArray: Array[OpenHashMap[String, Int]]): Dataset[_] = {
     val conditions: Seq[Column] = inputColNames.indices.map { i =>
       val inputColName = inputColNames(i)
       val labelToIndex = labelsToIndexArray(i)
@@ -365,9 +365,9 @@ class StringIndexerModel (
 
   private def getIndexer(
       labels: Seq[String],
-      labelToIndex: OpenHashMap[String, Double],
+      labelToIndex: OpenHashMap[String, Int],
       keepInvalid: Boolean) = {
-    val unknownIndex = labels.length.toDouble
+    val unknownIndex = labels.length
     if (keepInvalid) {
       udf { label: String =>
         if (label == null) {
@@ -397,7 +397,7 @@ class StringIndexerModel (
 
     val (inputColNames, outputColNames) = getInOutCols()
     val labelsToIndexArray = labelsArray.map { labels =>
-      val map = new OpenHashMap[String, Double](labels.length)
+      val map = new OpenHashMap[String, Int](labels.length)
       labels.zipWithIndex.foreach { case (label, idx) =>
         map.update(label, idx)
       }
@@ -429,7 +429,7 @@ class StringIndexerModel (
 
         val indexer = getIndexer(labels.toImmutableArraySeq, labelToIndex, keepInvalid)
 
-        outputColumns(i) = indexer(dataset(inputColName).cast(StringType))
+        outputColumns(i) = indexer(dataset(inputColName).cast(StringType)).cast(DoubleType)
           .as(outputColName, metadata)
       } catch {
         case _: AnalysisException =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `StringIndexerModel` label lookup maps from
`OpenHashMap[String, Double]` to `OpenHashMap[String, Int]`. The indexer UDF returns integer
indexes, and the output column is cast to `DoubleType` at the end of the transformation.

### Why are the changes needed?

String index values are inherently integral. Storing them as `Int` instead of `Double` reduces
the memory footprint of the lookup maps captured by `StringIndexerModel` transformations while
preserving the public double-valued output.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing `StringIndexerSuite` covers normal, unseen, skipped, kept, null, numeric, and
multi-column inputs as well as the `DoubleType` output contract. It passed all 28 tests:

`build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 'mllib/testOnly org.apache.spark.ml.feature.StringIndexerSuite'`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
