### PR TITLE
[SPARK-58659][SS] Set Real-Time Mode config defaults

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7725,11 +7725,6 @@
           "If you must continue with your existing checkpoint and accept that doing so exposes you to the possibility of data loss on failure, set <config> to true."
         ]
       },
-      "CONFIGURATION_NOT_SUPPORTED" : {
-        "message" : [
-          "The following session configuration(s) are incompatible with Real-Time Mode: <invalidReasons>. Update or remove them and restart the query."
-        ]
-      },
       "IDENTICAL_SOURCES_IN_UNION_NOT_SUPPORTED" : {
         "message" : [
           "Real-time mode does not support union on two or more identical streaming data sources in a single query. This includes scenarios such as referencing the same source DataFrame more than once, or using two data sources with identical configurations for some sources. For Kafka, avoid reusing the same DataFrame and create different ones. Sources provided in the query: <sources>"
@@ -7753,6 +7748,11 @@
       "SINK_NOT_SUPPORTED" : {
         "message" : [
           "The <className> sink is currently not supported. See the Real-Time Mode User Guide for a list of supported sinks."
+        ]
+      },
+      "SQL_CONFIGURATION_NOT_SUPPORTED" : {
+        "message" : [
+          "The following session configuration(s) are incompatible with Real-Time Mode: <invalidReasons>. Update or remove them and restart the query."
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7719,6 +7719,12 @@
           "The checkpointing interval for async progress tracking must be set to 0, which means each progress update is checkpointed. Set option asyncProgressTrackingCheckpointIntervalMs to 0 in DataStreamWriter options and retry your query."
         ]
       },
+      "CHECKPOINT_FORMAT_V1_NOT_SUPPORTED" : {
+        "message" : [
+          "Real-time mode does not support state store checkpoint format v1. If you encountered this while switching an existing query to real-time mode, use a fresh checkpoint location.",
+          "If you must continue with your existing checkpoint and accept that doing so exposes you to the possibility of data loss on failure, set <config> to true."
+        ]
+      },
       "IDENTICAL_SOURCES_IN_UNION_NOT_SUPPORTED" : {
         "message" : [
           "Real-time mode does not support union on two or more identical streaming data sources in a single query. This includes scenarios such as referencing the same source DataFrame more than once, or using two data sources with identical configurations for some sources. For Kafka, avoid reusing the same DataFrame and create different ones. Sources provided in the query: <sources>"

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7725,6 +7725,11 @@
           "If you must continue with your existing checkpoint and accept that doing so exposes you to the possibility of data loss on failure, set <config> to true."
         ]
       },
+      "CONFIGURATION_NOT_SUPPORTED" : {
+        "message" : [
+          "The following session configuration(s) are incompatible with Real-Time Mode: <invalidReasons>. Update or remove them and restart the query."
+        ]
+      },
       "IDENTICAL_SOURCES_IN_UNION_NOT_SUPPORTED" : {
         "message" : [
           "Real-time mode does not support union on two or more identical streaming data sources in a single query. This includes scenarios such as referencing the same source DataFrame more than once, or using two data sources with identical configurations for some sources. For Kafka, avoid reusing the same DataFrame and create different ones. Sources provided in the query: <sources>"

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7721,7 +7721,7 @@
       },
       "CHECKPOINT_FORMAT_V1_NOT_SUPPORTED" : {
         "message" : [
-          "Real-time mode does not support state store checkpoint format v1. If you encountered this while switching an existing query to real-time mode, use a fresh checkpoint location.",
+          "Real-time mode does not support state store checkpoint format v1, because a re-executed batch can reuse the state file names of a partially-written failed batch and lose data. If you encountered this while switching an existing query to real-time mode, use a fresh checkpoint location.",
           "If you must continue with your existing checkpoint and accept that doing so exposes you to the possibility of data loss on failure, set <config> to true."
         ]
       },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3641,10 +3641,12 @@ object SQLConf {
     buildConf("spark.sql.streaming.realTimeMode.dangerouslyAllowCheckpointV1.enabled")
       .internal()
       .doc("Whether to allow a Real-Time Mode query to start on a checkpoint whose commit log " +
-        "is at version 1. Real-Time Mode reruns a failed batch from committed offsets, which " +
-        "relies on the per-batch state store checkpoint ids that only commit log version 2 and " +
-        "above persist, so starting on a version 1 checkpoint exposes the query to data loss " +
-        "on failure. Escape hatch only; prefer a fresh checkpoint location.")
+        "is at version 1. Real-Time Mode re-executes a failed batch, and with checkpoint format " +
+        "version 1 the re-execution can reuse the state file names of the partially-written " +
+        "failed batch, so starting on a version 1 checkpoint exposes the query to data loss on " +
+        "failure. Format version 2 avoids this with per-batch state store checkpoint ids, which " +
+        "only a commit log at version 2 or above can persist. Escape hatch only; prefer a fresh " +
+        "checkpoint location.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
@@ -8813,7 +8815,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def streamingOffsetLogFormatVersion: Int = getConf(STREAMING_OFFSET_LOG_FORMAT_VERSION)
 
-  def streamingCommitLogFormatVersion: Int = getConf(STREAMING_COMMIT_LOG_FORMAT_VERSION)
+  def streamingCommitLogFormatVersion: Int =
+    getConf(STREAMING_COMMIT_LOG_FORMAT_VERSION).max(getConf(STATE_STORE_CHECKPOINT_FORMAT_VERSION))
 
   def stateStoreEncodingFormat: String = getConf(STREAMING_STATE_STORE_ENCODING_FORMAT)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3624,6 +3624,18 @@ object SQLConf {
       .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
       .createWithDefault(1)
 
+  val STREAMING_COMMIT_LOG_FORMAT_VERSION =
+    buildConf("spark.sql.streaming.commitLog.formatVersion")
+      .internal()
+      .doc("The version of the commit log format. The default value is 1. Will use the max of " +
+        "this and STATE_STORE_CHECKPOINT_FORMAT_VERSION as the commit log version, since a " +
+        "state store checkpoint format above 1 writes state store checkpoint ids that only a " +
+        "commit log at version 2 or above can persist.")
+      .version("4.3.0")
+      .intConf
+      .checkValue(v => Set(1, 2, 3).contains(v), "Valid versions are 1, 2 and 3")
+      .createWithDefault(1)
+
   val STREAMING_MAX_NUM_STATE_SCHEMA_FILES =
     buildConf("spark.sql.streaming.stateStore.maxNumStateSchemaFiles")
       .internal()
@@ -8786,6 +8798,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def stateStoreCheckpointFormatVersion: Int = getConf(STATE_STORE_CHECKPOINT_FORMAT_VERSION)
 
   def streamingOffsetLogFormatVersion: Int = getConf(STREAMING_OFFSET_LOG_FORMAT_VERSION)
+
+  def streamingCommitLogFormatVersion: Int = getConf(STREAMING_COMMIT_LOG_FORMAT_VERSION)
 
   def stateStoreEncodingFormat: String = getConf(STREAMING_STATE_STORE_ENCODING_FORMAT)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3632,6 +3632,7 @@ object SQLConf {
         "state store checkpoint format above 1 writes state store checkpoint ids that only a " +
         "commit log at version 2 or above can persist.")
       .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .intConf
       .checkValue(v => Set(1, 2, 3).contains(v), "Valid versions are 1, 2 and 3")
       .createWithDefault(1)
@@ -3645,6 +3646,7 @@ object SQLConf {
         "above persist, so starting on a version 1 checkpoint exposes the query to data loss " +
         "on failure. Escape hatch only; prefer a fresh checkpoint location.")
       .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3624,19 +3624,6 @@ object SQLConf {
       .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
       .createWithDefault(1)
 
-  val STREAMING_COMMIT_LOG_FORMAT_VERSION =
-    buildConf("spark.sql.streaming.commitLog.formatVersion")
-      .internal()
-      .doc("The version of the commit log format. The default value is 1. Will use the max of " +
-        "this and STATE_STORE_CHECKPOINT_FORMAT_VERSION as the commit log version, since a " +
-        "state store checkpoint format above 1 writes state store checkpoint ids that only a " +
-        "commit log at version 2 or above can persist.")
-      .version("4.3.0")
-      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
-      .intConf
-      .checkValue(v => Set(1, 2, 3).contains(v), "Valid versions are 1, 2 and 3")
-      .createWithDefault(1)
-
   val STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1 =
     buildConf("spark.sql.streaming.realTimeMode.dangerouslyAllowCheckpointV1.enabled")
       .internal()
@@ -8815,8 +8802,13 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def streamingOffsetLogFormatVersion: Int = getConf(STREAMING_OFFSET_LOG_FORMAT_VERSION)
 
+  // The commit log format version implied by the session config for a fresh checkpoint. A state
+  // store checkpoint format of v2 makes each batch write stateUniqueIds, which only a commit log at
+  // VERSION_2 or above can persist, so the commit log version tracks the state store format. It is
+  // capped at VERSION_2 here: VERSION_3 exists only to carry sink-evolution metadata and is written
+  // exclusively by the sink-evolution path in MicroBatchExecution, never derived from a config.
   def streamingCommitLogFormatVersion: Int =
-    getConf(STREAMING_COMMIT_LOG_FORMAT_VERSION).max(getConf(STATE_STORE_CHECKPOINT_FORMAT_VERSION))
+    if (getConf(STATE_STORE_CHECKPOINT_FORMAT_VERSION) >= 2) 2 else 1
 
   def stateStoreEncodingFormat: String = getConf(STREAMING_STATE_STORE_ENCODING_FORMAT)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3636,6 +3636,18 @@ object SQLConf {
       .checkValue(v => Set(1, 2, 3).contains(v), "Valid versions are 1, 2 and 3")
       .createWithDefault(1)
 
+  val STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1 =
+    buildConf("spark.sql.streaming.realTimeMode.dangerouslyAllowCheckpointV1.enabled")
+      .internal()
+      .doc("Whether to allow a Real-Time Mode query to start on a checkpoint whose commit log " +
+        "is at version 1. Real-Time Mode reruns a failed batch from committed offsets, which " +
+        "relies on the per-batch state store checkpoint ids that only commit log version 2 and " +
+        "above persist, so starting on a version 1 checkpoint exposes the query to data loss " +
+        "on failure. Escape hatch only; prefer a fresh checkpoint location.")
+      .version("4.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val STREAMING_MAX_NUM_STATE_SCHEMA_FILES =
     buildConf("spark.sql.streaming.stateStore.maxNumStateSchemaFiles")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/StreamingQueryManager.scala
@@ -226,7 +226,7 @@ class StreamingQueryManager private[sql] (
 
     if (invalidReasons.nonEmpty) {
       throw new SparkIllegalArgumentException(
-        errorClass = "STREAMING_REAL_TIME_MODE.CONFIGURATION_NOT_SUPPORTED",
+        errorClass = "STREAMING_REAL_TIME_MODE.SQL_CONFIGURATION_NOT_SUPPORTED",
         messageParameters = Map(
           "invalidReasons" -> invalidReasons.zipWithIndex.map {
             case ((confName, req), index) => s"${index + 1}. $confName must be $req"

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/StreamingQueryManager.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.continuous.ContinuousExecution
 import org.apache.spark.sql.execution.streaming.runtime.{AsyncProgressTrackingMicroBatchExecution, MicroBatchExecution, StreamingQueryListenerBus, StreamingQueryWrapper}
-import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorRef
+import org.apache.spark.sql.execution.streaming.state.{RocksDBStateStoreProvider, StateStoreCoordinatorRef}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.STREAMING_QUERY_LISTENERS
 import org.apache.spark.sql.streaming
@@ -186,6 +186,54 @@ class StreamingQueryManager private[sql] (
           SQLConf.STREAMING_ASYNC_PROGRESS_TRACKING_REAL_TIME_MODE_ENABLED_BY_DEFAULT))
   }
 
+  /**
+   * Rejects, before the query is built, session configurations that are incompatible with
+   * Real-Time Mode. Real-Time Mode defaults these when the user has not set them
+   * (see StreamExecution.setSparkSessionConfigsForRealTimeMode), but an explicit incompatible
+   * value is a mistake worth surfacing up front rather than silently overriding or failing later
+   * mid-query. Mirrors the Databricks runtime's throwIfConfsAreRTMIncompatible, limited to the
+   * checks that apply in OSS.
+   *
+   *  - state store checkpoint format below v2 (unless the v1 escape hatch is set): Real-Time Mode
+   *    requires v2 (see the fail-fast in MicroBatchExecution.initializeExecution);
+   *  - a non-RocksDB state store provider: v2 requires RocksDB;
+   *  - sortBeforeRepartition left true: the blocking sort never completes on an unbounded stream.
+   */
+  private def throwIfConfsAreRealTimeModeIncompatible(sparkSession: SparkSession): Unit = {
+    val conf = sparkSession.sessionState.conf
+    // Preserve declaration order for a stable message.
+    val invalidReasons = new mutable.LinkedHashMap[String, String]
+
+    val allowCheckpointV1 =
+      conf.getConf(SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1)
+    if (!allowCheckpointV1 &&
+        conf.contains(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) &&
+        conf.getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION) < 2) {
+      invalidReasons += (SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2 or above")
+    }
+
+    if (conf.contains(SQLConf.STATE_STORE_PROVIDER_CLASS.key) &&
+        conf.getConf(SQLConf.STATE_STORE_PROVIDER_CLASS) !=
+          classOf[RocksDBStateStoreProvider].getName) {
+      invalidReasons +=
+        (SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName)
+    }
+
+    if (conf.contains(SQLConf.SORT_BEFORE_REPARTITION.key) &&
+        conf.getConf(SQLConf.SORT_BEFORE_REPARTITION)) {
+      invalidReasons += (SQLConf.SORT_BEFORE_REPARTITION.key -> "false")
+    }
+
+    if (invalidReasons.nonEmpty) {
+      throw new SparkIllegalArgumentException(
+        errorClass = "STREAMING_REAL_TIME_MODE.CONFIGURATION_NOT_SUPPORTED",
+        messageParameters = Map(
+          "invalidReasons" -> invalidReasons.zipWithIndex.map {
+            case ((confName, req), index) => s"${index + 1}. $confName must be $req"
+          }.mkString("; ")))
+    }
+  }
+
   // scalastyle:off argcount
   private def createQuery(
       userSpecifiedName: Option[String],
@@ -217,6 +265,7 @@ class StreamingQueryManager private[sql] (
           )
         )
       }
+      throwIfConfsAreRealTimeModeIncompatible(sparkSession)
     }
 
     val dataStreamWritePlan = WriteToStreamStatement(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -172,19 +172,21 @@ object CheckpointVersionManager extends Logging {
   def setFormatVersion(
       sparkSessionForStream: SparkSession,
       logType: CheckpointLogType,
-      version: Int): Unit = {
+      version: Int,
+      commitMetadata: Option[CommitMetadataBase] = None): Unit = {
     logType match {
       case OffsetLogType =>
         setSparkSessionConfigsForOffsetLog(sparkSessionForStream, version)
       case CommitLogType =>
-        setSparkSessionConfigsForCommitLog(sparkSessionForStream, version)
+        setSparkSessionConfigsForCommitLog(sparkSessionForStream, version, commitMetadata)
     }
   }
 
   /**
-   * Records the state store checkpoint format implied by a commit log format version. A commit log
-   * at [[CommitLog.VERSION_2]] or above carries state store checkpoint ids, which requires state
-   * store checkpoint format v2; [[CommitLog.VERSION_1]] cannot carry them, which requires v1.
+   * Records the state store checkpoint format used by the existing commit log. VERSION_1 uses
+   * state store format v1 and VERSION_2 uses v2. VERSION_3 can represent either format because it
+   * was introduced independently for sink metadata; the presence of state store checkpoint ids
+   * distinguishes v2 from v1.
    *
    * The state store format is clamped to 2 rather than set to the commit log version, because the
    * two version spaces are separate: the commit log has a VERSION_3 (sink metadata) with no state
@@ -194,8 +196,14 @@ object CheckpointVersionManager extends Logging {
    */
   private def setSparkSessionConfigsForCommitLog(
       sparkSessionForStream: SparkSession,
-      commitLogFormatVersion: Int): Unit = {
-    val stateStoreVersion = if (commitLogFormatVersion >= CommitLog.VERSION_2) 2 else 1
+      commitLogFormatVersion: Int,
+      commitMetadata: Option[CommitMetadataBase]): Unit = {
+    val stateStoreVersion = commitMetadata match {
+      case Some(metadata) if metadata.version == CommitLog.VERSION_3 =>
+        if (metadata.stateUniqueIds.isDefined) 2 else 1
+      case _ =>
+        if (commitLogFormatVersion >= CommitLog.VERSION_2) 2 else 1
+    }
     sparkSessionForStream.conf
       .set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, stateStoreVersion.toString)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -116,12 +116,10 @@ object CheckpointVersionManager extends Logging {
 
   /**
    * The commit log format version requested by the session config.
-   * `streamingCommitLogFormatVersion` already takes the max of
-   * [[SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION]] and
-   * [[SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION]], so a state store checkpoint format of v2
-   * (which makes each batch write `stateUniqueIds`, persistable only by a commit log at
-   * [[CommitLog.VERSION_2]] or above) raises the commit log version even when the commit log config
-   * is left at 1.
+   * `streamingCommitLogFormatVersion` tracks [[SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION]]: a
+   * state store checkpoint format of v2 makes each batch write `stateUniqueIds`, which only a
+   * commit log at [[CommitLog.VERSION_2]] or above can persist, so a v2 state store format raises
+   * the commit log version to v2.
    */
   private def getCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
     val result = sparkSessionForStream.sessionState.conf.streamingCommitLogFormatVersion
@@ -200,7 +198,5 @@ object CheckpointVersionManager extends Logging {
     val stateStoreVersion = if (commitLogFormatVersion >= CommitLog.VERSION_2) 2 else 1
     sparkSessionForStream.conf
       .set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, stateStoreVersion.toString)
-    sparkSessionForStream.conf
-      .set(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key, commitLogFormatVersion.toString)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -128,14 +128,21 @@ object CheckpointVersionManager extends Logging {
    * for commit log v3 (sink metadata) is not dragged back down by a state store still on v1.
    */
   private def getCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
-    val conf = sparkSessionForStream.sessionState.conf
-    val configuredVersion = conf.streamingCommitLogFormatVersion
-    val minRequiredVersion = if (conf.stateStoreCheckpointFormatVersion >= 2) {
+    val currentDefaultVersion = CommitLog.VERSION_1
+    val minRequiredVersion = getMinRequiredCommitLogVersion(sparkSessionForStream)
+    val configuredVersion = sparkSessionForStream.sessionState.conf.streamingCommitLogFormatVersion
+    val result = List[Int](currentDefaultVersion, minRequiredVersion, configuredVersion).max
+    logInfo(s"Retrieved commit log writer version=$result")
+    result
+  }
+
+  private def getMinRequiredCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
+    if (sparkSessionForStream.sessionState.conf.stateStoreCheckpointFormatVersion >=
+        CommitLog.VERSION_2) {
       CommitLog.VERSION_2
     } else {
       CommitLog.VERSION_1
     }
-    math.max(configuredVersion, minRequiredVersion)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -116,33 +116,17 @@ object CheckpointVersionManager extends Logging {
 
   /**
    * The commit log format version requested by the session config.
-   *
-   * Two configs feed this, and the answer is the max of them:
-   *  - [[SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION]], which names a commit log version directly;
-   *  - [[SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION]], which implies a minimum, because a state
-   *    store checkpoint format above 1 makes each batch write `stateUniqueIds` and only a commit
-   *    log at [[CommitLog.VERSION_2]] or above can persist those.
-   *
-   * Taking the max means neither config can silently produce an unwritable combination: asking for
-   * state store v2 raises the commit log to v2 even when the commit log config says 1, and asking
-   * for commit log v3 (sink metadata) is not dragged back down by a state store still on v1.
+   * `streamingCommitLogFormatVersion` already takes the max of
+   * [[SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION]] and
+   * [[SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION]], so a state store checkpoint format of v2
+   * (which makes each batch write `stateUniqueIds`, persistable only by a commit log at
+   * [[CommitLog.VERSION_2]] or above) raises the commit log version even when the commit log config
+   * is left at 1.
    */
   private def getCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
-    val currentDefaultVersion = CommitLog.VERSION_1
-    val minRequiredVersion = getMinRequiredCommitLogVersion(sparkSessionForStream)
-    val configuredVersion = sparkSessionForStream.sessionState.conf.streamingCommitLogFormatVersion
-    val result = List[Int](currentDefaultVersion, minRequiredVersion, configuredVersion).max
+    val result = sparkSessionForStream.sessionState.conf.streamingCommitLogFormatVersion
     logInfo(s"Retrieved commit log writer version=$result")
     result
-  }
-
-  private def getMinRequiredCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
-    if (sparkSessionForStream.sessionState.conf.stateStoreCheckpointFormatVersion >=
-        CommitLog.VERSION_2) {
-      CommitLog.VERSION_2
-    } else {
-      CommitLog.VERSION_1
-    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -190,9 +190,8 @@ object CheckpointVersionManager extends Logging {
    *
    * The state store format is clamped to 2 rather than set to the commit log version, because the
    * two version spaces are separate: the commit log has a VERSION_3 (sink metadata) with no state
-   * store counterpart, and every consumer of the state store config tests `>= 2` (see
-   * StatefulOperatorStateInfo.enableStateStoreCheckpointIds). Writing 3 here would behave the same
-   * but report a state store format that does not exist.
+   * store counterpart, while the state store config accepts only versions 1 and 2. Writing 3 here
+   * would report a state store format that does not exist.
    */
   private def setSparkSessionConfigsForCommitLog(
       sparkSessionForStream: SparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -174,8 +174,26 @@ object CheckpointVersionManager extends Logging {
       case OffsetLogType =>
         setSparkSessionConfigsForOffsetLog(sparkSessionForStream, version)
       case CommitLogType =>
-        sparkSessionForStream.conf
-          .set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, version.toString)
+        setSparkSessionConfigsForCommitLog(sparkSessionForStream, version)
     }
+  }
+
+  /**
+   * Records the state store checkpoint format implied by a commit log format version. A commit log
+   * at [[CommitLog.VERSION_2]] or above carries state store checkpoint ids, which requires state
+   * store checkpoint format v2; [[CommitLog.VERSION_1]] cannot carry them, which requires v1.
+   *
+   * The state store format is clamped to 2 rather than set to the commit log version, because the
+   * two version spaces are separate: the commit log has a VERSION_3 (sink metadata) with no state
+   * store counterpart, and every consumer of the state store config tests `>= 2` (see
+   * StatefulOperatorStateInfo.enableStateStoreCheckpointIds). Writing 3 here would behave the same
+   * but report a state store format that does not exist.
+   */
+  private def setSparkSessionConfigsForCommitLog(
+      sparkSessionForStream: SparkSession,
+      commitLogFormatVersion: Int): Unit = {
+    val stateStoreVersion = if (commitLogFormatVersion >= CommitLog.VERSION_2) 2 else 1
+    sparkSessionForStream.conf
+      .set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, stateStoreVersion.toString)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -35,6 +35,7 @@ case class StreamingCheckpointVersion(offsetLogVersion: Int) {
 
 sealed trait CheckpointLogType
 case object OffsetLogType extends CheckpointLogType
+case object CommitLogType extends CheckpointLogType
 
 /**
  * The `CheckpointVersionManager` is responsible for managing the versioning of the streaming
@@ -109,6 +110,32 @@ object CheckpointVersionManager extends Logging {
       logType: CheckpointLogType): Int = {
     logType match {
       case OffsetLogType => getOffsetLogVersion(sparkSessionForStream)
+      case CommitLogType => getCommitLogVersion(sparkSessionForStream)
+    }
+  }
+
+  /**
+   * The commit log format version requested by the session config. The state store checkpoint
+   * format and the commit log format move together: format v2 makes each batch write
+   * `stateUniqueIds`, which only a commit log at [[CommitLog.VERSION_2]] or above can persist.
+   */
+  private def getCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
+    sparkSessionForStream.sessionState.conf
+      .getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)
+  }
+
+  /**
+   * Determines the commit log format version to WRITE for this query run. An existing checkpoint
+   * wins: a commit log that was created at a given version keeps being written at that version, so
+   * a session config change cannot start writing a format the checkpoint was not created with. Only
+   * a fresh checkpoint takes the version from the session config.
+   */
+  def resolveCommitLogVersion(
+      sparkSessionForStream: SparkSession,
+      latestCommittedBatch: Option[(Long, CommitMetadataBase)]): Int = {
+    latestCommittedBatch match {
+      case Some((_, commitMetadata)) => commitMetadata.version
+      case None => getFormatVersionFromSession(sparkSessionForStream, CommitLogType)
     }
   }
 
@@ -146,6 +173,9 @@ object CheckpointVersionManager extends Logging {
     logType match {
       case OffsetLogType =>
         setSparkSessionConfigsForOffsetLog(sparkSessionForStream, version)
+      case CommitLogType =>
+        sparkSessionForStream.conf
+          .set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, version.toString)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -115,13 +115,27 @@ object CheckpointVersionManager extends Logging {
   }
 
   /**
-   * The commit log format version requested by the session config. The state store checkpoint
-   * format and the commit log format move together: format v2 makes each batch write
-   * `stateUniqueIds`, which only a commit log at [[CommitLog.VERSION_2]] or above can persist.
+   * The commit log format version requested by the session config.
+   *
+   * Two configs feed this, and the answer is the max of them:
+   *  - [[SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION]], which names a commit log version directly;
+   *  - [[SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION]], which implies a minimum, because a state
+   *    store checkpoint format above 1 makes each batch write `stateUniqueIds` and only a commit
+   *    log at [[CommitLog.VERSION_2]] or above can persist those.
+   *
+   * Taking the max means neither config can silently produce an unwritable combination: asking for
+   * state store v2 raises the commit log to v2 even when the commit log config says 1, and asking
+   * for commit log v3 (sink metadata) is not dragged back down by a state store still on v1.
    */
   private def getCommitLogVersion(sparkSessionForStream: SparkSession): Int = {
-    sparkSessionForStream.sessionState.conf
-      .getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)
+    val conf = sparkSessionForStream.sessionState.conf
+    val configuredVersion = conf.streamingCommitLogFormatVersion
+    val minRequiredVersion = if (conf.stateStoreCheckpointFormatVersion >= 2) {
+      CommitLog.VERSION_2
+    } else {
+      CommitLog.VERSION_1
+    }
+    math.max(configuredVersion, minRequiredVersion)
   }
 
   /**
@@ -195,5 +209,7 @@ object CheckpointVersionManager extends Logging {
     val stateStoreVersion = if (commitLogFormatVersion >= CommitLog.VERSION_2) 2 else 1
     sparkSessionForStream.conf
       .set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, stateStoreVersion.toString)
+    sparkSessionForStream.conf
+      .set(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key, commitLogFormatVersion.toString)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CheckpointVersionManager.scala
@@ -128,10 +128,10 @@ object CheckpointVersionManager extends Logging {
   }
 
   /**
-   * Determines the commit log format version to WRITE for this query run. An existing checkpoint
-   * wins: a commit log that was created at a given version keeps being written at that version, so
-   * a session config change cannot start writing a format the checkpoint was not created with. Only
-   * a fresh checkpoint takes the version from the session config.
+   * Determines the commit log format version for ordinary writes in this query run. An existing
+   * checkpoint wins, so a session config change cannot start writing a format the checkpoint was
+   * not created with. Only a fresh checkpoint takes the version from the session config. Sink
+   * evolution may independently upgrade writes to [[CommitLog.VERSION_3]].
    */
   def resolveCommitLogVersion(
       sparkSessionForStream: SparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
@@ -28,7 +28,6 @@ import org.json4s.jackson.Serialization
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2}
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Used to write log files that represent batch commit points in structured streaming.
@@ -56,11 +55,6 @@ class CommitLog(
 
   import CommitLog._
 
-  // The configured commit log format version. Used as the default version when callers
-  // construct metadata through [[createMetadata]].
-  private[sql] val defaultVersion: Int = sparkSession.conf.get(
-    SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).toInt
-
   override protected[sql] def deserialize(in: InputStream): CommitMetadataBase = {
     CommitLog.readCommitMetadata(in)
   }
@@ -76,7 +70,12 @@ class CommitLog(
 
   /**
    * Factory for creating a [[CommitMetadataBase]] for the requested wire format version.
-   * Defaults to the version configured via [[SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION]].
+   *
+   * The version is a parameter rather than a field read from the session config, so that a caller
+   * always supplies the version it resolved for this query run. Reading the config here would
+   * capture whatever value happened to be set when this log was constructed -- which is during
+   * [[StreamExecution]]'s own initialization, before per-query configuration is applied -- and
+   * would ignore the format an existing checkpoint was created with.
    *
    * For [[VERSION_3]], [[sinkMetadataMap]] must be non-empty and contain exactly one active
    * sink; [[CommitMetadataV3]] enforces this invariant.
@@ -85,7 +84,7 @@ class CommitLog(
       nextBatchWatermarkMs: Long = 0,
       stateUniqueIds: Option[Map[Long, Array[Array[String]]]] = None,
       sinkMetadataMap: Map[String, SinkMetadataInfo] = Map.empty,
-      commitLogFormatVersion: Int = defaultVersion): CommitMetadataBase = {
+      commitLogFormatVersion: Int = VERSION_1): CommitMetadataBase = {
     commitLogFormatVersion match {
       case VERSION_3 =>
         CommitMetadataV3(nextBatchWatermarkMs, stateUniqueIds, sinkMetadataMap)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
@@ -73,11 +73,7 @@ class CommitLog(
    *
    * [[commitLogFormatVersion]] is a required parameter rather than a field read from the session
    * config, so that a caller always supplies the version it resolved for this query run. Reading
-   * the config here would capture whatever value happened to be set when this log was constructed
-   * -- which is during
-   * [[org.apache.spark.sql.execution.streaming.runtime.StreamExecution]]'s own initialization,
-   * before per-query configuration is applied -- and would ignore the format an existing
-   * checkpoint was created with.
+   * the config here would ignore the format an existing checkpoint was created with.
    *
    * For [[VERSION_3]], [[sinkMetadataMap]] must be non-empty and contain exactly one active
    * sink; [[CommitMetadataV3]] enforces this invariant.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
@@ -71,9 +71,10 @@ class CommitLog(
   /**
    * Factory for creating a [[CommitMetadataBase]] for the requested wire format version.
    *
-   * The version is a parameter rather than a field read from the session config, so that a caller
-   * always supplies the version it resolved for this query run. Reading the config here would
-   * capture whatever value happened to be set when this log was constructed -- which is during
+   * [[commitLogFormatVersion]] is a required parameter rather than a field read from the session
+   * config, so that a caller always supplies the version it resolved for this query run. Reading
+   * the config here would capture whatever value happened to be set when this log was constructed
+   * -- which is during
    * [[org.apache.spark.sql.execution.streaming.runtime.StreamExecution]]'s own initialization,
    * before per-query configuration is applied -- and would ignore the format an existing
    * checkpoint was created with.
@@ -85,7 +86,7 @@ class CommitLog(
       nextBatchWatermarkMs: Long = 0,
       stateUniqueIds: Option[Map[Long, Array[Array[String]]]] = None,
       sinkMetadataMap: Map[String, SinkMetadataInfo] = Map.empty,
-      commitLogFormatVersion: Int = VERSION_1): CommitMetadataBase = {
+      commitLogFormatVersion: Int): CommitMetadataBase = {
     commitLogFormatVersion match {
       case VERSION_3 =>
         CommitMetadataV3(nextBatchWatermarkMs, stateUniqueIds, sinkMetadataMap)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/CommitLog.scala
@@ -74,8 +74,9 @@ class CommitLog(
    * The version is a parameter rather than a field read from the session config, so that a caller
    * always supplies the version it resolved for this query run. Reading the config here would
    * capture whatever value happened to be set when this log was constructed -- which is during
-   * [[StreamExecution]]'s own initialization, before per-query configuration is applied -- and
-   * would ignore the format an existing checkpoint was created with.
+   * [[org.apache.spark.sql.execution.streaming.runtime.StreamExecution]]'s own initialization,
+   * before per-query configuration is applied -- and would ignore the format an existing
+   * checkpoint was created with.
    *
    * For [[VERSION_3]], [[sinkMetadataMap]] must be non-empty and contain exactly one active
    * sink; [[CommitMetadataV3]] enforces this invariant.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.streaming.WriteToStream
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming.{AvailableNowTrigger, OneTimeTrigger, ProcessingTimeTrigger, RealTimeTrigger, StreamingErrors}
-import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog, CommitMetadata, OffsetSeqBase, OffsetSeqLog}
+import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog, CommitMetadataBase, OffsetSeqBase, OffsetSeqLog}
 import org.apache.spark.sql.execution.streaming.operators.stateful.StateStoreWriter
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.util.{Clock, ThreadUtils}
@@ -261,7 +261,7 @@ class AsyncProgressTrackingMicroBatchExecution(
         || isFirstBatch) {
         isFirstBatch = false
         commitLog
-          .addAsync(execCtx.batchId, CommitMetadata(watermarkTracker.currentWatermark))
+          .addAsync(execCtx.batchId, createAsyncCommitMetadata(execCtx))
           .thenAccept((batchId: Long) => {
             logInfo(log"Committed async commit log to disk for batch ${MDC(BATCH_ID, batchId)}.")
           })
@@ -273,7 +273,7 @@ class AsyncProgressTrackingMicroBatchExecution(
           })
       } else {
         if (!commitLog.addInMemory(
-          execCtx.batchId, CommitMetadata(watermarkTracker.currentWatermark))) {
+          execCtx.batchId, createAsyncCommitMetadata(execCtx))) {
           throw QueryExecutionErrors.concurrentStreamLogUpdate(execCtx.batchId)
         }
         logInfo(
@@ -283,6 +283,21 @@ class AsyncProgressTrackingMicroBatchExecution(
     }
     signalProcessAllAvailableIfRealTimeMode(execCtx)
     committedOffsets ++= execCtx.endOffsets
+  }
+
+  /**
+   * Builds the commit log entry for an async batch at the version resolved for this run, so that a
+   * Real-Time Mode query writes the commit log format its state store checkpoint format implies
+   * (v2 for the RTM default) rather than always VERSION_1. Async progress tracking does not support
+   * stateful queries, so there are no state store checkpoint ids to persist.
+   */
+  private def createAsyncCommitMetadata(
+      execCtx: MicroBatchExecutionContext): CommitMetadataBase = {
+    commitLog.createMetadata(
+      nextBatchWatermarkMs = watermarkTracker.currentWatermark,
+      stateUniqueIds = None,
+      commitLogFormatVersion = execCtx.commitLogFormatVersionOpt.getOrElse(
+        sparkSessionForStream.sessionState.conf.streamingCommitLogFormatVersion))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -563,6 +563,35 @@ class MicroBatchExecution(
     CheckpointVersionManager.setFormatVersion(
       sparkSessionForStream, CommitLogType, commitLogFormatVersion)
 
+    // Real-Time Mode reruns a failed batch from committed offsets, which relies on the per-batch
+    // state store checkpoint ids that only commit log v2 and above persist; on a v1 commit log the
+    // rerun can silently lose data. Resolution above keeps an EXISTING checkpoint at the version it
+    // was created with, so switching an existing microbatch query to Real-Time Mode would otherwise
+    // run at v1 unnoticed. Reject that, with an escape hatch.
+    //
+    // Scoped twice, and both scopes matter:
+    //  - to an EXISTING checkpoint, because a fresh one takes its version from the session config
+    //    where v1 can only be the user's explicit choice (StreamRealTimeModeDefaultConfsSuite pins
+    //    exactly that), whereas an existing v1 checkpoint is a hazard they cannot anticipate;
+    //  - to a STATEFUL query, because the hazard is losing state on a rerun. A stateless query has
+    //    no stateUniqueIds to persist, so its commit log stays at VERSION_1 whatever the config
+    //    says, and rejecting its restart would break a query with nothing at risk.
+    if (trigger.isInstanceOf[RealTimeTrigger] && latestCommittedBatch.isDefined &&
+        commitLogFormatVersion < CommitLog.VERSION_2 &&
+        containsStatefulOperator(analyzedPlan)) {
+      if (!sparkSessionForStream.sessionState.conf
+          .getConf(SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1)) {
+        throw new SparkIllegalArgumentException(
+          errorClass = "STREAMING_REAL_TIME_MODE.CHECKPOINT_FORMAT_V1_NOT_SUPPORTED",
+          messageParameters = Map(
+            "config" -> SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key))
+      }
+      logWarning(log"Starting a Real-Time Mode query on a commit log at version " +
+        log"${MDC(LogKeys.FILE_VERSION, commitLogFormatVersion)} because " +
+        log"${MDC(LogKeys.CONFIG, SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1
+          .key)} is set. A failed batch may lose data on rerun.")
+    }
+
     val execCtx = new MicroBatchExecutionContext(id, runId, name, triggerClock, sources, sink,
       progressReporter, -1, sparkSession,
       offsetLogFormatVersionOpt = Some(offsetLogFormatVersion),
@@ -601,24 +630,28 @@ class MicroBatchExecution(
     }
   }
 
+  /**
+   * Whether the query has a streaming stateful operator, and so keeps state across batches that a
+   * rerun of a failed batch has to restore. Used to decide whether the commit log format matters.
+   */
+  private def containsStatefulOperator(p: LogicalPlan): Boolean = {
+    p.exists {
+      case node: Aggregate if node.isStreaming => true
+      case node: Deduplicate if node.isStreaming => true
+      case node: DeduplicateWithinWatermark if node.isStreaming => true
+      case node: Distinct if node.isStreaming => true
+      case node: Join if node.left.isStreaming && node.right.isStreaming => true
+      case node: FlatMapGroupsWithState if node.isStreaming => true
+      case node: FlatMapGroupsInPandasWithState if node.isStreaming => true
+      case node: TransformWithState if node.isStreaming => true
+      case node: TransformWithStateInPySpark if node.isStreaming => true
+      case node: GlobalLimit if node.isStreaming => true
+      case _ => false
+    }
+  }
+
   private def disableAQESupportInStatelessIfUnappropriated(
       sparkSessionToRunBatches: SparkSession): Unit = {
-    def containsStatefulOperator(p: LogicalPlan): Boolean = {
-      p.exists {
-        case node: Aggregate if node.isStreaming => true
-        case node: Deduplicate if node.isStreaming => true
-        case node: DeduplicateWithinWatermark if node.isStreaming => true
-        case node: Distinct if node.isStreaming => true
-        case node: Join if node.left.isStreaming && node.right.isStreaming => true
-        case node: FlatMapGroupsWithState if node.isStreaming => true
-        case node: FlatMapGroupsInPandasWithState if node.isStreaming => true
-        case node: TransformWithState if node.isStreaming => true
-        case node: TransformWithStateInPySpark if node.isStreaming => true
-        case node: GlobalLimit if node.isStreaming => true
-        case _ => false
-      }
-    }
-
     if (trigger.isInstanceOf[RealTimeTrigger]) {
       logWarning(log"Disabling AQE since AQE is not supported for Real-time Mode.")
       sparkSessionToRunBatches.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -563,13 +563,18 @@ class MicroBatchExecution(
     CheckpointVersionManager.setFormatVersion(
       sparkSessionForStream, CommitLogType, commitLogFormatVersion)
 
-    // Real-Time Mode requires commit log v2: it reruns a failed batch from committed offsets, which
-    // relies on the per-batch state store checkpoint ids that only commit log v2 and above persist,
-    // so on a v1 commit log the rerun can silently lose data. Resolution above keeps an existing
-    // checkpoint at the version it was created with, so a v1 checkpoint stays v1. Reject any
-    // Real-Time Mode query whose resolved commit log version is below v2, with an escape hatch.
-    // This is unconditional, matching the Databricks runtime -- a fresh checkpoint reaches v1 here
-    // only when the user explicitly pinned it, which is exactly the case worth rejecting.
+    // Real-Time Mode requires commit log v2. Real-Time Mode writes the offset log at batch end
+    // (markMicroBatchStart is a no-op for it), so a mid-batch failure can leave durable state at a
+    // version that was never logged; the re-execution then rewrites that same state version. With
+    // checkpoint format v1 the rewritten files reuse the same names as the orphaned ones, so a load
+    // can pick up a stale file (see the checksum hazard documented on
+    // StateStoreConf.skipChecksumOnFileMissingChecksum). Format v2 avoids this because each batch
+    // run generates unique state store checkpoint ids, and only a commit log at v2 or above can
+    // persist them. Resolution above keeps an existing checkpoint at the version it was created
+    // with, so a v1 checkpoint stays v1. Reject any Real-Time Mode query whose resolved commit log
+    // version is below v2, with an escape hatch. This is unconditional, matching the Databricks
+    // runtime -- a fresh checkpoint reaches v1 here only when the user explicitly pinned it, which
+    // is exactly the case worth rejecting.
     if (trigger.isInstanceOf[RealTimeTrigger] && commitLogFormatVersion < CommitLog.VERSION_2) {
       if (!sparkSessionForStream.sessionState.conf
           .getConf(SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -563,22 +563,14 @@ class MicroBatchExecution(
     CheckpointVersionManager.setFormatVersion(
       sparkSessionForStream, CommitLogType, commitLogFormatVersion)
 
-    // Real-Time Mode reruns a failed batch from committed offsets, which relies on the per-batch
-    // state store checkpoint ids that only commit log v2 and above persist; on a v1 commit log the
-    // rerun can silently lose data. Resolution above keeps an EXISTING checkpoint at the version it
-    // was created with, so switching an existing microbatch query to Real-Time Mode would otherwise
-    // run at v1 unnoticed. Reject that, with an escape hatch.
-    //
-    // Scoped twice, and both scopes matter:
-    //  - to an EXISTING checkpoint, because a fresh one takes its version from the session config
-    //    where v1 can only be the user's explicit choice (StreamRealTimeModeDefaultConfsSuite pins
-    //    exactly that), whereas an existing v1 checkpoint is a hazard they cannot anticipate;
-    //  - to a STATEFUL query, because the hazard is losing state on a rerun. A stateless query has
-    //    no stateUniqueIds to persist, so its commit log stays at VERSION_1 whatever the config
-    //    says, and rejecting its restart would break a query with nothing at risk.
-    if (trigger.isInstanceOf[RealTimeTrigger] && latestCommittedBatch.isDefined &&
-        commitLogFormatVersion < CommitLog.VERSION_2 &&
-        containsStatefulOperator(analyzedPlan)) {
+    // Real-Time Mode requires commit log v2: it reruns a failed batch from committed offsets, which
+    // relies on the per-batch state store checkpoint ids that only commit log v2 and above persist,
+    // so on a v1 commit log the rerun can silently lose data. Resolution above keeps an existing
+    // checkpoint at the version it was created with, so a v1 checkpoint stays v1. Reject any
+    // Real-Time Mode query whose resolved commit log version is below v2, with an escape hatch.
+    // This is unconditional, matching the Databricks runtime -- a fresh checkpoint reaches v1 here
+    // only when the user explicitly pinned it, which is exactly the case worth rejecting.
+    if (trigger.isInstanceOf[RealTimeTrigger] && commitLogFormatVersion < CommitLog.VERSION_2) {
       if (!sparkSessionForStream.sessionState.conf
           .getConf(SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1)) {
         throw new SparkIllegalArgumentException(
@@ -630,28 +622,24 @@ class MicroBatchExecution(
     }
   }
 
-  /**
-   * Whether the query has a streaming stateful operator, and so keeps state across batches that a
-   * rerun of a failed batch has to restore. Used to decide whether the commit log format matters.
-   */
-  private def containsStatefulOperator(p: LogicalPlan): Boolean = {
-    p.exists {
-      case node: Aggregate if node.isStreaming => true
-      case node: Deduplicate if node.isStreaming => true
-      case node: DeduplicateWithinWatermark if node.isStreaming => true
-      case node: Distinct if node.isStreaming => true
-      case node: Join if node.left.isStreaming && node.right.isStreaming => true
-      case node: FlatMapGroupsWithState if node.isStreaming => true
-      case node: FlatMapGroupsInPandasWithState if node.isStreaming => true
-      case node: TransformWithState if node.isStreaming => true
-      case node: TransformWithStateInPySpark if node.isStreaming => true
-      case node: GlobalLimit if node.isStreaming => true
-      case _ => false
-    }
-  }
-
   private def disableAQESupportInStatelessIfUnappropriated(
       sparkSessionToRunBatches: SparkSession): Unit = {
+    def containsStatefulOperator(p: LogicalPlan): Boolean = {
+      p.exists {
+        case node: Aggregate if node.isStreaming => true
+        case node: Deduplicate if node.isStreaming => true
+        case node: DeduplicateWithinWatermark if node.isStreaming => true
+        case node: Distinct if node.isStreaming => true
+        case node: Join if node.left.isStreaming && node.right.isStreaming => true
+        case node: FlatMapGroupsWithState if node.isStreaming => true
+        case node: FlatMapGroupsInPandasWithState if node.isStreaming => true
+        case node: TransformWithState if node.isStreaming => true
+        case node: TransformWithStateInPySpark if node.isStreaming => true
+        case node: GlobalLimit if node.isStreaming => true
+        case _ => false
+      }
+    }
+
     if (trigger.isInstanceOf[RealTimeTrigger]) {
       logWarning(log"Disabling AQE since AQE is not supported for Real-time Mode.")
       sparkSessionToRunBatches.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -557,7 +557,7 @@ class MicroBatchExecution(
 
     // Resolve the commit log format version the same way: an existing checkpoint keeps the version
     // it was created with, and only a fresh one takes the version from the session config. Persist
-    // it so a later read of the config agrees with what is actually being written.
+    // the implied state store checkpoint format so it agrees with what is actually being written.
     val commitLogFormatVersion = CheckpointVersionManager.resolveCommitLogVersion(
       sparkSessionForStream, latestCommittedBatch)
     CheckpointVersionManager.setFormatVersion(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -82,6 +82,7 @@ class MicroBatchExecution(
       -1,
       sparkSession,
       offsetLogFormatVersionOpt = None,
+      commitLogFormatVersionOpt = None,
       previousContext = None)
 
   override def getLatestExecutionContext(): StreamExecutionContext = latestExecutionContext
@@ -138,11 +139,6 @@ class MicroBatchExecution(
   /** True when the current query should persist V3 sink metadata in the commit log. */
   private def commitLogV3Enabled: Boolean =
     sparkSession.sessionState.conf.enableStreamingSinkEvolution
-
-  // The commit log format version to WRITE for this query run, resolved in initializeExecution:
-  // an existing checkpoint keeps the version it was created with, a fresh one takes the session
-  // config. Defaults to VERSION_1 until resolved.
-  @volatile private var commitLogFormatVersion: Int = CommitLog.VERSION_1
 
   @volatile protected[sql] var triggerExecutor: TriggerExecutor = _
 
@@ -562,7 +558,7 @@ class MicroBatchExecution(
     // Resolve the commit log format version the same way: an existing checkpoint keeps the version
     // it was created with, and only a fresh one takes the version from the session config. Persist
     // it so a later read of the config agrees with what is actually being written.
-    commitLogFormatVersion = CheckpointVersionManager.resolveCommitLogVersion(
+    val commitLogFormatVersion = CheckpointVersionManager.resolveCommitLogVersion(
       sparkSessionForStream, latestCommittedBatch)
     CheckpointVersionManager.setFormatVersion(
       sparkSessionForStream, CommitLogType, commitLogFormatVersion)
@@ -570,6 +566,7 @@ class MicroBatchExecution(
     val execCtx = new MicroBatchExecutionContext(id, runId, name, triggerClock, sources, sink,
       progressReporter, -1, sparkSession,
       offsetLogFormatVersionOpt = Some(offsetLogFormatVersion),
+      commitLogFormatVersionOpt = Some(commitLogFormatVersion),
       previousContext = None)
 
     execCtx.offsetSeqMetadata = offsetLogFormatVersion match {
@@ -1503,7 +1500,9 @@ class MicroBatchExecution(
         commitLog.createMetadata(
           nextBatchWatermarkMs = watermarkTracker.currentWatermark,
           stateUniqueIds = stateStoreCkptId,
-          commitLogFormatVersion = commitLogFormatVersion)
+          commitLogFormatVersion = execCtx.commitLogFormatVersionOpt.getOrElse(
+            sparkSessionForStream.sessionState.conf
+              .getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)))
       }
       if (!commitLog.add(execCtx.batchId, metadata)) {
         throw QueryExecutionErrors.concurrentStreamLogUpdate(execCtx.batchId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -371,31 +371,6 @@ class MicroBatchExecution(
             messageParameters = Map("className" -> s.getClass.getName)
           )
       }
-
-      // `repartition(n)` uses RoundRobinPartitioning, and by default (SPARK-23207) Spark inserts a
-      // local sort before a round-robin shuffle so the row-to-partition assignment is deterministic
-      // -- otherwise a retried task could emit rows in a different order and lose data. That sort
-      // is fully blocking: it drains its whole input before emitting a row. A Real-Time Mode task
-      // reads an unbounded stream, so the input never ends, the producer never emits, and the query
-      // makes no progress at all. Note this sort is not a SortExec node (it lives inside
-      // ShuffleExchangeExec's RDD), so the Real-Time Mode operator allowlist cannot catch it.
-      //
-      // Determinism is not needed here: Real-Time Mode does not retry tasks (TaskSetManager caps a
-      // pipelined task set at one attempt, and its group is aborted as a unit rather than
-      // recomputed), so the hazard the sort guards against does not arise.
-      //
-      // This overrides an explicit `true` as well. Honouring it would reintroduce the hang above,
-      // and a query that never produces a row is worse than silently ignoring a config that only
-      // guards against a retry that cannot happen here. Log at warning level when overriding an
-      // explicit setting so the operator can see their config is not the one in force.
-      if (sparkSessionForStream.conf.contains(SQLConf.SORT_BEFORE_REPARTITION.key) &&
-        sparkSessionForStream.conf.get(SQLConf.SORT_BEFORE_REPARTITION)) {
-        logWarning(log"Ignoring ${MDC(LogKeys.CONFIG, SQLConf.SORT_BEFORE_REPARTITION.key)}=true " +
-          log"for this Real-Time Mode query: the local sort it inserts before a round-robin " +
-          log"repartition never completes on an unbounded stream. It is not needed because a " +
-          log"Real-Time Mode task is not retried.")
-      }
-      sparkSessionForStream.conf.set(SQLConf.SORT_BEFORE_REPARTITION.key, "false")
     }
 
     // Initializing TriggerExecutor relies on `sources`, hence calling this after initializing

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -1501,8 +1501,7 @@ class MicroBatchExecution(
           nextBatchWatermarkMs = watermarkTracker.currentWatermark,
           stateUniqueIds = stateStoreCkptId,
           commitLogFormatVersion = execCtx.commitLogFormatVersionOpt.getOrElse(
-            sparkSessionForStream.sessionState.conf
-              .getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)))
+            sparkSessionForStream.sessionState.conf.streamingCommitLogFormatVersion))
       }
       if (!commitLog.add(execCtx.batchId, metadata)) {
         throw QueryExecutionErrors.concurrentStreamLogUpdate(execCtx.batchId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -561,7 +561,10 @@ class MicroBatchExecution(
     val commitLogFormatVersion = CheckpointVersionManager.resolveCommitLogVersion(
       sparkSessionForStream, latestCommittedBatch)
     CheckpointVersionManager.setFormatVersion(
-      sparkSessionForStream, CommitLogType, commitLogFormatVersion)
+      sparkSessionForStream,
+      CommitLogType,
+      commitLogFormatVersion,
+      latestCommittedBatch.map(_._2))
 
     // Real-Time Mode requires commit log v2. Real-Time Mode writes the offset log at batch end
     // (markMicroBatchStart is a no-op for it), so a mid-batch failure can leave durable state at a

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, RealTimeStreamScanExec, StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation, StreamWriterCommitProgress, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.{AvailableNowTrigger, Offset, OneTimeTrigger, ProcessingTimeTrigger, RealTimeTrigger, Sink, Source, StreamingQueryPlanTraverseHelper}
-import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, CheckpointVersionManager, CommitLog, CommitMetadataV3, OffsetLogType, OffsetSeqBase, OffsetSeqLog, OffsetSeqMetadata, OffsetSeqMetadataV2, SinkMetadataInfo}
+import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, CheckpointVersionManager, CommitLog, CommitLogType, CommitMetadataV3, OffsetLogType, OffsetSeqBase, OffsetSeqLog, OffsetSeqMetadata, OffsetSeqMetadataV2, SinkMetadataInfo}
 import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorStateInfo, StatefulOpStateStoreCheckpointInfo, StateStoreWriter}
 import org.apache.spark.sql.execution.streaming.runtime.StreamingCheckpointConstants.{DIR_NAME_COMMITS, DIR_NAME_OFFSETS, DIR_NAME_STATE}
 import org.apache.spark.sql.execution.streaming.sources.{ForeachBatchSink, WriteToMicroBatchDataSource, WriteToMicroBatchDataSourceV1}
@@ -138,6 +138,11 @@ class MicroBatchExecution(
   /** True when the current query should persist V3 sink metadata in the commit log. */
   private def commitLogV3Enabled: Boolean =
     sparkSession.sessionState.conf.enableStreamingSinkEvolution
+
+  // The commit log format version to WRITE for this query run, resolved in initializeExecution:
+  // an existing checkpoint keeps the version it was created with, a fresh one takes the session
+  // config. Defaults to VERSION_1 until resolved.
+  @volatile private var commitLogFormatVersion: Int = CommitLog.VERSION_1
 
   @volatile protected[sql] var triggerExecutor: TriggerExecutor = _
 
@@ -553,6 +558,14 @@ class MicroBatchExecution(
     // Persist the resolved offset log format version on the streaming session.
     CheckpointVersionManager.setFormatVersion(
       sparkSessionForStream, OffsetLogType, offsetLogFormatVersion)
+
+    // Resolve the commit log format version the same way: an existing checkpoint keeps the version
+    // it was created with, and only a fresh one takes the version from the session config. Persist
+    // it so a later read of the config agrees with what is actually being written.
+    commitLogFormatVersion = CheckpointVersionManager.resolveCommitLogVersion(
+      sparkSessionForStream, latestCommittedBatch)
+    CheckpointVersionManager.setFormatVersion(
+      sparkSessionForStream, CommitLogType, commitLogFormatVersion)
 
     val execCtx = new MicroBatchExecutionContext(id, runId, name, triggerClock, sources, sink,
       progressReporter, -1, sparkSession,
@@ -1489,7 +1502,8 @@ class MicroBatchExecution(
       } else {
         commitLog.createMetadata(
           nextBatchWatermarkMs = watermarkTracker.currentWatermark,
-          stateUniqueIds = stateStoreCkptId)
+          stateUniqueIds = stateStoreCkptId,
+          commitLogFormatVersion = commitLogFormatVersion)
       }
       if (!commitLog.add(execCtx.batchId, metadata)) {
         throw QueryExecutionErrors.concurrentStreamLogUpdate(execCtx.batchId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -488,21 +488,23 @@ abstract class StreamExecution(
   private def setSparkSessionConfigsForRealTimeMode(sparkSessionForStream: SparkSession): Unit = {
     val conf = sparkSessionForStream.conf
 
-    // SOFT DEFAULT. Real-Time Mode benefits from state store checkpoint format v2: it gives each
+    // SOFT DEFAULTS. Real-Time Mode benefits from state store checkpoint format v2: it gives each
     // batch its own state store checkpoint ids, which matters because a failed batch is rerun from
-    // committed offsets. v2 requires RocksDB -- HDFSBackedStateStoreProvider throws on
-    // checkpointFormatVersion > 1 -- so the two move together and are only defaulted when the user
-    // has pinned NEITHER. The commit log format follows this config for a fresh checkpoint, while
-    // an existing checkpoint keeps the version it was created with (see
-    // CheckpointVersionManager.resolveCommitLogVersion), so raising the default cannot start
-    // writing a format an existing checkpoint was not created with.
+    // committed offsets. v2 requires the RocksDB state store provider. These are defaulted with two
+    // INDEPENDENT guards, matching the Databricks runtime: each key is set only if the user has not
+    // set that key. If the user pins the provider to a non-RocksDB store but leaves the version
+    // unset, the version is still raised to 2 and the incompatible combination throws later
+    // (HDFSBackedStateStoreProvider rejects checkpointFormatVersion > 1) rather than silently
+    // running at v1 -- the runtime makes the same choice deliberately.
     val checkpointVersionKey = SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key
-    val providerKey = SQLConf.STATE_STORE_PROVIDER_CLASS.key
-    if (!conf.contains(checkpointVersionKey) && !conf.contains(providerKey)) {
+    if (!conf.contains(checkpointVersionKey)) {
       logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, checkpointVersionKey)}=2")
+      conf.set(checkpointVersionKey, CommitLog.VERSION_2.toString)
+    }
+    val providerKey = SQLConf.STATE_STORE_PROVIDER_CLASS.key
+    if (!conf.contains(providerKey)) {
       logInfo(log"Real-Time Mode: defaulting " +
         log"${MDC(CONFIG, providerKey)}=RocksDBStateStoreProvider")
-      conf.set(checkpointVersionKey, CommitLog.VERSION_2.toString)
       conf.set(providerKey, classOf[RocksDBStateStoreProvider].getName)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.CloseableThreadContext
 
 import org.apache.spark.{JobArtifactSet, SparkContext, SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{CHECKPOINT_PATH, CHECKPOINT_ROOT, LOGICAL_PLAN, PATH, PRETTY_ID_STRING, QUERY_ID, RUN_ID, SPARK_DATA_STREAM}
+import org.apache.spark.internal.LogKeys.{CHECKPOINT_PATH, CHECKPOINT_ROOT, CONFIG, LOGICAL_PLAN, PATH, PRETTY_ID_STRING, QUERY_ID, RUN_ID, SPARK_DATA_STREAM}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.classic.{SparkSession, StreamingQuery}
@@ -43,10 +43,11 @@ import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2, ReadLi
 import org.apache.spark.sql.connector.write.{LogicalWriteInfoImpl, SupportsTruncate, Write}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.StreamingExplainCommand
-import org.apache.spark.sql.execution.streaming.ContinuousTrigger
+import org.apache.spark.sql.execution.streaming.{ContinuousTrigger, RealTimeTrigger}
 import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, CommitLog, OffsetSeqLog, OffsetSeqMetadata}
 import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperator, StateStoreWriter}
 import org.apache.spark.sql.execution.streaming.sources.{ForeachBatchUserFuncException, ForeachUserFuncException}
+import org.apache.spark.sql.execution.streaming.state.{RocksDBConf, RocksDBStateStoreProvider}
 import org.apache.spark.sql.execution.streaming.state.OperatorStateMetadataV2FileManager
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.SupportsStreamingUpdateAsAppend
@@ -325,6 +326,10 @@ abstract class StreamExecution(
           sparkSessionForStream.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         }
 
+        if (trigger.isInstanceOf[RealTimeTrigger]) {
+          setDefaultConfsForRealTimeMode()
+        }
+
         sparkSessionForStream.conf.get(SQLConf.STATEFUL_SHUFFLE_PARTITIONS_INTERNAL) match {
           case Some(_) => // no-op
           case None =>
@@ -455,6 +460,48 @@ abstract class StreamExecution(
         }
         terminationLatch.countDown()
       }
+    }
+  }
+
+  /**
+   * Applies the configuration defaults a Real-Time Mode query wants but that are not the
+   * engine-wide defaults, because they are only the right choice for a low-latency, long-running
+   * batch.
+   *
+   * Each is applied ONLY IF THE USER HAS NOT SET IT (the `conf.contains` guard), so an explicit
+   * choice always wins. That differs deliberately from the `sortBeforeRepartition` override in
+   * [[MicroBatchExecution]], which forces its value because honouring `true` makes the query
+   * produce no rows at all; everything here is a sensible default rather than a correctness
+   * requirement, so a user who sets one is assumed to mean it. Each change is logged so a run's
+   * effective configuration is recoverable from the driver log.
+   *
+   * Deliberately NOT set here, though Databricks Runtime does default them for Real-Time Mode:
+   *  - `spark.sql.streaming.stateStore.checkpointFormatVersion=2` and the RocksDB state-store
+   *    provider that version requires. Real-Time Mode does benefit from v2 -- it assigns each batch
+   *    its own state-store checkpoint ids, which matters because a failed batch is rerun from
+   *    committed offsets -- but v2 state checkpointing writes `stateUniqueIds`, and a VERSION_1
+   *    commit log rejects those (see `CommitMetadata.withStateUniqueIds`). Defaulting the
+   *    state-store version without also moving an existing checkpoint's commit log to VERSION_2
+   *    turns a working query into a failing one, and migrating an existing commit log is a
+   *    backward-compatibility decision in its own right. Left to a follow-up.
+   *  - The incremental state-cleanup factor: that mechanism does not exist in OSS yet.
+   *  - The Python/Pandas UDF latency knobs: those configs do not exist in OSS.
+   */
+  private def setDefaultConfsForRealTimeMode(): Unit = {
+    val conf = sparkSessionForStream.conf
+
+    // Changelog checkpointing writes a changelog rather than a full snapshot on each commit, which
+    // shortens the state-commit step at a batch boundary. That step is on the critical path between
+    // batches in Real-Time Mode, so this is a latency optimization. Only meaningful with RocksDB,
+    // hence the check against the provider actually in force.
+    val changelogKey = s"${RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX}.changelogCheckpointing.enabled"
+    val usingRocksDb =
+      conf.get(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
+        SQLConf.STATE_STORE_PROVIDER_CLASS.defaultValueString) ==
+        classOf[RocksDBStateStoreProvider].getName
+    if (usingRocksDb && !conf.contains(changelogKey)) {
+      logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, changelogKey)}=true")
+      conf.set(changelogKey, "true")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -490,11 +490,11 @@ abstract class StreamExecution(
     // the state file names of a partially-written failed batch (see the v1 hazard described at the
     // fail-fast in MicroBatchExecution.initializeExecution). v2 requires the RocksDB state store
     // provider. These are defaulted with two INDEPENDENT guards, matching the Databricks runtime:
-    // each key is set only if the user has not set that key. If the user pins the provider to a
-    // non-RocksDB store but leaves the version unset, the version is still raised to 2 and the
-    // incompatible combination throws later (HDFSBackedStateStoreProvider rejects
-    // checkpointFormatVersion > 1) rather than silently running at v1 -- the runtime makes the same
-    // choice deliberately.
+    // each key is set only if the user has not set that key. An explicit non-RocksDB provider has
+    // already been rejected by the pre-flight in StreamingQueryManager
+    // (throwIfConfsAreRealTimeModeIncompatible), so by the time this runs the provider is either
+    // unset (defaulted to RocksDB just below) or already RocksDB; the version default is applied
+    // independently of the provider default.
     val checkpointVersionKey = SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key
     if (!conf.contains(checkpointVersionKey)) {
       logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, checkpointVersionKey)}=2")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -476,7 +476,7 @@ abstract class StreamExecution(
    * (throwIfConfsAreRealTimeModeIncompatible), so by the time this runs an explicit value is always
    * a safe one to keep.
    *
-   * Every change is logged, so a run's effective configuration is recoverable from the driver log.
+   * Every default applied here is logged, so those changes are recoverable from the driver log.
    *
    * Deliberately not set, though Databricks Runtime does default them for Real-Time Mode:
    *  - The incremental state-cleanup factor: that mechanism does not exist in OSS yet.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -469,15 +469,12 @@ abstract class StreamExecution(
    * start, before the logical plan is forced, so a config read during planning sees the final
    * value.
    *
-   * There are two kinds of setting here, and the difference is deliberate:
-   *
-   *  - SOFT DEFAULTS, applied only when the user has not set the key, so an explicit choice always
-   *    wins. These are performance choices, not correctness requirements, so a user who sets one is
-   *    assumed to mean it. The state store settings and `changelogCheckpointing` are these.
-   *  - HARD OVERRIDES, applied unconditionally because honouring the user's value would break the
-   *    query outright. `sortBeforeRepartition` is one: leaving it `true` makes a Real-Time Mode
-   *    query with a round-robin repartition produce no rows at all. An override logs a warning so
-   *    the operator can see their config is not the one in force.
+   * Every setting here is a SOFT DEFAULT: applied only when the user has not set the key, so an
+   * explicit choice always wins. The state store settings, `changelogCheckpointing`, and
+   * `sortBeforeRepartition` are these. An explicit value that is incompatible with Real-Time Mode
+   * is not overridden here -- it is rejected up front by the preflight in StreamingQueryManager
+   * (throwIfConfsAreRealTimeModeIncompatible), so by the time this runs an explicit value is always
+   * a safe one to keep.
    *
    * Every change is logged, so a run's effective configuration is recoverable from the driver log.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -464,16 +464,23 @@ abstract class StreamExecution(
   }
 
   /**
-   * Applies the configuration defaults a Real-Time Mode query wants but that are not the
-   * engine-wide defaults, because they are only the right choice for a low-latency, long-running
-   * batch.
+   * Applies the configuration a Real-Time Mode query needs but that is not the engine-wide default,
+   * because it is only the right choice for a low-latency, long-running batch. Runs once at query
+   * start, before the logical plan is forced, so a config read during planning sees the final
+   * value.
    *
-   * Each is applied ONLY IF THE USER HAS NOT SET IT (the `conf.contains` guard), so an explicit
-   * choice always wins. That differs deliberately from the `sortBeforeRepartition` override in
-   * [[MicroBatchExecution]], which forces its value because honouring `true` makes the query
-   * produce no rows at all; everything here is a sensible default rather than a correctness
-   * requirement, so a user who sets one is assumed to mean it. Each change is logged so a run's
-   * effective configuration is recoverable from the driver log.
+   * There are two kinds of setting here, and the difference is deliberate:
+   *
+   *  - SOFT DEFAULTS, applied only when the user has not set the key (`conf.contains` guard), so an
+   *    explicit choice always wins. These are performance choices, not correctness requirements,
+   *    so a user who sets one is assumed to mean it. `changelogCheckpointing` is one.
+   *  - HARD OVERRIDES, applied unconditionally because honouring the user's value would break the
+   *    query outright. `sortBeforeRepartition` is one: leaving it `true` makes a Real-Time Mode
+   *    query
+   *    with a round-robin repartition produce no rows at all. An override logs a warning so the
+   *    operator can see their config is not the one in force.
+   *
+   * Every change is logged, so a run's effective configuration is recoverable from the driver log.
    *
    * Deliberately NOT set here, though Databricks Runtime does default them for Real-Time Mode:
    *  - `spark.sql.streaming.stateStore.checkpointFormatVersion=2` and the RocksDB state-store
@@ -490,10 +497,11 @@ abstract class StreamExecution(
   private def setDefaultConfsForRealTimeMode(): Unit = {
     val conf = sparkSessionForStream.conf
 
-    // Changelog checkpointing writes a changelog rather than a full snapshot on each commit, which
-    // shortens the state-commit step at a batch boundary. That step is on the critical path between
-    // batches in Real-Time Mode, so this is a latency optimization. Only meaningful with RocksDB,
-    // hence the check against the provider actually in force.
+    // SOFT DEFAULT. Changelog checkpointing writes a changelog rather than a full snapshot on each
+    // commit, which shortens the state-commit step at a batch boundary. That step is on the
+    // critical path between batches in Real-Time Mode, so this is a latency optimization. Only
+    // meaningful
+    // with RocksDB, hence the check against the provider actually in force.
     val changelogKey = s"${RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX}.changelogCheckpointing.enabled"
     val usingRocksDb =
       conf.get(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
@@ -503,6 +511,31 @@ abstract class StreamExecution(
       logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, changelogKey)}=true")
       conf.set(changelogKey, "true")
     }
+
+    // HARD OVERRIDE. `repartition(n)` uses RoundRobinPartitioning, and by default (SPARK-23207)
+    // Spark inserts a local sort before a round-robin shuffle so the row-to-partition assignment is
+    // deterministic -- otherwise a retried task could emit rows in a different order and lose data.
+    // That sort is fully blocking: it drains its whole input before emitting a row. A Real-Time
+    // Mode
+    // task reads an unbounded stream, so the input never ends, the producer never emits, and the
+    // query makes no progress at all. Note this sort is not a SortExec node (it lives inside
+    // ShuffleExchangeExec's RDD), so the Real-Time Mode operator allowlist cannot catch it.
+    //
+    // Determinism is not needed here: Real-Time Mode does not retry tasks (TaskSetManager caps a
+    // pipelined task set at one attempt, and its group is aborted as a unit rather than
+    // recomputed), so the hazard the sort guards against does not arise.
+    //
+    // This overrides an explicit `true` as well. Honouring it would reintroduce the hang above, and
+    // a query that never produces a row is worse than silently ignoring a config that only guards
+    // against a retry that cannot happen here.
+    if (conf.contains(SQLConf.SORT_BEFORE_REPARTITION.key) &&
+      conf.get(SQLConf.SORT_BEFORE_REPARTITION)) {
+      logWarning(log"Ignoring ${MDC(CONFIG, SQLConf.SORT_BEFORE_REPARTITION.key)}=true " +
+        log"for this Real-Time Mode query: the local sort it inserts before a round-robin " +
+        log"repartition never completes on an unbounded stream. It is not needed because a " +
+        log"Real-Time Mode task is not retried.")
+    }
+    conf.set(SQLConf.SORT_BEFORE_REPARTITION.key, "false")
   }
 
   private def isInterruptedByStop(e: Throwable, sc: SparkContext): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.streaming.runtime
 
 import java.io.{InterruptedIOException, UncheckedIOException}
 import java.nio.channels.ClosedByInterruptException
-import java.util.{Locale, UUID}
+import java.util.UUID
 import java.util.concurrent.{CountDownLatch, ExecutionException, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
@@ -489,13 +489,15 @@ abstract class StreamExecution(
     val conf = sparkSessionForStream.conf
 
     // SOFT DEFAULTS. Real-Time Mode benefits from state store checkpoint format v2: it gives each
-    // batch its own state store checkpoint ids, which matters because a failed batch is rerun from
-    // committed offsets. v2 requires the RocksDB state store provider. These are defaulted with two
-    // INDEPENDENT guards, matching the Databricks runtime: each key is set only if the user has not
-    // set that key. If the user pins the provider to a non-RocksDB store but leaves the version
-    // unset, the version is still raised to 2 and the incompatible combination throws later
-    // (HDFSBackedStateStoreProvider rejects checkpointFormatVersion > 1) rather than silently
-    // running at v1 -- the runtime makes the same choice deliberately.
+    // batch run its own state store checkpoint ids, which prevents a re-executed batch from reusing
+    // the state file names of a partially-written failed batch (see the v1 hazard described at the
+    // fail-fast in MicroBatchExecution.initializeExecution). v2 requires the RocksDB state store
+    // provider. These are defaulted with two INDEPENDENT guards, matching the Databricks runtime:
+    // each key is set only if the user has not set that key. If the user pins the provider to a
+    // non-RocksDB store but leaves the version unset, the version is still raised to 2 and the
+    // incompatible combination throws later (HDFSBackedStateStoreProvider rejects
+    // checkpointFormatVersion > 1) rather than silently running at v1 -- the runtime makes the same
+    // choice deliberately.
     val checkpointVersionKey = SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key
     if (!conf.contains(checkpointVersionKey)) {
       logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, checkpointVersionKey)}=2")
@@ -517,15 +519,7 @@ abstract class StreamExecution(
       conf.get(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
         SQLConf.STATE_STORE_PROVIDER_CLASS.defaultValueString) ==
         classOf[RocksDBStateStoreProvider].getName
-    // RocksDB resolves its own configs through a CaseInsensitiveMap (see RocksDBConf.apply), so a
-    // user can set this key in any casing and RocksDB will honour it. `conf.contains` is
-    // case-SENSITIVE, so comparing only the canonical spelling would miss such a setting and
-    // silently override it. Match the way RocksDB reads the key instead.
-    val changelogAlreadySet = {
-      val canonical = changelogKey.toLowerCase(Locale.ROOT)
-      conf.getAll.keys.exists(_.toLowerCase(Locale.ROOT) == canonical)
-    }
-    if (usingRocksDb && !changelogAlreadySet) {
+    if (usingRocksDb && !conf.contains(changelogKey)) {
       logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, changelogKey)}=true")
       conf.set(changelogKey, "true")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -163,15 +163,6 @@ abstract class StreamExecution(
   /** Isolated spark session to run the batches with. */
   protected[sql] val sparkSessionForStream: SparkSession = sparkSession.cloneSession()
 
-  // Must run BEFORE `checkpointMetadata` below. `CommitLog.defaultVersion` is a val read when the
-  // commit log is constructed, and the eager `streamMetadata` field forces that lazy construction
-  // (it calls commitLog.getLatestBatchId). Setting the state-store checkpoint version any later
-  // would move the state store to v2 while leaving the commit log at v1, and a VERSION_1 commit log
-  // rejects the `stateUniqueIds` that v2 writes. See setStateStoreDefaultsForRealTimeMode.
-  if (trigger.isInstanceOf[RealTimeTrigger]) {
-    setStateStoreDefaultsForRealTimeMode()
-  }
-
   /**
    * Manages the metadata from this checkpoint location.
    */
@@ -336,7 +327,7 @@ abstract class StreamExecution(
         }
 
         if (trigger.isInstanceOf[RealTimeTrigger]) {
-          setDefaultConfsForRealTimeMode()
+          setSparkSessionConfigsForRealTimeMode(sparkSessionForStream)
         }
 
         sparkSessionForStream.conf.get(SQLConf.STATEFUL_SHUFFLE_PARTITIONS_INTERNAL) match {
@@ -473,38 +464,6 @@ abstract class StreamExecution(
   }
 
   /**
-   * Applies the state-store defaults a Real-Time Mode query wants. Separate from
-   * [[setDefaultConfsForRealTimeMode]] purely because of WHEN it has to run: these two keys are
-   * read while the commit log is constructed, which happens during this class's own
-   * initialization, so they cannot wait until `runStream`.
-   *
-   * Both are applied only when the user has pinned NEITHER, and they move together. Real-Time Mode
-   * benefits from checkpoint format v2 because it gives each batch its own state-store checkpoint
-   * ids, which matters when a failed batch is rerun from committed offsets. v2 requires RocksDB:
-   * `HDFSBackedStateStoreProvider` throws on `checkpointFormatVersion > 1`, so defaulting one
-   * without the other would turn a working query into a failing one. If the user has pinned either
-   * key, both are left alone and their combination stands or fails on its own terms.
-   *
-   * NOTE: a checkpoint's commit-log format is currently decided by the session config rather than
-   * by the format the checkpoint was created with -- `CheckpointVersionManager` resolves only
-   * `OffsetLogType`, and `CommitLog.createMetadata` defaults to the configured version. Reads are
-   * unaffected because each commit-log entry is self-describing, but resolving the write version
-   * from an existing checkpoint (as the Databricks runtime does) is a worthwhile follow-up.
-   */
-  private def setStateStoreDefaultsForRealTimeMode(): Unit = {
-    val conf = sparkSessionForStream.conf
-    val checkpointVersionKey = SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key
-    val providerKey = SQLConf.STATE_STORE_PROVIDER_CLASS.key
-    if (!conf.contains(checkpointVersionKey) && !conf.contains(providerKey)) {
-      logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, checkpointVersionKey)}=2")
-      logInfo(log"Real-Time Mode: defaulting " +
-        log"${MDC(CONFIG, providerKey)}=RocksDBStateStoreProvider")
-      conf.set(checkpointVersionKey, "2")
-      conf.set(providerKey, classOf[RocksDBStateStoreProvider].getName)
-    }
-  }
-
-  /**
    * Applies the configuration a Real-Time Mode query needs but that is not the engine-wide default,
    * because it is only the right choice for a low-latency, long-running batch. Runs once at query
    * start, before the logical plan is forced, so a config read during planning sees the final
@@ -512,9 +471,9 @@ abstract class StreamExecution(
    *
    * There are two kinds of setting here, and the difference is deliberate:
    *
-   *  - SOFT DEFAULTS, applied only when the user has not set the key (`conf.contains` guard), so an
-   *    explicit choice always wins. These are performance choices, not correctness requirements,
-   *    so a user who sets one is assumed to mean it. `changelogCheckpointing` is one.
+   *  - SOFT DEFAULTS, applied only when the user has not set the key, so an explicit choice always
+   *    wins. These are performance choices, not correctness requirements, so a user who sets one is
+   *    assumed to mean it. The state store settings and `changelogCheckpointing` are these.
    *  - HARD OVERRIDES, applied unconditionally because honouring the user's value would break the
    *    query outright. `sortBeforeRepartition` is one: leaving it `true` makes a Real-Time Mode
    *    query with a round-robin repartition produce no rows at all. An override logs a warning so
@@ -522,15 +481,30 @@ abstract class StreamExecution(
    *
    * Every change is logged, so a run's effective configuration is recoverable from the driver log.
    *
-   * The state-store checkpoint format and provider are NOT set here -- they must be applied before
-   * the commit log is constructed, so they live in [[setStateStoreDefaultsForRealTimeMode]].
-   *
-   * Deliberately not set at all, though Databricks Runtime does default them for Real-Time Mode:
+   * Deliberately not set, though Databricks Runtime does default them for Real-Time Mode:
    *  - The incremental state-cleanup factor: that mechanism does not exist in OSS yet.
    *  - The Python/Pandas UDF latency knobs: those configs do not exist in OSS.
    */
-  private def setDefaultConfsForRealTimeMode(): Unit = {
+  private def setSparkSessionConfigsForRealTimeMode(sparkSessionForStream: SparkSession): Unit = {
     val conf = sparkSessionForStream.conf
+
+    // SOFT DEFAULT. Real-Time Mode benefits from state store checkpoint format v2: it gives each
+    // batch its own state store checkpoint ids, which matters because a failed batch is rerun from
+    // committed offsets. v2 requires RocksDB -- HDFSBackedStateStoreProvider throws on
+    // checkpointFormatVersion > 1 -- so the two move together and are only defaulted when the user
+    // has pinned NEITHER. The commit log format follows this config for a fresh checkpoint, while
+    // an existing checkpoint keeps the version it was created with (see
+    // CheckpointVersionManager.resolveCommitLogVersion), so raising the default cannot start
+    // writing a format an existing checkpoint was not created with.
+    val checkpointVersionKey = SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key
+    val providerKey = SQLConf.STATE_STORE_PROVIDER_CLASS.key
+    if (!conf.contains(checkpointVersionKey) && !conf.contains(providerKey)) {
+      logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, checkpointVersionKey)}=2")
+      logInfo(log"Real-Time Mode: defaulting " +
+        log"${MDC(CONFIG, providerKey)}=RocksDBStateStoreProvider")
+      conf.set(checkpointVersionKey, CommitLog.VERSION_2.toString)
+      conf.set(providerKey, classOf[RocksDBStateStoreProvider].getName)
+    }
 
     // SOFT DEFAULT. Changelog checkpointing writes a changelog rather than a full snapshot on each
     // commit, which shortens the state-commit step at a batch boundary. That step is on the
@@ -558,9 +532,8 @@ abstract class StreamExecution(
     // Spark inserts a local sort before a round-robin shuffle so the row-to-partition assignment is
     // deterministic -- otherwise a retried task could emit rows in a different order and lose data.
     // That sort is fully blocking: it drains its whole input before emitting a row. A Real-Time
-    // Mode
-    // task reads an unbounded stream, so the input never ends, the producer never emits, and the
-    // query makes no progress at all. Note this sort is not a SortExec node (it lives inside
+    // Mode task reads an unbounded stream, so the input never ends, the producer never emits, and
+    // the query makes no progress at all. Note this sort is not a SortExec node (it lives inside
     // ShuffleExchangeExec's RDD), so the Real-Time Mode operator allowlist cannot catch it.
     //
     // Determinism is not needed here: Real-Time Mode does not retry tasks (TaskSetManager caps a

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -524,7 +524,7 @@ abstract class StreamExecution(
       conf.set(changelogKey, "true")
     }
 
-    // HARD OVERRIDE. `repartition(n)` uses RoundRobinPartitioning, and by default (SPARK-23207)
+    // SOFT DEFAULT. `repartition(n)` uses RoundRobinPartitioning, and by default (SPARK-23207)
     // Spark inserts a local sort before a round-robin shuffle so the row-to-partition assignment is
     // deterministic -- otherwise a retried task could emit rows in a different order and lose data.
     // That sort is fully blocking: it drains its whole input before emitting a row. A Real-Time
@@ -536,17 +536,12 @@ abstract class StreamExecution(
     // pipelined task set at one attempt, and its group is aborted as a unit rather than
     // recomputed), so the hazard the sort guards against does not arise.
     //
-    // This overrides an explicit `true` as well. Honouring it would reintroduce the hang above, and
-    // a query that never produces a row is worse than silently ignoring a config that only guards
-    // against a retry that cannot happen here.
-    if (conf.contains(SQLConf.SORT_BEFORE_REPARTITION.key) &&
-      conf.get(SQLConf.SORT_BEFORE_REPARTITION)) {
-      logWarning(log"Ignoring ${MDC(CONFIG, SQLConf.SORT_BEFORE_REPARTITION.key)}=true " +
-        log"for this Real-Time Mode query: the local sort it inserts before a round-robin " +
-        log"repartition never completes on an unbounded stream. It is not needed because a " +
-        log"Real-Time Mode task is not retried.")
+    // This is a soft default rather than an override: an explicit `true` is rejected up front by
+    // the pre-flight in StreamingQueryManager (throwIfConfsAreRealTimeModeIncompatible), so by the
+    // time we get here an explicit value can only be `false`. Matches the Databricks runtime.
+    if (!conf.contains(SQLConf.SORT_BEFORE_REPARTITION.key)) {
+      conf.set(SQLConf.SORT_BEFORE_REPARTITION.key, "false")
     }
-    conf.set(SQLConf.SORT_BEFORE_REPARTITION.key, "false")
   }
 
   private def isInterruptedByStop(e: Throwable, sc: SparkContext): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -471,10 +471,10 @@ abstract class StreamExecution(
    *
    * Every setting here is a SOFT DEFAULT: applied only when the user has not set the key, so an
    * explicit choice always wins. The state store settings, `changelogCheckpointing`, and
-   * `sortBeforeRepartition` are these. An explicit value that is incompatible with Real-Time Mode
-   * is not overridden here -- it is rejected up front by the preflight in StreamingQueryManager
-   * (throwIfConfsAreRealTimeModeIncompatible), so by the time this runs an explicit value is always
-   * a safe one to keep.
+   * `sortBeforeRepartition` are these. Except for checkpoint format v1 when its escape hatch is
+   * enabled, an explicit value that is incompatible with Real-Time Mode is rejected up front by the
+   * preflight in StreamingQueryManager (throwIfConfsAreRealTimeModeIncompatible). Therefore, an
+   * explicit value that reaches this method is safe to keep or was explicitly allowed.
    *
    * Every default applied here is logged, so those changes are recoverable from the driver log.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -163,6 +163,15 @@ abstract class StreamExecution(
   /** Isolated spark session to run the batches with. */
   protected[sql] val sparkSessionForStream: SparkSession = sparkSession.cloneSession()
 
+  // Must run BEFORE `checkpointMetadata` below. `CommitLog.defaultVersion` is a val read when the
+  // commit log is constructed, and the eager `streamMetadata` field forces that lazy construction
+  // (it calls commitLog.getLatestBatchId). Setting the state-store checkpoint version any later
+  // would move the state store to v2 while leaving the commit log at v1, and a VERSION_1 commit log
+  // rejects the `stateUniqueIds` that v2 writes. See setStateStoreDefaultsForRealTimeMode.
+  if (trigger.isInstanceOf[RealTimeTrigger]) {
+    setStateStoreDefaultsForRealTimeMode()
+  }
+
   /**
    * Manages the metadata from this checkpoint location.
    */
@@ -464,6 +473,38 @@ abstract class StreamExecution(
   }
 
   /**
+   * Applies the state-store defaults a Real-Time Mode query wants. Separate from
+   * [[setDefaultConfsForRealTimeMode]] purely because of WHEN it has to run: these two keys are
+   * read while the commit log is constructed, which happens during this class's own
+   * initialization, so they cannot wait until `runStream`.
+   *
+   * Both are applied only when the user has pinned NEITHER, and they move together. Real-Time Mode
+   * benefits from checkpoint format v2 because it gives each batch its own state-store checkpoint
+   * ids, which matters when a failed batch is rerun from committed offsets. v2 requires RocksDB:
+   * `HDFSBackedStateStoreProvider` throws on `checkpointFormatVersion > 1`, so defaulting one
+   * without the other would turn a working query into a failing one. If the user has pinned either
+   * key, both are left alone and their combination stands or fails on its own terms.
+   *
+   * NOTE: a checkpoint's commit-log format is currently decided by the session config rather than
+   * by the format the checkpoint was created with -- `CheckpointVersionManager` resolves only
+   * `OffsetLogType`, and `CommitLog.createMetadata` defaults to the configured version. Reads are
+   * unaffected because each commit-log entry is self-describing, but resolving the write version
+   * from an existing checkpoint (as the Databricks runtime does) is a worthwhile follow-up.
+   */
+  private def setStateStoreDefaultsForRealTimeMode(): Unit = {
+    val conf = sparkSessionForStream.conf
+    val checkpointVersionKey = SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key
+    val providerKey = SQLConf.STATE_STORE_PROVIDER_CLASS.key
+    if (!conf.contains(checkpointVersionKey) && !conf.contains(providerKey)) {
+      logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, checkpointVersionKey)}=2")
+      logInfo(log"Real-Time Mode: defaulting " +
+        log"${MDC(CONFIG, providerKey)}=RocksDBStateStoreProvider")
+      conf.set(checkpointVersionKey, "2")
+      conf.set(providerKey, classOf[RocksDBStateStoreProvider].getName)
+    }
+  }
+
+  /**
    * Applies the configuration a Real-Time Mode query needs but that is not the engine-wide default,
    * because it is only the right choice for a low-latency, long-running batch. Runs once at query
    * start, before the logical plan is forced, so a config read during planning sees the final
@@ -481,17 +522,10 @@ abstract class StreamExecution(
    *
    * Every change is logged, so a run's effective configuration is recoverable from the driver log.
    *
-   * Deliberately NOT set here, though Databricks Runtime does default them for Real-Time Mode:
-   *  - `spark.sql.streaming.stateStore.checkpointFormatVersion=2` and the RocksDB state-store
-   *    provider that version requires. Real-Time Mode does benefit from v2, since it gives each
-   *    batch its own state-store checkpoint ids and a failed batch is rerun from committed offsets.
-   *    Setting it here is not enough on its own: `CommitLog.defaultVersion` is a val read when the
-   *    commit log is constructed, and the eager `streamMetadata` above forces that construction
-   *    before this method runs, so the state store would move to v2 while the commit log stayed at
-   *    v1. Doing this properly also wants the commit log's version to be resolved from an existing
-   *    checkpoint rather than from the session config (`CheckpointVersionManager` currently handles
-   *    only `OffsetLogType`), so writes honour the format a checkpoint was created with. Left to a
-   *    follow-up.
+   * The state-store checkpoint format and provider are NOT set here -- they must be applied before
+   * the commit log is constructed, so they live in [[setStateStoreDefaultsForRealTimeMode]].
+   *
+   * Deliberately not set at all, though Databricks Runtime does default them for Real-Time Mode:
    *  - The incremental state-cleanup factor: that mechanism does not exist in OSS yet.
    *  - The Python/Pandas UDF latency knobs: those configs do not exist in OSS.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.streaming.runtime
 
 import java.io.{InterruptedIOException, UncheckedIOException}
 import java.nio.channels.ClosedByInterruptException
-import java.util.UUID
+import java.util.{Locale, UUID}
 import java.util.concurrent.{CountDownLatch, ExecutionException, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
@@ -507,7 +507,15 @@ abstract class StreamExecution(
       conf.get(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
         SQLConf.STATE_STORE_PROVIDER_CLASS.defaultValueString) ==
         classOf[RocksDBStateStoreProvider].getName
-    if (usingRocksDb && !conf.contains(changelogKey)) {
+    // RocksDB resolves its own configs through a CaseInsensitiveMap (see RocksDBConf.apply), so a
+    // user can set this key in any casing and RocksDB will honour it. `conf.contains` is
+    // case-SENSITIVE, so comparing only the canonical spelling would miss such a setting and
+    // silently override it. Match the way RocksDB reads the key instead.
+    val changelogAlreadySet = {
+      val canonical = changelogKey.toLowerCase(Locale.ROOT)
+      conf.getAll.keys.exists(_.toLowerCase(Locale.ROOT) == canonical)
+    }
+    if (usingRocksDb && !changelogAlreadySet) {
       logInfo(log"Real-Time Mode: defaulting ${MDC(CONFIG, changelogKey)}=true")
       conf.set(changelogKey, "true")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -476,21 +476,22 @@ abstract class StreamExecution(
    *    so a user who sets one is assumed to mean it. `changelogCheckpointing` is one.
    *  - HARD OVERRIDES, applied unconditionally because honouring the user's value would break the
    *    query outright. `sortBeforeRepartition` is one: leaving it `true` makes a Real-Time Mode
-   *    query
-   *    with a round-robin repartition produce no rows at all. An override logs a warning so the
-   *    operator can see their config is not the one in force.
+   *    query with a round-robin repartition produce no rows at all. An override logs a warning so
+   *    the operator can see their config is not the one in force.
    *
    * Every change is logged, so a run's effective configuration is recoverable from the driver log.
    *
    * Deliberately NOT set here, though Databricks Runtime does default them for Real-Time Mode:
    *  - `spark.sql.streaming.stateStore.checkpointFormatVersion=2` and the RocksDB state-store
-   *    provider that version requires. Real-Time Mode does benefit from v2 -- it assigns each batch
-   *    its own state-store checkpoint ids, which matters because a failed batch is rerun from
-   *    committed offsets -- but v2 state checkpointing writes `stateUniqueIds`, and a VERSION_1
-   *    commit log rejects those (see `CommitMetadata.withStateUniqueIds`). Defaulting the
-   *    state-store version without also moving an existing checkpoint's commit log to VERSION_2
-   *    turns a working query into a failing one, and migrating an existing commit log is a
-   *    backward-compatibility decision in its own right. Left to a follow-up.
+   *    provider that version requires. Real-Time Mode does benefit from v2, since it gives each
+   *    batch its own state-store checkpoint ids and a failed batch is rerun from committed offsets.
+   *    Setting it here is not enough on its own: `CommitLog.defaultVersion` is a val read when the
+   *    commit log is constructed, and the eager `streamMetadata` above forces that construction
+   *    before this method runs, so the state store would move to v2 while the commit log stayed at
+   *    v1. Doing this properly also wants the commit log's version to be resolved from an existing
+   *    checkpoint rather than from the session config (`CheckpointVersionManager` currently handles
+   *    only `OffsetLogType`), so writes honour the format a checkpoint was created with. Left to a
+   *    follow-up.
    *  - The incremental state-cleanup factor: that mechanism does not exist in OSS yet.
    *  - The Python/Pandas UDF latency knobs: those configs do not exist in OSS.
    */
@@ -499,9 +500,8 @@ abstract class StreamExecution(
 
     // SOFT DEFAULT. Changelog checkpointing writes a changelog rather than a full snapshot on each
     // commit, which shortens the state-commit step at a batch boundary. That step is on the
-    // critical path between batches in Real-Time Mode, so this is a latency optimization. Only
-    // meaningful
-    // with RocksDB, hence the check against the provider actually in force.
+    // critical path between batches in Real-Time Mode, so this is a latency optimization. It is
+    // only meaningful with RocksDB, hence the check against the provider actually in force.
     val changelogKey = s"${RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX}.changelogCheckpointing.enabled"
     val usingRocksDb =
       conf.get(SQLConf.STATE_STORE_PROVIDER_CLASS.key,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -537,6 +537,8 @@ abstract class StreamExecution(
     // the pre-flight in StreamingQueryManager (throwIfConfsAreRealTimeModeIncompatible), so by the
     // time we get here an explicit value can only be `false`. Matches the Databricks runtime.
     if (!conf.contains(SQLConf.SORT_BEFORE_REPARTITION.key)) {
+      logInfo(log"Real-Time Mode: defaulting " +
+        log"${MDC(CONFIG, SQLConf.SORT_BEFORE_REPARTITION.key)}=false")
       conf.set(SQLConf.SORT_BEFORE_REPARTITION.key, "false")
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecutionContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecutionContext.scala
@@ -128,6 +128,7 @@ class MicroBatchExecutionContext(
     var _batchId: Long,
     sparkSession: SparkSession,
     val offsetLogFormatVersionOpt: Option[Int],
+    val commitLogFormatVersionOpt: Option[Int],
     var previousContext: Option[MicroBatchExecutionContext])
   extends StreamExecutionContext(
     id,
@@ -192,6 +193,7 @@ class MicroBatchExecutionContext(
       batchId + 1,
       sparkSession,
       offsetLogFormatVersionOpt,
+      commitLogFormatVersionOpt,
       Some(this))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateRewriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateRewriter.scala
@@ -381,7 +381,7 @@ class StateRewriter(
     // StateRewriter from writing state files in a format that disagrees with the source
     // checkpoint. Using the read batch commit since the latest commit could be a skipped batch.
     readCheckpoint.commitLog.get(readBatchId).foreach { metadata =>
-      val configuredVersion = readCheckpoint.commitLog.defaultVersion
+      val configuredVersion = SQLConf.get.getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)
       if (metadata.version != configuredVersion) {
         throw StateRewriterErrors.stateCheckpointFormatVersionMismatchError(
           checkpointLocationForRead,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateRewriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateRewriter.scala
@@ -381,7 +381,8 @@ class StateRewriter(
     // StateRewriter from writing state files in a format that disagrees with the source
     // checkpoint. Using the read batch commit since the latest commit could be a skipped batch.
     readCheckpoint.commitLog.get(readBatchId).foreach { metadata =>
-      val configuredVersion = SQLConf.get.getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)
+      val configuredVersion =
+        sparkSession.sessionState.conf.getConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION)
       if (metadata.version != configuredVersion) {
         throw StateRewriterErrors.stateCheckpointFormatVersionMismatchError(
           checkpointLocationForRead,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
@@ -256,59 +256,44 @@ class CommitLogSuite extends SharedSparkSession {
     CheckpointVersionManager.resolveCommitLogVersion(spark, latestCommittedBatch = None)
   }
 
-  test("commit log version is the max of its own config and the state store minimum") {
-    // Neither set: both default to 1.
+  test("commit log version derives from the state store checkpoint format") {
+    // Nothing set: defaults to VERSION_1.
     assert(sessionCommitLogVersion() === CommitLog.VERSION_1)
 
-    // Only the commit log config: taken as-is, including V3, which has no state store counterpart.
-    Seq(1, 2, 3).foreach { v =>
-      withSQLConf(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> v.toString) {
-        assert(sessionCommitLogVersion() === v,
-          s"an explicit commit log version $v should be used as-is")
-      }
-    }
-
-    // Only the state store config at 2: implies a commit log minimum of 2, because state store v2
-    // writes stateUniqueIds and VERSION_1 cannot persist them.
+    // State store checkpoint format v2 makes each batch write stateUniqueIds, which only a commit
+    // log at VERSION_2 or above can persist, so it raises the commit log version to v2.
     withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2") {
       assert(sessionCommitLogVersion() === CommitLog.VERSION_2,
         "state store v2 must raise the commit log to v2")
     }
 
-    // Both set and disagreeing: the max wins, in both directions.
-    withSQLConf(
-      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
-      SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> "1") {
+    // The resolved version is capped at VERSION_2: VERSION_3 exists only to carry sink-evolution
+    // metadata and is written exclusively by the sink-evolution path, never derived from a config.
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "3") {
       assert(sessionCommitLogVersion() === CommitLog.VERSION_2,
-        "the state store minimum must win over a lower commit log config")
-    }
-    withSQLConf(
-      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1",
-      SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> "3") {
-      assert(sessionCommitLogVersion() === CommitLog.VERSION_3,
-        "a higher commit log config must not be dragged down by a state store on v1")
+        "a config-derived commit log version must never resolve to v3")
     }
   }
 
   test("an existing checkpoint's commit log version wins over the session config") {
     // The whole point of resolution: a commit log created at one version keeps being written at
-    // that version, so raising a config cannot start writing a format the checkpoint lacks.
-    withSQLConf(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> "3") {
+    // that version, so a higher state store checkpoint format cannot start writing a format the
+    // checkpoint lacks.
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2") {
       val existing: CommitMetadataBase = CommitMetadata(nextBatchWatermarkMs = 0)
       assert(existing.version === CommitLog.VERSION_1)
       val resolved =
         CheckpointVersionManager.resolveCommitLogVersion(spark, Some((7L, existing)))
       assert(resolved === CommitLog.VERSION_1,
-        s"an existing V1 commit log must stay V1 even with the config at 3, got $resolved")
+        s"an existing V1 commit log must stay V1 even with the state store at v2, got $resolved")
     }
   }
 
-  test("recording a commit log version keeps the two configs consistent") {
+  test("recording a commit log version sets the implied state store format") {
     // A V3 commit log has no state store counterpart, so the state store config is clamped to 2
     // rather than set to 3.
     val session = spark.cloneSession()
     CheckpointVersionManager.setFormatVersion(session, CommitLogType, CommitLog.VERSION_3)
-    assert(session.conf.get(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key) === "3")
     assert(session.conf.get(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) === "2",
       "the state store format must be clamped to 2 for a V3 commit log")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
@@ -290,12 +290,20 @@ class CommitLogSuite extends SharedSparkSession {
   }
 
   test("recording a commit log version sets the implied state store format") {
-    // A V3 commit log has no state store counterpart, so the state store config is clamped to 2
-    // rather than set to 3.
     val session = spark.cloneSession()
-    CheckpointVersionManager.setFormatVersion(session, CommitLogType, CommitLog.VERSION_3)
+    val v3WithStateIds = CommitMetadataV3(0, Some(Map.empty), Map.empty)
+    CheckpointVersionManager.setFormatVersion(
+      session, CommitLogType, CommitLog.VERSION_3, Some(v3WithStateIds))
     assert(session.conf.get(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) === "2",
-      "the state store format must be clamped to 2 for a V3 commit log")
+      "state checkpoint ids in a V3 commit imply state store format v2")
+
+    val v3WithoutStateIdsSession = spark.cloneSession()
+    val v3WithoutStateIds = CommitMetadataV3(0, None, Map.empty)
+    CheckpointVersionManager.setFormatVersion(
+      v3WithoutStateIdsSession, CommitLogType, CommitLog.VERSION_3, Some(v3WithoutStateIds))
+    assert(v3WithoutStateIdsSession.conf.get(
+      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) === "1",
+      "a V3 commit without state checkpoint ids must preserve state store format v1")
 
     val v1Session = spark.cloneSession()
     CheckpointVersionManager.setFormatVersion(v1Session, CommitLogType, CommitLog.VERSION_1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.streaming
 import java.io.{ByteArrayInputStream, FileInputStream, FileOutputStream}
 import java.nio.file.Path
 
-import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, CommitMetadata, CommitMetadataBase, CommitMetadataV2, CommitMetadataV3, OffsetSeqLog, SinkMetadataInfo}
+import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointVersionManager, CommitLog, CommitLogType, CommitMetadata, CommitMetadataBase, CommitMetadataV2, CommitMetadataV3, OffsetSeqLog, SinkMetadataInfo}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -250,4 +250,72 @@ class CommitLogSuite extends SharedSparkSession {
         commitLogFormatVersion = CommitLog.VERSION_1).version === CommitLog.VERSION_1)
     }
   }
+
+  /** The commit log version the session config asks for, via the public resolution entry point. */
+  private def sessionCommitLogVersion(): Int = {
+    CheckpointVersionManager.resolveCommitLogVersion(spark, latestCommittedBatch = None)
+  }
+
+  test("commit log version is the max of its own config and the state store minimum") {
+    // Neither set: both default to 1.
+    assert(sessionCommitLogVersion() === CommitLog.VERSION_1)
+
+    // Only the commit log config: taken as-is, including V3, which has no state store counterpart.
+    Seq(1, 2, 3).foreach { v =>
+      withSQLConf(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> v.toString) {
+        assert(sessionCommitLogVersion() === v,
+          s"an explicit commit log version $v should be used as-is")
+      }
+    }
+
+    // Only the state store config at 2: implies a commit log minimum of 2, because state store v2
+    // writes stateUniqueIds and VERSION_1 cannot persist them.
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2") {
+      assert(sessionCommitLogVersion() === CommitLog.VERSION_2,
+        "state store v2 must raise the commit log to v2")
+    }
+
+    // Both set and disagreeing: the max wins, in both directions.
+    withSQLConf(
+      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2",
+      SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> "1") {
+      assert(sessionCommitLogVersion() === CommitLog.VERSION_2,
+        "the state store minimum must win over a lower commit log config")
+    }
+    withSQLConf(
+      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1",
+      SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> "3") {
+      assert(sessionCommitLogVersion() === CommitLog.VERSION_3,
+        "a higher commit log config must not be dragged down by a state store on v1")
+    }
+  }
+
+  test("an existing checkpoint's commit log version wins over the session config") {
+    // The whole point of resolution: a commit log created at one version keeps being written at
+    // that version, so raising a config cannot start writing a format the checkpoint lacks.
+    withSQLConf(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key -> "3") {
+      val existing: CommitMetadataBase = CommitMetadata(nextBatchWatermarkMs = 0)
+      assert(existing.version === CommitLog.VERSION_1)
+      val resolved =
+        CheckpointVersionManager.resolveCommitLogVersion(spark, Some((7L, existing)))
+      assert(resolved === CommitLog.VERSION_1,
+        s"an existing V1 commit log must stay V1 even with the config at 3, got $resolved")
+    }
+  }
+
+  test("recording a commit log version keeps the two configs consistent") {
+    // A V3 commit log has no state store counterpart, so the state store config is clamped to 2
+    // rather than set to 3.
+    val session = spark.cloneSession()
+    CheckpointVersionManager.setFormatVersion(session, CommitLogType, CommitLog.VERSION_3)
+    assert(session.conf.get(SQLConf.STREAMING_COMMIT_LOG_FORMAT_VERSION.key) === "3")
+    assert(session.conf.get(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) === "2",
+      "the state store format must be clamped to 2 for a V3 commit log")
+
+    val v1Session = spark.cloneSession()
+    CheckpointVersionManager.setFormatVersion(v1Session, CommitLogType, CommitLog.VERSION_1)
+    assert(v1Session.conf.get(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) === "1",
+      "a V1 commit log cannot carry state store checkpoint ids, so the state store must be v1")
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
@@ -290,15 +290,20 @@ class CommitLogSuite extends SharedSparkSession {
   }
 
   test("recording a commit log version sets the implied state store format") {
+    val sinkMetadataMap = Map("sink" -> SinkMetadataInfo(
+      sinkName = "sink",
+      commitOffset = OffsetSeqLog.SERIALIZED_VOID_OFFSET,
+      providerName = "provider",
+      apiVersion = "DSv2"))
     val session = spark.cloneSession()
-    val v3WithStateIds = CommitMetadataV3(0, Some(Map.empty), Map.empty)
+    val v3WithStateIds = CommitMetadataV3(0, Some(Map.empty), sinkMetadataMap)
     CheckpointVersionManager.setFormatVersion(
       session, CommitLogType, CommitLog.VERSION_3, Some(v3WithStateIds))
     assert(session.conf.get(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key) === "2",
       "state checkpoint ids in a V3 commit imply state store format v2")
 
     val v3WithoutStateIdsSession = spark.cloneSession()
-    val v3WithoutStateIds = CommitMetadataV3(0, None, Map.empty)
+    val v3WithoutStateIds = CommitMetadataV3(0, None, sinkMetadataMap)
     CheckpointVersionManager.setFormatVersion(
       v3WithoutStateIdsSession, CommitLogType, CommitLog.VERSION_3, Some(v3WithoutStateIds))
     assert(v3WithoutStateIdsSession.conf.get(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -59,6 +59,50 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
     observed
   }
 
+  test("a Real-Time Mode query defaults to checkpoint format v2 with the RocksDB state store") {
+    val keys = Seq(
+      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key,
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key)
+    val observed = runRealTimeQueryAndReadConfs(keys)
+
+    assert(observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("2"),
+      "Real-Time Mode should default the state-store checkpoint format to v2, got " +
+        observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+    assert(observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key)
+        .contains(classOf[RocksDBStateStoreProvider].getName),
+      "Real-Time Mode should default the state-store provider to RocksDB, got " +
+        observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key))
+  }
+
+  test("pinning the state-store provider suppresses the checkpoint-format default") {
+    // The two move together: checkpoint format v2 is incompatible with
+    // HDFSBackedStateStoreProvider, which throws on checkpointFormatVersion > 1. Defaulting the
+    // version for a user who pinned the HDFS provider would break a query that works today.
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[HDFSBackedStateStoreProvider].getName) {
+      val observed = runRealTimeQueryAndReadConfs(
+        Seq(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
+          SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+      assert(observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key)
+          .contains(classOf[HDFSBackedStateStoreProvider].getName),
+        "a pinned state-store provider must be left alone, got " +
+          observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key))
+      assert(!observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("2"),
+        "pinning the provider must also suppress the checkpoint-format default, got " +
+          observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+    }
+  }
+
+  test("an explicit checkpoint format version is not overridden by Real-Time Mode") {
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1") {
+      val observed = runRealTimeQueryAndReadConfs(
+        Seq(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+      assert(observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("1"),
+        "an explicitly configured checkpoint format version must be left alone, got " +
+          observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+    }
+  }
+
   test("a Real-Time Mode query defaults changelog checkpointing on with RocksDB") {
     withSQLConf(
       SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -159,25 +159,6 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
     }
   }
 
-  test("an explicit changelog setting in non-canonical casing is not overridden") {
-    // RocksDB resolves its configs case-insensitively (RocksDBConf.apply uses a
-    // CaseInsensitiveMap), so a user setting the key in any casing has really configured it. A
-    // case-sensitive `conf.contains` check would miss this and silently override them.
-    val lowerCased = changelogKey.toLowerCase(java.util.Locale.ROOT)
-    assert(lowerCased != changelogKey,
-      "the key must have mixed case for this test to mean anything")
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
-      lowerCased -> "false") {
-      val observed = runRealTimeQueryAndReadConfs(Seq(lowerCased, changelogKey))
-      assert(observed(lowerCased).contains("false"),
-        s"a lower-cased $changelogKey must be left alone, got ${observed(lowerCased)}")
-      assert(observed(changelogKey).isEmpty,
-        "the canonical key must not be set alongside the user's lower-cased one, got " +
-          observed(changelogKey))
-    }
-  }
-
   test("switching an existing v1 checkpoint to Real-Time Mode fails fast") {
     // A Real-Time Mode query reruns a failed batch from committed offsets, which relies on the
     // per-batch state store checkpoint ids that only commit log v2 and above persist. Resolution

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.streaming
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.spark.{SparkIllegalArgumentException, SparkThrowable}
 import org.apache.spark.sql.execution.streaming.sources.{ContinuousMemorySink, LowLatencyMemoryStream}
 import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, RocksDBConf,
@@ -76,28 +78,26 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
   }
 
   test("the checkpoint-format and provider defaults are applied independently") {
-    // The two are defaulted by independent guards (matching the runtime): pinning the provider does
-    // NOT suppress the version default. A user who pins the HDFS provider still gets version 2, and
-    // the incompatible combination is caught downstream rather than silently running at v1.
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[HDFSBackedStateStoreProvider].getName) {
+    // The two are defaulted by independent guards (matching the runtime): pinning one does not
+    // suppress the other. Pin only the version (to a compatible v2, since an incompatible explicit
+    // config is rejected up front by the pre-flight) and confirm the provider is still defaulted.
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2") {
       val observed = runRealTimeQueryAndReadConfs(
         Seq(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
           SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
-      assert(observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key)
-          .contains(classOf[HDFSBackedStateStoreProvider].getName),
-        "a pinned state-store provider must be left alone, got " +
-          observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key))
       assert(observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("2"),
-        "the version default is independent of the provider, so it must still be 2, got " +
+        "the pinned version must be left alone, got " +
           observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+      assert(observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key)
+          .contains(classOf[RocksDBStateStoreProvider].getName),
+        "the provider default is independent of the version, so it must still be RocksDB, got " +
+          observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key))
     }
   }
 
   test("an explicit checkpoint format version is not overridden by Real-Time Mode") {
     // The defaulting guard respects an explicit version rather than forcing 2. v2 is used here
-    // (not v1) because a resolved commit log below v2 is rejected for a Real-Time Mode query, so v1
-    // could not run to completion -- that rejection is covered separately below.
+    // (not v1) because an explicit v1 is rejected up front by the pre-flight (covered below).
     withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2") {
       val observed = runRealTimeQueryAndReadConfs(
         Seq(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
@@ -107,21 +107,39 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
     }
   }
 
-  test("a fresh Real-Time Mode query with an explicit v1 checkpoint format is rejected") {
-    // The rejection is unconditional on the resolved commit log version, so even a fresh checkpoint
-    // is rejected when the user explicitly pins version 1 -- there is no way to honour it safely.
-    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1") {
+  test("an explicit incompatible config is rejected up front for a Real-Time Mode query") {
+    // The pre-flight in StreamingQueryManager rejects explicit RTM-incompatible session configs
+    // before the query is built: checkpoint format below v2, a non-RocksDB provider, and
+    // sortBeforeRepartition=true. Each is reported in a single CONFIGURATION_NOT_SUPPORTED error.
+    def assertRejected(confs: (String, String)*): Unit = {
+      withSQLConf(confs: _*) {
+        val inputData = LowLatencyMemoryStream[Int]
+        val e = intercept[SparkIllegalArgumentException] {
+          testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+            StartStream())
+        }
+        checkError(e, condition = "STREAMING_REAL_TIME_MODE.CONFIGURATION_NOT_SUPPORTED",
+          parameters = e.getMessageParameters.asScala.toMap)
+      }
+    }
+    assertRejected(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1")
+    assertRejected(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[HDFSBackedStateStoreProvider].getName)
+    assertRejected(SQLConf.SORT_BEFORE_REPARTITION.key -> "true")
+  }
+
+  test("the checkpoint-v1 escape hatch bypasses the pre-flight version check") {
+    // With the escape hatch on, an explicit v1 config is permitted through the pre-flight (the
+    // existing-v1-checkpoint fail-fast in initializeExecution is covered separately below).
+    withSQLConf(
+      SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key -> "true",
+      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1") {
       val inputData = LowLatencyMemoryStream[Int]
       testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(
         AddData(inputData, 1),
         StartStream(),
-        ExpectFailure[SparkIllegalArgumentException] { e =>
-          checkError(
-            e.asInstanceOf[SparkThrowable],
-            condition = "STREAMING_REAL_TIME_MODE.CHECKPOINT_FORMAT_V1_NOT_SUPPORTED",
-            parameters = Map(
-              "config" -> SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key))
-        }
+        CheckAnswerWithTimeout(60000, 1),
+        StopStream
       )
     }
   }
@@ -132,18 +150,6 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
       val observed = runRealTimeQueryAndReadConfs(Seq(changelogKey))
       assert(observed(changelogKey).contains("true"),
         s"Real-Time Mode should default $changelogKey to true, got ${observed(changelogKey)}")
-    }
-  }
-
-  test("changelog checkpointing is not defaulted when the state store is not RocksDB") {
-    // The config is RocksDB-specific, so setting it for the HDFS-backed provider would be
-    // meaningless noise in the effective configuration.
-    withSQLConf(
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[HDFSBackedStateStoreProvider].getName) {
-      val observed = runRealTimeQueryAndReadConfs(Seq(changelogKey))
-      assert(observed(changelogKey).isEmpty,
-        s"$changelogKey should be left unset for a non-RocksDB provider, got " +
-          observed(changelogKey))
     }
   }
 
@@ -160,11 +166,12 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
   }
 
   test("switching an existing v1 checkpoint to Real-Time Mode fails fast") {
-    // A Real-Time Mode query reruns a failed batch from committed offsets, which relies on the
-    // per-batch state store checkpoint ids that only commit log v2 and above persist. Resolution
-    // keeps an existing checkpoint at the version it was created with, so rather than silently
-    // running at v1 (and risking data loss on a rerun) the query is rejected at start. The
-    // rejection is unconditional -- a plain (stateless) query is rejected too.
+    // An existing v1 checkpoint carries no explicit config, so the pre-flight cannot see it; the
+    // initializeExecution fail-fast catches it instead, from the resolved commit log version.
+    // Resolution keeps an existing checkpoint at the version it was created with, so rather than
+    // silently running at v1 (where a re-executed batch can reuse the failed batch's state file
+    // names and lose data) the query is rejected at start. The rejection is unconditional -- a
+    // plain (stateless) query is rejected too.
     withTempDir { checkpointDir =>
       val inputData = LowLatencyMemoryStream[Int]
       val mapped = inputData.toDS().map(_ + 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -110,7 +110,7 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
   test("an explicit incompatible config is rejected up front for a Real-Time Mode query") {
     // The pre-flight in StreamingQueryManager rejects explicit RTM-incompatible session configs
     // before the query is built: checkpoint format below v2, a non-RocksDB provider, and
-    // sortBeforeRepartition=true. Each is reported in a single CONFIGURATION_NOT_SUPPORTED error.
+    // sortBeforeRepartition=true. Each is reported in one SQL_CONFIGURATION_NOT_SUPPORTED error.
     def assertRejected(confs: (String, String)*): Unit = {
       withSQLConf(confs: _*) {
         val inputData = LowLatencyMemoryStream[Int]
@@ -118,7 +118,7 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
           testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(
             StartStream())
         }
-        checkError(e, condition = "STREAMING_REAL_TIME_MODE.CONFIGURATION_NOT_SUPPORTED",
+        checkError(e, condition = "STREAMING_REAL_TIME_MODE.SQL_CONFIGURATION_NOT_SUPPORTED",
           parameters = e.getMessageParameters.asScala.toMap)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -75,10 +75,10 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
         observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key))
   }
 
-  test("pinning the state-store provider suppresses the checkpoint-format default") {
-    // The two move together: checkpoint format v2 is incompatible with
-    // HDFSBackedStateStoreProvider, which throws on checkpointFormatVersion > 1. Defaulting the
-    // version for a user who pinned the HDFS provider would break a query that works today.
+  test("the checkpoint-format and provider defaults are applied independently") {
+    // The two are defaulted by independent guards (matching the runtime): pinning the provider does
+    // NOT suppress the version default. A user who pins the HDFS provider still gets version 2, and
+    // the incompatible combination is caught downstream rather than silently running at v1.
     withSQLConf(
       SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[HDFSBackedStateStoreProvider].getName) {
       val observed = runRealTimeQueryAndReadConfs(
@@ -88,19 +88,41 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
           .contains(classOf[HDFSBackedStateStoreProvider].getName),
         "a pinned state-store provider must be left alone, got " +
           observed(SQLConf.STATE_STORE_PROVIDER_CLASS.key))
-      assert(!observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("2"),
-        "pinning the provider must also suppress the checkpoint-format default, got " +
+      assert(observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("2"),
+        "the version default is independent of the provider, so it must still be 2, got " +
           observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
     }
   }
 
   test("an explicit checkpoint format version is not overridden by Real-Time Mode") {
-    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1") {
+    // The defaulting guard respects an explicit version rather than forcing 2. v2 is used here
+    // (not v1) because a resolved commit log below v2 is rejected for a Real-Time Mode query, so v1
+    // could not run to completion -- that rejection is covered separately below.
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "2") {
       val observed = runRealTimeQueryAndReadConfs(
         Seq(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
-      assert(observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("1"),
+      assert(observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).contains("2"),
         "an explicitly configured checkpoint format version must be left alone, got " +
           observed(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key))
+    }
+  }
+
+  test("a fresh Real-Time Mode query with an explicit v1 checkpoint format is rejected") {
+    // The rejection is unconditional on the resolved commit log version, so even a fresh checkpoint
+    // is rejected when the user explicitly pins version 1 -- there is no way to honour it safely.
+    withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1") {
+      val inputData = LowLatencyMemoryStream[Int]
+      testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+        AddData(inputData, 1),
+        StartStream(),
+        ExpectFailure[SparkIllegalArgumentException] { e =>
+          checkError(
+            e.asInstanceOf[SparkThrowable],
+            condition = "STREAMING_REAL_TIME_MODE.CHECKPOINT_FORMAT_V1_NOT_SUPPORTED",
+            parameters = Map(
+              "config" -> SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key))
+        }
+      )
     }
   }
 
@@ -160,12 +182,12 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
     // A Real-Time Mode query reruns a failed batch from committed offsets, which relies on the
     // per-batch state store checkpoint ids that only commit log v2 and above persist. Resolution
     // keeps an existing checkpoint at the version it was created with, so rather than silently
-    // running at v1 (and risking data loss on a rerun) the query is rejected at start.
+    // running at v1 (and risking data loss on a rerun) the query is rejected at start. The
+    // rejection is unconditional -- a plain (stateless) query is rejected too.
     withTempDir { checkpointDir =>
       val inputData = LowLatencyMemoryStream[Int]
-      // Stateful on purpose: the rejection only applies to a query with state to lose on a rerun.
-      val stateful = inputData.toDS().dropDuplicates()
-      testStream(stateful, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+      val mapped = inputData.toDS().map(_ + 1)
+      testStream(mapped, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
         AddData(inputData, 1),
         // Phase 1: a microbatch trigger, which writes a v1 commit log.
         StartStream(
@@ -192,8 +214,8 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
       SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key -> "true") {
       withTempDir { checkpointDir =>
         val inputData = LowLatencyMemoryStream[Int]
-        val stateful = inputData.toDS().dropDuplicates()
-        testStream(stateful, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+        val mapped = inputData.toDS().map(_ + 1)
+        testStream(mapped, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
           AddData(inputData, 1),
           StartStream(
             trigger = Trigger.ProcessingTime("1 second"),
@@ -203,7 +225,7 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
           AddData(inputData, 2),
           StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
           // The sink accumulates across both phases, so batch 1's row is still present.
-          CheckAnswerWithTimeout(60000, 1, 2),
+          CheckAnswerWithTimeout(60000, 2, 3),
           StopStream
         )
       }
@@ -211,8 +233,9 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
   }
 
   test("a fresh Real-Time Mode checkpoint is not rejected") {
-    // The rejection is scoped to an EXISTING checkpoint: a fresh one takes v2 from the Real-Time
-    // Mode defaults and must start cleanly.
+    // A fresh checkpoint takes v2 from the Real-Time Mode defaults, so its resolved commit log is
+    // v2 and the rejection does not apply. Only a v1 commit log -- an existing v1 checkpoint, or an
+    // explicit v1 config -- is rejected.
     withTempDir { checkpointDir =>
       val inputData = LowLatencyMemoryStream[Int]
       testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(
@@ -224,47 +247,4 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
     }
   }
 
-  test("a stateless Real-Time Mode query restarts on its own v1 checkpoint") {
-    // Regression guard: a stateless query never writes stateUniqueIds, so its commit log stays at
-    // VERSION_1 regardless of the state store config. It has no state to lose on a rerun, so the
-    // v1 rejection must not apply -- gating only on the version would break every stateless
-    // Real-Time Mode restart.
-    withTempDir { checkpointDir =>
-      val inputData = LowLatencyMemoryStream[Int]
-      testStream(inputData.toDS().map(_ + 1), OutputMode.Update, Map.empty,
-        new ContinuousMemorySink())(
-        AddData(inputData, 1),
-        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
-        CheckAnswerWithTimeout(60000, 2),
-        // Commit the batch, so the restart below actually sees a committed batch in the commit log.
-        // Without this the commit log is empty, resolution falls back to the session config, and
-        // the restart never reaches the v1 check at all.
-        ProcessAllAvailable(),
-        StopStream,
-        AddData(inputData, 2),
-        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
-        CheckAnswerWithTimeout(60000, 2, 3),
-        StopStream
-      )
-    }
-  }
-
-  test("a fresh stateful Real-Time Mode query honours an explicitly pinned v1") {
-    // The rejection is for an EXISTING checkpoint the user cannot have anticipated. On a fresh
-    // checkpoint, v1 can only be their explicit choice, and this PR's own soft-default contract
-    // says an explicit choice wins. Rejecting here would turn a config they set deliberately into
-    // a startup failure, so the guard is scoped to a checkpoint that already has a committed batch.
-    withSQLConf(
-      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1",
-      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName) {
-      val inputData = LowLatencyMemoryStream[Int]
-      testStream(inputData.toDS().dropDuplicates(), OutputMode.Update, Map.empty,
-        new ContinuousMemorySink())(
-        AddData(inputData, 1),
-        StartStream(),
-        CheckAnswerWithTimeout(60000, 1),
-        StopStream
-      )
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.sql.execution.streaming.sources.{ContinuousMemorySink, LowLatencyMemoryStream}
+import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, RocksDBConf,
+  RocksDBStateStoreProvider}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Tests the configuration defaults a Real-Time Mode query applies at query start.
+ *
+ * These are not engine-wide defaults because they are only the right choice for a low-latency,
+ * long-running batch. Each is applied only when the user has not set it, so an explicit choice
+ * always wins -- both directions are asserted here, since a defaulting block that silently
+ * overrode a user's setting would be worse than having no default at all.
+ */
+class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
+
+  import testImplicits._
+
+  private val changelogKey =
+    s"${RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX}.changelogCheckpointing.enabled"
+
+  /** Runs a trivial RTM query to completion and returns the effective conf values afterwards. */
+  private def runRealTimeQueryAndReadConfs(keys: Seq[String]): Map[String, Option[String]] = {
+    val inputData = LowLatencyMemoryStream[Int]
+    val mapped = inputData.toDS().map(_ + 1)
+    var observed: Map[String, Option[String]] = Map.empty
+
+    testStream(mapped, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+      AddData(inputData, 1, 2, 3),
+      StartStream(),
+      CheckAnswerWithTimeout(60000, 2, 3, 4),
+      Execute { q =>
+        // Read from sparkSessionForStream, the isolated CLONE the batches actually run with
+        // (StreamExecution.sparkSessionForStream). The defaults are applied there, not to the
+        // caller's session, so reading `q.sparkSession` would observe the unmodified original.
+        val conf = q.sparkSessionForStream.conf
+        observed = keys.map(k => k -> conf.getOption(k)).toMap
+      },
+      StopStream
+    )
+    observed
+  }
+
+  test("a Real-Time Mode query defaults changelog checkpointing on with RocksDB") {
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName) {
+      val observed = runRealTimeQueryAndReadConfs(Seq(changelogKey))
+      assert(observed(changelogKey).contains("true"),
+        s"Real-Time Mode should default $changelogKey to true, got ${observed(changelogKey)}")
+    }
+  }
+
+  test("changelog checkpointing is not defaulted when the state store is not RocksDB") {
+    // The config is RocksDB-specific, so setting it for the HDFS-backed provider would be
+    // meaningless noise in the effective configuration.
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[HDFSBackedStateStoreProvider].getName) {
+      val observed = runRealTimeQueryAndReadConfs(Seq(changelogKey))
+      assert(observed(changelogKey).isEmpty,
+        s"$changelogKey should be left unset for a non-RocksDB provider, got " +
+          observed(changelogKey))
+    }
+  }
+
+  test("an explicit changelog checkpointing setting is not overridden by Real-Time Mode") {
+    withSQLConf(changelogKey -> "false") {
+      val observed = runRealTimeQueryAndReadConfs(Seq(changelogKey))
+      assert(observed(changelogKey).contains("false"),
+        s"an explicitly configured $changelogKey must be left alone, got ${observed(changelogKey)}")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.streaming
 
+import org.apache.spark.{SparkIllegalArgumentException, SparkThrowable}
 import org.apache.spark.sql.execution.streaming.sources.{ContinuousMemorySink, LowLatencyMemoryStream}
 import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, RocksDBConf,
   RocksDBStateStoreProvider}
@@ -152,6 +153,118 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
       assert(observed(changelogKey).isEmpty,
         "the canonical key must not be set alongside the user's lower-cased one, got " +
           observed(changelogKey))
+    }
+  }
+
+  test("switching an existing v1 checkpoint to Real-Time Mode fails fast") {
+    // A Real-Time Mode query reruns a failed batch from committed offsets, which relies on the
+    // per-batch state store checkpoint ids that only commit log v2 and above persist. Resolution
+    // keeps an existing checkpoint at the version it was created with, so rather than silently
+    // running at v1 (and risking data loss on a rerun) the query is rejected at start.
+    withTempDir { checkpointDir =>
+      val inputData = LowLatencyMemoryStream[Int]
+      // Stateful on purpose: the rejection only applies to a query with state to lose on a rerun.
+      val stateful = inputData.toDS().dropDuplicates()
+      testStream(stateful, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+        AddData(inputData, 1),
+        // Phase 1: a microbatch trigger, which writes a v1 commit log.
+        StartStream(
+          trigger = Trigger.ProcessingTime("1 second"),
+          checkpointLocation = checkpointDir.getAbsolutePath),
+        WaitUntilCurrentBatchProcessed,
+        StopStream,
+        AddData(inputData, 2),
+        // Phase 2: the same checkpoint under the Real-Time trigger must be rejected.
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        ExpectFailure[SparkIllegalArgumentException] { e =>
+          checkError(
+            e.asInstanceOf[SparkThrowable],
+            condition = "STREAMING_REAL_TIME_MODE.CHECKPOINT_FORMAT_V1_NOT_SUPPORTED",
+            parameters = Map(
+              "config" -> SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key))
+        }
+      )
+    }
+  }
+
+  test("the escape hatch allows Real-Time Mode on an existing v1 checkpoint") {
+    withSQLConf(
+      SQLConf.STREAMING_REAL_TIME_MODE_DANGEROUSLY_ALLOW_CHECKPOINT_V1.key -> "true") {
+      withTempDir { checkpointDir =>
+        val inputData = LowLatencyMemoryStream[Int]
+        val stateful = inputData.toDS().dropDuplicates()
+        testStream(stateful, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+          AddData(inputData, 1),
+          StartStream(
+            trigger = Trigger.ProcessingTime("1 second"),
+            checkpointLocation = checkpointDir.getAbsolutePath),
+          WaitUntilCurrentBatchProcessed,
+          StopStream,
+          AddData(inputData, 2),
+          StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+          // The sink accumulates across both phases, so batch 1's row is still present.
+          CheckAnswerWithTimeout(60000, 1, 2),
+          StopStream
+        )
+      }
+    }
+  }
+
+  test("a fresh Real-Time Mode checkpoint is not rejected") {
+    // The rejection is scoped to an EXISTING checkpoint: a fresh one takes v2 from the Real-Time
+    // Mode defaults and must start cleanly.
+    withTempDir { checkpointDir =>
+      val inputData = LowLatencyMemoryStream[Int]
+      testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+        AddData(inputData, 1, 2),
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        CheckAnswerWithTimeout(60000, 1, 2),
+        StopStream
+      )
+    }
+  }
+
+  test("a stateless Real-Time Mode query restarts on its own v1 checkpoint") {
+    // Regression guard: a stateless query never writes stateUniqueIds, so its commit log stays at
+    // VERSION_1 regardless of the state store config. It has no state to lose on a rerun, so the
+    // v1 rejection must not apply -- gating only on the version would break every stateless
+    // Real-Time Mode restart.
+    withTempDir { checkpointDir =>
+      val inputData = LowLatencyMemoryStream[Int]
+      testStream(inputData.toDS().map(_ + 1), OutputMode.Update, Map.empty,
+        new ContinuousMemorySink())(
+        AddData(inputData, 1),
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        CheckAnswerWithTimeout(60000, 2),
+        // Commit the batch, so the restart below actually sees a committed batch in the commit log.
+        // Without this the commit log is empty, resolution falls back to the session config, and
+        // the restart never reaches the v1 check at all.
+        ProcessAllAvailable(),
+        StopStream,
+        AddData(inputData, 2),
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        CheckAnswerWithTimeout(60000, 2, 3),
+        StopStream
+      )
+    }
+  }
+
+  test("a fresh stateful Real-Time Mode query honours an explicitly pinned v1") {
+    // The rejection is for an EXISTING checkpoint the user cannot have anticipated. On a fresh
+    // checkpoint, v1 can only be their explicit choice, and this PR's own soft-default contract
+    // says an explicit choice wins. Rejecting here would turn a config they set deliberately into
+    // a startup failure, so the guard is scoped to a checkpoint that already has a committed batch.
+    withSQLConf(
+      SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1",
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName) {
+      val inputData = LowLatencyMemoryStream[Int]
+      testStream(inputData.toDS().dropDuplicates(), OutputMode.Update, Map.empty,
+        new ContinuousMemorySink())(
+        AddData(inputData, 1),
+        StartStream(),
+        CheckAnswerWithTimeout(60000, 1),
+        StopStream
+      )
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -223,7 +223,7 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
   test("a fresh Real-Time Mode checkpoint is not rejected") {
     // A fresh checkpoint takes v2 from the Real-Time Mode defaults, so its resolved commit log is
     // v2 and the rejection does not apply. Only a v1 commit log -- an existing v1 checkpoint, or an
-    // explicit v1 config -- is rejected.
+    // explicit v1 config without the escape hatch -- is rejected.
     withTempDir { checkpointDir =>
       val inputData = LowLatencyMemoryStream[Int]
       testStream(inputData.toDS(), OutputMode.Update, Map.empty, new ContinuousMemorySink())(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -177,7 +177,7 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
       val mapped = inputData.toDS().map(_ + 1)
       testStream(mapped, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
         AddData(inputData, 1),
-        // Phase 1: a microbatch trigger, which writes a v1 commit log.
+        // Phase 1: a micro-batch trigger, which writes a v1 commit log.
         StartStream(
           trigger = Trigger.ProcessingTime("1 second"),
           checkpointLocation = checkpointDir.getAbsolutePath),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeDefaultConfsSuite.scala
@@ -81,10 +81,33 @@ class StreamRealTimeModeDefaultConfsSuite extends StreamRealTimeModeSuiteBase {
   }
 
   test("an explicit changelog checkpointing setting is not overridden by Real-Time Mode") {
-    withSQLConf(changelogKey -> "false") {
+    // The RocksDB provider must be in force, otherwise the `usingRocksDb` gate skips the block and
+    // the guard under test is never reached -- the assertion would hold vacuously.
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      changelogKey -> "false") {
       val observed = runRealTimeQueryAndReadConfs(Seq(changelogKey))
       assert(observed(changelogKey).contains("false"),
         s"an explicitly configured $changelogKey must be left alone, got ${observed(changelogKey)}")
+    }
+  }
+
+  test("an explicit changelog setting in non-canonical casing is not overridden") {
+    // RocksDB resolves its configs case-insensitively (RocksDBConf.apply uses a
+    // CaseInsensitiveMap), so a user setting the key in any casing has really configured it. A
+    // case-sensitive `conf.contains` check would miss this and silently override them.
+    val lowerCased = changelogKey.toLowerCase(java.util.Locale.ROOT)
+    assert(lowerCased != changelogKey,
+      "the key must have mixed case for this test to mean anything")
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      lowerCased -> "false") {
+      val observed = runRealTimeQueryAndReadConfs(Seq(lowerCased, changelogKey))
+      assert(observed(lowerCased).contains("false"),
+        s"a lower-cased $changelogKey must be left alone, got ${observed(lowerCased)}")
+      assert(observed(changelogKey).isEmpty,
+        "the canonical key must not be set alongside the user's lower-cased one, got " +
+          observed(changelogKey))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
 
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
@@ -695,10 +696,11 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
     }
   }
 
-  test("pipelined shuffle: an explicit sortBeforeRepartition=true does not stall the query") {
+  test("pipelined shuffle: an explicit sortBeforeRepartition=true is rejected") {
     // The deterministic local sort before a round-robin repartition never drains an unbounded
-    // stream, so Real-Time Mode overrides this config even when it is set explicitly -- honouring
-    // it would hang the query forever. See MicroBatchExecution.
+    // stream, so honouring sortBeforeRepartition=true would hang a Real-Time Mode query forever.
+    // Rather than silently override it, the pre-flight in StreamingQueryManager rejects the
+    // explicit value up front. See StreamingQueryManager.throwIfConfsAreRealTimeModeIncompatible.
     withSQLConf(
       SQLConf.SHUFFLE_PARTITIONS.key -> "2",
       SQLConf.SORT_BEFORE_REPARTITION.key -> "true") {
@@ -707,12 +709,14 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
         .repartition(4)
         .dropDuplicates("key")
         .select($"key")
-      testStream(result, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
-        AddData(inputData, ("a", 1), ("b", 1), ("c", 1), ("a", 2)),
-        StartStream(),
-        CheckAnswerWithTimeout(60000, "a", "b", "c"),
-        StopStream
-      )
+      val e = intercept[SparkIllegalArgumentException] {
+        testStream(result, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+          AddData(inputData, ("a", 1), ("b", 1), ("c", 1), ("a", 2)),
+          StartStream()
+        )
+      }
+      checkError(e, condition = "STREAMING_REAL_TIME_MODE.CONFIGURATION_NOT_SUPPORTED",
+        parameters = e.getMessageParameters.asScala.toMap)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -715,7 +715,7 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
           StartStream()
         )
       }
-      checkError(e, condition = "STREAMING_REAL_TIME_MODE.CONFIGURATION_NOT_SUPPORTED",
+      checkError(e, condition = "STREAMING_REAL_TIME_MODE.SQL_CONFIGURATION_NOT_SUPPORTED",
         parameters = e.getMessageParameters.asScala.toMap)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/StreamingSinkEvolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/StreamingSinkEvolutionSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, Commit
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.streaming.{StreamTest, Trigger}
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamTest, Trigger}
 import org.apache.spark.util.Utils
 
 /**
@@ -322,7 +322,7 @@ class StreamingSinkEvolutionSuite extends StreamTest with BeforeAndAfterEach {
         SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1",
         SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
           classOf[HDFSBackedStateStoreProvider].getName) {
-      def startQuery() = input.toDF()
+      def startQuery(): StreamingQuery = input.toDF()
         .groupBy("value")
         .count()
         .writeStream

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/StreamingSinkEvolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/StreamingSinkEvolutionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.{SparkException, SparkIllegalArgumentException}
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, CommitMetadataV3}
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{StreamTest, Trigger}
 import org.apache.spark.util.Utils
@@ -311,6 +312,40 @@ class StreamingSinkEvolutionSuite extends StreamTest with BeforeAndAfterEach {
     val v3 = commitLog.getLatest().get._2.asInstanceOf[CommitMetadataV3]
     assert(v3.activeSinkMetadataInfo.sinkName === "upgraded_sink")
     assert(v3.sinkMetadataMap.size === 1)
+  }
+
+  testWithSinkEvolution("restart V3 commit log with state checkpoint format V1") {
+    val checkpointDir = newMetadataDir
+    val input = MemoryStream[Int]
+
+    withSQLConf(
+        SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> "1",
+        SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+          classOf[HDFSBackedStateStoreProvider].getName) {
+      def startQuery() = input.toDF()
+        .groupBy("value")
+        .count()
+        .writeStream
+        .format("noop")
+        .outputMode("update")
+        .name("stateful_sink")
+        .option("checkpointLocation", checkpointDir)
+        .start()
+
+      input.addData(1)
+      val firstRun = startQuery()
+      firstRun.processAllAvailable()
+      firstRun.stop()
+
+      input.addData(2)
+      val restarted = startQuery()
+      restarted.processAllAvailable()
+      restarted.stop()
+    }
+
+    val commitLog = new CommitLog(spark, s"$checkpointDir/commits", readOnly = true)
+    val v3 = commitLog.getLatest().get._2.asInstanceOf[CommitMetadataV3]
+    assert(v3.stateUniqueIds.isEmpty)
   }
 
   // ==============


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR sets the configuration defaults a Real-Time Mode (RTM) streaming query needs, resolves the commit log format version from the checkpoint rather than blindly from the session config, and rejects incompatible session configs up front. All three are ported from the Databricks Runtime implementation of RTM.

**1. RTM configuration defaults.** A single method `setSparkSessionConfigsForRealTimeMode`, run once at query start on the query's isolated session, defaults the settings RTM wants but that are not the right engine-wide default. Each is applied only when the user has not set the key, so an explicit choice is preserved:

- `spark.sql.streaming.stateStore.checkpointFormatVersion=2` and the RocksDB state store provider that v2 requires, guarded independently (pinning the provider does not suppress the version default).
- `spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled=true` (RocksDB only), which shortens the state-commit step on the critical path between batches.
- `spark.sql.execution.sortBeforeRepartition=false`, consolidated here from `MicroBatchExecution` (originally added for RTM in SPARK-58508). The local sort before a round-robin repartition never drains an unbounded stream, so it would hang an RTM query; RTM does not retry tasks, so the determinism it provides is not needed.

**2. Commit log format version resolution.** Previously the commit log version was read from the session config at `CommitLog` construction (`CommitLog.defaultVersion`), which was forced early during `StreamExecution` initialization and ignored the format an existing checkpoint was created with. This PR removes that field and resolves the write version explicitly, mirroring the runtime:

- `CommitLog.createMetadata` requires callers to pass the resolved version explicitly.
- `CheckpointVersionManager` gains a `CommitLogType` and `resolveCommitLogVersion`: ordinary writes to an existing checkpoint keep its recorded version, while a fresh checkpoint uses the version implied by the state store checkpoint format. The sink-evolution path may independently upgrade writes to commit log v3.
- The resolved version travels on the execution context (`commitLogFormatVersionOpt`) and is written on both the synchronous and the async-progress-tracking commit paths.

**3. RTM requires commit log v2.** RTM re-executes a failed batch, and with checkpoint format v1 the re-execution can reuse the state file names of the partially-written failed batch and lose data; format v2 avoids this with per-batch state store checkpoint ids, which only a commit log at v2 or above can persist. Two guards enforce this, covering disjoint cases:

- A pre-flight in `StreamingQueryManager` (`throwIfConfsAreRealTimeModeIncompatible`) rejects explicit RTM-incompatible session configs before the query is built (checkpoint format below v2, a non-RocksDB provider, or `sortBeforeRepartition=true`), with `STREAMING_REAL_TIME_MODE.SQL_CONFIGURATION_NOT_SUPPORTED`.
- A fail-fast in `MicroBatchExecution.initializeExecution` rejects a resolved commit log version below v2 — the case of an existing v1 checkpoint, which carries no explicit config for the pre-flight to see — with `STREAMING_REAL_TIME_MODE.CHECKPOINT_FORMAT_V1_NOT_SUPPORTED`.

Both are bypassed by the escape hatch `spark.sql.streaming.realTimeMode.dangerouslyAllowCheckpointV1.enabled` (default false), which lets a query start on a v1 checkpoint while accepting the data-loss risk on failure.

One new internal config is added: `spark.sql.streaming.realTimeMode.dangerouslyAllowCheckpointV1.enabled` (default false).

### Why are the changes needed?

RTM commits state at every batch boundary, and that commit sits on the critical path between batches, so RTM needs a low-latency, recovery-correct state store configuration (RocksDB + checkpoint format v2 + changelog checkpointing) that is not the right default for the engine as a whole. Without these defaults an RTM query either runs with a slower configuration or, in the `sortBeforeRepartition` case, does not make progress at all.

Format v2 also matters for correctness: RTM re-executes a failed batch, and at v1 the re-execution can reuse the failed batch's state file names, so a stale file can be loaded (the checksum hazard documented on `StateStoreConf`). Resolving the commit log version from the checkpoint (rather than the session config) keeps ordinary writes at the format the checkpoint was created with, and the two guards prevent an RTM query from silently running on a v1 checkpoint.

This aligns OSS RTM with the Databricks Runtime, so the two share the same defaulting, version-resolution, and rejection behavior.

### Does this PR introduce _any_ user-facing change?

Yes, for Real-Time Mode queries (`Trigger.RealTime(...)`) only. Behavior for every non-RTM query is unchanged.

- An RTM query now defaults to the RocksDB state store, checkpoint format v2, and changelog checkpointing, when the user has not configured them. An explicit user setting is preserved.
- Starting an RTM query with an explicit RTM-incompatible session config (checkpoint format below v2, a non-RocksDB provider, or `sortBeforeRepartition=true`) now fails at query start with `STREAMING_REAL_TIME_MODE.SQL_CONFIGURATION_NOT_SUPPORTED`.
- Starting an RTM query on a checkpoint whose commit log is at version 1 now fails at start with `STREAMING_REAL_TIME_MODE.CHECKPOINT_FORMAT_V1_NOT_SUPPORTED`.
- The escape hatch `spark.sql.streaming.realTimeMode.dangerouslyAllowCheckpointV1.enabled=true` allows a v1 checkpoint to proceed, accepting the possibility of data loss on a failure.

The new config is `internal()`. These are new-in-unreleased changes; there is no behavior change for released Spark versions, which have no Real-Time Mode.

### How was this patch tested?

New and updated unit tests:

- `StreamRealTimeModeDefaultConfsSuite` (new) covers: the v2 + RocksDB defaults are applied; the version and provider defaults are independent; explicit settings are preserved; an explicit incompatible config is rejected up front; the escape hatch bypasses the pre-flight; an existing v1 checkpoint is rejected; and the escape hatch allows it.
- `CommitLogSuite` gains tests for fresh commit-log versions deriving from the state-store format, an existing checkpoint recorded version winning over the session setting, and commit metadata restoring the implied state-store format.
- `StreamRealTimeModeSuite`'s `sortBeforeRepartition` test is updated to expect the up-front rejection.

Verified against the existing RTM suites (`StreamRealTimeModeSuite`, `StreamRealTimeModeWithManualClockSuite`, the async-progress and streamline RTM suites) and, because the commit-log write path is shared, against `StreamingAggregationSuite` and `StreamingDeduplicationSuite` for non-RTM regressions.

### Was this patch authored or co-authored using generative AI tooling?

co-authored with Claude Code
