### PR TITLE
[SPARK-58665][BUILD] Upgrade `lz4-java` to 1.11.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -189,7 +189,7 @@ log4j-api/2.26.0//log4j-api-2.26.0.jar
 log4j-core/2.26.0//log4j-core-2.26.0.jar
 log4j-layout-template-json/2.26.0//log4j-layout-template-json-2.26.0.jar
 log4j-slf4j2-impl/2.26.0//log4j-slf4j2-impl-2.26.0.jar
-lz4-java/1.11.1//lz4-java-1.11.1.jar
+lz4-java/1.11.2//lz4-java-1.11.2.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar
 metrics-jmx/4.2.37//metrics-jmx-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -879,7 +879,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.1</version>
+        <version>1.11.2</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `at.yawk.lz4:lz4-java` to 1.11.2.

### Why are the changes needed?

This is a security release to bring the latest security fixes from the following release.

- https://github.com/yawkat/lz4-java/releases/tag/v1.11.2 (2026-08-06)
  - [LZ4DecompressorWithLength allocates the unvalidated size from the 4-byte length header, so a 5-byte input triggers a 1 GiB allocation and OutOfMemoryError](https://github.com/yawkat/lz4-java/security/advisories/GHSA-6cx8-rjf8-pr8g)
  - [LZ4BlockInputStream allocates an unvalidated compressed length from the stream header](https://github.com/yawkat/lz4-java/security/advisories/GHSA-4v53-57pg-c464)

**Full Changelog**: https://github.com/yawkat/lz4-java/compare/v1.11.1...v1.11.2

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5