### PR TITLE
[SPARK-58703][SQL] SQL DAG and Physical Plan Node Mapping Implementation

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
@@ -85,6 +85,18 @@ svg path {
   word-wrap: break-word;
 }
 
+.physical-plan-text {
+  font-family: monospace;
+}
+
+.plan-description-line {
+  white-space: pre;
+}
+
+.plan-description-line.selected {
+  background-color: var(--spark-sql-linked-fill);
+}
+
 svg g.node rect.selected {
   fill: var(--spark-sql-selected-fill);
   stroke: var(--spark-sql-selected-stroke);

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -67,6 +67,7 @@ function renderPlanViz() {
   setupLayoutForSparkPlanCluster(g, svg);
   setupSelectionForSparkPlanNode(g);
   setupTooltipForSparkPlanNode(g);
+  setupPlanDescriptionLinks();
   resizeSvg(svg);
   postprocessForAdditionalMetrics();
   setupDetailedLabelsToggle();
@@ -79,6 +80,45 @@ function renderPlanViz() {
  * -------------------- */
 
 function planVizContainer() { return d3.select("#plan-viz-graph"); }
+
+function setupPlanDescriptionLinks() {
+  document.querySelectorAll("#plan-viz-metadata .plan-node-links div").forEach(function(link) {
+    var graphNodeId = link.getAttribute("data-graph-node-id");
+    var planNodeIds = link.getAttribute("data-plan-node-ids");
+    var planNodeId = link.getAttribute("data-plan-node-id");
+    var graphNode = document.getElementById("node" + graphNodeId) ||
+      document.getElementById("cluster" + graphNodeId);
+    if (!graphNode) return;
+
+    graphNode.addEventListener("click", function() {
+      highlightPlanDescription(planNodeIds ? planNodeIds.split(",") : [planNodeId]);
+    });
+    graphNode.addEventListener("dblclick", function() {
+      focusPlanDescription(planNodeIds ? planNodeIds.split(",") : [planNodeId]);
+    });
+  });
+}
+
+function highlightPlanDescription(planNodeIds) {
+  document.querySelectorAll(".plan-description-line.selected").forEach(function(line) {
+    line.classList.remove("selected");
+  });
+  planNodeIds.filter(Boolean).forEach(function(planNodeId) {
+    var line = document.getElementById("plan-node-" + planNodeId);
+    if (line) line.classList.add("selected");
+  });
+}
+
+function focusPlanDescription(planNodeIds) {
+  highlightPlanDescription(planNodeIds);
+  var details = document.getElementById("physical-plan-details");
+  if (details && !details.classList.contains("show")) {
+    bootstrap.Collapse.getOrCreateInstance(details).show();
+  }
+  var firstNodeId = planNodeIds.filter(Boolean)[0];
+  var line = firstNodeId && document.getElementById("plan-node-" + firstNodeId);
+  if (line && line.scrollIntoView) line.scrollIntoView({behavior: "smooth", block: "center"});
+}
 
 /*
  * Set up the tooltip for a SparkPlan node using metadata. When the user moves the mouse on the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
@@ -31,6 +31,18 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
   def localIdMap: ThreadLocal[java.util.Map[QueryPlan[_], Int]] = QueryPlan.localIdMap
 
   /**
+   * Assign operator IDs to the supplied plan using the same traversal as explain output.
+   *
+   * The generated IDs remain available through [[localIdMap]] for callers that build SQL UI
+   * metadata immediately after generating the explain string.
+   */
+  def tagOperatorIds(plan: QueryPlan[_]): Unit = {
+    val idMap = new IdentityHashMap[QueryPlan[_], Int]()
+    localIdMap.set(idMap)
+    assignOperatorIds(plan, idMap)
+  }
+
+  /**
    * Given a input physical plan, performs the following tasks.
    *   1. Computes the whole stage codegen id for current operator and records it in the
    *      operator by setting a tag.
@@ -343,5 +355,9 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
    */
   def getOpId(plan: QueryPlan[_]): String = {
     Option(ExplainUtils.localIdMap.get().get(plan)).map(v => s"$v").getOrElse("unknown")
+  }
+
+  def getOpIdOption(plan: QueryPlan[_]): Option[Long] = {
+    Option(localIdMap.get()).flatMap(map => Option(map.get(plan))).map(_.toLong)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -211,9 +211,11 @@ object SQLExecution extends Logging {
                 case Right(f) =>
                   val planDescriptionMode =
                     ExplainMode.fromString(sparkSession.sessionState.conf.uiExplainMode)
+                  val executedPlan = queryExecution.executedPlan
+                  ExplainUtils.tagOperatorIds(executedPlan)
                   val planDesc = queryExecution.explainString(planDescriptionMode)
                   val planInfo = try {
-                    SparkPlanInfo.fromSparkPlan(queryExecution.executedPlan)
+                    SparkPlanInfo.fromSparkPlan(executedPlan)
                   } catch {
                     case NonFatal(e) =>
                       logDebug("Failed to generate SparkPlanInfo", e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
@@ -39,7 +39,8 @@ class SparkPlanInfo(
     val simpleString: String,
     val children: Seq[SparkPlanInfo],
     val metadata: Map[String, String],
-    val metrics: Seq[SQLMetricInfo]) {
+    val metrics: Seq[SQLMetricInfo],
+    val operatorId: Option[Long] = None) {
 
   override def hashCode(): Int = {
     // hashCode of simpleString should be good enough to distinguish the plans from each other
@@ -104,7 +105,8 @@ private[execution] object SparkPlanInfo {
       plan.simpleString(SQLConf.get.maxToStringFields),
       childrenInfo,
       metadata,
-      metrics)
+      metrics,
+      ExplainUtils.getOpIdOption(plan))
   }
 
   final lazy val EMPTY: SparkPlanInfo = new SparkPlanInfo("", "", Nil, Map.empty, Nil)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -890,10 +890,12 @@ case class AdaptiveSparkPlanExec(
         executionId, newMetrics))
     } else {
       val planDescriptionMode = ExplainMode.fromString(conf.uiExplainMode)
+      val executedPlan = context.qe.executedPlan
+      org.apache.spark.sql.execution.ExplainUtils.tagOperatorIds(executedPlan)
       context.session.sparkContext.listenerBus.post(SparkListenerSQLAdaptiveExecutionUpdate(
         executionId,
         context.qe.explainString(planDescriptionMode),
-        SparkPlanInfo.fromSparkPlan(context.qe.executedPlan)))
+        SparkPlanInfo.fromSparkPlan(executedPlan)))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -891,7 +891,7 @@ case class AdaptiveSparkPlanExec(
     } else {
       val planDescriptionMode = ExplainMode.fromString(conf.uiExplainMode)
       val executedPlan = context.qe.executedPlan
-      org.apache.spark.sql.execution.ExplainUtils.tagOperatorIds(executedPlan)
+      ExplainUtils.tagOperatorIds(executedPlan)
       context.session.sparkContext.listenerBus.post(SparkListenerSQLAdaptiveExecutionUpdate(
         executionId,
         context.qe.explainString(planDescriptionMode),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -231,7 +231,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
           {graph.makeNodeDetailsJson(metrics)}
         </div>
         <div class="plan-node-links">
-          {graph.nodes.map {
+          {graph.allNodes.map {
             case cluster: SparkPlanGraphCluster =>
               <div data-graph-node-id={cluster.id.toString}
                    data-plan-node-ids={cluster.subPlanNodeIds.mkString(",")}></div>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -34,6 +34,7 @@ import org.apache.spark.ui.jobs.ApiHelper
 class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging {
 
   private val pandasOnSparkConfPrefix = "pandas_on_Spark."
+  private val planNodeIdPattern = """^(.*)\((\d+)\)(.*)$""".r
 
   private val sqlStore = parent.sqlStore
   private val groupSubExecutionEnabled = parent.conf.get(UI_SQL_GROUP_SUB_EXECUTION_ENABLED)
@@ -120,7 +121,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
 
       summary ++
         planVisualization(request, metrics, graph) ++
-        physicalPlanDescription(executionUIData.physicalPlanDescription) ++
+        physicalPlanDescription(executionUIData.physicalPlanDescription, graph) ++
         jobsTable(request, executionUIData) ++
         modifiedConfigs(configs.filter { case (k, _) => !k.startsWith(pandasOnSparkConfPrefix) }) ++
         modifiedPandasOnSparkConfigs(
@@ -229,6 +230,16 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
         <div class="node-details">
           {graph.makeNodeDetailsJson(metrics)}
         </div>
+        <div class="plan-node-links">
+          {graph.nodes.map {
+            case cluster: SparkPlanGraphCluster =>
+              <div data-graph-node-id={cluster.id.toString}
+                   data-plan-node-ids={cluster.subPlanNodeIds.mkString(",")}></div>
+            case node =>
+              <div data-graph-node-id={node.id.toString}
+                   data-plan-node-id={node.planNodeId.map(_.toString).getOrElse("")}></div>
+          }}
+        </div>
       </div>
       {planVisualizationResources(request)}
     </div>
@@ -312,9 +323,14 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
     // scalastyle:on line.size.limit
   }
 
-  private def physicalPlanDescription(physicalPlanDescription: String): Seq[Node] = {
+  private def physicalPlanDescription(
+      physicalPlanDescription: String,
+      graph: SparkPlanGraph): Seq[Node] = {
     val (initialPlan, finalPlan) = extractInitialAndFinalPlans(physicalPlanDescription)
     val hasDiff = initialPlan.nonEmpty && finalPlan.nonEmpty
+    val graphNodeIdByPlanNodeId = graph.allNodes.flatMap { node =>
+      node.planNodeId.map(_ -> node.id)
+    }.toMap
 
     // scalastyle:off line.size.limit
     <div>
@@ -342,7 +358,9 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             </ul>
             <div class="tab-content">
               <div class="tab-pane fade show active" id="plan-unified-tab" role="tabpanel">
-                <pre>{physicalPlanDescription}</pre>
+                <div class="physical-plan-text">
+                  {renderPhysicalPlanLines(physicalPlanDescription, graphNodeIdByPlanNodeId)}
+                </div>
               </div>
               <div class="tab-pane fade" id="plan-split-tab" role="tabpanel">
                 <div class="row">
@@ -359,11 +377,29 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             </div>
           </div>
         } else {
-          <pre>{physicalPlanDescription}</pre>
+          <div class="physical-plan-text">
+            {renderPhysicalPlanLines(physicalPlanDescription, graphNodeIdByPlanNodeId)}
+          </div>
         }}
       </div>
     </div>
     // scalastyle:on line.size.limit
+  }
+
+  private def renderPhysicalPlanLines(
+      physicalPlanDescription: String,
+      graphNodeIdByPlanNodeId: Map[Long, Long]): Seq[Node] = {
+    physicalPlanDescription.split("\n", -1).toIndexedSeq.map { line =>
+      line match {
+        case planNodeIdPattern(_, planNodeId, _) =>
+          graphNodeIdByPlanNodeId.get(planNodeId.toLong).map { graphNodeId =>
+            <div id={s"plan-node-$planNodeId"}
+                 class="plan-description-line plan-description-operator"
+                 data-graph-node-id={graphNodeId.toString}>{line}</div>
+          }.getOrElse(<div class="plan-description-line">{line}</div>)
+        case _ => <div class="plan-description-line">{line}</div>
+      }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -334,7 +334,8 @@ class SQLAppStatusListener(
           cluster.name,
           cluster.desc,
           toStoredNodes(cluster.nodes.toSeq),
-          cluster.metrics)
+          cluster.metrics,
+          cluster.planNodeId)
         new SparkPlanGraphNodeWrapper(null, storedCluster)
 
       case node =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -152,12 +152,14 @@ class SparkPlanGraphClusterWrapper(
     val name: String,
     val desc: String,
     val nodes: collection.Seq[SparkPlanGraphNodeWrapper],
-    val metrics: collection.Seq[SQLPlanMetric]) {
+    val metrics: collection.Seq[SQLPlanMetric],
+    val planNodeId: Option[Long] = None) {
 
   def toSparkPlanGraphCluster(): SparkPlanGraphCluster = {
     new SparkPlanGraphCluster(id, name, desc,
       new ArrayBuffer() ++ nodes.map(_.toSparkPlanGraphNode()),
-      metrics)
+      metrics,
+      planNodeId)
   }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -144,7 +144,8 @@ object SparkPlanGraph {
           planInfo.nodeName,
           planInfo.simpleString,
           mutable.ArrayBuffer[SparkPlanGraphNode](),
-          metrics)
+          metrics,
+          planInfo.operatorId)
         nodes += cluster
 
         buildSparkPlanGraphNode(
@@ -189,7 +190,7 @@ object SparkPlanGraph {
         }
         val node = new SparkPlanGraphNode(
           nodeIdGenerator.getAndIncrement(), planInfo.nodeName,
-          planInfo.simpleString, metrics)
+          planInfo.simpleString, metrics, planInfo.operatorId)
         if (subgraph == null) {
           nodes += node
         } else {
@@ -219,7 +220,8 @@ class SparkPlanGraphNode(
     val id: Long,
     val name: String,
     val desc: String,
-    val metrics: collection.Seq[SQLPlanMetric]) {
+    val metrics: collection.Seq[SQLPlanMetric],
+    val planNodeId: Option[Long] = None) {
 
   def makeDotNode(metricsValue: Map[Long, String]): String = {
     val nodeId = s"node$id"
@@ -238,8 +240,11 @@ class SparkPlanGraphCluster(
     name: String,
     desc: String,
     val nodes: mutable.ArrayBuffer[SparkPlanGraphNode],
-    metrics: collection.Seq[SQLPlanMetric])
-  extends SparkPlanGraphNode(id, name, desc, metrics) {
+    metrics: collection.Seq[SQLPlanMetric],
+    planNodeId: Option[Long] = None)
+  extends SparkPlanGraphNode(id, name, desc, metrics, planNodeId) {
+
+  def subPlanNodeIds: Seq[Long] = nodes.flatMap(_.planNodeId).toSeq
 
   override def makeDotNode(metricsValue: Map[Long, String]): String = {
     val duration = metrics.filter(m =>

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -333,8 +333,18 @@ private[v1] class SqlResource extends BaseAppResource {
       val wholeStageCodegenId = nodeIdAndWSCGIdMap.get(node.id).flatten
       val metrics =
         node.metrics.flatMap(m => getMetric(metricValues, m.accumulatorId, m.name.trim))
-      Node(nodeId = node.id, nodeName = node.name.trim, wholeStageCodegenId, metrics,
-        desc = node.desc)
+      val subPlanNodeIds = node match {
+        case cluster: SparkPlanGraphCluster => cluster.subPlanNodeIds
+        case _ => Nil
+      }
+      Node(
+        nodeId = node.id,
+        nodeName = node.name.trim,
+        wholeStageCodegenId,
+        metrics,
+        desc = node.desc,
+        planNodeId = node.planNodeId,
+        subPlanNodeIds = subPlanNodeIds)
     }
 
     nodes.sortBy(_.nodeId).reverse

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -27,7 +27,9 @@ case class Node private[spark] (
     nodeName: String,
     wholeStageCodegenId: Option[Long] = None,
     metrics: collection.Seq[Metric],
-    desc: String = null)
+    desc: String = null,
+    planNodeId: Option[Long] = None,
+    subPlanNodeIds: collection.Seq[Long] = Nil)
 
 class ExecutionData private[spark] (
     val id: Long,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.connector.write.{BatchWrite, DataWriter, DataWriterFactory, LogicalWriteInfo, PhysicalWriteInfo, Write, WriteBuilder}
-import org.apache.spark.sql.execution.{LeafExecNode, QueryExecution, SparkPlanInfo, SQLExecution}
+import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode, QueryExecution, SparkPlanInfo, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -157,6 +157,14 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTes
   }
 
   protected def createStatusStore(): SQLAppStatusStore
+
+  test("SPARK-58703: spark plan graph exposes plan node ids after operator tagging") {
+    val dataFrame = createTestDataFrame
+    ExplainUtils.tagOperatorIds(dataFrame.queryExecution.executedPlan)
+
+    val graph = SparkPlanGraph(SparkPlanInfo.fromSparkPlan(dataFrame.queryExecution.executedPlan))
+    assert(graph.allNodes.exists(_.planNodeId.isDefined))
+  }
 
   test("basic") {
     def checkAnswer(actual: Map[Long, String], expected: Map[Long, Long]): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -396,7 +396,8 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
     val executionJson = mapper.writeValueAsString(executionData).replaceAll("\\s", "")
     assert(executionJson.contains("\"modifiedConfigs\":{}"))
     assert(executionJson.contains(
-      "\"nodes\":[{\"nodeId\":0,\"nodeName\":\"Scantext\",\"metrics\":[]}]"))
+      "\"nodes\":[{\"nodeId\":0,\"nodeName\":\"Scantext\",\"metrics\":[]," +
+        "\"subPlanNodeIds\":[]}]"))
     // totalTaskTime defaults to -1 (unknown) when not provided.
     assert(executionData.totalTaskTime == -1L)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Propagate stable physical plan operator IDs through the SQL UI DAG, REST API, and physical plan details. 
DAG nodes can now highlight and navigate to matching physical operators,
 including WholeStageCodegen nodes.

### Why are the changes needed?

SQL UI DAG IDs currently do not reliably match physical plan operators. 
Stable cross-references make SQL execution plans easier for LLMs to interpret and
 support building Spark-related agents.

### Does this PR introduce *any* user-facing change?

Yes. The SQL UI adds DAG-to-plan navigation, and the REST API exposes
 `planNodeId` and `subPlanNodeIds` for machine-readable plan correlation.

<img width="1716" height="944" alt="截屏2026-08-11 12 44 08" src="https://github.com/user-attachments/assets/e53d1201-31d9-431e-b749-d2eec89d563f" />

- Click a node to display its information and highlight the corresponding plan node.
- Double-click a node to navigate to the corresponding plan node.

### How was this patch tested?

Added UT & MT

### Was this patch authored or co-authored using generative AI tooling?

Yea