### PR TITLE
[SPARK-58675][R] Add SparkR Support for json_typof function

### DIFF
--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -3002,6 +3002,34 @@ setMethod("schema_of_json", signature(x = "characterOrColumn"),
           })
 
 #' @details
+#' \code{json_typeof}: Returns the type of the outermost JSON value as a string.
+#' Returns one of "object", "array", "string", "number", "boolean", or "null".
+#' Returns NULL if the input is not a valid JSON string or is an empty string.
+#'
+#' @rdname column_collection_functions
+#' @aliases json_typeof json_typeof,Column-method
+#' @examples
+#'
+#' \dontrun{
+#' df <- sql("SELECT * FROM range(1)")
+#' df <- mutate(df,
+#'   obj = json_typeof(lit("{\"a\": 1}")),
+#'   arr = json_typeof(lit("[1, 2, 3]")),
+#'   str = json_typeof(lit("\"hello\"")),
+#'   num = json_typeof(lit("123")),
+#'   bool = json_typeof(lit("true")),
+#'   null_val = json_typeof(lit("null")),
+#'   invalid = json_typeof(lit("not json"))
+#' )
+#' head(df)}
+#' @note json_typeof since 4.4.0
+setMethod("json_typeof", signature(x = "Column"),
+          function(x) {
+            jc <- callJStatic("org.apache.spark.sql.functions", "json_typeof", x@jc)
+            column(jc)
+          })
+
+#' @details
 #' \code{from_csv}: Parses a column containing a CSV string into a Column of \code{structType}
 #' with the specified \code{schema}.
 #' If the string is unparsable, the Column will contain the value NA.

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1136,6 +1136,9 @@ setGeneric("instr", function(y, x) { standardGeneric("instr") })
 #' @rdname column_nonaggregate_functions
 #' @name NULL
 setGeneric("isnan", function(x) { standardGeneric("isnan") })
+#' @rdname column_collection_functions
+#' @name NULL
+setGeneric("json_typeof", function(x) { standardGeneric("json_typeof") })
 
 #' @rdname column_aggregate_functions
 #' @name NULL

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -1817,6 +1817,19 @@ test_that("column functions", {
     expect_equal(arr$arrcol[[1]][[1]]$name, "Bob")
     expect_equal(arr$arrcol[[1]][[2]]$name, "Alice")
   }
+  # Test json_typeof()
+  df <- as.DataFrame(list(list("col" = "1")))
+  expect_equal(collect(select(df, json_typeof(lit("{\"a\": 1}"))))[[1]], "object")
+  expect_equal(collect(select(df, json_typeof(lit("[1, 2, 3]"))))[[1]], "array")
+  expect_equal(collect(select(df, json_typeof(lit("\"hello\""))))[[1]], "string")
+  expect_equal(collect(select(df, json_typeof(lit("123"))))[[1]], "number")
+  expect_equal(collect(select(df, json_typeof(lit("123.45"))))[[1]], "number")
+  expect_equal(collect(select(df, json_typeof(lit("true"))))[[1]], "boolean")
+  expect_equal(collect(select(df, json_typeof(lit("false"))))[[1]], "boolean")
+  expect_equal(collect(select(df, json_typeof(lit("null"))))[[1]], "null")
+  expect_equal(collect(select(df, json_typeof(lit("not json"))))[[1]], NA_character_)
+  expect_equal(collect(select(df, json_typeof(lit(""))))[[1]], NA_character_)
+
 
   # Test to_csv()
   df <- sql("SELECT named_struct('name', 'Bob') as people")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->



### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds SparkR API support for the json_typeof function that was introduced in [SPARK-58307](https://issues.apache.org/jira/browse/SPARK-58307). The function was previously available in SQL, Scala DataFrame API, and PySpark, but was missing from SparkR.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This change is needed to maintain API parity across all Spark language bindings

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. This PR adds a new function `json_typeof()` to the SparkR API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New Unit tests added in in `R/pkg/tests/fulltests/test_sparkSQL.R`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No