### PR TITLE
[SPARK-43940][SQL] Test the error class: BATCH_METADATA_NOT_FOUND

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -48,7 +48,9 @@ import org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProv
 import org.apache.spark.sql.execution.datasources.orc.OrcTest
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
-import org.apache.spark.sql.execution.streaming.checkpointing.FileSystemBasedCheckpointFileManager
+import org.apache.spark.sql.execution.streaming.checkpointing.{
+  FileSystemBasedCheckpointFileManager,
+  HDFSMetadataLog}
 import org.apache.spark.sql.execution.vectorized.{
   ColumnVectorUtils,
   ConstantColumnVector,
@@ -994,6 +996,22 @@ class QueryExecutionErrorsSuite
           parameters = Map("sourcePath" -> s"$expectedPath.+")
         )
       }
+    }
+  }
+
+  test("SPARK-43940: BATCH_METADATA_NOT_FOUND") {
+    withTempDir { dir =>
+      val metadataLog = new HDFSMetadataLog[String](spark, dir.getAbsolutePath)
+      val e = intercept[SparkFileNotFoundException] {
+        metadataLog.applyFnToBatchByStream(0L) { _ => () }
+      }
+
+      val batchMetadataFile = new Path(dir.getAbsolutePath, "0").toString
+      checkError(
+        exception = e,
+        condition = "BATCH_METADATA_NOT_FOUND",
+        parameters = Map("batchMetadataFile" -> batchMetadataFile),
+        sqlState = "42K03")
     }
   }
 


### PR DESCRIPTION
### Summary
Adds coverage for the missing batch metadata error path.

### Change
`HDFSMetadataLog.applyFnToBatchByStream` now has a focused test that checks `BATCH_METADATA_NOT_FOUND`, the missing batch file parameter, and SQLSTATE `42K03`.

### Tests
`JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH" ./build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite -- -z SPARK-43940"`

Fixes SPARK-43940

**JIRA assignee for credit:** deepujain
