### PR TITLE
[SPARK-58690][CORE] Fix typos in storage package comments

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -288,7 +288,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   }
 
   /**
-   * Helper for lock acquisistion.
+   * Helper for lock acquisition.
    */
   private def acquireLock(
       blockId: BlockId,

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -804,7 +804,7 @@ class BlockManagerMasterEndpoint(
      case ShuffleIndexBlockId(shuffleId, mapId, _) =>
        // SPARK-36782: Invoke `MapOutputTracker.updateMapOutput` within the thread
        // `dispatcher-BlockManagerMaster` could lead to the deadlock when
-       // `MapOutputTracker.serializeOutputStatuses` broadcasts the serialized mapstatues under
+       // `MapOutputTracker.serializeOutputStatuses` broadcasts the serialized map statuses under
        // the acquired write lock. The broadcast block would report its status to
        // `BlockManagerMasterEndpoint`, while the `BlockManagerMasterEndpoint` is occupied by
        // `updateMapOutput` since it's waiting for the write lock. Thus, we use `Future` to call

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -885,7 +885,7 @@ final class ShuffleBlockFetcherIterator(
                 bufIn
               }
             } catch {
-              // The exception could only be throwed by local shuffle block
+              // The exception could only be thrown by local shuffle block
               case e: IOException =>
                 assert(buf.isInstanceOf[FileSegmentManagedBuffer])
                 e match {
@@ -1668,7 +1668,7 @@ object ShuffleBlockFetcherIterator {
    *                       of shuffle by an indeterminate stage attempt.
    * @param reduceId reduce id.
    * @param bitmaps bitmaps for every chunk.
-   * @param localDirs local directories where the push-merged shuffle files are storedl
+   * @param localDirs local directories where the push-merged shuffle files are stored
    */
   private[storage] case class PushMergedLocalMetaFetchResult(
       shuffleId: Int,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes four comment typos under `core/src/main/scala/org/apache/spark/storage/`:

- `BlockInfoManager`: `Helper for lock acquisistion` to `acquisition`
- `BlockManagerMasterEndpoint`: `broadcasts the serialized mapstatues` to `map statuses`
- `ShuffleBlockFetcherIterator`: `The exception could only be throwed by` to `thrown`
- `ShuffleBlockFetcherIterator`: `push-merged shuffle files are storedl` to `stored`

### Why are the changes needed?

Each is a plain misspelling, and each is the only occurrence of that spelling in the repository. On the second one, the surrounding comment consistently wraps code identifiers in backticks (`` `MapOutputTracker.serializeOutputStatuses` ``, `` `updateMapOutput` ``), so the intent is the English plural rather than the `mapStatuses` field, and it is rendered as two words accordingly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Comment text only, with no effect on compiled code. Each edited line was confirmed to sit inside a scaladoc or `//` comment, and no identifier, string literal, or error message is touched. The longest resulting line is 97 characters, within the limit.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
