### PR TITLE
[MINOR][MLLIB] Exclude zero-weight observations from KMeans initialization

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -645,9 +645,12 @@ class KMeans @Since("1.5.0") (
       .setEpsilon($(tol))
       .setDistanceMeasure($(distanceMeasure))
 
-    val vectors = dataset.select(DatasetUtils.columnToVector(dataset, getFeaturesCol))
+    val vectors = dataset.select(
+        DatasetUtils.columnToVector(dataset, getFeaturesCol),
+        checkNonNegativeWeights(get(weightCol)))
       .rdd
-      .map { case Row(features: Vector) => OldVectors.fromML(features) }
+      .filter { case Row(_: Vector, weight: Double) => weight > 0 }
+      .map { case Row(features: Vector, _: Double) => OldVectors.fromML(features) }
 
     val centers = algo.initialize(vectors).map(_.asML)
     $(distanceMeasure) match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -268,10 +268,11 @@ class KMeans private (
       case Some(kMeansCenters) =>
         kMeansCenters.clusterCenters.map(new VectorWithNorm(_))
       case None =>
+        val initializationData = data.filter(_.weight > 0)
         if (initializationMode == KMeans.RANDOM) {
-          initRandom(data)
+          initRandom(initializationData)
         } else {
-          initKMeansParallel(data, distanceMeasureInstance)
+          initKMeansParallel(initializationData, distanceMeasureInstance)
         }
     }
     val numFeatures = centers.head.vector.size

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -430,13 +430,9 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       (Vectors.dense(10.0, 0.0), 1.0),
       (Vectors.dense(10.1, 0.0), 1.0)
     ).toDF("features", "weightCol")
-    val zeroWeightOutlierData = Seq(
-      (Vectors.dense(0.0, 0.0), 1.0),
-      (Vectors.dense(0.1, 0.0), 1.0),
-      (Vectors.dense(10.0, 0.0), 1.0),
-      (Vectors.dense(10.1, 0.0), 1.0),
+    val zeroWeightOutlierData = positiveWeightData.union(Seq(
       (Vectors.dense(1000000.0, 1000000.0), 0.0)
-    ).toDF("features", "weightCol")
+    ).toDF("features", "weightCol"))
 
     Seq(KMeans.ROW, KMeans.BLOCK).foreach { solver =>
       Seq(MLlibKMeans.RANDOM, MLlibKMeans.K_MEANS_PARALLEL).foreach { initMode =>

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -423,6 +423,39 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
     }
   }
 
+  test("zero-weight observations do not affect initialization") {
+    val positiveWeightData = Seq(
+      (Vectors.dense(0.0, 0.0), 1.0),
+      (Vectors.dense(0.1, 0.0), 1.0),
+      (Vectors.dense(10.0, 0.0), 1.0),
+      (Vectors.dense(10.1, 0.0), 1.0)
+    ).toDF("features", "weightCol")
+    val zeroWeightOutlierData = Seq(
+      (Vectors.dense(0.0, 0.0), 1.0),
+      (Vectors.dense(0.1, 0.0), 1.0),
+      (Vectors.dense(10.0, 0.0), 1.0),
+      (Vectors.dense(10.1, 0.0), 1.0),
+      (Vectors.dense(1000000.0, 1000000.0), 0.0)
+    ).toDF("features", "weightCol")
+
+    Seq(KMeans.ROW, KMeans.BLOCK).foreach { solver =>
+      Seq(MLlibKMeans.RANDOM, MLlibKMeans.K_MEANS_PARALLEL).foreach { initMode =>
+        val params = new KMeans()
+          .setK(2)
+          .setInitMode(initMode)
+          .setWeightCol("weightCol")
+          .setMaxIter(1)
+          .setSeed(1L)
+          .setSolver(solver)
+
+        val modelWithoutOutlier = params.fit(positiveWeightData)
+        val modelWithOutlier = params.fit(zeroWeightOutlierData)
+
+        assert(modelWithOutlier.clusterCenters === modelWithoutOutlier.clusterCenters)
+        assert(modelWithOutlier.summary.trainingCost === modelWithoutOutlier.summary.trainingCost)
+      }
+    }
+  }
   test("Four centers with weightCol") {
     // no weight
     val df1 = spark.createDataFrame(spark.sparkContext.parallelize(Seq(


### PR DESCRIPTION
﻿## What changes were proposed in this pull request?

This change prevents zero-weight observations from influencing KMeans centroid initialization.

The row solver now excludes zero-weight observations before RANDOM or k-means|| initialization. The block solver now carries `weightCol` into initialization and excludes zero-weight observations there as well.

## Why are the changes needed?

Weighted KMeans ignores zero-weight observations during cluster updates, but initialization could still select them as candidate centers. This meant adding a zero-weight outlier could change the fitted model.

## Does this PR introduce any user-facing changes?

It makes initialization consistent with the existing weighted update semantics: zero-weight observations no longer affect the fitted clusters.

## How was this patch tested?

A regression test compares datasets with and without an extreme zero-weight outlier across ROW and BLOCK solvers and RANDOM and k-means|| initialization.

`git diff --check` passes. The focused Spark suite could not run in the available Windows environment because WSL `/bin/bash` is unavailable.

## Was this patch authored or co-authored using generative AI tooling?
No
