### PR TITLE
[SPARK-58706][ML] Use SQL aggregation in OneHotEncoder fitting

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -547,9 +547,9 @@ private[feature] object OneHotEncoderCommon {
       val maxIndexError = raise_error(printf(
         lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got %s."),
         doubleCol))
-      when(isnan(doubleCol) || doubleCol > Int.MaxValue, maxIndexError)
+      when(!isnan(doubleCol) && doubleCol > Int.MaxValue, maxIndexError)
         .when(
-          doubleCol.isNull || doubleCol < 0.0 || doubleCol =!= intCol,
+          doubleCol.isNull || isnan(doubleCol) || doubleCol < 0.0 || doubleCol =!= intCol,
           invalidIndexError)
         .otherwise(intCol)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -547,10 +547,10 @@ private[feature] object OneHotEncoderCommon {
       val maxIndexError = raise_error(printf(
         lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got %s."),
         doubleCol))
-      when(!isnan(doubleCol) && doubleCol > Int.MaxValue, maxIndexError)
-        .when(
-          doubleCol.isNull || isnan(doubleCol) || doubleCol < 0.0 || doubleCol =!= intCol,
-          invalidIndexError)
+      when(
+        doubleCol.isNull || isnan(doubleCol) || doubleCol < 0.0 || doubleCol =!= intCol,
+        invalidIndexError)
+        .when(doubleCol > Int.MaxValue, maxIndexError)
         .otherwise(intCol)
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -538,7 +538,7 @@ private[feature] object OneHotEncoderCommon {
         lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got %s."),
         doubleCol))
       when(
-        doubleCol.isNull || isnan(doubleCol) || doubleCol < 0.0 || doubleCol =!= intCol,
+        isnull(doubleCol) || isnan(doubleCol) || doubleCol < 0.0 || doubleCol =!= intCol,
         invalidIndexError)
         .when(doubleCol > Int.MaxValue, maxIndexError)
         .otherwise(intCol)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -551,11 +551,11 @@ private[feature] object OneHotEncoderCommon {
         .when(
           doubleCol.isNull || doubleCol < 0.0 || doubleCol =!= intCol,
           invalidIndexError)
-        .otherwise(intCol + 1)
+        .otherwise(intCol)
     }
 
-    val maxValues = columns.map(c => coalesce(max(c), lit(1)))
-    val maxValuesRow = dataset.agg(maxValues.head, maxValues.tail: _*).head()
+    val maxValues = columns.map(c => coalesce(max(c) + 1, lit(1)))
+    val maxValuesRow = dataset.select(maxValues: _*).head()
     val numAttrsArray = Array.tabulate(maxValues.length)(maxValuesRow.getInt)
 
     outputColNames.zip(numAttrsArray).map { case (outputColName, numAttrs) =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -34,16 +34,16 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{
   coalesce,
   col,
-  concat,
   floor,
   isnan,
   lit,
   max,
+  printf,
   raise_error,
   udf,
   when
 }
-import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SizeEstimator
 
@@ -542,12 +542,11 @@ private[feature] object OneHotEncoderCommon {
       dropLast: Boolean): Seq[AttributeGroup] = {
     val columns = inputColNames.map { inputColName =>
       val inputCol = col(inputColName).cast(DoubleType)
-      val value = coalesce(inputCol.cast(StringType), lit("null"))
-      val invalidIndexError = raise_error(concat(
-        lit(s"Values from column $inputColName must be indices, but got "), value, lit(".")))
-      val maxIndexError = raise_error(concat(
-        lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got "), value,
-        lit(".")))
+      val invalidIndexError = raise_error(printf(
+        lit(s"Values from column $inputColName must be indices, but got %s."), inputCol))
+      val maxIndexError = raise_error(printf(
+        lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got %s."),
+        inputCol))
       when(inputCol.isNull, invalidIndexError)
         .when(isnan(inputCol) || inputCol > Int.MaxValue, maxIndexError)
         .when(inputCol < 0.0 || inputCol =!= floor(inputCol), invalidIndexError)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -31,17 +31,7 @@ import org.apache.spark.ml.param.shared.{HasHandleInvalid, HasInputCol, HasInput
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{
-  coalesce,
-  col,
-  isnan,
-  lit,
-  max,
-  printf,
-  raise_error,
-  udf,
-  when
-}
+import org.apache.spark.sql.functions.{printf => fprintf, _}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SizeEstimator
@@ -542,9 +532,9 @@ private[feature] object OneHotEncoderCommon {
     val columns = inputColNames.map { inputColName =>
       val doubleCol = col(inputColName).cast(DoubleType)
       val intCol = doubleCol.cast(IntegerType)
-      val invalidIndexError = raise_error(printf(
+      val invalidIndexError = raise_error(fprintf(
         lit(s"Values from column $inputColName must be indices, but got %s."), doubleCol))
-      val maxIndexError = raise_error(printf(
+      val maxIndexError = raise_error(fprintf(
         lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got %s."),
         doubleCol))
       when(

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{
   coalesce,
   col,
-  floor,
   isnan,
   lit,
   max,
@@ -43,7 +42,7 @@ import org.apache.spark.sql.functions.{
   udf,
   when
 }
-import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SizeEstimator
 
@@ -541,21 +540,23 @@ private[feature] object OneHotEncoderCommon {
       outputColNames: Seq[String],
       dropLast: Boolean): Seq[AttributeGroup] = {
     val columns = inputColNames.map { inputColName =>
-      val inputCol = col(inputColName).cast(DoubleType)
+      val doubleCol = col(inputColName).cast(DoubleType)
+      val intCol = doubleCol.cast(IntegerType)
       val invalidIndexError = raise_error(printf(
-        lit(s"Values from column $inputColName must be indices, but got %s."), inputCol))
+        lit(s"Values from column $inputColName must be indices, but got %s."), doubleCol))
       val maxIndexError = raise_error(printf(
         lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got %s."),
-        inputCol))
-      when(inputCol.isNull, invalidIndexError)
-        .when(isnan(inputCol) || inputCol > Int.MaxValue, maxIndexError)
-        .when(inputCol < 0.0 || inputCol =!= floor(inputCol), invalidIndexError)
-        .otherwise(inputCol)
+        doubleCol))
+      when(isnan(doubleCol) || doubleCol > Int.MaxValue, maxIndexError)
+        .when(
+          doubleCol.isNull || doubleCol < 0.0 || doubleCol =!= intCol,
+          invalidIndexError)
+        .otherwise(intCol + 1)
     }
 
-    val maxValues = columns.map(c => coalesce(max(c), lit(0.0)))
+    val maxValues = columns.map(c => coalesce(max(c), lit(1)))
     val maxValuesRow = dataset.agg(maxValues.head, maxValues.tail: _*).head()
-    val numAttrsArray = Array.tabulate(maxValues.length)(i => maxValuesRow.getDouble(i).toInt + 1)
+    val numAttrsArray = Array.tabulate(maxValues.length)(maxValuesRow.getInt)
 
     outputColNames.zip(numAttrsArray).map { case (outputColName, numAttrs) =>
       createAttrGroupForAttrNames(outputColName, numAttrs, dropLast, keepInvalid = false)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -31,8 +31,19 @@ import org.apache.spark.ml.param.shared.{HasHandleInvalid, HasInputCol, HasInput
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{col, lit, udf}
-import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+import org.apache.spark.sql.functions.{
+  coalesce,
+  col,
+  concat,
+  floor,
+  isnan,
+  lit,
+  max,
+  raise_error,
+  udf,
+  when
+}
+import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SizeEstimator
 
@@ -529,34 +540,22 @@ private[feature] object OneHotEncoderCommon {
       inputColNames: Seq[String],
       outputColNames: Seq[String],
       dropLast: Boolean): Seq[AttributeGroup] = {
-    // The RDD approach has advantage of early-stop if any values are invalid. It seems that
-    // DataFrame ops don't have equivalent functions.
     val columns = inputColNames.map { inputColName =>
-      col(inputColName).cast(DoubleType)
+      val inputCol = col(inputColName).cast(DoubleType)
+      val value = coalesce(inputCol.cast(StringType), lit("null"))
+      val invalidIndexError = raise_error(concat(
+        lit(s"Values from column $inputColName must be indices, but got "), value, lit(".")))
+      when(inputCol.isNull, invalidIndexError)
+        .when(isnan(inputCol) || inputCol > Int.MaxValue, raise_error(concat(
+          lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got "), value,
+          lit("."))))
+        .when(inputCol < 0.0 || inputCol =!= floor(inputCol), invalidIndexError)
+        .otherwise(inputCol)
     }
-    val numOfColumns = columns.length
 
-    val numAttrsArray = dataset.select(columns: _*).rdd.map { row =>
-      (0 until numOfColumns).map(idx => row.getDouble(idx)).toArray
-    }.treeAggregate(new Array[Double](numOfColumns))(
-      (maxValues, curValues) => {
-        (0 until numOfColumns).foreach { idx =>
-          val x = curValues(idx)
-          assert(x <= Int.MaxValue,
-            s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got $x.")
-          assert(x >= 0.0 && x == x.toInt,
-            s"Values from column ${inputColNames(idx)} must be indices, but got $x.")
-          maxValues(idx) = math.max(maxValues(idx), x)
-        }
-        maxValues
-      },
-      (m0, m1) => {
-        (0 until numOfColumns).foreach { idx =>
-          m0(idx) = math.max(m0(idx), m1(idx))
-        }
-        m0
-      }
-    ).map(_.toInt + 1)
+    val maxValues = columns.map(c => coalesce(max(c), lit(0.0)))
+    val maxValuesRow = dataset.agg(maxValues.head, maxValues.tail: _*).head()
+    val numAttrsArray = Array.tabulate(maxValues.length)(i => maxValuesRow.getDouble(i).toInt + 1)
 
     outputColNames.zip(numAttrsArray).map { case (outputColName, numAttrs) =>
       createAttrGroupForAttrNames(outputColName, numAttrs, dropLast, keepInvalid = false)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -545,10 +545,11 @@ private[feature] object OneHotEncoderCommon {
       val value = coalesce(inputCol.cast(StringType), lit("null"))
       val invalidIndexError = raise_error(concat(
         lit(s"Values from column $inputColName must be indices, but got "), value, lit(".")))
+      val maxIndexError = raise_error(concat(
+        lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got "), value,
+        lit(".")))
       when(inputCol.isNull, invalidIndexError)
-        .when(isnan(inputCol) || inputCol > Int.MaxValue, raise_error(concat(
-          lit(s"OneHotEncoder only supports up to ${Int.MaxValue} indices, but got "), value,
-          lit("."))))
+        .when(isnan(inputCol) || inputCol > Int.MaxValue, maxIndexError)
         .when(inputCol < 0.0 || inputCol =!= floor(inputCol), invalidIndexError)
         .otherwise(inputCol)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the RDD `treeAggregate` in `OneHotEncoder` fitting with a SQL aggregation. The SQL expressions validate category indices and compute the maximum category index for each input column.

The validation expressions use `raise_error`, so an executor fails when it evaluates an invalid index. This replaces the stale RDD-specific early-stop comment. As with the old implementation, Spark cancels the query after the failure, although independently running tasks may already be processing rows.

### Why are the changes needed?

The previous implementation serializes an array sized to all input columns as the aggregation zero value. SQL performs partial aggregation on executors and returns a single result row to the driver, reducing driver serialization and aggregation overhead for wide encoders.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 "mllib / Compile / compile"`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)