### PR TITLE
[MINOR][DOCS][SQL] Fix minor gaps and problems in Thrift server docs

### DIFF
--- a/docs/sql-distributed-sql-engine.md
+++ b/docs/sql-distributed-sql-engine.md
@@ -40,23 +40,23 @@ specify Hive properties. You may run `./sbin/start-thriftserver.sh --help` for a
 all available options. By default, the server listens on localhost:10000. You may override this
 behaviour via either environment variables, i.e.:
 
-{% highlight bash %}
+```bash
 export HIVE_SERVER2_THRIFT_PORT=<listening-port>
 export HIVE_SERVER2_THRIFT_BIND_HOST=<listening-host>
 ./sbin/start-thriftserver.sh \
   --master <master-uri> \
   ...
-{% endhighlight %}
+```
 
 or system properties:
 
-{% highlight bash %}
+```bash
 ./sbin/start-thriftserver.sh \
   --hiveconf hive.server2.thrift.port=<listening-port> \
   --hiveconf hive.server2.thrift.bind.host=<listening-host> \
   --master <master-uri>
   ...
-{% endhighlight %}
+```
 
 Now you can use beeline to test the Thrift JDBC/ODBC server:
 
@@ -88,10 +88,14 @@ To test, use beeline to connect to the JDBC/ODBC server in http mode with:
 If you closed a session and do CTAS, you must set `fs.%s.impl.disable.cache` to true in `hive-site.xml`.
 See more details in [[SPARK-21067]](https://issues.apache.org/jira/browse/SPARK-21067).
 
+To stop the Thrift JDBC/ODBC server, run:
+
+    ./sbin/stop-thriftserver.sh
+
 ## Running the Spark SQL CLI
 
 To use the Spark SQL command line interface (CLI) from the shell:
 
     ./bin/spark-sql
-    
+
 For details, please refer to [Spark SQL CLI](sql-distributed-sql-engine-spark-sql-cli.html)

--- a/docs/sql-distributed-sql-engine.md
+++ b/docs/sql-distributed-sql-engine.md
@@ -85,8 +85,11 @@ To test, use beeline to connect to the JDBC/ODBC server in http mode with:
 
     beeline> !connect jdbc:hive2://<host>:<port>/<database>;transportMode=http;httpPath=<http_endpoint>
 
-If you closed a session and do CTAS, you must set `fs.%s.impl.disable.cache` to true in `hive-site.xml`.
-See more details in [[SPARK-21067]](https://issues.apache.org/jira/browse/SPARK-21067).
+If you closed a session and do CTAS, you must set `fs.<scheme>.impl.disable.cache` to `true` in `hive-site.xml`. `<scheme>` is the Hadoop filesystem you are using, like `hdfs`, `s3a`, etc. For example:
+
+    fs.hdfs.impl.disable.cache=true
+
+See more details in [SPARK-21067](https://issues.apache.org/jira/browse/SPARK-21067).
 
 To stop the Thrift JDBC/ODBC server, run:
 
@@ -98,4 +101,4 @@ To use the Spark SQL command line interface (CLI) from the shell:
 
     ./bin/spark-sql
 
-For details, please refer to [Spark SQL CLI](sql-distributed-sql-engine-spark-sql-cli.html)
+For details, please refer to [Spark SQL CLI](sql-distributed-sql-engine-spark-sql-cli.html).

--- a/docs/sql-distributed-sql-engine.md
+++ b/docs/sql-distributed-sql-engine.md
@@ -54,7 +54,7 @@ or system properties:
 ./sbin/start-thriftserver.sh \
   --hiveconf hive.server2.thrift.port=<listening-port> \
   --hiveconf hive.server2.thrift.bind.host=<listening-host> \
-  --master <master-uri>
+  --master <master-uri> \
   ...
 ```
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Mention `sbin/stop-thriftserver.sh` in the SQL docs on the Thrift server.

Flesh out the Hive config example just a tiny bit.

Also fix some minor whitespace and Markdown style issues.

### Why are the changes needed?

The documentation currently mentions `start-thriftserver.sh`. It seems weird not to also mention the matching script to stop the service.

The existing `%s` is confusing by itself. Users may not immediately understand it's supposed to be a substitution marker.

### Does this PR introduce _any_ user-facing change?

Documentation only.

### How was this patch tested?

Built the docs with `SKIP_API=1 bundle exec jekyll serve` and reviewed them locally.

### Was this patch authored or co-authored using generative AI tooling?

No.
