### PR TITLE
[SPARK-57491][FOLLOWUP] Make stale push-based shuffle fallback chunk-granular and opt-in

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -138,6 +138,29 @@ private class ShuffleStatus(
   }
 
   /**
+   * Clear all stale pushed partition indexes. Called when the entire shuffle's map outputs are
+   * invalidated for a retry (e.g. barrier stage retry or indeterminate-stage rollback), so stale
+   * marks from the previous attempt do not carry over to the retried attempt's fresh push data.
+   */
+  def clearStaleMapIndexes(): Unit = withWriteLock {
+    staleMapIndexes.clear()
+  }
+
+  /**
+   * Check whether any stale pushed map index intersects the given chunk bitmap, without returning
+   * a defensive copy of the stale set. Called from PushBasedFetchHelper on the reduce side for
+   * chunk-level stale-data detection.
+   */
+  def intersectsStaleMapIndexes(bitmap: RoaringBitmap): Boolean = withReadLock {
+    val it = staleMapIndexes.iterator()
+    var found = false
+    while (!found && it.hasNext) {
+      found = bitmap.contains(it.next())
+    }
+    found
+  }
+
+  /**
    * MergeStatus for each shuffle partition when push-based shuffle is enabled. The index of the
    * array is the shuffle partition id (reduce id). Each value in the array is the MergeStatus for
    * a shuffle partition, or null if not available. When push-based shuffle is enabled, this array
@@ -779,6 +802,13 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
   def getStaleMapIndexes(shuffleId: Int): Set[Int]
 
   /**
+   * Check whether any stale pushed map index for the given shuffle is contained in the bitmap,
+   * without returning a defensive copy of the stale set. Called from PushBasedFetchHelper on the
+   * reduce side for chunk-level stale-data detection.
+   */
+  def intersectsStaleMapIndexes(shuffleId: Int, bitmap: RoaringBitmap): Boolean
+
+  /**
    * Deletes map output status information for the specified shuffle stage.
    */
   def unregisterShuffle(shuffleId: Int): Unit
@@ -982,6 +1012,9 @@ private[spark] class MapOutputTrackerMaster(
     shuffleStatus.removeOutputsByFilter(x => true)
     shuffleStatus.removeMergeResultsByFilter(x => true)
     shuffleStatus.removeShuffleMergerLocations()
+    // Reset stale-push marks: the shuffle's outputs are being invalidated for a retry, so marks
+    // from the previous attempt must not carry over to the retried attempt's fresh push data.
+    shuffleStatus.clearStaleMapIndexes()
     incrementEpoch()
   }
 
@@ -1386,6 +1419,10 @@ private[spark] class MapOutputTrackerMaster(
     shuffleStatuses.get(shuffleId).map(_.getStaleMapIndexes).getOrElse(Set.empty)
   }
 
+  override def intersectsStaleMapIndexes(shuffleId: Int, bitmap: RoaringBitmap): Boolean = {
+    shuffleStatuses.get(shuffleId).exists(_.intersectsStaleMapIndexes(bitmap))
+  }
+
   override def stop(): Unit = {
     mapOutputTrackerMasterMessages.offer(PoisonPill)
     threadpool.shutdown()
@@ -1450,6 +1487,22 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
         val result = new java.util.HashSet[Int](dupSet) // defensive copy
         result.asScala
       case None => Set.empty[Int]
+    }
+  }
+
+  /**
+   * Check whether any stale pushed map index for the given shuffle is contained in the bitmap,
+   * inspecting the published snapshot without returning a defensive copy. Avoids the O(S) copy
+   * that getStaleMapIndexes would do per chunk on the reducer fetch path.
+   */
+  def intersectsStaleMapIndexes(shuffleId: Int, bitmap: RoaringBitmap): Boolean = {
+    staleMapIndexes.get(shuffleId).exists { dupSet =>
+      val it = dupSet.iterator()
+      var found = false
+      while (!found && it.hasNext) {
+        found = bitmap.contains(it.next())
+      }
+      found
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2982,7 +2982,7 @@ package object config {
         "spark.shuffle.push.stale.detectAllStages.enabled is also true.")
       .version("4.4.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   private[spark] val STALE_PUSH_DETECT_ALL_STAGES_ENABLED =
     ConfigBuilder("spark.shuffle.push.stale.detectAllStages.enabled")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2973,6 +2973,27 @@ package object config {
       .doubleConf
       .createWithDefault(1.0)
 
+  private[spark] val STALE_PUSH_FALLBACK_ENABLED =
+    ConfigBuilder("spark.shuffle.push.stale.fallback.enabled")
+      .doc("When true, mark partitions with stale push data so reducers fallback to " +
+        "unmerged blocks. Default false to keep detection observational only: duplicate map " +
+        "attempts are always reported (logged), but reducer fallback must be explicitly " +
+        "enabled. When enabled, fallback marking applies to indeterminate stages only unless " +
+        "spark.shuffle.push.stale.detectAllStages.enabled is also true.")
+      .version("4.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  private[spark] val STALE_PUSH_DETECT_ALL_STAGES_ENABLED =
+    ConfigBuilder("spark.shuffle.push.stale.detectAllStages.enabled")
+      .doc("Stale-push detection is always reported for every duplicate map attempt; this flag " +
+        "only gates reducer fallback scope. When false (default), fallback marking (if enabled " +
+        "by spark.shuffle.push.stale.fallback.enabled) applies to indeterminate stages only; " +
+        "when true, to all map stages regardless of determinism.")
+      .version("4.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val JAR_IVY_REPO_PATH =
     ConfigBuilder("spark.jars.ivy")
       .doc("Path to specify the Ivy user directory, used for the local Ivy cache and " +

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -82,6 +82,19 @@ private[spark] class TaskSetManager(
   private val isShuffleMapTasks = tasks(0).isInstanceOf[ShuffleMapTask]
   // shuffleId is only available when isShuffleMapTasks=true
   private val shuffleId = taskSet.shuffleId
+  // Scopes stale-push reducer fallback to indeterminate stages (deterministic stages reproduce
+  // identical output across attempts, so a stale push there is benign). Defaults to false when the
+  // stage isn't registered (e.g. tests). Uses taskSet.stageId (constructor param) because the
+  // `stageId` field below is not initialized yet at this source position.
+  private val isIndeterminateShuffleMapStage: Boolean = isShuffleMapTasks &&
+    sched.dagScheduler.stageIdToStage.get(taskSet.stageId)
+      .collect {
+        case sms: ShuffleMapStage => sms.isStaticallyIndeterminate || sms.isRuntimeIndeterminate
+      }
+      .getOrElse(false)
+  private val stalePushFallbackEnabled = conf.get(config.STALE_PUSH_FALLBACK_ENABLED)
+  private val stalePushDetectAllStagesEnabled =
+    conf.get(config.STALE_PUSH_DETECT_ALL_STAGES_ENABLED)
   private[scheduler] val partitionToIndex = tasks.zipWithIndex
     .map { case (t, idx) => t.partitionId -> idx }.toMap
   val numTasks = tasks.length
@@ -944,10 +957,14 @@ private[spark] class TaskSetManager(
   }
 
   /**
-   * For ShuffleMapTasks, detect stale push: if a partition already has
-   * a registered MapStatus with a different mapId, it means another attempt for the same
-   * partition also pushed data to the merger. Mark this partition so that reducers will
-   * skip the merged block and fallback to unmerged blocks.
+   * Detect stale push for late/killed duplicate map attempts (called from handleSuccessfulTask
+   * when another attempt already succeeded). Every such attempt is reported (logged) on the
+   * driver with its indeterminacy so it is observable regardless of the fallback setting.
+   *
+   * Reducer fallback (marking the partition so reducers skip the merged block) is off by
+   * default (spark.shuffle.push.stale.fallback.enabled); when enabled it covers indeterminate
+   * stages only, and is extended to all map stages via
+   * spark.shuffle.push.stale.detectAllStages.enabled.
    *
    * This is called from handleSuccessfulTask for late-arriving or killed attempt results,
    * where the task result won't be forwarded to DAGScheduler (so DAGScheduler's own
@@ -964,11 +981,17 @@ private[spark] class TaskSetManager(
     val mapStatus = result.value().asInstanceOf[MapStatus]
     val sid = shuffleId.get
     val partitionId = tasks(index).partitionId
-    // Mark its mapIndex (== partitionId, NOT MapStatus.mapId) as stale so reducers can detect
-    // the stale data in merged block chunks via chunkBitmaps and fallback if needed.
     logInfo(s"[StalePush] Late/killed attempt tid=$tid for partition=$partitionId " +
-      s"(index=$index), attemptMapId=${mapStatus.mapId}. Marked as stale push.")
-    sched.mapOutputTracker.markStalePushedPartition(sid, partitionId)
+      s"(index=$index), attemptMapId=${mapStatus.mapId}, " +
+      s"indeterminate=$isIndeterminateShuffleMapStage.")
+    // Report every duplicate map attempt; gate reducer fallback by the fallback switch first,
+    // then by stage scope (indeterminate stages only, unless detectAllStages is enabled).
+    if (stalePushFallbackEnabled &&
+        (stalePushDetectAllStagesEnabled || isIndeterminateShuffleMapStage)) {
+      // Mark its mapIndex (== partitionId, NOT MapStatus.mapId) as stale so reducers can detect
+      // the stale data in merged block chunks via chunkBitmaps and fallback if needed.
+      sched.mapOutputTracker.markStalePushedPartition(sid, partitionId)
+    }
   }
 
   private[scheduler] def markPartitionCompleted(partitionId: Int): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -83,15 +83,15 @@ private[spark] class TaskSetManager(
   // shuffleId is only available when isShuffleMapTasks=true
   private val shuffleId = taskSet.shuffleId
   // Scopes stale-push reducer fallback to indeterminate stages (deterministic stages reproduce
-  // identical output across attempts, so a stale push there is benign). Defaults to false when the
-  // stage isn't registered (e.g. tests). Uses taskSet.stageId (constructor param) because the
-  // `stageId` field below is not initialized yet at this source position.
-  private val isIndeterminateShuffleMapStage: Boolean = isShuffleMapTasks &&
-    sched.dagScheduler.stageIdToStage.get(taskSet.stageId)
-      .collect {
-        case sms: ShuffleMapStage => sms.isStaticallyIndeterminate || sms.isRuntimeIndeterminate
-      }
-      .getOrElse(false)
+  // the same data set across attempts, so a stale push there is benign). Defaults to None when
+  // the stage isn't registered (e.g. tests). Uses taskSet.stageId (constructor param) because the
+  // `stageId` field below is not initialized yet at this source position. The reference is held
+  // (rather than caching a Boolean) so runtime indeterminacy (checksum mismatch, set by
+  // DAGScheduler during the stage) is re-evaluated when a late duplicate result arrives.
+  private val shuffleMapStage: Option[ShuffleMapStage] =
+    if (isShuffleMapTasks) sched.dagScheduler.stageIdToStage.get(taskSet.stageId)
+      .collect { case sms: ShuffleMapStage => sms }
+    else None
   private val stalePushFallbackEnabled = conf.get(config.STALE_PUSH_FALLBACK_ENABLED)
   private val stalePushDetectAllStagesEnabled =
     conf.get(config.STALE_PUSH_DETECT_ALL_STAGES_ENABLED)
@@ -981,13 +981,18 @@ private[spark] class TaskSetManager(
     val mapStatus = result.value().asInstanceOf[MapStatus]
     val sid = shuffleId.get
     val partitionId = tasks(index).partitionId
+    // Re-evaluate indeterminacy now rather than at construction: DAGScheduler may set
+    // isChecksumMismatched (runtime indeterminacy) during the stage, after this TaskSetManager
+    // was constructed. Reading the live ShuffleMapStage reference catches that transition.
+    val isIndeterminate = shuffleMapStage.exists(sms =>
+      sms.isStaticallyIndeterminate || sms.isRuntimeIndeterminate)
     logInfo(s"[StalePush] Late/killed attempt tid=$tid for partition=$partitionId " +
       s"(index=$index), attemptMapId=${mapStatus.mapId}, " +
-      s"indeterminate=$isIndeterminateShuffleMapStage.")
+      s"indeterminate=$isIndeterminate.")
     // Report every duplicate map attempt; gate reducer fallback by the fallback switch first,
     // then by stage scope (indeterminate stages only, unless detectAllStages is enabled).
     if (stalePushFallbackEnabled &&
-        (stalePushDetectAllStagesEnabled || isIndeterminateShuffleMapStage)) {
+        (stalePushDetectAllStagesEnabled || isIndeterminate)) {
       // Mark its mapIndex (== partitionId, NOT MapStatus.mapId) as stale so reducers can detect
       // the stale data in merged block chunks via chunkBitmaps and fallback if needed.
       sched.mapOutputTracker.markStalePushedPartition(sid, partitionId)

--- a/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
@@ -167,14 +167,8 @@ private class PushBasedFetchHelper(
           s" $reduceId) from ${req.address.host}:${req.address.port}")
         val mergedBlock = ShuffleMergedBlockId(shuffleId, shuffleMergeId, reduceId)
         try {
-          val chunkBitmaps = meta.readChunkBitmaps()
-          if (checkStaleMapIdInMergedBlock(mergedBlock, address, chunkBitmaps)) {
-            iterator.addToResultsQueue(PushMergedRemoteMetaFetchResult(shuffleId, shuffleMergeId,
-              reduceId, sizeMap((shuffleId, reduceId)), chunkBitmaps, address))
-          } else {
-            iterator.addToResultsQueue(PushMergedRemoteMetaFailedFetchResult(shuffleId,
-              shuffleMergeId, reduceId, address))
-          }
+          iterator.addToResultsQueue(PushMergedRemoteMetaFetchResult(shuffleId, shuffleMergeId,
+            reduceId, sizeMap((shuffleId, reduceId)), meta.readChunkBitmaps(), address))
         } catch {
           case exception: Exception =>
             logError(log"Failed to parse the meta of push-merged block for (" +
@@ -279,15 +273,9 @@ private class PushBasedFetchHelper(
     try {
       val shuffleBlockId = blockId.asInstanceOf[ShuffleMergedBlockId]
       val chunksMeta = blockManager.getLocalMergedBlockMeta(shuffleBlockId, localDirs)
-      val chunkBitmaps = chunksMeta.readChunkBitmaps()
-      if (checkStaleMapIdInMergedBlock(shuffleBlockId, blockManagerId, chunkBitmaps)) {
-        iterator.addToResultsQueue(PushMergedLocalMetaFetchResult(
-          shuffleBlockId.shuffleId, shuffleBlockId.shuffleMergeId,
-          shuffleBlockId.reduceId, chunkBitmaps, localDirs))
-      } else {
-        iterator.addToResultsQueue(FallbackOnPushMergedFailureResult(
-          blockId, blockManagerId, 0, isNetworkReqDone = false))
-      }
+      iterator.addToResultsQueue(PushMergedLocalMetaFetchResult(
+        shuffleBlockId.shuffleId, shuffleBlockId.shuffleMergeId,
+        shuffleBlockId.reduceId, chunksMeta.readChunkBitmaps(), localDirs))
     } catch {
       case e: Exception =>
         // If we see an exception with reading a push-merged-local meta, we fallback to
@@ -301,33 +289,19 @@ private class PushBasedFetchHelper(
   }
 
   /**
-   * Check whether a push-merged block contains data from stale (duplicate) task attempts.
-   * When speculation is enabled, multiple attempts for the same map output may both push data
-   * to the merger. The merger may include data from both attempts in the same merged block,
-   * but the driver only tracks one as the canonical MapStatus. We detect this by checking
-   * if any stale pushed map index appears in the server-side chunkBitmaps.
+   * Check whether a shuffle chunk contains any stale pushed map index, enabling
+   * chunk-granularity fallback: only chunks that actually contain stale data fall back to their
+   * original blocks, while the remaining chunks of the same merged block are read normally.
    *
-   * @param shuffleBlockId ShuffleMergedBlockId to be checked
-   * @param address BlockManagerId of push-based shuffle service
-   * @param chunkBitmaps Chunks bitmap from push-based shuffle service side
-   * @return false if any stale-marked mapIndex is present in this block (forcing fallback),
-   *         true otherwise
+   * @param blockId ShuffleBlockChunkId to be checked
+   * @return true if this chunk contains any stale-marked mapIndex (forcing a fallback for this
+   *         chunk only), false otherwise
    */
-  private[this] def checkStaleMapIdInMergedBlock(
-      shuffleBlockId: ShuffleMergedBlockId,
-      address: BlockManagerId,
-      chunkBitmaps: Array[RoaringBitmap]): Boolean = {
-    val staleMapIndexes =
-      mapOutputTracker.getStaleMapIndexes(shuffleBlockId.shuffleId)
-    if (staleMapIndexes.isEmpty) return true
-    val mergedBlockBitmap = new RoaringBitmap()
-    chunkBitmaps.foreach(mergedBlockBitmap.or)
-    val hasStale = staleMapIndexes.exists(id => mergedBlockBitmap.contains(id))
-    if (hasStale) {
-      logWarning(s"Found stale pushed map indexes in merged block $shuffleBlockId from" +
-        s" ${address.host}:${address.port}, falling back to fetch the original blocks")
+  private[spark] def isStaleChunk(blockId: ShuffleBlockChunkId): Boolean = {
+    val staleMapIndexes = mapOutputTracker.getStaleMapIndexes(blockId.shuffleId)
+    staleMapIndexes.nonEmpty && chunksMetaMap.get(blockId).exists { bitmap =>
+      staleMapIndexes.exists(bitmap.contains)
     }
-    !hasStale
   }
 
   /**
@@ -353,10 +327,15 @@ private class PushBasedFetchHelper(
    *    (local or remote).
    * 4. There is a zero-size buffer when processing SuccessFetchResult for a shuffle chunk
    *    (local or remote).
+   *
+   * @param fallbackPendingChunks when true (the default, for fetch-failure cases), also fall back
+   *                               the same host's pending shuffle chunks; when false (stale-push
+   *                               fallback), only the given chunk falls back.
    */
   def initiateFallbackFetchForPushMergedBlock(
       blockId: BlockId,
-      address: BlockManagerId): Unit = {
+      address: BlockManagerId,
+      fallbackPendingChunks: Boolean = true): Unit = {
     assert(blockId.isInstanceOf[ShuffleMergedBlockId] || blockId.isInstanceOf[ShuffleBlockChunkId])
     logWarning(log"Falling back to fetch the original blocks for push-merged block " +
       log"${MDC(BLOCK_ID, blockId)}")
@@ -380,7 +359,8 @@ private class PushBasedFetchHelper(
           // fail as well. Since, push-based shuffle is best effort and we try not to increase the
           // delay of the fetches, we immediately fallback for all the pending shuffle chunks in the
           // fetchRequests queue.
-          if (isRemotePushMergedBlockAddress(address)) {
+          // Stale-push fallback passes false: a stale chunk doesn't mean the host is unhealthy.
+          if (fallbackPendingChunks && isRemotePushMergedBlockAddress(address)) {
             // Fallback for all the pending fetch requests
             val pendingShuffleChunks = iterator.removePendingChunks(shuffleChunkId, address)
             pendingShuffleChunks.foreach { pendingBlockId =>

--- a/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
@@ -298,9 +298,10 @@ private class PushBasedFetchHelper(
    *         chunk only), false otherwise
    */
   private[spark] def isStaleChunk(blockId: ShuffleBlockChunkId): Boolean = {
-    val staleMapIndexes = mapOutputTracker.getStaleMapIndexes(blockId.shuffleId)
-    staleMapIndexes.nonEmpty && chunksMetaMap.get(blockId).exists { bitmap =>
-      staleMapIndexes.exists(bitmap.contains)
+    // Delegate the stale/chunk intersection to the tracker so it inspects the published stale
+    // snapshot without returning a defensive copy per chunk on the reducer fetch path.
+    chunksMetaMap.get(blockId).exists { bitmap =>
+      mapOutputTracker.intersectsStaleMapIndexes(blockId.shuffleId, bitmap)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -874,6 +874,21 @@ final class ShuffleBlockFetcherIterator(
             } else {
               throwFetchFailedException(blockId, mapIndex, address, new IOException(msg.message))
             }
+          } else if (blockId.isShuffleChunk &&
+              pushBasedFetchHelper.isStaleChunk(blockId.asInstanceOf[ShuffleBlockChunkId])) {
+            // Chunk-granularity stale-push fallback: fall back to fetching only the original
+            // blocks for this chunk (not the whole merged block). Other chunks of the same
+            // merged block are unaffected and can still be read from the merged block.
+            logWarning(log"Found stale pushed map index in ${MDC(BLOCK_ID, blockId)} from " +
+              log"${MDC(URI, address)}, falling back to fetch the original blocks for this chunk")
+            buf.release()
+            // Only this chunk falls back; a stale chunk doesn't mean the host is unhealthy.
+            pushBasedFetchHelper.initiateFallbackFetchForPushMergedBlock(
+              blockId, address, fallbackPendingChunks = false)
+            // Set result to null to trigger another iteration of the while loop to get either
+            // a SuccessFetchResult or a FailureFetchResult for the fallback blocks.
+            result = null
+            null
           } else {
             try {
               val bufIn = buf.createInputStream()

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1291,6 +1291,11 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
         s
       })
       assert(workerTracker.getStaleMapIndexes(0).contains(1))
+
+      // SPARK-57491 followup: stage retry (unregisterAllMapAndMergeOutput) must reset the stale
+      // set so a retried stage does not carry over stale marks from the previous attempt.
+      masterTracker.unregisterAllMapAndMergeOutput(0)
+      assert(shuffleStatus.getStaleMapIndexes.isEmpty)
     } finally {
       masterTracker.stop()
       rpcEnv.shutdown()

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -45,7 +45,7 @@ import org.apache.spark.resource.TestResourceIDs._
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.{AccumulatorV2, Clock, ManualClock, SystemClock}
+import org.apache.spark.util.{AccumulatorV2, CallSite, Clock, ManualClock, SystemClock}
 import org.apache.spark.util.ArrayImplicits._
 
 class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
@@ -2922,22 +2922,29 @@ class TaskSetManagerSuite
   }
 
   test("SPARK-57491: late speculative ShuffleMapTask marks stale only when fallback enabled") {
-    // (fallbackEnabled, detectAllStagesEnabled, expectStale)
+    // (fallbackEnabled, detectAllStagesEnabled, expectStale, runtimeIndeterminateAfterConstruction)
+    // fallbackEnabled/detectAllStagesEnabled as Option: None leaves the config unset so the real
+    // default is exercised; runtimeIndeterminateAfterConstruction sets isChecksumMismatched after
+    // the TaskSetManager is constructed, to verify indeterminacy is re-evaluated (not cached).
     Seq(
-      // Both switches enabled: the late attempt is marked stale regardless of stage determinism
-      // (the test does not register an indeterminate ShuffleMapStage, so detectAllStages is
-      // required here).
-      (true, true, true),
-      // Fallback disabled (default): the late attempt is reported (logged) but no map index is
-      // marked stale, so reducers keep reading the merged block.
-      (false, false, false)
-    ).foreach { case (fallbackEnabled, detectAllStagesEnabled, expectStale) =>
+      // Both switches enabled: the late attempt is marked stale regardless of stage determinism.
+      (Some(true), Some(true), true, false),
+      // Fallback disabled: the late attempt is reported (logged) but no map index is marked.
+      (Some(false), Some(false), false, false),
+      // Real defaults (no explicit config): fallback defaults to false, so no stale marking.
+      (None, None, false, false),
+      // Fallback enabled, detect-all disabled, runtime indeterminacy set AFTER construction:
+      // validates that indeterminacy is re-evaluated when the late duplicate arrives, not cached at
+      // TaskSetManager construction (the indeterminate-only path). A cached-at-construction Boolean
+      // would read false here and skip stale marking.
+      (Some(true), Some(false), true, true)
+    ).foreach { case (fallbackEnabled, detectAllStagesEnabled, expectStale, runtimeIndet) =>
       val staleMapIndexes =
-        runLateSpeculativeShuffleMapAttempt(fallbackEnabled, detectAllStagesEnabled)
+        runLateSpeculativeShuffleMapAttempt(fallbackEnabled, detectAllStagesEnabled, runtimeIndet)
       if (expectStale) {
         assert(staleMapIndexes.contains(0),
           s"Expected staleMapIndexes to contain mapIndex 0 " +
-            s"(fallback=$fallbackEnabled), got $staleMapIndexes")
+            s"(fallback=$fallbackEnabled, runtimeIndet=$runtimeIndet), got $staleMapIndexes")
       } else {
         assert(staleMapIndexes.isEmpty,
           s"Expected no stale map indexes (fallback=$fallbackEnabled), got $staleMapIndexes")
@@ -2952,32 +2959,60 @@ class TaskSetManagerSuite
    * the stale pushed map indexes recorded by the MapOutputTracker, which are non-empty only
    * when reducer fallback marking is enabled.
    *
-   * Each invocation gets its own SparkContext via [[withSpark]] so the caller can loop without
-   * leaking contexts.
+   * Each invocation gets its own SparkContext via [[LocalSparkContext.withSpark]] so the caller
+   * can loop without leaking contexts.
    */
   private def runLateSpeculativeShuffleMapAttempt(
-      fallbackEnabled: Boolean,
-      detectAllStagesEnabled: Boolean): Set[Int] = LocalSparkContext.withSpark(
+      fallbackEnabled: Option[Boolean],
+      detectAllStagesEnabled: Option[Boolean],
+      runtimeIndeterminateAfterConstruction: Boolean = false): Set[Int] =
+    LocalSparkContext.withSpark(
     new SparkContext("local", "test")) { sc =>
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
     sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
     sc.conf.set(config.SPECULATION_ENABLED, true)
-    sc.conf.set(config.STALE_PUSH_FALLBACK_ENABLED, fallbackEnabled)
-    sc.conf.set(config.STALE_PUSH_DETECT_ALL_STAGES_ENABLED, detectAllStagesEnabled)
+    // None leaves the config unset so the real default is exercised.
+    fallbackEnabled.foreach(v => sc.conf.set(config.STALE_PUSH_FALLBACK_ENABLED, v))
+    detectAllStagesEnabled.foreach(v => sc.conf.set(config.STALE_PUSH_DETECT_ALL_STAGES_ENABLED, v))
 
     val taskSet = FakeTask.createShuffleMapTaskSet(2, 0, 0,
       Seq(TaskLocation("host1", "exec1")),
       Seq(TaskLocation("host2", "exec2")))
     val clock = new ManualClock()
-    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
-    val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>
-      task.metrics.internalAccums
-    }
 
     // Register shuffle in MapOutputTrackerMaster so detectStalePushIfShuffleTask can find it
     val mapOutputTrackerMaster = sched.mapOutputTracker
     val shuffleId = taskSet.shuffleId.get
     mapOutputTrackerMaster.registerShuffle(shuffleId, 2, 2)
+
+    // Register a ShuffleMapStage so TaskSetManager resolves the stage reference and can
+    // re-evaluate runtime indeterminacy when the late duplicate arrives. The stage is statically
+    // determinate; runtime indeterminacy is toggled below via isChecksumMismatched.
+    val mapRdd = new MyRDD(sc, 2, Nil)
+    val shuffleDep = new ShuffleDependency[Int, Int, Int](mapRdd, new HashPartitioner(2))
+    val stage = new ShuffleMapStage(
+      id = taskSet.stageId,
+      rdd = mapRdd,
+      numTasks = 2,
+      parents = Nil,
+      firstJobId = 0,
+      callSite = CallSite("", ""),
+      shuffleDep = shuffleDep,
+      mapOutputTrackerMaster = mapOutputTrackerMaster,
+      resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
+    sched.dagScheduler.stageIdToStage(taskSet.stageId) = stage
+
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+    // Simulate DAGScheduler detecting a checksum mismatch during the stage, AFTER the
+    // TaskSetManager was constructed. Indeterminacy must be re-evaluated (not cached at
+    // construction) when the late duplicate arrives, so the indeterminate-only mode marks stale.
+    if (runtimeIndeterminateAfterConstruction) {
+      stage.isChecksumMismatched = true
+    }
+    val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>
+      task.metrics.internalAccums
+    }
+
 
     // Offer resources for 2 tasks to start
     val task0 = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1.get

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2921,11 +2921,49 @@ class TaskSetManagerSuite
         s"\nCaptured logs:\n${logs.mkString("\n")}")
   }
 
-  test("SPARK-57491: late-arriving speculative ShuffleMapTask marks stale partitionId") {
-    sc = new SparkContext("local", "test")
+  test("SPARK-57491: late speculative ShuffleMapTask marks stale only when fallback enabled") {
+    // (fallbackEnabled, detectAllStagesEnabled, expectStale)
+    Seq(
+      // Both switches enabled: the late attempt is marked stale regardless of stage determinism
+      // (the test does not register an indeterminate ShuffleMapStage, so detectAllStages is
+      // required here).
+      (true, true, true),
+      // Fallback disabled (default): the late attempt is reported (logged) but no map index is
+      // marked stale, so reducers keep reading the merged block.
+      (false, false, false)
+    ).foreach { case (fallbackEnabled, detectAllStagesEnabled, expectStale) =>
+      val staleMapIndexes =
+        runLateSpeculativeShuffleMapAttempt(fallbackEnabled, detectAllStagesEnabled)
+      if (expectStale) {
+        assert(staleMapIndexes.contains(0),
+          s"Expected staleMapIndexes to contain mapIndex 0 " +
+            s"(fallback=$fallbackEnabled), got $staleMapIndexes")
+      } else {
+        assert(staleMapIndexes.isEmpty,
+          s"Expected no stale map indexes (fallback=$fallbackEnabled), got $staleMapIndexes")
+      }
+    }
+  }
+
+  /**
+   * Drives a shuffle map stage through a late speculative attempt: task 0 and task 1 start,
+   * task 1 finishes, task 0 is speculated, then the original task 0 finishes (killing the
+   * speculative attempt) and finally the speculative attempt's result arrives late. Returns
+   * the stale pushed map indexes recorded by the MapOutputTracker, which are non-empty only
+   * when reducer fallback marking is enabled.
+   *
+   * Each invocation gets its own SparkContext via [[withSpark]] so the caller can loop without
+   * leaking contexts.
+   */
+  private def runLateSpeculativeShuffleMapAttempt(
+      fallbackEnabled: Boolean,
+      detectAllStagesEnabled: Boolean): Set[Int] = LocalSparkContext.withSpark(
+    new SparkContext("local", "test")) { sc =>
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
     sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
     sc.conf.set(config.SPECULATION_ENABLED, true)
+    sc.conf.set(config.STALE_PUSH_FALLBACK_ENABLED, fallbackEnabled)
+    sc.conf.set(config.STALE_PUSH_DETECT_ALL_STAGES_ENABLED, detectAllStagesEnabled)
 
     val taskSet = FakeTask.createShuffleMapTaskSet(2, 0, 0,
       Seq(TaskLocation("host1", "exec1")),
@@ -2952,8 +2990,8 @@ class TaskSetManagerSuite
 
     // Complete task 1 (partition 1) successfully with a MapStatus
     val mapStatus1 = MapStatus(BlockManagerId("exec2", "host2", 2000), Array(2L, 2L), mapTaskId = 1)
-    val result1 = createMapStatusTaskResult(mapStatus1, accumUpdatesByTask(1))
-    manager.handleSuccessfulTask(task1.taskId, result1)
+    manager.handleSuccessfulTask(task1.taskId,
+      createMapStatusTaskResult(mapStatus1, accumUpdatesByTask(1)))
     assert(sched.endedTasks(task1.index) === Success)
 
     // Advance clock so task 0 has been running long enough for speculation.
@@ -2976,8 +3014,8 @@ class TaskSetManagerSuite
 
     // Complete original task 0 (partition 0) - this will kill the speculative attempt
     val mapStatus0 = MapStatus(BlockManagerId("exec1", "host1", 1000), Array(1L, 1L), mapTaskId = 0)
-    val result0 = createMapStatusTaskResult(mapStatus0, accumUpdatesByTask(0))
-    manager.handleSuccessfulTask(task0.taskId, result0)
+    manager.handleSuccessfulTask(task0.taskId,
+      createMapStatusTaskResult(mapStatus0, accumUpdatesByTask(0)))
 
     // Verify no stale pushed map indexes yet (stale is only marked when late result arrives)
     assert(mapOutputTrackerMaster.getStaleMapIndexes(shuffleId).isEmpty)
@@ -2987,13 +3025,10 @@ class TaskSetManagerSuite
     // the speculative tid, triggering detectStalePushIfShuffleTask.
     val specMapStatus = MapStatus(
       BlockManagerId("exec3", "host3", 3000), Array(3L, 3L), mapTaskId = 999)
-    val specResult = createMapStatusTaskResult(specMapStatus, accumUpdatesByTask(0))
-    manager.handleSuccessfulTask(specTask.taskId, specResult)
+    manager.handleSuccessfulTask(specTask.taskId,
+      createMapStatusTaskResult(specMapStatus, accumUpdatesByTask(0)))
 
-    // Verify that partition 0 is now tracked as stale
-    val staleMapIndexes = mapOutputTrackerMaster.getStaleMapIndexes(shuffleId)
-    assert(staleMapIndexes.contains(0),
-      s"Expected staleMapIndexes to contain mapIndex 0, got $staleMapIndexes")
+    mapOutputTrackerMaster.getStaleMapIndexes(shuffleId).toSet
   }
 
   private def createMapStatusTaskResult(

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -2078,7 +2078,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     assert(!iterator.hasNext)
   }
 
-  test("SPARK-57491: fallback behavior when stale mapIndex is in/not in merged block") {
+  test("SPARK-57491: chunk-granularity fallback when stale mapIndex is in a chunk") {
     val blockManager = createMockBlockManager()
     val localHost = "test-local-host"
     val localBmId = BlockManagerId("test-client", localHost, 1)
@@ -2087,23 +2087,24 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     initHostLocalDirManager(blockManager, Map(SHUFFLE_MERGER_IDENTIFIER -> localDirs))
 
     when(mapOutputTracker.getStaleMapIndexes(0)).thenReturn(mutable.Set(1))
-    when(mapOutputTracker.getMapSizesForMergeResult(0, 2))
-      .thenReturn(Seq((localBmId,
-        toBlockList(Seq(ShuffleBlockId(0, 0, 2), ShuffleBlockId(0, 1, 2)), 1L, 1))).iterator)
     doReturn(createMockManagedBuffer(100)).when(blockManager)
       .getLocalBlockData(ShuffleBlockId(0, 0, 2))
     doReturn(createMockManagedBuffer(100)).when(blockManager)
       .getLocalBlockData(ShuffleBlockId(0, 1, 2))
 
-    // Stale mapIndex IS in the merged block's bitmap -> should trigger fallback
+    // Stale mapIndex (1) IS in the only chunk's bitmap -> that chunk falls back to its
+    // original blocks (mapIndex 0 and 1), instead of falling back the whole merged block.
     val bitmaps1 = Array(new RoaringBitmap)
     bitmaps1(0).add(0) // chunk 0 has mapIndex 0
     bitmaps1(0).add(1) // chunk 0 also has mapIndex 1 (stale)
+    when(mapOutputTracker.getMapSizesForMergeResult(0, 2, bitmaps1(0)))
+      .thenReturn(Seq((localBmId,
+        toBlockList(Seq(ShuffleBlockId(0, 0, 2), ShuffleBlockId(0, 1, 2)), 1L, 1))).iterator)
 
     val pushMergedBlockMeta1 = createMockPushMergedBlockMeta(bitmaps1.length, bitmaps1)
     when(blockManager.getLocalMergedBlockMeta(ShuffleMergedBlockId(0, 0, 2), localDirs))
       .thenReturn(pushMergedBlockMeta1)
-    doReturn(Seq(createMockManagedBuffer(100), createMockManagedBuffer(100)))
+    doReturn(Seq(createMockManagedBuffer(100)))
       .when(blockManager).getLocalMergedBlockData(ShuffleMergedBlockId(0, 0, 2), localDirs)
     doReturn(createMockManagedBuffer(100)).when(blockManager)
       .getLocalBlockData(ShuffleBlockId(0, 3, 2))
@@ -2129,7 +2130,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     assert(!iterator1.hasNext)
     assert(shuffleMetrics1.mergedFetchFallbackCount === 1)
 
-    // Stale mapIndex is NOT in the merged block's bitmap -> should NOT trigger fallback
+    // Stale mapIndex is NOT in any chunk's bitmap -> no fallback, chunks are read normally.
     val bitmaps2 = Array(new RoaringBitmap, new RoaringBitmap)
     bitmaps2(0).add(0) // chunk 0 has mapIndex 0
     bitmaps2(1).add(2) // chunk 1 has mapIndex 2
@@ -2156,5 +2157,45 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     assert(id5.isInstanceOf[ShuffleBlockChunkId])
     assert(!iterator2.hasNext)
     assert(shuffleMetrics2.mergedFetchFallbackCount === 0)
+
+    // Only the chunk containing the stale mapIndex falls back; the other chunk of the same
+    // merged block is still read normally as a shuffle chunk (no whole-block fallback).
+    val bitmaps3 = Array(new RoaringBitmap, new RoaringBitmap)
+    bitmaps3(0).add(0) // chunk 0 has mapIndex 0
+    bitmaps3(0).add(1) // chunk 0 also has mapIndex 1 (stale)
+    bitmaps3(1).add(2) // chunk 1 has mapIndex 2 (not stale)
+    when(mapOutputTracker.getMapSizesForMergeResult(0, 2, bitmaps3(0)))
+      .thenReturn(Seq((localBmId,
+        toBlockList(Seq(ShuffleBlockId(0, 0, 2), ShuffleBlockId(0, 1, 2)), 1L, 1))).iterator)
+
+    val pushMergedBlockMeta3 = createMockPushMergedBlockMeta(bitmaps3.length, bitmaps3)
+    when(blockManager.getLocalMergedBlockMeta(ShuffleMergedBlockId(0, 0, 2), localDirs))
+      .thenReturn(pushMergedBlockMeta3)
+    doReturn(Seq(createMockManagedBuffer(100), createMockManagedBuffer(100)))
+      .when(blockManager).getLocalMergedBlockData(ShuffleMergedBlockId(0, 0, 2), localDirs)
+
+    val blocksByAddress3 = Map[BlockManagerId, Seq[(BlockId, Long, Int)]](
+      (pushMergedBmId, toBlockList(Seq(ShuffleMergedBlockId(0, 0, 2)), 200L,
+        SHUFFLE_PUSH_MAP_ID)))
+
+    val taskContext3 = TaskContext.empty()
+    val shuffleMetrics3 = taskContext3.taskMetrics.createTempShuffleReadMetrics()
+    val iterator3 = createShuffleBlockIteratorWithDefaults(blocksByAddress3,
+      blockManager = Some(blockManager),
+      shuffleMetrics = Some(shuffleMetrics3))
+
+    val results3 = scala.collection.mutable.ArrayBuffer[BlockId]()
+    while (iterator3.hasNext) {
+      results3 += iterator3.next()._1
+    }
+    // chunk 0 (stale) falls back to original blocks 0 and 1; chunk 1 (not stale) is read
+    // normally as a ShuffleBlockChunkId.
+    assert(results3.exists(_.isInstanceOf[ShuffleBlockChunkId]),
+      "Expected the non-stale chunk to be read as a shuffle chunk")
+    assert(results3.exists(_ == ShuffleBlockId(0, 0, 2)),
+      "Expected stale chunk to fall back to original block 0")
+    assert(results3.exists(_ == ShuffleBlockId(0, 1, 2)),
+      "Expected stale chunk to fall back to original block 1")
+    assert(shuffleMetrics3.mergedFetchFallbackCount === 1)
   }
 }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -32,7 +32,7 @@ import scala.concurrent.Future
 import io.netty.util.internal.OutOfDirectMemoryError
 import org.apache.logging.log4j.Level
 import org.mockito.ArgumentMatchers.{any, eq => meq}
-import org.mockito.Mockito.{doThrow, mock, times, verify, when}
+import org.mockito.Mockito.{doAnswer, doThrow, mock, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.roaringbitmap.RoaringBitmap
@@ -59,7 +59,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     mapOutputTracker = mock(classOf[MapOutputTracker])
     when(mapOutputTracker.getMapSizesForMergeResult(any(), any(), any()))
       .thenReturn(Seq.empty.iterator)
-    when(mapOutputTracker.getStaleMapIndexes(any())).thenReturn(mutable.Set.empty[Int])
+    when(mapOutputTracker.intersectsStaleMapIndexes(any(), any[RoaringBitmap])).thenReturn(false)
   }
 
   private def doReturn(value: Any) = org.mockito.Mockito.doReturn(value, Seq.empty: _*)
@@ -2086,7 +2086,10 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     val localDirs = Array("test-merged-dir-1", "test-merged-dir-2")
     initHostLocalDirManager(blockManager, Map(SHUFFLE_MERGER_IDENTIFIER -> localDirs))
 
-    when(mapOutputTracker.getStaleMapIndexes(0)).thenReturn(mutable.Set(1))
+    // Stale mapIndex is 1; a chunk falls back iff its bitmap contains mapIndex 1.
+    doAnswer { invocation =>
+      invocation.getArgument(1, classOf[RoaringBitmap]).contains(1)
+    }.when(mapOutputTracker).intersectsStaleMapIndexes(any(), any[RoaringBitmap])
     doReturn(createMockManagedBuffer(100)).when(blockManager)
       .getLocalBlockData(ShuffleBlockId(0, 0, 2))
     doReturn(createMockManagedBuffer(100)).when(blockManager)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-57491 (stale push-based shuffle data detection). SPARK-57491's reducer fallback was too coarse; this PR makes it chunk-granular and opt-in.

1. Chunk-granularity fallback. Replaces checkStaleMapIdInMergedBlock (which fell back the entire merged block if any stale map index was present) with isStaleChunk, which checks a single chunk's bitmap. The meta fetch no longer short-circuits, so in ShuffleBlockFetcherIterator.next() only the chunk that actually contains a stale index falls back to its original blocks; other chunks of the same merged block keep being read from the merged block.
2. No cascade for stale fallback. initiateFallbackFetchForPushMergedBlock gains a fallbackPendingChunks flag (default true). Fetch-failure paths keep cascading to same-host pending chunks; the stale path passes false, since a stale chunk doesn't imply the host is unhealthy, so pending chunks retain their merged-block reads.
3. Opt-in, indeterminate-scoped reducer fallback. Two new configs (both default false): spark.shuffle.push.stale.fallback.enabled gates markStalePushedPartition; spark.shuffle.push.stale.detectAllStages.enabled extends it to all map stages. Duplicate map attempts are now always logged for observability, but marked stale only when fallback is enabled and the stage is in scope. Stage indeterminacy is resolved once at TaskSetManager construction (isIndeterminateShuffleMapStage).


### Why are the changes needed?

Speculation is common on large stages in production, so duplicate map attempts that both push are routine. SPARK-57491's fallback had too wide a blast radius:

- Whole-block fallback amplifies fetch load across the whole stage. A stale index in one chunk forced fallback of the entire merged block, turning 1 merged fetch into N original-block fetches per affected reducer. On a large shuffle, a single stale partition multiplies network requests by an order of magnitude and slows the whole stage, rather than protecting just the one partition at risk.
- Deterministic stages pay for nothing. Duplicate deterministic attempts produce byte-identical output, so the data in the merged block is actually correct — the fallback is pure overhead and a false positive. The real risk is confined to indeterminate stages, where duplicate attempts can diverge.
- Safe rollout. SPARK-57491 is unreleased; its always-on fallback could land as a silent perf regression for any job that hits speculation. Opt-in (default: log-only) fallback lets the detection ship safely, enabled only where the correctness gain justifies the extra fetches.

Net effect: a stale partition now costs roughly 1 chunk's worth of extra fetches instead of a full merged block, and only indeterminate stages pay it.


### Does this PR introduce _any_ user-facing change?

Yes — two new optional configs (both default false): spark.shuffle.push.stale.fallback.enabled and spark.shuffle.push.stale.detectAllStages.enabled.


### How was this patch tested?

Added/updated unit tests:

- TaskSetManagerSuite: updated the SPARK-57491 test to enable both fallback switches and assert the partition is marked stale; new test verifies that with fallback disabled (default) the stale attempt is reported but not marked.
- ShuffleBlockFetcherIteratorSuite: updated to chunk granularity — a stale index in a chunk's bitmap triggers fallback for that chunk only; new case asserts the non-stale chunk is still read as a ShuffleBlockChunkId.


### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code (Anthropic)