### PR TITLE
[SPARK-41246][CORE] Fail-fast RDD id overflow with optional 64-bit continue

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -262,7 +262,7 @@ message RDDPartitionInfo {
 }
 
 message RDDStorageInfo {
-  int32 id = 1;
+  int64 id = 1;
   optional string name = 2;
   int32 num_partitions = 3;
   int32 num_cached_partitions = 4;
@@ -462,8 +462,8 @@ message SparkPlanGraphWrapper {
 }
 
 message RDDOperationEdge {
-  int32 from_id = 1;
-  int32 to_id = 2;
+  int64 from_id = 1;
+  int64 to_id = 2;
 }
 
 enum DeterministicLevel {
@@ -474,7 +474,7 @@ enum DeterministicLevel {
 }
 
 message RDDOperationNode {
-  int32 id = 1;
+  int64 id = 1;
   optional string name = 2;
   bool cached = 3;
   bool barrier = 4;

--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -36,11 +36,11 @@ import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, ThreadUtils, Ut
  * Classes that represent cleaning tasks.
  */
 private sealed trait CleanupTask
-private case class CleanRDD(rddId: Int) extends CleanupTask
+private case class CleanRDD(rddId: Long) extends CleanupTask
 private case class CleanShuffle(shuffleId: Int) extends CleanupTask
 private case class CleanBroadcast(broadcastId: Long) extends CleanupTask
 private case class CleanAccum(accId: Long) extends CleanupTask
-private case class CleanCheckpoint(rddId: Int) extends CleanupTask
+private case class CleanCheckpoint(rddId: Long) extends CleanupTask
 private case class CleanSparkListener(listener: SparkListener) extends CleanupTask
 
 /**
@@ -153,7 +153,7 @@ private[spark] class ContextCleaner(
 
   /** Register an RDD for cleanup when it is garbage collected. */
   def registerRDDForCleanup(rdd: RDD[_]): Unit = {
-    registerForCleanup(rdd, CleanRDD(rdd.id))
+    registerForCleanup(rdd, CleanRDD(rdd.idLong))
   }
 
   def registerAccumulatorForCleanup(a: AccumulatorV2[_, _]): Unit = {
@@ -171,7 +171,7 @@ private[spark] class ContextCleaner(
   }
 
   /** Register a RDDCheckpointData for cleanup when it is garbage collected. */
-  def registerRDDCheckpointDataForCleanup[T](rdd: RDD[_], parentId: Int): Unit = {
+  def registerRDDCheckpointDataForCleanup[T](rdd: RDD[_], parentId: Long): Unit = {
     registerForCleanup(rdd, CleanCheckpoint(parentId))
   }
 
@@ -222,7 +222,7 @@ private[spark] class ContextCleaner(
   }
 
   /** Perform RDD cleanup. */
-  def doCleanupRDD(rddId: Int, blocking: Boolean): Unit = {
+  def doCleanupRDD(rddId: Long, blocking: Boolean): Unit = {
     try {
       logDebug("Cleaning RDD " + rddId)
       sc.unpersistRDD(rddId, blocking)
@@ -299,7 +299,7 @@ private[spark] class ContextCleaner(
    * Clean up checkpoint files written to a reliable storage.
    * Locally checkpointed files are cleaned up separately through RDD cleanups.
    */
-  def doCleanCheckpoint(rddId: Int): Unit = {
+  def doCleanCheckpoint(rddId: Long): Unit = {
     try {
       logDebug("Cleaning rdd checkpoint data " + rddId)
       ReliableRDDCheckpointData.cleanCheckpoint(sc, rddId)
@@ -337,7 +337,7 @@ private object ContextCleaner {
  * Listener class used when any item has been cleaned by the Cleaner class.
  */
 private[spark] trait CleanerListener {
-  def rddCleaned(rddId: Int): Unit
+  def rddCleaned(rddId: Long): Unit
   def shuffleCleaned(shuffleId: Int): Unit
   def broadcastCleaned(broadcastId: Long): Unit
   def accumCleaned(accId: Long): Unit

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -227,7 +227,7 @@ class RangePartitioner[K : Ordering : ClassTag, V](
         if (imbalancedPartitions.nonEmpty) {
           // Re-sample imbalanced partitions with the desired sampling probability.
           val imbalanced = new PartitionPruningRDD(rdd.map(_._1), imbalancedPartitions.contains)
-          val seed = byteswap32(-rdd.id - 1)
+          val seed = byteswap32(-rdd.idLong.hashCode - 1)
           val reSampled = imbalanced.sample(withReplacement = false, fraction, seed).collect()
           val weight = (1.0 / fraction).toFloat
           candidates ++= reSampled.map(x => (x, weight))

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -21,7 +21,7 @@ import java.io._
 import java.net.URI
 import java.util.{Arrays, Locale, Properties, ServiceLoader, UUID}
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
 
 import scala.collection.Map
 import scala.collection.concurrent.{Map => ScalaConcurrentMap}
@@ -2901,10 +2901,55 @@ class SparkContext(config: SparkConf) extends Logging {
 
   private[spark] def newShuffleId(): Int = nextShuffleId.getAndIncrement()
 
-  private val nextRddId = new AtomicInteger(0)
+  private val nextRddId = new AtomicLong(0)
 
-  /** Register a new RDD, returning its RDD ID */
-  private[spark] def newRddId(): Int = nextRddId.getAndIncrement()
+  /**
+   * Testing helper: set the next value that [[newRddId]] will return.
+   */
+  private[spark] def setNextRddIdForTesting(value: Long): Unit = nextRddId.set(value)
+
+  /**
+   * Register a new RDD, returning its 64-bit id.
+   *
+   * The public [[org.apache.spark.rdd.RDD.id]] API remains a 32-bit Int for
+   * source/binary compatibility (`int id = rdd.id()` still compiles). The
+   * allocator uses AtomicLong so overflow past Int.MaxValue is detected
+   * instead of silently wrapping to negative values (which breaks
+   * BlockId parsing and other id-keyed state).
+   *
+   * Under spark.rdd.id.overflow.policy=fail (default), allocation past
+   * Int.MaxValue throws. Under 'legacy', ids wrap like AtomicInteger and
+   * BlockId accepts the resulting negative names.
+   */
+  private[spark] def newRddId(): Long = {
+    val id = nextRddId.getAndIncrement()
+    if (id > Int.MaxValue) {
+      conf.get(RDD_ID_OVERFLOW_POLICY) match {
+        case "legacy" =>
+          if (id == Int.MaxValue.toLong + 1L) {
+            logError("The RDD id counter has overflowed Int.MaxValue under " +
+              "spark.rdd.id.overflow.policy=legacy. Negative RDD ids will be " +
+              "used; this can affect BlockManager, UI, and other id-keyed " +
+              "state. Restart the application. Prefer the default 'fail' " +
+              "policy.")
+          }
+          id
+        case _ =>
+          // Stay pegged so subsequent allocations keep failing clearly.
+          nextRddId.set(id)
+          throw new SparkException(
+            "RDD id counter would exceed Int.MaxValue (" + Int.MaxValue +
+              "). This application has created too many RDDs; restart it. " +
+              "Set spark.rdd.id.overflow.policy=legacy only as an emergency " +
+              "workaround (negative ids; not recommended).")
+      }
+    } else if (id == Int.MaxValue) {
+      logWarning("Allocated the last valid 32-bit RDD id (Int.MaxValue). " +
+        "Further RDD creation will fail under " +
+        "spark.rdd.id.overflow.policy=fail.")
+    }
+    id
+  }
 
   /**
    * Registers listeners specified in spark.extraListeners, then starts the listener bus.

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2912,17 +2912,38 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Register a new RDD, returning its 64-bit id.
    *
-   * Ids increase monotonically via AtomicLong so applications can create
-   * more than Int.MaxValue RDDs. The public [[org.apache.spark.rdd.RDD.id]]
-   * accessor remains Int for Java compatibility (`int id = rdd.id()`) and
-   * throws once the id exceeds Int.MaxValue; callers should use
-   * [[org.apache.spark.rdd.RDD.idLong]] in that case.
+   * Allocation uses AtomicLong so overflow past Int.MaxValue is detected
+   * instead of silently wrapping to negative Ints.
+   *
+   * Under spark.rdd.id.overflow.policy=fail (default), allocation past
+   * Int.MaxValue throws (fail-fast). Under 'continue', ids keep growing as
+   * Long values for [[org.apache.spark.rdd.RDD.idLong]]; the Int accessor
+   * [[org.apache.spark.rdd.RDD.id]] throws past Int.MaxValue.
    */
   private[spark] def newRddId(): Long = {
     val id = nextRddId.getAndIncrement()
-    if (id == Int.MaxValue.toLong + 1L) {
-      logWarning("RDD id counter has exceeded Int.MaxValue. Subsequent RDD " +
-        "ids use 64-bit values; use RDD.idLong instead of RDD.id.")
+    if (id > Int.MaxValue) {
+      conf.get(RDD_ID_OVERFLOW_POLICY) match {
+        case "continue" =>
+          if (id == Int.MaxValue.toLong + 1L) {
+            logWarning("RDD id counter has exceeded Int.MaxValue under " +
+              "spark.rdd.id.overflow.policy=continue. Subsequent RDD ids " +
+              "use 64-bit values; use RDD.idLong instead of RDD.id.")
+          }
+          id
+        case _ =>
+          // Stay pegged so subsequent allocations keep failing clearly.
+          nextRddId.set(id)
+          throw new SparkException(
+            "RDD id counter would exceed Int.MaxValue (" + Int.MaxValue +
+              "). This application has created too many RDDs; restart it. " +
+              "Set spark.rdd.id.overflow.policy=continue to keep allocating " +
+              "64-bit ids (use RDD.idLong).")
+      }
+    } else if (id == Int.MaxValue) {
+      logWarning("Allocated the last valid 32-bit RDD id (Int.MaxValue). " +
+        "Further RDD creation will fail under " +
+        "spark.rdd.id.overflow.policy=fail.")
     }
     id
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -311,7 +311,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
   // Keeps track of all persisted RDDs
   private[spark] val persistentRdds = {
-    val map: ConcurrentMap[Int, RDD[_]] = new MapMaker().weakValues().makeMap[Int, RDD[_]]()
+    val map: ConcurrentMap[Long, RDD[_]] =
+      new MapMaker().weakValues().makeMap[Long, RDD[_]]()
     map.asScala
   }
   def statusTracker: SparkStatusTracker = _statusTracker
@@ -2108,7 +2109,7 @@ class SparkContext(config: SparkConf) extends Logging {
    *
    * @note This does not necessarily mean the caching or computation was successful.
    */
-  def getPersistentRDDs: Map[Int, RDD[_]] = persistentRdds.toMap
+  def getPersistentRDDs: Map[Long, RDD[_]] = persistentRdds.toMap
 
   /**
    * :: DeveloperApi ::
@@ -2153,13 +2154,13 @@ class SparkContext(config: SparkConf) extends Logging {
    * Register an RDD to be persisted in memory and/or disk storage
    */
   private[spark] def persistRDD(rdd: RDD[_]): Unit = {
-    persistentRdds(rdd.id) = rdd
+    persistentRdds(rdd.idLong) = rdd
   }
 
   /**
    * Unpersist an RDD from memory and/or disk storage
    */
-  private[spark] def unpersistRDD(rddId: Int, blocking: Boolean): Unit = {
+  private[spark] def unpersistRDD(rddId: Long, blocking: Boolean): Unit = {
     env.blockManager.master.removeRdd(rddId, blocking)
     persistentRdds.remove(rddId)
     listenerBus.post(SparkListenerUnpersistRDD(rddId))
@@ -2911,42 +2912,17 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Register a new RDD, returning its 64-bit id.
    *
-   * The public [[org.apache.spark.rdd.RDD.id]] API remains a 32-bit Int for
-   * source/binary compatibility (`int id = rdd.id()` still compiles). The
-   * allocator uses AtomicLong so overflow past Int.MaxValue is detected
-   * instead of silently wrapping to negative values (which breaks
-   * BlockId parsing and other id-keyed state).
-   *
-   * Under spark.rdd.id.overflow.policy=fail (default), allocation past
-   * Int.MaxValue throws. Under 'legacy', ids wrap like AtomicInteger and
-   * BlockId accepts the resulting negative names.
+   * Ids increase monotonically via AtomicLong so applications can create
+   * more than Int.MaxValue RDDs. The public [[org.apache.spark.rdd.RDD.id]]
+   * accessor remains Int for Java compatibility (`int id = rdd.id()`) and
+   * throws once the id exceeds Int.MaxValue; callers should use
+   * [[org.apache.spark.rdd.RDD.idLong]] in that case.
    */
   private[spark] def newRddId(): Long = {
     val id = nextRddId.getAndIncrement()
-    if (id > Int.MaxValue) {
-      conf.get(RDD_ID_OVERFLOW_POLICY) match {
-        case "legacy" =>
-          if (id == Int.MaxValue.toLong + 1L) {
-            logError("The RDD id counter has overflowed Int.MaxValue under " +
-              "spark.rdd.id.overflow.policy=legacy. Negative RDD ids will be " +
-              "used; this can affect BlockManager, UI, and other id-keyed " +
-              "state. Restart the application. Prefer the default 'fail' " +
-              "policy.")
-          }
-          id
-        case _ =>
-          // Stay pegged so subsequent allocations keep failing clearly.
-          nextRddId.set(id)
-          throw new SparkException(
-            "RDD id counter would exceed Int.MaxValue (" + Int.MaxValue +
-              "). This application has created too many RDDs; restart it. " +
-              "Set spark.rdd.id.overflow.policy=legacy only as an emergency " +
-              "workaround (negative ids; not recommended).")
-      }
-    } else if (id == Int.MaxValue) {
-      logWarning("Allocated the last valid 32-bit RDD id (Int.MaxValue). " +
-        "Further RDD creation will fail under " +
-        "spark.rdd.id.overflow.policy=fail.")
+    if (id == Int.MaxValue.toLong + 1L) {
+      logWarning("RDD id counter has exceeded Int.MaxValue. Subsequent RDD " +
+        "ids use 64-bit values; use RDD.idLong instead of RDD.id.")
     }
     id
   }

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -824,9 +824,10 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    *
    * @note This does not necessarily mean the caching or computation was successful.
    */
-  def getPersistentRDDs: JMap[java.lang.Integer, JavaRDD[_]] = {
-    sc.getPersistentRDDs.toMap.transform((_, s) => JavaRDD.fromRDD(s))
-      .asJava.asInstanceOf[JMap[java.lang.Integer, JavaRDD[_]]]
+  def getPersistentRDDs: JMap[java.lang.Long, JavaRDD[_]] = {
+    sc.getPersistentRDDs.map { case (k, v) =>
+      (java.lang.Long.valueOf(k), JavaRDD.fromRDD(v))
+    }.asJava
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/BasicEventFilterBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/BasicEventFilterBuilder.scala
@@ -32,7 +32,7 @@ import org.apache.spark.storage.BlockManagerId
 private[spark] class BasicEventFilterBuilder extends SparkListener with EventFilterBuilder {
   private val liveJobToStages = new mutable.HashMap[Int, Set[Int]]
   private val stageToTasks = new mutable.HashMap[Int, mutable.Set[Long]]
-  private val stageToRDDs = new mutable.HashMap[Int, Set[Int]]
+  private val stageToRDDs = new mutable.HashMap[Int, Set[Long]]
   private val _liveExecutors = new mutable.HashSet[String]
 
   private var totalJobs: Long = 0L
@@ -42,7 +42,7 @@ private[spark] class BasicEventFilterBuilder extends SparkListener with EventFil
   private[history] def liveJobs: Set[Int] = liveJobToStages.keySet.toSet
   private[history] def liveStages: Set[Int] = stageToRDDs.keySet.toSet
   private[history] def liveTasks: Set[Long] = stageToTasks.values.flatten.toSet
-  private[history] def liveRDDs: Set[Int] = stageToRDDs.values.flatten.toSet
+  private[history] def liveRDDs: Set[Long] = stageToRDDs.values.flatten.toSet
   private[history] def liveExecutors: Set[String] = _liveExecutors.toSet
 
   override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
@@ -98,7 +98,7 @@ private[spark] abstract class JobEventFilter(
     liveJobs: Set[Int],
     liveStages: Set[Int],
     liveTasks: Set[Long],
-    liveRDDs: Set[Int]) extends EventFilter with Logging {
+    liveRDDs: Set[Long]) extends EventFilter with Logging {
 
   logDebug(s"jobs : $liveJobs")
   logDebug(s"stages : $liveStages")
@@ -143,7 +143,7 @@ private[spark] class BasicEventFilter(
     liveJobs: Set[Int],
     liveStages: Set[Int],
     liveTasks: Set[Long],
-    liveRDDs: Set[Int],
+    liveRDDs: Set[Long],
     liveExecutors: Set[String])
   extends JobEventFilter(
     Some(stats),

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2494,20 +2494,6 @@ package object config {
     .booleanConf
     .createWithDefault(true)
 
-  private[spark] val RDD_ID_OVERFLOW_POLICY =
-    ConfigBuilder("spark.rdd.id.overflow.policy")
-      .doc("Policy when the RDD id counter would exceed Int.MaxValue. " +
-        "'fail' (default) aborts further RDD creation so overflow is not " +
-        "silent across BlockManager, UI, and other id-keyed state. " +
-        "'legacy' wraps like a 32-bit counter (negative ids) for emergency " +
-        "use only; BlockId parsing accepts those names. Prefer restarting " +
-        "the application over 'legacy'.")
-      .version("4.4.0")
-      .stringConf
-      .transform(_.toLowerCase(Locale.ROOT))
-      .checkValues(Set("fail", "legacy"))
-      .createWithDefault("fail")
-
   private[spark] val RDD_PARALLEL_LISTING_THRESHOLD =
     ConfigBuilder("spark.rdd.parallelListingThreshold")
       .version("2.0.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2494,6 +2494,20 @@ package object config {
     .booleanConf
     .createWithDefault(true)
 
+  private[spark] val RDD_ID_OVERFLOW_POLICY =
+    ConfigBuilder("spark.rdd.id.overflow.policy")
+      .doc("Policy when the RDD id counter would exceed Int.MaxValue. " +
+        "'fail' (default) aborts further RDD creation with a clear error " +
+        "so overflow is not silent. 'continue' keeps allocating 64-bit ids " +
+        "(RDD.idLong); RDD.id throws past Int.MaxValue and callers must " +
+        "use idLong. Prefer 'fail' unless the application is prepared for " +
+        "64-bit RDD ids throughout.")
+      .version("4.4.0")
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValues(Set("fail", "continue"))
+      .createWithDefault("fail")
+
   private[spark] val RDD_PARALLEL_LISTING_THRESHOLD =
     ConfigBuilder("spark.rdd.parallelListingThreshold")
       .version("2.0.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2494,6 +2494,20 @@ package object config {
     .booleanConf
     .createWithDefault(true)
 
+  private[spark] val RDD_ID_OVERFLOW_POLICY =
+    ConfigBuilder("spark.rdd.id.overflow.policy")
+      .doc("Policy when the RDD id counter would exceed Int.MaxValue. " +
+        "'fail' (default) aborts further RDD creation so overflow is not " +
+        "silent across BlockManager, UI, and other id-keyed state. " +
+        "'legacy' wraps like a 32-bit counter (negative ids) for emergency " +
+        "use only; BlockId parsing accepts those names. Prefer restarting " +
+        "the application over 'legacy'.")
+      .version("4.4.0")
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValues(Set("fail", "legacy"))
+      .createWithDefault("fail")
+
   private[spark] val RDD_PARALLEL_LISTING_THRESHOLD =
     ConfigBuilder("spark.rdd.parallelListingThreshold")
       .version("2.0.0")

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -51,12 +51,12 @@ import org.apache.spark.util.ArrayImplicits._
 /**
  * A Spark split class that wraps around a Hadoop InputSplit.
  */
-private[spark] class HadoopPartition(rddId: Int, override val index: Int, s: InputSplit)
+private[spark] class HadoopPartition(rddId: Long, override val index: Int, s: InputSplit)
   extends Partition {
 
   val inputSplit = new SerializableWritable[InputSplit](s)
 
-  override def hashCode(): Int = 31 * (31 + rddId) + index
+  override def hashCode(): Int = 31 * (31 + java.lang.Long.hashCode(rddId)) + index
 
   override def equals(other: Any): Boolean = super.equals(other)
 
@@ -252,7 +252,7 @@ class HadoopRDD[K, V](
       }
       val array = new Array[Partition](inputSplits.size)
       for (i <- 0 until inputSplits.size) {
-        array(i) = new HadoopPartition(id, i, inputSplits(i))
+        array(i) = new HadoopPartition(idLong, i, inputSplits(i))
       }
       array
     } catch {

--- a/core/src/main/scala/org/apache/spark/rdd/LocalCheckpointRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/LocalCheckpointRDD.scala
@@ -37,12 +37,12 @@ import org.apache.spark.storage.RDDBlockId
  */
 private[spark] class LocalCheckpointRDD[T: ClassTag](
     sc: SparkContext,
-    rddId: Int,
+    rddId: Long,
     numPartitions: Int)
   extends CheckpointRDD[T](sc) {
 
   def this(rdd: RDD[T]) = {
-    this(rdd.context, rdd.id, rdd.partitions.length)
+    this(rdd.context, rdd.idLong, rdd.partitions.length)
   }
 
   protected override def getPartitions: Array[Partition] = {

--- a/core/src/main/scala/org/apache/spark/rdd/LocalRDDCheckpointData.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/LocalRDDCheckpointData.scala
@@ -49,7 +49,7 @@ private[spark] class LocalRDDCheckpointData[T: ClassTag](@transient private val 
     // must cache any missing partitions. TODO: avoid running another job here (SPARK-8582).
     val action = (tc: TaskContext, iterator: Iterator[T]) => Utils.getIteratorSize(iterator)
     val missingPartitionIndices = rdd.partitions.map(_.index).filter { i =>
-      !SparkEnv.get.blockManager.master.contains(RDDBlockId(rdd.id, i))
+      !SparkEnv.get.blockManager.master.contains(RDDBlockId(rdd.idLong, i))
     }
     if (missingPartitionIndices.nonEmpty) {
       rdd.sparkContext.runJob(rdd, action, missingPartitionIndices.toImmutableArraySeq)

--- a/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
@@ -48,14 +48,14 @@ import org.apache.spark.util.{SerializableConfiguration, ShutdownHookManager, Ut
 import org.apache.spark.util.ArrayImplicits._
 
 private[spark] class NewHadoopPartition(
-    rddId: Int,
+    rddId: Long,
     val index: Int,
     rawSplit: InputSplit with Writable)
   extends Partition {
 
   val serializableHadoopSplit = new SerializableWritable(rawSplit)
 
-  override def hashCode(): Int = 31 * (31 + rddId) + index
+  override def hashCode(): Int = 31 * (31 + java.lang.Long.hashCode(rddId)) + index
 
   override def equals(other: Any): Boolean = super.equals(other)
 }
@@ -184,7 +184,7 @@ class NewHadoopRDD[K, V](
       val result = new Array[Partition](rawSplits.size)
       for (i <- rawSplits.indices) {
         result(i) =
-            new NewHadoopPartition(id, i, rawSplits(i).asInstanceOf[InputSplit with Writable])
+            new NewHadoopPartition(idLong, i, rawSplits(i).asInstanceOf[InputSplit with Writable])
       }
       result
     } catch {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -145,8 +145,22 @@ abstract class RDD[T: ClassTag](
   /** The SparkContext that created this RDD. */
   def sparkContext: SparkContext = sc
 
-  /** A unique ID for this RDD (within its SparkContext). */
-  val id: Int = sc.newRddId()
+  /**
+   * A unique ID for this RDD (within its SparkContext), as a 64-bit value.
+   * Prefer this in new code. Under the default overflow policy, successfully
+   * created RDDs always have idLong within Int range, so [[id]] matches.
+   */
+  @Since("4.4.0")
+  val idLong: Long = sc.newRddId()
+
+  /**
+   * A unique ID for this RDD (within its SparkContext).
+   *
+   * Retained as Int for compatibility with existing callers such as
+   * `int id = rdd.id()` in Java. Equal to [[idLong]].toInt (two's-complement
+   * wrap if spark.rdd.id.overflow.policy=legacy after Int.MaxValue).
+   */
+  val id: Int = idLong.toInt
 
   /** A friendly name for this RDD */
   @transient var name: String = _

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -147,7 +147,8 @@ abstract class RDD[T: ClassTag](
 
   /**
    * A unique ID for this RDD (within its SparkContext), as a 64-bit value.
-   * Prefer this in new code, especially once ids exceed Int.MaxValue.
+   * Prefer this in new code, especially with
+   * spark.rdd.id.overflow.policy=continue once ids exceed Int.MaxValue.
    */
   @Since("4.4.0")
   val idLong: Long = sc.newRddId()
@@ -157,7 +158,7 @@ abstract class RDD[T: ClassTag](
    *
    * Retained as Int for compatibility with existing callers such as
    * `int id = rdd.id()` in Java. Throws if [[idLong]] exceeds Int.MaxValue;
-   * use [[idLong]] in that case.
+   * use [[idLong]] in that case (requires overflow.policy=continue).
    */
   def id: Int = {
     if (idLong > Int.MaxValue) {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -147,8 +147,7 @@ abstract class RDD[T: ClassTag](
 
   /**
    * A unique ID for this RDD (within its SparkContext), as a 64-bit value.
-   * Prefer this in new code. Under the default overflow policy, successfully
-   * created RDDs always have idLong within Int range, so [[id]] matches.
+   * Prefer this in new code, especially once ids exceed Int.MaxValue.
    */
   @Since("4.4.0")
   val idLong: Long = sc.newRddId()
@@ -157,10 +156,16 @@ abstract class RDD[T: ClassTag](
    * A unique ID for this RDD (within its SparkContext).
    *
    * Retained as Int for compatibility with existing callers such as
-   * `int id = rdd.id()` in Java. Equal to [[idLong]].toInt (two's-complement
-   * wrap if spark.rdd.id.overflow.policy=legacy after Int.MaxValue).
+   * `int id = rdd.id()` in Java. Throws if [[idLong]] exceeds Int.MaxValue;
+   * use [[idLong]] in that case.
    */
-  val id: Int = idLong.toInt
+  def id: Int = {
+    if (idLong > Int.MaxValue) {
+      throw new SparkException(
+        "RDD id " + idLong + " exceeds Int.MaxValue; use idLong instead.")
+    }
+    idLong.toInt
+  }
 
   /** A friendly name for this RDD */
   @transient var name: String = _
@@ -230,8 +235,8 @@ abstract class RDD[T: ClassTag](
       logWarning(log"RDD ${MDC(RDD_ID, id)} was locally checkpointed, its lineage has been" +
         log" truncated and cannot be recomputed after unpersisting")
     }
-    logInfo(log"Removing RDD ${MDC(RDD_ID, id)} from persistence list")
-    sc.unpersistRDD(id, blocking)
+    logInfo(log"Removing RDD ${MDC(RDD_ID, idLong)} from persistence list")
+    sc.unpersistRDD(idLong, blocking)
     storageLevel = StorageLevel.NONE
     this
   }
@@ -428,7 +433,7 @@ abstract class RDD[T: ClassTag](
         log"marked for checksum verification; nothing to seal.")
       return
     }
-    val unverified = SparkEnv.get.blockManager.master.sealRddChecksums(id)
+    val unverified = SparkEnv.get.blockManager.master.sealRddChecksums(idLong)
     if (unverified > 0) {
       // A partition with no checksum was materialized before this RDD was marked for verification
       // (e.g. a prior persist() + action), or under a deserialized storage level.
@@ -442,7 +447,7 @@ abstract class RDD[T: ClassTag](
    * Gets or computes an RDD partition. Used by RDD.iterator() when an RDD is cached.
    */
   private[spark] def getOrCompute(partition: Partition, context: TaskContext): Iterator[T] = {
-    val blockId = RDDBlockId(id, partition.index)
+    val blockId = RDDBlockId(idLong, partition.index)
     var readCachedBlock = true
     // This method is called on executors, so we need call SparkEnv.get instead of sc.env.
     SparkEnv.get.blockManager.getOrElseUpdateRDDBlock(
@@ -2083,7 +2088,7 @@ abstract class RDD[T: ClassTag](
       import Utils.bytesToString
 
       val persistence = if (storageLevel != StorageLevel.NONE) storageLevel.description else ""
-      val storageInfo = rdd.context.getRDDStorageInfo(_.id == rdd.id).map(info =>
+      val storageInfo = rdd.context.getRDDStorageInfo(_.id == rdd.idLong).map(info =>
         "    CachedPartitions: %d; MemorySize: %s; DiskSize: %s".format(
           info.numCachedPartitions, bytesToString(info.memSize), bytesToString(info.diskSize)))
       (s"$rdd [$persistence]" +: storageInfo).toImmutableArraySeq

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
@@ -37,7 +37,7 @@ private[spark] class ReliableRDDCheckpointData[T: ClassTag](@transient private v
   // The directory to which the associated RDD has been checkpointed to
   // This is assumed to be a non-local path that points to some reliable storage
   private val cpDir: String =
-    ReliableRDDCheckpointData.checkpointPath(rdd.context, rdd.id)
+    ReliableRDDCheckpointData.checkpointPath(rdd.context, rdd.idLong)
       .map(_.toString)
       .getOrElse { throw SparkCoreErrors.mustSpecifyCheckpointDirError() }
 
@@ -63,12 +63,13 @@ private[spark] class ReliableRDDCheckpointData[T: ClassTag](@transient private v
     // Optionally clean our checkpoint files if the reference is out of scope
     if (rdd.conf.get(CLEANER_REFERENCE_TRACKING_CLEAN_CHECKPOINTS)) {
       rdd.context.cleaner.foreach { cleaner =>
-        cleaner.registerRDDCheckpointDataForCleanup(newRDD, rdd.id)
+        cleaner.registerRDDCheckpointDataForCleanup(newRDD, rdd.idLong)
       }
     }
 
-    logInfo(log"Done checkpointing RDD ${MDC(RDD_ID, rdd.id)}" +
-      log" to ${MDC(RDD_CHECKPOINT_DIR, cpDir)}, new parent is RDD ${MDC(NEW_RDD_ID, newRDD.id)}")
+    logInfo(log"Done checkpointing RDD ${MDC(RDD_ID, rdd.idLong)}" +
+      log" to ${MDC(RDD_CHECKPOINT_DIR, cpDir)}, new parent is RDD " +
+      log"${MDC(NEW_RDD_ID, newRDD.idLong)}")
     newRDD
   }
 
@@ -77,12 +78,12 @@ private[spark] class ReliableRDDCheckpointData[T: ClassTag](@transient private v
 private[spark] object ReliableRDDCheckpointData extends Logging {
 
   /** Return the path of the directory to which this RDD's checkpoint data is written. */
-  def checkpointPath(sc: SparkContext, rddId: Int): Option[Path] = {
+  def checkpointPath(sc: SparkContext, rddId: Long): Option[Path] = {
     sc.checkpointDir.map { dir => new Path(dir, s"rdd-$rddId") }
   }
 
   /** Clean up the files associated with the checkpoint data for this RDD. */
-  def cleanCheckpoint(sc: SparkContext, rddId: Int): Unit = {
+  def cleanCheckpoint(sc: SparkContext, rddId: Long): Unit = {
     checkpointPath(sc, rddId).foreach { path =>
       path.getFileSystem(sc.hadoopConfiguration).delete(path, true)
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -249,7 +249,7 @@ private[spark] class DAGScheduler(
     if (injectShuffleFetchFailuresCleanerAttached) return
     sc.cleaner.foreach { cleaner =>
       cleaner.attachListener(new CleanerListener {
-        override def rddCleaned(rddId: Int): Unit = {}
+        override def rddCleaned(rddId: Long): Unit = {}
         override def shuffleCleaned(shuffleId: Int): Unit = {
           injectShuffleFetchFailuresCorruptedAttempt.remove(shuffleId)
           injectShuffleFetchFailuresPendingDelayedCorruption.remove(shuffleId)
@@ -292,7 +292,7 @@ private[spark] class DAGScheduler(
    * first synchronize on the RDD, and then synchronize on this map to avoid deadlocks. The RDD
    * could try to access the cache locations after synchronizing on the RDD.
    */
-  private val cacheLocs = new HashMap[Int, IndexedSeq[Seq[TaskLocation]]]
+  private val cacheLocs = new HashMap[Long, IndexedSeq[Seq[TaskLocation]]]
 
   /**
    * Tracks the latest epoch of a fully processed error related to the given executor. (We use
@@ -596,20 +596,20 @@ private[spark] class DAGScheduler(
   def getCacheLocs(rdd: RDD[_]): IndexedSeq[Seq[TaskLocation]] = rdd.stateLock.synchronized {
     cacheLocs.synchronized {
       // Note: this doesn't use `getOrElse()` because this method is called O(num tasks) times
-      if (!cacheLocs.contains(rdd.id)) {
+      if (!cacheLocs.contains(rdd.idLong)) {
         // Note: if the storage level is NONE, we don't need to get locations from block manager.
         val locs: IndexedSeq[Seq[TaskLocation]] = if (rdd.getStorageLevel == StorageLevel.NONE) {
           IndexedSeq.fill(rdd.partitions.length)(Nil)
         } else {
           val blockIds =
-            rdd.partitions.indices.map(index => RDDBlockId(rdd.id, index)).toArray[BlockId]
+            rdd.partitions.indices.map(index => RDDBlockId(rdd.idLong, index)).toArray[BlockId]
           blockManagerMaster.getLocations(blockIds).map { bms =>
             bms.map(bm => TaskLocation(bm.host, bm.executorId))
           }
         }
-        cacheLocs(rdd.id) = locs
+        cacheLocs(rdd.idLong) = locs
       }
-      cacheLocs(rdd.id)
+      cacheLocs(rdd.idLong)
     }
   }
 
@@ -1212,7 +1212,7 @@ private[spark] class DAGScheduler(
     // Walk the whole RDD graph once, collecting for each pipelined shuffleId the distinct consumer
     // RDDs that read it (for the fan-out check), the producer RDDs that write it (roots of producer
     // member stages), and every reliably-checkpointed RDD (to locate ones inside a member stage).
-    val consumersByShuffleId = new HashMap[Int, HashSet[Int]]
+    val consumersByShuffleId = new HashMap[Int, HashSet[Long]]
     val producerRoots = new HashSet[RDD[_]]           // RDDs that WRITE a pipelined shuffle
     val reliablyCheckpointed = new HashSet[RDD[_]]     // RDDs with a reliable checkpoint pending
     var hasNonDefaultResourceProfile = false          // any member RDD with a non-default RP
@@ -1230,7 +1230,8 @@ private[spark] class DAGScheduler(
       }
       rdd.dependencies.foreach {
         case pd: PipelinedShuffleDependency[_, _, _] =>
-          consumersByShuffleId.getOrElseUpdate(pd.shuffleId, new HashSet[Int]) += rdd.id
+          consumersByShuffleId.getOrElseUpdate(pd.shuffleId, new HashSet[Long]) +=
+            rdd.idLong
           producerRoots += pd.rdd
           enqueue(pd.rdd)
         case dep =>

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -113,7 +113,7 @@ case class SparkListenerBlockManagerRemoved(time: Long, blockManagerId: BlockMan
   extends SparkListenerEvent
 
 @DeveloperApi
-case class SparkListenerUnpersistRDD(rddId: Int) extends SparkListenerEvent
+case class SparkListenerUnpersistRDD(rddId: Long) extends SparkListenerEvent
 
 @DeveloperApi
 case class SparkListenerExecutorAdded(time: Long, executorId: String, executorInfo: ExecutorInfo)

--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
@@ -449,7 +449,7 @@ private[spark] class ExecutorMonitor(
     case _ =>
   }
 
-  override def rddCleaned(rddId: Int): Unit = { }
+  override def rddCleaned(rddId: Long): Unit = { }
 
   override def shuffleCleaned(shuffleId: Int): Unit = {
     // Only post the event if tracking is enabled
@@ -550,7 +550,7 @@ private[spark] class ExecutorMonitor(
 
     // Maps RDD IDs to the partition IDs stored in the executor.
     // This should only be used in the event thread.
-    val cachedBlocks = new mutable.HashMap[Int, mutable.BitSet]()
+    val cachedBlocks = new mutable.HashMap[Long, mutable.BitSet]()
 
     // The set of shuffles for which shuffle data is held by the executor.
     // This should only be used in the event thread.

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -78,7 +78,7 @@ private[spark] class AppStatusListener(
   private[spark] val liveExecutors = new HashMap[String, LiveExecutor]()
   private[spark] val deadExecutors = new HashMap[String, LiveExecutor]()
   private val liveTasks = new HashMap[Long, LiveTask]()
-  private val liveRDDs = new HashMap[Int, LiveRDD]()
+  private val liveRDDs = new HashMap[Long, LiveRDD]()
   private val pools = new HashMap[String, SchedulerPool]()
   private val liveResourceProfiles = new HashMap[Int, LiveResourceProfile]()
   private[spark] val liveMiscellaneousProcess = new HashMap[String, LiveMiscellaneousProcess]()

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -773,7 +773,7 @@ private[spark] class AppStatusStore(
     }
   }
 
-  def rdd(rddId: Int): v1.RDDStorageInfo = {
+  def rdd(rddId: Long): v1.RDDStorageInfo = {
     store.read(classOf[RDDStorageInfoWrapper], rddId).info
   }
 

--- a/core/src/main/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
@@ -101,7 +101,7 @@ private[v1] class AbstractApplicationResource extends BaseAppResource {
 
   @GET
   @Path("storage/rdd/{rddId: \\d+}")
-  def rddData(@PathParam("rddId") rddId: Int): RDDStorageInfo = withUI { ui =>
+  def rddData(@PathParam("rddId") rddId: Long): RDDStorageInfo = withUI { ui =>
     try {
       ui.store.rdd(rddId)
     } catch {

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -218,7 +218,7 @@ class JobData private[spark](
     val killedTasksSummary: Map[String, Int])
 
 class RDDStorageInfo private[spark](
-    val id: Int,
+    val id: Long,
     val name: String,
     val numPartitions: Int,
     val numCachedPartitions: Int,
@@ -306,7 +306,7 @@ class StageData private[spark](
     val details: String,
     val schedulingPool: String,
 
-    val rddIds: collection.Seq[Int],
+    val rddIds: collection.Seq[Long],
     val accumulatorUpdates: collection.Seq[AccumulableInfo],
     val tasks: Option[Map[Long, TaskData]],
     val executorSummary: Option[Map[String, ExecutorStageSummary]],

--- a/core/src/main/scala/org/apache/spark/status/protobuf/StageDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/StageDataWrapperSerializer.scala
@@ -107,7 +107,7 @@ private[protobuf] class StageDataWrapperSerializer extends ProtobufSerDe[StageDa
     stageData.description.foreach { d =>
       stageDataBuilder.setDescription(d)
     }
-    stageData.rddIds.foreach(id => stageDataBuilder.addRddIds(id.toLong))
+    stageData.rddIds.foreach(id => stageDataBuilder.addRddIds(id))
     stageData.accumulatorUpdates.foreach { update =>
       stageDataBuilder.addAccumulatorUpdates(
         AccumulableInfoSerializer.serialize(update))
@@ -469,7 +469,7 @@ private[protobuf] class StageDataWrapperSerializer extends ProtobufSerDe[StageDa
       description = description,
       details = getStringField(binary.hasDetails, () => binary.getDetails),
       schedulingPool = getStringField(binary.hasSchedulingPool, () => binary.getSchedulingPool),
-      rddIds = binary.getRddIdsList.asScala.map(_.toInt),
+      rddIds = binary.getRddIdsList.asScala.map(_.longValue),
       accumulatorUpdates = accumulatorUpdates,
       tasks = tasks,
       executorSummary = executorSummary,

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -428,7 +428,7 @@ private[spark] class TaskDataWrapper(
 private[spark] class RDDStorageInfoWrapper(val info: RDDStorageInfo) {
 
   @JsonIgnore @KVIndex
-  def id: Int = info.id
+  def id: Long = info.id
 
   @JsonIgnore @KVIndex("cached")
   def cached: Boolean = info.numCachedPartitions > 0

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -263,7 +263,12 @@ case class CacheId(sessionUUID: String, hash: String) extends BlockId {
 
 @DeveloperApi
 object BlockId {
-  val RDD = "rdd_([0-9]+)_([0-9]+)".r
+  // RDD ids come from SparkContext.newRddId (AtomicLong). Under the default
+  // overflow policy they stay non-negative and fit in Int. The optional minus
+  // supports legacy wrap-around (spark.rdd.id.overflow.policy=legacy) and any
+  // negative names already in flight, so BlockId.apply does not throw
+  // UnrecognizedBlockId for names like rdd_-1330910599_36.
+  val RDD = "rdd_(-?[0-9]+)_([0-9]+)".r
   val SHUFFLE = "shuffle_([0-9]+)_([0-9]+)_([0-9]+)".r
   val SHUFFLE_BATCH = "shuffle_([0-9]+)_([0-9]+)_([0-9]+)_([0-9]+)".r
   val SHUFFLE_DATA = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).data".r

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -52,7 +52,7 @@ sealed abstract class BlockId {
 }
 
 @DeveloperApi
-case class RDDBlockId(rddId: Int, splitIndex: Int) extends BlockId {
+case class RDDBlockId(rddId: Long, splitIndex: Int) extends BlockId {
   override def name: String = "rdd_" + rddId + "_" + splitIndex
 }
 
@@ -263,11 +263,10 @@ case class CacheId(sessionUUID: String, hash: String) extends BlockId {
 
 @DeveloperApi
 object BlockId {
-  // RDD ids come from SparkContext.newRddId (AtomicLong). Under the default
-  // overflow policy they stay non-negative and fit in Int. The optional minus
-  // supports legacy wrap-around (spark.rdd.id.overflow.policy=legacy) and any
-  // negative names already in flight, so BlockId.apply does not throw
-  // UnrecognizedBlockId for names like rdd_-1330910599_36.
+  // RDD ids come from SparkContext.newRddId (AtomicLong) and may exceed
+  // Int.MaxValue. The optional minus keeps BlockId.apply from throwing
+  // UnrecognizedBlockId for any negative names already in flight
+  // (e.g. rdd_-1330910599_36).
   val RDD = "rdd_(-?[0-9]+)_([0-9]+)".r
   val SHUFFLE = "shuffle_([0-9]+)_([0-9]+)_([0-9]+)".r
   val SHUFFLE_BATCH = "shuffle_([0-9]+)_([0-9]+)_([0-9]+)_([0-9]+)".r
@@ -294,7 +293,7 @@ object BlockId {
 
   def apply(name: String): BlockId = name match {
     case RDD(rddId, splitIndex) =>
-      RDDBlockId(rddId.toInt, splitIndex.toInt)
+      RDDBlockId(rddId.toLong, splitIndex.toInt)
     case SHUFFLE(shuffleId, mapId, reduceId) =>
       ShuffleBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case SHUFFLE_BATCH(shuffleId, mapId, startReduceId, endReduceId) =>

--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -175,7 +175,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
 
   // Cache mappings to avoid O(n) scans in remove operations.
   private[this] val rddToBlockIds =
-    new ConcurrentHashMap[Int, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]]()
+    new ConcurrentHashMap[Long, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]]()
   private[this] val broadcastToBlockIds =
     new ConcurrentHashMap[Long, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]]()
   private[this] val sessionToBlockIds =
@@ -610,7 +610,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   /**
    * Return all blocks belonging to the given RDD.
    */
-  def rddBlockIds(rddId: Int): Seq[BlockId] = getBlockIdsFromMapping(rddToBlockIds, rddId)
+  def rddBlockIds(rddId: Long): Seq[BlockId] = getBlockIdsFromMapping(rddToBlockIds, rddId)
 
   /**
    * Return all blocks belonging to the given broadcast.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -2311,7 +2311,7 @@ private[spark] class BlockManager(
    *
    * @return The number of blocks removed.
    */
-  def removeRdd(rddId: Int): Int = {
+  def removeRdd(rddId: Long): Int = {
     logInfo(log"Removing RDD ${MDC(RDD_ID, rddId)}")
     val blocksToRemove = blockInfoManager.rddBlockIds(rddId)
     blocksToRemove.foreach { blockId => removeBlock(blockId, tellMaster = false) }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
@@ -143,7 +143,7 @@ class BlockManagerMaster(
    * plurality checksum), evict divergent copies, and reject future divergent registrations. Returns
    * the count of present blocks that had no recorded checksum and so could not be sealed.
    */
-  def sealRddChecksums(rddId: Int): Int = {
+  def sealRddChecksums(rddId: Long): Int = {
     driverEndpoint.askSync[Int](SealRddChecksums(rddId))
   }
 
@@ -151,7 +151,7 @@ class BlockManagerMaster(
    * Verify every block of a sealed RDD is sealed and the directory tracks only replicas carrying
    * the sealed checksum. Returns None if the invariant holds, else a diagnostic string.
    */
-  def verifyRddChecksumSeal(rddId: Int): Option[String] = {
+  def verifyRddChecksumSeal(rddId: Long): Option[String] = {
     driverEndpoint.askSync[Option[String]](VerifyRddChecksumSeal(rddId))
   }
 
@@ -221,7 +221,7 @@ class BlockManagerMaster(
   }
 
   /** Remove all blocks belonging to the given RDD. */
-  def removeRdd(rddId: Int, blocking: Boolean): Unit = {
+  def removeRdd(rddId: Long, blocking: Boolean): Unit = {
     val future = driverEndpoint.askSync[Future[Seq[Int]]](RemoveRdd(rddId))
     future.failed.foreach(e =>
       logWarning(log"Failed to remove RDD ${MDC(RDD_ID, rddId)} - " +

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -94,7 +94,7 @@ class BlockManagerMasterEndpoint(
 
   // rddId -> its sealed block ids, letting `removeRdd` reclaim the `sealedChecksums` tombstones by
   // rddId without scanning the whole map.
-  private val sealedBlocksByRdd = new mutable.HashMap[Int, mutable.HashSet[RDDBlockId]]
+  private val sealedBlocksByRdd = new mutable.HashMap[Long, mutable.HashSet[RDDBlockId]]
 
   // Mapping from task id to the set of rdd blocks which are generated from the task.
   private val tidToRddBlockIds = new mutable.HashMap[Long, mutable.HashSet[RDDBlockId]]
@@ -365,7 +365,7 @@ class BlockManagerMasterEndpoint(
       }
   }
 
-  private def removeRdd(rddId: Int): Future[Seq[Int]] = {
+  private def removeRdd(rddId: Long): Future[Seq[Int]] = {
     // First remove the metadata for the given RDD, and then asynchronously remove the blocks
     // from the storage endpoints.
 
@@ -956,7 +956,7 @@ class BlockManagerMasterEndpoint(
    *
    * Returns the number of present blocks that had no recorded checksum and so could not be sealed.
    */
-  private def sealRddChecksums(rddId: Int): Int = {
+  private def sealRddChecksums(rddId: Long): Int = {
     val rddBlocks = blockLocations.asScala.keys.flatMap(_.asRDDId).filter(_.rddId == rddId).toSeq
     var unchecksummed = 0
     rddBlocks.foreach { blockId =>
@@ -991,7 +991,7 @@ class BlockManagerMasterEndpoint(
    * message-handler thread, so it observes a consistent snapshot of the directory and the checksum
    * maps.
    */
-  private def verifyRddChecksumSeal(rddId: Int): Option[String] = {
+  private def verifyRddChecksumSeal(rddId: Long): Option[String] = {
     val rddBlocks = blockLocations.asScala.keys.flatMap(_.asRDDId).filter(_.rddId == rddId)
     rddBlocks.iterator.map { blockId =>
       val sealedValue = Option(sealedChecksums.get(blockId)).map(_.longValue)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
@@ -39,7 +39,7 @@ private[spark] object BlockManagerMessages {
   case object DecommissionBlockManager extends ToBlockManagerMasterStorageEndpoint
 
   // Remove all blocks belonging to a specific RDD.
-  case class RemoveRdd(rddId: Int) extends ToBlockManagerMasterStorageEndpoint
+  case class RemoveRdd(rddId: Long) extends ToBlockManagerMasterStorageEndpoint
 
   // Remove all blocks belonging to a specific shuffle.
   case class RemoveShuffle(shuffleId: Int) extends ToBlockManagerMasterStorageEndpoint
@@ -120,10 +120,10 @@ private[spark] object BlockManagerMessages {
 
   // Seal an RDD's per-block content checksums: per block keep the plurality checksum, evict
   // divergent copies, and reject future divergent registrations.
-  case class SealRddChecksums(rddId: Int) extends ToBlockManagerMaster
+  case class SealRddChecksums(rddId: Long) extends ToBlockManagerMaster
 
   // Invariant-check a sealed RDD; see BlockManagerMasterEndpoint.verifyRddChecksumSeal.
-  case class VerifyRddChecksumSeal(rddId: Int) extends ToBlockManagerMaster
+  case class VerifyRddChecksumSeal(rddId: Long) extends ToBlockManagerMaster
 
   case class GetLocations(blockId: BlockId) extends ToBlockManagerMaster
 

--- a/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
+++ b/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
@@ -25,12 +25,12 @@ import org.apache.spark.util.Utils
 
 @DeveloperApi
 class RDDInfo(
-    val id: Int,
+    val id: Long,
     var name: String,
     val numPartitions: Int,
     var storageLevel: StorageLevel,
     val isBarrier: Boolean,
-    val parentIds: Seq[Int],
+    val parentIds: Seq[Long],
     val callSite: String = "",
     val scope: Option[RDDOperationScope] = None,
     val outputDeterministicLevel: DeterministicLevel.Value = DeterministicLevel.DETERMINATE)
@@ -51,14 +51,14 @@ class RDDInfo(
   }
 
   override def compare(that: RDDInfo): Int = {
-    this.id - that.id
+    java.lang.Long.compare(this.id, that.id)
   }
 }
 
 private[spark] object RDDInfo {
   def fromRdd(rdd: RDD[_]): RDDInfo = {
     val rddName = Option(rdd.name).getOrElse(Utils.getFormattedClassName(rdd))
-    val parentIds = rdd.dependencies.map(_.rdd.id)
+    val parentIds = rdd.dependencies.map(_.rdd.idLong)
     val ifCallSiteLongForm = Option(SparkEnv.get).exists(_.conf.get(EVENT_LOG_CALLSITE_LONG_FORM))
 
     val callSite = if (ifCallSiteLongForm) {
@@ -66,7 +66,7 @@ private[spark] object RDDInfo {
     } else {
       rdd.creationSite.shortForm
     }
-    new RDDInfo(rdd.id, rddName, rdd.partitions.length,
+    new RDDInfo(rdd.idLong, rddName, rdd.partitions.length,
       rdd.getStorageLevel, rdd.isBarrier(), parentIds, callSite, rdd.scope,
       rdd.outputDeterministicLevel)
   }

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -43,11 +43,11 @@ private[spark] class StorageStatus(
   /**
    * Internal representation of the blocks stored in this block manager.
    */
-  private val _rddBlocks = new mutable.HashMap[Int, mutable.Map[BlockId, BlockStatus]]
+  private val _rddBlocks = new mutable.HashMap[Long, mutable.Map[BlockId, BlockStatus]]
   private val _nonRddBlocks = new mutable.HashMap[BlockId, BlockStatus]
 
   private case class RddStorageInfo(memoryUsage: Long, diskUsage: Long, level: StorageLevel)
-  private val _rddStorageInfo = new mutable.HashMap[Int, RddStorageInfo]
+  private val _rddStorageInfo = new mutable.HashMap[Long, RddStorageInfo]
 
   private case class NonRddStorageInfo(var onHeapUsage: Long, var offHeapUsage: Long,
       var diskUsage: Long)
@@ -148,7 +148,7 @@ private[spark] class StorageStatus(
   def diskUsed: Long = _nonRddStorageInfo.diskUsage + _rddBlocks.keys.toSeq.map(diskUsedByRdd).sum
 
   /** Return the disk space used by the given RDD in this block manager in O(1) time. */
-  def diskUsedByRdd(rddId: Int): Long = _rddStorageInfo.get(rddId).map(_.diskUsage).getOrElse(0L)
+  def diskUsedByRdd(rddId: Long): Long = _rddStorageInfo.get(rddId).map(_.diskUsage).getOrElse(0L)
 
   /**
    * Update the relevant storage info, taking into account any existing status for this block.

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -456,7 +456,7 @@ private[spark] class MemoryStore(
   /**
    * Return the RDD ID that a given block ID is from, or None if it is not an RDD block.
    */
-  private def getRddId(blockId: BlockId): Option[Int] = {
+  private def getRddId(blockId: BlockId): Option[Long] = {
     blockId.asRDDId.map(_.rddId)
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -46,7 +46,7 @@ private[spark] case class RDDOperationGraph(
 
 /** A node in an RDDOperationGraph. This represents an RDD. */
 private[spark] case class RDDOperationNode(
-    id: Int,
+    id: Long,
     name: String,
     cached: Boolean,
     barrier: Boolean,
@@ -57,7 +57,7 @@ private[spark] case class RDDOperationNode(
  * A directed edge connecting two nodes in an RDDOperationGraph.
  * This represents an RDD dependency.
  */
-private[spark] case class RDDOperationEdge(fromId: Int, toId: Int)
+private[spark] case class RDDOperationEdge(fromId: Long, toId: Long)
 
 /**
  * A cluster that groups nodes together in an RDDOperationGraph.
@@ -130,7 +130,7 @@ private[spark] object RDDOperationGraph extends Logging {
    */
   def makeOperationGraph(stage: StageInfo, retainedNodes: Int): RDDOperationGraph = {
     val edges = new ListBuffer[RDDOperationEdge]
-    val nodes = new mutable.HashMap[Int, RDDOperationNode]
+    val nodes = new mutable.HashMap[Long, RDDOperationNode]
     val clusters = new mutable.HashMap[String, RDDOperationCluster] // indexed by cluster ID
 
     // Root cluster is the stage cluster
@@ -141,8 +141,8 @@ private[spark] object RDDOperationGraph extends Logging {
     val rootCluster = new RDDOperationCluster(stageClusterId, false, stageClusterName)
 
     var rootNodeCount = 0
-    val addRDDIds = new mutable.HashSet[Int]()
-    val dropRDDIds = new mutable.HashSet[Int]()
+    val addRDDIds = new mutable.HashSet[Long]()
+    val dropRDDIds = new mutable.HashSet[Long]()
 
     // Find nodes, edges, and operation scopes that belong to this stage
     stage.rddInfos.sortBy(_.id).foreach { rdd =>

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1120,7 +1120,7 @@ private[spark] object JsonProtocol extends JsonUtils {
   }
 
   def unpersistRDDFromJson(json: JsonNode): SparkListenerUnpersistRDD = {
-    SparkListenerUnpersistRDD(json.get("RDD ID").extractInt)
+    SparkListenerUnpersistRDD(json.get("RDD ID").extractLong)
   }
 
   def applicationStartFromJson(json: JsonNode): SparkListenerApplicationStart = {
@@ -1518,14 +1518,14 @@ private[spark] object JsonProtocol extends JsonUtils {
   }
 
   def rddInfoFromJson(json: JsonNode): RDDInfo = {
-    val rddId = json.get("RDD ID").extractInt
+    val rddId = json.get("RDD ID").extractLong
     val name = json.get("Name").extractString
     val scope = jsonOption(json.get("Scope"))
       .map(_.asText)
       .map(RDDOperationScope.fromJson)
     val callsite = jsonOption(json.get("Callsite")).map(_.asText).getOrElse("")
     val parentIds = jsonOption(json.get("Parent IDs"))
-      .map { l => l.extractElements.map(_.extractInt).toArray.toImmutableArraySeq }
+      .map { l => l.extractElements.map(_.extractLong).toArray.toImmutableArraySeq }
       .getOrElse(Seq.empty)
     val storageLevel = storageLevelFromJson(json.get("Storage Level"))
     // The "Barrier" field was added in Spark 3.0.0:

--- a/core/src/main/scala/org/apache/spark/util/LastAttemptAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/util/LastAttemptAccumulator.scala
@@ -124,7 +124,7 @@ import org.apache.spark.scheduler.TaskInfo
 
 
 private class LastAttemptRDDVals[@specialized T](
-    val rddId: Int,
+    val rddId: Long,
     val rddScopeId: Option[String],
     // Array of partial metric values, indexed by RDD partition id.
     // Metric updates to a given RDD partition can come from different stageAttempts if a retry
@@ -345,7 +345,7 @@ private object LastAttemptRDDVals {
   val EMPTY_ID: Int = -1
 
   def apply[@specialized T](
-      rddId: Int,
+      rddId: Long,
       rddScopeId: Option[String],
       numPartitions: Int)(implicit ct: ClassTag[T]): LastAttemptRDDVals[T] = {
     new LastAttemptRDDVals[T](rddId, rddScopeId, new Array[T](numPartitions))
@@ -395,7 +395,7 @@ private class LastAttemptMap[K, V] {
 
 private case class AccumulatorPartialVal[PARTIAL](
     partialMergeVal: PARTIAL,
-    rddId: Int,
+    rddId: Long,
     rddPartitionId: Int,
     rddNumPartitions: Int,
     rddScopeId: Option[String],
@@ -482,13 +482,13 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
 
   // For every RDD that participated in the computation of this accumulator, keep the partial
   // value of the accumulator for the latest stage and stage attempt that computed it.
-  // Keyed by rdd.id.
+  // Keyed by rdd.idLong.
   // Only kept and accessed on the driver, in the instance of the LastAttemptAccumulator that was
   // created and registered with AccumulatorContext with AccumulatorV2.register().
   // Should not be copied / reset by the implementation of copy() / reset() functions.
   // Transient: only needed on the driver and doesn't need to be serialized.
   @transient
-  private var lastAttemptRddsMap: LastAttemptMap[Int, LastAttemptRDDVals[PARTIAL]] = _
+  private var lastAttemptRddsMap: LastAttemptMap[Long, LastAttemptRDDVals[PARTIAL]] = _
 
   // ClassTag for PARTIAL, captured at initialization time.
   @transient private var partialClassTag: ClassTag[PARTIAL] = _
@@ -536,7 +536,7 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
     assert(lastAttemptRddsMap == null)
     assert(lastAttemptDirectDriverValue == null)
     partialClassTag = ct
-    lastAttemptRddsMap = new LastAttemptMap[Int, LastAttemptRDDVals[PARTIAL]]
+    lastAttemptRddsMap = new LastAttemptMap[Long, LastAttemptRDDVals[PARTIAL]]
     lastAttemptDirectDriverValue = None
     lastAttemptAccumulatorInitialized = true
   } catch {
@@ -730,7 +730,7 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
 
     val update = AccumulatorPartialVal(
       partialMergeVal = lastAttemptOther.partialMergeVal,
-      rddId = rdd.id,
+      rddId = rdd.idLong,
       rddPartitionId = taskInfo.partitionId,
       rddNumPartitions = rdd.getNumPartitions,
       rddScopeId = rdd.scope.map(_.id),
@@ -807,7 +807,7 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
   }
 
   /** Accumulates last attempt values from given RDD into an acc. */
-  private def lastAttemptValueAggregateInternal(rddId: Int, acc: this.type) = {
+  private def lastAttemptValueAggregateInternal(rddId: Long, acc: this.type) = {
     // Note: even if the given RDD is not present, we can't tell if it executed but just never
     // updated this accumulator, so we still report the zero value back.
     for {
@@ -831,7 +831,7 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
    *
    * @return None if the last attempt value cannot be established, Some(value) otherwise.
    */
-  def lastAttemptValueForRDDIds(rddIds: Seq[Int]): Option[OUT] = try {
+  def lastAttemptValueForRDDIds(rddIds: Seq[Long]): Option[OUT] = try {
     if (lastAttemptAccumulatorInvalid) return None
     assertValid()
     if (lastAttemptDirectDriverValue.isDefined) {
@@ -859,7 +859,7 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
    *
    * @return None if the last attempt value cannot be established, Some(value) otherwise.
    */
-  def lastAttemptValueForRDDId(rddId: Int): Option[OUT] = try {
+  def lastAttemptValueForRDDId(rddId: Long): Option[OUT] = try {
     lastAttemptValueForRDDIds(Seq(rddId))
   } catch {
     case NonFatal(e) =>
@@ -968,7 +968,7 @@ trait LastAttemptAccumulator[IN, OUT, PARTIAL] extends Logging {
   }
 
   /** Visible for testing */
-  def getHighestRDDId: Option[Int] = {
+  def getHighestRDDId: Option[Long] = {
     if (lastAttemptRddsMap.nonEmpty) Some(lastAttemptRddsMap.keys.max) else None
   }
 

--- a/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
@@ -1521,14 +1521,14 @@ public class JavaAPISuite implements Serializable {
 
   @Test
   public void testGetPersistentRDDs() {
-    java.util.Map<Integer, JavaRDD<?>> cachedRddsMap = sc.getPersistentRDDs();
+    java.util.Map<Long, JavaRDD<?>> cachedRddsMap = sc.getPersistentRDDs();
     assertTrue(cachedRddsMap.isEmpty());
     JavaRDD<String> rdd1 = sc.parallelize(Arrays.asList("a", "b")).setName("RDD1").cache();
     JavaRDD<String> rdd2 = sc.parallelize(Arrays.asList("c", "d")).setName("RDD2").cache();
     cachedRddsMap = sc.getPersistentRDDs();
     assertEquals(2, cachedRddsMap.size());
-    assertEquals("RDD1", cachedRddsMap.get(0).name());
-    assertEquals("RDD2", cachedRddsMap.get(1).name());
+    assertEquals("RDD1", cachedRddsMap.get(0L).name());
+    assertEquals("RDD2", cachedRddsMap.get(1L).name());
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -105,10 +105,10 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
   test("cleanup RDD") {
     val rdd = newRDD().persist()
     val collected = rdd.collect().toList
-    val tester = new CleanerTester(sc, rddIds = Seq(rdd.id))
+    val tester = new CleanerTester(sc, rddIds = Seq(rdd.idLong))
 
     // Explicit cleanup
-    cleaner.doCleanupRDD(rdd.id, blocking = true)
+    cleaner.doCleanupRDD(rdd.idLong, blocking = true)
     tester.assertCleanup()
 
     // Verify that RDDs can be re-executed after cleaning up
@@ -188,7 +188,7 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
     rdd.count()
 
     // Test that GC does not cause RDD cleanup due to a strong reference
-    val preGCTester = new CleanerTester(sc, rddIds = Seq(rdd.id))
+    val preGCTester = new CleanerTester(sc, rddIds = Seq(rdd.idLong))
     runGC()
     intercept[Exception] {
       preGCTester.assertCleanup()(timeout(1.second))
@@ -196,7 +196,7 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
 
     // Test that GC causes RDD cleanup after dereferencing the RDD
     // Note rdd is used after previous GC to avoid early collection by the JVM
-    val postGCTester = new CleanerTester(sc, rddIds = Seq(rdd.id))
+    val postGCTester = new CleanerTester(sc, rddIds = Seq(rdd.idLong))
     rdd = null // Make RDD out of scope
     runGC()
     postGCTester.assertCleanup()
@@ -344,14 +344,14 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
     assert(rdd.checkpointData.get.checkpointRDD.isDefined)
 
     // Test that GC does not cause checkpoint cleanup due to a strong reference
-    val preGCTester = new CleanerTester(sc, rddIds = Seq(rdd.id))
+    val preGCTester = new CleanerTester(sc, rddIds = Seq(rdd.idLong))
     runGC()
     intercept[Exception] {
       preGCTester.assertCleanup()(timeout(1.second))
     }
 
     // Test that RDD going out of scope does cause the checkpoint blocks to be cleaned up
-    val postGCTester = new CleanerTester(sc, rddIds = Seq(rdd.id))
+    val postGCTester = new CleanerTester(sc, rddIds = Seq(rdd.idLong))
     rdd = null
     runGC()
     postGCTester.assertCleanup()
@@ -445,20 +445,20 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
  */
 class CleanerTester(
     sc: SparkContext,
-    rddIds: Seq[Int] = Seq.empty,
+    rddIds: Seq[Long] = Seq.empty,
     shuffleIds: Seq[Int] = Seq.empty,
     broadcastIds: Seq[Long] = Seq.empty,
     checkpointIds: Seq[Long] = Seq.empty)
   extends Logging {
 
-  val toBeCleanedRDDIds = new HashSet[Int] ++= rddIds
+  val toBeCleanedRDDIds = new HashSet[Long] ++= rddIds
   val toBeCleanedShuffleIds = new HashSet[Int] ++= shuffleIds
   val toBeCleanedBroadcastIds = new HashSet[Long] ++= broadcastIds
   val toBeCheckpointIds = new HashSet[Long] ++= checkpointIds
   val isDistributed = !sc.isLocal
 
   val cleanerListener = new CleanerListener {
-    def rddCleaned(rddId: Int): Unit = {
+    def rddCleaned(rddId: Long): Unit = {
       toBeCleanedRDDIds.synchronized { toBeCleanedRDDIds -= rddId }
       logInfo("RDD " + rddId + " cleaned")
     }
@@ -609,7 +609,7 @@ class CleanerTester(
     toBeCleanedBroadcastIds.synchronized { toBeCleanedBroadcastIds.isEmpty } &&
     toBeCheckpointIds.synchronized { toBeCheckpointIds.isEmpty }
 
-  private def getRDDBlocks(rddId: Int): Seq[BlockId] = {
+  private def getRDDBlocks(rddId: Long): Seq[BlockId] = {
     blockManager.master.getMatchingBlockIds( _ match {
       case RDDBlockId(`rddId`, _) => true
       case _ => false

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -47,6 +47,7 @@ import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
 import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorMetricsUpdate, SparkListenerJobStart, SparkListenerTaskEnd, SparkListenerTaskStart}
 import org.apache.spark.shuffle.FetchFailedException
+import org.apache.spark.storage.{BlockId, RDDBlockId}
 import org.apache.spark.util.{ThreadUtils, Utils}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -1520,6 +1521,47 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       .set(MEMORY_OFFHEAP_SIZE, 5L * 1024 * 1024)
     sc = new SparkContext(conf)
     assert(sc.env.memoryManager.maxOffHeapStorageMemory > 0)
+  }
+
+  test("SPARK-41246: id and idLong stay in sync for normal RDD ids") {
+    val conf = new SparkConf().setAppName("test").setMaster("local[1]")
+    sc = new SparkContext(conf)
+    val rdd = sc.parallelize(1 to 2, 1)
+    assert(rdd.idLong === rdd.id.toLong)
+    assert(rdd.id >= 0)
+  }
+
+  test("SPARK-41246: fail policy rejects RDD id overflow") {
+    val conf = new SparkConf()
+      .setAppName("test")
+      .setMaster("local[1]")
+      .set(RDD_ID_OVERFLOW_POLICY, "fail")
+    sc = new SparkContext(conf)
+    sc.setNextRddIdForTesting(Int.MaxValue.toLong)
+    // Consumes Int.MaxValue (allowed, with warning).
+    val last = sc.parallelize(Seq(1), 1)
+    assert(last.id === Int.MaxValue)
+    assert(last.idLong === Int.MaxValue.toLong)
+    val err = intercept[SparkException] {
+      sc.parallelize(Seq(2), 1)
+    }
+    assert(err.getMessage.contains("Int.MaxValue"))
+    assert(err.getMessage.contains("overflow"))
+  }
+
+  test("SPARK-41246: legacy policy wraps and BlockId still parses") {
+    val conf = new SparkConf()
+      .setAppName("test")
+      .setMaster("local[1]")
+      .set(RDD_ID_OVERFLOW_POLICY, "legacy")
+    sc = new SparkContext(conf)
+    sc.setNextRddIdForTesting(Int.MaxValue.toLong + 1L)
+    val rdd = sc.parallelize(Seq(1), 1)
+    assert(rdd.idLong === Int.MaxValue.toLong + 1L)
+    assert(rdd.id === Int.MinValue) // two's-complement wrap of the Int view
+    val block = RDDBlockId(rdd.id, 0)
+    assert(block.name === s"rdd_${rdd.id}_0")
+    assert(BlockId(block.name) === block)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1531,37 +1531,24 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     assert(rdd.id >= 0)
   }
 
-  test("SPARK-41246: fail policy rejects RDD id overflow") {
-    val conf = new SparkConf()
-      .setAppName("test")
-      .setMaster("local[1]")
-      .set(RDD_ID_OVERFLOW_POLICY, "fail")
-    sc = new SparkContext(conf)
-    sc.setNextRddIdForTesting(Int.MaxValue.toLong)
-    // Consumes Int.MaxValue (allowed, with warning).
-    val last = sc.parallelize(Seq(1), 1)
-    assert(last.id === Int.MaxValue)
-    assert(last.idLong === Int.MaxValue.toLong)
-    val err = intercept[SparkException] {
-      sc.parallelize(Seq(2), 1)
-    }
-    assert(err.getMessage.contains("Int.MaxValue"))
-    assert(err.getMessage.contains("overflow"))
-  }
-
-  test("SPARK-41246: legacy policy wraps and BlockId still parses") {
-    val conf = new SparkConf()
-      .setAppName("test")
-      .setMaster("local[1]")
-      .set(RDD_ID_OVERFLOW_POLICY, "legacy")
+  test("SPARK-41246: Long RDD ids past Int.MaxValue") {
+    val conf = new SparkConf().setAppName("test").setMaster("local[1]")
     sc = new SparkContext(conf)
     sc.setNextRddIdForTesting(Int.MaxValue.toLong + 1L)
     val rdd = sc.parallelize(Seq(1), 1)
     assert(rdd.idLong === Int.MaxValue.toLong + 1L)
-    assert(rdd.id === Int.MinValue) // two's-complement wrap of the Int view
-    val block = RDDBlockId(rdd.id, 0)
-    assert(block.name === s"rdd_${rdd.id}_0")
+    assert(rdd.idLong > Int.MaxValue)
+    val err = intercept[SparkException] {
+      rdd.id
+    }
+    assert(err.getMessage.contains("exceeds Int.MaxValue"))
+    assert(err.getMessage.contains("idLong"))
+    val block = RDDBlockId(rdd.idLong, 0)
+    assert(block.name === s"rdd_${rdd.idLong}_0")
     assert(BlockId(block.name) === block)
+    // Cache and count should work with Long-backed block ids.
+    rdd.cache()
+    assert(rdd.count() === 1)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1531,8 +1531,29 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     assert(rdd.id >= 0)
   }
 
-  test("SPARK-41246: Long RDD ids past Int.MaxValue") {
-    val conf = new SparkConf().setAppName("test").setMaster("local[1]")
+  test("SPARK-41246: fail-fast policy rejects RDD id overflow") {
+    val conf = new SparkConf()
+      .setAppName("test")
+      .setMaster("local[1]")
+      .set(RDD_ID_OVERFLOW_POLICY, "fail")
+    sc = new SparkContext(conf)
+    sc.setNextRddIdForTesting(Int.MaxValue.toLong)
+    val last = sc.parallelize(Seq(1), 1)
+    assert(last.id === Int.MaxValue)
+    assert(last.idLong === Int.MaxValue.toLong)
+    val err = intercept[SparkException] {
+      sc.parallelize(Seq(2), 1)
+    }
+    assert(err.getMessage.contains("Int.MaxValue"))
+    assert(err.getMessage.contains("overflow") ||
+      err.getMessage.contains("exceed"))
+  }
+
+  test("SPARK-41246: continue policy allows Long RDD ids past Int.MaxValue") {
+    val conf = new SparkConf()
+      .setAppName("test")
+      .setMaster("local[1]")
+      .set(RDD_ID_OVERFLOW_POLICY, "continue")
     sc = new SparkContext(conf)
     sc.setNextRddIdForTesting(Int.MaxValue.toLong + 1L)
     val rdd = sc.parallelize(Seq(1), 1)
@@ -1546,7 +1567,6 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     val block = RDDBlockId(rdd.idLong, 0)
     assert(block.name === s"rdd_${rdd.idLong}_0")
     assert(BlockId(block.name) === block)
-    // Cache and count should work with Long-backed block ids.
     rdd.cache()
     assert(rdd.count() === 1)
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/BasicEventFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/BasicEventFilterSuite.scala
@@ -34,7 +34,7 @@ class BasicEventFilterSuite extends SparkFunSuite {
     val liveJobs = Set(2)
     val liveStages = Set(2, 3)
     val liveTasks = Set(3L, 4L, 5L, 6L)
-    val liveRDDs = Set(3, 4, 5, 6)
+    val liveRDDs = Set(3L, 4L, 5L, 6L)
     val liveExecutors: Set[String] = Set("1", "2")
     val filterStats = FilterStatistics(
       // counts finished job 1

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -275,7 +275,7 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext with Eventuall
   def generateFakeHadoopPartition(): HadoopPartition = {
     val split = new FileSplit(new Path("/some/path"), 0, 1,
       Array[String]("loc1", "loc2", "loc3", "loc4", "loc5"))
-    new HadoopPartition(sc.newRddId(), 1, split)
+    new HadoopPartition(sc.newRddId().toInt, 1, split)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -275,7 +275,7 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext with Eventuall
   def generateFakeHadoopPartition(): HadoopPartition = {
     val split = new FileSplit(new Path("/some/path"), 0, 1,
       Array[String]("loc1", "loc2", "loc3", "loc4", "loc5"))
-    new HadoopPartition(sc.newRddId().toInt, 1, split)
+    new HadoopPartition(sc.newRddId(), 1, split)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -323,7 +323,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
    * Keys are (rdd ID, partition ID). Anything not present will return an empty
    * list of cache locations silently.
    */
-  val cacheLocations = new HashMap[(Int, Int), Seq[BlockManagerId]]
+  val cacheLocations = new HashMap[(Long, Int), Seq[BlockManagerId]]
   // stub out BlockManagerMaster.getLocations to use our cacheLocations
   class MyBlockManagerMaster(conf: SparkConf) extends BlockManagerMaster(null, null, conf, true) {
     override def getLocations(blockIds: Array[BlockId]): IndexedSeq[Seq[BlockManagerId]] = {
@@ -852,7 +852,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   test("cache location preferences w/ dependency") {
     val baseRdd = new MyRDD(sc, 1, Nil).cache()
     val finalRdd = new MyRDD(sc, 1, List(new OneToOneDependency(baseRdd)))
-    cacheLocations(baseRdd.id -> 0) =
+    cacheLocations(baseRdd.idLong -> 0) =
       Seq(makeBlockManagerId("hostA"), makeBlockManagerId("hostB"))
     submit(finalRdd, Array(0))
     val taskSet = taskSets(0)
@@ -863,11 +863,11 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
   test("regression test for getCacheLocs") {
     val rdd = new MyRDD(sc, 3, Nil).cache()
-    cacheLocations(rdd.id -> 0) =
+    cacheLocations(rdd.idLong -> 0) =
       Seq(makeBlockManagerId("hostA"), makeBlockManagerId("hostB"))
-    cacheLocations(rdd.id -> 1) =
+    cacheLocations(rdd.idLong -> 1) =
       Seq(makeBlockManagerId("hostB"), makeBlockManagerId("hostC"))
-    cacheLocations(rdd.id -> 2) =
+    cacheLocations(rdd.idLong -> 2) =
       Seq(makeBlockManagerId("hostC"), makeBlockManagerId("hostD"))
     val locs = scheduler.getCacheLocs(rdd).map(_.map(_.host))
     assert(locs === Seq(Seq("hostA", "hostB"), Seq("hostB", "hostC"), Seq("hostC", "hostD")))
@@ -892,7 +892,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
       tracker = mapOutputTracker)
     val rddC = new MyRDD(sc, 1, List(new OneToOneDependency(rddB))).cache()
     val rddD = new MyRDD(sc, 1, List(new OneToOneDependency(rddC)))
-    cacheLocations(rddC.id -> 0) =
+    cacheLocations(rddC.idLong -> 0) =
       Seq(makeBlockManagerId("hostA"), makeBlockManagerId("hostB"))
     submit(rddD, Array(0))
     assert(scheduler.runningStages.size === 1)
@@ -2224,8 +2224,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     val shuffleDepTwo = new ShuffleDependency(shuffleTwoRdd, new HashPartitioner(1))
     val finalRdd = new MyRDD(sc, 1, List(shuffleDepTwo), tracker = mapOutputTracker)
     submit(finalRdd, Array(0))
-    cacheLocations(shuffleTwoRdd.id -> 0) = Seq(makeBlockManagerId("hostD"))
-    cacheLocations(shuffleTwoRdd.id -> 1) = Seq(makeBlockManagerId("hostC"))
+    cacheLocations(shuffleTwoRdd.idLong -> 0) = Seq(makeBlockManagerId("hostD"))
+    cacheLocations(shuffleTwoRdd.idLong -> 1) = Seq(makeBlockManagerId("hostC"))
     // complete stage 0
     completeShuffleMapStageSuccessfully(0, 0, 2)
     // complete stage 1
@@ -6277,8 +6277,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     val reduceRdd = new MyRDD(sc, 1, List(shuffleDep1), tracker = mapOutputTracker)
 
     // Cache for shuffleMapRdd1 are available
-    cacheLocations(shuffleMapRdd1.id -> 0) = Seq(makeBlockManagerId("hostA"))
-    cacheLocations(shuffleMapRdd1.id -> 1) = Seq(makeBlockManagerId("hostB"))
+    cacheLocations(shuffleMapRdd1.idLong -> 0) = Seq(makeBlockManagerId("hostA"))
+    cacheLocations(shuffleMapRdd1.idLong -> 1) = Seq(makeBlockManagerId("hostB"))
 
     val callCount = new AtomicInteger(0)
     doAnswer(invocation => {

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -1297,7 +1297,7 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       description = Some("test description"),
       details = details,
       schedulingPool = schedulingPool,
-      rddIds = Seq(1, 2, 3, 4, 5, 6),
+      rddIds = Seq(1L, 2L, 3L, 4L, 5L, 6L),
       accumulatorUpdates = accumulatorUpdates,
       tasks = tasks,
       executorSummary = executorSummary,

--- a/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -51,6 +51,15 @@ class BlockIdSuite extends SparkFunSuite {
     assertSame(id, BlockId(id.toString))
   }
 
+  test("SPARK-41246: rdd with a negative id") {
+    // Legacy overflow wraps to negative Int ids; BlockId must still parse them.
+    val id = RDDBlockId(-1330910599, 36)
+    assert(id.name === "rdd_-1330910599_36")
+    assertSame(id, BlockId(id.name))
+    assertDifferent(id, RDDBlockId(1330910599, 36))
+    assertSame(RDDBlockId(Int.MinValue, 0), BlockId("rdd_-2147483648_0"))
+  }
+
   test("shuffle") {
     val id = ShuffleBlockId(1, 2, 3)
     assertSame(id, ShuffleBlockId(1, 2, 3))

--- a/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -52,7 +52,7 @@ class BlockIdSuite extends SparkFunSuite {
   }
 
   test("SPARK-41246: rdd with a negative id") {
-    // Legacy overflow wraps to negative Int ids; BlockId must still parse them.
+    // Optional minus in BlockId.RDD keeps negative names parseable.
     val id = RDDBlockId(-1330910599, 36)
     assert(id.name === "rdd_-1330910599_36")
     assertSame(id, BlockId(id.name))

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -550,7 +550,7 @@ class JsonProtocolSuite extends SparkFunSuite {
     // "Callsite" was introduced in Spark 1.6.0
     // "Barrier" was introduced in Spark 3.0.0
     // "DeterministicLevel" was introduced in Spark 3.2.0
-    val rddInfo = new RDDInfo(1, "one", 100, StorageLevel.NONE, true, Seq(1, 6, 8),
+    val rddInfo = new RDDInfo(1, "one", 100, StorageLevel.NONE, true, Seq(1L, 6L, 8L),
       "callsite", Some(new RDDOperationScope("fable")), DeterministicLevel.INDETERMINATE)
     val oldRddInfoJson = toJsonString(JsonProtocol.rddInfoToJson(rddInfo, _))
       .removeField("Parent IDs")
@@ -1503,7 +1503,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
   private def makeRddInfo(a: Int, b: Int, c: Int, d: Long, e: Long,
       deterministic: DeterministicLevel.Value) = {
     val r =
-      new RDDInfo(a, "mayor", b, StorageLevel.MEMORY_AND_DISK, false, Seq(1, 4, 7), a.toString,
+      new RDDInfo(a, "mayor", b, StorageLevel.MEMORY_AND_DISK, false, Seq(1L, 4L, 7L), a.toString,
         outputDeterministicLevel = deterministic)
     r.numCachedPartitions = c
     r.memSize = d

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -37,7 +37,47 @@ object MimaExcludes {
   lazy val v50excludes: Seq[Problem => Boolean] = v44excludes
 
   // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
-  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes
+  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes ++ Seq(
+    // [SPARK-41246] Widen RDD identity to Long for allocation/storage; keep RDD.id as Int
+    // accessor for Java `int id = rdd.id()` compatibility (throws past Int.MaxValue).
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.rdd.RDD.id"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.rdd.RDD.id"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.rdd.RDD.id"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.SparkContext.getPersistentRDDs"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.api.java.JavaSparkContext.getPersistentRDDs"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.storage.RDDBlockId.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.storage.RDDBlockId.apply"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.storage.RDDBlockId.copy"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.storage.RDDBlockId.rddId"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.storage.RDDBlockId.copy$default$1"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.storage.RDDInfo.id"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.storage.RDDInfo.parentIds"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.storage.RDDInfo.this"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.status.api.v1.RDDStorageInfo.id"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.status.api.v1.StageData.rddIds"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.scheduler.SparkListenerUnpersistRDD.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.scheduler.SparkListenerUnpersistRDD.apply"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "org.apache.spark.scheduler.SparkListenerUnpersistRDD.copy"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.scheduler.SparkListenerUnpersistRDD.rddId"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "org.apache.spark.scheduler.SparkListenerUnpersistRDD.copy$default$1")
+  )
 
   // Exclude rules for 4.3.x from 4.2.0 (add 4.3-specific filters below as needed).
   lazy val v43excludes: Seq[Problem => Boolean] = v42excludes ++ Seq(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/history/SQLEventFilterBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/history/SQLEventFilterBuilder.scala
@@ -38,14 +38,14 @@ private[spark] class SQLEventFilterBuilder extends SparkListener with EventFilte
   private val liveExecutionToJobs = new mutable.HashMap[Long, mutable.Set[Int]]
   private val jobToStages = new mutable.HashMap[Int, Set[Int]]
   private val stageToTasks = new mutable.HashMap[Int, mutable.Set[Long]]
-  private val stageToRDDs = new mutable.HashMap[Int, Set[Int]]
+  private val stageToRDDs = new mutable.HashMap[Int, Set[Long]]
   private val stages = new mutable.HashSet[Int]
 
   private[history] def liveSQLExecutions: Set[Long] = liveExecutionToJobs.keySet.toSet
   private[history] def liveJobs: Set[Int] = liveExecutionToJobs.values.flatten.toSet
   private[history] def liveStages: Set[Int] = stageToRDDs.keySet.toSet
   private[history] def liveTasks: Set[Long] = stageToTasks.values.flatten.toSet
-  private[history] def liveRDDs: Set[Int] = stageToRDDs.values.flatten.toSet
+  private[history] def liveRDDs: Set[Long] = stageToRDDs.values.flatten.toSet
 
   override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
     val executionIdString = jobStart.properties.getProperty(SQLExecution.EXECUTION_ID_KEY)
@@ -118,7 +118,7 @@ private[spark] class SQLLiveEntitiesEventFilter(
     liveJobs: Set[Int],
     liveStages: Set[Int],
     liveTasks: Set[Long],
-    liveRDDs: Set[Int])
+    liveRDDs: Set[Long])
   extends JobEventFilter(None, liveJobs, liveStages, liveTasks, liveRDDs) with Logging {
 
   logDebug(s"live SQL executions : $liveSQLExecutions")

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -485,7 +485,7 @@ class CachedTableSuite extends SharedSparkSession
       toBeCleanedAccIds += accId2
 
       val cleanerListener = new CleanerListener {
-        def rddCleaned(rddId: Int): Unit = {}
+        def rddCleaned(rddId: Long): Unit = {}
         def shuffleCleaned(shuffleId: Int): Unit = {}
         def broadcastCleaned(broadcastId: Long): Unit = {}
         def accumCleaned(accId: Long): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/history/SQLLiveEntitiesEventFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/history/SQLLiveEntitiesEventFilterSuite.scala
@@ -33,7 +33,7 @@ class SQLLiveEntitiesEventFilterSuite extends SparkFunSuite {
     val liveJobs = Set(2)
     val liveStages = Set(2, 3)
     val liveTasks = Set(3L, 4L, 5L, 6L)
-    val liveRDDs = Set(3, 4, 5, 6)
+    val liveRDDs = Set(3L, 4L, 5L, 6L)
     val liveExecutors: Set[String] = Set("1", "2")
 
     val filter = new SQLLiveEntitiesEventFilter(liveSQLExecutions, liveJobs, liveStages, liveTasks,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLLastAttemptMetricIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLLastAttemptMetricIntegrationSuite.scala
@@ -46,9 +46,10 @@ class SQLLastAttemptMetricIntegrationSuite
     assert(withRetries || slam.value === 10)
     assert(slam.lastAttemptValueForAllRDDs() === Some(10))
     assert(slam.lastAttemptValueForRDDId(rdd1.id) === Some(10))
-    assert(slam.lastAttemptValueForRDDIds(Seq(rdd1.id, rdd1.id)) === Some(10))
-    assert(slam.lastAttemptValueForRDDIds(Seq(rdd1.id + 1, rdd1.id + 2)) === Some(0))
-    assert(slam.lastAttemptValueForRDDIds(Seq(rdd1.id, rdd1.id + 10, rdd1.id)) === Some(10))
+    assert(slam.lastAttemptValueForRDDIds(Seq(rdd1.idLong, rdd1.idLong)) === Some(10))
+    assert(slam.lastAttemptValueForRDDIds(Seq(rdd1.idLong + 1, rdd1.idLong + 2)) === Some(0))
+    assert(slam.lastAttemptValueForRDDIds(
+      Seq(rdd1.idLong, rdd1.idLong + 10, rdd1.idLong)) === Some(10))
     assert(slam.lastAttemptValueForHighestRDDId() === Some(10))
 
     val rdd2 = spark.sparkContext.parallelize(1 to 50, 3).map { x =>
@@ -128,11 +129,11 @@ class SQLLastAttemptMetricIntegrationSuite
     assert(slam1.lastAttemptValueForRDDId(mapStageRddId) === Some(10))
 
     // Test passing multiple ids.
-    assert(slam1.lastAttemptValueForRDDIds(Seq(rdd1.id, repartition.id)) === Some(0))
+    assert(slam1.lastAttemptValueForRDDIds(Seq(rdd1.idLong, repartition.idLong)) === Some(0))
     assert(slam1.lastAttemptValueForRDDIds(
-      Seq(rdd1.id, mapStageRddId, repartition.id)) === Some(10))
-    assert(slam1.lastAttemptValueForRDDIds(Seq(rdd1.id, rdd2.id)) === Some(0))
-    assert(slam1.lastAttemptValueForRDDIds(Seq(-10)) === Some(0))
+      Seq(rdd1.idLong, mapStageRddId, repartition.idLong)) === Some(10))
+    assert(slam1.lastAttemptValueForRDDIds(Seq(rdd1.idLong, rdd2.idLong)) === Some(0))
+    assert(slam1.lastAttemptValueForRDDIds(Seq(-10L)) === Some(0))
 
     rdd2.collect()
     // Repartition stage is reused, but result stage is re-executed.
@@ -409,7 +410,7 @@ class SQLLastAttemptMetricIntegrationSuite
     assert(slam.getNumRDDs === 0)
     // When specific RDDs are requested, driver value is not returned.
     assert(slam.lastAttemptValueForRDDId(42) === Some(0))
-    assert(slam.lastAttemptValueForRDDIds(Seq(7, 42)) === Some(0))
+    assert(slam.lastAttemptValueForRDDIds(Seq(7L, 42L)) === Some(0))
 
     // Incrementing works
     slam.add(5)
@@ -451,7 +452,7 @@ class SQLLastAttemptMetricIntegrationSuite
     assert(slam.lastAttemptValueForHighestRDDId() === None)
     assert(slam.lastAttemptValueForAllRDDs() === None)
     assert(slam.lastAttemptValueForRDDId(42) === None)
-    assert(slam.lastAttemptValueForRDDIds(Seq(7, 42)) === None)
+    assert(slam.lastAttemptValueForRDDIds(Seq(7L, 42L)) === None)
     assert(slam.lastAttemptValueForDataset(df) === None)
     assert(!slam.getValid)
     assert(slam.getNumRDDs === 0) // invalidated before RDD got recorded
@@ -466,7 +467,7 @@ class SQLLastAttemptMetricIntegrationSuite
     assert(slam.lastAttemptValueForHighestRDDId() === None)
     assert(slam.lastAttemptValueForAllRDDs() === None)
     assert(slam.lastAttemptValueForRDDId(42) === None)
-    assert(slam.lastAttemptValueForRDDIds(Seq(7, 42)) === None)
+    assert(slam.lastAttemptValueForRDDIds(Seq(7L, 42L)) === None)
     assert(slam.lastAttemptValueForDataset(df) === None)
     assert(!slam.getValid)
     // SLAM info doesn't get updated anymore when invalid, but stays around for debugging purposes.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLLastAttemptMetricUnitSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLLastAttemptMetricUnitSuite.scala
@@ -107,7 +107,7 @@ class SQLLastAttemptMetricUnitSuite extends SparkFunSuite with SharedSparkContex
     // but assertions should be caught and None should be returned.
     assert(deser.lastAttemptValueForHighestRDDId() === None)
     assert(deser.lastAttemptValueForRDDId(1) === None)
-    assert(deser.lastAttemptValueForRDDIds(Seq(1, 2, 3)) === None)
+    assert(deser.lastAttemptValueForRDDIds(Seq(1L, 2L, 3L)) === None)
     assert(deser.lastAttemptValueForAllRDDs() === None)
     // mergeLastAttempt shouldn't be used on the deserialized metric,
     // but it should catch error and not fail.
@@ -141,7 +141,7 @@ class SQLLastAttemptMetricUnitSuite extends SparkFunSuite with SharedSparkContex
     // but assertions should be caught and None should be returned.
     assert(acc.lastAttemptValueForHighestRDDId() === None)
     assert(acc.lastAttemptValueForRDDId(1) === None)
-    assert(acc.lastAttemptValueForRDDIds(Seq(1, 2, 3)) === None)
+    assert(acc.lastAttemptValueForRDDIds(Seq(1L, 2L, 3L)) === None)
     assert(acc.lastAttemptValueForAllRDDs() === None)
     // mergeLastAttempt shouldn't be used on the copy,
     // but it should catch error and not fail.

--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -730,14 +730,14 @@ class BasicOperationsSuite extends TestSuiteBase {
         val input = Seq(1, 2, 3, 4, 5, 6)
 
         val blockRdds = new mutable.HashMap[Time, BlockRDD[_]]
-        val persistentRddIds = new mutable.HashMap[Time, Int]
+        val persistentRddIds = new mutable.HashMap[Time, Long]
 
         def collectRddInfo(): Unit = { // get all RDD info required for verification
           networkStream.generatedRDDs.foreach { case (time, rdd) =>
             blockRdds(time) = rdd.asInstanceOf[BlockRDD[_]]
           }
           mappedStream.generatedRDDs.foreach { case (time, rdd) =>
-            persistentRddIds(time) = rdd.id
+            persistentRddIds(time) = rdd.idLong
           }
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Treat SPARK-41246 with an explicit overflow policy and 64-bit identity plumbing:

1. **Fail-fast (default)**: `spark.rdd.id.overflow.policy=fail` aborts RDD creation once the counter would exceed `Int.MaxValue`, with a clear error (no silent wrap to negative ids, no silent cover-up of overflow).
2. **Optional continue**: `spark.rdd.id.overflow.policy=continue` keeps allocating via `AtomicLong`; use `RDD.idLong`. Storage/BlockManager/cleanup/listeners are Long-keyed so caching works past `Int.MaxValue` without `UnrecognizedBlockId`.
3. **Compatibility**: `RDD.id` remains an **Int** accessor so Java `int id = rdd.id()` still **compiles**. Under `continue`, `id` throws past `Int.MaxValue` (use `idLong`).
4. **`RDDBlockId(rddId: Long, ...)`** and related paths widened to Long; BlockId parsing accepts large / optional-minus names.

This addresses review feedback that parse-only fixes leave overflow untreated elsewhere, while defaulting to fail-fast so overflow is visible.

Related: prefer this over parse-only #57893.

### Why are the changes needed?

`AtomicInteger` wrap past `Int.MaxValue` produced negative block names (`rdd_-N_split`) and `UnrecognizedBlockId` on `UpdateBlockInfo`, and could corrupt Int-keyed state. Silent wrap (or parse-only acceptance of negatives) covers up the overflow. Fail-fast makes overflow an explicit failure by default; `continue` is the escape hatch for apps ready for 64-bit ids.

### Does this PR introduce _any_ user-facing change?

Yes.

- **Default (`fail`)**: creating an RDD after `Int.MaxValue` throws instead of wrapping. Restart the application (or set `continue`).
- **`continue`**: Long ids past `Int.MaxValue`; `RDD.id` throws; use `idLong`.
- `RDD.idLong` added; `RDD.id` type unchanged (`Int`) for compile compatibility.
- `getPersistentRDDs` is `Map[Long, RDD[_]]` (MiMa excludes added).

### How was this patch tested?

- `SparkContextSuite`: id/idLong sync; **fail-fast** rejects overflow; **continue** allows Long ids, `id` throws, BlockId round-trip, cache+count
- `BlockIdSuite`: negative / large id parse
- Updated DAGScheduler / cleaner / Java API / JsonProtocol / SQL last-attempt suites for Long ids

```
build/sbt "core/testOnly org.apache.spark.SparkContextSuite -- -z SPARK-41246"
build/sbt "core/testOnly org.apache.spark.storage.BlockIdSuite"
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Agent