### PR TITLE
[MINOR][INFRA] Add spacing before JIRA update prompt

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -1321,6 +1321,7 @@ def resolve_jira_issues(title, merge_branches, comment, title_components=(), all
 
 def update_jira_for_pr(pr_num, title, merge_branches, title_components, allow_resolved=False):
     # asf_jira is guaranteed to be set here: initialize_jira() fails fast otherwise.
+    print()
     continue_maybe("Would you like to update an associated JIRA?")
     jira_comment = "Issue resolved by pull request %s\n[%s/%s]" % (
         pr_num,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Print a blank line before `merge_spark_pr.py` asks whether to update an associated JIRA.

### Why are the changes needed?

After a merge summary is posted, the JIRA prompt currently appears immediately after the
summary attribution:

```
*Posted by `merge_spark_pr.py`*
Would you like to update an associated JIRA? (y/N):
```

The blank line makes the transition to the next interactive step easier to read.

### Does this PR introduce _any_ user-facing change?

No. This only adjusts output formatting in the Spark committer merge tool.

### How was this patch tested?

The following checks passed:

```
cd dev
conda run -n spark-dev-313 python -m doctest merge_spark_pr.py
```

79 doctests passed.

```
conda run -n spark-dev-313 ruff check --config pyproject.toml dev/merge_spark_pr.py
conda run -n spark-dev-313 ruff format --check --config pyproject.toml dev/merge_spark_pr.py
git diff --check
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
