### PR TITLE
[SPARK-58638][INFRA] Recognize Examples as a primary component tag in the merge script

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -1299,7 +1299,7 @@ COMPONENTS = (
     Component("DOC", ("DOCS", "DOCUMENTATION"), primary=True, jira_name="Documentation"),
     Component("DOCKER", primary=True, jira_name="Spark Docker"),
     Component("EC2", jira_name="EC2"),
-    Component("EXAMPLE", ("EXAMPLES",), jira_name="Examples"),
+    Component("EXAMPLES", ("EXAMPLE",), primary=True, jira_name="Examples"),
     Component("GRAPHX", primary=True, jira_name="GraphX"),
     Component("INFRA", ("PROJECT_INFRA",), primary=True, jira_name="Project Infra"),
     Component("IO", jira_name="Input/Output"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR marks the `EXAMPLES` component as `primary` in the `COMPONENTS` registry of `dev/merge_spark_pr.py`, and makes the plural spelling the canonical tag.

`EXAMPLE` remains an accepted alias, so both `[EXAMPLES]` and `[EXAMPLE]` continue to be recognized; the canonical form used when the script rewrites a title is now the plural `[EXAMPLES]`.

### Why are the changes needed?

Since SPARK-56979, the merge script requires every PR title to carry at least one **primary** component tag. `EXAMPLES` maps to the JIRA component "Examples" and names a real top-level build module (`examples/` in `pom.xml`), but it was not marked `primary`. As a result, a PR titled e.g. `[SPARK-XXXXX][EXAMPLES] ...` is rejected at merge time with:

```
PR title is missing a primary [COMPONENT] tag.
Primary components (one of these is required):
  ...
Enter comma-separated component(s) to insert into the title (e.g. CORE,SQL):
```

This forces the committer to bolt on a possibly unrelated primary tag, which produces worse changelog attribution than `[EXAMPLES]` alone for a change that lives entirely in the examples module. The plural `[EXAMPLES]` is also the more common historical spelling (92 vs 38 for the singular) and the form implied by deriving the tag from the JIRA component name ("Examples"), so it is made the canonical spelling while the singular stays as an alias.

### Does this PR introduce _any_ user-facing change?

No. This only affects the committer-facing interactive merge tool (`dev/merge_spark_pr.py`).

### How was this patch tested?

- Existing doctests pass:

  ```
  python3 -m doctest dev/merge_spark_pr.py
  ```

- Manually verified against the registry and the merge-time gate.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
