### PR TITLE
[SPARK-58732][ML] Avoid MLlib vector conversion in Normalizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -62,15 +62,19 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
         // For dense vector, we've to allocate new memory for new output vector.
         // However, for sparse vector, the `index` array will not be changed,
         // so we can re-use it to save memory.
-        val normalized = vector match {
+        vector match {
           case DenseVector(vs) =>
-            Vectors.dense(vs.clone())
+            val values = vs.clone()
+            val normalized = Vectors.dense(values)
+            BLAS.scal(1.0 / norm, normalized)
+            normalized
           case SparseVector(size, ids, vs) =>
-            Vectors.sparse(size, ids, vs.clone())
+            val values = vs.clone()
+            val normalized = Vectors.sparse(size, ids, values)
+            BLAS.scal(1.0 / norm, normalized)
+            normalized
           case v => throw new IllegalArgumentException("Do not support vector type " + v.getClass)
         }
-        BLAS.scal(1.0 / norm, normalized)
-        normalized
       } else {
         // Since the norm is zero, return the input vector object itself.
         // Note that it's safe since we always assume that the data in RDD

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -20,11 +20,10 @@ package org.apache.spark.ml.feature
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.attribute.AttributeGroup
-import org.apache.spark.ml.linalg.{SQLDataTypes, Vector, VectorUDT}
+import org.apache.spark.ml.linalg.{BLAS, DenseVector, SparseVector, SQLDataTypes, Vector, Vectors,
+  VectorUDT}
 import org.apache.spark.ml.param.{DoubleParam, ParamValidators}
 import org.apache.spark.ml.util._
-import org.apache.spark.mllib.feature
-import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 import org.apache.spark.sql.types._
 
 /**
@@ -56,8 +55,29 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
   def setP(value: Double): this.type = set(p, value)
 
   override protected def createTransformFunc: Vector => Vector = {
-    val normalizer = new feature.Normalizer($(p))
-    vector => normalizer.transform(OldVectors.fromML(vector)).asML
+    val localP = $(p)
+    vector => {
+      val norm = Vectors.norm(vector, localP)
+      if (norm != 0.0) {
+        // For dense vector, we've to allocate new memory for new output vector.
+        // However, for sparse vector, the `index` array will not be changed,
+        // so we can re-use it to save memory.
+        val normalized = vector match {
+          case DenseVector(vs) =>
+            Vectors.dense(vs.clone())
+          case SparseVector(size, ids, vs) =>
+            Vectors.sparse(size, ids, vs.clone())
+          case v => throw new IllegalArgumentException("Do not support vector type " + v.getClass)
+        }
+        BLAS.scal(1.0 / norm, normalized)
+        normalized
+      } else {
+        // Since the norm is zero, return the input vector object itself.
+        // Note that it's safe since we always assume that the data in RDD
+        // should be immutable.
+        vector
+      }
+    }
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.attribute.AttributeGroup
-import org.apache.spark.ml.linalg.{BLAS, DenseVector, SparseVector, SQLDataTypes, Vector, Vectors,
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, SQLDataTypes, Vector, Vectors,
   VectorUDT}
 import org.apache.spark.ml.param.{DoubleParam, ParamValidators}
 import org.apache.spark.ml.util._
@@ -65,14 +65,22 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
         vector match {
           case DenseVector(vs) =>
             val values = vs.clone()
-            val normalized = Vectors.dense(values)
-            BLAS.scal(1.0 / norm, normalized)
-            normalized
+            val size = values.length
+            var i = 0
+            while (i < size) {
+              values(i) /= norm
+              i += 1
+            }
+            Vectors.dense(values)
           case SparseVector(size, ids, vs) =>
             val values = vs.clone()
-            val normalized = Vectors.sparse(size, ids, values)
-            BLAS.scal(1.0 / norm, normalized)
-            normalized
+            val nnz = values.length
+            var i = 0
+            while (i < nnz) {
+              values(i) /= norm
+              i += 1
+            }
+            Vectors.sparse(size, ids, values)
           case v => throw new IllegalArgumentException("Do not support vector type " + v.getClass)
         }
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -59,6 +59,7 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
     vector => {
       val norm = Vectors.norm(vector, localP)
       if (norm != 0.0) {
+        val scale = 1.0 / norm
         // For dense vector, we've to allocate new memory for new output vector.
         // However, for sparse vector, the `index` array will not be changed,
         // so we can re-use it to save memory.
@@ -68,7 +69,7 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
             val size = values.length
             var i = 0
             while (i < size) {
-              values(i) /= norm
+              values(i) *= scale
               i += 1
             }
             Vectors.dense(values)
@@ -77,7 +78,7 @@ class Normalizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
             val nnz = values.length
             var i = 0
             while (i < nnz) {
-              values(i) /= norm
+              values(i) *= scale
               i += 1
             }
             Vectors.sparse(size, ids, values)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update ML Normalizer to calculate the norm and normalize values with ML vectors directly. The normalization implementation follows the existing MLlib Normalizer transform method, including cloning dense and sparse value arrays and reusing sparse indices.

### Why are the changes needed?

ML Normalizer currently converts every input vector from ML to MLlib and converts the normalized result back to ML. Avoiding those conversions reduces allocation and transform overhead.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing NormalizerSuite covers dense, sparse, zero-vector, and parameterized normalization behavior.

build/sbt 'mllib/testOnly org.apache.spark.ml.feature.NormalizerSuite'

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)