### PR TITLE
[SPARK-58684][PYTHON] Make PySpark error sub-conditions inherit the parent condition error state

### DIFF
--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -118,11 +118,19 @@ class ErrorsTest(unittest.TestCase):
         error = PySparkRuntimeError(errorClass="APPLICATION_NAME_NOT_SET", messageParameters={})
         self.assertIsNone(error.getSqlState())
 
+        # Neither the sub-class nor the main class declares a sqlState.
         error = PySparkRuntimeError(
             errorClass="SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
             messageParameters={"method": "set"},
         )
         self.assertIsNone(error.getSqlState())
+
+        # A sub-class without its own sqlState inherits the main class's.
+        error = PySparkRuntimeError(
+            errorClass="NEAREST_BY_JOIN.UNSUPPORTED_MODE",
+            messageParameters={"mode": "invalid", "supported": "nearest"},
+        )
+        self.assertEqual(error.getSqlState(), "42604")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -125,12 +125,27 @@ class ErrorsTest(unittest.TestCase):
         )
         self.assertIsNone(error.getSqlState())
 
-        # A sub-class without its own sqlState inherits the main class's.
+        # A sub-class inherits the main class's sqlState.
         error = PySparkRuntimeError(
             errorClass="NEAREST_BY_JOIN.UNSUPPORTED_MODE",
             messageParameters={"mode": "invalid", "supported": "nearest"},
         )
         self.assertEqual(error.getSqlState(), "42604")
+
+    def test_sqlstate_is_taken_from_the_main_class(self):
+        # The sqlState is looked up on the main class only, so a sub-class entry never
+        # takes precedence and an unknown sub-class name still resolves.
+        error_reader = ErrorClassesReader()
+        error_reader.error_info_map = {
+            "TEST_ERROR": {
+                "message": ["Error message."],
+                "sqlState": "42604",
+                "sub_class": {"SUBCLASS": {"message": ["Subclass message."], "sqlState": "08003"}},
+            },
+        }
+        self.assertEqual(error_reader.get_sqlstate("TEST_ERROR.SUBCLASS"), "42604")
+        self.assertEqual(error_reader.get_sqlstate("TEST_ERROR.NON_EXISTENT_SUB"), "42604")
+        self.assertIsNone(error_reader.get_sqlstate("NON_EXISTENT_ERROR.SUBCLASS"))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -99,20 +99,14 @@ class ErrorClassesReader:
         """
         Returns the SQL state for the given error class.
 
-        A sub-class with its own sqlState overrides the main class's; a sub-class
-        without one inherits the main class's.
+        The SQL state is declared on the main class, so a sub-class inherits it.
         """
         if errorClass is None:
             return None
 
-        error_classes = errorClass.split(".")
-        main_class_info = self.error_info_map.get(error_classes[0])
+        main_class_info = self.error_info_map.get(errorClass.split(".")[0])
         if main_class_info is None:
             return None
-        if len(error_classes) == 2:
-            sub_class_info = main_class_info.get("sub_class", {}).get(error_classes[1], {})
-            if "sqlState" in sub_class_info:
-                return sub_class_info["sqlState"]
         return main_class_info.get("sqlState")
 
     def get_error_message(self, errorClass: str, messageParameters: Dict[str, str]) -> str:

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -98,20 +98,22 @@ class ErrorClassesReader:
     def get_sqlstate(self, errorClass: Optional[str]) -> Optional[str]:
         """
         Returns the SQL state for the given error class.
+
+        A sub-class with its own sqlState overrides the main class's; a sub-class
+        without one inherits the main class's.
         """
         if errorClass is None:
             return None
 
         error_classes = errorClass.split(".")
-        try:
-            if len(error_classes) == 1:
-                return self.error_info_map[errorClass]["sqlState"]
-            else:
-                return self.error_info_map[error_classes[0]]["sub_class"][error_classes[1]][
-                    "sqlState"
-                ]
-        except KeyError:
+        main_class_info = self.error_info_map.get(error_classes[0])
+        if main_class_info is None:
             return None
+        if len(error_classes) == 2:
+            sub_class_info = main_class_info.get("sub_class", {}).get(error_classes[1], {})
+            if "sqlState" in sub_class_info:
+                return sub_class_info["sqlState"]
+        return main_class_info.get("sqlState")
 
     def get_error_message(self, errorClass: str, messageParameters: Dict[str, str]) -> str:
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ErrorClassesReader.get_sqlstate` looks the error state up under the sub-condition, so a sub-condition reports `None` even when its condition declares one. This makes the lookup resolve on the condition only, matching `ErrorClassesJsonReader.getSqlState` on the JVM side.

Split out of #57831; the two are unrelated, as `python/pyspark/errors/error-conditions.json` is a separate file and does not contain the condition that PR is about.

### Why are the changes needed?

`getSqlState()` is public API on `PySparkException`. `NEAREST_BY_JOIN` declares `42604`, but:

```python
>>> from pyspark.errors import PySparkRuntimeError
>>> e = PySparkRuntimeError(
...     errorClass="NEAREST_BY_JOIN.UNSUPPORTED_MODE",
...     messageParameters={"mode": "invalid", "supported": "nearest"},
... )
>>> print(e.getSqlState())
None
```

The JVM reader resolves on the condition here, so the two sides report different error states for the same condition.

### Does this PR introduce _any_ user-facing change?

Yes. `getSqlState()` returns the condition's error state for a sub-condition instead of `None`: `NEAREST_BY_JOIN.*` goes from `None` to `42604`, the only condition affected today. Where the condition itself declares no error state, it still returns `None`.

### How was this patch tested?

Added a case to `test_sqlstate` pinning `NEAREST_BY_JOIN.UNSUPPORTED_MODE` to `42604`, written test-first and confirmed failing before the fix. Added `test_sqlstate_is_taken_from_the_main_class` covering a sub-condition that declares a different error state, an unknown sub-condition name, and an unknown condition. All 7 tests in `pyspark.errors.tests.test_errors` pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5, claude-opus-5)

