### PR TITLE
[MINOR][INFRA][4.X] Run post-merge Build every ten commits

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -25,11 +25,30 @@ on:
     - '**'
 
 jobs:
+  count-commits:
+    name: Count commits
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      commit-count: ${{ steps.count.outputs.commit-count }}
+    steps:
+      - name: Check out the full branch history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Count commits on the pushed branch
+        id: count
+        run: echo "commit-count=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+
   call-build-and-test:
     permissions:
       packages: write
     name: Run
-    # Skip pushes on apache/spark: post-merge CI on this integration/staging
-    # branch is disabled to save resources.
-    if: github.repository != 'apache/spark'
+    needs: count-commits
+    # GitHub Actions expressions do not support modulo. A non-negative decimal
+    # count is divisible by ten when it ends in 0.
+    if: >-
+      github.repository != 'apache/spark'
+      || endsWith(needs.count-commits.outputs.commit-count, '0')
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apply the commit-count gating pattern from #57555 to the branch-4.x copy of .github/workflows/build_main.yml.

The workflow checks out the full pushed branch history and counts its commits. Builds on forks continue to run for every push, while post-merge Build runs on apache/spark run when the commit count is divisible by ten.

### Why are the changes needed?

Post-merge Build runs on branch-4.x are currently disabled completely to save CI resources. Running the workflow every ten commits restores periodic validation while retaining most of those resource savings.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran git diff --check and reviewed the workflow diff against the pattern in #57555.

No runtime tests were run because this change modifies only GitHub Actions orchestration.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)