### PR TITLE
[SPARK-58760][SQL] Use consistent colName interpolation in CatalogColumnStat

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -972,17 +972,17 @@ case class CatalogColumnStat(
    */
   def toMap(colName: String): Map[String, String] = {
     val map = new scala.collection.mutable.HashMap[String, String]
-    map.put(s"${colName}.${CatalogColumnStat.KEY_VERSION}", CatalogColumnStat.VERSION.toString)
+    map.put(s"$colName.${CatalogColumnStat.KEY_VERSION}", CatalogColumnStat.VERSION.toString)
     distinctCount.foreach { v =>
-      map.put(s"${colName}.${CatalogColumnStat.KEY_DISTINCT_COUNT}", v.toString)
+      map.put(s"$colName.${CatalogColumnStat.KEY_DISTINCT_COUNT}", v.toString)
     }
     nullCount.foreach { v =>
-      map.put(s"${colName}.${CatalogColumnStat.KEY_NULL_COUNT}", v.toString)
+      map.put(s"$colName.${CatalogColumnStat.KEY_NULL_COUNT}", v.toString)
     }
-    avgLen.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_AVG_LEN}", v.toString) }
-    maxLen.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_MAX_LEN}", v.toString) }
-    min.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_MIN_VALUE}", v) }
-    max.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_MAX_VALUE}", v) }
+    avgLen.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_AVG_LEN}", v.toString) }
+    maxLen.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_MAX_LEN}", v.toString) }
+    min.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_MIN_VALUE}", v) }
+    max.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_MAX_VALUE}", v) }
     histogram.foreach { h =>
       CatalogTable.splitLargeTableProp(
         s"$colName.${CatalogColumnStat.KEY_HISTOGRAM}",
@@ -1096,15 +1096,15 @@ object CatalogColumnStat extends Logging {
 
     try {
       Some(CatalogColumnStat(
-        distinctCount = map.get(s"${colName}.${KEY_DISTINCT_COUNT}").map(v => BigInt(v.toLong)),
-        min = map.get(s"${colName}.${KEY_MIN_VALUE}"),
-        max = map.get(s"${colName}.${KEY_MAX_VALUE}"),
-        nullCount = map.get(s"${colName}.${KEY_NULL_COUNT}").map(v => BigInt(v.toLong)),
-        avgLen = map.get(s"${colName}.${KEY_AVG_LEN}").map(_.toLong),
-        maxLen = map.get(s"${colName}.${KEY_MAX_LEN}").map(_.toLong),
+        distinctCount = map.get(s"$colName.${KEY_DISTINCT_COUNT}").map(v => BigInt(v.toLong)),
+        min = map.get(s"$colName.${KEY_MIN_VALUE}"),
+        max = map.get(s"$colName.${KEY_MAX_VALUE}"),
+        nullCount = map.get(s"$colName.${KEY_NULL_COUNT}").map(v => BigInt(v.toLong)),
+        avgLen = map.get(s"$colName.${KEY_AVG_LEN}").map(_.toLong),
+        maxLen = map.get(s"$colName.${KEY_MAX_LEN}").map(_.toLong),
         histogram = CatalogTable.readLargeTableProp(map, s"$colName.$KEY_HISTOGRAM")
           .map(HistogramSerializer.deserialize),
-        version = map(s"${colName}.${KEY_VERSION}").toInt
+        version = map(s"$colName.${KEY_VERSION}").toInt
       ))
     } catch {
       case NonFatal(e) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Unbraces 14 `${colName}` interpolations to `$colName` in `CatalogColumnStat.toMap`/`fromMap`, leaving the qualified `${CatalogColumnStat.KEY_...}` / `${KEY_...}` selects braced.

### Why are the changes needed?

The two methods mix `${colName}` and the bare `$colName` for the same value, including on adjacent lines: the histogram key already reads `s"$colName.${CatalogColumnStat.KEY_HISTOGRAM}"`. This makes all 14 remaining sites consistent with that style. The qualified selects keep their braces on purpose, because unbracing `${CatalogColumnStat.KEY_VERSION}` would interpolate the object and append `.KEY_VERSION` as literal text.

### Does this PR introduce _any_ user-facing change?

No. These strings are the on-disk table-property keys for column statistics. In every case `colName` is a simple parameter immediately followed by `.`, so `$colName.` parses identically to `${colName}.` and the generated keys are byte-for-byte unchanged, preserving metadata compatibility.

### How was this patch tested?

Existing catalog statistics tests cover `toMap`/`fromMap`. The change is a lexical simplification with identical output.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
