### PR TITLE
[SPARK-58602][PYTHON][TESTS][FOLLOWUP] Fix the test entry point of test_pyarrow_array_from_pandas_default

### DIFF
--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_from_pandas_default.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_from_pandas_default.py
@@ -410,4 +410,4 @@ class PyArrowArrayFromPandasDefaultTests(GoldenFileTestMixin, unittest.TestCase)
 if __name__ == "__main__":
     from pyspark.testing import main
 
-    main(globals()["__file__"])
+    main()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the `__main__` entry point of `test_pyarrow_array_from_pandas_default.py` from `main(globals()["__file__"])` to a bare `main()`.

### Why are the changes needed?

`pyspark.testing.main(module=None)` expects either no argument (it then resolves the real module name via `__spec__`) or a module name -- it forwards its argument straight to `unittest.main(module=...)`. Passing `globals()["__file__"]` hands it a filesystem path, which `unittest` tries to import as a module name and fails:

```
ModuleNotFoundError: No module named '/__w/spark/spark/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_from_pandas_default'
```

This aborts the `pyspark-sql` test module on master (exit code 19) before the rest of the shard completes, so it is currently failing CI on master and on open PRs. Every other pyspark test file uses a bare `main()`; this was the only one passing a path.

### Does this PR introduce _any_ user-facing change?

No. Test-only fix.

### How was this patch tested?

Ran the module both ways locally. Before, `python -m pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_default` raised `ModuleNotFoundError`; after, it runs to completion (`Ran 1 test ... OK`). `dev/lint-python --ruff` is clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
