### PR TITLE
[SPARK-58662][SS] Remove redundant toString in RocksDBStateStoreProvider state transition messages

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -148,10 +148,10 @@ private[sql] class RocksDBStateStoreProvider
         case Some(nextState) => nextState
         case None =>
           val errorMsg = operation match {
-            case UPDATE => s"Cannot update after ${oldState.toString}"
-            case ABORT => s"Cannot abort after ${oldState.toString}"
-            case RELEASE => s"Cannot release after ${oldState.toString}"
-            case COMMIT => s"Cannot commit after ${oldState.toString}"
+            case UPDATE => s"Cannot update after ${oldState}"
+            case ABORT => s"Cannot abort after ${oldState}"
+            case RELEASE => s"Cannot release after ${oldState}"
+            case COMMIT => s"Cannot commit after ${oldState}"
             case METRICS => s"Cannot get metrics in ${oldState} state"
           }
           throw StateStoreErrors.stateStoreOperationOutOfOrder(errorMsg)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes the redundant `.toString` from four error-message interpolations in `RocksDBStateStoreProvider.validateAndTransitionState`:

```scala
case UPDATE => s"Cannot update after ${oldState}"
```

### Why are the changes needed?

String interpolation already stringifies embedded values via `String.valueOf`, so the explicit call adds nothing. The `METRICS` branch in the same `match` already reads `s"Cannot get metrics in ${oldState} state"`, so dropping the calls makes all five branches read the same way.

`oldState` is a `case object` of the provider's `STATE` trait with a compiler-generated `toString` and no custom override, and `state` is initialized to `UPDATING` and only ever assigned other case objects, so the rendered text is unchanged.

### Does this PR introduce _any_ user-facing change?

No. The error message text is identical.

### How was this patch tested?

Existing tests cover this path. No test asserts these four message strings; the messages asserted in `RocksDBStateStoreSuite` and `RocksDBStateStoreLockHardeningSuite` come from `validateState` and from the unchanged `METRICS` branch, and the error condition and its `errorMsg` parameter are untouched.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
