### PR TITLE
[SPARK-58683][ML] Optimize NGram transform closure

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
@@ -61,7 +61,8 @@ class NGram @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   setDefault(n -> 2)
 
   override protected def createTransformFunc: Seq[String] => Seq[String] = {
-    _.iterator.sliding($(n)).withPartial(false).map(_.mkString(" ")).toSeq
+    val nGramSize = $(n)
+    _.iterator.sliding(nGramSize).withPartial(false).map(_.mkString(" ")).toSeq
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
@@ -61,8 +61,8 @@ class NGram @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   setDefault(n -> 2)
 
   override protected def createTransformFunc: Seq[String] => Seq[String] = {
-    val nGramSize = $(n)
-    _.iterator.sliding(nGramSize).withPartial(false).map(_.mkString(" ")).toSeq
+    val localN = $(n)
+    _.iterator.sliding(localN).withPartial(false).map(_.mkString(" ")).toSeq
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Snapshot the configured n-gram size while creating NGram's transform function. The resulting function no longer captures the NGram transformer.

The serialized transform function decreases from 2,988 bytes to 1,277 bytes (57.3%).

### Why are the changes needed?

Avoiding the transformer capture reduces the memory retained by the transform closure, which is especially useful for Spark Connect server workloads.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Compiled the edited NGram source and serialized its generated transform function with Java serialization. The existing NGramSuite covers the unchanged transform behavior.

The targeted SBT suite could not run locally because dependency resolution for `at.yawk:lz4-java:1.11.2` was denied by the configured Maven mirror.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)