### PR TITLE
[SPARK-58758][DOCS] Remove the stale Highlights in 3.0 section from the ML guide

### DIFF
--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -40,7 +40,7 @@ The primary Machine Learning API for Spark is now the [DataFrame](sql-programmin
 
 * MLlib will still support the RDD-based API in `spark.mllib` with bug fixes.
 * MLlib will not add new features to the RDD-based API.
-* In the Spark 2.x releases, MLlib will add features to the DataFrames-based API to reach feature parity with the RDD-based API.
+* MLlib added features to the DataFrame-based API in the Spark 2.x releases, reaching feature parity with the RDD-based API.
 
 *Why is MLlib switching to the DataFrame-based API?*
 
@@ -73,32 +73,6 @@ To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.23
 
 [^1]: To learn more about the benefits and background of system optimised natives, you may wish to
     watch Sam Halliday's ScalaX talk on [High Performance Linear Algebra in Scala](http://fommil.github.io/scalax14/).
-
-# Highlights in 3.0
-
-The list below highlights some of the new features and enhancements added to MLlib in the `3.0`
-release of Spark:
-
-* Multiple columns support was added to `Binarizer` ([SPARK-23578](https://issues.apache.org/jira/browse/SPARK-23578)), `StringIndexer` ([SPARK-11215](https://issues.apache.org/jira/browse/SPARK-11215)), `StopWordsRemover` ([SPARK-29808](https://issues.apache.org/jira/browse/SPARK-29808)) and PySpark `QuantileDiscretizer` ([SPARK-22796](https://issues.apache.org/jira/browse/SPARK-22796)).
-* Tree-Based Feature Transformation was added
-([SPARK-13677](https://issues.apache.org/jira/browse/SPARK-13677)).
-* Two new evaluators `MultilabelClassificationEvaluator` ([SPARK-16692](https://issues.apache.org/jira/browse/SPARK-16692)) and `RankingEvaluator` ([SPARK-28045](https://issues.apache.org/jira/browse/SPARK-28045)) were added.
-* Sample weights support was added in `DecisionTreeClassifier/Regressor` ([SPARK-19591](https://issues.apache.org/jira/browse/SPARK-19591)), `RandomForestClassifier/Regressor` ([SPARK-9478](https://issues.apache.org/jira/browse/SPARK-9478)), `GBTClassifier/Regressor` ([SPARK-9612](https://issues.apache.org/jira/browse/SPARK-9612)),  `MulticlassClassificationEvaluator` ([SPARK-24101](https://issues.apache.org/jira/browse/SPARK-24101)), `RegressionEvaluator` ([SPARK-24102](https://issues.apache.org/jira/browse/SPARK-24102)), `BinaryClassificationEvaluator` ([SPARK-24103](https://issues.apache.org/jira/browse/SPARK-24103)), `BisectingKMeans` ([SPARK-30351](https://issues.apache.org/jira/browse/SPARK-30351)), `KMeans` ([SPARK-29967](https://issues.apache.org/jira/browse/SPARK-29967)) and `GaussianMixture` ([SPARK-30102](https://issues.apache.org/jira/browse/SPARK-30102)).
-* R API for `PowerIterationClustering` was added
-([SPARK-19827](https://issues.apache.org/jira/browse/SPARK-19827)).
-* Added Spark ML listener for tracking ML pipeline status
-([SPARK-23674](https://issues.apache.org/jira/browse/SPARK-23674)).
-* Fit with validation set was added to Gradient Boosted Trees in Python
-([SPARK-24333](https://issues.apache.org/jira/browse/SPARK-24333)).
-* [`RobustScaler`](ml-features.html#robustscaler) transformer was added
-([SPARK-28399](https://issues.apache.org/jira/browse/SPARK-28399)).
-* [`Factorization Machines`](ml-classification-regression.html#factorization-machines) classifier and regressor were added
-([SPARK-29224](https://issues.apache.org/jira/browse/SPARK-29224)).
-* Gaussian Naive Bayes Classifier ([SPARK-16872](https://issues.apache.org/jira/browse/SPARK-16872)) and Complement Naive Bayes Classifier ([SPARK-29942](https://issues.apache.org/jira/browse/SPARK-29942)) were added.
-* ML function parity between Scala and Python
-([SPARK-28958](https://issues.apache.org/jira/browse/SPARK-28958)).
-* `predictRaw` is made public in all the Classification models. `predictProbability` is made public in all the Classification models except `LinearSVCModel`
-([SPARK-30358](https://issues.apache.org/jira/browse/SPARK-30358)).
 
 # Migration Guide
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes the `Highlights in 3.0` section from `docs/ml-guide.md`, and rewrites a sentence that still described DataFrame-based API feature parity as future work in the Spark 2.x releases.

### Why are the changes needed?

Both are stale on the current codebase. The guide keeps no equivalent `Highlights` section for 1.x or 2.x, so dropping superseded highlights is the established practice: SPARK-30934 replaced the 2.3 highlights with the 3.0 ones rather than accumulating them. The `Migration Guide` section immediately below already points readers to the archived migration guide, and the 3.0 features remain documented on their own pages, so no user-facing information is lost. Feature parity between the DataFrame-based and RDD-based APIs was reached at Spark 2.3, as `ml-pipeline.md` states, so the future-tense sentence is corrected to past tense.

### Does this PR introduce _any_ user-facing change?

No, other than the updated documentation.

### How was this patch tested?

Documentation only. No internal doc links point at the removed section's anchor, and the surrounding sections remain well-formed after the deletion.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
