### PR TITLE
[SPARK-58663][BUILD] Fix typos and grammar in root pom.xml comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1008,7 +1008,7 @@
         </exclusions>
       </dependency>
       <!-- SPARK-38885: After Netty 4.1.76, add the following `Netty` dependencies explicitly
-           to ensure `./dev/test-dependencies.sh` produce the same results on Linux and MacOS.
+           to ensure `./dev/test-dependencies.sh` produces the same results on Linux and macOS.
       -->
       <dependency>
         <groupId>io.netty</groupId>
@@ -2315,7 +2315,7 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- hive-llap-client is needed when run MapReduce test in Hive 2.3. -->
+      <!-- hive-llap-client is needed when running MapReduce tests in Hive 2.3. -->
       <dependency>
         <groupId>${hive.group}</groupId>
         <artifactId>hive-llap-client</artifactId>
@@ -2642,7 +2642,7 @@
         <artifactId>arpack</artifactId>
         <version>${netlib.ludovic.dev.version}</version>
       </dependency>
-      <!-- SPARK-16484 add `datasketches-java` for support Datasketches HllSketch -->
+      <!-- SPARK-16484 add `datasketches-java` to support Datasketches HllSketch -->
       <dependency>
         <groupId>org.apache.datasketches</groupId>
         <artifactId>datasketches-java</artifactId>
@@ -3365,10 +3365,10 @@
         </executions>
       </plugin>
       <!--
-        Couple of dependencies are coming in bundle format (bundle is just a normal jar which
-        contains OSGi metadata in the manifest). If one don't use OSGi, then a bundle will work as
+        A couple of dependencies are coming in bundle format (bundle is just a normal jar which
+        contains OSGi metadata in the manifest). If one doesn't use OSGi, then a bundle will work as
         any other jar. Since maven doesn't have native bundle support it needs an external plugin
-        handle it. If the plugin is not added then the build can't resolve bundle dependencies.
+        to handle it. If the plugin is not added then the build can't resolve bundle dependencies.
       -->
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -3577,7 +3577,7 @@
     <!--
      This is a profile to enable the use of the ASF snapshot and staging repositories
      during a build. It is useful when testing against nightly or RC releases of dependencies.
-     It MUST NOT be used when building copies of Spark to use in production of for distribution,
+     It MUST NOT be used when building copies of Spark to use in production or for distribution,
      -->
     <profile>
       <id>snapshots-and-staging</id>
@@ -3652,7 +3652,7 @@
     <profile>
       <id>jjwt-provided</id>
     </profile>
-    <!-- use org.openlabtesting.leveldbjni on aarch64 platform except MacOS -->
+    <!-- use org.openlabtesting.leveldbjni on aarch64 platform except macOS -->
     <profile>
       <id>aarch64</id>
       <properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes grammar and typos in comments within the root `pom.xml`:

- `produce the same results` to `produces the same results` (singular subject)
- `needed when run MapReduce test in Hive 2.3` to `needed when running MapReduce tests in Hive 2.3`
- `for support Datasketches HllSketch` to `to support Datasketches HllSketch`
- `Couple of dependencies` to `A couple of dependencies`
- `If one don't use OSGi` to `If one doesn't use OSGi`
- `needs an external plugin handle it` to `needs an external plugin to handle it`
- `in production of for distribution` to `in production or for distribution`

It also spells `macOS` consistently in the two comments that used `MacOS`; the file already uses `macOS` elsewhere, including the profile id.

### Why are the changes needed?

These are plain grammatical errors in comments that explain non-obvious build decisions, so they are worth keeping readable. The `macOS` casing is corrected because one of the affected lines is already being touched.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Every edit is inside an XML comment body: no versions, coordinates, scopes, or ordering are changed, and the `SPARK-38885` and `SPARK-16484` references in those comments are preserved. The POM was confirmed to still parse as well-formed XML, and no dev script or CI workflow matches on this comment text, so the build is unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
