### PR TITLE
[SPARK-58722][CORE] Bump OIDC credential propagation version annotations from `4.3.0` to `4.4.0`

### DIFF
--- a/core/src/main/java/org/apache/spark/security/CredentialProvider.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProvider.java
@@ -36,7 +36,7 @@ import org.apache.spark.annotation.DeveloperApi;
  * Implementations must be thread-safe: {@code resolve()} may be called concurrently from
  * multiple threads after {@code init()} completes.
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @DeveloperApi
 public interface CredentialProvider extends AutoCloseable {
@@ -58,7 +58,7 @@ public interface CredentialProvider extends AutoCloseable {
    *
    * @param conf Spark configuration properties scoped to {@code spark.security.oidc.*}
    *     keys (must not be null)
-   * @since 4.3.0
+   * @since 4.4.0
    */
   void init(Map<String, String> conf);
 
@@ -69,7 +69,7 @@ public interface CredentialProvider extends AutoCloseable {
    * set must be non-empty and stable across calls.
    *
    * @return a non-empty set of supported scheme names
-   * @since 4.3.0
+   * @since 4.4.0
    */
   Set<String> supportedSchemes();
 
@@ -85,7 +85,7 @@ public interface CredentialProvider extends AutoCloseable {
    * @param target the target URI for which credentials are requested (must not be null)
    * @return a short-lived service credential for the target
    * @throws CredentialResolutionException if the credential exchange fails
-   * @since 4.3.0
+   * @since 4.4.0
    */
   ServiceCredential resolve(UserContext user, URI target) throws CredentialResolutionException;
 
@@ -96,7 +96,7 @@ public interface CredentialProvider extends AutoCloseable {
    * The default is 15 minutes.
    *
    * @return the suggested credential TTL (never null)
-   * @since 4.3.0
+   * @since 4.4.0
    */
   default Duration suggestedTtl() {
     return Duration.ofMinutes(15);
@@ -119,7 +119,7 @@ public interface CredentialProvider extends AutoCloseable {
    * clause in their override (e.g., declare {@code close()} with no {@code throws} or
    * with a more specific exception type).
    *
-   * @since 4.3.0
+   * @since 4.4.0
    */
   @Override
   default void close() throws Exception {}

--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -59,7 +59,7 @@ import org.apache.spark.annotation.Private;
  * {@link CredentialProvider} contract, implementations must be thread-safe, so a returned
  * instance may be used concurrently.
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @Private
 public final class CredentialProviderLoader {

--- a/core/src/main/java/org/apache/spark/security/CredentialResolutionException.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialResolutionException.java
@@ -26,7 +26,7 @@ import org.apache.spark.annotation.DeveloperApi;
  * This is a checked exception to ensure callers handle credential resolution failures
  * explicitly (e.g., retry, fail the job, or fall back to another mechanism).
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @DeveloperApi
 public class CredentialResolutionException extends Exception {

--- a/core/src/main/java/org/apache/spark/security/FileTokenIngestor.java
+++ b/core/src/main/java/org/apache/spark/security/FileTokenIngestor.java
@@ -50,7 +50,7 @@ import org.apache.spark.internal.SparkLoggerFactory;
  *       returns empty rather than throwing</li>
  * </ul>
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @Private
 public class FileTokenIngestor implements TokenIngestor {

--- a/core/src/main/java/org/apache/spark/security/ServiceCredential.java
+++ b/core/src/main/java/org/apache/spark/security/ServiceCredential.java
@@ -36,7 +36,7 @@ import org.apache.spark.annotation.DeveloperApi;
  * <p>
  * This class is immutable and {@link Serializable}.
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @DeveloperApi
 public final class ServiceCredential implements Serializable {

--- a/core/src/main/java/org/apache/spark/security/TokenIngestor.java
+++ b/core/src/main/java/org/apache/spark/security/TokenIngestor.java
@@ -29,7 +29,7 @@ import org.apache.spark.annotation.DeveloperApi;
  * configuration is passed at construction time.
  * Implementations must be thread-safe because {@link #load()} may be called concurrently.
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @DeveloperApi
 public interface TokenIngestor {

--- a/core/src/main/java/org/apache/spark/security/UserContext.java
+++ b/core/src/main/java/org/apache/spark/security/UserContext.java
@@ -31,7 +31,7 @@ import org.apache.spark.annotation.DeveloperApi;
  * <b>not</b> {@link java.io.Serializable} and must never be transmitted to executors.
  * The {@code rawToken} field is always redacted in {@link #toString()}.
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @DeveloperApi
 public final class UserContext {

--- a/core/src/main/java/org/apache/spark/security/UserCredentials.java
+++ b/core/src/main/java/org/apache/spark/security/UserCredentials.java
@@ -38,7 +38,7 @@ import org.apache.spark.annotation.DeveloperApi;
  * This class is transmitted to executors and does <b>not</b> contain any reference
  * to {@link UserContext} or raw identity tokens. It is immutable and {@link Serializable}.
  *
- * @since 4.3.0
+ * @since 4.4.0
  */
 @DeveloperApi
 public final class UserCredentials implements Serializable {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1710,7 +1710,7 @@ package object config {
       .doc("Whether to enable OIDC credential propagation. When enabled, the driver reads an " +
         "identity token from a file, exchanges it for short-lived service credentials via " +
         "CredentialProvider implementations, and propagates those credentials to executors.")
-      .version("4.3.0")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
@@ -1720,7 +1720,7 @@ package object config {
       .doc("Path to the OIDC identity token file on the driver. Required when " +
         "spark.security.oidc.enabled is true. The file should contain a JWT token " +
         "(e.g., a Kubernetes projected service account token).")
-      .version("4.3.0")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .stringConf
       .createOptional
@@ -1729,7 +1729,7 @@ package object config {
     ConfigBuilder("spark.security.oidc.renewal.safetyMargin")
       .doc("How long before credential expiry to trigger renewal. Credentials are refreshed " +
         "at min(identity token expiry, service credential expiry) minus this margin.")
-      .version("4.3.0")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .timeConf(TimeUnit.MILLISECONDS)
       .checkValue(_ > 0, "The safety margin must be a positive time value.")
@@ -1739,7 +1739,7 @@ package object config {
     ConfigBuilder("spark.security.oidc.renewal.minInterval")
       .doc("Minimum interval between credential renewal attempts. This prevents tight renewal " +
         "loops when credentials have very short TTLs or when failures cause rapid retries.")
-      .version("4.3.0")
+      .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .timeConf(TimeUnit.MILLISECONDS)
       .checkValue(_ > 0, "The minimum renewal interval must be a positive time value.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates `@since` and `.version()` annotations for all OIDC credential propagation APIs and configuration keys from `4.3.0` to `4.4.0` to reflect the actual release version.

The OIDC credential propagation feature was originally developed targeting `4.3.0` but will ship in `4.4.0`. This PR corrects the version annotations accordingly.

**Affected files:**
- `TokenIngestor.java`
- `CredentialProvider.java`
- `FileTokenIngestor.java`
- `CredentialProviderLoader.java`
- `CredentialResolutionException.java`
- `UserCredentials.java`
- `ServiceCredential.java`
- `UserContext.java`
- `config/package.scala` (`spark.security.oidc.*` keys)

**Note:** `AwsStsCredentialProvider.java` (`connector/credential-aws`) also contains `@since 4.3.0` but is excluded from this PR because it will be corrected to `4.4.0` as part of #57655

### Why are the changes needed?
Version annotations should reflect the actual release in which APIs and configurations become available, not the originally planned version during development.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
