### PR TITLE
[SPARK-58484][SQL] Fix ArrayIndexOutOfBoundsException in OrderedFilters when the required schema is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/OrderedFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/OrderedFilters.scala
@@ -47,22 +47,23 @@ class OrderedFilters(filters: Seq[sources.Filter], requiredSchema: StructType)
     val len = requiredSchema.fields.length
     val groupedPredicates = Array.fill[BasePredicate](len)(null)
     val groupedFilters = Array.fill(len)(Seq.empty[sources.Filter])
-    // Nothing to group when the required schema has no fields, for example `SELECT COUNT(*)`.
-    // Filters w/o references have no position to be applied at, and `skipRow()` is never called.
-    if (len > 0) {
-      for (filter <- filters) {
-        val refs = filter.references
-        val index = if (refs.isEmpty) {
-          // For example, `AlwaysTrue` and `AlwaysFalse` doesn't have any references
-          // Filters w/o refs always return the same result. Taking into account
-          // that predicates are combined via `And`, we can apply such filters only
-          // once at the position 0.
-          0
-        } else {
-          // readSchema must contain attributes of all filters.
-          // Accordingly, `fieldIndex()` returns a valid index always.
-          refs.map(requiredSchema.fieldIndex).max
-        }
+    for (filter <- filters) {
+      val refs = filter.references
+      val index = if (refs.isEmpty) {
+        // For example, `AlwaysTrue` and `AlwaysFalse` doesn't have any references
+        // Filters w/o refs always return the same result. Taking into account
+        // that predicates are combined via `And`, we can apply such filters only
+        // once at the position 0.
+        0
+      } else {
+        // readSchema must contain attributes of all filters.
+        // Accordingly, `fieldIndex()` returns a valid index always.
+        refs.map(requiredSchema.fieldIndex).max
+      }
+      // When the required schema has no fields, for example `SELECT COUNT(*)`, there is no
+      // position at which a filter w/o references could be applied, and `skipRow()` is
+      // never called for such a schema.
+      if (len > 0) {
         groupedFilters(index) :+= filter
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/OrderedFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/OrderedFilters.scala
@@ -47,20 +47,24 @@ class OrderedFilters(filters: Seq[sources.Filter], requiredSchema: StructType)
     val len = requiredSchema.fields.length
     val groupedPredicates = Array.fill[BasePredicate](len)(null)
     val groupedFilters = Array.fill(len)(Seq.empty[sources.Filter])
-    for (filter <- filters) {
-      val refs = filter.references
-      val index = if (refs.isEmpty) {
-        // For example, `AlwaysTrue` and `AlwaysFalse` doesn't have any references
-        // Filters w/o refs always return the same result. Taking into account
-        // that predicates are combined via `And`, we can apply such filters only
-        // once at the position 0.
-        0
-      } else {
-        // readSchema must contain attributes of all filters.
-        // Accordingly, `fieldIndex()` returns a valid index always.
-        refs.map(requiredSchema.fieldIndex).max
+    // Nothing to group when the required schema has no fields, for example `SELECT COUNT(*)`.
+    // Filters w/o references have no position to be applied at, and `skipRow()` is never called.
+    if (len > 0) {
+      for (filter <- filters) {
+        val refs = filter.references
+        val index = if (refs.isEmpty) {
+          // For example, `AlwaysTrue` and `AlwaysFalse` doesn't have any references
+          // Filters w/o refs always return the same result. Taking into account
+          // that predicates are combined via `And`, we can apply such filters only
+          // once at the position 0.
+          0
+        } else {
+          // readSchema must contain attributes of all filters.
+          // Accordingly, `fieldIndex()` returns a valid index always.
+          refs.map(requiredSchema.fieldIndex).max
+        }
+        groupedFilters(index) :+= filter
       }
-      groupedFilters(index) :+= filter
     }
     if (len > 0 && groupedFilters(0).nonEmpty) {
       // We assume that filters w/o refs like `AlwaysTrue` and `AlwaysFalse`

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/StructFiltersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/StructFiltersSuite.scala
@@ -58,6 +58,14 @@ abstract class StructFiltersSuite extends SparkFunSuite {
     case _ => StructType.fromDDL(str)
   }
 
+  test("SPARK-58484: reference-free filters with an empty required schema") {
+    // Filters w/o references are not excluded by an empty required schema.
+    Seq(AlwaysTrue, AlwaysFalse).foreach { filter =>
+      val structFilters = createFilters(Seq(filter), getSchema(""))
+      structFilters.reset()
+    }
+  }
+
   test("skipping rows") {
     def check(
       requiredSchema: String = "i INTEGER, d DOUBLE",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -4072,6 +4072,14 @@ abstract class CSVSuite
       }
     }
   }
+
+  test("SPARK-58484: count with a pushed filter that has no column references") {
+    withTable("m") {
+      sql("CREATE TABLE m(c0 INT) USING CSV")
+      sql("INSERT INTO m VALUES (1)")
+      checkAnswer(sql("SELECT COUNT(*) FROM m WHERE (SELECT BOOL_OR(true) FROM m)"), Row(1))
+    }
+  }
 }
 
 class CSVv1Suite extends CSVSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -4074,10 +4074,13 @@ abstract class CSVSuite
   }
 
   test("SPARK-58484: count with a pushed filter that has no column references") {
-    withTable("m") {
-      sql("CREATE TABLE m(c0 INT) USING CSV")
-      sql("INSERT INTO m VALUES (1)")
-      checkAnswer(sql("SELECT COUNT(*) FROM m WHERE (SELECT BOOL_OR(true) FROM m)"), Row(1))
+    withTempDir { dir =>
+      val path = new File(dir, "csv").getCanonicalPath
+      Seq(1).toDF("c0").write.csv(path)
+      withTempView("m") {
+        spark.read.schema("c0 INT").csv(path).createOrReplaceTempView("m")
+        checkAnswer(sql("SELECT COUNT(*) FROM m WHERE (SELECT BOOL_OR(true) FROM m)"), Row(1))
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`OrderedFilters` groups pushed down filters by the position of the last schema
field they reference, so that a filter can be applied to a partially parsed row
as soon as its referenced fields are set. The group arrays are sized by
`requiredSchema.fields.length`, but filters without references (`AlwaysTrue`,
`AlwaysFalse`) are assigned to index 0. When the required schema has no fields
the arrays are empty and the assignment throws.

This PR skips only that assignment when the required schema has no fields. In that
case `skipRow()` can never be invoked, because it asserts that the index points to
a field of the required schema, so there is no position at which such a filter
could be applied.

The guard is deliberately placed on the assignment rather than around the whole
loop. `OrderedFilters` does not use the list computed by
`StructFilters.pushedFilters()`: its constructor parameter is named `filters`,
which shadows the inherited `protected val filters`, so the loop iterates the raw
pushed filters. `JsonFilters` names its parameter `pushedFilters` and therefore
does use the filtered list. As a result a filter that references a field missing
from the required schema still reaches `fieldIndex()` here and raises
`FIELD_NOT_FOUND`, which `UnivocityParserSuite` asserts. Skipping the loop
entirely would suppress that validation.

`JsonFilters` already handles the same input, because it spreads reference-free
filters over the set of schema field names rather than pinning them to index 0.
With an empty schema that set is empty and the filter is dropped, which is why
JSON does not crash on an equivalent query.

The reordering step immediately below the loop already guarded `len > 0`; the
assignment loop did not.

### Why are the changes needed?

The following query fails at execution time:

```sql
CREATE TABLE m(c0 INT) USING CSV;
INSERT INTO m VALUES (1);
SELECT COUNT(*) FROM m WHERE (SELECT BOOL_OR(true) FROM m);
```

```
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
        at org.apache.spark.sql.catalyst.OrderedFilters.$anonfun$predicates$3(OrderedFilters.scala:63)
        at org.apache.spark.sql.catalyst.OrderedFilters.<init>(OrderedFilters.scala:50)
        at org.apache.spark.sql.catalyst.csv.UnivocityParser.<init>(UnivocityParser.scala:119)
```

Through the SQL path the exception surfaces wrapped as
`[FAILED_READ_FILE.NO_HINT]` with the `ArrayIndexOutOfBoundsException` as its
cause.

The `WHERE` clause is an uncorrelated boolean scalar subquery referencing no
columns. Since SPARK-43402 such predicates are retained as data filters; at
execution the finished subquery is substituted as `Literal(true)` and translated
to `sources.AlwaysTrue`, a filter with no references. With `COUNT(*)` the
required schema is empty, so both conditions hold at once.

`OrderedFilters` is also used by the Avro reader, which is affected in the same
way and is fixed by the same change.

### Does this PR introduce _any_ user-facing change?

Yes. A query that pushes down a filter without column references while requiring
no columns previously failed with `ArrayIndexOutOfBoundsException` and now
returns the correct result.

### How was this patch tested?

Two new tests, both confirmed to fail before this change and pass after it.

`StructFiltersSuite` is shared by `OrderedFiltersSuite` and `JsonFiltersSuite`,
so the unit test covers both implementations and shows that JSON was already
correct. The test asserts only that building the filters succeeds, because with
an empty required schema there is nothing observable to assert: the predicates
are private and `skipRow()` cannot be called at all.

```
build/sbt 'catalyst/testOnly *OrderedFiltersSuite *JsonFiltersSuite'
```

An end to end test was added to `CSVSuite`, covering the query from the JIRA and
checking its result. It reads a written CSV file through a temporary view rather
than a catalog table, because `CSVSuite` mixes in `CommonFileDataSourceSuite`,
whose Hadoop configuration test leaves table creation in that suite unusable.

```
build/sbt 'sql/testOnly *CSVv1Suite *CSVv2Suite *CSVLegacyTimeParserSuite'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
