### PR TITLE
[SPARK-58715][ML][CONNECT] Use explicit fields for clustering model size estimation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -182,6 +182,9 @@ class BisectingKMeansModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     if (parentModel != null) {
+      // root: ClusteringTreeNode
+      // distanceMeasure: String
+      // trainingCost: Double
       size += SizeEstimator.estimate((
         parentModel.root,
         parentModel.distanceMeasure,

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -182,11 +182,10 @@ class BisectingKMeansModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     if (parentModel != null) {
-      // parentModel contains:
-      // - root: ClusteringTreeNode containing centers, costs, and children.
-      // - distanceMeasure: String and trainingCost: Double.
-      // - distanceMeasureInstance, derived from distanceMeasure.
-      size += SizeEstimator.estimate(parentModel)
+      size += SizeEstimator.estimate((
+        parentModel.root,
+        parentModel.distanceMeasure,
+        parentModel.trainingCost))
     }
     size
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -225,9 +225,9 @@ class GaussianMixtureModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     // weights: Array[Double]
+    size += SizeEstimator.estimate(weights)
     // gaussians: Array[MultivariateGaussian], each with mean: Vector and cov: Matrix
-    val gaussianParams = gaussians.map(gaussian => (gaussian.mean, gaussian.cov))
-    size += SizeEstimator.estimate((weights, gaussianParams))
+    gaussians.foreach(gaussian => size += SizeEstimator.estimate((gaussian.mean, gaussian.cov)))
     size
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -226,7 +226,8 @@ class GaussianMixtureModel private[ml] (
     var size = estimateMatadataSize
     // weights: Array[Double]
     // gaussians: Array[MultivariateGaussian], each containing a mean Vector and covariance Matrix
-    size += SizeEstimator.estimate((weights, gaussians))
+    val gaussianParams = gaussians.map(gaussian => (gaussian.mean, gaussian.cov))
+    size += SizeEstimator.estimate((weights, gaussianParams))
     size
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -225,7 +225,7 @@ class GaussianMixtureModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     // weights: Array[Double]
-    // gaussians: Array[MultivariateGaussian], each containing a mean Vector and covariance Matrix
+    // gaussians: Array[MultivariateGaussian], each with mean: Vector and cov: Matrix
     val gaussianParams = gaussians.map(gaussian => (gaussian.mean, gaussian.cov))
     size += SizeEstimator.estimate((weights, gaussianParams))
     size

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -216,9 +216,11 @@ class KMeansModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     if (parentModel != null) {
-      // parentModel contains clusterCenters, distanceMeasure, trainingCost, and numIter.
-      // It also has transient derived fields for distance calculation and statistics.
-      size += SizeEstimator.estimate(parentModel)
+      size += SizeEstimator.estimate((
+        parentModel.clusterCenters,
+        parentModel.distanceMeasure,
+        parentModel.trainingCost,
+        parentModel.numIter))
     }
     size
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -216,6 +216,10 @@ class KMeansModel private[ml] (
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
     if (parentModel != null) {
+      // clusterCenters: Array[Vector]
+      // distanceMeasure: String
+      // trainingCost: Double
+      // numIter: Int
       size += SizeEstimator.estimate((
         parentModel.clusterCenters,
         parentModel.distanceMeasure,

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala
@@ -41,7 +41,7 @@ import org.apache.spark.util.ArrayImplicits._
  */
 @Since("1.6.0")
 class BisectingKMeansModel private[clustering] (
-    private[clustering] val root: ClusteringTreeNode,
+    private[spark] val root: ClusteringTreeNode,
     @Since("2.4.0") val distanceMeasure: String,
     @Since("3.0.0") val trainingCost: Double
   ) extends Serializable with Saveable with Logging {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the ML `KMeansModel`, `BisectingKMeansModel`, and `GaussianMixtureModel` size estimates to pass only their persisted MLlib data fields to `SizeEstimator`.

For Gaussian mixture models, it estimates each Gaussian mean and covariance rather than the `MultivariateGaussian` wrapper. For bisecting K-means, it makes the MLlib model root available to Spark-internal code so the ML wrapper can list the fields directly.

### Why are the changes needed?

`SizeEstimator` recursively follows object references. Estimating an entire parent MLlib model can include transient or lazily initialized derived state, such as distance structures, statistics, or logging fields, rather than only persisted model data. Explicit fields make the accounting predictable and avoid retaining those auxiliary object graphs during estimation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 'mllib / Compile / compile'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)