### PR TITLE
[SPARK-58639][DOCS] Replace stale listCachedTables reference in the SQL performance tuning guide

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -30,7 +30,7 @@ Spark SQL can cache tables using an in-memory columnar format by calling `spark.
 Then Spark SQL will scan only required columns and will automatically tune compression to minimize
 memory usage and GC pressure. You can call `spark.catalog.uncacheTable("tableName")` or `dataFrame.unpersist()` to remove the table from memory.
 
-To list relations cached with an explicit name, use `spark.catalog.listCachedTables()`. Entries cached only via `Dataset.cache()` without a name are not included.
+To check whether a specific table or view is cached, use `spark.catalog.isCached("tableName")`. To inspect the storage level of an arbitrary `Dataset`, read its `storageLevel` property, which returns `StorageLevel.NONE` when the data is not currently cached. For an overview of everything persisted in the running application, including data cached directly via `Dataset.cache()`, use the [Storage tab](web-ui.html#storage-tab) of the web UI, which shows the storage levels, sizes and partitions of each persisted relation once an action has materialized it.
 
 Spark supports two cache formats:
 - **Default cache format**: The standard in-memory columnar cache (used by default).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces a stale sentence in the caching section of `docs/sql-performance-tuning.md`. The old text told users to call `spark.catalog.listCachedTables()`; the new text points to `spark.catalog.isCached`, the `Dataset.storageLevel` property, and the web UI Storage tab.

### Why are the changes needed?

`spark.catalog.listCachedTables()` no longer exists. It was removed by the SPARK-56221 followup (`a3930d31665`) along with the `SHOW CACHED TABLES` command. That commit edited this sentence to drop the SQL command but left the `listCachedTables()` call in place, so the guide currently points at a method that cannot be called. This is the only remaining reference to the removed API in the repository.

Each replacement is a documented API: `Catalog.isCached` (`sql/api/.../catalog/Catalog.scala`), `Dataset.storageLevel`, whose implementation returns `StorageLevel.NONE` when the data is not cached, and the Storage tab, which `docs/web-ui.md` describes as showing "the storage levels, sizes and partitions of all RDDs" and notes does not list a relation "before they are materialized". The Storage tab also covers data cached via `Dataset.cache()` without a name, which is what the removed API could not report.

### Does this PR introduce _any_ user-facing change?

No, other than the corrected documentation.

### How was this patch tested?

Documentation only. The `#storage-tab` anchor matches the `## Storage Tab` heading in `docs/web-ui.md`, and the link style matches the existing `[SQL UI](web-ui.html#sql-tab)` reference in this same file.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
