### PR TITLE
[SPARK-58727][DOC] Update `json` gem version to 2.21.2

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.21.1)
+    json (2.21.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `json` gem from 2.21.1 to 2.21.2 in `docs/Gemfile.lock`. It is a transitive dependency (pulled in by `jekyll`, which requires `json (~> 2.6)`), and 2.21.2 satisfies that constraint, so only the locked spec version changes.

`json` has no runtime dependencies, so no other lock entries change and `docs/Gemfile` does not need to be touched.

### Why are the changes needed?

2.21.2 includes the fix for a security advisory that affects `>= 2.20.0, <= 2.21.1`:

- [GHSA-9hj4-r449-hfvc](https://github.com/advisories/GHSA-9hj4-r449-hfvc) / CVE-2026-71847 (low): heap use-after-free in the native C extension's `JSON::ResumableParser`. When the current input buffer is consumed, `cResumableParser_parse` calls `json_str_clear(parser->buffer)` and drops the reference but leaves `state.start`, `state.cursor`, and `state.end` pointing into the released storage. If `partial_value` then reconstructs an incomplete object containing duplicate keys, the duplicate-key warning path reaches `cursor_position`, which dereferences those stale pointers and can terminate the process. Fixed in 2.21.2.

This addresses https://github.com/apache/spark/security/dependabot/227.

Following the same pattern as SPARK-58371 (`json` 2.21.1) and SPARK-57633 (`concurrent-ruby` 1.3.7), this picks up the latest release, which here is also the minimum patched version.

### Does this PR introduce _any_ user-facing change?

No. This only affects the documentation build toolchain.

### How was this patch tested?

Manually verified against `docs/Gemfile` and `docs/Gemfile.lock`:

1. Lock resolution matches. `bundle lock --update=json` resolves `json` to exactly 2.21.2 and touches no other locked spec, confirming 2.21.2 satisfies jekyll's `json (~> 2.6)`. The committed lock is a one-line hand edit so the local Bundler version does not rewrite the `RUBY VERSION` / `BUNDLED WITH` stanzas.

2. Frozen install succeeds. `BUNDLE_FROZEN=true bundle install` installs all 36 gems without modifying the lock file, and `bundle list` reports `json (2.21.2)`.

3. The docs site builds:

```
$ cd docs && SKIP_API=1 bundle exec jekyll build
Configuration file: .../docs/_config.yml

************************
* Building error docs. *
************************
Generated: docs/_generated/error-conditions.html
            Source: .../docs
       Destination: .../docs/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
Warning: Tolerating missing API files because the following skip flags are set: SKIP_API
                    done in 3.207 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

4. Ran the advisory's `JSON::ResumableParser` sequence (two chunks so the first buffer is consumed and cleared, incomplete trailing object, duplicate key, heap churn plus `GC.start` before `partial_value`) against both 2.21.1 and 2.21.2. Both complete without crashing on this platform, so this is not a local reproduction of the use-after-free -- the advisory's own evidence for the release-build crash is an AddressSanitizer build. The check confirms the version bump does not regress the `ResumableParser` duplicate-key path.

5. Pass GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
