### PR TITLE
[SPARK-58746][INFRA] Remove a dead lsof workaround and fix stale references in release tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,7 +7,7 @@ Thanks for sending a pull request!  Here are some tips for you:
   5. Please write your PR title to summarize what this PR proposes.
   6. If possible, provide a concise example to reproduce the issue for a faster review.
   7. If you want to add a new configuration, please read the guideline first for naming configurations in
-     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
+     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
   8. If you want to add or modify an error type or message, please read the guideline first in
      'common/utils/src/main/resources/error/README.md'.
 -->

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -40,7 +40,7 @@ SPARK_VERSION - (optional) Version of Spark being built (e.g. 2.1.2)
 
 ASF_USERNAME - Username of ASF committer account
 ASF_PASSWORD - Password of ASF committer account
-ASF_NEXUS_TOKEN - API token in ASF Nexus reposiotry
+ASF_NEXUS_TOKEN - API token in ASF Nexus repository
 
 GPG_KEY - GPG key used to sign release artifacts
 GPG_PASSPHRASE - Passphrase for GPG key
@@ -695,14 +695,6 @@ elif [[ $JAVA_VERSION < "17.0." ]] && [[ $SPARK_VERSION > "3.5.99" ]]; then
   echo "Java version $JAVA_VERSION is less than required 17 for 4.0+"
   echo "Please set JAVA_HOME correctly."
   exit 1
-fi
-
-# This is a band-aid fix to avoid the failure of Maven nightly snapshot in some Jenkins
-# machines by explicitly calling /usr/sbin/lsof. Please see SPARK-22377 and the discussion
-# in its pull request.
-LSOF=lsof
-if ! hash $LSOF 2>/dev/null; then
-  LSOF=/usr/sbin/lsof
 fi
 
 if [ -z "$SPARK_PACKAGE_VERSION" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

Three fixes to developer and release tooling:

- `dev/create-release/release-build.sh`: removes the dead `lsof` band-aid block, and fixes a typo in the usage help (`reposiotry` to `repository`).
- `.github/PULL_REQUEST_TEMPLATE`: updates the `ConfigEntry.scala` path to its current location under `common/utils`.

### Why are the changes needed?

The `lsof` block assigns `$LSOF` and probes for the binary, but `$LSOF` is never used anywhere in the script or in anything it sources or that calls it, so the SPARK-22377 workaround has had no effect since the Jenkins machines it targeted were retired. The PR template points contributors at `core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala`, which no longer exists; the file now lives under `common/utils`.

### Does this PR introduce _any_ user-facing change?

No. Developer and release tooling only.

### How was this patch tested?

No functional change. `release-build.sh` still parses (`bash -n`), `$LSOF` was confirmed to have no reference outside the removed block (including in `release-util.sh` and `do-release.sh`), and the corrected `ConfigEntry.scala` path exists on master while the old one does not.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
