### PR TITLE
[SPARK-58761][SQL][TESTS] Add DESCRIBE / SHOW CREATE TABLE tests for nanosecond-timestamp columns

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3479,4 +3479,32 @@ class HiveDDLSuite
       }
     }
   }
+
+  test("SPARK-56822: DESCRIBE TABLE and SHOW CREATE TABLE render nanos columns with the flag on") {
+    withTable("nanos_basic_render", "nanos_basic_render_rt") {
+      // The preview flag is on by default in tests (via Utils.isTesting), so this exercises the
+      // normal happy path: create a table with nanos columns and introspect it with the flag on.
+      // SPARK-57835 covers the flag-off read-through path; this covers the basic flag-on case.
+      sql(
+        """CREATE TABLE nanos_basic_render (id INT, ntz TIMESTAMP_NTZ(9), ltz TIMESTAMP_LTZ(7))
+          |USING parquet""".stripMargin)
+
+      // DESCRIBE TABLE renders each column's type name (lowercase, with precision).
+      val describeRows = sql("DESCRIBE TABLE nanos_basic_render").collect()
+        .map(r => r.getString(0) -> r.getString(1)).toMap
+      assert(describeRows("ntz") === "timestamp_ntz(9)")
+      assert(describeRows("ltz") === "timestamp_ltz(7)")
+
+      // SHOW CREATE TABLE renders the parseable, uppercased DDL type for each column.
+      val showCreate = sql("SHOW CREATE TABLE nanos_basic_render").head().getString(0)
+      assert(showCreate.contains("TIMESTAMP_NTZ(9)"))
+      assert(showCreate.contains("TIMESTAMP_LTZ(7)"))
+
+      // Round-trip: the emitted DDL re-parses and re-creates an identical nanos schema.
+      sql(showCreate.replace("nanos_basic_render", "nanos_basic_render_rt"))
+      val rtSchema = spark.table("nanos_basic_render_rt").schema
+      assert(rtSchema("ntz").dataType === TimestampNTZNanosType(9))
+      assert(rtSchema("ltz").dataType === TimestampLTZNanosType(7))
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a `HiveDDLSuite` test that creates a table with `TIMESTAMP_NTZ(9)` / `TIMESTAMP_LTZ(7)` columns while the nanosecond-timestamp preview flag is on (the default in tests via `Utils.isTesting`), then asserts that:
- `DESCRIBE TABLE` renders `timestamp_ntz(9)` / `timestamp_ltz(7)`;
- `SHOW CREATE TABLE` renders the parseable, uppercased `TIMESTAMP_NTZ(9)` / `TIMESTAMP_LTZ(7)`;
- the emitted `SHOW CREATE TABLE` DDL re-parses and re-creates an identical nanos schema (round-trip).

### Why are the changes needed?
SPARK-57835 added DESCRIBE / SHOW CREATE coverage only for the read-through path (table created with the flag on, introspected with the flag off). The basic happy path -- introspecting a nanos table with the flag on -- was still untested. This closes that DDL-introspection coverage gap for SPARK-56822.

### Does this PR introduce any user-facing change?
No. Test-only.

### How was this patch tested?
`build/sbt 'hive/testOnly org.apache.spark.sql.hive.execution.HiveDDLSuite'` (new test green). Non-vacuity confirmed by temporarily breaking the expected rendered value and observing the assertion fail.


### Was this patch authored or co-authored using generative AI tooling?
Co-Authored-By: Claude Opus 4.8