### PR TITLE
[SPARK-58681][CORE][SQL][TESTS] Fix race in job cancellation tests

### DIFF
--- a/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
@@ -317,8 +317,9 @@ class JobCancellationSuite extends SparkFunSuite with Matchers with BeforeAndAft
         }
 
         override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
-          sem.release()
+          // Update the counter before waking the test thread so it observes the new value.
           jobEnded.incrementAndGet()
+          sem.release()
         }
       })
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
@@ -160,8 +160,8 @@ class SparkSessionJobTaggingAndCancellationSuite
         }
 
         override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
-          sem.release()
           jobEnded.incrementAndGet()
+          sem.release()
         }
       })
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
@@ -160,6 +160,7 @@ class SparkSessionJobTaggingAndCancellationSuite
         }
 
         override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+          // Update the counter before waking the test thread so it observes the new value.
           jobEnded.incrementAndGet()
           sem.release()
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request updates the test listeners in `SparkSessionJobTaggingAndCancellationSuite` and `JobCancellationSuite` so they increment `jobEnded` before releasing the semaphore that wakes the test thread. A short comment documents the required ordering.

### Why are the changes needed?

`Semaphore.release()` could wake the test thread before `jobEnded.incrementAndGet()` completed. The test could then observe the previous counter value and fail intermittently with `2 did not equal 3`.

Updating the counter before releasing the semaphore establishes the required ordering between the listener callback and the waiting test thread.

JIRA: https://issues.apache.org/jira/browse/SPARK-58681

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The affected existing tests passed with:

```
build/sbt 'core/testOnly org.apache.spark.JobCancellationSuite -- -z "job tags"'
build/sbt 'sql/testOnly org.apache.spark.sql.SparkSessionJobTaggingAndCancellationSuite -- -z "Cancellation APIs in SparkSession are isolated"'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
