### PR TITLE
[SPARK-57894][SPARK-57895][CORE][K8S][DOCS][FOLLOWUP] Add documentation comments and `@volatile` fix for credential delivery

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -513,6 +513,12 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
         arguments.hostname, arguments.cores, cfg.ioEncryptionKey, isLocal = false)
 
       // Apply initial user credentials to the executor credential store.
+      // Uses unconditional set() rather than updateIfNewer() because the store is guaranteed
+      // null at this point (executor startup, before any RPC or task is received).
+      // Note: there is a narrow window where a renewal broadcast (vN+1) could arrive between
+      // the SparkAppConfig reply (vN) and executor registration in executorDataMap, leaving
+      // this executor on vN until vN+2. The TaskDescription path covers this case since
+      // every dispatched task carries the latest credentials.
       cfg.userCredentials.foreach { case (version, credentials) =>
         env.userCredentials.set(VersionedCredentials(version, credentials))
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
@@ -69,7 +69,7 @@ private[spark] class TaskDescription(
     // This is acceptable because OIDC credentials are short-lived (minutes) unlike Hadoop
     // delegation tokens (hours/days), making the race between RPC broadcast and task dispatch
     // a practical concern. For short-task-heavy workloads, the overhead is bounded by
-    // credential size x tasks-in-flight (not total task count).
+    // credential size x tasks-in-flight at any instant (not total task count).
     val userCredentials: Option[(Long, Array[Byte])],
     val serializedTask: ByteBuffer) {
 

--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -803,8 +803,8 @@ private[spark] class MockExecutorRpcEndpointRef(conf: SparkConf) extends RpcEndp
   import scala.concurrent.ExecutionContext.Implicits.global
   // scalastyle:on executioncontextglobal
 
-  var decommissionReceived = false
-  var receivedUserCredentials: Option[(Long, Array[Byte])] = None
+  @volatile var decommissionReceived = false
+  @volatile var receivedUserCredentials: Option[(Long, Array[Byte])] = None
 
   override def address: RpcAddress = null
   override def name: String = "executor"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -129,6 +129,12 @@ private[spark] object KubernetesExecutorBackend extends Logging {
         arguments.hostname, arguments.cores, cfg.ioEncryptionKey, isLocal = false)
 
       // Apply initial user credentials to the executor credential store.
+      // Uses unconditional set() rather than updateIfNewer() because the store is guaranteed
+      // null at this point (executor startup, before any RPC or task is received).
+      // Note: there is a narrow window where a renewal broadcast (vN+1) could arrive between
+      // the SparkAppConfig reply (vN) and executor registration in executorDataMap, leaving
+      // this executor on vN until vN+2. The TaskDescription path covers this case since
+      // every dispatched task carries the latest credentials.
       cfg.userCredentials.foreach { case (version, credentials) =>
         env.userCredentials.set(VersionedCredentials(version, credentials))
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #57675 addressing non-blocking review comments.

1. **Document missed-update window for late-registering executors**: Added comments explaining the narrow window where a renewal broadcast (vN+1) could arrive between an executor's `SparkAppConfig` reply (vN) and its registration in `executorDataMap`, and noting that the `TaskDescription` path covers this case.

2. **Document why initial credential application uses `set()` instead of `updateIfNewer()`**: The store is guaranteed null at executor startup (before any RPC or task is received), so the version guard comparison is unnecessary.

3. **Add `@volatile` to `MockExecutorRpcEndpointRef` test fields**: `decommissionReceived` and `receivedUserCredentials` are written by the RPC dispatcher thread and read by the test thread inside `eventually`, so visibility must be guaranteed.

4. **Clarify TaskDescription overhead comment**: Qualified as "in-memory overhead at any instant" to distinguish from cumulative network transfer cost.

### Why are the changes needed?

These address non-blocking review feedback on #57675 to improve code documentation and test correctness.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.

### Was this patch authored or co-authored using generative AI tooling?

Kiro CLI / Claude