### PR TITLE
[MINOR][DOCS] Fix missing subject in event log compaction note

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -131,7 +131,7 @@ The compaction tries to exclude the events which point to the outdated data. As 
 Once rewriting is done, original log files will be deleted, via best-effort manner. The History Server may not be able to delete
 the original log files, but it will not affect the operation of the History Server.
 
-Please note that Spark History Server may not compact the old event log files if figures out not a lot of space
+Please note that Spark History Server may not compact the old event log files if it figures out that not a lot of space
 would be reduced during compaction. For streaming query we normally expect compaction
 will run as each micro-batch will trigger one or more jobs which will be finished shortly, but compaction won't run
 in many cases for batch query.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes an ungrammatical sentence in `docs/monitoring.md`. The clause
`if figures out not a lot of space would be reduced during compaction` is
missing its subject.

Before:
> ... may not compact the old event log files if figures out not a lot of
> space would be reduced during compaction.

After:
> ... may not compact the old event log files if it determines that
> compaction would not reclaim much space.

### Why are the changes needed?

The sentence is grammatically incomplete and hard to parse. "Space would be
reduced" is also the wrong sense — compaction reclaims space rather than
reducing it.

### Does this PR introduce _any_ user-facing change?

No. Documentation only.

### How was this patch tested?

N/A. Documentation change only.

### Was this patch authored or co-authored using generative AI tooling?

No.