### PR TITLE
[SPARK-51830][SQL] Fix partition type mismatch when validatePartitionColumns is disabled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -200,7 +200,8 @@ case class InsertIntoHadoopFsRelationCommand(
         && partitionColumns.length == staticPartitions.size) {
         // Avoid empty static partition can't loaded to datasource table.
         val staticPathFragment =
-          PartitioningUtils.getPathFragment(staticPartitions, partitionColumns)
+          PartitioningUtils.getPathFragment(
+            staticPartitions, partitionColumns, conf.validatePartitionColumns)
         refreshUpdatedPartitions(Set(staticPathFragment))
       } else {
         refreshUpdatedPartitions(updatedPartitionPaths)
@@ -267,9 +268,11 @@ case class InsertIntoHadoopFsRelationCommand(
       table: CatalogTable,
       qualifiedOutputPath: Path,
       partitions: Seq[CatalogTablePartition]): Map[TablePartitionSpec, String] = {
+    val validatePartitionColumns = conf.validatePartitionColumns
     partitions.flatMap { p =>
       val defaultLocation = qualifiedOutputPath.suffix(
-        "/" + PartitioningUtils.getPathFragment(p.spec, table.partitionSchema)).toString
+        "/" + PartitioningUtils.getPathFragment(
+          p.spec, table.partitionSchema, validatePartitionColumns)).toString
       val catalogLocation = new Path(p.location).makeQualified(
         fs.getUri, fs.getWorkingDirectory).toString
       if (catalogLocation != defaultLocation) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -357,23 +357,54 @@ object PartitioningUtils extends SQLConfHelper {
   /**
    * This is the inverse of parsePathFragment().
    */
-  def getPathFragment(spec: TablePartitionSpec, partitionSchema: StructType): String = {
+  def getPathFragment(
+      spec: TablePartitionSpec,
+      partitionSchema: StructType,
+      validatePartitionColumns: Boolean): String = {
     partitionSchema.map { field =>
       escapePathName(field.name) + "=" +
         getPartitionValueString(
-          removeLeadingZerosFromNumberTypePartition(spec(field.name), field.dataType))
+          removeLeadingZerosFromNumberTypePartition(
+            spec(field.name), field.dataType, validatePartitionColumns))
     }.mkString("/")
   }
 
-  def removeLeadingZerosFromNumberTypePartition(value: String, dataType: DataType): String =
+  def getPathFragment(spec: TablePartitionSpec, partitionSchema: StructType): String = {
+    getPathFragment(spec, partitionSchema, validatePartitionColumns = true)
+  }
+
+  def removeLeadingZerosFromNumberTypePartition(
+      value: String,
+      dataType: DataType,
+      validatePartitionColumns: Boolean): String =
     dataType match {
       case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType =>
-        Option(castPartValueToDesiredType(dataType, value, null)).map(_.toString).orNull
+        if (value == null) {
+          null
+        } else {
+          try {
+            Option(castPartValueToDesiredType(dataType, value, null)).map(_.toString).orNull
+          } catch {
+            case _: NumberFormatException if !validatePartitionColumns =>
+              // If validation is disabled and value cannot be cast to numeric type, return as-is.
+              // This handles legacy tables with string partition values that don't match
+              // the partition column's numeric type definition.
+              // Leading zeros (e.g., "007") are still normalized to "7" since they parse.
+              value
+          }
+        }
       case _ => value
     }
 
+  def getPathFragment(
+      spec: TablePartitionSpec,
+      partitionColumns: Seq[Attribute],
+      validatePartitionColumns: Boolean): String = {
+    getPathFragment(spec, DataTypeUtils.fromAttributes(partitionColumns), validatePartitionColumns)
+  }
+
   def getPathFragment(spec: TablePartitionSpec, partitionColumns: Seq[Attribute]): String = {
-    getPathFragment(spec, DataTypeUtils.fromAttributes(partitionColumns))
+    getPathFragment(spec, partitionColumns, validatePartitionColumns = true)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PartitioningUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PartitioningUtilsSuite.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types._
+
+class PartitioningUtilsSuite extends SparkFunSuite {
+
+  test("SPARK-51830: removeLeadingZerosFromNumberTypePartition with validation disabled") {
+    // Test with validation enabled (default behavior)
+    // String values that cannot be cast to numeric types should throw NumberFormatException
+    intercept[NumberFormatException] {
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "abc", IntegerType, validatePartitionColumns = true)
+    }
+
+    intercept[NumberFormatException] {
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "xyz", LongType, validatePartitionColumns = true)
+    }
+
+    intercept[NumberFormatException] {
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "invalid", DoubleType, validatePartitionColumns = true)
+    }
+
+    // Test with validation disabled
+    // String values should be preserved as-is for legacy compatibility
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "abc", IntegerType, validatePartitionColumns = false) === "abc"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "xyz", LongType, validatePartitionColumns = false) === "xyz"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "invalid", DoubleType, validatePartitionColumns = false) === "invalid"
+    )
+
+    // Valid numeric strings should still be normalized when validation is disabled
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "42", IntegerType, validatePartitionColumns = false) === "42"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "9223372036854775807", LongType, validatePartitionColumns = false) === "9223372036854775807"
+    )
+
+    // Leading zeros should be removed for valid numbers
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "007", IntegerType, validatePartitionColumns = false) === "7"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "00123", LongType, validatePartitionColumns = true) === "123"
+    )
+
+    // Non-numeric types should pass through unchanged
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "abc", StringType, validatePartitionColumns = true) === "abc"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "2024-01-15", DateType, validatePartitionColumns = false) === "2024-01-15"
+    )
+
+    // Null values should be handled
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        null, IntegerType, validatePartitionColumns = true) === null
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        null, StringType, validatePartitionColumns = false) === null
+    )
+  }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PartitioningUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PartitioningUtilsSuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types._
+
+class PartitioningUtilsSuite extends SparkFunSuite {
+
+  test("SPARK-51830: removeLeadingZerosFromNumberTypePartition with validation disabled") {
+    // Test with validation enabled (default behavior)
+    // String values that cannot be cast to numeric types should throw NumberFormatException
+    intercept[NumberFormatException] {
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "abc", IntegerType, validatePartitionColumns = true)
+    }
+
+    intercept[NumberFormatException] {
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "xyz", LongType, validatePartitionColumns = true)
+    }
+
+    intercept[NumberFormatException] {
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "invalid", DoubleType, validatePartitionColumns = true)
+    }
+
+    // Test with validation disabled
+    // String values should be preserved as-is for legacy compatibility
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "abc", IntegerType, validatePartitionColumns = false) === "abc"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "xyz", LongType, validatePartitionColumns = false) === "xyz"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "invalid", DoubleType, validatePartitionColumns = false) === "invalid"
+    )
+
+    // Valid numeric strings should still be normalized when validation is disabled
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "42", IntegerType, validatePartitionColumns = false) === "42"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "9223372036854775807", LongType, validatePartitionColumns = false) === "9223372036854775807"
+    )
+
+    // Leading zeros should be removed for valid numbers
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "007", IntegerType, validatePartitionColumns = false) === "7"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "00123", LongType, validatePartitionColumns = true) === "123"
+    )
+
+    // Non-numeric types should pass through unchanged
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "abc", StringType, validatePartitionColumns = true) === "abc"
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        "2024-01-15", DateType, validatePartitionColumns = false) === "2024-01-15"
+    )
+
+    // Null values should be handled
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        null, IntegerType, validatePartitionColumns = true) === null
+    )
+
+    assert(
+      PartitioningUtils.removeLeadingZerosFromNumberTypePartition(
+        null, StringType, validatePartitionColumns = false) === null
+    )
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1443,6 +1443,40 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
     assert(s"p_int=${ExternalCatalogUtils.DEFAULT_PARTITION_NAME}" === path)
   }
 
+  test("SPARK-51830: insertInto with string partition values " +
+    "when validatePartitionColumns is disabled") {
+    withTempDir { base =>
+      val legacyPartitionDir = new java.io.File(base, "p_int=partition_value")
+      legacyPartitionDir.mkdirs()
+      makeParquetFile(
+        (1 to 5).map(i => ParquetData(i, s"str$i")),
+        legacyPartitionDir)
+
+      val df = spark.read.parquet(base.getCanonicalPath)
+      df.createOrReplaceTempView("legacy_table")
+
+      withTempView("legacy_table") {
+        checkAnswer(
+          sql("SELECT * FROM legacy_table"),
+          (1 to 5).map(i => Row(i, s"str$i", "partition_value")))
+
+        val newData = Seq((6, "str6")).toDF("intField", "stringField")
+        intercept[NumberFormatException] {
+          newData.write.mode("append").insertInto("legacy_table")
+        }
+
+        withSQLConf(SQLConf.VALIDATE_PARTITION_COLUMNS.key -> "false") {
+          newData.write.mode("append").insertInto("legacy_table")
+
+          checkAnswer(
+            sql("SELECT * FROM legacy_table ORDER BY intField"),
+            (1 to 6).map(i => Row(i, s"str$i", "partition_value")))
+        }
+      }
+    }
+  }
+
+
   test("read partitioned table - partition key included in Parquet file") {
     withTempDir { base =>
       for {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1443,6 +1443,17 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
     assert(s"p_int=${ExternalCatalogUtils.DEFAULT_PARTITION_NAME}" === path)
   }
 
+  test("SPARK-51830: get path fragment of a non-numeric partition value " +
+    "when partition column validation is disabled") {
+    val spec = Map("p_int" -> "partition_value")
+    val schema = new StructType().add("p_int", "int")
+    assert("p_int=partition_value" ===
+      PartitioningUtils.getPathFragment(spec, schema, validatePartitionColumns = false))
+    intercept[NumberFormatException] {
+      PartitioningUtils.getPathFragment(spec, schema)
+    }
+  }
+
   test("read partitioned table - partition key included in Parquet file") {
     withTempDir { base =>
       for {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connector.{FakeV2Provider, FakeV2ProviderWithCustomSchema}
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.PartitionOverwriteMode
+import org.apache.spark.sql.internal.SQLConf.{PartitionOverwriteMode, StoreAssignmentPolicy}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -3117,6 +3117,60 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         // The table path must survive a failed overwrite.
         assert(new java.io.File(tablePath).exists(),
           "Table path should not be permanently lost after a failed INSERT OVERWRITE")
+      }
+    }
+  }
+
+  test("SPARK-51830: dynamic partition insert into a table with a non-numeric partition value") {
+    // `spark.sql.legacy.skipTypeValidationOnAlterPartition` lets us register a partition whose
+    // value does not match the numeric type of the partition column
+    withSQLConf(SQLConf.SKIP_TYPE_VALIDATION_ON_ALTER_PARTITION.key -> "true") {
+      withTable("t") {
+        sql("CREATE TABLE t(c1 int, p1 int) USING parquet PARTITIONED BY (p1)")
+        sql("ALTER TABLE t ADD PARTITION (p1 = 'legacy_value')")
+        val legacyLocation = new File(spark.sessionState.catalog
+          .getPartition(TableIdentifier("t"), Map("p1" -> "legacy_value")).location)
+        assert(legacyLocation.getName === "p1=legacy_value")
+
+        // A dynamic partition insert lists all the partitions of the table to collect the custom
+        // partition locations, which computes the default path of every existing partition.
+        intercept[NumberFormatException] {
+          sql("INSERT INTO t VALUES (1, 1)")
+        }
+
+        withSQLConf(SQLConf.VALIDATE_PARTITION_COLUMNS.key -> "false") {
+          sql("INSERT INTO t VALUES (1, 1)")
+        }
+        val newLocation = new File(spark.sessionState.catalog
+          .getPartition(TableIdentifier("t"), Map("p1" -> "1")).location)
+        assert(newLocation.getParentFile === legacyLocation.getParentFile)
+        checkAnswer(spark.read.parquet(newLocation.getCanonicalPath), Row(1))
+      }
+    }
+  }
+
+  test("SPARK-51830: static partition insert with a non-numeric partition value") {
+    // The LEGACY store assignment policy keeps the non-numeric static partition value out of an
+    // ANSI cast, so the insert reaches the partition metadata refresh of the write command.
+    withSQLConf(
+      SQLConf.SKIP_TYPE_VALIDATION_ON_ALTER_PARTITION.key -> "true",
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.LEGACY.toString) {
+      withTable("t") {
+        sql("CREATE TABLE t(c1 int, p1 int) USING parquet PARTITIONED BY (p1)")
+
+        // Inserting no rows into a fully specified static partition registers the partition
+        // from its path fragment, which is computed from the static partition value.
+        intercept[NumberFormatException] {
+          sql("INSERT INTO t PARTITION (p1 = 'legacy_value') SELECT c1 FROM VALUES (1) t(c1)" +
+            " WHERE false")
+        }
+
+        withSQLConf(SQLConf.VALIDATE_PARTITION_COLUMNS.key -> "false") {
+          sql("INSERT INTO t PARTITION (p1 = 'legacy_value') SELECT c1 FROM VALUES (1) t(c1)" +
+            " WHERE false")
+        }
+        assert(spark.sessionState.catalog.listPartitions(TableIdentifier("t")).map(_.spec) ===
+          Seq(Map("p1" -> "legacy_value")))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes a bug where `insertInto()` operations fail with NumberFormatException when writing to legacy tables that have string partition values but numeric partition column schemas, even when `spark.sql.sources.validatePartitionColumns=false` is configured.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is a real issue for users migrating from legacy systems or working with tables where partition naming conventions don't match the schema. The validatePartitionColumns=false config exists specifically to handle such cases, but it wasn't being respected during writes.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, This PR fixes a bug where users could not write to legacy tables with mismatched partition types even when `spark.sql.sources.validatePartitionColumns=false `was configured.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Additional UTs added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No