### PR TITLE
[SPARK-57794][BUILD] Remove hadoop-huaweicloud and its okhttp/okio dependencies

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -220,8 +220,6 @@ com.google.flatbuffers:flatbuffers-java
 com.google.guava:guava
 com.jamesmurty.utils:java-xmlbuilder
 com.ning:compress-lzf
-com.squareup.okhttp3:okhttp
-com.squareup.okio:okio
 com.tdunning:json
 com.twitter:chill-java
 com.twitter:chill_2.13

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -218,7 +218,6 @@ com.google.code.gson:gson
 com.google.crypto.tink:tink
 com.google.flatbuffers:flatbuffers-java
 com.google.guava:guava
-com.jamesmurty.utils:java-xmlbuilder
 com.ning:compress-lzf
 com.tdunning:json
 com.twitter:chill-java

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -64,7 +64,6 @@ derbyshared/10.16.1.1//derbyshared-10.16.1.1.jar
 derbytools/10.16.1.1//derbytools-10.16.1.1.jar
 dom4j/2.1.4//dom4j-2.1.4.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
-esdk-obs-java/3.20.4.2//esdk-obs-java-3.20.4.2.jar
 failureaccess/1.0.3//failureaccess-1.0.3.jar
 flatbuffers-java/25.2.10//flatbuffers-java-25.2.10.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
@@ -119,7 +118,6 @@ jakarta.xml.bind-api/4.0.5//jakarta.xml.bind-api-4.0.5.jar
 janino/3.1.9//janino-3.1.9.jar
 java-diff-utils/4.16//java-diff-utils-4.16.jar
 java-trace-api/0.2.11-beta//java-trace-api-0.2.11-beta.jar
-java-xmlbuilder/1.2//java-xmlbuilder-1.2.jar
 javassist/3.30.2-GA//javassist-3.30.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -79,7 +79,6 @@ hadoop-client-api/3.5.0//hadoop-client-api-3.5.0.jar
 hadoop-client-runtime/3.5.0//hadoop-client-runtime-3.5.0.jar
 hadoop-cloud-storage/3.5.0//hadoop-cloud-storage-3.5.0.jar
 hadoop-gcp/3.5.0//hadoop-gcp-3.5.0.jar
-hadoop-huaweicloud/3.5.0//hadoop-huaweicloud-3.5.0.jar
 hadoop-shaded-guava/1.5.0//hadoop-shaded-guava-1.5.0.jar
 hive-beeline/2.3.10//hive-beeline-2.3.10.jar
 hive-cli/2.3.10//hive-cli-2.3.10.jar
@@ -226,8 +225,6 @@ netty-transport-native-kqueue/4.2.16.Final/osx-x86_64/netty-transport-native-kqu
 netty-transport-native-unix-common/4.2.16.Final//netty-transport-native-unix-common-4.2.16.Final.jar
 netty-transport/4.2.16.Final//netty-transport-4.2.16.Final.jar
 objenesis/3.5//objenesis-3.5.jar
-okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.17.6//okio-1.17.6.jar
 opencsv/2.3//opencsv-2.3.jar
 opentelemetry-api/1.49.0//opentelemetry-api-1.49.0.jar
 opentelemetry-context/1.49.0//opentelemetry-context-1.49.0.jar

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -34,8 +34,6 @@
   </description>
   <properties>
     <sbt.project.name>hadoop-cloud</sbt.project.name>
-    <okhttp.version>3.12.12</okhttp.version>
-    <okio.version>1.17.6</okio.version>
     <wildfly-openssl.version>2.3.0.Final</wildfly-openssl.version>
   </properties>
 
@@ -158,12 +156,6 @@
       <version>${hadoop.version}</version>
       <scope>${hadoop.deps.scope}</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-huaweicloud</artifactId>
-      <version>${hadoop.version}</version>
-      <scope>${huaweicloud.deps.scope}</scope>
-    </dependency>
     <!--
     There's now a hadoop-cloud-storage which transitively pulls in the store JARs,
     but it still needs some selective exclusion across versions, especially 3.0.x.
@@ -203,18 +195,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>${okhttp.version}</version>
-      <scope>${huaweicloud.deps.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>${okio.version}</version>
-      <scope>${huaweicloud.deps.scope}</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -242,12 +222,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>huaweicloud-provided</id>
-      <properties>
-        <huaweicloud.deps.scope>provided</huaweicloud.deps.scope>
-      </properties>
-    </profile>
     <profile>
       <id>integration-test</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,6 @@
     -->
     <derby.deps.scope>compile</derby.deps.scope>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
-    <huaweicloud.deps.scope>compile</huaweicloud.deps.scope>
     <hive.deps.scope>compile</hive.deps.scope>
     <hive.storage.version>2.8.1</hive.storage.version>
     <hive.storage.scope>compile</hive.storage.scope>
@@ -3631,7 +3630,6 @@
       <id>hadoop-provided</id>
       <properties>
         <spark.yarn.isHadoopProvided>true</spark.yarn.isHadoopProvided>
-        <huaweicloud.deps.scope>provided</huaweicloud.deps.scope>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the direct `hadoop-huaweicloud` dependency from `hadoop-cloud`, together with its
explicit OkHttp and Okio dependencies, version properties, dependency scope property, and
`huaweicloud-provided` profile.

Keep the `hadoop-huaweicloud` exclusion on `hadoop-cloud-storage` so that the connector is not
reintroduced transitively. Update `LICENSE-binary` and the Hadoop 3 dependency manifest to
remove the three JARs.

Closes #57794.

### Why are the changes needed?

Spark has no source code, tests, or documentation that use the Huawei OBS connector. Bundling
it pulls in the obsolete OkHttp 3.12.12 and Okio 1.17.6 dependency tree, including an OkHttp
version affected by CVE-2021-0341. Removing the unused connector eliminates that dependency
tree without changing Spark's supported default paths.

### Does this PR introduce _any_ user-facing change?

Yes. Spark distributions built with the Hadoop cloud module no longer bundle
`hadoop-huaweicloud`, OkHttp 3.12.12, or Okio 1.17.6. Spark APIs and documented/default cloud
storage paths are unchanged.

### How was this patch tested?

No unit tests were added because this patch only removes Maven and binary-distribution metadata.
It was validated with:

```bash
./build/mvn -Phadoop-3,hadoop-cloud -pl hadoop-cloud help:effective-pom \
  -Doutput=/private/tmp/spark-hadoop-cloud-effective-pom.xml
./build/mvn -Phadoop-3,hadoop-cloud,hadoop-provided -pl hadoop-cloud help:effective-pom \
  -Doutput=/private/tmp/spark-hadoop-cloud-provided-effective-pom.xml -q
xmllint --noout pom.xml hadoop-cloud/pom.xml
LC_ALL=C sort -c dev/deps/spark-deps-hadoop-3-hive-2.3
git diff --check upstream/master
```

Both effective POMs contain zero direct `hadoop-huaweicloud`, `okhttp`, or `okio`
dependencies, retain exactly one `hadoop-huaweicloud` exclusion, and contain no
`huaweicloud-provided` profile or `huaweicloud.deps.scope` property.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (codex-cli 0.146.0)
