### PR TITLE
[MINOR][INFRA][4.X] Explain skipped post-merge Build runs

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -45,14 +45,16 @@ jobs:
 
           if ((remainder == 0)); then
             should_run=true
+            icon=":white_check_mark:"
             title="Commit count matched"
             details="Commit count $count is divisible by 10."
             next_count=$count
           else
             should_run=false
+            icon=":pause_button:"
             next_count=$(( (count / 10 + 1) * 10 ))
             title="Commit count not matched"
-            details="Commit count $count is not divisible by 10. Next match: $next_count."
+            details="Commit count $count is not divisible by 10."
           fi
 
           echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
@@ -64,7 +66,7 @@ jobs:
           echo "Next matching count: $next_count"
           echo "Details: $details"
           echo "::notice title=$title::$details"
-          echo "### Commit count check" >> "$GITHUB_STEP_SUMMARY"
+          echo "### $icon Commit count check" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch: $GITHUB_REF_NAME" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
@@ -73,9 +75,6 @@ jobs:
           echo "- Should run: $should_run" >> "$GITHUB_STEP_SUMMARY"
           echo "- Next matching count: $next_count" >> "$GITHUB_STEP_SUMMARY"
           echo "- Details: $details" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Build runs for forks or when should-run is true." \
-            >> "$GITHUB_STEP_SUMMARY"
 
   call-build-and-test:
     permissions:

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -25,30 +25,58 @@ on:
     - '**'
 
 jobs:
-  count-commits:
-    name: Count commits
+  check-build:
+    name: Check Build decision
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
-      commit-count: ${{ steps.count.outputs.commit-count }}
+      should-build: ${{ steps.decision.outputs.should-build }}
     steps:
       - name: Check out the full branch history
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Count commits on the pushed branch
-        id: count
-        run: echo "commit-count=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Determine whether Build should run
+        id: decision
+        run: |
+          count=$(git rev-list --count HEAD)
+
+          if [[ "$GITHUB_REPOSITORY" != "apache/spark" ]]; then
+            should_build=true
+            title="Build scheduled"
+            details="Fork pushes always run Build. Commit count: $count."
+          elif ((count % 10 == 0)); then
+            should_build=true
+            title="Build scheduled"
+            details="Commit count $count is divisible by 10."
+          else
+            should_build=false
+            next_count=$(( (count / 10 + 1) * 10 ))
+            title="Build skipped"
+            details="Commit count $count is not divisible by 10. Next Build: $next_count."
+          fi
+
+          echo "should-build=$should_build" >> "$GITHUB_OUTPUT"
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Branch: $GITHUB_REF_NAME"
+          echo "Commit: $GITHUB_SHA"
+          echo "Commit count: $count"
+          echo "Decision: $title"
+          echo "Details: $details"
+          echo "::notice title=$title::$details"
+          echo "### $title" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Repository: $GITHUB_REPOSITORY" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: $GITHUB_REF_NAME" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit count: $count" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Details: $details" >> "$GITHUB_STEP_SUMMARY"
 
   call-build-and-test:
     permissions:
       packages: write
     name: Run
-    needs: count-commits
-    # GitHub Actions expressions do not support modulo. A non-negative decimal
-    # count is divisible by ten when it ends in 0.
-    if: >-
-      github.repository != 'apache/spark'
-      || endsWith(needs.count-commits.outputs.commit-count, '0')
+    needs: check-build
+    if: needs.check-build.outputs.should-build == 'true'
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -25,58 +25,64 @@ on:
     - '**'
 
 jobs:
-  check-build:
-    name: Check Build decision
+  check-commit-count:
+    name: Check commit count
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
-      should-build: ${{ steps.decision.outputs.should-build }}
+      is-tenth-commit: ${{ steps.count.outputs.is-tenth-commit }}
     steps:
       - name: Check out the full branch history
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Determine whether Build should run
-        id: decision
+      - name: Check whether this is every tenth commit
+        id: count
         run: |
           count=$(git rev-list --count HEAD)
+          remainder=$((count % 10))
 
-          if [[ "$GITHUB_REPOSITORY" != "apache/spark" ]]; then
-            should_build=true
-            title="Build scheduled"
-            details="Fork pushes always run Build. Commit count: $count."
-          elif ((count % 10 == 0)); then
-            should_build=true
-            title="Build scheduled"
+          if ((remainder == 0)); then
+            is_tenth_commit=true
+            title="Commit count matched"
             details="Commit count $count is divisible by 10."
+            next_count=$count
           else
-            should_build=false
+            is_tenth_commit=false
             next_count=$(( (count / 10 + 1) * 10 ))
-            title="Build skipped"
-            details="Commit count $count is not divisible by 10. Next Build: $next_count."
+            title="Commit count not matched"
+            details="Commit count $count is not divisible by 10. Next match: $next_count."
           fi
 
-          echo "should-build=$should_build" >> "$GITHUB_OUTPUT"
-          echo "Repository: $GITHUB_REPOSITORY"
+          echo "is-tenth-commit=$is_tenth_commit" >> "$GITHUB_OUTPUT"
           echo "Branch: $GITHUB_REF_NAME"
           echo "Commit: $GITHUB_SHA"
           echo "Commit count: $count"
-          echo "Decision: $title"
+          echo "Remainder: $remainder"
+          echo "Every tenth commit: $is_tenth_commit"
+          echo "Next matching count: $next_count"
           echo "Details: $details"
           echo "::notice title=$title::$details"
-          echo "### $title" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Commit count check" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Repository: $GITHUB_REPOSITORY" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch: $GITHUB_REF_NAME" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit count: $count" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Remainder: $remainder" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Every tenth commit: $is_tenth_commit" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Next matching count: $next_count" >> "$GITHUB_STEP_SUMMARY"
           echo "- Details: $details" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Build runs for forks or when every tenth commit is true." \
+            >> "$GITHUB_STEP_SUMMARY"
 
   call-build-and-test:
     permissions:
       packages: write
     name: Run
-    needs: check-build
-    if: needs.check-build.outputs.should-build == 'true'
+    needs: check-commit-count
+    if: >-
+      github.repository != 'apache/spark'
+      || needs.check-commit-count.outputs.is-tenth-commit == 'true'
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      is-tenth-commit: ${{ steps.count.outputs.is-tenth-commit }}
+      should-run: ${{ steps.count.outputs.should-run }}
     steps:
       - name: Check out the full branch history
         uses: actions/checkout@v6
@@ -44,23 +44,23 @@ jobs:
           remainder=$((count % 10))
 
           if ((remainder == 0)); then
-            is_tenth_commit=true
+            should_run=true
             title="Commit count matched"
             details="Commit count $count is divisible by 10."
             next_count=$count
           else
-            is_tenth_commit=false
+            should_run=false
             next_count=$(( (count / 10 + 1) * 10 ))
             title="Commit count not matched"
             details="Commit count $count is not divisible by 10. Next match: $next_count."
           fi
 
-          echo "is-tenth-commit=$is_tenth_commit" >> "$GITHUB_OUTPUT"
+          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
           echo "Branch: $GITHUB_REF_NAME"
           echo "Commit: $GITHUB_SHA"
           echo "Commit count: $count"
           echo "Remainder: $remainder"
-          echo "Every tenth commit: $is_tenth_commit"
+          echo "Should run: $should_run"
           echo "Next matching count: $next_count"
           echo "Details: $details"
           echo "::notice title=$title::$details"
@@ -70,11 +70,11 @@ jobs:
           echo "- Commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit count: $count" >> "$GITHUB_STEP_SUMMARY"
           echo "- Remainder: $remainder" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Every tenth commit: $is_tenth_commit" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Should run: $should_run" >> "$GITHUB_STEP_SUMMARY"
           echo "- Next matching count: $next_count" >> "$GITHUB_STEP_SUMMARY"
           echo "- Details: $details" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Build runs for forks or when every tenth commit is true." \
+          echo "Build runs for forks or when should-run is true." \
             >> "$GITHUB_STEP_SUMMARY"
 
   call-build-and-test:
@@ -84,5 +84,5 @@ jobs:
     needs: check-commit-count
     if: >-
       github.repository != 'apache/spark'
-      || needs.check-commit-count.outputs.is-tenth-commit == 'true'
+      || needs.check-commit-count.outputs.should-run == 'true'
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -48,11 +48,9 @@ jobs:
             icon=":white_check_mark:"
             title="Commit count matched"
             details="Commit count $count is divisible by 10."
-            next_count=$count
           else
             should_run=false
             icon=":pause_button:"
-            next_count=$(( (count / 10 + 1) * 10 ))
             title="Commit count not matched"
             details="Commit count $count is not divisible by 10."
           fi
@@ -63,7 +61,6 @@ jobs:
           echo "Commit count: $count"
           echo "Remainder: $remainder"
           echo "Should run: $should_run"
-          echo "Next matching count: $next_count"
           echo "Details: $details"
           echo "::notice title=$title::$details"
           echo "### $icon Commit count check" >> "$GITHUB_STEP_SUMMARY"
@@ -73,7 +70,6 @@ jobs:
           echo "- Commit count: $count" >> "$GITHUB_STEP_SUMMARY"
           echo "- Remainder: $remainder" >> "$GITHUB_STEP_SUMMARY"
           echo "- Should run: $should_run" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Next matching count: $next_count" >> "$GITHUB_STEP_SUMMARY"
           echo "- Details: $details" >> "$GITHUB_STEP_SUMMARY"
 
   call-build-and-test:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the commit-count job in build_main.yml to check-commit-count and make it expose a should-run boolean. The job only checks whether the full branch commit count is divisible by ten.

The downstream Run job uses should-run together with the existing repository condition, keeping repository-specific behavior outside check-commit-count.

The count step prints the branch, commit SHA, commit count, remainder, boolean result, and explanation. It publishes the same information as a GitHub job summary and notice, with a check-mark or pause icon indicating whether the count matched.

### Why are the changes needed?

When the commit-count check succeeds but the Run job is skipped, GitHub marks the overall workflow run green. Previously, the commit count was redirected only to a job output, so the run did not visibly explain why the Build job was skipped.

An explicit boolean keeps the downstream condition readable, while the job summary makes the cadence decision visible without inspecting the workflow source.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran git diff --check and bash syntax validation for the count script. Also checked the changed workflow for non-ASCII characters and lines over 100 characters.

No runtime tests were run because this changes only GitHub Actions orchestration and reporting.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)