### PR TITLE
[MINOR][INFRA][4.3] Enable post-merge Build on branch-4.3

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -29,7 +29,4 @@ jobs:
     permissions:
       packages: write
     name: Run
-    # Skip pushes on apache/spark: post-merge CI on this integration/staging
-    # branch is disabled to save resources.
-    if: github.repository != 'apache/spark'
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the repository condition from the branch-4.3 copy of .github/workflows/build_main.yml so pushes to apache/spark invoke the reusable Build workflow.

This makes branch-4.3 consistent with the other stable release branches, such as branch-4.2.

### Why are the changes needed?

branch-4.3 inherited the condition from the branch-4.x integration/staging branch, where post-merge Build runs are intentionally disabled to save resources. As a stable release branch, branch-4.3 advertises the Build workflow in its CI badge list, but every push currently creates a skipped Build run.

The branch-specific scheduler dispatches the separate Java, Maven, Non-ANSI, and Python workflows; it does not enable the main Build workflow.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran git diff --check and verified that branch-4.3 build_main.yml now matches the branch-4.2 stable-branch configuration. No runtime tests were run because this is a GitHub Actions configuration-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)