### PR TITLE
[WIP][ML] Avoid VectorUDT deserialization in Summarizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -412,7 +412,7 @@ private[spark] object SummaryBuilderImpl extends Logging {
       copy(featuresExpr = newLeft, weightExpr = newRight)
 
     override def update(state: SummarizerBuffer, row: InternalRow): SummarizerBuffer = {
-      val features = vectorUDT.deserialize(featuresExpr.eval(row))
+      val features = featuresExpr.eval(row).asInstanceOf[InternalRow]
       val weight = weightExpr.eval(row).asInstanceOf[Double]
       state.add(features, weight)
       state
@@ -571,6 +571,32 @@ private[spark] class SummarizerBuffer(
     weightSquareSum += weight * weight
     totalCnt += 1
     this
+  }
+
+  /**
+   * Add a vector in its internal SQL representation without materializing a [[Vector]].
+   */
+  def add(instance: InternalRow, weight: Double): this.type = {
+    require(instance.numFields == 4,
+      s"SummarizerBuffer.add given row with length ${instance.numFields} but requires length == 4")
+    instance.getByte(0) match {
+      case 0 => // Sparse vector
+        val values = instance.getArray(3)
+        add(arrayDataIterator(instance.getArray(2), values), instance.getInt(1), weight)
+      case 1 => // Dense vector
+        val values = instance.getArray(3)
+        add(arrayDataIterator(null, values), values.numElements(), weight)
+    }
+  }
+
+  private def arrayDataIterator(
+      indices: ArrayData,
+      values: ArrayData): Iterator[(Int, Double)] = {
+    if (requestedCompMetrics.isEmpty) {
+      Iterator.empty
+    } else {
+      new NonZeroArrayDataIterator(indices, values)
+    }
   }
 
   /**
@@ -794,5 +820,33 @@ private[spark] class SummarizerBuffer(
     require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
 
     Vectors.dense(currL1)
+  }
+}
+
+private class NonZeroArrayDataIterator(indices: ArrayData, values: ArrayData)
+    extends Iterator[(Int, Double)] {
+
+  private val numValues = values.numElements()
+  private var position = 0
+  skipZeros()
+
+  override def hasNext: Boolean = position < numValues
+
+  override def next(): (Int, Double) = {
+    if (!hasNext) {
+      throw new NoSuchElementException("next on empty iterator")
+    }
+    val currentPosition = position
+    val value = values.getDouble(currentPosition)
+    position += 1
+    skipZeros()
+    val index = if (indices == null) currentPosition else indices.getInt(currentPosition)
+    (index, value)
+  }
+
+  private def skipZeros(): Unit = {
+    while (position < numValues && values.getDouble(position) == 0.0) {
+      position += 1
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the DataFrame Summarizer aggregate to consume vectors from their internal SQL
representation. A nonzero iterator reads dense values and sparse index-value pairs directly from
Catalyst ArrayData. Count-only summaries avoid iterating over vector values.

### Why are the changes needed?

Summarizer currently calls VectorUDT.deserialize for every input row. This copies the dense values
array, or both sparse indices and values arrays, and then allocates a Vector wrapper before
aggregation. Reading the internal row directly avoids these per-row copies and Vector allocation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing SummarizerSuite covers dense, sparse, weighted, count-only, and multi-metric summary
behavior.

    build/sbt 'mllib/testOnly org.apache.spark.ml.stat.SummarizerSuite'
    build/sbt mllib/scalastyle

I also ran an ad hoc update-path benchmark on 100k rows in the same JVM, comparing the old path
(`VectorUDT.deserialize(row)` then `SummarizerBuffer.add(Vector)`) with the new path
(`SummarizerBuffer.add(InternalRow)`). Each case used 3 warmup runs and 7 measured runs; medians
are shown below.

| Case | Old median | New median | Gain |
|---|---:|---:|---:|
| dense all metrics | 415.608 ms | 271.495 ms | 34.7% faster, 1.53x |
| dense count-only | 342.092 ms | 7.216 ms | 97.9% faster, 47.41x |
| sparse all metrics | 35.206 ms | 28.815 ms | 18.2% faster, 1.22x |
| sparse count-only | 28.540 ms | 4.547 ms | 84.1% faster, 6.28x |

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
