### PR TITLE
[SPARK-58692][ML] Optimize PolynomialExpansion transform closure

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PolynomialExpansion.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PolynomialExpansion.scala
@@ -64,8 +64,9 @@ class PolynomialExpansion @Since("1.4.0") (@Since("1.4.0") override val uid: Str
   @Since("1.4.0")
   def setDegree(value: Int): this.type = set(degree, value)
 
-  override protected def createTransformFunc: Vector => Vector = { v =>
-    PolynomialExpansion.expand(v, $(degree))
+  override protected def createTransformFunc: Vector => Vector = {
+    val localDegree = $(degree)
+    v => PolynomialExpansion.expand(v, localDegree)
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Snapshot the configured polynomial degree while creating PolynomialExpansion's transform function. The resulting function no longer captures the PolynomialExpansion transformer.

The serialized transform function decreases from 3,086 bytes to 1,322 bytes (57.2%).

### Why are the changes needed?

Avoiding the transformer capture reduces the memory retained by the transform closure, which is especially useful for Spark Connect server workloads.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Compiled the edited PolynomialExpansion source and serialized its generated transform function with Java serialization. The existing PolynomialExpansionSuite covers the unchanged transform behavior.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)