### PR TITLE
[SPARK-58714][SS] Fix AdminClient leak in KafkaTokenUtil.obtainToken

### DIFF
--- a/connector/kafka-0-10-token-provider/src/main/scala/org/apache/spark/kafka010/KafkaTokenUtil.scala
+++ b/connector/kafka-0-10-token-provider/src/main/scala/org/apache/spark/kafka010/KafkaTokenUtil.scala
@@ -68,9 +68,13 @@ object KafkaTokenUtil extends Logging {
     checkProxyUser()
 
     val adminClient = AdminClient.create(createAdminClientProperties(sparkConf, clusterConf))
-    val createDelegationTokenOptions = new CreateDelegationTokenOptions()
-    val createResult = adminClient.createDelegationToken(createDelegationTokenOptions)
-    val token = createResult.delegationToken().get()
+    val token = try {
+      val createDelegationTokenOptions = new CreateDelegationTokenOptions()
+      val createResult = adminClient.createDelegationToken(createDelegationTokenOptions)
+      createResult.delegationToken().get()
+    } finally {
+      Utils.closeQuietly(adminClient)
+    }
     printToken(token)
 
     (new Token[KafkaDelegationTokenIdentifier](


### PR DESCRIPTION
### What changes were proposed in this pull request?

Wrap the token acquisition in `KafkaTokenUtil.obtainToken` in `try`/`finally` so the created `AdminClient` is always closed, via `Utils.closeQuietly`.

### Why are the changes needed?

`obtainToken` creates an `AdminClient` but never closes it, on either the success or the exception path. Each token obtain (per cluster, per renewal cycle) and each failed attempt leaks the client's network thread and sockets, which accumulate in long-running drivers.

Present since the feature was introduced in SPARK-25501 (Spark 3.0.0).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests (`KafkaTokenUtilSuite`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)
