### PR TITLE
[SPARK-58658][CONNECT] Do not return spark.connect.authenticate.token from the Config RPC

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectConfigHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectConfigHandler.scala
@@ -24,6 +24,7 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.RuntimeConfig
+import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.internal.SQLConf
 
 class SparkConnectConfigHandler(responseObserver: StreamObserver[proto.ConfigResponse])
@@ -97,7 +98,7 @@ class SparkConnectConfigHandler(responseObserver: StreamObserver[proto.ConfigRes
       conf: RuntimeConfig): proto.ConfigResponse.Builder = {
     val builder = proto.ConfigResponse.newBuilder()
     operation.getKeysList.asScala.iterator.foreach { key =>
-      val value = conf.get(key)
+      val value = if (SparkConnectConfigHandler.isUndisclosed(key)) null else conf.get(key)
       builder.addPairs(SparkConnectConfigHandler.toProtoKeyValue(key, Option(value)))
       getWarning(key).foreach(builder.addWarnings)
     }
@@ -110,7 +111,13 @@ class SparkConnectConfigHandler(responseObserver: StreamObserver[proto.ConfigRes
     val builder = proto.ConfigResponse.newBuilder()
     operation.getPairsList.asScala.iterator.foreach { pair =>
       val (key, default) = SparkConnectConfigHandler.toKeyValue(pair)
-      val value = conf.get(key, default.orNull)
+      // An undisclosed key falls back to the caller's default, which is
+      // what an unset key would do.
+      val value = if (SparkConnectConfigHandler.isUndisclosed(key)) {
+        default.orNull
+      } else {
+        conf.get(key, default.orNull)
+      }
       builder.addPairs(SparkConnectConfigHandler.toProtoKeyValue(key, Option(value)))
       getWarning(key).foreach(builder.addWarnings)
     }
@@ -122,7 +129,7 @@ class SparkConnectConfigHandler(responseObserver: StreamObserver[proto.ConfigRes
       conf: RuntimeConfig): proto.ConfigResponse.Builder = {
     val builder = proto.ConfigResponse.newBuilder()
     operation.getKeysList.asScala.iterator.foreach { key =>
-      val value = conf.getOption(key)
+      val value = if (SparkConnectConfigHandler.isUndisclosed(key)) None else conf.getOption(key)
       builder.addPairs(SparkConnectConfigHandler.toProtoKeyValue(key, value))
       getWarning(key).foreach(builder.addWarnings)
     }
@@ -133,13 +140,18 @@ class SparkConnectConfigHandler(responseObserver: StreamObserver[proto.ConfigRes
       operation: proto.ConfigRequest.GetAll,
       conf: RuntimeConfig): proto.ConfigResponse.Builder = {
     val builder = proto.ConfigResponse.newBuilder()
+    // Filtering happens on the full key, before the prefix is stripped
+    // off below.
+    val disclosed = conf.getAll.iterator.filterNot { case (key, _) =>
+      SparkConnectConfigHandler.isUndisclosed(key)
+    }
     val results = if (operation.hasPrefix) {
       val prefix = operation.getPrefix
-      conf.getAll.iterator
+      disclosed
         .filter { case (key, _) => key.startsWith(prefix) }
         .map { case (key, value) => (key.substring(prefix.length), value) }
     } else {
-      conf.getAll.iterator
+      disclosed
     }
     results.foreach { case (key, value) =>
       builder.addPairs(SparkConnectConfigHandler.toProtoKeyValue(key, Option(value)))
@@ -184,6 +196,27 @@ object SparkConnectConfigHandler {
 
   private[connect] val unsupportedConfigurations =
     Set("spark.sql.execution.arrow.enabled", "spark.sql.execution.arrow.pyspark.fallback.enabled")
+
+  /**
+   * Configurations the server holds but never hands back to a client. Reads
+   * report them as unset: `Get` and `GetOption` return no value,
+   * `GetWithDefault` returns the caller's default, and `GetAll` omits them.
+   *
+   * `SQLConf.mergeSparkConf` copies every `SparkConf` entry into the session
+   * config, static ones included, so without this the pre-shared
+   * authentication token is readable through the Config RPC. That discloses
+   * nothing to a client of a standalone server, which had to present the
+   * token to connect at all. It does matter to deployments that place a
+   * proxy in front of Spark Connect and treat the token as a secret shared
+   * between the proxy and the servers, with end users authenticating by
+   * other means: there, any client the proxy admits could read the token and
+   * then reach a server directly. Not disclosing a server-side credential is
+   * the right default either way.
+   */
+  private[connect] val undisclosedConfigurations = Set(Connect.CONNECT_AUTHENTICATE_TOKEN.key)
+
+  private[connect] def isUndisclosed(key: String): Boolean =
+    undisclosedConfigurations.contains(key)
 
   def toKeyValue(pair: proto.KeyValue): (String, Option[String]) = {
     val key = pair.getKey

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectAuthSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectAuthSuite.scala
@@ -20,11 +20,14 @@ package org.apache.spark.sql.connect.service
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.connect.{SparkConnectServerTest, SparkSession}
+import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.service.SparkConnectService
 
 class SparkConnectAuthSuite extends SparkConnectServerTest {
   override protected def sparkConf = {
-    super.sparkConf.set("spark.connect.authenticate.token", "deadbeef")
+    super.sparkConf
+      .set("spark.connect.authenticate.token", "deadbeef")
+      .set("spark.connect.test.marker", "server-side-only")
   }
 
   test("Test local authentication") {
@@ -42,5 +45,30 @@ class SparkConnectAuthSuite extends SparkConnectServerTest {
       invalidSession.range(5).collect()
     }
     assert(exception.getMessage.contains("Invalid authentication token"))
+  }
+
+  test("The authentication token is not readable through the Config RPC") {
+    val session = SparkSession
+      .builder()
+      .remote(s"sc://localhost:${SparkConnectService.localPort}/;token=deadbeef")
+      .create()
+    val tokenKey = Connect.CONNECT_AUTHENTICATE_TOKEN.key
+
+    // Every read path reports the key the way an unset key is reported.
+    assert(session.conf.getOption(tokenKey).isEmpty)
+    assert(session.conf.get(tokenKey, "fallback") === "fallback")
+    intercept[NoSuchElementException] {
+      session.conf.get(tokenKey)
+    }
+    val all = session.conf.getAll
+    assert(!all.contains(tokenKey))
+    // Nothing else carries the value either.
+    assert(!all.exists { case (_, value) => value == "deadbeef" })
+
+    // A control key proves the Config RPC is otherwise working and really
+    // is reading server-side configuration: it is set in `sparkConf` below,
+    // never sent by the client.
+    assert(session.conf.get("spark.connect.test.marker") === "server-side-only")
+    assert(all.get("spark.connect.test.marker").contains("server-side-only"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkConnectConfigHandler` no longer discloses `spark.connect.authenticate.token` through the Config RPC. Every read path now reports it the way an unset key is reported: `Get` and `GetOption` return no value, `GetWithDefault` returns the caller's default, and `GetAll` omits it. The filtering in `handleGetAll` runs on the full key, before the requested prefix is stripped off the returned keys.

### Why are the changes needed?

`SQLConf.mergeSparkConf` copies every `SparkConf` entry into the session config, static ones included, and the Config RPC's read paths apply no denylist, so a client can read the server's pre-shared authentication token back out of it. `RuntimeConfig` already guards writes to static configs; reads are unguarded.

For the client-to-server deployment Spark documents this discloses nothing -- the client had to present the token to connect at all. It matters to deployments that put a proxy in front of Spark Connect and treat the token as a proxy-to-server secret while end users authenticate by other means: there, any user the proxy admits can read the token and then reach a server directly. Spark does not promise that property, so this is defense in depth rather than a fix for a Spark vulnerability; a server not handing out its own credential is the better default either way.

### Does this PR introduce _any_ user-facing change?

Yes, in a narrow sense: reading `spark.connect.authenticate.token` through a Connect session now behaves as though the key were unset instead of returning the token. No other configuration is affected.

### How was this patch tested?

New test in `SparkConnectAuthSuite` (which already runs a server with the token configured) asserting that `get`, `get` with a default, `getOption` and `getAll` all report the key as unset, and that no other entry carries the token's value. A control key set only on the server proves the Config RPC is otherwise working and really is reading server-side configuration.

### Was this patch authored or co-authored using generative AI tooling?

Yes, Generated-by: Claude
