### PR TITLE
[SPARK-58697][SQL] Make initcap use collation locale

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -420,8 +420,7 @@ public class CollationAwareUTF8String {
   private static UTF8String toUpperCaseSlow(final UTF8String target, final int collationId) {
     // Note: In order to achieve the desired behavior, we use the ICU UCharacter class to
     // convert the string to uppercase, which only accepts a Java strings as input.
-    ULocale locale = CollationFactory.fetchCollation(collationId)
-      .getCollator().getLocale(ULocale.ACTUAL_LOCALE);
+    ULocale locale = CollationFactory.fetchCollation(collationId).caseConversionLocale;
     return UTF8String.fromString(UCharacter.toUpperCase(locale, target.toValidString()));
   }
 
@@ -456,8 +455,7 @@ public class CollationAwareUTF8String {
   private static UTF8String toLowerCaseSlow(final UTF8String target, final int collationId) {
     // Note: In order to achieve the desired behavior, we use the ICU UCharacter class to
     // convert the string to lowercase, which only accepts a Java strings as input.
-    ULocale locale = CollationFactory.fetchCollation(collationId)
-      .getCollator().getLocale(ULocale.ACTUAL_LOCALE);
+    ULocale locale = CollationFactory.fetchCollation(collationId).caseConversionLocale;
     return UTF8String.fromString(UCharacter.toLowerCase(locale, target.toValidString()));
   }
 
@@ -543,8 +541,7 @@ public class CollationAwareUTF8String {
    * Convert the input string to titlecase using the specified ICU collation rules.
    */
   public static UTF8String toTitleCase(final UTF8String target, final int collationId) {
-    ULocale locale = CollationFactory.fetchCollation(collationId)
-      .getCollator().getLocale(ULocale.ACTUAL_LOCALE);
+    ULocale locale = CollationFactory.fetchCollation(collationId).caseConversionLocale;
     return UTF8String.fromString(UCharacter.toTitleCase(locale, target.toValidString(),
       BreakIterator.getWordInstance(locale)));
   }

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -111,6 +111,7 @@ public final class CollationFactory {
     public final String collationName;
     public final String provider;
     private final ThreadLocal<Collator> threadLocalCollator;
+    public final ULocale caseConversionLocale;
     public final Comparator<UTF8String> comparator;
 
     /**
@@ -188,6 +189,7 @@ public final class CollationFactory {
         String collationName,
         String provider,
         ThreadLocal<Collator> threadLocalCollator,
+        ULocale caseConversionLocale,
         Comparator<UTF8String> comparator,
         String version,
         Function<UTF8String, byte[]> sortKeyFunction,
@@ -198,6 +200,7 @@ public final class CollationFactory {
       this.collationName = collationName;
       this.provider = provider;
       this.threadLocalCollator = threadLocalCollator;
+      this.caseConversionLocale = caseConversionLocale;
       this.comparator = comparator;
       this.version = version;
       this.sortKeyFunction = sortKeyFunction;
@@ -609,6 +612,7 @@ public final class CollationFactory {
             normalizedCollationName(),
             PROVIDER_SPARK,
             null,
+            ULocale.ROOT,
             comparator,
             CollationSpecICU.ICU_VERSION,
             sortKeyFunction,
@@ -636,6 +640,7 @@ public final class CollationFactory {
             normalizedCollationName(),
             PROVIDER_SPARK,
             null,
+            ULocale.ROOT,
             comparator,
             CollationSpecICU.ICU_VERSION,
             sortKeyFunction,
@@ -1050,6 +1055,7 @@ public final class CollationFactory {
           normalizedCollationName(),
           PROVIDER_ICU,
           threadLocalCollator,
+          ICULocaleMap.get(locale),
           comparator,
           ICU_VERSION,
           sortKeyFunction,

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -1151,6 +1151,7 @@ public final class CollationFactory {
           "null",
           "null",
           null,
+          ULocale.ROOT,
           (s1, s2) -> {
             throw indeterminateError();
           },

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -1410,6 +1410,9 @@ public class CollationSupportSuite {
     assertInitCap("ÄBĆΔE", UNICODE_CI, "Äbćδe");
     assertInitCap("êéfgh", "AF_CI_AI", "Êéfgh");
     assertInitCap("öoAÄ", "DE_CI_AI", "Öoaä");
+    assertInitCap("erik ijzermans", "NL", "Erik IJzermans");
+    assertInitCap("erik ijzermans", "NL_CI", "Erik IJzermans");
+    assertInitCap("erik ijzermans", UNICODE, "Erik Ijzermans");
     // Case-variable character length
     assertInitCap("İo", UTF8_BINARY, "İo", "I\u0307o");
     assertInitCap("İo", UTF8_LCASE, "İo");

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLFunctionsSuite.scala
@@ -17,18 +17,12 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{Column, Dataset, Row}
+import org.apache.spark.sql.{Column, Dataset}
 import org.apache.spark.sql.functions.{from_json, from_xml}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 class CollationSQLFunctionsSuite extends SharedSparkSession {
-
-  test("initcap uses locale-specific collation rules") {
-    checkAnswer(
-      sql("SELECT initcap('erik ijzermans' COLLATE NL)"),
-      Seq(Row("Erik IJzermans")))
-  }
 
   test("SPARK-50214: from_json and from_xml work correctly with session collation") {
     import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLFunctionsSuite.scala
@@ -17,12 +17,18 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{Column, Dataset}
+import org.apache.spark.sql.{Column, Dataset, Row}
 import org.apache.spark.sql.functions.{from_json, from_xml}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 class CollationSQLFunctionsSuite extends SharedSparkSession {
+
+  test("initcap uses locale-specific collation rules") {
+    checkAnswer(
+      sql("SELECT initcap('erik ijzermans' COLLATE NL)"),
+      Seq(Row("Erik IJzermans")))
+  }
 
   test("SPARK-50214: from_json and from_xml work correctly with session collation") {
     import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -96,6 +96,12 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("initcap uses locale-specific collation rules") {
+    checkAnswer(
+      sql("SELECT initcap('erik ijzermans' COLLATE NL)"),
+      Seq(Row("Erik IJzermans")))
+  }
+
   test("collation name is case insensitive") {
     Seq(
       "uTf8_BiNaRy",

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -97,9 +97,15 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
   }
 
   test("initcap uses locale-specific collation rules") {
-    checkAnswer(
-      sql("SELECT initcap('erik ijzermans' COLLATE NL)"),
-      Seq(Row("Erik IJzermans")))
+    Seq(
+      ("NL", "Erik IJzermans"),
+      ("UTF8_LCASE", "Erik Ijzermans"),
+      ("UTF8_BINARY", "Erik Ijzermans")
+    ).foreach { case (collationName, expected) =>
+      checkAnswer(
+        sql(s"SELECT initcap('erik ijzermans' COLLATE $collationName)"),
+        Seq(Row(expected)))
+    }
   }
 
   test("collation name is case insensitive") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR makes collation-aware ICU case conversion use the requested collation locale instead of the collator's resolved actual locale.

In particular, `CollationFactory.Collation` now stores the locale to use for case conversion. ICU upper, lower, and title case conversion then read that locale directly instead of calling `getLocale(ULocale.ACTUAL_LOCALE)` on the collator.

### Why are the changes needed?

Some ICU collators resolve their actual locale to root even when the requested collation locale has language-specific case conversion rules. Dutch titlecase is one such case: `initcap('erik ijzermans' COLLATE NL)` should capitalize the Dutch `ij` digraph as `Erik IJzermans`, not `Erik Ijzermans`.

### Does this PR introduce _any_ user-facing change?

Yes. This is a correctness fix for collation-aware case conversion. For example, `initcap('erik ijzermans' COLLATE NL)` now returns `Erik IJzermans`.

### How was this patch tested?

New tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex

