### PR TITLE
[SPARK-56998][FOLLOWUP][DOCS] Refine SECURITY.md reporting instructions and add known non-findings

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,24 @@
 
 ## Reporting a vulnerability
 
-To report a security vulnerability in Apache Spark, follow the ASF security process at <https://www.apache.org/security/>. Reports can be sent privately to security@apache.org or to private@spark.apache.org.
+To report a security vulnerability in Apache Spark, follow the ASF security process at <https://www.apache.org/security/>. Send reports privately to the ASF Security Team at [security@apache.org](mailto:security@apache.org?subject=%5BSECURITY%5D%20Spark).
+
+Please send one plain-text, unencrypted email per vulnerability, and describe the issue in the **message body** rather than as an image, HTML, or PDF attachment. Do not open a public GitHub issue or pull request for a security vulnerability, and do not disclose it publicly until the project has responded.
 
 ## Threat model
 
-Apache Spark's security guidance for operators — covering authentication, encryption, access control, Kerberos integration, trust boundaries, environmental assumptions, security properties provided and not provided, and downstream operator responsibilities — is documented at:
+Apache Spark's security guidance for operators (covering authentication, encryption, access control, Kerberos integration, trust boundaries, environmental assumptions, security properties provided and not provided, and downstream operator responsibilities) is documented at:
 
 <https://spark.apache.org/docs/latest/security.html>
 
 Automated security scanning agents should consult that document for the project's in-scope / out-of-scope declarations before reporting issues.
+
+## Known non-findings
+
+Two categories of reports are rejected outright.
+
+**Unconfigured deployments.** Like much infrastructure software, Spark is not meant to be deployed as it ships. Its security features are opt-in: as the guidance above puts it, "none are secure by default", and evaluating the environment and securing the deployment is the operator's responsibility. A report whose premise is a deployment that does not follow that guidance is **out of scope**.
+
+**Spark executing the code it was given.** Spark is, by design, remote code execution as a service: submitting a job means asking a cluster to run user-supplied code on the driver and the executors. The ability of an **authorized submitter** to run arbitrary code, read local files, or start processes on cluster nodes is therefore the product working as intended. A report that only demonstrates that Spark executes remote code, without breaking a security property Spark claims to provide, is **out of scope**.
+
+A report is in scope when it crosses a boundary the security documentation says Spark enforces, for example, code execution by a party that never authenticated to a properly configured deployment, or escalation past the authentication and authorization controls Spark does provide.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to [SPARK-56998](https://issues.apache.org/jira/browse/SPARK-56998), which added `SECURITY.md`.

**Reporting a vulnerability**

- Point at the ASF Security Team address only, instead of `private@spark.apache.org`. Reports that are sent to `private@spark.apache.org` are already **delivered** to the PMC, so they bypass triage.
- Restate the requirements for "one plain-text, unencrypted, email for each vulnerability", described in the message body rather than as an image, HTML, or PDF attachment.
- State explicitly that a vulnerability must not be filed as a public issue or pull request, and must not be disclosed publicly before the project responds.

**Threat model**

Add a `Known non-findings` section declaring two categories of report out of scope:

- **Unconfigured deployments.** Spark's security features are opt-in, and `docs/security.md` already says "none are secure by default". Reports whose premise is a deployment that ignores that guidance are out of scope.
- **Spark executing the code it was given.** Submitting a job means asking a cluster to run user-supplied code on the driver and the executors, so an authorized submitter running arbitrary code is the product working as intended.

The section closes by naming what remains in scope (execution by a party that never authenticated to a properly configured deployment, or escalation past controls Spark does provide), so the exclusions are not read as a blanket disclaimer.

### Why are the changes needed?

Together with your `/security.html` page, `SECURITY.md` is one of the pages used by reporters to learn the security contact for the project. There is no sense triaging reports that were already delivered to the PMC: all the reports that arrived directly to `private@spark.apache.org` (including all the false positives) are for the PMC to handle, i.e. [step 3 of the handling process](https://www.apache.org/security/committers.html) is **skipped**.

BTW: you need to remove `security@spark.apache.org` from the `/security.html` page of your website too.

### Does this PR introduce _any_ user-facing change?

No. Documentation only.

### How was this patch tested?

No tests. The change is a Markdown file with no build or site integration; it was proofread and the links were checked by hand.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
