### PR TITLE
[SPARK-57787][CONNECT][PYTHON][FOLLOWUP][4.3] Fix syntax error in `local_server.py`

### DIFF
--- a/python/pyspark/sql/connect/local_server.py
+++ b/python/pyspark/sql/connect/local_server.py
@@ -88,7 +88,7 @@ def _is_local_connect_server(pid: int) -> Optional[bool]:
             text=True,
             timeout=5,
         )
-    e1xcept (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError):
         return None
     return result.returncode == 0 and _SERVER_CLASS in result.stdout
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a typo `e1xcept` -> `except` in `python/pyspark/sql/connect/local_server.py`

### Why are the changes needed?
The cherry-pick of #57854 to `branch-4.3` introduced a typo during conflict resolution, causing a `SyntaxError` that breaks `dev/lint-python` (Python compilation check).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
