### PR TITLE
[SPARK-58759][BUILD] Fix grammar in build file comments

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -554,7 +554,7 @@ object SparkParallelTestGrouping {
   // SBT project. Here, we take an opt-in approach where the default behavior is to run all
   // tests sequentially in a single JVM, requiring us to manually opt-in to the extra parallelism.
   //
-  // There are a reasons why such an opt-in approach is good:
+  // There are reasons why such an opt-in approach is good:
   //
   //    1. Launching one JVM per suite adds significant overhead for short-running suites. In
   //       addition to JVM startup time and JIT warmup, it appears that initialization of Derby

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -162,7 +162,7 @@
            so that the tests classes of external modules can use them. The two execution profiles
            are necessary - first one for 'mvn package', second one for 'mvn test-compile'. Ideally,
            'mvn compile' should not compile test classes and therefore should not need this.
-           However, a closed due to "Cannot Reproduce" Maven bug (https://issues.apache.org/jira/browse/MNG-3559)
+           However, a Maven bug closed as "Cannot Reproduce" (https://issues.apache.org/jira/browse/MNG-3559)
            causes the compilation to fail if catalyst test-jar is not generated. Hence, the
            second execution profile for 'mvn test-compile'.
       -->

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -273,8 +273,8 @@
       <artifactId>htmlunit3-driver</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Explicit declaration of bouncy-castle dependencies are
-         needed for maven test builds on later hadoop releases.-->
+    <!-- Explicit declaration of bouncy-castle dependencies is
+         needed for Maven test builds on later Hadoop releases. -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
@@ -348,7 +348,7 @@
             so that the tests classes of external modules can use them. The two execution profiles
             are necessary - first one for 'mvn package', second one for 'mvn test-compile'. Ideally,
             'mvn compile' should not compile test classes and therefore should not need this.
-            However, a closed due to "Cannot Reproduce" Maven bug (https://issues.apache.org/jira/browse/MNG-3559)
+            However, a Maven bug closed as "Cannot Reproduce" (https://issues.apache.org/jira/browse/MNG-3559)
             causes the compilation to fail if catalyst test-jar is not generated. Hence, the
             second execution profile for 'mvn test-compile'.
       -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes four grammar errors in build-file comments:

- `sql/catalyst/pom.xml` and `sql/core/pom.xml`: `However, a closed due to "Cannot Reproduce" Maven bug` becomes `However, a Maven bug closed as "Cannot Reproduce"`.
- `sql/core/pom.xml`: `dependencies are needed for maven test builds on later hadoop releases` becomes `dependencies is needed for Maven test builds on later Hadoop releases` (the subject is the singular "declaration"; also fixes proper-noun casing and a missing space before the comment close).
- `project/SparkBuild.scala`: `There are a reasons` becomes `There are reasons`.

### Why are the changes needed?

These comments explain non-obvious build decisions, so they are worth keeping readable. The first is duplicated verbatim across the two POMs, which is how the error propagated.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Comment text only: Maven and SBT never parse it, so there is no build impact, and no version, coordinate, scope, or ordering is touched. Both POMs were confirmed to still parse as well-formed XML.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
