### PR TITLE
[SPARK-58666][BUILD] Upgrade `zstd-jni` to 1.5.7-13

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -287,4 +287,4 @@ xz/1.12//xz-1.12.jar
 zjsonpatch/7.8.0//zjsonpatch-7.8.0.jar
 zookeeper-jute/3.9.5//zookeeper-jute-3.9.5.jar
 zookeeper/3.9.5//zookeeper-3.9.5.jar
-zstd-jni/1.5.7-9//zstd-jni-1.5.7-9.jar
+zstd-jni/1.5.7-13//zstd-jni-1.5.7-13.jar

--- a/pom.xml
+++ b/pom.xml
@@ -884,7 +884,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.7-9</version>
+        <version>1.5.7-13</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.7-13.

### Why are the changes needed?

To bring the latest bug fixes and improvements. `zstd-jni` 1.5.7-13 was released on 2026-08-08 and includes the following notable changes since 1.5.7-9.

- [v1.5.7-13](https://github.com/luben/zstd-jni/releases/tag/v1.5.7-13) (2026-08-08)
- [v1.5.7-12](https://github.com/luben/zstd-jni/releases/tag/v1.5.7-12) (2026-07-25)
- [v1.5.7-11](https://github.com/luben/zstd-jni/releases/tag/v1.5.7-11) (2026-06-08)

Notable changes:
- Support heap buffers in streaming compression
- Fix wrong lookup of the OOM exception class
- Fix `loadDict(null)` on `ZstdCompressCtx` and `ZstdDecompressCtx`
- Add nullability annotations and missing nullability safeguards
- Stricter checks on dict training data
- Remove the support for legacy (pre-1.0) formats

Full changelog: https://github.com/luben/zstd-jni/compare/v1.5.7-9...v1.5.7-13

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5