### PR TITLE
[SPARK-58210][SQL][FOLLOWUP] Extend CombineAdjacentAggregation to partial merge

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CombineAdjacentAggregation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CombineAdjacentAggregation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final, Partial}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateMode, Complete, Final, Partial, PartialMerge}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
@@ -49,13 +49,10 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
     }
 
     plan.transformDown {
-      case finalAgg @ HashAggregateExec(_, _, _, _, _, _, _, _, partialAgg: HashAggregateExec)
-          if isPartialAgg(partialAgg, finalAgg) =>
-        finalAgg.copy(
-          groupingExpressions = partialAgg.groupingExpressions,
-          aggregateExpressions = partialAgg.aggregateExpressions.map(_.copy(mode = Complete)),
-          initialInputBufferOffset = 0,
-          child = partialAgg.child)
+      case finalAgg @ HashAggregateExec(_, _, _, _, _, _, _, _, partialAgg: HashAggregateExec) =>
+        combinedMode(partialAgg, finalAgg)
+          .map(combineHashAggregates(partialAgg, finalAgg, _))
+          .getOrElse(finalAgg)
 
       case finalAgg @ SortAggregateExec(_, _, _, _, _, _, _, _, partialAgg: SortAggregateExec)
           if isPartialAgg(partialAgg, finalAgg) =>
@@ -76,6 +73,43 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
     }
   }
 
+  private def combineHashAggregates(
+      partialAgg: HashAggregateExec,
+      finalAgg: HashAggregateExec,
+      mode: AggregateMode): HashAggregateExec = {
+    val aggregateExpressions = mode match {
+      case Complete => partialAgg.aggregateExpressions.map(_.copy(mode = Complete))
+      case Final => finalAgg.aggregateExpressions
+      case other => throw new IllegalArgumentException(s"Unexpected aggregate mode: $other")
+    }
+    finalAgg.copy(
+      requiredChildDistributionExpressions = partialAgg.requiredChildDistributionExpressions,
+      isStreaming = partialAgg.isStreaming,
+      numShufflePartitions = partialAgg.numShufflePartitions,
+      groupingExpressions = partialAgg.groupingExpressions,
+      aggregateExpressions = aggregateExpressions,
+      initialInputBufferOffset = if (mode == Complete) 0 else finalAgg.initialInputBufferOffset,
+      child = partialAgg.child)
+  }
+
+  private def combinedMode(
+      partialAgg: HashAggregateExec,
+      finalAgg: HashAggregateExec): Option[AggregateMode] = {
+    if (!isCompatibleAggregates(partialAgg, finalAgg)) {
+      None
+    } else if (partialAgg.outputSet != finalAgg.usedInputs) {
+      None
+    } else if (partialAgg.aggregateExpressions.forall(_.mode == Partial)) {
+      Some(Complete)
+    } else if (partialAgg.aggregateExpressions.forall(_.mode == PartialMerge) &&
+        partialAgg.aggregateExpressions.forall(_.filter.isEmpty) &&
+        finalAgg.aggregateExpressions.forall(_.filter.isEmpty)) {
+      Some(Final)
+    } else {
+      None
+    }
+  }
+
   /**
    * Check if `partialAgg` is the partial aggregate of `finalAgg`.
    */
@@ -83,7 +117,13 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
       partialAgg: BaseAggregateExec,
       finalAgg: BaseAggregateExec): Boolean = {
     partialAgg.aggregateExpressions.forall(_.mode == Partial) &&
-      finalAgg.aggregateExpressions.forall(_.mode == Final) &&
+      isCompatibleAggregates(partialAgg, finalAgg)
+  }
+
+  private def isCompatibleAggregates(
+      partialAgg: BaseAggregateExec,
+      finalAgg: BaseAggregateExec): Boolean = {
+    finalAgg.aggregateExpressions.forall(_.mode == Final) &&
       partialAgg.groupingExpressions.map(_.canonicalized) ==
         finalAgg.groupingExpressions.map(_.canonicalized) &&
       finalAgg.logicalLink.isDefined &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CombineAdjacentAggregation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CombineAdjacentAggregation.scala
@@ -17,15 +17,15 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateMode, Complete, Final, Partial, PartialMerge}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Final, Partial, PartialMerge}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
- * This rule combines adjacent aggregation with `Partial` and `Final` to `Complete` mode, or
- * `PartialMerge` and `Final` to `Final` mode. The latter can be produced by physical plan
- * extensions that add an extra aggregation stage.
+ * This rule combines adjacent aggregation with `Partial` and `Final` to `Complete` mode. For
+ * [[HashAggregateExec]], it also combines `PartialMerge` and `Final` to `Final` mode. The latter
+ * can be produced by physical plan extensions that add an extra aggregation stage.
  * Example for hash aggregate:
  *    HashAggregate (Final)         HashAggregate (Complete)
  *          |                             |
@@ -45,6 +45,10 @@ import org.apache.spark.sql.internal.SQLConf
  * It supports [[HashAggregateExec]], [[SortAggregateExec]] and [[ObjectHashAggregateExec]].
  */
 object CombineAdjacentAggregation extends Rule[SparkPlan] {
+  private case class CombinedAggregate(
+      aggregateExpressions: Seq[AggregateExpression],
+      initialInputBufferOffset: Int)
+
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.getConf(SQLConf.COMBINE_ADJACENT_AGGREGATION_ENABLED)) {
       return plan
@@ -52,7 +56,7 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
 
     plan.transformDown {
       case finalAgg @ HashAggregateExec(_, _, _, _, _, _, _, _, partialAgg: HashAggregateExec) =>
-        combinedMode(partialAgg, finalAgg)
+        combinedAggregate(partialAgg, finalAgg)
           .map(combineHashAggregates(partialAgg, finalAgg, _))
           .getOrElse(finalAgg)
 
@@ -78,33 +82,33 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
   private def combineHashAggregates(
       partialAgg: HashAggregateExec,
       finalAgg: HashAggregateExec,
-      mode: AggregateMode): HashAggregateExec = {
-    val aggregateExpressions = mode match {
-      case Complete => partialAgg.aggregateExpressions.map(_.copy(mode = Complete))
-      case Final => finalAgg.aggregateExpressions
-      case other => throw new IllegalArgumentException(s"Unexpected aggregate mode: $other")
-    }
+      combined: CombinedAggregate): HashAggregateExec = {
+    // Keep the final aggregate's distribution requirement because the rule runs after
+    // EnsureRequirements. The other child-facing metadata comes from the removed aggregate.
     finalAgg.copy(
-      requiredChildDistributionExpressions = finalAgg.requiredChildDistributionExpressions,
       isStreaming = partialAgg.isStreaming,
       numShufflePartitions = partialAgg.numShufflePartitions,
       groupingExpressions = partialAgg.groupingExpressions,
-      aggregateExpressions = aggregateExpressions,
-      initialInputBufferOffset = if (mode == Complete) 0 else partialAgg.initialInputBufferOffset,
+      aggregateExpressions = combined.aggregateExpressions,
+      initialInputBufferOffset = combined.initialInputBufferOffset,
       child = partialAgg.child)
   }
 
-  private def combinedMode(
+  private def combinedAggregate(
       partialAgg: HashAggregateExec,
-      finalAgg: HashAggregateExec): Option[AggregateMode] = {
+      finalAgg: HashAggregateExec): Option[CombinedAggregate] = {
     if (!isCompatibleAggregates(partialAgg, finalAgg)) {
       None
     } else if (partialAgg.aggregateExpressions.forall(_.mode == Partial)) {
-      Some(Complete)
+      Some(CombinedAggregate(
+        partialAgg.aggregateExpressions.map(_.copy(mode = Complete)),
+        initialInputBufferOffset = 0))
     } else if (partialAgg.aggregateExpressions.forall(_.mode == PartialMerge) &&
         partialAgg.aggregateExpressions.forall(_.filter.isEmpty) &&
         finalAgg.aggregateExpressions.forall(_.filter.isEmpty)) {
-      Some(Final)
+      Some(CombinedAggregate(
+        finalAgg.aggregateExpressions,
+        partialAgg.initialInputBufferOffset))
     } else {
       None
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CombineAdjacentAggregation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CombineAdjacentAggregation.scala
@@ -23,7 +23,9 @@ import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregat
 import org.apache.spark.sql.internal.SQLConf
 
 /**
- * This rule combines adjacent aggregation with `Partial` and `Final` to `Complete` mode.
+ * This rule combines adjacent aggregation with `Partial` and `Final` to `Complete` mode, or
+ * `PartialMerge` and `Final` to `Final` mode. The latter can be produced by physical plan
+ * extensions that add an extra aggregation stage.
  * Example for hash aggregate:
  *    HashAggregate (Final)         HashAggregate (Complete)
  *          |                             |
@@ -83,12 +85,12 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
       case other => throw new IllegalArgumentException(s"Unexpected aggregate mode: $other")
     }
     finalAgg.copy(
-      requiredChildDistributionExpressions = partialAgg.requiredChildDistributionExpressions,
+      requiredChildDistributionExpressions = finalAgg.requiredChildDistributionExpressions,
       isStreaming = partialAgg.isStreaming,
       numShufflePartitions = partialAgg.numShufflePartitions,
       groupingExpressions = partialAgg.groupingExpressions,
       aggregateExpressions = aggregateExpressions,
-      initialInputBufferOffset = if (mode == Complete) 0 else finalAgg.initialInputBufferOffset,
+      initialInputBufferOffset = if (mode == Complete) 0 else partialAgg.initialInputBufferOffset,
       child = partialAgg.child)
   }
 
@@ -96,8 +98,6 @@ object CombineAdjacentAggregation extends Rule[SparkPlan] {
       partialAgg: HashAggregateExec,
       finalAgg: HashAggregateExec): Option[AggregateMode] = {
     if (!isCompatibleAggregates(partialAgg, finalAgg)) {
-      None
-    } else if (partialAgg.outputSet != finalAgg.usedInputs) {
       None
     } else if (partialAgg.aggregateExpressions.forall(_.mode == Partial)) {
       Some(Complete)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
@@ -266,9 +266,11 @@ class CombineAdjacentAggregationSuite extends QueryTest
         assert(collect(df.queryExecution.executedPlan) {
           case agg: HashAggregateExec => agg
         }.size == 1)
-        assert(collect(df.queryExecution.executedPlan) {
+        val partitionSpecs = collect(df.queryExecution.executedPlan) {
           case read: AQEShuffleReadExec => read
-        }.flatMap(_.partitionSpecs).forall(!_.isInstanceOf[PartialReducerPartitionSpec]))
+        }.flatMap(_.partitionSpecs)
+        assert(partitionSpecs.nonEmpty)
+        assert(partitionSpecs.forall(!_.isInstanceOf[PartialReducerPartitionSpec]))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final}
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final, PartialMerge}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
@@ -188,6 +189,54 @@ class CombineAdjacentAggregationSuite extends QueryTest
           |FROM (SELECT /*+ repartition(k1, k2) */ * FROM t) GROUP BY k1, k2""".stripMargin,
         numAggWithDisabled = 2,
         numAggWithEnabled = 1)
+    }
+  }
+
+  test("Combine adjacent partial merge and final hash aggregates") {
+    withTempView("t") {
+      spark.range(20).selectExpr("id % 3 as k", "id % 7 as v").createOrReplaceTempView("t")
+      val query = "SELECT k, count(*) FROM (SELECT /*+ repartition(k) */ * FROM t) GROUP BY k"
+      val finalAgg = withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.COMBINE_ADJACENT_AGGREGATION_ENABLED.key -> "false") {
+        collect(sql(query).queryExecution.executedPlan) {
+          case agg: HashAggregateExec if agg.child.isInstanceOf[HashAggregateExec] => agg
+        }.head
+      }
+      val partialAgg = finalAgg.child.asInstanceOf[HashAggregateExec]
+      val partialMergeAgg = partialAgg.copy(
+        requiredChildDistributionExpressions = Some(partialAgg.groupingExpressions),
+        isStreaming = true,
+        numShufflePartitions = Some(5),
+        aggregateExpressions = partialAgg.aggregateExpressions.map(_.copy(mode = PartialMerge)))
+      partialMergeAgg.copyTagsFrom(partialAgg)
+      val finalOverPartialMerge = finalAgg.copy(child = partialMergeAgg)
+      finalOverPartialMerge.copyTagsFrom(finalAgg)
+
+      val combined = CombineAdjacentAggregation(finalOverPartialMerge)
+        .asInstanceOf[HashAggregateExec]
+      assert(combined.aggregateExpressions.forall(_.mode == Final))
+      assert(combined.requiredChildDistributionExpressions ==
+        partialMergeAgg.requiredChildDistributionExpressions)
+      assert(combined.isStreaming == partialMergeAgg.isStreaming)
+      assert(combined.numShufflePartitions == partialMergeAgg.numShufflePartitions)
+      assert(combined.groupingExpressions == partialMergeAgg.groupingExpressions)
+      assert(combined.aggregateAttributes == finalAgg.aggregateAttributes)
+      assert(combined.resultExpressions == finalAgg.resultExpressions)
+      assert(combined.initialInputBufferOffset == finalAgg.initialInputBufferOffset)
+      assert(combined.child == partialMergeAgg.child)
+
+      val filteredPartialMerge = partialMergeAgg.copy(
+        aggregateExpressions = partialMergeAgg.aggregateExpressions.zipWithIndex.map {
+          case (agg, 0) => agg.copy(filter = Some(Literal.TrueLiteral))
+          case (agg, _) => agg
+        })
+      filteredPartialMerge.copyTagsFrom(partialAgg)
+      val finalOverFilteredPartialMerge = finalAgg.copy(child = filteredPartialMerge)
+      finalOverFilteredPartialMerge.copyTagsFrom(finalAgg)
+      assert(collect(CombineAdjacentAggregation(finalOverFilteredPartialMerge)) {
+        case agg: HashAggregateExec => agg
+      }.size == 2)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final, PartialMerge}
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEShuffleReadExec}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -204,11 +204,14 @@ class CombineAdjacentAggregationSuite extends QueryTest
         }.head
       }
       val partialAgg = finalAgg.child.asInstanceOf[HashAggregateExec]
+      val partialMergeInput = InputAdapter(partialAgg)
       val partialMergeAgg = partialAgg.copy(
         requiredChildDistributionExpressions = Some(partialAgg.groupingExpressions),
         isStreaming = true,
         numShufflePartitions = Some(5),
-        aggregateExpressions = partialAgg.aggregateExpressions.map(_.copy(mode = PartialMerge)))
+        initialInputBufferOffset = finalAgg.initialInputBufferOffset,
+        aggregateExpressions = partialAgg.aggregateExpressions.map(_.copy(mode = PartialMerge)),
+        child = partialMergeInput)
       partialMergeAgg.copyTagsFrom(partialAgg)
       val finalOverPartialMerge = finalAgg.copy(child = partialMergeAgg)
       finalOverPartialMerge.copyTagsFrom(finalAgg)
@@ -217,14 +220,16 @@ class CombineAdjacentAggregationSuite extends QueryTest
         .asInstanceOf[HashAggregateExec]
       assert(combined.aggregateExpressions.forall(_.mode == Final))
       assert(combined.requiredChildDistributionExpressions ==
-        partialMergeAgg.requiredChildDistributionExpressions)
+        finalAgg.requiredChildDistributionExpressions)
       assert(combined.isStreaming == partialMergeAgg.isStreaming)
       assert(combined.numShufflePartitions == partialMergeAgg.numShufflePartitions)
       assert(combined.groupingExpressions == partialMergeAgg.groupingExpressions)
       assert(combined.aggregateAttributes == finalAgg.aggregateAttributes)
       assert(combined.resultExpressions == finalAgg.resultExpressions)
-      assert(combined.initialInputBufferOffset == finalAgg.initialInputBufferOffset)
-      assert(combined.child == partialMergeAgg.child)
+      assert(combined.initialInputBufferOffset == partialMergeAgg.initialInputBufferOffset)
+      assert(combined.child == partialMergeInput)
+      assert(finalOverPartialMerge.executeCollect().map(_.copy()).toSet ==
+        combined.executeCollect().map(_.copy()).toSet)
 
       val filteredPartialMerge = partialMergeAgg.copy(
         aggregateExpressions = partialMergeAgg.aggregateExpressions.zipWithIndex.map {
@@ -237,6 +242,34 @@ class CombineAdjacentAggregationSuite extends QueryTest
       assert(collect(CombineAdjacentAggregation(finalOverFilteredPartialMerge)) {
         case agg: HashAggregateExec => agg
       }.size == 2)
+    }
+  }
+
+  test("Combined aggregate retains its distribution requirement under AQE") {
+    import testImplicits._
+
+    withTempView("t") {
+      spark.sparkContext.parallelize(
+        (1 to 10).map(i => (if (i > 4) 5 else i, i.toString)), 3)
+        .toDF("k", "v").createOrReplaceTempView("t")
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_OPTIMIZE_SKEWS_IN_REBALANCE_PARTITIONS_ENABLED.key -> "true",
+          SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true",
+          SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
+          SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+          SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "150") {
+        val df = sql(
+          "SELECT k, count(*) FROM (SELECT /*+ REBALANCE(k) */ * FROM t) GROUP BY k")
+        checkAnswer(df, Seq(Row(1, 1), Row(2, 1), Row(3, 1), Row(4, 1), Row(5, 6)))
+        assert(collect(df.queryExecution.executedPlan) {
+          case agg: HashAggregateExec => agg
+        }.size == 1)
+        assert(collect(df.queryExecution.executedPlan) {
+          case read: AQEShuffleReadExec => read
+        }.flatMap(_.partitionSpecs).forall(!_.isInstanceOf[PartialReducerPartitionSpec]))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CombineAdjacentAggregationSuite.scala
@@ -241,7 +241,7 @@ class CombineAdjacentAggregationSuite extends QueryTest
       finalOverFilteredPartialMerge.copyTagsFrom(finalAgg)
       assert(collect(CombineAdjacentAggregation(finalOverFilteredPartialMerge)) {
         case agg: HashAggregateExec => agg
-      }.size == 2)
+      }.size == 3)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This is a follow-up to #57363. It extends `CombineAdjacentAggregation` to combine adjacent
`PartialMerge` and `Final` hash aggregates into one `Final` aggregate. This pattern can be
produced by physical-plan extensions that add an aggregation stage; Spark's built-in query
planning does not currently produce it.

The combined aggregate preserves the upper `Final` aggregate's child distribution requirement.
Because the lower aggregate is removed, the combined aggregate takes its streaming and
shuffle-partition metadata from that lower aggregate and reads its original child. Filtered
`Partial` aggregation remains supported, while a `PartialMerge` pair with filters is not combined.

### Why are the changes needed?

`CombineAdjacentAggregation` currently handles only `Partial` followed by `Final`. A compatible
adjacent `PartialMerge` and `Final` hash aggregate pair can also be collapsed safely, avoiding an
unnecessary hash aggregation stage.

The upper aggregate's distribution requirement must remain after the rule runs so that later AQE
optimization does not split partitions that the combined aggregate requires to remain clustered.
The lower aggregate's streaming and shuffle-partition metadata remain child-facing properties and
therefore move to the combined aggregate when the lower node is removed.

### Does this PR introduce _any_ user-facing change?

Yes. Spark may produce a single final hash aggregate instead of adjacent partial-merge and final
hash aggregates when their grouping and logical lineage are compatible. Query results are
unchanged.

### How was this patch tested?

Added coverage to `CombineAdjacentAggregationSuite` for:

- combining an executable `PartialMerge` and `Final` hash aggregate pipeline and comparing the
  uncombined and combined results;
- preserving the upper distribution requirement and lower streaming, shuffle-partition,
  grouping, child, and buffer-offset metadata;
- refusing to combine a filtered `PartialMerge` pair;
- retaining the distribution requirement under AQE and verifying that shuffle partition specs
  are present but are not partial reducer specs.

Ran:

```
build/sbt 'sql/testOnly org.apache.spark.sql.execution.CombineAdjacentAggregationSuite' sql/scalastyle
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
