### PR TITLE
[SPARK-49442][SS][FOLLOWUP] Use monotonic clock for Kafka partition cache TTL

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -62,7 +63,7 @@ private[kafka010] class KafkaOffsetReaderAdmin(
 
   // Protected by this.synchronized (always accessed inside withRetries, which holds the lock).
   private var cachedPartitions: Set[TopicPartition] = Set.empty
-  private var cacheTimestampMs: Long = 0L
+  private var cacheTimestampNanos: Option[Long] = None
 
   /**
    * An AdminClient used in the driver to query the latest Kafka offsets.
@@ -451,16 +452,20 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     if (partitionMetadataCacheTtlMs <= 0) {
       return consumerStrategy.assignedTopicPartitions(admin)
     }
-    val now = System.currentTimeMillis()
-    if (cacheTimestampMs > 0 && (now - cacheTimestampMs) < partitionMetadataCacheTtlMs) {
-      logDebug(s"Reusing cached partitions (age ${now - cacheTimestampMs}ms < " +
-        s"${partitionMetadataCacheTtlMs}ms TTL): $cachedPartitions")
-      cachedPartitions
-    } else {
-      val fresh = consumerStrategy.assignedTopicPartitions(admin)
-      cachedPartitions = fresh
-      cacheTimestampMs = now
-      fresh
+    val nowNanos = System.nanoTime()
+    cacheTimestampNanos match {
+      case Some(timestampNanos)
+          if nowNanos - timestampNanos <
+            TimeUnit.MILLISECONDS.toNanos(partitionMetadataCacheTtlMs) =>
+        val cacheAgeMs = TimeUnit.NANOSECONDS.toMillis(nowNanos - timestampNanos)
+        logDebug(s"Reusing cached partitions (age ${cacheAgeMs}ms < " +
+          s"${partitionMetadataCacheTtlMs}ms TTL): $cachedPartitions")
+        cachedPartitions
+      case _ =>
+        val fresh = consumerStrategy.assignedTopicPartitions(admin)
+        cachedPartitions = fresh
+        cacheTimestampNanos = Some(nowNanos)
+        fresh
     }
   }
 
@@ -519,6 +524,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     stopAdmin()
     _admin = null  // will automatically get reinitialized again
     cachedPartitions = Set.empty
-    cacheTimestampMs = 0L
+    cacheTimestampNanos = None
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Followup to https://github.com/apache/spark/pull/57351.

This PR measures the Kafka partition metadata cache TTL with `System.nanoTime` instead of
`System.currentTimeMillis`. It also represents the cached timestamp with `Option[Long]` rather than
using zero as a sentinel. Debug logging continues to report cache age in milliseconds.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

TTL measurement should use a monotonic time source. Wall-clock adjustments can otherwise make a
cache entry appear older or younger than it is, causing premature refreshes or extending its
lifetime. `System.nanoTime` measures elapsed time without that sensitivity.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. The cache option and its behavior under a stable clock are unchanged.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing cache reuse and expiry coverage was run with Java 17:

```
build/sbt 'sql-kafka-0-10/testOnly org.apache.spark.sql.kafka010.KafkaOffsetReaderSuite'
```

All 22 tests passed. No new test was added because the change only substitutes the JVM's monotonic
elapsed-time source; reliably simulating host wall-clock changes is not practical in this suite.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Codex (GPT-5)
