### PR TITLE
[PIPELINES] Support partition transforms in Declarative Pipelines partition_cols

### DIFF
--- a/python/pyspark/pipelines/api.py
+++ b/python/pyspark/pipelines/api.py
@@ -153,7 +153,8 @@ def table(
         confs set for the pipeline or on the cluster.
     :param table_properties: A dict where the keys are the property names and the values are the \
         property values. These properties will be set on the table.
-    :param partition_cols: A list containing the column names of the partition columns.
+    :param partition_cols: A list containing partitioning expressions. Entries can be column names \
+        for identity partitioning or partition transforms like ``months(ts)`` or ``bucket(16, id)``.
     :param cluster_by: A list containing the column names of the cluster columns.
     :param schema: Explicit Spark SQL schema to materialize this table with. Supports either a \
         Pyspark StructType or a SQL DDL string, such as "a INT, b STRING".
@@ -257,7 +258,8 @@ def materialized_view(
         confs set for the pipeline or on the cluster.
     :param table_properties: A dict where the keys are the property names and the values are the \
         property values. These properties will be set on the table.
-    :param partition_cols: A list containing the column names of the partition columns.
+    :param partition_cols: A list containing partitioning expressions. Entries can be column names \
+        for identity partitioning or partition transforms like ``months(ts)`` or ``bucket(16, id)``.
     :param cluster_by: A list containing the column names of the cluster columns.
     :param schema: Explicit Spark SQL schema to materialize this table with. Supports either a \
         Pyspark StructType or a SQL DDL string, such as "a INT, b STRING".
@@ -435,7 +437,8 @@ def create_streaming_table(
     :param comment: Description of the table.
     :param table_properties: A dict where the keys are the property names and the values are the \
         property values. These properties will be set on the table.
-    :param partition_cols: A list containing the column names of the partition columns.
+    :param partition_cols: A list containing partitioning expressions. Entries can be column names \
+        for identity partitioning or partition transforms like ``months(ts)`` or ``bucket(16, id)``.
     :param cluster_by: A list containing the column names of the cluster columns.
     :param schema: Explicit Spark SQL schema to materialize this table with. Supports either a \
         Pyspark StructType or a SQL DDL string, such as "a INT, b STRING".

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AbstractSqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AbstractSqlParser.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.parser.ParserUtils.withOrigin
 import org.apache.spark.sql.catalyst.plans.logical.{CompoundPlanStatement, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.connector.catalog.PathElement
+import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryParsingErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
@@ -122,24 +123,32 @@ abstract class AbstractSqlParser extends AbstractParser with ParserInterface {
   }
 
   /**
-   * Default splitter implementation that defers directly to [[SqlStatementSplitter]].
-   * Subclasses that perform additional input preprocessing (e.g. variable
-   * substitution) should override this to apply that preprocessing before
-   * splitting so the splitter sees the same tokens the parser would.
+   * Default splitter implementation that defers directly to [[SqlStatementSplitter]]. Subclasses
+   * that perform additional input preprocessing (e.g. variable substitution) should override this
+   * to apply that preprocessing before splitting so the splitter sees the same tokens the parser
+   * would.
    */
   override def splitStatements(sqlText: String): SqlStatementSplitResult = {
     SqlStatementSplitter.split(sqlText)
   }
 
   /**
-   * Parse the right-hand side of `SET PATH = ...` (a comma-separated list of path elements).
-   * Used by [[org.apache.spark.sql.connector.catalog.CatalogManager]] to honor the
+   * Parse the right-hand side of `SET PATH = ...` (a comma-separated list of path elements). Used
+   * by [[org.apache.spark.sql.connector.catalog.CatalogManager]] to honor the
    * [[SQLConf.DEFAULT_PATH]] conf without re-implementing the SET PATH grammar.
    */
-  private[sql] def parsePathElements(sqlText: String): Seq[PathElement] = parse(sqlText) { parser =>
-    val ctx = parser.singlePathElementList()
+  private[sql] def parsePathElements(sqlText: String): Seq[PathElement] = parse(sqlText) {
+    parser =>
+      val ctx = parser.singlePathElementList()
+      withErrorHandling(ctx, Some(sqlText)) {
+        astBuilder.visitSinglePathElementList(ctx)
+      }
+  }
+
+  private[sql] def parsePartitioning(sqlText: String): Seq[Transform] = parse(sqlText) { parser =>
+    val ctx = parser.partitionFieldList()
     withErrorHandling(ctx, Some(sqlText)) {
-      astBuilder.visitSinglePathElementList(ctx)
+      astBuilder.visitPartitionFieldList(ctx)._1
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
 import org.apache.spark.sql.connector.catalog.{ChangelogContext, ChangelogRange}
+import org.apache.spark.sql.connector.expressions.Expressions
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, LongType, StringType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -36,7 +37,8 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * Parser test cases for rules defined in [[CatalystSqlParser]] / [[AstBuilder]].
  *
- * There is also SparkSqlParserSuite in sql/core module for parser rules defined in sql/core module.
+ * There is also SparkSqlParserSuite in sql/core module for parser rules defined in sql/core
+ * module.
  */
 class PlanParserSuite extends AnalysisTest {
   import CatalystSqlParser._
@@ -64,14 +66,13 @@ class PlanParserSuite extends AnalysisTest {
       plan: LogicalPlan,
       allowRecursion: Boolean,
       namedPlans: (String, (LogicalPlan, Seq[String]))*): UnresolvedWith = {
-    val ctes = namedPlans.map {
-      case (name, (cte, columnAliases)) =>
-        val subquery = if (columnAliases.isEmpty) {
-          cte
-        } else {
-          UnresolvedSubqueryColumnAliases(columnAliases, cte)
-        }
-        (name, SubqueryAlias(name, subquery), None)
+    val ctes = namedPlans.map { case (name, (cte, columnAliases)) =>
+      val subquery = if (columnAliases.isEmpty) {
+        cte
+      } else {
+        UnresolvedSubqueryColumnAliases(columnAliases, cte)
+      }
+      (name, SubqueryAlias(name, subquery), None)
     }
     UnresolvedWith(plan, ctes, allowRecursion)
   }
@@ -94,7 +95,8 @@ class PlanParserSuite extends AnalysisTest {
         | * select 'multi-line';
         | */
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("bracketed comment case two") {
@@ -105,7 +107,8 @@ class PlanParserSuite extends AnalysisTest {
         |SELECT 'trailing' as x1; -- inside block comment
         |*/
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case one") {
@@ -116,7 +119,8 @@ class PlanParserSuite extends AnalysisTest {
         |SELECT /* embedded single line */ 'embedded' AS x2;
         |*/
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case two") {
@@ -137,7 +141,8 @@ class PlanParserSuite extends AnalysisTest {
         |Now just one deep...
         |*/
         |* FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case three") {
@@ -149,7 +154,8 @@ class PlanParserSuite extends AnalysisTest {
         |*/
         |*/
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case four") {
@@ -158,7 +164,8 @@ class PlanParserSuite extends AnalysisTest {
       """
         |/*/**/*/
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case five") {
@@ -167,7 +174,8 @@ class PlanParserSuite extends AnalysisTest {
       """
         |/*/*abc*/*/
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case six") {
@@ -176,7 +184,8 @@ class PlanParserSuite extends AnalysisTest {
       """
         |/*/*foo*//*bar*/*/
         |SELECT * FROM a
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("nested bracketed comment case seven") {
@@ -193,7 +202,8 @@ class PlanParserSuite extends AnalysisTest {
         |
         |/**/
         |*/
-      """.stripMargin, plan)
+      """.stripMargin,
+      plan)
   }
 
   test("unclosed bracketed comment one") {
@@ -244,25 +254,21 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql1),
       condition = "INVALID_SQL_SYNTAX.UNSUPPORTED_SQL_STATEMENT",
       parameters = Map("sqlText" -> "EXPLAIN logical SELECT 1"),
-      context = ExpectedContext(
-        fragment = sql1,
-        start = 0,
-        stop = 23))
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 23))
 
     val sql2 = "EXPLAIN formatted SELECT 1"
     checkError(
       exception = parseException(sql2),
       condition = "INVALID_SQL_SYNTAX.UNSUPPORTED_SQL_STATEMENT",
       parameters = Map("sqlText" -> "EXPLAIN formatted SELECT 1"),
-      context = ExpectedContext(
-        fragment = sql2,
-        start = 0,
-        stop = 25))
+      context = ExpectedContext(fragment = sql2, start = 0, stop = 25))
   }
 
   test("SPARK-42552: select and union without parentheses") {
-    val plan = Distinct(OneRowRelation().select(Literal(1))
-      .union(OneRowRelation().select(Literal(1))))
+    val plan = Distinct(
+      OneRowRelation()
+        .select(Literal(1))
+        .union(OneRowRelation().select(Literal(1))))
     assertEqual("select 1 union select 1", plan)
   }
 
@@ -279,22 +285,34 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual("select * from a minus select * from b", a.except(b, isAll = false))
     assertEqual("select * from a minus all select * from b", a.except(b, isAll = true))
     assertEqual("select * from a minus distinct select * from b", a.except(b, isAll = false))
-    assertEqual("select * from a " +
-      "intersect select * from b", a.intersect(b, isAll = false))
-    assertEqual("select * from a intersect distinct select * from b", a.intersect(b, isAll = false))
+    assertEqual(
+      "select * from a " +
+        "intersect select * from b",
+      a.intersect(b, isAll = false))
+    assertEqual(
+      "select * from a intersect distinct select * from b",
+      a.intersect(b, isAll = false))
     assertEqual("select * from a intersect all select * from b", a.intersect(b, isAll = true))
   }
 
   test("common table expressions") {
     assertEqual(
       "with cte1 as (select * from a) select * from cte1",
-      cte(table("cte1").select(star()), false, "cte1" -> ((table("a").select(star()), Seq.empty))))
+      cte(
+        table("cte1").select(star()),
+        false,
+        "cte1" -> ((table("a").select(star()), Seq.empty))))
     assertEqual(
       "with cte1 (select 1) select * from cte1",
-      cte(table("cte1").select(star()), false, "cte1" -> ((OneRowRelation().select(1), Seq.empty))))
+      cte(
+        table("cte1").select(star()),
+        false,
+        "cte1" -> ((OneRowRelation().select(1), Seq.empty))))
     assertEqual(
       "with cte1 (select 1), cte2 as (select * from cte1) select * from cte2",
-      cte(table("cte2").select(star()), false,
+      cte(
+        table("cte2").select(star()),
+        false,
         "cte1" -> ((OneRowRelation().select(1), Seq.empty)),
         "cte2" -> ((table("cte1").select(star()), Seq.empty))))
     val sql1 = "with cte1 (select 1), cte1 as (select 1 from cte1) select * from cte1"
@@ -302,27 +320,22 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql1),
       condition = "DUPLICATED_CTE_NAMES",
       parameters = Map("duplicateNames" -> "`cte1`"),
-      context = ExpectedContext(
-        fragment = sql1,
-        start = 0,
-        stop = 68))
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 68))
     // Case-insensitive duplicate CTE names should also be detected.
     val sql2 = "with CTE1 (select 1), cte1 as (select 2) select * from cte1"
     checkError(
       exception = parseException(sql2),
       condition = "DUPLICATED_CTE_NAMES",
       parameters = Map("duplicateNames" -> "`cte1`"),
-      context = ExpectedContext(
-        fragment = sql2,
-        start = 0,
-        stop = 58))
+      context = ExpectedContext(fragment = sql2, start = 0, stop = 58))
   }
 
   test("simple select query") {
     assertEqual("select 1", OneRowRelation().select(1))
     assertEqual("select a, b", OneRowRelation().select($"a", $"b"))
     assertEqual("select a, b from db.c", table("db", "c").select($"a", $"b"))
-    assertEqual("select a, b from db.c where x < 1",
+    assertEqual(
+      "select a, b from db.c where x < 1",
       table("db", "c").where($"x" < 1).select($"a", $"b"))
     assertEqual(
       "select a, b from db.c having x < 1",
@@ -336,10 +349,12 @@ class PlanParserSuite extends AnalysisTest {
   test("hive-style single-FROM statement") {
     assertEqual("from a select b, c", table("a").select($"b", $"c"))
     assertEqual(
-      "from db.a select b, c where d < 1", table("db", "a").where($"d" < 1).select($"b", $"c"))
+      "from db.a select b, c where d < 1",
+      table("db", "a").where($"d" < 1).select($"b", $"c"))
     assertEqual("from a select distinct b, c", Distinct(table("a").select($"b", $"c")))
     assertEqual("from a", table("a"))
-    assertEqual("from (from a union all from b) c select *",
+    assertEqual(
+      "from (from a union all from b) c select *",
       table("a").union(table("b")).subquery("c").select(star()))
   }
 
@@ -359,13 +374,17 @@ class PlanParserSuite extends AnalysisTest {
       parameters = Map("error" -> "'from'", "hint" -> ""))
     assertEqual(
       "from a insert into tbl1 select * insert into tbl2 select * where s < 10",
-      table("a").select(star()).insertInto("tbl1").union(
-        table("a").where($"s" < 10).select(star()).insertInto("tbl2")))
+      table("a")
+        .select(star())
+        .insertInto("tbl1")
+        .union(table("a").where($"s" < 10).select(star()).insertInto("tbl2")))
     assertEqual(
       "select * from (from a select * select *)",
-      table("a").select(star())
+      table("a")
+        .select(star())
         .union(table("a").select(star()))
-        .as("__auto_generated_subquery_name").select(star()))
+        .as("__auto_generated_subquery_name")
+        .select(star()))
   }
 
   test("query organization") {
@@ -378,22 +397,17 @@ class PlanParserSuite extends AnalysisTest {
       ("", (p: LogicalPlan) => p),
       (" limit 10", (p: LogicalPlan) => p.limit(10)),
       (" window w1 as ()", (p: LogicalPlan) => WithWindowDefinition(ws, p)),
-      (" window w1 as () limit 10", (p: LogicalPlan) =>
-        WithWindowDefinition(ws, p).limit(10))
-    )
+      (" window w1 as () limit 10", (p: LogicalPlan) => WithWindowDefinition(ws, p).limit(10)))
 
     val orderSortDistrClusterClauses = Seq(
       ("", basePlan),
       (" order by a, b desc", basePlan.orderBy($"a".asc, $"b".desc)),
-      (" sort by a, b desc", basePlan.sortBy($"a".asc, $"b".desc))
-    )
+      (" sort by a, b desc", basePlan.sortBy($"a".asc, $"b".desc)))
 
-    orderSortDistrClusterClauses.foreach {
-      case (s1, p1) =>
-        limitWindowClauses.foreach {
-          case (s2, pf2) =>
-            assertEqual(baseSql + s1 + s2, pf2(p1))
-        }
+    orderSortDistrClusterClauses.foreach { case (s1, p1) =>
+      limitWindowClauses.foreach { case (s2, pf2) =>
+        assertEqual(baseSql + s1 + s2, pf2(p1))
+      }
     }
 
     val sql1 = s"$baseSql order by a sort by a"
@@ -401,40 +415,28 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql1),
       condition = "UNSUPPORTED_FEATURE.COMBINATION_QUERY_RESULT_CLAUSES",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = "order by a sort by a",
-        start = 16,
-        stop = 35))
+      context = ExpectedContext(fragment = "order by a sort by a", start = 16, stop = 35))
 
     val sql2 = s"$baseSql cluster by a distribute by a"
     checkError(
       exception = parseException(sql2),
       condition = "UNSUPPORTED_FEATURE.COMBINATION_QUERY_RESULT_CLAUSES",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = "cluster by a distribute by a",
-        start = 16,
-        stop = 43))
+      context = ExpectedContext(fragment = "cluster by a distribute by a", start = 16, stop = 43))
 
     val sql3 = s"$baseSql order by a cluster by a"
     checkError(
       exception = parseException(sql3),
       condition = "UNSUPPORTED_FEATURE.COMBINATION_QUERY_RESULT_CLAUSES",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = "order by a cluster by a",
-        start = 16,
-        stop = 38))
+      context = ExpectedContext(fragment = "order by a cluster by a", start = 16, stop = 38))
 
     val sql4 = s"$baseSql order by a distribute by a"
     checkError(
       exception = parseException(sql4),
       condition = "UNSUPPORTED_FEATURE.COMBINATION_QUERY_RESULT_CLAUSES",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = "order by a distribute by a",
-        start = 16,
-        stop = 41))
+      context = ExpectedContext(fragment = "order by a distribute by a", start = 16, stop = 41))
   }
 
   test("DISTRIBUTE BY is not supported in the Catalyst parser") {
@@ -443,10 +445,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql),
       condition = "UNSUPPORTED_FEATURE.DISTRIBUTE_BY",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = "distribute by a",
-        start = 16,
-        stop = 30))
+      context = ExpectedContext(fragment = "distribute by a", start = 16, stop = 30))
   }
 
   test("insert into") {
@@ -461,18 +460,19 @@ class PlanParserSuite extends AnalysisTest {
       InsertIntoStatement(table("s"), partition, Nil, plan, overwrite, ifPartitionNotExists)
 
     // Single inserts
-    assertEqual(s"insert overwrite table s $sql",
-      insert(Map.empty, overwrite = true))
-    assertEqual(s"insert overwrite table s partition (e = 1) if not exists $sql",
+    assertEqual(s"insert overwrite table s $sql", insert(Map.empty, overwrite = true))
+    assertEqual(
+      s"insert overwrite table s partition (e = 1) if not exists $sql",
       insert(Map("e" -> Option("1")), overwrite = true, ifPartitionNotExists = true))
-    assertEqual(s"insert into s $sql",
-      insert(Map.empty))
-    assertEqual(s"insert into table s partition (c = 'd', e = 1) $sql",
+    assertEqual(s"insert into s $sql", insert(Map.empty))
+    assertEqual(
+      s"insert into table s partition (c = 'd', e = 1) $sql",
       insert(Map("c" -> Option("d"), "e" -> Option("1"))))
 
     // Multi insert
     val plan2 = table("t").where($"x" > 5).select(star())
-    assertEqual("from t insert into s select * limit 1 insert into u select * where x > 5",
+    assertEqual(
+      "from t insert into s select * limit 1 insert into u select * where x > 5",
       plan.limit(1).insertInto("s").union(plan2.insertInto("u")))
   }
 
@@ -484,35 +484,71 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual(sql, table("d").groupBy($"a", $"b")($"a", $"b", $"sum".function($"c").as("c")))
 
     // Cube
-    assertEqual(s"$sql with cube",
-      table("d").groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", $"sum".function($"c")
-        .as("c")))
-    assertEqual(s"$sqlWithoutGroupBy group by cube(a, b)",
-      table("d").groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", $"sum".function($"c")
-        .as("c")))
-    assertEqual(s"$sqlWithoutGroupBy group by cube (a, b)",
-      table("d").groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", $"sum".function($"c")
-        .as("c")))
+    assertEqual(
+      s"$sql with cube",
+      table("d").groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))(
+        $"a",
+        $"b",
+        $"sum"
+          .function($"c")
+          .as("c")))
+    assertEqual(
+      s"$sqlWithoutGroupBy group by cube(a, b)",
+      table("d").groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))(
+        $"a",
+        $"b",
+        $"sum"
+          .function($"c")
+          .as("c")))
+    assertEqual(
+      s"$sqlWithoutGroupBy group by cube (a, b)",
+      table("d").groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))(
+        $"a",
+        $"b",
+        $"sum"
+          .function($"c")
+          .as("c")))
 
     // Rollup
-    assertEqual(s"$sql with rollup",
-      table("d").groupBy(Rollup(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", $"sum".function($"c")
-        .as("c")))
-    assertEqual(s"$sqlWithoutGroupBy group by rollup(a, b)",
-      table("d").groupBy(Rollup(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", $"sum".function($"c")
-        .as("c")))
-    assertEqual(s"$sqlWithoutGroupBy group by rollup (a, b)",
-      table("d").groupBy(Rollup(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", $"sum".function($"c")
-        .as("c")))
+    assertEqual(
+      s"$sql with rollup",
+      table("d").groupBy(Rollup(Seq(Seq($"a"), Seq($"b"))))(
+        $"a",
+        $"b",
+        $"sum"
+          .function($"c")
+          .as("c")))
+    assertEqual(
+      s"$sqlWithoutGroupBy group by rollup(a, b)",
+      table("d").groupBy(Rollup(Seq(Seq($"a"), Seq($"b"))))(
+        $"a",
+        $"b",
+        $"sum"
+          .function($"c")
+          .as("c")))
+    assertEqual(
+      s"$sqlWithoutGroupBy group by rollup (a, b)",
+      table("d").groupBy(Rollup(Seq(Seq($"a"), Seq($"b"))))(
+        $"a",
+        $"b",
+        $"sum"
+          .function($"c")
+          .as("c")))
 
     // Grouping Sets
-    assertEqual(s"$sql grouping sets((a, b), (a), ())",
-      Aggregate(Seq(GroupingSets(Seq(Seq($"a", $"b"), Seq($"a"), Seq()), Seq($"a", $"b"))),
-        Seq($"a", $"b", $"sum".function($"c").as("c")), table("d")))
+    assertEqual(
+      s"$sql grouping sets((a, b), (a), ())",
+      Aggregate(
+        Seq(GroupingSets(Seq(Seq($"a", $"b"), Seq($"a"), Seq()), Seq($"a", $"b"))),
+        Seq($"a", $"b", $"sum".function($"c").as("c")),
+        table("d")))
 
-    assertEqual(s"$sqlWithoutGroupBy group by grouping sets((a, b), (a), ())",
-      Aggregate(Seq(GroupingSets(Seq(Seq($"a", $"b"), Seq($"a"), Seq()))),
-        Seq($"a", $"b", $"sum".function($"c").as("c")), table("d")))
+    assertEqual(
+      s"$sqlWithoutGroupBy group by grouping sets((a, b), (a), ())",
+      Aggregate(
+        Seq(GroupingSets(Seq(Seq($"a", $"b"), Seq($"a"), Seq()))),
+        Seq($"a", $"b", $"sum".function($"c").as("c")),
+        table("d")))
 
     val sql1 = "SELECT a, b, count(distinct a, distinct b) as c FROM d GROUP BY a, b"
     checkError(
@@ -532,7 +568,9 @@ class PlanParserSuite extends AnalysisTest {
     // Note that WindowSpecs are testing in the ExpressionParserSuite
     val sql = "select * from t"
     val plan = table("t").select(star())
-    val spec = WindowSpecDefinition(Seq($"a", $"b"), Seq($"c".asc),
+    val spec = WindowSpecDefinition(
+      Seq($"a", $"b"),
+      Seq($"c".asc),
       SpecifiedWindowFrame(RowFrame, -Literal(1), Literal(1)))
 
     // Test window resolution.
@@ -579,10 +617,11 @@ class PlanParserSuite extends AnalysisTest {
         |select *
         |where s < 10
       """.stripMargin,
-      Union(from
-        .generate(jsonTuple, alias = Some("jtup"), outputNames = Seq("q", "z"))
-        .select(star())
-        .insertInto("t2"),
+      Union(
+        from
+          .generate(jsonTuple, alias = Some("jtup"), outputNames = Seq("q", "z"))
+          .select(star())
+          .insertInto("t2"),
         from.where($"s" < 10).select(star()).insertInto("t3")))
 
     // Unresolved generator.
@@ -592,9 +631,7 @@ class PlanParserSuite extends AnalysisTest {
         alias = Some("posexpl"),
         outputNames = Seq("x", "y"))
       .select(star())
-    assertEqual(
-      "select * from t lateral view posexplode(x) posexpl as x, y",
-      expected)
+    assertEqual("select * from t lateral view posexplode(x) posexpl as x, y", expected)
 
     val sql1 =
       """select *
@@ -615,10 +652,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql1),
       condition = "NOT_ALLOWED_IN_FROM.LATERAL_WITH_PIVOT",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = fragment1,
-        start = 9,
-        stop = 84))
+      context = ExpectedContext(fragment = fragment1, start = 9, stop = 84))
 
     val sql2 =
       """select *
@@ -637,10 +671,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql2),
       condition = "NOT_ALLOWED_IN_FROM.LATERAL_WITH_UNPIVOT",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = fragment2,
-        start = 9,
-        stop = 74))
+      context = ExpectedContext(fragment = fragment2, start = 9, stop = 74))
 
     val sql3 =
       """select *
@@ -667,16 +698,11 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql3),
       condition = "NOT_ALLOWED_IN_FROM.UNPIVOT_WITH_PIVOT",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = fragment3,
-        start = 9,
-        stop = 115))
+      context = ExpectedContext(fragment = fragment3, start = 9, stop = 115))
   }
 
   test("unnest in FROM clause") {
-    def unnest(
-        exprs: Seq[Expression],
-        withOrdinality: Boolean = false): LogicalPlan =
+    def unnest(exprs: Seq[Expression], withOrdinality: Boolean = false): LogicalPlan =
       Generate(
         Unnest(exprs, withOrdinality),
         unrequiredChildIndex = Nil,
@@ -688,8 +714,9 @@ class PlanParserSuite extends AnalysisTest {
     // Single array.
     assertEqual(
       "select * from unnest(array(1, 2, 3))",
-      unnest(Seq(UnresolvedFunction("array", Seq(Literal(1), Literal(2), Literal(3)),
-        isDistinct = false))).select(star()))
+      unnest(Seq(
+        UnresolvedFunction("array", Seq(Literal(1), Literal(2), Literal(3)), isDistinct = false)))
+        .select(star()))
 
     // Multiple arrays.
     assertEqual(
@@ -718,12 +745,13 @@ class PlanParserSuite extends AnalysisTest {
     // Correlated via LATERAL, with WITH ORDINALITY and column aliases.
     assertEqual(
       "select * from t, lateral unnest(t.arr) with ordinality u(v, o)",
-      table("t").lateralJoin(
-        SubqueryAlias(
-          "u",
-          UnresolvedSubqueryColumnAliases(
-            Seq("v", "o"),
-            unnest(Seq(UnresolvedAttribute(Seq("t", "arr"))), withOrdinality = true))))
+      table("t")
+        .lateralJoin(
+          SubqueryAlias(
+            "u",
+            UnresolvedSubqueryColumnAliases(
+              Seq("v", "o"),
+              unnest(Seq(UnresolvedAttribute(Seq("t", "arr"))), withOrdinality = true))))
         .select(star()))
 
     // With no arguments the dedicated UNNEST relation rule does not match; the statement instead
@@ -735,9 +763,7 @@ class PlanParserSuite extends AnalysisTest {
 
     // `UNNEST` and `ORDINALITY` are non-reserved keywords, so they remain usable as regular
     // table and column identifiers for backwards compatibility.
-    assertEqual(
-      "select ordinality from unnest",
-      table("unnest").select($"ordinality"))
+    assertEqual("select ordinality from unnest", table("unnest").select($"ordinality"))
     assertEqual(
       "select unnest.ordinality from unnest",
       table("unnest").select($"unnest.ordinality"))
@@ -777,13 +803,11 @@ class PlanParserSuite extends AnalysisTest {
     val testLateralJoin = (sql: String, jt: JoinType) => {
       assertEqual(
         s"select * from t $sql lateral (select * from u) uu",
-        LateralJoin(
-          table("t"),
-          LateralSubquery(table("u").select(star()).as("uu")),
-          jt, None).select(star()))
+        LateralJoin(table("t"), LateralSubquery(table("u").select(star()).as("uu")), jt, None)
+          .select(star()))
     }
-    val testAllExceptLateral = Seq(testUnconditionalJoin, testConditionalJoin, testNaturalJoin,
-      testUsingJoin)
+    val testAllExceptLateral =
+      Seq(testUnconditionalJoin, testConditionalJoin, testNaturalJoin, testUsingJoin)
     val testAll = testAllExceptLateral :+ testLateralJoin
     val testExistence = Seq(testUnconditionalJoin, testConditionalJoin, testUsingJoin)
     def test(sql: String, jt: JoinType, tests: Seq[(String, JoinType) => Unit]): Unit = {
@@ -811,10 +835,7 @@ class PlanParserSuite extends AnalysisTest {
       condition = "INCOMPATIBLE_JOIN_TYPES",
       parameters = Map("joinType1" -> "NATURAL", "joinType2" -> "CROSS"),
       sqlState = "42613",
-      context = ExpectedContext(
-        fragment = "natural cross join b",
-        start = 16,
-        stop = 35))
+      context = ExpectedContext(fragment = "natural cross join b", start = 16, stop = 35))
 
     // Test natural join with a condition
     val sql2 = "select * from a natural join b on a.id = b.id"
@@ -848,9 +869,11 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual(
       "select * from t1 inner join (t2 inner join t3 on col3 = col2) on col3 = col1",
       table("t1")
-        .join(table("t2")
-          .join(table("t3"), Inner, Option($"col3" === $"col2")), Inner,
-            Option($"col3" === $"col1"))
+        .join(
+          table("t2")
+            .join(table("t3"), Inner, Option($"col3" === $"col2")),
+          Inner,
+          Option($"col3" === $"col1"))
         .select(star()))
     assertEqual(
       "select * from t1 inner join (t2 inner join t3) on col3 = col2",
@@ -886,14 +909,15 @@ class PlanParserSuite extends AnalysisTest {
 
       assertEqual(
         "select * from t1, t3 join t2 on t1.col1 = t2.col2",
-        table("t1").join(
-          table("t3").join(table("t2"), Inner, Option($"t1.col1" === $"t2.col2")))
+        table("t1")
+          .join(table("t3").join(table("t2"), Inner, Option($"t1.col1" === $"t2.col2")))
           .select(star()))
 
       assertEqual(
         "select * from t1 JOIN t2, t3 join t2 on t1.col1 = t2.col2",
-        table("t1").join(table("t2")).join(
-          table("t3").join(table("t2"), Inner, Option($"t1.col1" === $"t2.col2")))
+        table("t1")
+          .join(table("t2"))
+          .join(table("t3").join(table("t2"), Inner, Option($"t1.col1" === $"t2.col2")))
           .select(star()))
     }
 
@@ -903,19 +927,17 @@ class PlanParserSuite extends AnalysisTest {
       LateralJoin(
         table("t"),
         LateralSubquery(table("u").select(star()).as("uu")),
-        Inner, Option(true)).select(star()))
+        Inner,
+        Option(true)).select(star()))
 
     // Test multiple lateral joins
     assertEqual(
       "select * from a, lateral (select * from b) bb, lateral (select * from c) cc",
       LateralJoin(
-        LateralJoin(
-          table("a"),
-          LateralSubquery(table("b").select(star()).as("bb")),
-          Inner, None),
+        LateralJoin(table("a"), LateralSubquery(table("b").select(star()).as("bb")), Inner, None),
         LateralSubquery(table("c").select(star()).as("cc")),
-        Inner, None).select(star())
-    )
+        Inner,
+        None).select(star()))
   }
 
   test("nearest-by join") {
@@ -958,9 +980,7 @@ class PlanParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sqlRightOuter),
       condition = "NEAREST_BY_JOIN.UNSUPPORTED_JOIN_TYPE",
-      parameters = Map(
-        "joinType" -> "RIGHT OUTER",
-        "supported" -> "'INNER', 'LEFT OUTER'"),
+      parameters = Map("joinType" -> "RIGHT OUTER", "supported" -> "'INNER', 'LEFT OUTER'"),
       context = ExpectedContext(
         fragment = "right outer join u approx nearest 1 by similarity t.a",
         start = 16,
@@ -971,9 +991,7 @@ class PlanParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sqlFullOuter),
       condition = "NEAREST_BY_JOIN.UNSUPPORTED_JOIN_TYPE",
-      parameters = Map(
-        "joinType" -> "FULL OUTER",
-        "supported" -> "'INNER', 'LEFT OUTER'"),
+      parameters = Map("joinType" -> "FULL OUTER", "supported" -> "'INNER', 'LEFT OUTER'"),
       context = ExpectedContext(
         fragment = "full outer join u approx nearest 1 by similarity t.a",
         start = 16,
@@ -984,9 +1002,7 @@ class PlanParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sqlCross),
       condition = "NEAREST_BY_JOIN.UNSUPPORTED_JOIN_TYPE",
-      parameters = Map(
-        "joinType" -> "CROSS",
-        "supported" -> "'INNER', 'LEFT OUTER'"),
+      parameters = Map("joinType" -> "CROSS", "supported" -> "'INNER', 'LEFT OUTER'"),
       context = ExpectedContext(
         fragment = "cross join u approx nearest 1 by similarity t.a",
         start = 16,
@@ -1034,10 +1050,7 @@ class PlanParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sqlOverflow),
       condition = "NEAREST_BY_JOIN.NUM_RESULTS_OUT_OF_RANGE",
-      parameters = Map(
-        "numResults" -> "99999999999999999999",
-        "min" -> "1",
-        "max" -> "100000"),
+      parameters = Map("numResults" -> "99999999999999999999", "min" -> "1", "max" -> "100000"),
       context = ExpectedContext(
         fragment = "join u approx nearest 99999999999999999999 by distance t.a",
         start = 16,
@@ -1048,48 +1061,56 @@ class PlanParserSuite extends AnalysisTest {
     withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a >= u.a)",
-        AsOfJoin.fromMatchCondition(
-          table("t"),
-          table("u"),
-          $"t.a",
-          GreaterThanOrEqualOp,
-          $"u.a",
-          None,
-          Inner).select(star()))
+        AsOfJoin
+          .fromMatchCondition(
+            table("t"),
+            table("u"),
+            $"t.a",
+            GreaterThanOrEqualOp,
+            $"u.a",
+            None,
+            Inner)
+          .select(star()))
 
       assertEqual(
         "select * from t left asof join u match_condition (t.a >= u.a) on t.b = u.b",
-        AsOfJoin.fromMatchCondition(
-          table("t"),
-          table("u"),
-          $"t.a",
-          GreaterThanOrEqualOp,
-          $"u.a",
-          Some($"t.b" === $"u.b"),
-          LeftOuter).select(star()))
+        AsOfJoin
+          .fromMatchCondition(
+            table("t"),
+            table("u"),
+            $"t.a",
+            GreaterThanOrEqualOp,
+            $"u.a",
+            Some($"t.b" === $"u.b"),
+            LeftOuter)
+          .select(star()))
 
       assertEqual(
         "select * from t asof join u match_condition (t.a >= u.a) using (b)",
-        AsOfJoin.fromMatchCondition(
-          table("t"),
-          table("u"),
-          $"t.a",
-          GreaterThanOrEqualOp,
-          $"u.a",
-          None,
-          Inner,
-          usingColumns = Some(Seq("b"))).select(star()))
+        AsOfJoin
+          .fromMatchCondition(
+            table("t"),
+            table("u"),
+            $"t.a",
+            GreaterThanOrEqualOp,
+            $"u.a",
+            None,
+            Inner,
+            usingColumns = Some(Seq("b")))
+          .select(star()))
 
       assertEqual(
         "select * from t asof join u match_condition (u.a <= t.a)",
-        AsOfJoin.fromMatchCondition(
-          table("t"),
-          table("u"),
-          $"u.a",
-          LessThanOrEqualOp,
-          $"t.a",
-          None,
-          Inner).select(star()))
+        AsOfJoin
+          .fromMatchCondition(
+            table("t"),
+            table("u"),
+            $"u.a",
+            LessThanOrEqualOp,
+            $"t.a",
+            None,
+            Inner)
+          .select(star()))
     }
   }
 
@@ -1113,8 +1134,7 @@ class PlanParserSuite extends AnalysisTest {
   test("asof join - not equal match operator") {
     withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       checkError(
-        exception = parseException(
-          "select * from t asof join u match_condition (t.a <> u.a)"),
+        exception = parseException("select * from t asof join u match_condition (t.a <> u.a)"),
         condition = "ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR",
         sqlState = Some("42K0E"),
         parameters = Map("operator" -> "<>"),
@@ -1124,8 +1144,7 @@ class PlanParserSuite extends AnalysisTest {
             start = 16,
             stop = 55)))
       checkError(
-        exception = parseException(
-          "select * from t asof join u match_condition (t.a != u.a)"),
+        exception = parseException("select * from t asof join u match_condition (t.a != u.a)"),
         condition = "ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR",
         sqlState = Some("42K0E"),
         parameters = Map("operator" -> "!="),
@@ -1140,8 +1159,7 @@ class PlanParserSuite extends AnalysisTest {
   test("asof join - null-safe equal match operator") {
     withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       checkError(
-        exception = parseException(
-          "select * from t asof join u match_condition (t.a <=> u.a)"),
+        exception = parseException("select * from t asof join u match_condition (t.a <=> u.a)"),
         condition = "ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR",
         sqlState = Some("42K0E"),
         parameters = Map("operator" -> "<=>"),
@@ -1224,16 +1242,19 @@ class PlanParserSuite extends AnalysisTest {
 
   test("sampled relations") {
     val sql = "select * from t"
-    assertEqual(s"$sql tablesample(100 rows)",
-      table("t").limit(100).select(star()))
-    assertEqual(s"$sql tablesample(43 percent) as x",
+    assertEqual(s"$sql tablesample(100 rows)", table("t").limit(100).select(star()))
+    assertEqual(
+      s"$sql tablesample(43 percent) as x",
       Sample(0, .43d, withReplacement = false, None, table("t").as("x")).select(star()))
-    assertEqual(s"$sql tablesample(bucket 4 out of 10) as x",
+    assertEqual(
+      s"$sql tablesample(bucket 4 out of 10) as x",
       Sample(0, .4d, withReplacement = false, None, table("t").as("x")).select(star()))
     // REPEATABLE clause produces Some(seed)
-    assertEqual(s"$sql tablesample(43 percent) repeatable (10) as x",
+    assertEqual(
+      s"$sql tablesample(43 percent) repeatable (10) as x",
       Sample(0, .43d, withReplacement = false, 10L, table("t").as("x")).select(star()))
-    assertEqual(s"$sql tablesample(bucket 4 out of 10) repeatable (99) as x",
+    assertEqual(
+      s"$sql tablesample(bucket 4 out of 10) repeatable (99) as x",
       Sample(0, .4d, withReplacement = false, 99L, table("t").as("x")).select(star()))
 
     val sql1 = s"$sql tablesample(bucket 4 out of 10 on x) as x"
@@ -1242,10 +1263,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql1),
       condition = "_LEGACY_ERROR_TEMP_0015",
       parameters = Map("msg" -> "BUCKET x OUT OF y ON colname"),
-      context = ExpectedContext(
-        fragment = fragment1,
-        start = 16,
-        stop = 51))
+      context = ExpectedContext(fragment = fragment1, start = 16, stop = 51))
 
     val sql2 = s"$sql tablesample(bucket 11 out of 10) as x"
     val fragment2 = "tablesample(bucket 11 out of 10)"
@@ -1253,10 +1271,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql2),
       condition = "INVALID_TABLESAMPLE_FRACTION",
       parameters = Map("fraction" -> "1.1"),
-      context = ExpectedContext(
-        fragment = fragment2,
-        start = 16,
-        stop = 47))
+      context = ExpectedContext(fragment = fragment2, start = 16, stop = 47))
 
     val sql3 = "SELECT * FROM parquet_t0 TABLESAMPLE(300M) s"
     val fragment3 = "TABLESAMPLE(300M)"
@@ -1264,10 +1279,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql3),
       condition = "_LEGACY_ERROR_TEMP_0015",
       parameters = Map("msg" -> "byteLengthLiteral"),
-      context = ExpectedContext(
-        fragment = fragment3,
-        start = 25,
-        stop = 41))
+      context = ExpectedContext(fragment = fragment3, start = 25, stop = 41))
 
     val sql4 = "SELECT * FROM parquet_t0 TABLESAMPLE(BUCKET 3 OUT OF 32 ON rand()) s"
     val fragment4 = "TABLESAMPLE(BUCKET 3 OUT OF 32 ON rand())"
@@ -1275,10 +1287,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql4),
       condition = "_LEGACY_ERROR_TEMP_0015",
       parameters = Map("msg" -> "BUCKET x OUT OF y ON function"),
-      context = ExpectedContext(
-        fragment = fragment4,
-        start = 25,
-        stop = 65))
+      context = ExpectedContext(fragment = fragment4, start = 25, stop = 65))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM and BERNOULLI - basic parsing") {
@@ -1286,18 +1295,17 @@ class PlanParserSuite extends AnalysisTest {
     // SYSTEM produces SampleMethod.System
     assertEqual(
       s"$sql tablesample system (43 percent) as x",
-      Sample(0, .43d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.System).select(star()))
+      Sample(0, .43d, withReplacement = false, None, table("t").as("x"), SampleMethod.System)
+        .select(star()))
     // BERNOULLI produces SampleMethod.Bernoulli
     assertEqual(
       s"$sql tablesample bernoulli (43 percent) as x",
-      Sample(0, .43d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.Bernoulli).select(star()))
+      Sample(0, .43d, withReplacement = false, None, table("t").as("x"), SampleMethod.Bernoulli)
+        .select(star()))
     // No qualifier defaults to Bernoulli (backward compat)
     assertEqual(
       s"$sql tablesample(43 percent) as x",
-      Sample(0, .43d, withReplacement = false, None,
-        table("t").as("x")).select(star()))
+      Sample(0, .43d, withReplacement = false, None, table("t").as("x")).select(star()))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM - case insensitivity") {
@@ -1305,16 +1313,16 @@ class PlanParserSuite extends AnalysisTest {
     // Keywords are case-insensitive
     assertEqual(
       s"$sql TABLESAMPLE SYSTEM (43 PERCENT) as x",
-      Sample(0, .43d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.System).select(star()))
+      Sample(0, .43d, withReplacement = false, None, table("t").as("x"), SampleMethod.System)
+        .select(star()))
     assertEqual(
       s"$sql TabLeSaMpLe SyStEm (43 PeRcEnT) as x",
-      Sample(0, .43d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.System).select(star()))
+      Sample(0, .43d, withReplacement = false, None, table("t").as("x"), SampleMethod.System)
+        .select(star()))
     assertEqual(
       s"$sql TABLESAMPLE BERNOULLI (43 PERCENT) as x",
-      Sample(0, .43d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.Bernoulli).select(star()))
+      Sample(0, .43d, withReplacement = false, None, table("t").as("x"), SampleMethod.Bernoulli)
+        .select(star()))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM - boundary fractions") {
@@ -1322,18 +1330,18 @@ class PlanParserSuite extends AnalysisTest {
     // 0 PERCENT
     assertEqual(
       s"$sql tablesample system (0 percent) as x",
-      Sample(0, 0d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.System).select(star()))
+      Sample(0, 0d, withReplacement = false, None, table("t").as("x"), SampleMethod.System)
+        .select(star()))
     // 100 PERCENT
     assertEqual(
       s"$sql tablesample system (100 percent) as x",
-      Sample(0, 1d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.System).select(star()))
+      Sample(0, 1d, withReplacement = false, None, table("t").as("x"), SampleMethod.System)
+        .select(star()))
     // Fractional percent
     assertEqual(
       s"$sql tablesample system (0.1 percent) as x",
-      Sample(0, 0.001d, withReplacement = false, None,
-        table("t").as("x"), SampleMethod.System).select(star()))
+      Sample(0, 0.001d, withReplacement = false, None, table("t").as("x"), SampleMethod.System)
+        .select(star()))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM - unsupported sample methods") {
@@ -1344,20 +1352,15 @@ class PlanParserSuite extends AnalysisTest {
       condition = "UNSUPPORTED_FEATURE.TABLESAMPLE_SYSTEM_SAMPLE_METHOD",
       sqlState = "0A000",
       parameters = Map("sampleMethod" -> "ROWS"),
-      context = ExpectedContext(
-        fragment = "tablesample system (100 rows)",
-        start = 16,
-        stop = 44))
+      context =
+        ExpectedContext(fragment = "tablesample system (100 rows)", start = 16, stop = 44))
     // SYSTEM + BYTES -> error
     checkError(
       exception = parseException(s"$sql tablesample system (300M)"),
       condition = "UNSUPPORTED_FEATURE.TABLESAMPLE_SYSTEM_SAMPLE_METHOD",
       sqlState = "0A000",
       parameters = Map("sampleMethod" -> "BYTES"),
-      context = ExpectedContext(
-        fragment = "tablesample system (300M)",
-        start = 16,
-        stop = 40))
+      context = ExpectedContext(fragment = "tablesample system (300M)", start = 16, stop = 40))
     // SYSTEM + BUCKET -> error
     checkError(
       exception = parseException(s"$sql tablesample system (bucket 4 out of 10)"),
@@ -1393,8 +1396,8 @@ class PlanParserSuite extends AnalysisTest {
   test("SPARK-55978: TABLESAMPLE BERNOULLI - REPEATABLE is supported") {
     assertEqual(
       "select * from t tablesample bernoulli (43 percent) repeatable (123) as x",
-      Sample(0, .43d, withReplacement = false, 123L,
-        table("t").as("x"), SampleMethod.Bernoulli).select(star()))
+      Sample(0, .43d, withReplacement = false, 123L, table("t").as("x"), SampleMethod.Bernoulli)
+        .select(star()))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM - REPEATABLE not supported") {
@@ -1416,70 +1419,83 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(s"$sql tablesample system (150 percent) as x"),
       condition = "INVALID_TABLESAMPLE_FRACTION",
       parameters = Map("fraction" -> "1.5"),
-      context = ExpectedContext(
-        fragment = "tablesample system (150 percent)",
-        start = 16,
-        stop = 47))
+      context =
+        ExpectedContext(fragment = "tablesample system (150 percent)", start = 16, stop = 47))
     // Negative PERCENT
     checkError(
       exception = parseException(s"$sql tablesample system (-10 percent) as x"),
       condition = "INVALID_TABLESAMPLE_FRACTION",
       parameters = Map("fraction" -> "-0.1"),
-      context = ExpectedContext(
-        fragment = "tablesample system (-10 percent)",
-        start = 16,
-        stop = 47))
+      context =
+        ExpectedContext(fragment = "tablesample system (-10 percent)", start = 16, stop = 47))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM and BERNOULLI as identifiers") {
     // SYSTEM usable as column name (nonReserved)
-    assertEqual("SELECT system FROM t",
-      table("t").select($"system"))
+    assertEqual("SELECT system FROM t", table("t").select($"system"))
     // BERNOULLI usable as column name
-    assertEqual("SELECT bernoulli FROM t",
-      table("t").select($"bernoulli"))
+    assertEqual("SELECT bernoulli FROM t", table("t").select($"bernoulli"))
     // Usable as table alias
-    assertEqual("SELECT * FROM t system",
-      table("t").as("system").select(star()))
-    assertEqual("SELECT * FROM t bernoulli",
-      table("t").as("bernoulli").select(star()))
+    assertEqual("SELECT * FROM t system", table("t").as("system").select(star()))
+    assertEqual("SELECT * FROM t bernoulli", table("t").as("bernoulli").select(star()))
     // SYSTEM as table name with default (Bernoulli) TABLESAMPLE
-    assertEqual("SELECT * FROM system TABLESAMPLE(10 PERCENT) AS x",
-      Sample(0, .1d, withReplacement = false, None,
-        table("system").as("x")).select(star()))
+    assertEqual(
+      "SELECT * FROM system TABLESAMPLE(10 PERCENT) AS x",
+      Sample(0, .1d, withReplacement = false, None, table("system").as("x")).select(star()))
     // SYSTEM as table name with TABLESAMPLE SYSTEM qualifier
-    assertEqual("SELECT * FROM system TABLESAMPLE SYSTEM (10 PERCENT) AS x",
-      Sample(0, .1d, withReplacement = false, None,
-        table("system").as("x"), SampleMethod.System).select(star()))
+    assertEqual(
+      "SELECT * FROM system TABLESAMPLE SYSTEM (10 PERCENT) AS x",
+      Sample(0, .1d, withReplacement = false, None, table("system").as("x"), SampleMethod.System)
+        .select(star()))
     // SYSTEM as both table name and alias with TABLESAMPLE
-    assertEqual("SELECT * FROM system TABLESAMPLE(10 PERCENT) system",
-      Sample(0, .1d, withReplacement = false, None,
-        table("system").as("system")).select(star()))
+    assertEqual(
+      "SELECT * FROM system TABLESAMPLE(10 PERCENT) system",
+      Sample(0, .1d, withReplacement = false, None, table("system").as("system")).select(star()))
     // BERNOULLI as table name with TABLESAMPLE BERNOULLI qualifier
-    assertEqual("SELECT * FROM bernoulli TABLESAMPLE BERNOULLI (10 PERCENT) AS x",
-      Sample(0, .1d, withReplacement = false, None,
-        table("bernoulli").as("x"), SampleMethod.Bernoulli).select(star()))
+    assertEqual(
+      "SELECT * FROM bernoulli TABLESAMPLE BERNOULLI (10 PERCENT) AS x",
+      Sample(
+        0,
+        .1d,
+        withReplacement = false,
+        None,
+        table("bernoulli").as("x"),
+        SampleMethod.Bernoulli).select(star()))
     // SYSTEM as table name with TABLESAMPLE BERNOULLI (cross-keyword)
-    assertEqual("SELECT * FROM system TABLESAMPLE BERNOULLI (10 PERCENT) AS x",
-      Sample(0, .1d, withReplacement = false, None,
-        table("system").as("x"), SampleMethod.Bernoulli).select(star()))
+    assertEqual(
+      "SELECT * FROM system TABLESAMPLE BERNOULLI (10 PERCENT) AS x",
+      Sample(
+        0,
+        .1d,
+        withReplacement = false,
+        None,
+        table("system").as("x"),
+        SampleMethod.Bernoulli).select(star()))
     // BERNOULLI as both table name and alias with TABLESAMPLE
-    assertEqual("SELECT * FROM bernoulli TABLESAMPLE(10 PERCENT) bernoulli",
-      Sample(0, .1d, withReplacement = false, None,
-        table("bernoulli").as("bernoulli")).select(star()))
+    assertEqual(
+      "SELECT * FROM bernoulli TABLESAMPLE(10 PERCENT) bernoulli",
+      Sample(0, .1d, withReplacement = false, None, table("bernoulli").as("bernoulli"))
+        .select(star()))
     // Schema-qualified SYSTEM table name with TABLESAMPLE SYSTEM
-    assertEqual("SELECT * FROM mydb.system TABLESAMPLE SYSTEM (10 PERCENT) AS x",
-      Sample(0, .1d, withReplacement = false, None,
-        table("mydb", "system").as("x"), SampleMethod.System).select(star()))
+    assertEqual(
+      "SELECT * FROM mydb.system TABLESAMPLE SYSTEM (10 PERCENT) AS x",
+      Sample(
+        0,
+        .1d,
+        withReplacement = false,
+        None,
+        table("mydb", "system").as("x"),
+        SampleMethod.System).select(star()))
   }
 
   test("SPARK-55978: TABLESAMPLE SYSTEM - subquery and join contexts") {
     // SYSTEM sample in subquery
     assertEqual(
       "SELECT * FROM (SELECT * FROM t TABLESAMPLE SYSTEM (50 PERCENT)) sub",
-      Sample(0, .5d, withReplacement = false, None,
-        table("t"), SampleMethod.System)
-        .select(star()).as("sub").select(star()))
+      Sample(0, .5d, withReplacement = false, None, table("t"), SampleMethod.System)
+        .select(star())
+        .as("sub")
+        .select(star()))
   }
 
   test("sub-query") {
@@ -1491,8 +1507,9 @@ class PlanParserSuite extends AnalysisTest {
       Distinct(table("t1").select(star()).union(table("t2").select(star()))))
     assertEqual(
       "select * from ((select * from t1) union (select * from t2)) t",
-      Distinct(
-        table("t1").select(star()).union(table("t2").select(star()))).as("t").select(star()))
+      Distinct(table("t1").select(star()).union(table("t2").select(star())))
+        .as("t")
+        .select(star()))
     assertEqual(
       """select  id
         |from (((select id from t0)
@@ -1530,16 +1547,13 @@ class PlanParserSuite extends AnalysisTest {
     // SPARK-34627 - Qualified table-valued functions are now supported
     assertEqual(
       "select * from default.range(2)",
-      UnresolvedTableValuedFunction(
-        Seq("default", "range"),
-        Literal(2) :: Nil).select(star()))
+      UnresolvedTableValuedFunction(Seq("default", "range"), Literal(2) :: Nil).select(star()))
 
     // SPARK-38957 - Fully qualified table-valued functions are now supported
     assertEqual(
       "select * from spark_catalog.default.range(2)",
-      UnresolvedTableValuedFunction(
-        Seq("spark_catalog", "default", "range"),
-        Literal(2) :: Nil).select(star()))
+      UnresolvedTableValuedFunction(Seq("spark_catalog", "default", "range"), Literal(2) :: Nil)
+        .select(star()))
   }
 
   test("SPARK-20311 range(N) as alias") {
@@ -1549,10 +1563,12 @@ class PlanParserSuite extends AnalysisTest {
         .select(star()))
     assertEqual(
       "SELECT * FROM range(7) AS t(a)",
-      SubqueryAlias("t",
-        UnresolvedTVFAliases("range",
-          UnresolvedTableValuedFunction("range", Literal(7) :: Nil), "a" :: Nil)
-      ).select(star()))
+      SubqueryAlias(
+        "t",
+        UnresolvedTVFAliases(
+          "range",
+          UnresolvedTableValuedFunction("range", Literal(7) :: Nil),
+          "a" :: Nil)).select(star()))
   }
 
   test("SPARK-20841 Support table column aliases in FROM clause") {
@@ -1562,9 +1578,7 @@ class PlanParserSuite extends AnalysisTest {
         "t",
         UnresolvedSubqueryColumnAliases(
           Seq("col1", "col2"),
-          UnresolvedRelation(TableIdentifier("testData"))
-        )
-      ).select(star()))
+          UnresolvedRelation(TableIdentifier("testData")))).select(star()))
   }
 
   test("SPARK-20962 Support subquery column aliases in FROM clause") {
@@ -1574,9 +1588,8 @@ class PlanParserSuite extends AnalysisTest {
         "t",
         UnresolvedSubqueryColumnAliases(
           Seq("col1", "col2"),
-          UnresolvedRelation(TableIdentifier("t")).select($"a".as("x"), $"b".as("y"))
-        )
-      ).select(star()))
+          UnresolvedRelation(TableIdentifier("t")).select($"a".as("x"), $"b".as("y"))))
+        .select(star()))
   }
 
   test("SPARK-20963 Support aliases for join relations in FROM clause") {
@@ -1588,9 +1601,7 @@ class PlanParserSuite extends AnalysisTest {
         "dst",
         UnresolvedSubqueryColumnAliases(
           Seq("a", "b", "c", "d"),
-          src1.join(src2, Inner, Option($"s1.id" === $"s2.id"))
-        )
-      ).select(star()))
+          src1.join(src2, Inner, Option($"s1.id" === $"s2.id")))).select(star()))
   }
 
   test("SPARK-34335 Support referencing subquery with column aliases by table alias") {
@@ -1600,14 +1611,14 @@ class PlanParserSuite extends AnalysisTest {
         "t",
         UnresolvedSubqueryColumnAliases(
           Seq("col1", "col2"),
-          UnresolvedRelation(TableIdentifier("t")).select($"a".as("x"), $"b".as("y")))
-      ).select($"t.col1", $"t.col2")
-    )
+          UnresolvedRelation(TableIdentifier("t")).select($"a".as("x"), $"b".as("y"))))
+        .select($"t.col1", $"t.col2"))
   }
 
   test("inline table") {
     for (optimizeValues <- Seq(true, false)) {
-      withSQLConf(SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key ->
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key ->
           optimizeValues.toString) {
         val unresolvedTable1 =
           UnresolvedInlineTable(Seq("col1"), Seq(1, 2, 3, 4).map(x => Seq(Literal(x))))
@@ -1619,7 +1630,8 @@ class PlanParserSuite extends AnalysisTest {
         assertEqual("values 1, 2, 3, 4", table1)
 
         val unresolvedTable2 = UnresolvedInlineTable(
-          Seq("a", "b"), Seq(Literal(1), Literal("a")) :: Seq(Literal(2), Literal("b")) :: Nil)
+          Seq("a", "b"),
+          Seq(Literal(1), Literal("a")) :: Seq(Literal(2), Literal("b")) :: Nil)
         val table2 = if (optimizeValues) {
           EvaluateUnresolvedInlineTable.evaluate(unresolvedTable2)
         } else {
@@ -1632,10 +1644,12 @@ class PlanParserSuite extends AnalysisTest {
 
   test("simple select query with !> and !<") {
     // !< is equivalent to >=
-    assertEqual("select a, b from db.c where x !< 1",
+    assertEqual(
+      "select a, b from db.c where x !< 1",
       table("db", "c").where($"x" >= 1).select($"a", $"b"))
     // !> is equivalent to <=
-    assertEqual("select a, b from db.c where x !> 1",
+    assertEqual(
+      "select a, b from db.c where x !> 1",
       table("db", "c").where($"x" <= 1).select($"a", $"b"))
   }
 
@@ -1676,37 +1690,46 @@ class PlanParserSuite extends AnalysisTest {
 
     assertEqual(
       "SELECT /*+ MAPJOIN(`default.t`) */ * from `default.t`",
-      UnresolvedHint("MAPJOIN", Seq(UnresolvedAttribute.quoted("default.t")),
+      UnresolvedHint(
+        "MAPJOIN",
+        Seq(UnresolvedAttribute.quoted("default.t")),
         table("default.t").select(star())))
 
     assertEqual(
       "SELECT /*+ MAPJOIN(t) */ a from t where true group by a order by a",
-      UnresolvedHint("MAPJOIN", Seq($"t"),
-        table("t").where(Literal(true)).groupBy($"a")($"a")).orderBy($"a".asc))
+      UnresolvedHint("MAPJOIN", Seq($"t"), table("t").where(Literal(true)).groupBy($"a")($"a"))
+        .orderBy($"a".asc))
 
     assertEqual(
       "SELECT /*+ COALESCE(10) */ * FROM t",
-      UnresolvedHint("COALESCE", Seq(Literal(10)),
-        table("t").select(star())))
+      UnresolvedHint("COALESCE", Seq(Literal(10)), table("t").select(star())))
 
     assertEqual(
       "SELECT /*+ REPARTITION(100) */ * FROM t",
-      UnresolvedHint("REPARTITION", Seq(Literal(100)),
-        table("t").select(star())))
+      UnresolvedHint("REPARTITION", Seq(Literal(100)), table("t").select(star())))
 
     assertEqual(
       "INSERT INTO s SELECT /*+ REPARTITION(100), COALESCE(500), COALESCE(10) */ * FROM t",
-      InsertIntoStatement(table("s"), Map.empty, Nil,
-        UnresolvedHint("REPARTITION", Seq(Literal(100)),
-          UnresolvedHint("COALESCE", Seq(Literal(500)),
-            UnresolvedHint("COALESCE", Seq(Literal(10)),
-              table("t").select(star())))), overwrite = false, ifPartitionNotExists = false))
+      InsertIntoStatement(
+        table("s"),
+        Map.empty,
+        Nil,
+        UnresolvedHint(
+          "REPARTITION",
+          Seq(Literal(100)),
+          UnresolvedHint(
+            "COALESCE",
+            Seq(Literal(500)),
+            UnresolvedHint("COALESCE", Seq(Literal(10)), table("t").select(star())))),
+        overwrite = false,
+        ifPartitionNotExists = false))
 
     assertEqual(
       "SELECT /*+ BROADCASTJOIN(u), REPARTITION(100) */ * FROM t",
-      UnresolvedHint("BROADCASTJOIN", Seq($"u"),
-        UnresolvedHint("REPARTITION", Seq(Literal(100)),
-          table("t").select(star()))))
+      UnresolvedHint(
+        "BROADCASTJOIN",
+        Seq($"u"),
+        UnresolvedHint("REPARTITION", Seq(Literal(100)), table("t").select(star()))))
 
     val sql3 = "SELECT /*+ COALESCE(30 + 50) */ * FROM t"
     checkError(
@@ -1716,26 +1739,31 @@ class PlanParserSuite extends AnalysisTest {
 
     assertEqual(
       "SELECT /*+ REPARTITION(c) */ * FROM t",
-      UnresolvedHint("REPARTITION", Seq(UnresolvedAttribute("c")),
-        table("t").select(star())))
+      UnresolvedHint("REPARTITION", Seq(UnresolvedAttribute("c")), table("t").select(star())))
 
     assertEqual(
       "SELECT /*+ REPARTITION(100, c) */ * FROM t",
-      UnresolvedHint("REPARTITION", Seq(Literal(100), UnresolvedAttribute("c")),
+      UnresolvedHint(
+        "REPARTITION",
+        Seq(Literal(100), UnresolvedAttribute("c")),
         table("t").select(star())))
 
     assertEqual(
       "SELECT /*+ REPARTITION(100, c), COALESCE(50) */ * FROM t",
-      UnresolvedHint("REPARTITION", Seq(Literal(100), UnresolvedAttribute("c")),
-        UnresolvedHint("COALESCE", Seq(Literal(50)),
-          table("t").select(star()))))
+      UnresolvedHint(
+        "REPARTITION",
+        Seq(Literal(100), UnresolvedAttribute("c")),
+        UnresolvedHint("COALESCE", Seq(Literal(50)), table("t").select(star()))))
 
     assertEqual(
       "SELECT /*+ REPARTITION(100, c), BROADCASTJOIN(u), COALESCE(50) */ * FROM t",
-      UnresolvedHint("REPARTITION", Seq(Literal(100), UnresolvedAttribute("c")),
-        UnresolvedHint("BROADCASTJOIN", Seq($"u"),
-          UnresolvedHint("COALESCE", Seq(Literal(50)),
-            table("t").select(star())))))
+      UnresolvedHint(
+        "REPARTITION",
+        Seq(Literal(100), UnresolvedAttribute("c")),
+        UnresolvedHint(
+          "BROADCASTJOIN",
+          Seq($"u"),
+          UnresolvedHint("COALESCE", Seq(Literal(50)), table("t").select(star())))))
 
     assertEqual(
       """
@@ -1743,169 +1771,164 @@ class PlanParserSuite extends AnalysisTest {
         |/*+ REPARTITION(100, c), BROADCASTJOIN(u), COALESCE(50), REPARTITION(300, c) */
         |* FROM t
       """.stripMargin,
-      UnresolvedHint("REPARTITION", Seq(Literal(100), UnresolvedAttribute("c")),
-        UnresolvedHint("BROADCASTJOIN", Seq($"u"),
-          UnresolvedHint("COALESCE", Seq(Literal(50)),
-            UnresolvedHint("REPARTITION", Seq(Literal(300), UnresolvedAttribute("c")),
+      UnresolvedHint(
+        "REPARTITION",
+        Seq(Literal(100), UnresolvedAttribute("c")),
+        UnresolvedHint(
+          "BROADCASTJOIN",
+          Seq($"u"),
+          UnresolvedHint(
+            "COALESCE",
+            Seq(Literal(50)),
+            UnresolvedHint(
+              "REPARTITION",
+              Seq(Literal(300), UnresolvedAttribute("c")),
               table("t").select(star()))))))
 
     assertEqual(
       "SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t",
-      UnresolvedHint("REPARTITION_BY_RANGE", Seq(UnresolvedAttribute("c")),
+      UnresolvedHint(
+        "REPARTITION_BY_RANGE",
+        Seq(UnresolvedAttribute("c")),
         table("t").select(star())))
 
     assertEqual(
       "SELECT /*+ REPARTITION_BY_RANGE(100, c) */ * FROM t",
-      UnresolvedHint("REPARTITION_BY_RANGE", Seq(Literal(100), UnresolvedAttribute("c")),
+      UnresolvedHint(
+        "REPARTITION_BY_RANGE",
+        Seq(Literal(100), UnresolvedAttribute("c")),
         table("t").select(star())))
   }
 
   test("SPARK-20854: select hint syntax with expressions") {
     comparePlans(
       parsePlan("SELECT /*+ HINT1(a, array(1, 2, 3)) */ * from t"),
-      UnresolvedHint("HINT1", Seq($"a",
-        UnresolvedFunction("array", Literal(1) :: Literal(2) :: Literal(3) :: Nil, false)),
-        table("t").select(star())
-      )
-    )
+      UnresolvedHint(
+        "HINT1",
+        Seq(
+          $"a",
+          UnresolvedFunction("array", Literal(1) :: Literal(2) :: Literal(3) :: Nil, false)),
+        table("t").select(star())))
 
     comparePlans(
       parsePlan("SELECT /*+ HINT1(a, 5, 'a', b) */ * from t"),
-      UnresolvedHint("HINT1", Seq($"a", Literal(5), Literal("a"), $"b"),
-        table("t").select(star())
-      )
-    )
+      UnresolvedHint(
+        "HINT1",
+        Seq($"a", Literal(5), Literal("a"), $"b"),
+        table("t").select(star())))
 
     comparePlans(
       parsePlan("SELECT /*+ HINT1('a', (b, c), (1, 2)) */ * from t"),
-      UnresolvedHint("HINT1",
-        Seq(Literal("a"),
+      UnresolvedHint(
+        "HINT1",
+        Seq(
+          Literal("a"),
           CreateStruct($"b" :: $"c" :: Nil),
           CreateStruct(Literal(1) :: Literal(2) :: Nil)),
-        table("t").select(star())
-      )
-    )
+        table("t").select(star())))
   }
 
   test("SPARK-20854: multiple hints") {
     comparePlans(
       parsePlan("SELECT /*+ HINT1(a, 1) hint2(b, 2) */ * from t"),
-      UnresolvedHint("HINT1", Seq($"a", Literal(1)),
-        UnresolvedHint("hint2", Seq($"b", Literal(2)),
-          table("t").select(star())
-        )
-      )
-    )
+      UnresolvedHint(
+        "HINT1",
+        Seq($"a", Literal(1)),
+        UnresolvedHint("hint2", Seq($"b", Literal(2)), table("t").select(star()))))
 
     comparePlans(
       parsePlan("SELECT /*+ HINT1(a, 1),hint2(b, 2) */ * from t"),
-      UnresolvedHint("HINT1", Seq($"a", Literal(1)),
-        UnresolvedHint("hint2", Seq($"b", Literal(2)),
-          table("t").select(star())
-        )
-      )
-    )
+      UnresolvedHint(
+        "HINT1",
+        Seq($"a", Literal(1)),
+        UnresolvedHint("hint2", Seq($"b", Literal(2)), table("t").select(star()))))
 
     comparePlans(
       parsePlan("SELECT /*+ HINT1(a, 1) */ /*+ hint2(b, 2) */ * from t"),
-      UnresolvedHint("HINT1", Seq($"a", Literal(1)),
-        UnresolvedHint("hint2", Seq($"b", Literal(2)),
-          table("t").select(star())
-        )
-      )
-    )
+      UnresolvedHint(
+        "HINT1",
+        Seq($"a", Literal(1)),
+        UnresolvedHint("hint2", Seq($"b", Literal(2)), table("t").select(star()))))
 
     comparePlans(
       parsePlan("SELECT /*+ HINT1(a, 1), hint2(b, 2) */ /*+ hint3(c, 3) */ * from t"),
-      UnresolvedHint("HINT1", Seq($"a", Literal(1)),
-        UnresolvedHint("hint2", Seq($"b", Literal(2)),
-          UnresolvedHint("hint3", Seq($"c", Literal(3)),
-            table("t").select(star())
-          )
-        )
-      )
-    )
+      UnresolvedHint(
+        "HINT1",
+        Seq($"a", Literal(1)),
+        UnresolvedHint(
+          "hint2",
+          Seq($"b", Literal(2)),
+          UnresolvedHint("hint3", Seq($"c", Literal(3)), table("t").select(star())))))
   }
 
   test("TRIM function") {
     def assertTrimPlans(inputSQL: String, expectedExpression: Expression): Unit = {
       comparePlans(
         parsePlan(inputSQL),
-        Project(Seq(UnresolvedAlias(expectedExpression)), OneRowRelation())
-      )
+        Project(Seq(UnresolvedAlias(expectedExpression)), OneRowRelation()))
     }
 
     val sql1 = "select ltrim(both 'S' from 'SS abc S'"
     checkError(
       exception = parseException(sql1),
       condition = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "'from'", "hint" -> "")) // expecting {')'
+      parameters = Map("error" -> "'from'", "hint" -> "")
+    ) // expecting {')'
 
     val sql2 = "select rtrim(trailing 'S' from 'SS abc S'"
     checkError(
       exception = parseException(sql2),
       condition = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "'from'", "hint" -> "")) // expecting {')'
+      parameters = Map("error" -> "'from'", "hint" -> "")
+    ) // expecting {')'
 
     assertTrimPlans(
       "SELECT TRIM(BOTH '@$%&( )abc' FROM '@ $ % & ()abc ' )",
-      StringTrim(Literal("@ $ % & ()abc "), Some(Literal("@$%&( )abc")))
-    )
+      StringTrim(Literal("@ $ % & ()abc "), Some(Literal("@$%&( )abc"))))
     assertTrimPlans(
       "SELECT TRIM(LEADING 'c []' FROM '[ ccccbcc ')",
-      StringTrimLeft(Literal("[ ccccbcc "), Some(Literal("c []")))
-    )
+      StringTrimLeft(Literal("[ ccccbcc "), Some(Literal("c []"))))
     assertTrimPlans(
       "SELECT TRIM(TRAILING 'c&^,.' FROM 'bc...,,,&&&ccc')",
-      StringTrimRight(Literal("bc...,,,&&&ccc"), Some(Literal("c&^,.")))
-    )
+      StringTrimRight(Literal("bc...,,,&&&ccc"), Some(Literal("c&^,."))))
 
     assertTrimPlans(
       "SELECT TRIM(BOTH FROM '  bunch o blanks  ')",
-      StringTrim(Literal("  bunch o blanks  "), None)
-    )
+      StringTrim(Literal("  bunch o blanks  "), None))
     assertTrimPlans(
       "SELECT TRIM(LEADING FROM '  bunch o blanks  ')",
-      StringTrimLeft(Literal("  bunch o blanks  "), None)
-    )
+      StringTrimLeft(Literal("  bunch o blanks  "), None))
     assertTrimPlans(
       "SELECT TRIM(TRAILING FROM '  bunch o blanks  ')",
-      StringTrimRight(Literal("  bunch o blanks  "), None)
-    )
+      StringTrimRight(Literal("  bunch o blanks  "), None))
 
     assertTrimPlans(
       "SELECT TRIM('xyz' FROM 'yxTomxx')",
-      StringTrim(Literal("yxTomxx"), Some(Literal("xyz")))
-    )
+      StringTrim(Literal("yxTomxx"), Some(Literal("xyz"))))
   }
 
   test("OVERLAY function") {
     def assertOverlayPlans(inputSQL: String, expectedExpression: Expression): Unit = {
       comparePlans(
         parsePlan(inputSQL),
-        Project(Seq(UnresolvedAlias(expectedExpression)), OneRowRelation())
-      )
+        Project(Seq(UnresolvedAlias(expectedExpression)), OneRowRelation()))
     }
 
     assertOverlayPlans(
       "SELECT OVERLAY('Spark SQL' PLACING '_' FROM 6)",
-      new Overlay(Literal("Spark SQL"), Literal("_"), Literal(6))
-    )
+      new Overlay(Literal("Spark SQL"), Literal("_"), Literal(6)))
 
     assertOverlayPlans(
       "SELECT OVERLAY('Spark SQL' PLACING 'CORE' FROM 7)",
-      new Overlay(Literal("Spark SQL"), Literal("CORE"), Literal(7))
-    )
+      new Overlay(Literal("Spark SQL"), Literal("CORE"), Literal(7)))
 
     assertOverlayPlans(
       "SELECT OVERLAY('Spark SQL' PLACING 'ANSI ' FROM 7 FOR 0)",
-      Overlay(Literal("Spark SQL"), Literal("ANSI "), Literal(7), Literal(0))
-    )
+      Overlay(Literal("Spark SQL"), Literal("ANSI "), Literal(7), Literal(0)))
 
     assertOverlayPlans(
       "SELECT OVERLAY('Spark SQL' PLACING 'tructured' FROM 2 FOR 4)",
-      Overlay(Literal("Spark SQL"), Literal("tructured"), Literal(2), Literal(4))
-    )
+      Overlay(Literal("Spark SQL"), Literal("tructured"), Literal(2), Literal(4)))
   }
 
   test("precedence of set operations") {
@@ -1941,14 +1964,16 @@ class PlanParserSuite extends AnalysisTest {
 
     // Now disable precedence enforcement to verify the old behaviour.
     withSQLConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED.key -> "true") {
-      assertEqual(query1,
+      assertEqual(
+        query1,
         Distinct(a.union(b)).except(c, isAll = false).intersect(d, isAll = false))
       assertEqual(query2, Distinct(a.union(b)).except(c, isAll = true).intersect(d, isAll = true))
     }
 
     // Explicitly enable the precedence enforcement
     withSQLConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED.key -> "false") {
-      assertEqual(query1,
+      assertEqual(
+        query1,
         Distinct(a.union(b)).except(c.intersect(d, isAll = false), isAll = false))
       assertEqual(query2, Distinct(a.union(b)).except(c.intersect(d, isAll = true), isAll = true))
     }
@@ -2011,7 +2036,9 @@ class PlanParserSuite extends AnalysisTest {
         |WITH cte1 AS (SELECT * FROM testcat.db.tab)
         |SELECT * FROM cte1
       """.stripMargin,
-      cte(table("cte1").select(star()), false,
+      cte(
+        table("cte1").select(star()),
+        false,
         "cte1" -> ((table("testcat", "db", "tab").select(star()), Seq.empty))))
 
     assertEqual(
@@ -2033,7 +2060,9 @@ class PlanParserSuite extends AnalysisTest {
         |  SELECT level + 1 FROM r WHERE level < 9
         |)
         |SELECT * FROM r""".stripMargin,
-      cte(table("r").select(star()), true,
+      cte(
+        table("r").select(star()),
+        true,
         "r" -> (
           table("t").select($"level").union(table("r").where($"level" < 9).select($"level" + 1)),
           Seq("level"))))
@@ -2050,14 +2079,16 @@ class PlanParserSuite extends AnalysisTest {
     // All named arguments
     assertEqual(
       "select * from my_tvf(arg1 => 'value1', arg2 => true)",
-      UnresolvedTableValuedFunction("my_tvf",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
         NamedArgumentExpression("arg1", Literal("value1")) ::
           NamedArgumentExpression("arg2", Literal(true)) :: Nil).select(star()))
 
     // Unnamed and named arguments
     assertEqual(
       "select * from my_tvf(2, arg1 => 'value1', arg2 => true)",
-      UnresolvedTableValuedFunction("my_tvf",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
         Literal(2) ::
           NamedArgumentExpression("arg1", Literal("value1")) ::
           NamedArgumentExpression("arg2", Literal(true)) :: Nil).select(star()))
@@ -2065,20 +2096,23 @@ class PlanParserSuite extends AnalysisTest {
     // Mixed arguments
     assertEqual(
       "select * from my_tvf(arg1 => 'value1', 2, arg2 => true)",
-      UnresolvedTableValuedFunction("my_tvf",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
         NamedArgumentExpression("arg1", Literal("value1")) ::
           Literal(2) ::
           NamedArgumentExpression("arg2", Literal(true)) :: Nil).select(star()))
     assertEqual(
       "select * from my_tvf(group => 'abc')",
-      UnresolvedTableValuedFunction("my_tvf",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
         NamedArgumentExpression("group", Literal("abc")) :: Nil).select(star()))
   }
 
   test("table valued function with table arguments") {
     assertEqual(
       "select * from my_tvf(table (v1), table (select 1))",
-      UnresolvedTableValuedFunction("my_tvf",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
         FunctionTableSubqueryArgumentExpression(UnresolvedRelation(Seq("v1"))) ::
           FunctionTableSubqueryArgumentExpression(
             Project(Seq(UnresolvedAlias(Literal(1))), OneRowRelation())) :: Nil).select(star()))
@@ -2086,28 +2120,37 @@ class PlanParserSuite extends AnalysisTest {
     // All named arguments
     assertEqual(
       "select * from my_tvf(arg1 => table (v1), arg2 => table (select 1))",
-      UnresolvedTableValuedFunction("my_tvf",
-        NamedArgumentExpression("arg1",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
+        NamedArgumentExpression(
+          "arg1",
           FunctionTableSubqueryArgumentExpression(UnresolvedRelation(Seq("v1")))) ::
-          NamedArgumentExpression("arg2",
+          NamedArgumentExpression(
+            "arg2",
             FunctionTableSubqueryArgumentExpression(
-              Project(Seq(UnresolvedAlias(Literal(1))), OneRowRelation()))) :: Nil).select(star()))
+              Project(Seq(UnresolvedAlias(Literal(1))), OneRowRelation()))) :: Nil)
+        .select(star()))
 
     // Unnamed and named arguments
     assertEqual(
       "select * from my_tvf(2, table (v1), arg1 => table (select 1))",
-      UnresolvedTableValuedFunction("my_tvf",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
         Literal(2) ::
           FunctionTableSubqueryArgumentExpression(UnresolvedRelation(Seq("v1"))) ::
-          NamedArgumentExpression("arg1",
+          NamedArgumentExpression(
+            "arg1",
             FunctionTableSubqueryArgumentExpression(
-              Project(Seq(UnresolvedAlias(Literal(1))), OneRowRelation()))) :: Nil).select(star()))
+              Project(Seq(UnresolvedAlias(Literal(1))), OneRowRelation()))) :: Nil)
+        .select(star()))
 
     // Mixed arguments
     assertEqual(
       "select * from my_tvf(arg1 => table (v1), 2, arg2 => true)",
-      UnresolvedTableValuedFunction("my_tvf",
-        NamedArgumentExpression("arg1",
+      UnresolvedTableValuedFunction(
+        "my_tvf",
+        NamedArgumentExpression(
+          "arg1",
           FunctionTableSubqueryArgumentExpression(UnresolvedRelation(Seq("v1")))) ::
           Literal(2) ::
           NamedArgumentExpression("arg2", Literal(true)) :: Nil).select(star()))
@@ -2120,10 +2163,7 @@ class PlanParserSuite extends AnalysisTest {
       condition =
         "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_IDENTIFIER_ARGUMENT_MISSING_PARENTHESES",
       parameters = Map("argumentName" -> "`v1`"),
-      context = ExpectedContext(
-        fragment = "table v1",
-        start = 29,
-        stop = sql1.length - 2))
+      context = ExpectedContext(fragment = "table v1", start = 29, stop = sql1.length - 2))
   }
 
   test("SPARK-44503: Support PARTITION BY and ORDER BY clause for TVF TABLE arguments") {
@@ -2141,27 +2181,27 @@ class PlanParserSuite extends AnalysisTest {
                 key = "arg1",
                 value = FunctionTableSubqueryArgumentExpression(
                   plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
-                  partitionByExpressions = Seq(UnresolvedAttribute("col1"))
-                ))))))
-        val sql2 = s"select * from my_tvf(arg1 => table(v1) $partition by col1 $order by col2 asc)"
+                  partitionByExpressions = Seq(UnresolvedAttribute("col1"))))))))
+        val sql2 =
+          s"select * from my_tvf(arg1 => table(v1) $partition by col1 $order by col2 asc)"
         assertEqual(
           sql2,
           Project(
             projectList = Seq(UnresolvedStar(target = None)),
             child = UnresolvedTableValuedFunction(
               name = Seq("my_tvf"),
-              functionArgs = Seq(NamedArgumentExpression(
-                key = "arg1",
-                value = FunctionTableSubqueryArgumentExpression(
-                  plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
-                  partitionByExpressions = Seq(
-                    UnresolvedAttribute("col1")),
-                  orderByExpressions = Seq(SortOrder(
-                    child = UnresolvedAttribute("col2"),
-                    direction = Ascending,
-                    nullOrdering = NullsFirst,
-                    sameOrderExpressions = Seq.empty))
-                ))))))
+              functionArgs = Seq(
+                NamedArgumentExpression(
+                  key = "arg1",
+                  value = FunctionTableSubqueryArgumentExpression(
+                    plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
+                    partitionByExpressions = Seq(UnresolvedAttribute("col1")),
+                    orderByExpressions = Seq(
+                      SortOrder(
+                        child = UnresolvedAttribute("col2"),
+                        direction = Ascending,
+                        nullOrdering = NullsFirst,
+                        sameOrderExpressions = Seq.empty))))))))
         val sql3 = s"select * from my_tvf(arg1 => table(v1) " +
           s"$partition by (col1, col2) $order by (col2 asc, col3 desc))"
         assertEqual(
@@ -2170,25 +2210,24 @@ class PlanParserSuite extends AnalysisTest {
             projectList = Seq(UnresolvedStar(target = None)),
             child = UnresolvedTableValuedFunction(
               name = Seq("my_tvf"),
-              functionArgs = Seq(NamedArgumentExpression(
-                key = "arg1",
-                value = FunctionTableSubqueryArgumentExpression(
-                  plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
-                  partitionByExpressions = Seq(
-                    UnresolvedAttribute("col1"),
-                    UnresolvedAttribute("col2")),
-                  orderByExpressions = Seq(
-                    SortOrder(
-                      child = UnresolvedAttribute("col2"),
-                      direction = Ascending,
-                      nullOrdering = NullsFirst,
-                      sameOrderExpressions = Seq.empty),
-                    SortOrder(
-                      child = UnresolvedAttribute("col3"),
-                      direction = Descending,
-                      nullOrdering = NullsLast,
-                      sameOrderExpressions = Seq.empty))
-                ))))))
+              functionArgs = Seq(
+                NamedArgumentExpression(
+                  key = "arg1",
+                  value = FunctionTableSubqueryArgumentExpression(
+                    plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
+                    partitionByExpressions =
+                      Seq(UnresolvedAttribute("col1"), UnresolvedAttribute("col2")),
+                    orderByExpressions = Seq(
+                      SortOrder(
+                        child = UnresolvedAttribute("col2"),
+                        direction = Ascending,
+                        nullOrdering = NullsFirst,
+                        sameOrderExpressions = Seq.empty),
+                      SortOrder(
+                        child = UnresolvedAttribute("col3"),
+                        direction = Descending,
+                        nullOrdering = NullsLast,
+                        sameOrderExpressions = Seq.empty))))))))
         val sql4 = s"select * from my_tvf(arg1 => table(select col1, col2, col3 from v2) " +
           s"$partition by (col1, col2) order by (col2 asc, col3 desc))"
         assertEqual(
@@ -2197,30 +2236,29 @@ class PlanParserSuite extends AnalysisTest {
             projectList = Seq(UnresolvedStar(target = None)),
             child = UnresolvedTableValuedFunction(
               name = Seq("my_tvf"),
-              functionArgs = Seq(NamedArgumentExpression(
-                key = "arg1",
-                value = FunctionTableSubqueryArgumentExpression(
-                  plan = Project(
-                    projectList = Seq(
-                      UnresolvedAttribute("col1"),
-                      UnresolvedAttribute("col2"),
-                      UnresolvedAttribute("col3")),
-                    child = UnresolvedRelation(multipartIdentifier = Seq("v2"))),
-                  partitionByExpressions = Seq(
-                    UnresolvedAttribute("col1"),
-                    UnresolvedAttribute("col2")),
-                  orderByExpressions = Seq(
-                    SortOrder(
-                      child = UnresolvedAttribute("col2"),
-                      direction = Ascending,
-                      nullOrdering = NullsFirst,
-                      sameOrderExpressions = Seq.empty),
-                    SortOrder(
-                      child = UnresolvedAttribute("col3"),
-                      direction = Descending,
-                      nullOrdering = NullsLast,
-                      sameOrderExpressions = Seq.empty))
-                ))))))
+              functionArgs = Seq(
+                NamedArgumentExpression(
+                  key = "arg1",
+                  value = FunctionTableSubqueryArgumentExpression(
+                    plan = Project(
+                      projectList = Seq(
+                        UnresolvedAttribute("col1"),
+                        UnresolvedAttribute("col2"),
+                        UnresolvedAttribute("col3")),
+                      child = UnresolvedRelation(multipartIdentifier = Seq("v2"))),
+                    partitionByExpressions =
+                      Seq(UnresolvedAttribute("col1"), UnresolvedAttribute("col2")),
+                    orderByExpressions = Seq(
+                      SortOrder(
+                        child = UnresolvedAttribute("col2"),
+                        direction = Ascending,
+                        nullOrdering = NullsFirst,
+                        sameOrderExpressions = Seq.empty),
+                      SortOrder(
+                        child = UnresolvedAttribute("col3"),
+                        direction = Descending,
+                        nullOrdering = NullsLast,
+                        sameOrderExpressions = Seq.empty))))))))
         val sql5 = s"select * from my_tvf(arg1 => table(v1) with single partition)"
         assertEqual(
           sql5,
@@ -2228,27 +2266,24 @@ class PlanParserSuite extends AnalysisTest {
             projectList = Seq(UnresolvedStar(target = None)),
             child = UnresolvedTableValuedFunction(
               name = Seq("my_tvf"),
-              functionArgs = Seq(NamedArgumentExpression(
-                key = "arg1",
-                value = FunctionTableSubqueryArgumentExpression(
-                  plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
-                  withSinglePartition = true
-                ))))))
+              functionArgs = Seq(
+                NamedArgumentExpression(
+                  key = "arg1",
+                  value = FunctionTableSubqueryArgumentExpression(
+                    plan = UnresolvedRelation(multipartIdentifier = Seq("v1")),
+                    withSinglePartition = true))))))
         // Negative tests.
-        val sql6 = "select * from my_tvf(arg1 => table(1) partition by col1 with single partition)"
+        val sql6 =
+          "select * from my_tvf(arg1 => table(1) partition by col1 with single partition)"
         checkError(
           exception = parseException(sql6),
           condition = "PARSE_SYNTAX_ERROR",
-          parameters = Map(
-            "error" -> "'partition'",
-            "hint" -> ""))
+          parameters = Map("error" -> "'partition'", "hint" -> ""))
         val sql7 = "select * from my_tvf(arg1 => table(1) order by col1)"
         checkError(
           exception = parseException(sql7),
           condition = "PARSE_SYNTAX_ERROR",
-          parameters = Map(
-            "error" -> "'order'",
-            "hint" -> ""))
+          parameters = Map("error" -> "'order'", "hint" -> ""))
         val sql8tableArg = "table(select col1, col2, col3 from v2)"
         val sql8partition = s"$partition by col1, col2 order by col2 asc, col3 desc"
         val sql8 = s"select * from my_tvf(arg1 => $sql8tableArg $sql8partition)"
@@ -2259,8 +2294,7 @@ class PlanParserSuite extends AnalysisTest {
           context = ExpectedContext(
             fragment = s"$sql8tableArg $sql8partition",
             start = 29,
-            stop = 110 + partition.length)
-        )
+            stop = 110 + partition.length))
         val sql9tableArg = "table(select col1, col2, col3 from v2)"
         val sql9partition = s"$partition by col1 $order by col2 asc, col3 desc"
         val sql9 = s"select * from my_tvf(arg1 => $sql9tableArg $sql9partition)"
@@ -2271,8 +2305,7 @@ class PlanParserSuite extends AnalysisTest {
           context = ExpectedContext(
             fragment = s"$sql9tableArg $sql9partition",
             start = 29,
-            stop = 99 + partition.length + order.length)
-        )
+            stop = 99 + partition.length + order.length))
       }
     }
   }
@@ -2287,12 +2320,18 @@ class PlanParserSuite extends AnalysisTest {
       """.stripMargin,
       ScriptTransformation(
         "cat",
-        Seq(AttributeReference("key", StringType)(),
-          AttributeReference("value", StringType)()),
+        Seq(AttributeReference("key", StringType)(), AttributeReference("value", StringType)()),
         Project(Seq($"a", $"b", $"c"), UnresolvedRelation(TableIdentifier("testData"))),
-        ScriptInputOutputSchema(List.empty, List.empty, None, None,
-          List.empty, List.empty, None, None, true))
-    )
+        ScriptInputOutputSchema(
+          List.empty,
+          List.empty,
+          None,
+          None,
+          List.empty,
+          List.empty,
+          None,
+          None,
+          true)))
 
     // verify without output schema
     assertEqual(
@@ -2303,12 +2342,21 @@ class PlanParserSuite extends AnalysisTest {
       """.stripMargin,
       ScriptTransformation(
         "cat",
-        Seq(AttributeReference("a", StringType)(),
+        Seq(
+          AttributeReference("a", StringType)(),
           AttributeReference("b", StringType)(),
           AttributeReference("c", StringType)()),
         Project(Seq($"a", $"b", $"c"), UnresolvedRelation(TableIdentifier("testData"))),
-        ScriptInputOutputSchema(List.empty, List.empty, None, None,
-          List.empty, List.empty, None, None, false)))
+        ScriptInputOutputSchema(
+          List.empty,
+          List.empty,
+          None,
+          None,
+          List.empty,
+          List.empty,
+          None,
+          None,
+          false)))
 
     // verify with output schema
     assertEqual(
@@ -2319,12 +2367,21 @@ class PlanParserSuite extends AnalysisTest {
       """.stripMargin,
       ScriptTransformation(
         "cat",
-        Seq(AttributeReference("a", IntegerType)(),
+        Seq(
+          AttributeReference("a", IntegerType)(),
           AttributeReference("b", StringType)(),
           AttributeReference("c", LongType)()),
         Project(Seq($"a", $"b", $"c"), UnresolvedRelation(TableIdentifier("testData"))),
-        ScriptInputOutputSchema(List.empty, List.empty, None, None,
-          List.empty, List.empty, None, None, false)))
+        ScriptInputOutputSchema(
+          List.empty,
+          List.empty,
+          None,
+          None,
+          List.empty,
+          List.empty,
+          None,
+          None,
+          false)))
 
     // verify with ROW FORMAT DELIMETED
     @nowarn("cat=deprecation")
@@ -2350,22 +2407,31 @@ class PlanParserSuite extends AnalysisTest {
       sqlWithRowFormatDelimiters,
       ScriptTransformation(
         "cat",
-        Seq(AttributeReference("a", StringType)(),
+        Seq(
+          AttributeReference("a", StringType)(),
           AttributeReference("b", StringType)(),
           AttributeReference("c", StringType)()),
         Project(Seq($"a", $"b", $"c"), UnresolvedRelation(TableIdentifier("testData"))),
         ScriptInputOutputSchema(
-          Seq(("TOK_TABLEROWFORMATFIELD", "\t"),
+          Seq(
+            ("TOK_TABLEROWFORMATFIELD", "\t"),
             ("TOK_TABLEROWFORMATCOLLITEMS", "\u0002"),
             ("TOK_TABLEROWFORMATMAPKEYS", "\u0003"),
             ("TOK_TABLEROWFORMATNULL", "null"),
             ("TOK_TABLEROWFORMATLINES", "\n")),
-          Seq(("TOK_TABLEROWFORMATFIELD", "\t"),
+          Seq(
+            ("TOK_TABLEROWFORMATFIELD", "\t"),
             ("TOK_TABLEROWFORMATCOLLITEMS", "\u0004"),
             ("TOK_TABLEROWFORMATMAPKEYS", "\u0005"),
             ("TOK_TABLEROWFORMATNULL", "NULL"),
-            ("TOK_TABLEROWFORMATLINES", "\n")), None, None,
-          List.empty, List.empty, None, None, false)))
+            ("TOK_TABLEROWFORMATLINES", "\n")),
+          None,
+          None,
+          List.empty,
+          List.empty,
+          None,
+          None,
+          false)))
 
     // verify with ROW FORMAT SERDE
     val sql =
@@ -2386,10 +2452,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql),
       condition = "UNSUPPORTED_FEATURE.TRANSFORM_NON_HIVE",
       parameters = Map.empty,
-      context = ExpectedContext(
-        fragment = sql,
-        start = 0,
-        stop = 393))
+      context = ExpectedContext(fragment = sql, start = 0, stop = 393))
   }
 
   test("as of syntax") {
@@ -2400,17 +2463,20 @@ class PlanParserSuite extends AnalysisTest {
       }
     }
 
-    testVersion("'Snapshot123456789'", Project(Seq(UnresolvedStar(None)),
-      RelationTimeTravel(
-        UnresolvedRelation(Seq("a", "b", "c")),
-        None,
-        Some("Snapshot123456789"))))
+    testVersion(
+      "'Snapshot123456789'",
+      Project(
+        Seq(UnresolvedStar(None)),
+        RelationTimeTravel(
+          UnresolvedRelation(Seq("a", "b", "c")),
+          None,
+          Some("Snapshot123456789"))))
 
-    testVersion("123456789", Project(Seq(UnresolvedStar(None)),
-      RelationTimeTravel(
-        UnresolvedRelation(Seq("a", "b", "c")),
-        None,
-        Some("123456789"))))
+    testVersion(
+      "123456789",
+      Project(
+        Seq(UnresolvedStar(None)),
+        RelationTimeTravel(UnresolvedRelation(Seq("a", "b", "c")), None, Some("123456789"))))
 
     def testTimestamp(timestamp: String, plan: LogicalPlan): Unit = {
       Seq("TIMESTAMP", "SYSTEM_TIME").foreach { keyword =>
@@ -2419,24 +2485,37 @@ class PlanParserSuite extends AnalysisTest {
       }
     }
 
-    testTimestamp("'2019-01-29 00:37:58'", Project(Seq(UnresolvedStar(None)),
-      RelationTimeTravel(
-        UnresolvedRelation(Seq("a", "b", "c")),
-        Some(Literal("2019-01-29 00:37:58")),
-        None)))
+    testTimestamp(
+      "'2019-01-29 00:37:58'",
+      Project(
+        Seq(UnresolvedStar(None)),
+        RelationTimeTravel(
+          UnresolvedRelation(Seq("a", "b", "c")),
+          Some(Literal("2019-01-29 00:37:58")),
+          None)))
 
-    testTimestamp("current_date()", Project(Seq(UnresolvedStar(None)),
-      RelationTimeTravel(
-        UnresolvedRelation(Seq("a", "b", "c")),
-        Some(UnresolvedFunction(Seq("current_date"), Nil, isDistinct = false)),
-        None)))
+    testTimestamp(
+      "current_date()",
+      Project(
+        Seq(UnresolvedStar(None)),
+        RelationTimeTravel(
+          UnresolvedRelation(Seq("a", "b", "c")),
+          Some(UnresolvedFunction(Seq("current_date"), Nil, isDistinct = false)),
+          None)))
 
-    testTimestamp("(SELECT current_date())", Project(Seq(UnresolvedStar(None)),
-      RelationTimeTravel(
-        UnresolvedRelation(Seq("a", "b", "c")),
-        Some(ScalarSubquery(Project(UnresolvedAlias(UnresolvedFunction(
-          Seq("current_date"), Nil, isDistinct = false)) :: Nil, OneRowRelation()))),
-        None)))
+    testTimestamp(
+      "(SELECT current_date())",
+      Project(
+        Seq(UnresolvedStar(None)),
+        RelationTimeTravel(
+          UnresolvedRelation(Seq("a", "b", "c")),
+          Some(
+            ScalarSubquery(
+              Project(
+                UnresolvedAlias(
+                  UnresolvedFunction(Seq("current_date"), Nil, isDistinct = false)) :: Nil,
+                OneRowRelation()))),
+          None)))
 
     val sql = "SELECT * FROM a.b.c TIMESTAMP AS OF col"
     val fragment = "TIMESTAMP AS OF col"
@@ -2444,15 +2523,13 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(sql),
       condition = "_LEGACY_ERROR_TEMP_0056",
       parameters = Map("reason" -> "timestamp expression cannot refer to any columns"),
-      context = ExpectedContext(
-        fragment = fragment,
-        start = 20,
-        stop = 38))
+      context = ExpectedContext(fragment = fragment, start = 20, stop = 38))
   }
 
   test("at syntax time travel") {
     def versionPlan(version: String): LogicalPlan = {
-      Project(Seq(UnresolvedStar(None)),
+      Project(
+        Seq(UnresolvedStar(None)),
         RelationTimeTravel(UnresolvedRelation(Seq("a", "b", "c")), None, Some(version)))
     }
     assertEqual("SELECT * FROM a.b.c@v123456789", versionPlan("123456789"))
@@ -2463,8 +2540,10 @@ class PlanParserSuite extends AnalysisTest {
     val micros = DateTimeUtils.stringToTimestampAnsi(
       UTF8String.fromString("2019-01-29 00:37:58"),
       DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-    assertEqual("SELECT * FROM a.b.c@20190129003758000",
-      Project(Seq(UnresolvedStar(None)),
+    assertEqual(
+      "SELECT * FROM a.b.c@20190129003758000",
+      Project(
+        Seq(UnresolvedStar(None)),
         RelationTimeTravel(
           UnresolvedRelation(Seq("a", "b", "c")),
           Some(Literal(micros, TimestampType)),
@@ -2473,19 +2552,23 @@ class PlanParserSuite extends AnalysisTest {
     val microsWithMillis = DateTimeUtils.stringToTimestampAnsi(
       UTF8String.fromString("2019-01-29 00:37:58.123"),
       DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-    assertEqual("SELECT * FROM a.b.c@20190129003758123",
-      Project(Seq(UnresolvedStar(None)),
+    assertEqual(
+      "SELECT * FROM a.b.c@20190129003758123",
+      Project(
+        Seq(UnresolvedStar(None)),
         RelationTimeTravel(
           UnresolvedRelation(Seq("a", "b", "c")),
           Some(Literal(microsWithMillis, TimestampType)),
           None)))
 
-    assertEqual("SELECT * FROM `t@v1`",
+    assertEqual(
+      "SELECT * FROM `t@v1`",
       Project(Seq(UnresolvedStar(None)), UnresolvedRelation(Seq("t@v1"))))
 
     // A non-time-travel '@' suffix is always a parse error.
     Seq("SELECT * FROM a@foo", "SELECT * FROM a@", "SELECT * FROM a@v").foreach { q =>
-      assert(intercept[ParseException](parsePlan(q)).getCondition == "PARSE_SYNTAX_ERROR",
+      assert(
+        intercept[ParseException](parsePlan(q)).getCondition == "PARSE_SYNTAX_ERROR",
         s"expected PARSE_SYNTAX_ERROR for: $q")
     }
 
@@ -2506,7 +2589,8 @@ class PlanParserSuite extends AnalysisTest {
       parameters = Map.empty,
       context = ExpectedContext(fragment = "VERSION AS OF 2", start = 34, stop = 48))
     checkError(
-      exception = parseException("SELECT * FROM t@20190129003758000 TIMESTAMP AS OF '2019-01-29'"),
+      exception =
+        parseException("SELECT * FROM t@20190129003758000 TIMESTAMP AS OF '2019-01-29'"),
       condition = "MULTIPLE_TIME_TRAVEL_SPEC",
       parameters = Map.empty,
       context = ExpectedContext(fragment = "TIMESTAMP AS OF '2019-01-29'", start = 34, stop = 61))
@@ -2549,17 +2633,21 @@ class PlanParserSuite extends AnalysisTest {
   }
 
   test("parseTemporalTableIdentifier") {
-    assert(parseTemporalTableIdentifier("a.b") ===
-      TemporalIdentifier(Seq("a", "b"), None, None))
-    assert(parseTemporalTableIdentifier("a.b@v5") ===
-      TemporalIdentifier(Seq("a", "b"), None, Some("5")))
-    assert(parseTemporalTableIdentifier("`t@v1`") ===
-      TemporalIdentifier(Seq("t@v1"), None, None))
+    assert(
+      parseTemporalTableIdentifier("a.b") ===
+        TemporalIdentifier(Seq("a", "b"), None, None))
+    assert(
+      parseTemporalTableIdentifier("a.b@v5") ===
+        TemporalIdentifier(Seq("a", "b"), None, Some("5")))
+    assert(
+      parseTemporalTableIdentifier("`t@v1`") ===
+        TemporalIdentifier(Seq("t@v1"), None, None))
     val micros = DateTimeUtils.stringToTimestampAnsi(
       UTF8String.fromString("2019-01-29 00:37:58"),
       DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-    assert(parseTemporalTableIdentifier("t@20190129003758000") ===
-      TemporalIdentifier(Seq("t"), Some(Literal(micros, TimestampType)), None))
+    assert(
+      parseTemporalTableIdentifier("t@20190129003758000") ===
+        TemporalIdentifier(Seq("t"), Some(Literal(micros, TimestampType)), None))
     Seq("a.b@x", "a@foo", "a@", "a@v").foreach { s =>
       intercept[ParseException](parseTemporalTableIdentifier(s))
     }
@@ -2576,7 +2664,8 @@ class PlanParserSuite extends AnalysisTest {
         new ChangelogContext(
           new ChangelogRange.VersionRange(
             startVersion,
-            endVersion.map(java.util.Optional.of[String])
+            endVersion
+              .map(java.util.Optional.of[String])
               .getOrElse(java.util.Optional.empty[String]),
             startInclusive,
             endInclusive),
@@ -2588,49 +2677,48 @@ class PlanParserSuite extends AnalysisTest {
     Seq("VERSION", "SYSTEM_VERSION").foreach { keyword =>
       comparePlans(
         parsePlan(s"SELECT * FROM a.b.c CHANGES FROM $keyword 10 TO $keyword 20"),
-        Project(Seq(UnresolvedStar(None)),
-          changesFromVersion("10", Some("20"))))
+        Project(Seq(UnresolvedStar(None)), changesFromVersion("10", Some("20"))))
     }
 
     // Version range with string version
     comparePlans(
-      parsePlan("SELECT * FROM a.b.c CHANGES FROM VERSION '5765898212649545898' " +
-        "TO VERSION '8439568982649545102'"),
-      Project(Seq(UnresolvedStar(None)),
+      parsePlan(
+        "SELECT * FROM a.b.c CHANGES FROM VERSION '5765898212649545898' " +
+          "TO VERSION '8439568982649545102'"),
+      Project(
+        Seq(UnresolvedStar(None)),
         changesFromVersion("5765898212649545898", Some("8439568982649545102"))))
 
     // No ending version: CHANGES FROM VERSION 5
     comparePlans(
       parsePlan("SELECT * FROM a.b.c CHANGES FROM VERSION 5"),
-      Project(Seq(UnresolvedStar(None)),
-        changesFromVersion("5")))
+      Project(Seq(UnresolvedStar(None)), changesFromVersion("5")))
 
     // EXCLUSIVE starting bound
     comparePlans(
       parsePlan("SELECT * FROM a.b.c CHANGES FROM VERSION 10 EXCLUSIVE TO VERSION 20"),
-      Project(Seq(UnresolvedStar(None)),
+      Project(
+        Seq(UnresolvedStar(None)),
         changesFromVersion("10", Some("20"), startInclusive = false)))
 
     // EXCLUSIVE ending bound
     comparePlans(
       parsePlan("SELECT * FROM a.b.c CHANGES FROM VERSION 10 TO VERSION 20 EXCLUSIVE"),
-      Project(Seq(UnresolvedStar(None)),
+      Project(
+        Seq(UnresolvedStar(None)),
         changesFromVersion("10", Some("20"), endInclusive = false)))
 
     // Both bounds EXCLUSIVE
     comparePlans(
-      parsePlan(
-        "SELECT * FROM a.b.c CHANGES FROM VERSION 10 EXCLUSIVE TO VERSION 20 EXCLUSIVE"),
-      Project(Seq(UnresolvedStar(None)),
-        changesFromVersion("10", Some("20"),
-          startInclusive = false, endInclusive = false)))
+      parsePlan("SELECT * FROM a.b.c CHANGES FROM VERSION 10 EXCLUSIVE TO VERSION 20 EXCLUSIVE"),
+      Project(
+        Seq(UnresolvedStar(None)),
+        changesFromVersion("10", Some("20"), startInclusive = false, endInclusive = false)))
 
     // INCLUSIVE is explicit (but default)
     comparePlans(
-      parsePlan(
-        "SELECT * FROM a.b.c CHANGES FROM VERSION 10 INCLUSIVE TO VERSION 20 INCLUSIVE"),
-      Project(Seq(UnresolvedStar(None)),
-        changesFromVersion("10", Some("20"))))
+      parsePlan("SELECT * FROM a.b.c CHANGES FROM VERSION 10 INCLUSIVE TO VERSION 20 INCLUSIVE"),
+      Project(Seq(UnresolvedStar(None)), changesFromVersion("10", Some("20"))))
   }
 
   test("CHANGES clause - timestamp range") {
@@ -2658,8 +2746,7 @@ class PlanParserSuite extends AnalysisTest {
     assert(range2.endingTimestamp() == range1.endingTimestamp())
 
     // No ending timestamp
-    val range3 = assertTimestampRange(
-      "SELECT * FROM a.b.c CHANGES FROM TIMESTAMP '2026-01-01'")
+    val range3 = assertTimestampRange("SELECT * FROM a.b.c CHANGES FROM TIMESTAMP '2026-01-01'")
     assert(!range3.endingTimestamp().isPresent)
 
     // EXCLUSIVE bounds on timestamp
@@ -2690,8 +2777,8 @@ class PlanParserSuite extends AnalysisTest {
     }
 
     // Default: DROP_CARRYOVERS and computeUpdates = false
-    val info1 = assertChangelogContext(
-      "SELECT * FROM a.b.c CHANGES FROM VERSION 10 TO VERSION 20")
+    val info1 =
+      assertChangelogContext("SELECT * FROM a.b.c CHANGES FROM VERSION 10 TO VERSION 20")
     assert(info1.deduplicationMode() == ChangelogContext.DeduplicationMode.DROP_CARRYOVERS)
     assert(!info1.computeUpdates())
 
@@ -2742,8 +2829,7 @@ class PlanParserSuite extends AnalysisTest {
 
   test("CHANGES clause - aliased table") {
     // CHANGES with table alias
-    val plan = parsePlan(
-      "SELECT t.* FROM a.b.c CHANGES FROM VERSION 10 TO VERSION 20 AS t")
+    val plan = parsePlan("SELECT t.* FROM a.b.c CHANGES FROM VERSION 10 TO VERSION 20 AS t")
     assert(plan.isInstanceOf[Project])
     val project = plan.asInstanceOf[Project]
     val alias = project.child.asInstanceOf[SubqueryAlias]
@@ -2754,19 +2840,19 @@ class PlanParserSuite extends AnalysisTest {
   test("CHANGES clause - simple table name") {
     comparePlans(
       parsePlan("SELECT * FROM my_table CHANGES FROM VERSION 1"),
-      Project(Seq(UnresolvedStar(None)),
+      Project(
+        Seq(UnresolvedStar(None)),
         RelationChanges(
           UnresolvedRelation(Seq("my_table")),
           new ChangelogContext(
-            new ChangelogRange.VersionRange(
-              "1", java.util.Optional.empty[String], true, true),
+            new ChangelogRange.VersionRange("1", java.util.Optional.empty[String], true, true),
             ChangelogContext.DeduplicationMode.DROP_CARRYOVERS,
             false))))
   }
 
   test("CHANGES clause - in subquery") {
-    val plan = parsePlan(
-      "SELECT * FROM (SELECT * FROM t CHANGES FROM VERSION 1 TO VERSION 5) sub")
+    val plan =
+      parsePlan("SELECT * FROM (SELECT * FROM t CHANGES FROM VERSION 1 TO VERSION 5) sub")
     assert(plan.isInstanceOf[Project])
   }
 
@@ -2787,8 +2873,7 @@ class PlanParserSuite extends AnalysisTest {
   test("CHANGES clause - error: subquery in starting timestamp") {
     checkError(
       intercept[AnalysisException] {
-        parsePlan(
-          "SELECT * FROM t CHANGES FROM TIMESTAMP (SELECT MAX(ts) FROM other_table)")
+        parsePlan("SELECT * FROM t CHANGES FROM TIMESTAMP (SELECT MAX(ts) FROM other_table)")
       },
       condition = "INVALID_CDC_OPTION.INVALID_TIMESTAMP_EXPR")
   }
@@ -2807,8 +2892,7 @@ class PlanParserSuite extends AnalysisTest {
     def assertPercentilePlans(inputSQL: String, expectedExpression: Expression): Unit = {
       comparePlans(
         parsePlan(inputSQL),
-        Project(Seq(UnresolvedAlias(expectedExpression)), OneRowRelation())
-      )
+        Project(Seq(UnresolvedAlias(expectedExpression)), OneRowRelation()))
     }
 
     assertPercentilePlans(
@@ -2818,8 +2902,7 @@ class PlanParserSuite extends AnalysisTest {
         Seq(Literal(Decimal(0.1), DecimalType(1, 1))),
         false,
         None,
-        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending)))
-    )
+        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending))))
 
     assertPercentilePlans(
       "SELECT PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY col DESC)",
@@ -2828,8 +2911,7 @@ class PlanParserSuite extends AnalysisTest {
         Seq(Literal(Decimal(0.1), DecimalType(1, 1))),
         false,
         None,
-        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Descending)))
-    )
+        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Descending))))
 
     assertPercentilePlans(
       "SELECT PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY col) FILTER (WHERE id > 10)",
@@ -2838,8 +2920,7 @@ class PlanParserSuite extends AnalysisTest {
         Seq(Literal(Decimal(0.1), DecimalType(1, 1))),
         false,
         Some(GreaterThan(UnresolvedAttribute("id"), Literal(10))),
-        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending)))
-    )
+        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending))))
 
     assertPercentilePlans(
       "SELECT PERCENTILE_DISC(0.1) WITHIN GROUP (ORDER BY col)",
@@ -2848,8 +2929,7 @@ class PlanParserSuite extends AnalysisTest {
         Seq(Literal(Decimal(0.1), DecimalType(1, 1))),
         false,
         None,
-        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending)))
-    )
+        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending))))
 
     assertPercentilePlans(
       "SELECT PERCENTILE_DISC(0.1) WITHIN GROUP (ORDER BY col DESC)",
@@ -2858,8 +2938,7 @@ class PlanParserSuite extends AnalysisTest {
         Seq(Literal(Decimal(0.1), DecimalType(1, 1))),
         false,
         None,
-        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Descending)))
-    )
+        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Descending))))
 
     assertPercentilePlans(
       "SELECT PERCENTILE_DISC(0.1) WITHIN GROUP (ORDER BY col) FILTER (WHERE id > 10)",
@@ -2868,8 +2947,7 @@ class PlanParserSuite extends AnalysisTest {
         Seq(Literal(Decimal(0.1), DecimalType(1, 1))),
         false,
         Some(GreaterThan(UnresolvedAttribute("id"), Literal(10))),
-        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending)))
-    )
+        orderingWithinGroup = Seq(SortOrder(UnresolvedAttribute("col"), Ascending))))
   }
 
   test("SPARK-41271: parameter substitution before parsing") {
@@ -2878,30 +2956,24 @@ class PlanParserSuite extends AnalysisTest {
 
     // Test named parameters
     val sql1 = "SELECT :param_1"
-    val (substituted1, _, _) = substitutor.substitute(
-      sql1, Map("param_1" -> "42"))
+    val (substituted1, _, _) = substitutor.substitute(sql1, Map("param_1" -> "42"))
     comparePlans(
       parsePlan(substituted1),
       Project(UnresolvedAlias(Literal(42), None) :: Nil, OneRowRelation()))
 
     val sql2 = "SELECT abs(:1Abc)"
-    val (substituted2, _, _) = substitutor.substitute(
-      sql2, Map("1Abc" -> "123"))
+    val (substituted2, _, _) = substitutor.substitute(sql2, Map("1Abc" -> "123"))
     comparePlans(
       parsePlan(substituted2),
-      Project(UnresolvedAlias(
-        UnresolvedFunction(
-          "abs" :: Nil,
-          Literal(123) :: Nil,
-          isDistinct = false), None) :: Nil,
+      Project(
+        UnresolvedAlias(
+          UnresolvedFunction("abs" :: Nil, Literal(123) :: Nil, isDistinct = false),
+          None) :: Nil,
         OneRowRelation()))
 
     val sql3 = "SELECT * FROM a LIMIT :limitA"
-    val (substituted3, _, _) = substitutor.substitute(
-      sql3, Map("limitA" -> "10"))
-    comparePlans(
-      parsePlan(substituted3),
-      table("a").select(star()).limit(Literal(10)))
+    val (substituted3, _, _) = substitutor.substitute(sql3, Map("limitA" -> "10"))
+    comparePlans(parsePlan(substituted3), table("a").select(star()).limit(Literal(10)))
 
     // Test error cases - invalid parameter syntax should be caught by SubstituteParamsParser
     checkError(
@@ -2922,7 +2994,8 @@ class PlanParserSuite extends AnalysisTest {
 
   test("SPARK-42553: NonReserved keyword 'interval' can be column name") {
     for (optimizeValues <- Seq(true, false)) {
-      withSQLConf(SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key ->
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key ->
           optimizeValues.toString) {
         val unresolvedTable =
           UnresolvedInlineTable(Seq("interval"), Seq(Literal("abc")) :: Nil)
@@ -2933,8 +3006,7 @@ class PlanParserSuite extends AnalysisTest {
         }
         comparePlans(
           parsePlan("SELECT interval FROM VALUES ('abc') AS tbl(interval);"),
-          table.as("tbl").select($"interval")
-        )
+          table.as("tbl").select($"interval"))
       }
     }
   }
@@ -2945,34 +3017,29 @@ class PlanParserSuite extends AnalysisTest {
 
     // Test positional parameters
     val sql1 = "SELECT ?"
-    val (substituted1, _, _) = substitutor.substitute(
-      sql1, positionalParams = List("42"))
+    val (substituted1, _, _) = substitutor.substitute(sql1, positionalParams = List("42"))
     comparePlans(
       parsePlan(substituted1),
       Project(UnresolvedAlias(Literal(42), None) :: Nil, OneRowRelation()))
 
     val sql2 = "SELECT abs(?)"
-    val (substituted2, _, _) = substitutor.substitute(
-      sql2, positionalParams = List("123"))
+    val (substituted2, _, _) = substitutor.substitute(sql2, positionalParams = List("123"))
     comparePlans(
       parsePlan(substituted2),
-      Project(UnresolvedAlias(
-        UnresolvedFunction(
-          "abs" :: Nil,
-          Literal(123) :: Nil,
-          isDistinct = false), None) :: Nil,
+      Project(
+        UnresolvedAlias(
+          UnresolvedFunction("abs" :: Nil, Literal(123) :: Nil, isDistinct = false),
+          None) :: Nil,
         OneRowRelation()))
 
     val sql3 = "SELECT * FROM a LIMIT ?"
-    val (substituted3, _, _) = substitutor.substitute(
-      sql3, positionalParams = List("10"))
-    comparePlans(
-      parsePlan(substituted3),
-      table("a").select(star()).limit(Literal(10)))
+    val (substituted3, _, _) = substitutor.substitute(sql3, positionalParams = List("10"))
+    comparePlans(parsePlan(substituted3), table("a").select(star()).limit(Literal(10)))
   }
 
-  test("SPARK-45189: Creating UnresolvedRelation from TableIdentifier should include the" +
-    " catalog field") {
+  test(
+    "SPARK-45189: Creating UnresolvedRelation from TableIdentifier should include the" +
+      " catalog field") {
     val tableId = TableIdentifier("t", Some("db"), Some("cat"))
     val unresolvedRelation = UnresolvedRelation(tableId)
     assert(unresolvedRelation.multipartIdentifier == Seq("cat", "db", "t"))
@@ -2996,8 +3063,7 @@ class PlanParserSuite extends AnalysisTest {
           UnresolvedAttribute("ts"),
           IntervalUtils.fromIntervalString("INTERVAL 10 seconds"))
         .where($"a" > 1)
-        .select(UnresolvedStar(None))
-    )
+        .select(UnresolvedStar(None)))
   }
 
   test("watermark clause - table & expression with alias") {
@@ -3013,12 +3079,13 @@ class PlanParserSuite extends AnalysisTest {
         .unresolvedWithWatermark(
           Alias(
             UnresolvedFunction(
-              Seq("timestamp_seconds"), Seq(UnresolvedAttribute("value")), isDistinct = false),
+              Seq("timestamp_seconds"),
+              Seq(UnresolvedAttribute("value")),
+              isDistinct = false),
             "eventTime")(),
           IntervalUtils.fromIntervalString("INTERVAL 10 seconds"))
         .where($"a" > 1)
-        .select(UnresolvedStar(None))
-    )
+        .select(UnresolvedStar(None)))
   }
 
   test("watermark clause - table & expression without alias") {
@@ -3034,11 +3101,12 @@ class PlanParserSuite extends AnalysisTest {
         .unresolvedWithWatermark(
           UnresolvedAlias(
             UnresolvedFunction(
-              Seq("timestamp_seconds"), Seq(UnresolvedAttribute("value")), isDistinct = false)),
+              Seq("timestamp_seconds"),
+              Seq(UnresolvedAttribute("value")),
+              isDistinct = false)),
           IntervalUtils.fromIntervalString("INTERVAL 10 seconds"))
         .where($"a" > 1)
-        .select(UnresolvedStar(None))
-    )
+        .select(UnresolvedStar(None)))
   }
 
   test("watermark clause - aliased query") {
@@ -3060,8 +3128,7 @@ class PlanParserSuite extends AnalysisTest {
           UnresolvedAttribute("ts"),
           IntervalUtils.fromIntervalString("INTERVAL 10 seconds"))
         .where($"a" > 1)
-        .select(UnresolvedStar(None))
-    )
+        .select(UnresolvedStar(None)))
   }
 
   test("watermark clause - subquery") {
@@ -3082,14 +3149,15 @@ class PlanParserSuite extends AnalysisTest {
         .unresolvedWithWatermark(
           Alias(
             UnresolvedFunction(
-              Seq("timestamp_seconds"), Seq(UnresolvedAttribute("ts")), isDistinct = false),
+              Seq("timestamp_seconds"),
+              Seq(UnresolvedAttribute("ts")),
+              isDistinct = false),
             "time")(),
           IntervalUtils.fromIntervalString("INTERVAL 10 seconds"))
         .select($"key", $"time")
         .as("tbl")
         .where($"key" === "a")
-        .select($"key", $"time")
-    )
+        .select($"key", $"time"))
   }
 
   test("watermark clause - table valued function") {
@@ -3107,8 +3175,7 @@ class PlanParserSuite extends AnalysisTest {
           IntervalUtils.fromIntervalString("INTERVAL 10 seconds"))
         .as("dst")
         .where($"a" > 1)
-        .select(UnresolvedStar(None))
-    )
+        .select(UnresolvedStar(None)))
   }
 
   test("watermark clause - inline table (not allowed)") {
@@ -3127,8 +3194,7 @@ class PlanParserSuite extends AnalysisTest {
 
   test("BIN BY: clause parses into the expected UnresolvedBinBy") {
     // Minimal clause: all optionals (ALIGN TO, output renames) omitted.
-    val minimal = singleBinBy(parsePlan(
-      """SELECT * FROM metrics BIN BY (
+    val minimal = singleBinBy(parsePlan("""SELECT * FROM metrics BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '5' MINUTE
         |  DISTRIBUTE UNIFORM (value)
@@ -3140,8 +3206,7 @@ class PlanParserSuite extends AnalysisTest {
     assert(minimal.outputAliases == BinByOutputAliases.empty)
 
     // Qualified column references and a partial HOUR TO MINUTE interval as BIN WIDTH.
-    val qualified = singleBinBy(parsePlan(
-      """SELECT * FROM t1 JOIN t2 ON t1.id = t2.id BIN BY (
+    val qualified = singleBinBy(parsePlan("""SELECT * FROM t1 JOIN t2 ON t1.id = t2.id BIN BY (
         |  RANGE t1.ts_start TO t1.ts_end
         |  BIN WIDTH INTERVAL '5:30' HOUR TO MINUTE
         |  DISTRIBUTE UNIFORM (t1.value)
@@ -3151,8 +3216,7 @@ class PlanParserSuite extends AnalysisTest {
     assert(qualified.distributeColumns == Seq(UnresolvedAttribute(Seq("t1", "value"))))
 
     // Maximal clause: explicit ALIGN TO, multiple DISTRIBUTE UNIFORM columns, all three renames.
-    val maximal = singleBinBy(parsePlan(
-      """SELECT * FROM metrics BIN BY (
+    val maximal = singleBinBy(parsePlan("""SELECT * FROM metrics BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '1' HOUR
         |  ALIGN TO TIMESTAMP '2024-01-01 00:30:00'
@@ -3162,9 +3226,10 @@ class PlanParserSuite extends AnalysisTest {
         |  BIN_DISTRIBUTE_RATIO AS frac
         |)""".stripMargin))
     assert(maximal.originExpr.contains(parseExpression("TIMESTAMP '2024-01-01 00:30:00'")))
-    assert(maximal.distributeColumns == Seq(
-      UnresolvedAttribute(Seq("bytes_sent")),
-      UnresolvedAttribute(Seq("requests"))))
+    assert(
+      maximal.distributeColumns == Seq(
+        UnresolvedAttribute(Seq("bytes_sent")),
+        UnresolvedAttribute(Seq("requests"))))
     assert(maximal.outputAliases.binStart.contains("ws"))
     assert(maximal.outputAliases.binEnd.contains("we"))
     assert(maximal.outputAliases.binRatio.contains("frac"))
@@ -3175,37 +3240,32 @@ class PlanParserSuite extends AnalysisTest {
       assert(parseException(query).getCondition == "PARSE_SYNTAX_ERROR")
 
     // BIN WIDTH missing.
-    assertSyntaxError(
-      """SELECT * FROM metrics BIN BY (
+    assertSyntaxError("""SELECT * FROM metrics BIN BY (
         |  RANGE ts_start TO ts_end
         |  DISTRIBUTE UNIFORM (value)
         |)""".stripMargin)
 
     // DISTRIBUTE UNIFORM missing.
-    assertSyntaxError(
-      """SELECT * FROM metrics BIN BY (
+    assertSyntaxError("""SELECT * FROM metrics BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '5' MINUTE
         |)""".stripMargin)
 
     // DISTRIBUTE UNIFORM with an empty column list.
-    assertSyntaxError(
-      """SELECT * FROM metrics BIN BY (
+    assertSyntaxError("""SELECT * FROM metrics BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '5' MINUTE
         |  DISTRIBUTE UNIFORM ()
         |)""".stripMargin)
 
     // RANGE missing.
-    assertSyntaxError(
-      """SELECT * FROM metrics BIN BY (
+    assertSyntaxError("""SELECT * FROM metrics BIN BY (
         |  BIN WIDTH INTERVAL '5' MINUTE
         |  DISTRIBUTE UNIFORM (value)
         |)""".stripMargin)
 
     // Clauses out of order: BIN WIDTH must come after RANGE.
-    assertSyntaxError(
-      """SELECT * FROM metrics BIN BY (
+    assertSyntaxError("""SELECT * FROM metrics BIN BY (
         |  BIN WIDTH INTERVAL '5' MINUTE
         |  RANGE ts_start TO ts_end
         |  DISTRIBUTE UNIFORM (value)
@@ -3215,9 +3275,10 @@ class PlanParserSuite extends AnalysisTest {
   test("BIN BY: new keywords stay non-reserved and `bin` still parses as a table alias") {
     // The seven new keywords are in `ansiNonReserved`, so they stay usable as plain identifiers
     // outside a BIN BY clause.
-    assert(binByNodes(parsePlan(
-      "SELECT bin, width, uniform, align, bin_start, bin_end, bin_distribute_ratio " +
-        "FROM t WHERE bin > 0")).isEmpty)
+    assert(
+      binByNodes(
+        parsePlan("SELECT bin, width, uniform, align, bin_start, bin_end, bin_distribute_ratio " +
+          "FROM t WHERE bin > 0")).isEmpty)
 
     // `bin` not followed by BY stays a table alias, both bare and when referenced downstream.
     assert(binByNodes(parsePlan("SELECT * FROM t bin")).isEmpty)
@@ -3226,16 +3287,14 @@ class PlanParserSuite extends AnalysisTest {
 
   test("BIN BY: composition, chaining, trailing alias, and pipe operator") {
     // Composes with a subquery in FROM and a downstream WHERE.
-    assert(binByNodes(parsePlan(
-      """SELECT * FROM (SELECT * FROM metrics) BIN BY (
+    assert(binByNodes(parsePlan("""SELECT * FROM (SELECT * FROM metrics) BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '5' MINUTE
         |  DISTRIBUTE UNIFORM (value)
         |) WHERE value > 0""".stripMargin)).size == 1)
 
     // Composes after PIVOT.
-    assert(binByNodes(parsePlan(
-      """SELECT * FROM events
+    assert(binByNodes(parsePlan("""SELECT * FROM events
         |PIVOT (sum(amount) FOR category IN ('a', 'b'))
         |BIN BY (
         |  RANGE ts_start TO ts_end
@@ -3244,8 +3303,7 @@ class PlanParserSuite extends AnalysisTest {
         |)""".stripMargin)).size == 1)
 
     // Two BIN BY clauses chain on the same relation.
-    assert(binByNodes(parsePlan(
-      """SELECT * FROM metrics
+    assert(binByNodes(parsePlan("""SELECT * FROM metrics
         |BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '5' MINUTE
@@ -3262,8 +3320,7 @@ class PlanParserSuite extends AnalysisTest {
 
     // Trailing alias, with and without the AS keyword, wraps the BinBy in a SubqueryAlias.
     Seq(") AS binned", ") binned").foreach { tail =>
-      val parsed = parsePlan(
-        s"""SELECT * FROM metrics BIN BY (
+      val parsed = parsePlan(s"""SELECT * FROM metrics BIN BY (
            |  RANGE ts_start TO ts_end
            |  BIN WIDTH INTERVAL '5' MINUTE
            |  DISTRIBUTE UNIFORM (value)
@@ -3274,13 +3331,27 @@ class PlanParserSuite extends AnalysisTest {
     }
 
     // Works as a SQL pipe-operator stage with |>.
-    assert(binByNodes(parsePlan(
-      """FROM metrics
+    assert(binByNodes(parsePlan("""FROM metrics
         ||> BIN BY (
         |  RANGE ts_start TO ts_end
         |  BIN WIDTH INTERVAL '5' MINUTE
         |  DISTRIBUTE UNIFORM (value)
         |)""".stripMargin)).size == 1)
+  }
+
+  test("parse partitioning transforms") {
+    val actual = CatalystSqlParser.parsePartitioning(
+      "(id, years(ts), months(ts), days(ts), hours(ts), bucket(16, id))")
+
+    val expected = Seq(
+      Expressions.identity("id"),
+      Expressions.years("ts"),
+      Expressions.months("ts"),
+      Expressions.days("ts"),
+      Expressions.hours("ts"),
+      Expressions.bucket(16, "id"))
+
+    assert(actual == expected)
   }
 
   private def intercept(sqlCommand: String, messages: String*): Unit =

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -25,32 +25,21 @@ import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, PersistedView, Resolver}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.classic.SparkSession
-import org.apache.spark.sql.connector.catalog.{
-  CatalogV2Util,
-  Identifier,
-  SupportsRowLevelOperations,
-  Table => V2Table,
-  TableCatalog,
-  TableChange,
-  TableInfo
-}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, SupportsRowLevelOperations, Table => V2Table, TableCatalog, TableChange, TableInfo}
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.v2ColumnsToStructType
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, Expressions, Transform}
 import org.apache.spark.sql.execution.command.CreateViewCommand
 import org.apache.spark.sql.pipelines.graph.QueryOrigin.ExceptionHelpers
-import org.apache.spark.sql.pipelines.util.{
-  PipelinesCatalogUtils,
-  SchemaInferenceUtils,
-  SchemaMergingUtils
-}
+import org.apache.spark.sql.pipelines.util.{PipelinesCatalogUtils, SchemaInferenceUtils, SchemaMergingUtils}
 import org.apache.spark.sql.pipelines.util.SchemaInferenceUtils.diffSchemas
 import org.apache.spark.sql.types.StructType
 
 /**
  * `DatasetManager` is responsible for materializing tables in the catalog based on the given
- * graph. For each table in the graph, it will create a table if none exists (or if this is a
- * full refresh), or merge the schema of an existing table to match the new flows writing to it.
+ * graph. For each table in the graph, it will create a table if none exists (or if this is a full
+ * refresh), or merge the schema of an existing table to match the new flows writing to it.
  */
 object DatasetManager extends Logging {
 
@@ -58,31 +47,32 @@ object DatasetManager extends Logging {
    * Wraps table materialization exceptions.
    *
    * The target use case of this exception is merely as a means to capture attribution -
-   * 1. Indicate that the exception is associated with table materialization.
-   * 2. Indicate which table materialization failed for.
+   *   1. Indicate that the exception is associated with table materialization.
+   *   2. Indicate which table materialization failed for.
    *
-   * @param tableName The name of the table that failed to materialize.
-   * @param cause The underlying exception that caused the materialization to fail.
+   * @param tableName
+   *   The name of the table that failed to materialize.
+   * @param cause
+   *   The underlying exception that caused the materialization to fail.
    */
-  case class TableMaterializationException(
-      tableName: String,
-      cause: Throwable
-  ) extends Exception(cause)
+  case class TableMaterializationException(tableName: String, cause: Throwable)
+      extends Exception(cause)
       with NoStackTrace
 
   /**
-   * Materializes the tables in the given graph. This method will create or update the tables
-   * in the catalog based on the given graph and context.
+   * Materializes the tables in the given graph. This method will create or update the tables in
+   * the catalog based on the given graph and context.
    *
-   * @param resolvedDataflowGraph The resolved [[DataflowGraph]] with resolved [[Flow]] sorted
-   *                              in topological order.
-   * @param context The context for the pipeline update.
-   * @return The graph with materialized tables.
+   * @param resolvedDataflowGraph
+   *   The resolved [[DataflowGraph]] with resolved [[Flow]] sorted in topological order.
+   * @param context
+   *   The context for the pipeline update.
+   * @return
+   *   The graph with materialized tables.
    */
   def materializeDatasets(
       resolvedDataflowGraph: DataflowGraph,
-      context: PipelineUpdateContext
-  ): DataflowGraph = {
+      context: PipelineUpdateContext): DataflowGraph = {
     val (_, refreshTableIdentsSet, fullRefreshTableIdentsSet) = {
       constructFullRefreshSet(resolvedDataflowGraph.tables, context)
     }
@@ -92,9 +82,9 @@ object DatasetManager extends Logging {
       graph.tables
         .filter(t => fullRefreshTableIdentsSet.contains(t.identifier))
         .map(table => TableRefreshType(table, isFullRefresh = true)) ++
-      graph.tables
-        .filter(t => refreshTableIdentsSet.contains(t.identifier))
-        .map(table => TableRefreshType(table, isFullRefresh = false))
+        graph.tables
+          .filter(t => refreshTableIdentsSet.contains(t.identifier))
+          .map(table => TableRefreshType(table, isFullRefresh = false))
     }
 
     val tablesToMaterialize = {
@@ -106,38 +96,37 @@ object DatasetManager extends Logging {
 
     // materialized [[DataflowGraph]] where each table has been materialized and each table
     // has metadata (e.g., normalized table storage path) populated
-    val materializedGraph: DataflowGraph = try {
-      DataflowGraphTransformer
-        .withDataflowGraphTransformer(resolvedDataflowGraph) { transformer =>
-          transformer.transformTables { table =>
-            if (tablesToMaterialize.keySet.contains(table.identifier)) {
-              try {
-                val isFullRefresh = tablesToMaterialize(table.identifier).isFullRefresh
-                // Load the existing auxiliary table (if any) once here and thread the snapshot into
-                // both materializeTable (which uses it for AutoCDC config-drift validation) and
-                // materializeAuxiliaryTable (which uses it to decide evolve-vs-create). Nothing
-                // between them mutates the auxiliary table, so a single load is safe and avoids a
-                // redundant catalog round trip.
-                val auxiliaryTableSpecOpt = auxiliaryTableSpecs.get(table.identifier)
-                val existingAuxiliaryTable = auxiliaryTableSpecOpt.flatMap { spec =>
-                  val (auxCatalog, auxId) =
-                    PipelinesCatalogUtils.resolveTableCatalog(context.spark, spec.identifier)
-                  loadTableIfExists(auxCatalog, auxId)
-                }
-                val (tableWithMaterializationMetadata, catalogTableEntity) = materializeTable(
-                  resolvedDataflowGraph = resolvedDataflowGraph,
-                  table = table,
-                  inferredSchemas = inferredSchemas,
-                  isFullRefresh = isFullRefresh,
-                  auxiliaryTableSpecOpt = auxiliaryTableSpecOpt,
-                  existingAuxiliaryTable = existingAuxiliaryTable,
-                  context = context
-                )
-                // Auxiliary tables' lifecycle should follow the table that it is complementary to.
-                // If this table has any auxiliary tables, validate the target can host them and
-                // materialize/full-refresh them accordingly.
-                auxiliaryTableSpecOpt.foreach {
-                  auxiliaryTableSpec =>
+    val materializedGraph: DataflowGraph =
+      try {
+        DataflowGraphTransformer
+          .withDataflowGraphTransformer(resolvedDataflowGraph) { transformer =>
+            transformer.transformTables { table =>
+              if (tablesToMaterialize.keySet.contains(table.identifier)) {
+                try {
+                  val isFullRefresh = tablesToMaterialize(table.identifier).isFullRefresh
+                  // Load the existing auxiliary table (if any) once here and thread the snapshot
+                  // into both materializeTable (which uses it for AutoCDC config-drift validation)
+                  // and materializeAuxiliaryTable (which uses it to decide evolve-vs-create).
+                  // Nothing between them mutates the auxiliary table, so a single load is safe and
+                  // avoids a redundant catalog round trip.
+                  val auxiliaryTableSpecOpt = auxiliaryTableSpecs.get(table.identifier)
+                  val existingAuxiliaryTable = auxiliaryTableSpecOpt.flatMap { spec =>
+                    val (auxCatalog, auxId) =
+                      PipelinesCatalogUtils.resolveTableCatalog(context.spark, spec.identifier)
+                    loadTableIfExists(auxCatalog, auxId)
+                  }
+                  val (tableWithMaterializationMetadata, catalogTableEntity) = materializeTable(
+                    resolvedDataflowGraph = resolvedDataflowGraph,
+                    table = table,
+                    inferredSchemas = inferredSchemas,
+                    isFullRefresh = isFullRefresh,
+                    auxiliaryTableSpecOpt = auxiliaryTableSpecOpt,
+                    existingAuxiliaryTable = existingAuxiliaryTable,
+                    context = context)
+                  // Auxiliary tables' lifecycle should follow the table that it is complementary
+                  // to. If this table has any auxiliary tables, validate the target can host them
+                  // and materialize/full-refresh them accordingly.
+                  auxiliaryTableSpecOpt.foreach { auxiliaryTableSpec =>
                     // If this table is an AutoCDC target table, as identified by being
                     // accompanied by an AutoCDC auxiliary table, additionally validate that the
                     // target table supports row level mutations. This is a relevant validation for
@@ -147,8 +136,7 @@ object DatasetManager extends Logging {
                       case _: AutoCdcAuxiliaryTableSpec =>
                         requireAutoCdcTargetSupportsRowLevelOps(
                           targetTable = table,
-                          targetTableCatalogEntity = catalogTableEntity
-                        )
+                          targetTableCatalogEntity = catalogTableEntity)
                     }
 
                     materializeAuxiliaryTable(
@@ -158,28 +146,28 @@ object DatasetManager extends Logging {
                       // The auxiliary schema is derived from its target's, so it evolves under the
                       // target's effective case sensitivity.
                       caseSensitive = effectiveCaseSensitivityFor(
-                        resolvedDataflowGraph, table.identifier, context),
-                      context = context
-                    )
+                        resolvedDataflowGraph,
+                        table.identifier,
+                        context),
+                      context = context)
+                  }
+                  tableWithMaterializationMetadata
+                } catch {
+                  case NonFatal(e) =>
+                    throw TableMaterializationException(
+                      table.displayName,
+                      cause = e.addOrigin(table.origin))
                 }
-                tableWithMaterializationMetadata
-              } catch {
-                case NonFatal(e) =>
-                  throw TableMaterializationException(
-                    table.displayName,
-                    cause = e.addOrigin(table.origin)
-                  )
+              } else {
+                table
               }
-            } else {
-              table
             }
-          }
 
-        }
-        .getDataflowGraph
-    } catch {
-      case e: SparkException if e.getCause != null => throw e.getCause
-    }
+          }
+          .getDataflowGraph
+      } catch {
+        case e: SparkException if e.getCause != null => throw e.getCause
+      }
     materializeViews(materializedGraph, context)
     materializedGraph
   }
@@ -187,8 +175,8 @@ object DatasetManager extends Logging {
   /**
    * Publish or refresh all the [[PersistedView]]s in the specified [[DataflowGraph]]
    *
-   * @param virtualizedConnectedGraphWithTables virtualizedConnectedGraph that has table information
-   *                                            from the graph.
+   * @param virtualizedConnectedGraphWithTables
+   *   virtualizedConnectedGraph that has table information from the graph.
    */
   private def materializeViews(
       virtualizedConnectedGraphWithTables: DataflowGraph,
@@ -245,11 +233,7 @@ object DatasetManager extends Logging {
             viewsToPublish -= v
           } catch {
             case NonFatal(ex) =>
-              context.flowProgressEventLogger.recordFailed(
-                flowToView,
-                ex,
-                logAsWarn = false
-              )
+              context.flowProgressEventLogger.recordFailed(flowToView, ex, logAsWarn = false)
               failedViews += v.identifier
               viewsToPublish -= v
           }
@@ -269,8 +253,7 @@ object DatasetManager extends Logging {
       plan = flow.df.logicalPlan,
       allowExisting = true,
       replace = true,
-      isAnalyzed = true
-    )
+      isAnalyzed = true)
 
     val queryContext = flow.queryContext
 
@@ -292,17 +275,25 @@ object DatasetManager extends Logging {
   /**
    * Materializes a table in the catalog. This method will create or update the table in the
    * catalog based on the given table and context.
-   * @param resolvedDataflowGraph The resolved [[DataflowGraph]] used for table metadata.
-   * @param table The table to be materialized.
-   * @param inferredSchemas The schemas inferred from the resolved graph, keyed by table.
-   * @param isFullRefresh Whether this table should be full refreshed or not.
-   * @param auxiliaryTableSpecOpt The spec for the auxiliary table (if this table has one)
-   * @param existingAuxiliaryTable The already-loaded auxiliary table for this target (if it has one
-   *                               and it exists), used for AutoCDC config-drift validation. Loaded
-   *                               once by the caller and shared with [[materializeAuxiliaryTable]].
-   * @param context The context for the pipeline update.
-   * @return The materialized graph [[Table]] (with additional metadata set) paired with the loaded
-   *         DSv2 handle of the just created/evolved table.
+   * @param resolvedDataflowGraph
+   *   The resolved [[DataflowGraph]] used for table metadata.
+   * @param table
+   *   The table to be materialized.
+   * @param inferredSchemas
+   *   The schemas inferred from the resolved graph, keyed by table.
+   * @param isFullRefresh
+   *   Whether this table should be full refreshed or not.
+   * @param auxiliaryTableSpecOpt
+   *   The spec for the auxiliary table (if this table has one)
+   * @param existingAuxiliaryTable
+   *   The already-loaded auxiliary table for this target (if it has one and it exists), used for
+   *   AutoCDC config-drift validation. Loaded once by the caller and shared with
+   *   [[materializeAuxiliaryTable]].
+   * @param context
+   *   The context for the pipeline update.
+   * @return
+   *   The materialized graph [[Table]] (with additional metadata set) paired with the loaded DSv2
+   *   handle of the just created/evolved table.
    */
   private def materializeTable(
       resolvedDataflowGraph: DataflowGraph,
@@ -317,21 +308,27 @@ object DatasetManager extends Logging {
     val (catalog, identifier) =
       PipelinesCatalogUtils.resolveTableCatalog(context.spark, table.identifier)
 
-    val outputSchema = table.specifiedSchema.getOrElse(
-      inferredSchemas(table.identifier).asNullable
-    )
+    val outputSchema =
+      table.specifiedSchema.getOrElse(inferredSchemas(table.identifier).asNullable)
     val mergedProperties = resolveTableProperties(table, identifier)
-    val partitioning = table.partitionCols.toSeq.flatten.map(Expressions.identity)
-    val clustering = table.clusterCols.map(cols =>
-      ClusterByTransform(cols.map(col => Expressions.column(col)))
-    ).toSeq
+
+    // GitHub issue 57908: Support partition transforms
+    val partitioning = table.partitionCols.toSeq.flatten match {
+      case Seq() =>
+        Seq.empty
+      case partitionCols =>
+        CatalystSqlParser.parsePartitioning(partitionCols.mkString("(", ",", ")"))
+    }
+
+    val clustering = table.clusterCols
+      .map(cols => ClusterByTransform(cols.map(col => Expressions.column(col))))
+      .toSeq
 
     // Validate that partition and cluster columns don't coexist
     if (partitioning.nonEmpty && clustering.nonEmpty) {
       throw new AnalysisException(
         errorClass = "SPECIFY_CLUSTER_BY_WITH_PARTITIONED_BY_IS_NOT_ALLOWED",
-        messageParameters = Map.empty
-      )
+        messageParameters = Map.empty)
     }
 
     val allTransforms = partitioning ++ clustering
@@ -346,9 +343,7 @@ object DatasetManager extends Logging {
           errorClass = "CANNOT_UPDATE_PARTITION_COLUMNS",
           messageParameters = Map(
             "existingPartitionColumns" -> existingTransforms.mkString(", "),
-            "requestedPartitionColumns" -> allTransforms.mkString(", ")
-          )
-        )
+            "requestedPartitionColumns" -> allTransforms.mkString(", ")))
       }
     }
 
@@ -364,10 +359,10 @@ object DatasetManager extends Logging {
     }
 
     val autoCdcAuxTableSpecOpt = auxiliaryTableSpecOpt.collect {
-        case autoCdcSpec: AutoCdcAuxiliaryTableSpec => autoCdcSpec
-      }
-    val effectiveCaseSensitive = effectiveCaseSensitivityFor(
-      resolvedDataflowGraph, table.identifier, context)
+      case autoCdcSpec: AutoCdcAuxiliaryTableSpec => autoCdcSpec
+    }
+    val effectiveCaseSensitive =
+      effectiveCaseSensitivityFor(resolvedDataflowGraph, table.identifier, context)
     val effectiveResolver = SchemaInferenceUtils.resolverFor(effectiveCaseSensitive)
 
     // For an incrementally-updated AutoCDC target, validate that the AutoCDC configuration recorded
@@ -397,13 +392,11 @@ object DatasetManager extends Logging {
         if (isTableIncrementallyUpdated) {
           autoCdcAuxTableSpecOpt.foreach { autoCdcSpec =>
             AutoCdcAuxiliaryTable.validateNoTargetSequencingTypeDrift(
-              existingTargetSchema =
-                CatalogV2Util.v2ColumnsToStructType(existingTable.columns()),
+              existingTargetSchema = CatalogV2Util.v2ColumnsToStructType(existingTable.columns()),
               targetTableIdentifier = autoCdcSpec.targetTableIdentifier,
               expectedScdType = autoCdcSpec.expectedScdType,
               expectedSequencingType = autoCdcSpec.expectedSequencingType,
-              resolver = effectiveResolver
-            )
+              resolver = effectiveResolver)
           }
         }
         evolveTable(
@@ -413,24 +406,20 @@ object DatasetManager extends Logging {
           desiredSchema = outputSchema,
           properties = mergedProperties,
           mergeWithExistingSchema = isTableIncrementallyUpdated,
-          caseSensitive = effectiveCaseSensitive
-        )
+          caseSensitive = effectiveCaseSensitive)
       case None =>
         createTable(
           catalog = catalog,
           tableIdentifier = identifier,
           schema = outputSchema,
           properties = mergedProperties,
-          transforms = allTransforms
-        )
+          transforms = allTransforms)
     }
 
     val catalogTableEntity = catalog.loadTable(identifier)
     val tableWithMaterializationMetadata =
-      table.copy(
-        normalizedPath =
-          Option(catalogTableEntity.properties().get(TableCatalog.PROP_LOCATION))
-      )
+      table.copy(normalizedPath =
+        Option(catalogTableEntity.properties().get(TableCatalog.PROP_LOCATION)))
 
     (tableWithMaterializationMetadata, catalogTableEntity)
   }
@@ -442,9 +431,11 @@ object DatasetManager extends Logging {
    * [[materializeTable]], so it performs no additional catalog I/O. Only AutoCDC auxiliary specs
    * carry a MERGE-backed target; other auxiliary tables have no such requirement.
    *
-   * @param targetTable              the target table graph entity, source of the identifier and
-   *                                 declared format used in the error message.
-   * @param targetTableCatalogEntity the target table's loaded DSv2 handle.
+   * @param targetTable
+   *   the target table graph entity, source of the identifier and declared format used in the
+   *   error message.
+   * @param targetTableCatalogEntity
+   *   the target table's loaded DSv2 handle.
    */
   private def requireAutoCdcTargetSupportsRowLevelOps(
       targetTable: Table,
@@ -457,23 +448,25 @@ object DatasetManager extends Logging {
           // Prefer the flow-declared format, falling back to the connector's provider property.
           "format" -> targetTable.format
             .orElse(Option(targetTableCatalogEntity.properties.get(TableCatalog.PROP_PROVIDER)))
-            .getOrElse("<unknown>")
-        )
-      )
+            .getOrElse("<unknown>")))
     }
   }
 
   /**
    * Materialize the auxiliary table according to the provided spec.
    *
-   * @param auxiliaryTableSpec the spec describing the auxiliary table to create/evolve.
-   * @param isFullRefresh whether the owning table is being fully refreshed.
-   * @param existingAuxiliaryTable the already-loaded auxiliary table (if it exists), loaded once by
-   *                               the caller and shared with the config-drift validation in
-   *                               [[materializeTable]] rather than re-loaded here.
-   * @param caseSensitive the effective case sensitivity of the flows writing to the auxiliary
-   *                      table's TARGET, whose schema the auxiliary schema is derived from.
-   * @param context the context for the pipeline update.
+   * @param auxiliaryTableSpec
+   *   the spec describing the auxiliary table to create/evolve.
+   * @param isFullRefresh
+   *   whether the owning table is being fully refreshed.
+   * @param existingAuxiliaryTable
+   *   the already-loaded auxiliary table (if it exists), loaded once by the caller and shared
+   *   with the config-drift validation in [[materializeTable]] rather than re-loaded here.
+   * @param caseSensitive
+   *   the effective case sensitivity of the flows writing to the auxiliary table's TARGET, whose
+   *   schema the auxiliary schema is derived from.
+   * @param context
+   *   the context for the pipeline update.
    */
   private def materializeAuxiliaryTable(
       auxiliaryTableSpec: AuxiliaryTableSpec,
@@ -487,8 +480,7 @@ object DatasetManager extends Logging {
 
     logInfo(
       log"Materializing auxiliary table " +
-      log"${MDC(LogKeys.TABLE_NAME, auxiliaryTableSpec.identifier)}."
-    )
+        log"${MDC(LogKeys.TABLE_NAME, auxiliaryTableSpec.identifier)}.")
 
     if (isFullRefresh) {
       // Intentionally DROP and not TRUNCATE on full refresh. The auxiliary table is an internal
@@ -501,8 +493,7 @@ object DatasetManager extends Logging {
       // via the create path below).
       logInfo(
         log"Dropping and recreating auxiliary table " +
-        log"${MDC(LogKeys.TABLE_NAME, auxiliaryTableSpec.identifier)} as part of full refresh."
-      )
+          log"${MDC(LogKeys.TABLE_NAME, auxiliaryTableSpec.identifier)} as part of full refresh.")
 
       // [[dropTable]] is a no-op if the table does not exist.
       catalog.dropTable(auxiliaryTableIdentifier)
@@ -512,8 +503,7 @@ object DatasetManager extends Logging {
         tableIdentifier = auxiliaryTableIdentifier,
         schema = auxiliaryTableSpec.schema,
         properties = auxiliaryTableSpec.properties,
-        transforms = Seq.empty
-      )
+        transforms = Seq.empty)
     } else {
       // Uses the auxiliary-table snapshot loaded by the caller (see materializeDatasets), rather
       // than re-loading it here.
@@ -531,37 +521,38 @@ object DatasetManager extends Logging {
             desiredSchema = auxiliaryTableSpec.schema,
             properties = auxiliaryTableSpec.properties,
             mergeWithExistingSchema = true,
-            caseSensitive = caseSensitive
-          )
+            caseSensitive = caseSensitive)
         case None =>
           createTable(
             catalog = catalog,
             tableIdentifier = auxiliaryTableIdentifier,
             schema = auxiliaryTableSpec.schema,
             properties = auxiliaryTableSpec.properties,
-            transforms = Seq.empty
-          )
+            transforms = Seq.empty)
       }
     }
   }
 
   /**
    * Validate that an incrementally-updated AutoCDC flow's configuration has not drifted from what
-   * its auxiliary table recorded. Called from [[materializeTable]] before the target and auxiliary
-   * tables are created/evolved this run, so a rejected run leaves both untouched.
+   * its auxiliary table recorded. Called from [[materializeTable]] before the target and
+   * auxiliary tables are created/evolved this run, so a rejected run leaves both untouched.
    *
    * Covers the checks that read the recorded configuration off the existing auxiliary table: key
    * columns, SCD type, and track-history columns. Runs whenever the auxiliary table exists,
    * independent of the target's existence (see the call site). If the auxiliary table does not
    * exist yet (first AutoCDC run), all three are skipped -- there is no recorded configuration to
    * drift from. The sequencing-type check is separate ([[AutoCdcAuxiliaryTable]]
-   * `.validateNoTargetSequencingTypeDrift`) because it reads the target schema, not the aux table.
+   * `.validateNoTargetSequencingTypeDrift`) because it reads the target schema, not the aux
+   * table.
    *
-   * @param autoCdcSpec the auxiliary-table spec carrying this run's expected AutoCDC configuration.
-   * @param existingAuxiliaryTableOpt the already-loaded auxiliary table (if it exists), shared with
-   *                                  the caller and [[materializeAuxiliaryTable]] to avoid a
-   *                                  redundant load.
-   * @param resolver the effective resolver of the flows writing to the AutoCDC target.
+   * @param autoCdcSpec
+   *   the auxiliary-table spec carrying this run's expected AutoCDC configuration.
+   * @param existingAuxiliaryTableOpt
+   *   the already-loaded auxiliary table (if it exists), shared with the caller and
+   *   [[materializeAuxiliaryTable]] to avoid a redundant load.
+   * @param resolver
+   *   the effective resolver of the flows writing to the AutoCDC target.
    */
   private def validateNoAutoCdcAuxConfigDrift(
       autoCdcSpec: AutoCdcAuxiliaryTableSpec,
@@ -572,27 +563,24 @@ object DatasetManager extends Logging {
         existingAuxiliaryTable = existingAuxiliaryTable,
         targetTableIdentifier = autoCdcSpec.targetTableIdentifier,
         expectedKeyFields = autoCdcSpec.expectedKeyFields,
-        resolver = resolver
-      )
+        resolver = resolver)
       AutoCdcAuxiliaryTable.validateNoScdTypeDrift(
         existingAuxiliaryTable = existingAuxiliaryTable,
         targetTableIdentifier = autoCdcSpec.targetTableIdentifier,
-        expectedScdType = autoCdcSpec.expectedScdType
-      )
+        expectedScdType = autoCdcSpec.expectedScdType)
       AutoCdcAuxiliaryTable.validateNoTrackHistoryDrift(
         existingAuxiliaryTable = existingAuxiliaryTable,
         targetTableIdentifier = autoCdcSpec.targetTableIdentifier,
         expectedTrackHistoryColumnNames = autoCdcSpec.expectedTrackHistoryColumnNames,
-        resolver = resolver
-      )
+        resolver = resolver)
     }
   }
 
   /**
    * The effective `spark.sql.caseSensitive` for schema evolution of `tableIdentifier`, read from
    * the flows writing to it rather than from the session, so evolution stays consistent with the
-   * flows whose schemas it is evolving (a pipeline-level `SET` never reaches the session). Fails if
-   * those flows disagree; see [[SchemaInferenceUtils.effectiveCaseSensitivity]].
+   * flows whose schemas it is evolving (a pipeline-level `SET` never reaches the session). Fails
+   * if those flows disagree; see [[SchemaInferenceUtils.effectiveCaseSensitivity]].
    */
   private def effectiveCaseSensitivityFor(
       resolvedDataflowGraph: DataflowGraph,
@@ -601,8 +589,7 @@ object DatasetManager extends Logging {
     SchemaInferenceUtils.effectiveCaseSensitivity(
       tableIdentifier = tableIdentifier,
       flows = resolvedDataflowGraph.flowsTo.getOrElse(tableIdentifier, Seq.empty),
-      sessionCaseSensitive = context.spark.sessionState.conf.caseSensitiveAnalysis
-    )
+      sessionCaseSensitive = context.spark.sessionState.conf.caseSensitiveAnalysis)
   }
 
   /**
@@ -610,7 +597,8 @@ object DatasetManager extends Logging {
    * `loadTable` guarded by a `NoSuchTableException` catch, rather than a `tableExists` +
    * `loadTable` pair: one catalog round trip instead of two, and no window where the table can
    * disappear between the existence check and the load. A missing *namespace* is not treated as
-   * "table absent" -- it surfaces as its own `NoSuchDatabaseException` rather than being swallowed.
+   * "table absent" -- it surfaces as its own `NoSuchDatabaseException` rather than being
+   * swallowed.
    */
   private def loadTableIfExists(
       catalog: TableCatalog,
@@ -624,9 +612,12 @@ object DatasetManager extends Logging {
    * transforms. Used both for graph datasets and for internal auxiliary tables when no table yet
    * exists at the identifier.
    *
-   * @param schema     the schema to create the table with.
-   * @param properties the table properties to create the table with.
-   * @param transforms the partition/cluster transforms to create the table with.
+   * @param schema
+   *   the schema to create the table with.
+   * @param properties
+   *   the table properties to create the table with.
+   * @param transforms
+   *   the partition/cluster transforms to create the table with.
    */
   private def createTable(
       catalog: TableCatalog,
@@ -640,37 +631,35 @@ object DatasetManager extends Logging {
         .withProperties(properties.asJava)
         .withColumns(CatalogV2Util.structTypeToV2Columns(schema))
         .withPartitions(transforms.toArray)
-        .build()
-    )
+        .build())
   }
 
   /**
-   * Evolves the already-existing `existingTable` at `identifier` in place by diffing its schema and
-   * properties, skipping the catalog `alterTable` entirely when nothing actually changes.
+   * Evolves the already-existing `existingTable` at `identifier` in place by diffing its schema
+   * and properties, skipping the catalog `alterTable` entirely when nothing actually changes.
    * Partitioning/clustering cannot change in place, so no transforms are accepted here. Used both
    * for graph datasets and for internal auxiliary tables.
    *
-   * @param existingTable           the currently materialized table.
-   * @param desiredSchema           the schema the table should have as computed in the current
-   *                                execution (for graph datasets, the user-specified or inferred
-   *                                schema; for auxiliary tables, the derived schema). This is the
-   *                                "incoming" side and may differ from `existingTable`'s recorded
-   *                                schema due to schema evolution across runs.
-   * @param properties              the declared table properties to (re)set on the table. Note
-   *                                that properties absent here are NOT removed from the table (see
-   *                                the TODO in the body).
-   * @param mergeWithExistingSchema whether the effective schema is the merge of the existing and
-   *                                desired schemas (additive evolution) rather than the desired
-   *                                schema as-is.
-   * @param caseSensitive           whether the additive schema merge treats field names differing
-   *                                only in case as distinct columns. Callers should pass the
-   *                                effective `spark.sql.caseSensitive` used to resolve the schema
-   *                                being evolved. When `false`, an incoming column differing from
-   *                                an existing one only in case is folded onto it rather than
-   *                                added as a duplicate. Only affects the merge (i.e.
-   *                                `mergeWithExistingSchema = true`); the subsequent diff always
-   *                                keys columns on their exact names, so a case-only rename on a
-   *                                non-merging path stays an explicit drop-then-add.
+   * @param existingTable
+   *   the currently materialized table.
+   * @param desiredSchema
+   *   the schema the table should have as computed in the current execution (for graph datasets,
+   *   the user-specified or inferred schema; for auxiliary tables, the derived schema). This is
+   *   the "incoming" side and may differ from `existingTable`'s recorded schema due to schema
+   *   evolution across runs.
+   * @param properties
+   *   the declared table properties to (re)set on the table. Note that properties absent here are
+   *   NOT removed from the table (see the TODO in the body).
+   * @param mergeWithExistingSchema
+   *   whether the effective schema is the merge of the existing and desired schemas (additive
+   *   evolution) rather than the desired schema as-is.
+   * @param caseSensitive
+   *   whether the additive schema merge treats field names differing only in case as distinct
+   *   columns. Callers should pass the effective `spark.sql.caseSensitive` used to resolve the
+   *   schema being evolved. When `false`, an incoming column differing from an existing one only
+   *   in case is folded onto it rather than added as a duplicate. Only affects the merge (i.e.
+   *   `mergeWithExistingSchema = true`); the subsequent diff always keys columns on their exact
+   *   names, so a case-only rename on a non-merging path stays an explicit drop-then-add.
    */
   private def evolveTable(
       catalog: TableCatalog,
@@ -714,31 +703,30 @@ object DatasetManager extends Logging {
   }
 
   /**
-   * Some fields on the [[Table]] object are represented as reserved table properties by the catalog
-   * APIs. This method creates a table properties map that merges the user-provided table properties
-   * with these reserved properties.
+   * Some fields on the [[Table]] object are represented as reserved table properties by the
+   * catalog APIs. This method creates a table properties map that merges the user-provided table
+   * properties with these reserved properties.
    */
-  private def resolveTableProperties(table: Table, identifier: Identifier): Map[String, String] = {
+  private def resolveTableProperties(
+      table: Table,
+      identifier: Identifier): Map[String, String] = {
     val validatedAndCanonicalizedProps =
       PipelinesTableProperties.validateAndCanonicalize(
         table.properties,
-        warnFunction = s => logWarning(s)
-      )
+        warnFunction = s => logWarning(s))
 
     val specialProps = Seq(
       (table.comment, "comment", TableCatalog.PROP_COMMENT),
-      (table.format, "format", TableCatalog.PROP_PROVIDER)
-    ).map {
-        case (value, name, reservedPropKey) =>
-          validatedAndCanonicalizedProps.get(reservedPropKey).foreach { pc =>
-            if (value.isDefined && value.get != pc) {
-              throw new IllegalArgumentException(
-                s"For dataset $identifier, $name '${value.get}' does not match value '$pc' for " +
-                s"reserved table property '$reservedPropKey''"
-              )
-            }
+      (table.format, "format", TableCatalog.PROP_PROVIDER))
+      .map { case (value, name, reservedPropKey) =>
+        validatedAndCanonicalizedProps.get(reservedPropKey).foreach { pc =>
+          if (value.isDefined && value.get != pc) {
+            throw new IllegalArgumentException(
+              s"For dataset $identifier, $name '${value.get}' does not match value '$pc' for " +
+                s"reserved table property '$reservedPropKey''")
           }
-          reservedPropKey -> value
+        }
+        reservedPropKey -> value
       }
       .collect { case (key, Some(value)) => key -> value }
 
@@ -747,25 +735,26 @@ object DatasetManager extends Logging {
 
   /**
    * A case class that represents the type of refresh for a table.
-   * @param table The table to be refreshed.
-   * @param isFullRefresh Whether this table should be fully refreshed or not.
+   * @param table
+   *   The table to be refreshed.
+   * @param isFullRefresh
+   *   Whether this table should be fully refreshed or not.
    */
   private case class TableRefreshType(table: Table, isFullRefresh: Boolean)
 
   /**
-   * Constructs the set of tables that should be fully refreshed and the set of tables that
-   * should be refreshed.
+   * Constructs the set of tables that should be fully refreshed and the set of tables that should
+   * be refreshed.
    */
-  private def constructFullRefreshSet(
-      graphTables: Seq[Table],
-      context: PipelineUpdateContext
-  ): (Seq[Table], Seq[TableIdentifier], Seq[TableIdentifier]) = {
+  private def constructFullRefreshSet(graphTables: Seq[Table], context: PipelineUpdateContext)
+      : (Seq[Table], Seq[TableIdentifier], Seq[TableIdentifier]) = {
     val (fullRefreshTablesSet, refreshTablesSet) = {
       val specifiedFullRefreshTables = context.fullRefreshTables.filter(graphTables)
       val specifiedRefreshTables = context.refreshTables.filter(graphTables)
 
-      val (fullRefreshAllowed, fullRefreshNotAllowed) = specifiedFullRefreshTables.partition { t =>
-        PipelinesTableProperties.resetAllowed.fromMap(t.properties)
+      val (fullRefreshAllowed, fullRefreshNotAllowed) = specifiedFullRefreshTables.partition {
+        t =>
+          PipelinesTableProperties.resetAllowed.fromMap(t.properties)
       }
 
       val refreshTables = (specifiedRefreshTables ++ fullRefreshNotAllowed).filterNot { t =>
@@ -775,10 +764,9 @@ object DatasetManager extends Logging {
       if (fullRefreshNotAllowed.nonEmpty) {
         logInfo(
           log"Skipping full refresh on some tables because " +
-          log"${MDC(LogKeys.PROPERTY_NAME, PipelinesTableProperties.resetAllowed.key)} " +
-          log"was set to false. Tables: " +
-          log"${MDC(LogKeys.TABLE_NAME, fullRefreshNotAllowed.map(_.identifier))}"
-        )
+            log"${MDC(LogKeys.PROPERTY_NAME, PipelinesTableProperties.resetAllowed.key)} " +
+            log"was set to false. Tables: " +
+            log"${MDC(LogKeys.TABLE_NAME, fullRefreshNotAllowed.map(_.identifier))}")
       }
 
       (fullRefreshAllowed, refreshTables)

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -22,14 +22,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{AnalysisException, Row, SQLContext}
-import org.apache.spark.sql.connector.catalog.{
-  CatalogV2Util,
-  Identifier,
-  InMemoryTableCatalog,
-  Table => V2Table,
-  TableCatalog,
-  TableChange
-}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, InMemoryTableCatalog, Table => V2Table, TableCatalog, TableChange}
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, Expressions, FieldReference}
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.internal.SQLConf
@@ -57,14 +50,11 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = false, "comment1")
-              .add("x2", IntegerType, nullable = true, "comment2")
-          ),
+              .add("x2", IntegerType, nullable = true, "comment2")),
           comment = Option("p-comment"),
-          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-        )
+          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "a")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -74,9 +64,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       catalogTable.columns() sameElements CatalogV2Util.structTypeToV2Columns(
         new StructType()
           .add("x", IntegerType, nullable = false, "comment1")
-          .add("x2", IntegerType, nullable = true, "comment2")
-      )
-    )
+          .add("x2", IntegerType, nullable = true, "comment2")))
     assert(catalogTable.properties().get(TableCatalog.PROP_COMMENT) == "p-comment")
 
     materializeGraph(
@@ -86,22 +74,17 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = false, "comment3")
-              .add("x2", IntegerType, nullable = true, "comment4")
-          ),
+              .add("x2", IntegerType, nullable = true, "comment4")),
           comment = Option("p-comment"),
-          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-        )
+          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
     val catalogTable2 = catalog.loadTable(identifier)
     assert(
       catalogTable2.columns() sameElements CatalogV2Util.structTypeToV2Columns(
         new StructType()
           .add("x", IntegerType, nullable = false, "comment3")
-          .add("x2", IntegerType, nullable = true, "comment4")
-      )
-    )
+          .add("x2", IntegerType, nullable = true, "comment4")))
     assert(catalogTable2.properties().get(TableCatalog.PROP_COMMENT) == "p-comment")
 
     materializeGraph(
@@ -111,23 +94,18 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = false)
-              .add("x2", IntegerType, nullable = true)
-          ),
+              .add("x2", IntegerType, nullable = true)),
           comment = Option("p-comment"),
-          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-        )
+          query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val catalogTable3 = catalog.loadTable(identifier)
     assert(
       catalogTable3.columns() sameElements CatalogV2Util.structTypeToV2Columns(
         new StructType()
           .add("x", IntegerType, nullable = false, comment = null)
-          .add("x2", IntegerType, nullable = true, comment = null)
-      )
-    )
+          .add("x2", IntegerType, nullable = true, comment = null)))
     assert(catalogTable3.properties().get(TableCatalog.PROP_COMMENT) == "p-comment")
   }
 
@@ -135,21 +113,12 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow(
-          "t1",
-          "t1",
-          query = dfFlowFunc(Seq(1, 2, 3).toDF("x"))
-        )
-        registerFlow(
-          "t2",
-          "t2",
-          query = dfFlowFunc(Seq("a", "b").toDF("y"))
-        )
+        registerFlow("t1", "t1", query = dfFlowFunc(Seq(1, 2, 3).toDF("x")))
+        registerFlow("t2", "t2", query = dfFlowFunc(Seq("a", "b").toDF("y")))
         registerTable("t1")
         registerTable("t2")
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val identifier1 = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t1")
     val identifier2 = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t2")
@@ -159,41 +128,29 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     assert(
       catalogTable1.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("x", IntegerType))
-    )
+        .structTypeToV2Columns(new StructType().add("x", IntegerType)))
     assert(
       catalogTable2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("y", StringType))
-    )
+        .structTypeToV2Columns(new StructType().add("y", StringType)))
   }
 
   test("temporary views don't get materialized") {
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow(
-          "t2",
-          "t2",
-          query = dfFlowFunc(Seq("a", "b").toDF("y"))
-        )
+        registerFlow("t2", "t2", query = dfFlowFunc(Seq("a", "b").toDF("y")))
         registerTable("t2")
-        registerView(
-          "t1",
-          dfFlowFunc(Seq(1, 2, 3).toDF("x"))
-        )
+        registerView("t1", dfFlowFunc(Seq(1, 2, 3).toDF("x")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     assert(
       !catalog.tableExists(
-        Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t1")
-      )
-    )
+        Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t1")))
     assert(
-      catalog.tableExists(Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t2"))
-    )
+      catalog.tableExists(
+        Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t2")))
   }
 
   // TableManager performs different validations for batch tables vs streaming tables when
@@ -202,15 +159,11 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   // it is possible to do that.
   test("batch flow reading from streaming table") {
     class P1 extends TestGraphRegistrationContext(spark) {
-      registerTable(
-        "a",
-        query = Option(dfFlowFunc(spark.readStream.format("rate").load()))
-      )
+      registerTable("a", query = Option(dfFlowFunc(spark.readStream.format("rate").load())))
       // Defines a column called timestamp as `int`.
       registerMaterializedView(
         "b",
-        query = sqlFlowFunc(spark, "SELECT value AS timestamp FROM a")
-      )
+        query = sqlFlowFunc(spark, "SELECT value AS timestamp FROM a"))
     }
     materializeGraph(new P1().resolveToDataflowGraph(), storageRoot = storageRoot)
 
@@ -219,27 +172,19 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       catalog.loadTable(Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "b"))
     assert(
       b.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("timestamp", LongType))
-    )
+        .structTypeToV2Columns(new StructType().add("timestamp", LongType)))
 
     class P2 extends TestGraphRegistrationContext(spark) {
-      registerTable(
-        "a",
-        query = Option(dfFlowFunc(spark.readStream.format("rate").load()))
-      )
+      registerTable("a", query = Option(dfFlowFunc(spark.readStream.format("rate").load())))
       // Defines a column called timestamp as `timestamp`.
-      registerMaterializedView(
-        "b",
-        query = sqlFlowFunc(spark, "SELECT timestamp FROM a")
-      )
+      registerMaterializedView("b", query = sqlFlowFunc(spark, "SELECT timestamp FROM a"))
     }
     materializeGraph(new P2().resolveToDataflowGraph(), storageRoot = storageRoot)
     val b2 =
       catalog.loadTable(Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "b"))
     assert(
       b2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("timestamp", TimestampType))
-    )
+        .structTypeToV2Columns(new StructType().add("timestamp", TimestampType)))
   }
 
   test("schema matches existing table schema") {
@@ -250,23 +195,19 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     val table = catalog.loadTable(identifier)
     assert(
       table.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        new StructType().add("x", IntegerType)
-      )
-    )
+        new StructType().add("x", IntegerType)))
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
         registerFlow("t2", "t2", query = dfFlowFunc(Seq(1, 2, 3).toDF("x")))
         registerTable("t2")
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val table2 = catalog.loadTable(identifier)
     assert(
       table2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("x", IntegerType))
-    )
+        .structTypeToV2Columns(new StructType().add("x", IntegerType)))
   }
 
   test("invalid schema merge") {
@@ -280,8 +221,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerView("a", query = dfFlowFunc(streamInts.toDF()))
         registerTable("b", query = Option(sqlFlowFunc(spark, "SELECT value AS x FROM STREAM a")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val streamStrings = MemoryStream[String]
     streamStrings.addData("a", "b")
@@ -306,9 +246,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     val table = catalog.loadTable(identifier)
     assert(
       table.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        new StructType().add("x", IntegerType)
-      )
-    )
+        new StructType().add("x", IntegerType)))
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -317,22 +255,17 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           specifiedSchema = Option(
             new StructType()
               .add("x", IntegerType, nullable = true, "this is column x")
-              .add("z", LongType, nullable = true, "this is column z")
-          ),
-          query = dfFlowFunc(Seq[Short](1, 2).toDF("x"))
-        )
+              .add("z", LongType, nullable = true, "this is column z")),
+          query = dfFlowFunc(Seq[Short](1, 2).toDF("x")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val table2 = catalog.loadTable(identifier)
     assert(
       table2.columns() sameElements CatalogV2Util.structTypeToV2Columns(
         new StructType()
           .add("x", IntegerType, nullable = true, "this is column x")
-          .add("z", LongType, nullable = true, "this is column z")
-      )
-    )
+          .add("z", LongType, nullable = true, "this is column z")))
   }
 
   test("specified schema incompatible with existing table") {
@@ -344,40 +277,98 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     val table = catalog.loadTable(identifier)
     assert(
       table.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        new StructType().add("x", BooleanType)
-      )
-    )
+        new StructType().add("x", BooleanType)))
 
     val ex = intercept[TableMaterializationException] {
-      materializeGraph(new TestGraphRegistrationContext(spark) {
-        val source: MemoryStream[Int] = MemoryStream[Int]
-        source.addData(1, 2)
-        registerTable(
-          "t6",
-          specifiedSchema = Option(new StructType().add("x", IntegerType)),
-          query = Option(dfFlowFunc(source.toDF().select($"value" as "x")))
-        )
+      materializeGraph(
+        new TestGraphRegistrationContext(spark) {
+          val source: MemoryStream[Int] = MemoryStream[Int]
+          source.addData(1, 2)
+          registerTable(
+            "t6",
+            specifiedSchema = Option(new StructType().add("x", IntegerType)),
+            query = Option(dfFlowFunc(source.toDF().select($"value" as "x"))))
 
-      }.resolveToDataflowGraph(), storageRoot = storageRoot)
+        }.resolveToDataflowGraph(),
+        storageRoot = storageRoot)
     }
     val cause = ex.cause
     val exStr = exceptionString(cause)
     assert(exStr.contains("Failed to merge incompatible data types"))
 
     // Works fine for a complete table
-    materializeGraph(new TestGraphRegistrationContext(spark) {
-      registerMaterializedView(
-        "t6",
-        specifiedSchema = Option(new StructType().add("x", IntegerType)),
-        query = dfFlowFunc(Seq(1, 2).toDF("x"))
-      )
-    }.resolveToDataflowGraph(),
-    storageRoot = storageRoot)
+    materializeGraph(
+      new TestGraphRegistrationContext(spark) {
+        registerMaterializedView(
+          "t6",
+          specifiedSchema = Option(new StructType().add("x", IntegerType)),
+          query = dfFlowFunc(Seq(1, 2).toDF("x")))
+      }.resolveToDataflowGraph(),
+      storageRoot = storageRoot)
     val table2 = catalog.loadTable(identifier)
     assert(
       table2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("x", IntegerType))
-    )
+        .structTypeToV2Columns(new StructType().add("x", IntegerType)))
+  }
+
+  test("partition columns support transforms") {
+    withSQLConf("spark.sql.catalog.testcat" -> classOf[InMemoryTableCatalog].getName) {
+      materializeGraph(
+        new TestGraphRegistrationContext(spark) {
+          registerTable(
+            "testcat.default.xdd",
+            query = Option(
+              dfFlowFunc(
+                Seq(
+                  (java.sql.Timestamp.valueOf("2025-01-01 00:00:00"), 1),
+                  (java.sql.Timestamp.valueOf("2025-02-01 00:00:00"), 2))
+                  .toDF("event_time", "value"))),
+            specifiedSchema = Option(
+              new StructType()
+                .add("event_time", TimestampType)
+                .add("value", IntegerType)),
+            partitionCols = Option(Seq("months(event_time)")))
+        }.resolveToDataflowGraph(),
+        storageRoot = storageRoot)
+
+      val catalog =
+        spark.sessionState.catalogManager.catalog("testcat").asInstanceOf[TableCatalog]
+      val identifier = Identifier.of(Array("default"), "xdd")
+      val table = catalog.loadTable(identifier)
+      assert(table.partitioning().toSeq == Seq(Expressions.months("event_time")))
+    }
+  }
+
+  test("partition columns support identity AND transforms") {
+    withSQLConf("spark.sql.catalog.testcat" -> classOf[InMemoryTableCatalog].getName) {
+      materializeGraph(
+        new TestGraphRegistrationContext(spark) {
+          registerTable(
+            "testcat.default.xd",
+            query = Option(
+              dfFlowFunc(
+                Seq(
+                  ("kebab", java.sql.Timestamp.valueOf("2025-01-01 00:00:00"), 1),
+                  ("pizza", java.sql.Timestamp.valueOf("2025-02-01 00:00:00"), 2))
+                  .toDF("food", "event_time", "value"))),
+            specifiedSchema = Option(
+              new StructType()
+                .add("food", TimestampType)
+                .add("event_time", TimestampType)
+                .add("value", IntegerType)),
+            partitionCols = Option(Seq("food", "months(event_time)")))
+        }.resolveToDataflowGraph(),
+        storageRoot = storageRoot)
+
+      val catalog =
+        spark.sessionState.catalogManager.catalog("testcat").asInstanceOf[TableCatalog]
+      val identifier = Identifier.of(Array("default"), "xd")
+      val table = catalog.loadTable(identifier)
+      assert(
+        table.partitioning().toSeq == Seq(
+          Expressions.identity("food"),
+          Expressions.months("event_time")))
+    }
   }
 
   test("partition columns with user schema") {
@@ -390,21 +381,16 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           specifiedSchema = Option(
             new StructType()
               .add("x1", IntegerType)
-              .add("x2", IntegerType)
-          ),
-          partitionCols = Option(Seq("x2"))
-        )
+              .add("x2", IntegerType)),
+          partitionCols = Option(Seq("x2")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "a")
     val table = catalog.loadTable(identifier)
     assert(
       table.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        new StructType().add("x1", IntegerType).add("x2", IntegerType)
-      )
-    )
+        new StructType().add("x1", IntegerType).add("x2", IntegerType)))
     assert(table.partitioning().toSeq == Seq(Expressions.identity("x2")))
   }
 
@@ -412,8 +398,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t7(x BOOLEAN, y INT) " +
-      s"PARTITIONED BY (x)"
-    )
+        s"PARTITIONED BY (x)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t7")
     val table = catalog.loadTable(identifier)
@@ -422,54 +407,39 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         .add("x", BooleanType)
         .add("y", IntegerType)
         .fieldNames
-        .toSet
-    )
+        .toSet)
     assert(table.partitioning().toSeq == Seq(Expressions.identity("x")))
 
     // Specify the same partition column.
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
-        registerFlow(
-          "t7",
-          "t7",
-          query = dfFlowFunc(Seq((true, 1), (false, 3)).toDF("x", "y"))
-        )
-        registerTable(
-          "t7",
-          partitionCols = Option(Seq("x"))
-        )
+        registerFlow("t7", "t7", query = dfFlowFunc(Seq((true, 1), (false, 3)).toDF("x", "y")))
+        registerTable("t7", partitionCols = Option(Seq("x")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val table2 = catalog.loadTable(identifier)
     assert(
       table2.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType))
-    )
+        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType)))
     assert(table2.partitioning().toSeq == Seq(Expressions.identity("x")))
 
     // Don't specify any partition column; should throw.
     val ex = intercept[TableMaterializationException] {
       materializeGraph(
         new TestGraphRegistrationContext(spark) {
-          registerFlow(
-            "t7",
-            "t7",
-            query = dfFlowFunc(Seq((true, 1), (false, 3)).toDF("x", "y"))
-          )
+          registerFlow("t7", "t7", query = dfFlowFunc(Seq((true, 1), (false, 3)).toDF("x", "y")))
           registerTable("t7")
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
     }
-    assert(ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
+    assert(
+      ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
 
     val table3 = catalog.loadTable(identifier)
     assert(
       table3.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType))
-    )
+        .structTypeToV2Columns(new StructType().add("y", IntegerType).add("x", BooleanType)))
     assert(table3.partitioning().toSeq == Seq(Expressions.identity("x")))
   }
 
@@ -477,26 +447,22 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t8(x BOOLEAN, y INT) " +
-      s"PARTITIONED BY (x)"
-    )
+        s"PARTITIONED BY (x)")
 
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t8")
 
     // Specify a different partition column. Should throw.
     val graph = new TestGraphRegistrationContext(spark) {
-      registerFlow(
-        "t8",
-        "t8",
-        query = dfFlowFunc(Seq((true, 1), (false, 3)).toDF("x", "y"))
-      )
+      registerFlow("t8", "t8", query = dfFlowFunc(Seq((true, 1), (false, 3)).toDF("x", "y")))
       registerTable("t8", partitionCols = Option(Seq("y")))
     }.resolveToDataflowGraph()
 
     val ex = intercept[TableMaterializationException] {
       materializeGraph(graph, storageRoot = storageRoot)
     }
-    assert(ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
+    assert(
+      ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
     val table = catalog.loadTable(identifier)
     assert(table.partitioning().toSeq == Seq(Expressions.identity("x")))
   }
@@ -507,19 +473,13 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerTable(
           "a",
           query = Option(dfFlowFunc(spark.readStream.format("rate").load())),
-          properties = Map(
-            "pipelines.reset.allowed" -> "true",
-            "some.prop" -> "foo"
-          )
-        )
+          properties = Map("pipelines.reset.allowed" -> "true", "some.prop" -> "foo"))
         registerTable(
           "b",
           query = Option(sqlFlowFunc(spark, "SELECT * FROM STREAM a")),
-          properties = Map("pipelines.reset.alloweD" -> "true", "some.prop" -> "foo")
-        )
+          properties = Map("pipelines.reset.alloweD" -> "true", "some.prop" -> "foo"))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifierA = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "a")
@@ -527,10 +487,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     val tableA = catalog.loadTable(identifierA)
     val tableB = catalog.loadTable(identifierB)
 
-    val expectedProps = Map(
-      "pipelines.reset.allowed" -> "true",
-      "some.prop" -> "foo"
-    )
+    val expectedProps = Map("pipelines.reset.allowed" -> "true", "some.prop" -> "foo")
 
     assert(expectedProps.forall { case (k, v) => tableA.properties().asScala.get(k).contains(v) })
     assert(expectedProps.forall { case (k, v) => tableB.properties().asScala.get(k).contains(v) })
@@ -544,8 +501,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerTable(
           "a",
           query = Option(dfFlowFunc(Seq(1).toDF())),
-          properties = Map("pipelines.reset.allowed" -> "123")
-        )
+          properties = Map("pipelines.reset.allowed" -> "123"))
       }.resolveToDataflowGraph()
     val ex1 =
       intercept[TableMaterializationException] {
@@ -561,8 +517,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   ) {
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t9(x INT) " +
-      s"TBLPROPERTIES ('pipelines.someProperty' = 'foo')"
-    )
+        s"TBLPROPERTIES ('pipelines.someProperty' = 'foo')")
 
     val graph1 = new TestGraphRegistrationContext(spark) {
       registerTable("a", query = Option(dfFlowFunc(spark.readStream.format("rate").load())))
@@ -572,9 +527,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   for (isFullRefresh <- Seq(true, false)) {
-    test(
-      s"Complete tables should not evolve schema - isFullRefresh = $isFullRefresh"
-    ) {
+    test(s"Complete tables should not evolve schema - isFullRefresh = $isFullRefresh") {
       val rawGraph =
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y")))
@@ -596,11 +549,8 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             unresolvedGraph = graph,
             refreshTables = refreshSelection,
             fullRefreshTables = fullRefreshSelection,
-            storageRoot = storageRoot
-          )
-        ),
-        storageRoot = storageRoot
-      )
+            storageRoot = storageRoot)),
+        storageRoot = storageRoot)
 
       val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
       val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "b")
@@ -608,28 +558,23 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       val table = catalog.loadTable(identifier)
       assert(
         table.columns() sameElements CatalogV2Util
-          .structTypeToV2Columns(new StructType().add("x", IntegerType))
-      )
+          .structTypeToV2Columns(new StructType().add("x", IntegerType)))
 
       materializeGraph(
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y")))
           registerMaterializedView("b", query = sqlFlowFunc(spark, "SELECT y FROM a"))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
       val table2 = catalog.loadTable(identifier)
       assert(
         table2.columns() sameElements CatalogV2Util
-          .structTypeToV2Columns(new StructType().add("y", IntegerType))
-      )
+          .structTypeToV2Columns(new StructType().add("y", IntegerType)))
     }
   }
 
   for (isFullRefresh <- Seq(true, false)) {
-    test(
-      s"Streaming tables should evolve schema only if not full refresh = $isFullRefresh"
-    ) {
+    test(s"Streaming tables should evolve schema only if not full refresh = $isFullRefresh") {
       implicit val sqlCtx: SQLContext = spark.sqlContext
 
       val streamInts = MemoryStream[Int]
@@ -638,7 +583,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       val graph =
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(streamInts.toDF()))
-          registerTable("b", query = Option(sqlFlowFunc(spark, "SELECT value AS x FROM STREAM a")))
+          registerTable(
+            "b",
+            query = Option(sqlFlowFunc(spark, "SELECT value AS x FROM STREAM a")))
         }.resolveToDataflowGraph().validate(spark.sessionState.conf.caseSensitiveAnalysis)
 
       val (refreshSelection, fullRefreshSelection) = if (isFullRefresh) {
@@ -652,9 +599,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           unresolvedGraph = graph,
           refreshTables = refreshSelection,
           fullRefreshTables = fullRefreshSelection,
-          storageRoot = storageRoot
-        )
-      )
+          storageRoot = storageRoot))
       materializeGraph(graph, contextOpt = updateContextOpt, storageRoot = storageRoot)
 
       val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -662,41 +607,35 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       val table = catalog.loadTable(identifier)
       assert(
         table.columns() sameElements CatalogV2Util
-          .structTypeToV2Columns(new StructType().add("x", IntegerType))
-      )
+          .structTypeToV2Columns(new StructType().add("x", IntegerType)))
 
       materializeGraph(
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(streamInts.toDF()))
-          registerTable("b", query = Option(sqlFlowFunc(spark, "SELECT value AS y FROM STREAM a")))
+          registerTable(
+            "b",
+            query = Option(sqlFlowFunc(spark, "SELECT value AS y FROM STREAM a")))
         }.resolveToDataflowGraph().validate(spark.sessionState.conf.caseSensitiveAnalysis),
         contextOpt = updateContextOpt,
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
 
       val table2 = catalog.loadTable(identifier)
 
       if (isFullRefresh) {
         assert(
           table2.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-            new StructType().add("y", IntegerType)
-          )
-        )
+            new StructType().add("y", IntegerType)))
       } else {
         assert(
           table2.columns() sameElements CatalogV2Util.structTypeToV2Columns(
             new StructType()
               .add("x", IntegerType)
-              .add("y", IntegerType)
-          )
-        )
+              .add("y", IntegerType)))
       }
     }
   }
 
-  test(
-    "materialize only selected tables"
-  ) {
+  test("materialize only selected tables") {
 
     val graph = new TestGraphRegistrationContext(spark) {
       registerTable("a", query = Option(dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y"))))
@@ -711,19 +650,16 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           unresolvedGraph = graph,
           refreshTables = SomeTables(Set(fullyQualifiedIdentifier("a"))),
           fullRefreshTables = SomeTables(Set(fullyQualifiedIdentifier("c"))),
-          storageRoot = storageRoot
-        )
-      ),
-      storageRoot = storageRoot
-    )
+          storageRoot = storageRoot)),
+      storageRoot = storageRoot)
 
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
 
     val tableA =
       catalog.loadTable(Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "a"))
     assert(
-      !catalog.tableExists(Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "b"))
-    )
+      !catalog.tableExists(
+        Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "b")))
     val tableC =
       catalog.loadTable(Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "c"))
 
@@ -731,31 +667,27 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       tableA.columns() sameElements CatalogV2Util.structTypeToV2Columns(
         new StructType()
           .add("x", IntegerType)
-          .add("y", IntegerType)
-      )
-    )
+          .add("y", IntegerType)))
 
     assert(
       tableC.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(new StructType().add("y", IntegerType))
-    )
+        .structTypeToV2Columns(new StructType().add("y", IntegerType)))
   }
 
   test("tables with arrays and maps") {
 
     val rawGraph =
       new TestGraphRegistrationContext(spark) {
-        registerTable("a", query = Option(sqlFlowFunc(spark, "select map(1, struct('a', 'b')) m")))
+        registerTable(
+          "a",
+          query = Option(sqlFlowFunc(spark, "select map(1, struct('a', 'b')) m")))
         registerTable(
           "b",
-          query = Option(dfFlowFunc(Seq(Array(1, 3, 5), Array(2, 4, 6)).toDF("arr")))
-        )
+          query = Option(dfFlowFunc(Seq(Array(1, 3, 5), Array(2, 4, 6)).toDF("arr"))))
         registerTable(
           "c",
           query = Option(
-            sqlFlowFunc(spark, "select * from a join b where map_entries(m)[0].key = arr[0]")
-          )
-        )
+            sqlFlowFunc(spark, "select * from a join b where map_entries(m)[0].key = arr[0]")))
       }.resolveToDataflowGraph()
     materializeGraph(rawGraph, storageRoot = storageRoot)
     // Materialize twice because some logic compares the incoming schema with the previous one.
@@ -771,19 +703,13 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     assert(
       tableA.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        StructType.fromDDL("m MAP<int, struct<col1: string, col2: string>>")
-      )
-    )
+        StructType.fromDDL("m MAP<int, struct<col1: string, col2: string>>")))
     assert(
       tableB.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        StructType.fromDDL("arr ARRAY<int>")
-      )
-    )
+        StructType.fromDDL("arr ARRAY<int>")))
     assert(
       tableC.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        StructType.fromDDL("m MAP<int, struct<col1: string, col2: string>>, arr ARRAY<int>")
-      )
-    )
+        StructType.fromDDL("m MAP<int, struct<col1: string, col2: string>>, arr ARRAY<int>")))
   }
 
   test("tables with nested arrays and maps") {
@@ -791,19 +717,15 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       new TestGraphRegistrationContext(spark) {
         registerTable(
           "a",
-          query = Option(sqlFlowFunc(spark, "select map(0, map(0, struct('a', 'b'))) m"))
-        )
+          query = Option(sqlFlowFunc(spark, "select map(0, map(0, struct('a', 'b'))) m")))
         registerTable(
           "b",
           query = Option(
-            sqlFlowFunc(spark, "select array(array('a', 'b', 'c'), array('d', 'e', 'f')) arr")
-          )
-        )
+            sqlFlowFunc(spark, "select array(array('a', 'b', 'c'), array('d', 'e', 'f')) arr")))
         registerTable(
           "c",
           query =
-            Option(sqlFlowFunc(spark, "select * from a join b where m[0][0].col1 = arr[0][0]"))
-        )
+            Option(sqlFlowFunc(spark, "select * from a join b where m[0][0].col1 = arr[0][0]")))
 
       }.resolveToDataflowGraph()
     materializeGraph(rawGraph, storageRoot = storageRoot)
@@ -819,32 +741,25 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
     assert(
       tableA.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        StructType.fromDDL("m MAP<int, MAP<int, struct<col1: string, col2: string>>>")
-      )
-    )
+        StructType.fromDDL("m MAP<int, MAP<int, struct<col1: string, col2: string>>>")))
     assert(
       tableB.columns() sameElements CatalogV2Util
-        .structTypeToV2Columns(StructType.fromDDL("arr ARRAY<ARRAY<string>>"))
-    )
+        .structTypeToV2Columns(StructType.fromDDL("arr ARRAY<ARRAY<string>>")))
     assert(
-      tableC.columns() sameElements CatalogV2Util.structTypeToV2Columns(
-        StructType.fromDDL(
-          "m MAP<int, MAP<int, struct<col1: string, col2: string>>>, arr ARRAY<ARRAY<string>>"
-        )
-      )
-    )
+      tableC.columns() sameElements CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(
+        "m MAP<int, MAP<int, struct<col1: string, col2: string>>>, arr ARRAY<ARRAY<string>>")))
   }
 
   test("materializing no tables doesn't throw") {
 
     val graph1 =
-      new DataflowGraph(flows = Seq.empty, tables = Seq.empty, views = Seq.empty, sinks = Seq.empty)
+      new DataflowGraph(
+        flows = Seq.empty,
+        tables = Seq.empty,
+        views = Seq.empty,
+        sinks = Seq.empty)
     val graph2 = new TestGraphRegistrationContext(spark) {
-      registerFlow(
-        "a",
-        "a",
-        query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2"))
-      )
+      registerFlow("a", "a", query = dfFlowFunc(Seq((1, 1), (2, 3)).toDF("x", "x2")))
       registerTable("a")
     }.resolveToDataflowGraph()
 
@@ -857,11 +772,8 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           unresolvedGraph = graph2,
           refreshTables = NoTables,
           fullRefreshTables = NoTables,
-          storageRoot = storageRoot
-        )
-      ),
-      storageRoot = storageRoot
-    )
+          storageRoot = storageRoot)),
+      storageRoot = storageRoot)
   }
 
   test("cluster columns with user schema") {
@@ -875,13 +787,10 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             new StructType()
               .add("x1", IntegerType)
               .add("x2", IntegerType)
-              .add("x3", StringType)
-          ),
-          clusterCols = Option(Seq("x1", "x3"))
-        )
+              .add("x3", StringType)),
+          clusterCols = Option(Seq("x1", "x3")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "a")
     val table = catalog.loadTable(identifier)
@@ -890,12 +799,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         new StructType()
           .add("x1", IntegerType)
           .add("x2", IntegerType)
-          .add("x3", StringType)
-      )
-    )
-    val expectedClusterTransform = ClusterByTransform(
-      Seq(FieldReference("x1"), FieldReference("x3")).toSeq
-    )
+          .add("x3", StringType)))
+    val expectedClusterTransform =
+      ClusterByTransform(Seq(FieldReference("x1"), FieldReference("x3")).toSeq)
     assert(table.partitioning().contains(expectedClusterTransform))
   }
 
@@ -906,18 +812,15 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerTable(
           "t10",
           query = Option(dfFlowFunc(Seq((1, true, "a"), (2, false, "b")).toDF("x", "y", "z"))),
-          clusterCols = Option(Seq("x", "z"))
-        )
+          clusterCols = Option(Seq("x", "z")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t10")
     val table = catalog.loadTable(identifier)
-    val expectedClusterTransform = ClusterByTransform(
-      Seq(FieldReference("x"), FieldReference("z")).toSeq
-    )
+    val expectedClusterTransform =
+      ClusterByTransform(Seq(FieldReference("x"), FieldReference("z")).toSeq)
     assert(table.partitioning().contains(expectedClusterTransform))
 
     // Specify the same cluster columns - should work
@@ -926,12 +829,10 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerFlow(
           "t10",
           "t10",
-          query = dfFlowFunc(Seq((3, true, "c"), (4, false, "d")).toDF("x", "y", "z"))
-        )
+          query = dfFlowFunc(Seq((3, true, "c"), (4, false, "d")).toDF("x", "y", "z")))
         registerTable("t10", clusterCols = Option(Seq("x", "z")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val table2 = catalog.loadTable(identifier)
     assert(table2.partitioning().contains(expectedClusterTransform))
@@ -943,14 +844,13 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           registerFlow(
             "t10",
             "t10",
-            query = dfFlowFunc(Seq((5, true, "e"), (6, false, "f")).toDF("x", "y", "z"))
-          )
+            query = dfFlowFunc(Seq((5, true, "e"), (6, false, "f")).toDF("x", "y", "z")))
           registerTable("t10")
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
     }
-    assert(ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
+    assert(
+      ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
   }
 
   test("specifying cluster column different from existing clustered table") {
@@ -960,11 +860,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerTable(
           "t11",
           query = Option(dfFlowFunc(Seq((1, true, "a"), (2, false, "b")).toDF("x", "y", "z"))),
-          clusterCols = Option(Seq("x"))
-        )
+          clusterCols = Option(Seq("x")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
 
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t11")
@@ -976,14 +874,13 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           registerFlow(
             "t11",
             "t11",
-            query = dfFlowFunc(Seq((3, true, "c"), (4, false, "d")).toDF("x", "y", "z"))
-          )
+            query = dfFlowFunc(Seq((3, true, "c"), (4, false, "d")).toDF("x", "y", "z")))
           registerTable("t11", clusterCols = Option(Seq("y")))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
     }
-    assert(ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
+    assert(
+      ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
 
     val table = catalog.loadTable(identifier)
     val expectedClusterTransform = ClusterByTransform(Seq(FieldReference("x")).toSeq)
@@ -1001,13 +898,10 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             new StructType()
               .add("x1", IntegerType)
               .add("x2", IntegerType)
-              .add("x3", StringType)
-          ),
-          clusterCols = Option(Seq("x1", "x3"))
-        )
+              .add("x3", StringType)),
+          clusterCols = Option(Seq("x1", "x3")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t12")
     val table = catalog.loadTable(identifier)
@@ -1016,14 +910,11 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         new StructType()
           .add("x1", IntegerType)
           .add("x2", IntegerType)
-          .add("x3", StringType)
-      )
-    )
+          .add("x3", StringType)))
 
     val transforms = table.partitioning()
-    val expectedClusterTransform = ClusterByTransform(
-      Seq(FieldReference("x1"), FieldReference("x3")).toSeq
-    )
+    val expectedClusterTransform =
+      ClusterByTransform(Seq(FieldReference("x1"), FieldReference("x3")).toSeq)
     assert(transforms.contains(expectedClusterTransform))
   }
 
@@ -1034,11 +925,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerMaterializedView(
           "mv1",
           query = dfFlowFunc(Seq((1, 1, "x"), (2, 3, "y")).toDF("x1", "x2", "x3")),
-          clusterCols = Option(Seq("x1", "x2"))
-        )
+          clusterCols = Option(Seq("x1", "x2")))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "mv1")
     val table = catalog.loadTable(identifier)
@@ -1047,12 +936,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         new StructType()
           .add("x1", IntegerType)
           .add("x2", IntegerType)
-          .add("x3", StringType)
-      )
-    )
-    val expectedClusterTransform = ClusterByTransform(
-      Seq(FieldReference("x1"), FieldReference("x2")).toSeq
-    )
+          .add("x3", StringType)))
+    val expectedClusterTransform =
+      ClusterByTransform(Seq(FieldReference("x1"), FieldReference("x2")).toSeq)
     assert(table.partitioning().contains(expectedClusterTransform))
   }
 
@@ -1065,11 +951,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             "invalid_table",
             query = Option(dfFlowFunc(Seq((1, 1, "x"), (2, 3, "y")).toDF("x1", "x2", "x3"))),
             partitionCols = Option(Seq("x2")),
-            clusterCols = Option(Seq("x1", "x3"))
-          )
+            clusterCols = Option(Seq("x1", "x3")))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
     }
     assert(ex.cause.isInstanceOf[AnalysisException])
     val analysisEx = ex.cause.asInstanceOf[AnalysisException]
@@ -1084,11 +968,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           registerTable(
             "invalid_cluster_table",
             query = Option(dfFlowFunc(Seq((1, 1, "x"), (2, 3, "y")).toDF("x1", "x2", "x3"))),
-            clusterCols = Option(Seq("nonexistent_column"))
-          )
+            clusterCols = Option(Seq("nonexistent_column")))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
     }
     assert(ex.cause.isInstanceOf[AnalysisException])
   }
@@ -1105,8 +987,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   private def withRecordingCatalog(body: => Unit): Unit = {
     spark.conf.set(
       s"spark.sql.catalog.$recordingCatalogName",
-      classOf[RecordingInMemoryTableCatalog].getName
-    )
+      classOf[RecordingInMemoryTableCatalog].getName)
     try {
       spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $recordingCatalogName.$recordingNamespace")
       body
@@ -1135,11 +1016,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           specifiedSchema = Option(schema),
           properties = properties,
           catalog = Option(recordingCatalogName),
-          database = Option(recordingNamespace)
-        )
+          database = Option(recordingNamespace))
       }.resolveToDataflowGraph(),
-      storageRoot = storageRoot
-    )
+      storageRoot = storageRoot)
   }
 
   private def recordingCatalog: RecordingInMemoryTableCatalog =
@@ -1179,8 +1058,8 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
       val changes = recordingCatalog.recordedAlters.flatten
       assert(changes.forall(_.isInstanceOf[TableChange.SetProperty]))
-      val set = changes.collect {
-        case s: TableChange.SetProperty => s.property() -> s.value()
+      val set = changes.collect { case s: TableChange.SetProperty =>
+        s.property() -> s.value()
       }.toMap
       assert(set == Map("p.a" -> "2", "p.new" -> "n"))
 
@@ -1199,8 +1078,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       materializeStreamingTable(
         "t",
         new StructType().add("id", IntegerType).add("value", StringType),
-        Map("p.a" -> "1")
-      )
+        Map("p.a" -> "1"))
       assert(recordingCatalog.recordedAlters.size == 1)
 
       val changes = recordingCatalog.recordedAlters.flatten
@@ -1209,14 +1087,13 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       assert(
         loadTableFromRecordingCatalog("t").columns() sameElements
           CatalogV2Util.structTypeToV2Columns(
-            new StructType().add("id", IntegerType).add("value", StringType)
-          )
-      )
+            new StructType().add("id", IntegerType).add("value", StringType)))
     }
   }
 
-  test("SPARK-58517: re-materializing with a case-only column difference is a no-op under " +
-    "case-insensitive resolution") {
+  test(
+    "SPARK-58517: re-materializing with a case-only column difference is a no-op under " +
+      "case-insensitive resolution") {
     withRecordingCatalog {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         // Create the table with `value`, then re-materialize with the same column cased as `Value`.
@@ -1225,27 +1102,31 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         // original name/case. Before SPARK-58517 the case-sensitive merge instead added a second
         // `Value` column, corrupting the table.
         materializeStreamingTable(
-          "t", new StructType().add("id", IntegerType).add("value", StringType), Map.empty)
+          "t",
+          new StructType().add("id", IntegerType).add("value", StringType),
+          Map.empty)
         assert(recordingCatalog.recordedAlters.isEmpty)
 
         materializeStreamingTable(
-          "t", new StructType().add("id", IntegerType).add("Value", StringType), Map.empty)
-        assert(recordingCatalog.recordedAlters.isEmpty,
+          "t",
+          new StructType().add("id", IntegerType).add("Value", StringType),
+          Map.empty)
+        assert(
+          recordingCatalog.recordedAlters.isEmpty,
           s"expected no alter, got: ${recordingCatalog.recordedAlters}")
 
         assert(
           loadTableFromRecordingCatalog("t").columns() sameElements
             CatalogV2Util.structTypeToV2Columns(
-              new StructType().add("id", IntegerType).add("value", StringType)
-            ),
-          "the persisted schema should keep the original `value` column, not gain a `Value` column"
-        )
+              new StructType().add("id", IntegerType).add("value", StringType)),
+          "the persisted schema should keep the original `value` column, not gain a `Value` column")
       }
     }
   }
 
-  test("SPARK-58517: multi-flow schema inference folds case-only column differences under " +
-    "case-insensitive resolution") {
+  test(
+    "SPARK-58517: multi-flow schema inference folds case-only column differences under " +
+      "case-insensitive resolution") {
     withRecordingCatalog {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         // Two append flows write to the same streaming table, one emitting `value` and the other
@@ -1266,18 +1147,25 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             catalog = Option(recordingCatalogName),
             database = Option(recordingNamespace))
           registerFlow(
-            "t", "f1", dfFlowFunc(df1),
-            catalog = Option(recordingCatalogName), database = Option(recordingNamespace))
+            "t",
+            "f1",
+            dfFlowFunc(df1),
+            catalog = Option(recordingCatalogName),
+            database = Option(recordingNamespace))
           registerFlow(
-            "t", "f2", dfFlowFunc(df2),
-            catalog = Option(recordingCatalogName), database = Option(recordingNamespace))
+            "t",
+            "f2",
+            dfFlowFunc(df2),
+            catalog = Option(recordingCatalogName),
+            database = Option(recordingNamespace))
         }
 
         val graph = ctx.resolveToDataflowGraph()
         val inferredSchemas = graph.inferSchemas(spark.sessionState.conf.caseSensitiveAnalysis)
         val (targetIdentifier, inferred) = inferredSchemas.head
         val lowestIdentifierFlowValueField =
-          graph.resolvedFlowsTo(targetIdentifier)
+          graph
+            .resolvedFlowsTo(targetIdentifier)
             .sortBy(_.identifier.unquotedString)
             .head
             .schema
@@ -1289,8 +1177,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     }
   }
 
-  test("SPARK-58517: a case-only fold picks the same spelling for the materialized table and for " +
-    "downstream resolution, in either flow declaration order") {
+  test(
+    "SPARK-58517: a case-only fold picks the same spelling for the materialized table and for " +
+      "downstream resolution, in either flow declaration order") {
     // The table's schema is derived twice from the same flows, by two different callers: the graph
     // materializes the table from `inferSchemas`, while downstream flows resolve against the
     // `VirtualTableInput` schema, whose `availableFlows` is in declaration order, not sorted. Both
@@ -1348,8 +1237,9 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     }
   }
 
-  test("multi-flow schema inference keeps case-only column differences distinct under " +
-    "case-sensitive resolution") {
+  test(
+    "multi-flow schema inference keeps case-only column differences distinct under " +
+      "case-sensitive resolution") {
     withRecordingCatalog {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         // The case-sensitive control: `value` and `Value` are distinct columns, so inference
@@ -1367,24 +1257,31 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             catalog = Option(recordingCatalogName),
             database = Option(recordingNamespace))
           registerFlow(
-            "t", "f1", dfFlowFunc(df1),
-            catalog = Option(recordingCatalogName), database = Option(recordingNamespace))
+            "t",
+            "f1",
+            dfFlowFunc(df1),
+            catalog = Option(recordingCatalogName),
+            database = Option(recordingNamespace))
           registerFlow(
-            "t", "f2", dfFlowFunc(df2),
-            catalog = Option(recordingCatalogName), database = Option(recordingNamespace))
+            "t",
+            "f2",
+            dfFlowFunc(df2),
+            catalog = Option(recordingCatalogName),
+            database = Option(recordingNamespace))
         }
 
         val graph = ctx.resolveToDataflowGraph()
-        val inferred = graph.inferSchemas(
-          spark.sessionState.conf.caseSensitiveAnalysis).values.head
+        val inferred =
+          graph.inferSchemas(spark.sessionState.conf.caseSensitiveAnalysis).values.head
         // Both spellings survive as distinct columns in sorted flow identifier order.
         assert(inferred.fieldNames.toSeq === Seq("id", "value", "Value"))
       }
     }
   }
 
-  test("SPARK-58517: a materialized view's case-only column rename is applied under " +
-    "case-insensitive resolution") {
+  test(
+    "SPARK-58517: a materialized view's case-only column rename is applied under " +
+      "case-insensitive resolution") {
     // The non-merging path: for a materialized view `targetSchema` is the run's declared schema
     // as-is (no merge with the persisted schema), so a case-only rename must remain visible to
     // `diffSchemas` as a drop-then-add. Case-insensitive matching here would emit no change at all
@@ -1397,35 +1294,33 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           registerView("src", query = dfFlowFunc(Seq((1, 2L)).toDF("id", "total")))
           registerMaterializedView("mv", query = sqlFlowFunc(spark, "SELECT id, total FROM src"))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
 
       val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
       val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "mv")
       assert(
         catalog.loadTable(identifier).columns() sameElements CatalogV2Util.structTypeToV2Columns(
-          new StructType().add("id", IntegerType).add("total", LongType))
-      )
+          new StructType().add("id", IntegerType).add("total", LongType)))
 
       // Re-materialize with the column cased as `Total`. The table must follow the definition.
       materializeGraph(
         new TestGraphRegistrationContext(spark) {
           registerView("src", query = dfFlowFunc(Seq((1, 2L)).toDF("id", "total")))
           registerMaterializedView(
-            "mv", query = sqlFlowFunc(spark, "SELECT id, total AS Total FROM src"))
+            "mv",
+            query = sqlFlowFunc(spark, "SELECT id, total AS Total FROM src"))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
       assert(
         catalog.loadTable(identifier).columns() sameElements CatalogV2Util.structTypeToV2Columns(
           new StructType().add("id", IntegerType).add("Total", LongType)),
-        "the materialized view should adopt the declared `Total` casing, not keep `total`"
-      )
+        "the materialized view should adopt the declared `Total` casing, not keep `total`")
     }
   }
 
-  test("SPARK-58517: a full-refreshed streaming table's case-only column rename is applied " +
-    "under case-insensitive resolution") {
+  test(
+    "SPARK-58517: a full-refreshed streaming table's case-only column rename is applied " +
+      "under case-insensitive resolution") {
     // The streaming-table analog of the materialized-view case above: a full refresh also takes
     // `targetSchema` as the declared schema without merging, so the same case-only rename must be
     // applied rather than silently ignored.
@@ -1435,21 +1330,20 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           registerView("src", query = dfFlowFunc(Seq((1, 2L)).toDF("id", "total")))
           registerTable("st", query = Option(sqlFlowFunc(spark, "SELECT id, total FROM src")))
         }.resolveToDataflowGraph(),
-        storageRoot = storageRoot
-      )
+        storageRoot = storageRoot)
 
       val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
       val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "st")
       assert(
         catalog.loadTable(identifier).columns() sameElements CatalogV2Util.structTypeToV2Columns(
-          new StructType().add("id", IntegerType).add("total", LongType))
-      )
+          new StructType().add("id", IntegerType).add("total", LongType)))
 
       val renamedGraph =
         new TestGraphRegistrationContext(spark) {
           registerView("src", query = dfFlowFunc(Seq((1, 2L)).toDF("id", "total")))
           registerTable(
-            "st", query = Option(sqlFlowFunc(spark, "SELECT id, total AS Total FROM src")))
+            "st",
+            query = Option(sqlFlowFunc(spark, "SELECT id, total AS Total FROM src")))
         }.resolveToDataflowGraph()
 
       materializeGraph(
@@ -1460,34 +1354,36 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
             unresolvedGraph = graph,
             refreshTables = NoTables,
             fullRefreshTables = AllTables,
-            storageRoot = storageRoot
-          )
-        ),
-        storageRoot = storageRoot
-      )
+            storageRoot = storageRoot)),
+        storageRoot = storageRoot)
       assert(
         catalog.loadTable(identifier).columns() sameElements CatalogV2Util.structTypeToV2Columns(
           new StructType().add("id", IntegerType).add("Total", LongType)),
-        "a full-refreshed streaming table should adopt the declared `Total` casing"
-      )
+        "a full-refreshed streaming table should adopt the declared `Total` casing")
     }
   }
 
-  test("re-materializing with a case-only column difference adds a column under case-sensitive " +
-    "resolution") {
+  test(
+    "re-materializing with a case-only column difference adds a column under case-sensitive " +
+      "resolution") {
     withRecordingCatalog {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         // The case-sensitive counterpart: `value` and `Value` are distinct, so `Value` is added.
         materializeStreamingTable(
-          "t", new StructType().add("id", IntegerType).add("value", StringType), Map.empty)
+          "t",
+          new StructType().add("id", IntegerType).add("value", StringType),
+          Map.empty)
         assert(recordingCatalog.recordedAlters.isEmpty)
 
         materializeStreamingTable(
-          "t", new StructType().add("id", IntegerType).add("Value", StringType), Map.empty)
+          "t",
+          new StructType().add("id", IntegerType).add("Value", StringType),
+          Map.empty)
         assert(recordingCatalog.recordedAlters.size == 1)
         val changes = recordingCatalog.recordedAlters.flatten
-        assert(changes.collect { case ac: TableChange.AddColumn => ac.fieldNames()(0) } ==
-          Seq("Value"))
+        assert(
+          changes.collect { case ac: TableChange.AddColumn => ac.fieldNames()(0) } ==
+            Seq("Value"))
       }
     }
   }
@@ -1500,8 +1396,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     withRecordingCatalog {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         materializeGraph(
-          new TestGraphRegistrationContext(
-            spark, Map(SQLConf.CASE_SENSITIVE.key -> "true")) {
+          new TestGraphRegistrationContext(spark, Map(SQLConf.CASE_SENSITIVE.key -> "true")) {
             registerView("src", query = dfFlowFunc(Seq((1, "a")).toDF("id", "value")))
             registerTable(
               "t",
@@ -1509,16 +1404,14 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
               catalog = Option(recordingCatalogName),
               database = Option(recordingNamespace))
           }.resolveToDataflowGraph(),
-          storageRoot = storageRoot
-        )
+          storageRoot = storageRoot)
         assert(
           loadTableFromRecordingCatalog("t").columns() sameElements
             CatalogV2Util.structTypeToV2Columns(
               new StructType().add("id", IntegerType).add("value", StringType)))
 
         materializeGraph(
-          new TestGraphRegistrationContext(
-            spark, Map(SQLConf.CASE_SENSITIVE.key -> "true")) {
+          new TestGraphRegistrationContext(spark, Map(SQLConf.CASE_SENSITIVE.key -> "true")) {
             registerView("src", query = dfFlowFunc(Seq((1, "a")).toDF("id", "value")))
             registerTable(
               "t",
@@ -1526,8 +1419,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
               catalog = Option(recordingCatalogName),
               database = Option(recordingNamespace))
           }.resolveToDataflowGraph(),
-          storageRoot = storageRoot
-        )
+          storageRoot = storageRoot)
         assert(
           loadTableFromRecordingCatalog("t").columns() sameElements
             CatalogV2Util.structTypeToV2Columns(
@@ -1548,16 +1440,19 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       registerView("src", query = dfFlowFunc(Seq((1, "a")).toDF("id", "value")))
       registerTable("t")
       registerFlow(
-        "t", "f1", sqlFlowFunc(spark, "SELECT id, value FROM src"),
+        "t",
+        "f1",
+        sqlFlowFunc(spark, "SELECT id, value FROM src"),
         sqlConf = Map(SQLConf.CASE_SENSITIVE.key -> "true"))
       registerFlow(
-        "t", "f2", sqlFlowFunc(spark, "SELECT id, value AS Value FROM src"),
+        "t",
+        "f2",
+        sqlFlowFunc(spark, "SELECT id, value AS Value FROM src"),
         sqlConf = Map(SQLConf.CASE_SENSITIVE.key -> "false"))
     }
 
     val ex = intercept[AnalysisException] {
-      ctx.resolveToDataflowGraph().inferSchemas(
-        spark.sessionState.conf.caseSensitiveAnalysis)
+      ctx.resolveToDataflowGraph().inferSchemas(spark.sessionState.conf.caseSensitiveAnalysis)
     }
     checkError(
       exception = ex,
@@ -1566,9 +1461,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         "tableName" -> "spark_catalog.test_db.t",
         "configKey" -> SQLConf.CASE_SENSITIVE.key,
         "flowConfigurations" ->
-          ("false (spark_catalog.test_db.f2); true (spark_catalog.test_db.f1)")
-      )
-    )
+          ("false (spark_catalog.test_db.f2); true (spark_catalog.test_db.f1)")))
   }
 
   test("SPARK-58517: a flow inheriting the session value conflicts with one that overrides it") {
@@ -1580,14 +1473,15 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerView("src", query = dfFlowFunc(Seq((1, "a")).toDF("id", "value")))
         registerTable("t")
         registerFlow(
-          "t", "f1", sqlFlowFunc(spark, "SELECT id, value FROM src"),
+          "t",
+          "f1",
+          sqlFlowFunc(spark, "SELECT id, value FROM src"),
           sqlConf = Map(SQLConf.CASE_SENSITIVE.key -> "true"))
         registerFlow("t", "f2", sqlFlowFunc(spark, "SELECT id, value FROM src"))
       }
 
       val ex = intercept[AnalysisException] {
-        ctx.resolveToDataflowGraph().inferSchemas(
-          spark.sessionState.conf.caseSensitiveAnalysis)
+        ctx.resolveToDataflowGraph().inferSchemas(spark.sessionState.conf.caseSensitiveAnalysis)
       }
       assert(ex.getCondition === "CONFLICTING_PIPELINE_FLOW_CASE_SENSITIVITY")
       assert(ex.getMessage.contains("session default"))
@@ -1602,13 +1496,18 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
         registerView("src", query = dfFlowFunc(Seq((1, "a")).toDF("id", "value")))
         registerTable("t")
         registerFlow(
-          "t", "f1", sqlFlowFunc(spark, "SELECT id, value FROM src"),
+          "t",
+          "f1",
+          sqlFlowFunc(spark, "SELECT id, value FROM src"),
           sqlConf = Map(SQLConf.CASE_SENSITIVE.key -> "true"))
         registerFlow(
-          "t", "f2", sqlFlowFunc(spark, "SELECT id, value AS Value FROM src"),
+          "t",
+          "f2",
+          sqlFlowFunc(spark, "SELECT id, value AS Value FROM src"),
           sqlConf = Map(SQLConf.CASE_SENSITIVE.key -> "TRUE"))
       }
-      val inferred = ctx.resolveToDataflowGraph()
+      val inferred = ctx
+        .resolveToDataflowGraph()
         .inferSchemas(spark.sessionState.conf.caseSensitiveAnalysis)(
           fullyQualifiedIdentifier("t"))
       // Case-sensitive, so both spellings survive.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support partition transforms in SDP `partition_cols`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently all entries in `partition_cols` are converted to identity transform and cannot use partition transform even though Spark SQL and the V2 catalog support them.

Creating any table like 

```python
@dp.materialized_view(partition_cols=["months(event_ts)"])
def table():
    ...
```

would treat `months(event_ts)` as a column name instead of a partition transform.

Fixes #57908

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, `partition_cols` can now contain partition transform expressions.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Added Catalyst parser tests for partition transforms.
- Added materialization tests for transformed and mixed/transformed partitioning.
- Ran `./build/mvn -dskipTests package` OK
- `./build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.parser.PlanParserSuite"`
- `./build/sbt "pipelines/testOnly org.apache.spark.sql.pipelines.graph.DefaultMaterializeTablesSuite"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
I used OpenAI GPT-5.6 Sol for brainstorming etc.