### PR TITLE
[SPARK-58630][PS] Use native Spark function for NumPy copysign

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -118,14 +118,23 @@ def _fmod_func(c1: Column, c2: Column) -> Column:
     )
 
 
+def _copysign_func(c1: Column, c2: Column) -> Column:
+    # np.copysign: magnitude of c1 with the sign BIT of c2. The sign test is
+    # bit-aware: c2 == -0.0 counts as negative (sign bit set) though -0.0 < 0 is False.
+    c1_double = c1.cast("double")
+    return (
+        F.when(c1.isNull() | c2.isNull(), F.lit(None).cast("double"))
+        .when((c2 < 0) | (c2.cast("string") == "-0.0"), -F.abs(c1_double))
+        .otherwise(F.abs(c1_double))
+    )
+
+
 binary_np_spark_mappings = {
     "arctan2": F.atan2,
     "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
     "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
     "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
-    "copysign": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.copysign(s1, s2), DoubleType()
-    ),
+    "copysign": _copysign_func,
     "float_power": lambda c1, c2: F.pow(c1.cast("double"), c2.cast("double")),
     "floor_divide": pandas_udf(  # type: ignore[call-overload]
         lambda s1, s2: np.floor_divide(s1, s2), DoubleType()

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -284,6 +284,47 @@ class NumPyCompatTestsMixin:
                 np.heaviside(psdf.x1, psdf.x2), np.heaviside(pdf.x1, pdf.x2), almost=True
             )
 
+    def test_np_copysign(self):
+        # Integer inputs -> float result.
+        pdf = pd.DataFrame({"x1": [-64, -2, -1, 0, 1, 2, 64], "x2": [2, 3, -2, -3, 1, -1, 2]})
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.copysign(psdf.x1, psdf.x2), np.copysign(pdf.x1, pdf.x2), almost=True)
+
+        # inf and nan in both positions. Rows are chosen so the result sign differs
+        # from x1's own sign, so only correct sign transfer (not passing x1 through) passes.
+        pdf = pd.DataFrame(
+            {
+                "x1": [np.inf, -np.inf, np.inf, -np.inf, 2.0, -2.0, np.nan, 1.0],
+                "x2": [1.0, 1.0, -1.0, -1.0, np.inf, -np.inf, -1.0, np.nan],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.copysign(psdf.x1, psdf.x2), np.copysign(pdf.x1, pdf.x2), almost=True)
+
+        # Signed zero: -0.0 has its sign bit set though -0.0 < 0 is False. Since
+        # +0.0 and -0.0 compare equal under almost=, pin the outputs with signbit.
+        pdf = pd.DataFrame(
+            {
+                "x1": [1.0, 1.0, 0.0, 0.0, -0.0, -0.0],
+                "x2": [-0.0, 0.0, -1.0, 1.0, -1.0, 1.0],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        result = np.copysign(psdf.x1, psdf.x2)
+        expected = np.copysign(pdf.x1, pdf.x2)
+        self.assert_eq(result, expected, almost=True)
+        self.assert_eq(np.signbit(result.to_pandas()), np.signbit(expected))
+
+        # NA in either argument propagates to NA.
+        pdf = pd.DataFrame(
+            {
+                "x1": pd.array([1, 2, None, None], dtype="Int64"),
+                "x2": pd.array([2, None, 2, None], dtype="Int64"),
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.copysign(psdf.x1, psdf.x2), np.copysign(pdf.x1, pdf.x2), almost=True)
+
     def test_np_spark_compat_series(self):
         from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the `pandas_udf`-based implementation of `numpy.copysign` in the pandas API on Spark with a native Spark SQL expression.

`np.copysign(a, b)` returns the magnitude of `a` with the sign bit of `b`. The native expression handles the edge cases that a naive `b < 0` test would miss:

- **Signed zero**: `-0.0` has its sign bit set (`np.copysign(1.0, -0.0) == -1.0`) even though `-0.0 < 0` is `False` in Spark. The sign test additionally checks `cast(b as string) == '-0.0'`, mirroring the existing `reciprocal` mapping in the same file.
- **Null**: NA in either argument propagates to NULL, guarded explicitly so that a null `b` does not fall through the sign predicate (a null condition in a `CASE WHEN` is not matched, which would otherwise leak a wrong non-null result).

### Why are the changes needed?

The `pandas_udf` fallback ships every row JVM -> Python worker -> JVM through Arrow serialization, runs NumPy, and ships the results back. A native expression runs in the JVM, code-generates, and is visible to the optimizer. This is part of the umbrella [SPARK-58532](https://issues.apache.org/jira/browse/SPARK-58532).

### Does this PR introduce _any_ user-facing change?

No. The behavior is preserved, including the double result type of the previous `pandas_udf` implementation.

### How was this patch tested?

Added `test_np_copysign` to `NumPyCompatTestsMixin`, covering integer inputs (float result), infinities and NaN in both positions, signed zero (pinned with `np.signbit` since `almost=` cannot distinguish `-0.0` from `+0.0`), and null propagation via a nullable `Int64` frame. The Connect parity suite inherits the mixin automatically.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
