### PR TITLE
[SPARK-58637][ML] Optimize HashingTF transform closure

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -91,12 +91,37 @@ class HashingTF @Since("3.0.0") private[ml] (
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema)
     val n = $(numFeatures)
-    val updateFunc = if ($(binary)) (v: Double) => 1.0 else (v: Double) => v + 1.0
+    def binaryHashUDF(hashFunc: Any => Int) = udf { terms: Seq[_] =>
+      val map = new OpenHashMap[Int, Int]
+      terms.foreach { term =>
+        map.update(Utils.nonNegativeMod(hashFunc(term), n), 1)
+      }
+      Vectors.sparse(n, map.iterator.map { case (index, count) =>
+        (index, count.toDouble)
+      }.toSeq)
+    }
 
-    val hashUDF = udf { terms: Seq[_] =>
-      val map = new OpenHashMap[Int, Double]()
-      terms.foreach { term => map.changeValue(indexOf(term), 1.0, updateFunc) }
-      Vectors.sparse(n, map.toSeq)
+    def countHashUDF(hashFunc: Any => Int) = udf { terms: Seq[_] =>
+      val map = new OpenHashMap[Int, Int]
+      terms.foreach { term =>
+        val index = Utils.nonNegativeMod(hashFunc(term), n)
+        map.changeValue(index, 1, _ + 1)
+      }
+      Vectors.sparse(n, map.iterator.map { case (index, count) =>
+        (index, count.toDouble)
+      }.toSeq)
+    }
+
+    val hashUDF = ($(binary), hashFuncVersion) match {
+      case (true, HashingTF.SPARK_2_MURMUR3_HASH) =>
+        binaryHashUDF(OldHashingTF.murmur3Hash)
+      case (false, HashingTF.SPARK_2_MURMUR3_HASH) =>
+        countHashUDF(OldHashingTF.murmur3Hash)
+      case (true, HashingTF.SPARK_3_MURMUR3_HASH) =>
+        binaryHashUDF(FeatureHasher.murmur3Hash)
+      case (false, HashingTF.SPARK_3_MURMUR3_HASH) =>
+        countHashUDF(FeatureHasher.murmur3Hash)
+      case _ => throw new IllegalArgumentException("Illegal hash function version setting.")
     }
 
     dataset.withColumn($(outputCol), hashUDF(col($(inputCol))),

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
@@ -97,6 +97,18 @@ class HashingTFSuite extends MLTest with DefaultReadWriteTest {
     assert(loadedHashingTF.indexOf("c") === mLlibHashingTF.indexOf("c"))
     assert(loadedHashingTF.indexOf("d") === mLlibHashingTF.indexOf("d"))
 
+    mLlibHashingTF.setBinary(loadedHashingTF.getBinary)
+    val terms = "a a b b c d".split(" ").toSeq
+    val df = Seq(Tuple1(terms)).toDF("words")
+    val features = loadedHashingTF
+      .setInputCol("words")
+      .setOutputCol("features")
+      .transform(df)
+      .select("features")
+      .first()
+      .getAs[Vector](0)
+    assert(features ~== mLlibHashingTF.transform(terms).asML absTol 1e-14)
+
     val metadata = spark.read.json(s"$hashingTFPath/metadata")
     val sparkVersionStr = metadata.select("sparkVersion").first().getString(0)
     assert(sparkVersionStr === "2.4.4")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR optimizes `HashingTF.transform` by selecting the binary/counting UDF and hash function
from `($(binary), hashFuncVersion)` before executing the UDF. The UDF calculates feature indexes
from the captured hash function and local `numFeatures` value instead of calling the instance
`indexOf` method.

Binary mode uses `OpenHashMap.update`, while counting mode uses `changeValue`. Both store integer
term counts and convert them to `Double` only when constructing the output sparse vector.

The compatibility test for HashingTF models saved before Spark 3.0 now also verifies `transform`,
including the saved binary mode and legacy hash function.

### Why are the changes needed?

Calling `indexOf` from the UDF captures the `HashingTF` transformer and performs a parameter lookup
and hash-version match for every term. Selecting the behavior before constructing the UDF reduces
the closure to the values it needs, removes repeated branching and parameter lookups, and reduces
the term-count map value size from `Double` to `Int`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 'mllib/testOnly org.apache.spark.ml.feature.HashingTFSuite'`

All 6 tests passed. The compiled UDF helper signatures were also inspected to confirm that they do
not retain a `HashingTF` receiver.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
