### PR TITLE
[SPARK-58705][ML] Optimize AFTSurvivalRegressionModel transform closure

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -408,11 +408,8 @@ class AFTSurvivalRegressionModel private[ml] (
     }
   }
 
-  private def lambda2Quantiles(lambda: Double): Vector = {
-    val quantiles = _quantiles.copy
-    BLAS.scal(lambda, quantiles)
-    quantiles
-  }
+  private def lambda2Quantiles(lambda: Double): Vector =
+    AFTSurvivalRegressionModel.lambda2Quantiles(lambda, _quantiles)
 
   @Since("2.0.0")
   def predictQuantiles(features: Vector): Vector = {
@@ -447,11 +444,8 @@ class AFTSurvivalRegressionModel private[ml] (
 
     if (hasQuantilesCol) {
       val localQuantiles = _quantiles
-      val lambda2QuantilesFunc = (lambda: Double) => {
-        val quantiles = localQuantiles.copy
-        BLAS.scal(lambda, quantiles)
-        quantiles
-      }
+      val lambda2QuantilesFunc = (lambda: Double) =>
+        AFTSurvivalRegressionModel.lambda2Quantiles(lambda, localQuantiles)
       val quanCol = if ($(predictionCol).nonEmpty) {
         udf(lambda2QuantilesFunc).apply(predictionColumns.head)
       } else {
@@ -512,6 +506,12 @@ class AFTSurvivalRegressionModel private[ml] (
 @Since("1.6.0")
 object AFTSurvivalRegressionModel extends MLReadable[AFTSurvivalRegressionModel] {
   private[ml] case class Data(coefficients: Vector, intercept: Double, scale: Double)
+
+  private def lambda2Quantiles(lambda: Double, quantiles: Vector): Vector = {
+    val scaledQuantiles = quantiles.copy
+    BLAS.scal(lambda, scaledQuantiles)
+    scaledQuantiles
+  }
 
   private[ml] def serializeData(data: Data, dos: DataOutputStream): Unit = {
     import ReadWriteUtils._

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -408,20 +408,13 @@ class AFTSurvivalRegressionModel private[ml] (
     }
   }
 
-  private def lambda2Quantiles(lambda: Double): Vector =
-    AFTSurvivalRegressionModel.lambda2Quantiles(lambda, _quantiles)
+  @Since("2.0.0")
+  def predictQuantiles(features: Vector): Vector =
+    AFTSurvivalRegressionModel.predictQuantiles(features, coefficients, intercept, _quantiles)
 
   @Since("2.0.0")
-  def predictQuantiles(features: Vector): Vector = {
-    // scale parameter for the Weibull distribution of lifetime
-    val lambda = predict(features)
-    lambda2Quantiles(lambda)
-  }
-
-  @Since("2.0.0")
-  def predict(features: Vector): Double = {
-    math.exp(BLAS.dot(coefficients, features) + intercept)
-  }
+  def predict(features: Vector): Double =
+    AFTSurvivalRegressionModel.predict(features, coefficients, intercept)
 
   @Since("2.0.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
@@ -431,9 +424,8 @@ class AFTSurvivalRegressionModel private[ml] (
     var predictionColumns = Seq.empty[Column]
     val localCoefficients = coefficients
     val localIntercept = intercept
-    val predictFunc = (features: Vector) => {
-      math.exp(BLAS.dot(localCoefficients, features) + localIntercept)
-    }
+    val predictFunc = (features: Vector) =>
+      AFTSurvivalRegressionModel.predict(features, localCoefficients, localIntercept)
 
     if ($(predictionCol).nonEmpty) {
       val predCol = udf(predictFunc).apply(col($(featuresCol)))
@@ -449,7 +441,10 @@ class AFTSurvivalRegressionModel private[ml] (
       val quanCol = if ($(predictionCol).nonEmpty) {
         udf(lambda2QuantilesFunc).apply(predictionColumns.head)
       } else {
-        udf((features: Vector) => lambda2QuantilesFunc(predictFunc(features)))
+        val predictQuantilesFunc = (features: Vector) =>
+          AFTSurvivalRegressionModel.predictQuantiles(
+            features, localCoefficients, localIntercept, localQuantiles)
+        udf(predictQuantilesFunc)
           .apply(col($(featuresCol)))
       }
       predictionColNames :+= $(quantilesCol)
@@ -511,6 +506,17 @@ object AFTSurvivalRegressionModel extends MLReadable[AFTSurvivalRegressionModel]
     val scaledQuantiles = quantiles.copy
     BLAS.scal(lambda, scaledQuantiles)
     scaledQuantiles
+  }
+
+  private def predict(features: Vector, coefficients: Vector, intercept: Double): Double =
+    math.exp(BLAS.dot(coefficients, features) + intercept)
+
+  private def predictQuantiles(
+      features: Vector,
+      coefficients: Vector,
+      intercept: Double,
+      quantiles: Vector): Vector = {
+    lambda2Quantiles(predict(features, coefficients, intercept), quantiles)
   }
 
   private[ml] def serializeData(data: Data, dos: DataOutputStream): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -424,11 +424,11 @@ class AFTSurvivalRegressionModel private[ml] (
     var predictionColumns = Seq.empty[Column]
     val localCoefficients = coefficients
     val localIntercept = intercept
-    val predictFunc = (features: Vector) =>
-      AFTSurvivalRegressionModel.predict(features, localCoefficients, localIntercept)
 
     if ($(predictionCol).nonEmpty) {
-      val predCol = udf(predictFunc).apply(col($(featuresCol)))
+      val predCol = udf((features: Vector) =>
+        AFTSurvivalRegressionModel.predict(features, localCoefficients, localIntercept))
+        .apply(col($(featuresCol)))
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predCol
         .as($(predictionCol), outputSchema($(predictionCol)).metadata)
@@ -436,16 +436,15 @@ class AFTSurvivalRegressionModel private[ml] (
 
     if (hasQuantilesCol) {
       val localQuantiles = _quantiles
-      val lambda2QuantilesFunc = (lambda: Double) =>
-        AFTSurvivalRegressionModel.lambda2Quantiles(lambda, localQuantiles)
       val quanCol = if ($(predictionCol).nonEmpty) {
-        udf(lambda2QuantilesFunc).apply(predictionColumns.head)
+        udf((lambda: Double) =>
+          AFTSurvivalRegressionModel.lambda2Quantiles(lambda, localQuantiles))
+          .apply(predictionColumns.head)
       } else {
-        val predictQuantilesFunc = (features: Vector) =>
+        udf((features: Vector) =>
           AFTSurvivalRegressionModel.predictQuantiles(
             features, localCoefficients, localIntercept, localQuantiles)
-        udf(predictQuantilesFunc)
-          .apply(col($(featuresCol)))
+        ).apply(col($(featuresCol)))
       }
       predictionColNames :+= $(quantilesCol)
       predictionColumns :+= quanCol

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -432,19 +432,31 @@ class AFTSurvivalRegressionModel private[ml] (
 
     var predictionColNames = Seq.empty[String]
     var predictionColumns = Seq.empty[Column]
+    val localCoefficients = coefficients
+    val localIntercept = intercept
+    val predictFunc = (features: Vector) => {
+      math.exp(BLAS.dot(localCoefficients, features) + localIntercept)
+    }
 
     if ($(predictionCol).nonEmpty) {
-      val predCol = udf(predict _).apply(col($(featuresCol)))
+      val predCol = udf(predictFunc).apply(col($(featuresCol)))
       predictionColNames :+= $(predictionCol)
       predictionColumns :+= predCol
         .as($(predictionCol), outputSchema($(predictionCol)).metadata)
     }
 
     if (hasQuantilesCol) {
+      val localQuantiles = _quantiles
+      val lambda2QuantilesFunc = (lambda: Double) => {
+        val quantiles = localQuantiles.copy
+        BLAS.scal(lambda, quantiles)
+        quantiles
+      }
       val quanCol = if ($(predictionCol).nonEmpty) {
-        udf(lambda2Quantiles _).apply(predictionColumns.head)
+        udf(lambda2QuantilesFunc).apply(predictionColumns.head)
       } else {
-        udf(predictQuantiles _).apply(col($(featuresCol)))
+        udf((features: Vector) => lambda2QuantilesFunc(predictFunc(features)))
+          .apply(col($(featuresCol)))
       }
       predictionColNames :+= $(quantilesCol)
       predictionColumns :+= quanCol


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR snapshots the prediction and quantile state in local functions while constructing `AFTSurvivalRegressionModel.transform` UDFs. The UDF closures therefore retain only the required vectors and scalar rather than the complete model.

### Why are the changes needed?

Avoiding model capture reduces transform-closure retained memory, particularly for Spark Connect server workloads.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 "mllib / Compile / compile"`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)