### PR TITLE
[SPARK-58712][EXAMPLES] Fix incorrect usage strings in four examples

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
@@ -159,7 +159,7 @@ public final class JavaRecoverableNetworkWordCount {
 
   public static void main(String[] args) throws Exception {
     if (args.length != 4) {
-      System.err.println("You arguments were " + Arrays.asList(args));
+      System.err.println("Your arguments were " + Arrays.asList(args));
       System.err.println(
           "Usage: JavaRecoverableNetworkWordCount <hostname> <port> <checkpoint-directory>\n" +
           "     <output-file>. <hostname> and <port> describe the TCP server that Spark\n" +

--- a/examples/src/main/scala/org/apache/spark/examples/SkewedGroupByTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SkewedGroupByTest.scala
@@ -23,7 +23,7 @@ import java.util.Random
 import org.apache.spark.sql.SparkSession
 
 /**
- * Usage: GroupByTest [numMappers] [numKVPairs] [KeySize] [numReducers]
+ * Usage: SkewedGroupByTest [numMappers] [numKVPairs] [KeySize] [numReducers]
  */
 object SkewedGroupByTest {
   def main(args: Array[String]): Unit = {

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKafkaWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKafkaWordCount.scala
@@ -27,7 +27,7 @@ import org.apache.spark.streaming.kafka010._
 
 /**
  * Consumes messages from one or more topics in Kafka and does wordcount.
- * Usage: DirectKafkaWordCount <brokers> <topics>
+ * Usage: DirectKafkaWordCount <brokers> <groupId> <topics>
  *   <brokers> is a list of one or more Kafka brokers
  *   <groupId> is a consumer group name to consume from topics
  *   <topics> is a list of one or more kafka topics to consume from

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKerberizedKafkaWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/DirectKerberizedKafkaWordCount.scala
@@ -29,7 +29,7 @@ import org.apache.spark.streaming.kafka010._
 
 /**
  * Consumes messages from one or more topics in Kafka and does wordcount.
- * Usage: DirectKerberizedKafkaWordCount <brokers> <topics>
+ * Usage: DirectKerberizedKafkaWordCount <brokers> <groupId> <topics>
  *   <brokers> is a list of one or more Kafka brokers
  *   <groupId> is a consumer group name to consume from topics
  *   <topics> is a list of one or more kafka topics to consume from


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes four usage strings that disagree with the code around them:

- `DirectKafkaWordCount` and `DirectKerberizedKafkaWordCount`: the class comment gains the missing `<groupId>` argument
- `SkewedGroupByTest`: `Usage: GroupByTest` becomes `Usage: SkewedGroupByTest`
- `JavaRecoverableNetworkWordCount`: `You arguments were` becomes `Your arguments were`

### Why are the changes needed?

Each defect is contradicted by its own file:

- Both Kafka examples gate on `args.length < 3`, destructure `val Array(brokers, groupId, topics) = args`, already print the three-argument form at runtime, and already describe `<groupId>` on the line below the usage string. SPARK-27973 corrected the runtime message for the first example but left the comment out of sync. The Java twins (`JavaDirectKafkaWordCount`, `JavaDirectKerberizedKafkaWordCount`) are already correct, so this closes the gap.
- `SkewedGroupByTest`'s comment names `GroupByTest`, which is a different example that also exists, so copying the line runs the wrong job. The sibling `SimpleSkewedGroupByTest` self-names correctly.
- The Scala counterpart `RecoverableNetworkWordCount` already reads `Your arguments were`, so the fix aligns the twins.

### Does this PR introduce _any_ user-facing change?

No, other than the corrected example text.

### How was this patch tested?

Comment and message text only. Each correction was cross-checked against the example's own argument gate, destructuring, and runtime message. A sweep of every Scala and Java example for a mismatch between the comment's `Usage:` class name and the enclosing object name found only the `SkewedGroupByTest` case fixed here.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
