### PR TITLE
[SPARK-58661][SQL][DOCS] Document return values and fix stale column references in DataFrameStatFunctions

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -489,7 +489,7 @@ abstract class DataFrameStatFunctions {
    * @param seed
    *   random seed
    * @return
-   *   a `CountMinSketch` over column `colName`
+   *   a `CountMinSketch` over column `col`
    * @since 2.0.0
    */
   def countMinSketch(col: Column, depth: Int, width: Int, seed: Int): CountMinSketch = {
@@ -510,7 +510,7 @@ abstract class DataFrameStatFunctions {
    * @param seed
    *   random seed
    * @return
-   *   a `CountMinSketch` over column `colName`
+   *   a `CountMinSketch` over column `col`
    * @since 2.0.0
    */
   def countMinSketch(col: Column, eps: Double, confidence: Double, seed: Int): CountMinSketch =
@@ -529,6 +529,8 @@ abstract class DataFrameStatFunctions {
    *   expected number of items which will be put into the filter.
    * @param fpp
    *   expected false positive probability of the filter.
+   * @return
+   *   a `BloomFilter` over column `colName`
    * @since 2.0.0
    */
   def bloomFilter(colName: String, expectedNumItems: Long, fpp: Double): BloomFilter = {
@@ -544,6 +546,8 @@ abstract class DataFrameStatFunctions {
    *   expected number of items which will be put into the filter.
    * @param fpp
    *   expected false positive probability of the filter.
+   * @return
+   *   a `BloomFilter` over column `col`
    * @since 2.0.0
    */
   def bloomFilter(col: Column, expectedNumItems: Long, fpp: Double): BloomFilter = {
@@ -560,6 +564,8 @@ abstract class DataFrameStatFunctions {
    *   expected number of items which will be put into the filter.
    * @param numBits
    *   expected number of bits of the filter.
+   * @return
+   *   a `BloomFilter` over column `colName`
    * @since 2.0.0
    */
   def bloomFilter(colName: String, expectedNumItems: Long, numBits: Long): BloomFilter = {
@@ -575,6 +581,8 @@ abstract class DataFrameStatFunctions {
    *   expected number of items which will be put into the filter.
    * @param numBits
    *   expected number of bits of the filter.
+   * @return
+   *   a `BloomFilter` over column `col`
    * @since 2.0.0
    */
   def bloomFilter(col: Column, expectedNumItems: Long, numBits: Long): BloomFilter = withOrigin {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two scaladoc fixes in `DataFrameStatFunctions`:

1. Adds the missing `@return` tag to the four `bloomFilter` overloads.
2. Corrects the `@return` text of the two `countMinSketch(col: Column, ...)` overloads, which described the result as being over column `colName` even though those overloads declare `col`.

### Why are the changes needed?

The `countMinSketch` overloads all document their return value while the parallel `bloomFilter` overloads document none, so the published API docs are inconsistent between two families of methods that the file otherwise describes in parallel wording. Each added tag names the parameter its own overload declares, alternating `colName`/`col` to match the four signatures.

The two stale `colName` references are a copy-paste artifact of the unified Scala interface refactor: the text was carried over from the `colName: String` overloads without being updated for the `Column` ones. The `colName` overloads themselves are correct and are left untouched.

### Does this PR introduce _any_ user-facing change?

No, other than the corrected API documentation.

### How was this patch tested?

Scaladoc only, so no behavior to test. Stripping comments from the file before and after the change yields byte-identical source, confirming no signature or code change and no binary compatibility impact.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
