### PR TITLE
[SPARK-58710][MLLIB] Remove unused members from the decision tree Node classes

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -77,9 +77,6 @@ sealed abstract class Node extends Serializable {
    * @return  Max feature index used in a split, or -1 if there are no splits (single leaf node).
    */
   private[ml] def maxSplitFeatureIndex(): Int
-
-  /** Returns a deep copy of the subtree rooted at this node. */
-  private[tree] def deepCopy(): Node
 }
 
 private[ml] object Node {
@@ -146,10 +143,6 @@ class LeafNode private[ml] (
   }
 
   override private[ml] def maxSplitFeatureIndex(): Int = -1
-
-  override private[tree] def deepCopy(): Node = {
-    new LeafNode(prediction, impurity, impurityStats)
-  }
 }
 
 /**
@@ -237,11 +230,6 @@ class InternalNode private[ml] (
   override private[ml] def maxSplitFeatureIndex(): Int = {
     math.max(split.featureIndex,
       math.max(leftChild.maxSplitFeatureIndex(), rightChild.maxSplitFeatureIndex()))
-  }
-
-  override private[tree] def deepCopy(): Node = {
-    new InternalNode(prediction, impurity, gain, leftChild.deepCopy(), rightChild.deepCopy(),
-      split, impurityStats)
   }
 }
 
@@ -394,53 +382,12 @@ private[tree] object LearningNode {
   def rightChildIndex(nodeIndex: Int): Int = (nodeIndex << 1) + 1
 
   /**
-   * Get the parent index of the given node, or 0 if it is the root.
-   */
-  def parentIndex(nodeIndex: Int): Int = nodeIndex >> 1
-
-  /**
    * Return the level of a tree which the given node is in.
    */
   def indexToLevel(nodeIndex: Int): Int = if (nodeIndex == 0) {
     throw new IllegalArgumentException(s"0 is not a valid node index.")
   } else {
     java.lang.Integer.numberOfTrailingZeros(java.lang.Integer.highestOneBit(nodeIndex))
-  }
-
-  /**
-   * Returns true if this is a left child.
-   * Note: Returns false for the root.
-   */
-  def isLeftChild(nodeIndex: Int): Boolean = nodeIndex > 1 && nodeIndex % 2 == 0
-
-  /**
-   * Return the maximum number of nodes which can be in the given level of the tree.
-   * @param level  Level of tree (0 = root).
-   */
-  def maxNodesInLevel(level: Int): Int = 1 << level
-
-  /**
-   * Return the index of the first node in the given level.
-   * @param level  Level of tree (0 = root).
-   */
-  def startIndexInLevel(level: Int): Int = 1 << level
-
-  /**
-   * Traces down from a root node to get the node with the given node index.
-   * This assumes the node exists.
-   */
-  def getNode(nodeIndex: Int, rootNode: LearningNode): LearningNode = {
-    var tmpNode: LearningNode = rootNode
-    var levelsToGo = indexToLevel(nodeIndex)
-    while (levelsToGo > 0) {
-      if ((nodeIndex & (1 << levelsToGo - 1)) == 0) {
-        tmpNode = tmpNode.leftChild.get
-      } else {
-        tmpNode = tmpNode.rightChild.get
-      }
-      levelsToGo -= 1
-    }
-    tmpNode
   }
 
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
@@ -81,23 +81,6 @@ class Node @Since("1.2.0") (
   }
 
   /**
-   * Returns a deep copy of the subtree rooted at this node.
-   */
-  private[tree] def deepCopy(): Node = {
-    val leftNodeCopy = if (leftNode.isEmpty) {
-      None
-    } else {
-      Some(leftNode.get.deepCopy())
-    }
-    val rightNodeCopy = if (rightNode.isEmpty) {
-      None
-    } else {
-      Some(rightNode.get.deepCopy())
-    }
-    new Node(id, predict, impurity, isLeaf, split, leftNodeCopy, rightNodeCopy, stats)
-  }
-
-  /**
    * Get the number of nodes in tree below this node, including leaf nodes.
    * E.g., if this is a leaf, returns 0.  If both children are leaves, returns 2.
    */
@@ -158,12 +141,6 @@ class Node @Since("1.2.0") (
 private[spark] object Node {
 
   /**
-   * Return a node with the given node id (but nothing else set).
-   */
-  def emptyNode(nodeIndex: Int): Node = new Node(nodeIndex, new Predict(Double.MinValue), -1.0,
-    false, None, None, None, None)
-
-  /**
    * Construct a node with nodeIndex, predict, impurity and isLeaf parameters.
    * This is used in `DecisionTree.findBestSplits` to construct child nodes
    * after finding the best splits for parent nodes.
@@ -191,55 +168,5 @@ private[spark] object Node {
    * Return the index of the right child of this node.
    */
   def rightChildIndex(nodeIndex: Int): Int = (nodeIndex << 1) + 1
-
-  /**
-   * Get the parent index of the given node, or 0 if it is the root.
-   */
-  def parentIndex(nodeIndex: Int): Int = nodeIndex >> 1
-
-  /**
-   * Return the level of a tree which the given node is in.
-   */
-  def indexToLevel(nodeIndex: Int): Int = if (nodeIndex == 0) {
-    throw new IllegalArgumentException(s"0 is not a valid node index.")
-  } else {
-    java.lang.Integer.numberOfTrailingZeros(java.lang.Integer.highestOneBit(nodeIndex))
-  }
-
-  /**
-   * Returns true if this is a left child.
-   * Note: Returns false for the root.
-   */
-  def isLeftChild(nodeIndex: Int): Boolean = nodeIndex > 1 && nodeIndex % 2 == 0
-
-  /**
-   * Return the maximum number of nodes which can be in the given level of the tree.
-   * @param level  Level of tree (0 = root).
-   */
-  def maxNodesInLevel(level: Int): Int = 1 << level
-
-  /**
-   * Return the index of the first node in the given level.
-   * @param level  Level of tree (0 = root).
-   */
-  def startIndexInLevel(level: Int): Int = 1 << level
-
-  /**
-   * Traces down from a root node to get the node with the given node index.
-   * This assumes the node exists.
-   */
-  def getNode(nodeIndex: Int, rootNode: Node): Node = {
-    var tmpNode: Node = rootNode
-    var levelsToGo = indexToLevel(nodeIndex)
-    while (levelsToGo > 0) {
-      if ((nodeIndex & (1 << levelsToGo - 1)) == 0) {
-        tmpNode = tmpNode.leftNode.get
-      } else {
-        tmpNode = tmpNode.rightNode.get
-      }
-      levelsToGo -= 1
-    }
-    tmpNode
-  }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes members with no callers from the two decision tree `Node` files.

`mllib/tree/model/Node.scala`: `deepCopy`, and the companion helpers `isLeftChild`, `maxNodesInLevel`, `startIndexInLevel`, `emptyNode`, `parentIndex`, `getNode`, `indexToLevel`.

`ml/tree/Node.scala`: the `deepCopy` declaration and its two overrides, plus `parentIndex`, `isLeftChild`, `maxNodesInLevel`, `startIndexInLevel`, `getNode`.

### Why are the changes needed?

None of these has a caller. `deepCopy` is reachable only from itself, so the declaration and both overrides are dead as a unit. The last callers of the indexing helpers disappeared when the decision tree implementation moved from `spark.mllib` to `spark.ml`.

Both files are covered because `ml/tree/Node.scala` carries the comment `// The below indexing methods were copied from spark.mllib.tree.model.Node`, so removing only the original would leave the labelled copy behind.

The live members are kept: `apply`, `leftChildIndex` and `rightChildIndex` in both objects, plus `emptyNode` and `indexToLevel` in `LearningNode`, which `RandomForest` still calls.

### Does this PR introduce _any_ user-facing change?

No. The `mllib` companion object is `private[spark]` and `deepCopy` is `private[tree]`, so nothing removed is public API. `GenerateMIMAIgnore` already excludes package-private members, so no `MimaExcludes` entry is required.

### How was this patch tested?

Pure removal of unreferenced code; no test references any removed member. Deadness was checked for each name across all file types, and dynamic reachability was ruled out explicitly: none appears as a string literal, there is no reflection or codegen in either tree package, and no MiMa filter names them. The two `Node` hierarchies are unrelated (`ml` imports the `mllib` one under an alias), so removing from one cannot affect the other.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
