### PR TITLE
[SPARK-58789][CORE] Add CredentialProvider.additionalSparkProperties() SPI and auto-config wiring

### DIFF
--- a/connector/credential-aws/src/main/java/org/apache/spark/security/aws/AwsStsCredentialProvider.java
+++ b/connector/credential-aws/src/main/java/org/apache/spark/security/aws/AwsStsCredentialProvider.java
@@ -414,6 +414,13 @@ public class AwsStsCredentialProvider implements CredentialProvider {
     return Duration.ofMinutes(15);
   }
 
+  @Override
+  public Map<String, String> additionalSparkProperties() {
+    return Map.of(
+        "spark.hadoop.fs.s3a.aws.credentials.provider",
+        "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider");
+  }
+
   /**
    * Walks the cause chain of the given throwable and checks whether the raw token
    * appears in any layer's message. Used to decide whether the original exception

--- a/connector/credential-aws/src/test/java/org/apache/spark/security/aws/AwsStsCredentialProviderSuite.java
+++ b/connector/credential-aws/src/test/java/org/apache/spark/security/aws/AwsStsCredentialProviderSuite.java
@@ -1002,4 +1002,33 @@ public class AwsStsCredentialProviderSuite {
         .thenReturn(response);
     return mockSts;
   }
+
+  // ========== additionalSparkProperties() ==========
+
+  @Test
+  public void testAdditionalSparkPropertiesReturnsS3aProviderMapping() {
+    AwsStsCredentialProvider provider = new AwsStsCredentialProvider();
+    Map<String, String> props = provider.additionalSparkProperties();
+    assertEquals(1, props.size());
+    assertEquals(
+        "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider",
+        props.get("spark.hadoop.fs.s3a.aws.credentials.provider"));
+  }
+
+  @Test
+  public void testAdditionalSparkPropertiesKeyIncludesSparkHadoopPrefix() {
+    AwsStsCredentialProvider provider = new AwsStsCredentialProvider();
+    Map<String, String> props = provider.additionalSparkProperties();
+    props.keySet().forEach(key ->
+        assertTrue(key.startsWith("spark.hadoop."),
+            "Key must include spark.hadoop. prefix: " + key));
+  }
+
+  @Test
+  public void testAdditionalSparkPropertiesIsUnmodifiable() {
+    AwsStsCredentialProvider provider = new AwsStsCredentialProvider();
+    Map<String, String> props = provider.additionalSparkProperties();
+    assertThrows(UnsupportedOperationException.class,
+        () -> props.put("foo", "bar"));
+  }
 }

--- a/core/src/main/java/org/apache/spark/security/CredentialProvider.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProvider.java
@@ -103,6 +103,28 @@ public interface CredentialProvider extends AutoCloseable {
   }
 
   /**
+   * Returns additional Spark configuration properties that should be set when this
+   * provider is active.
+   * <p>
+   * The credential management layer applies these entries to {@code SparkConf} after
+   * successful startup, only if the user has not already set them explicitly. This
+   * allows provider modules to declare executor-side wiring (e.g., the Hadoop
+   * credentials provider class for a particular filesystem scheme) without requiring
+   * core to have vendor-specific knowledge.
+   * <p>
+   * Keys must include the {@code spark.hadoop.} prefix if they target Hadoop
+   * configuration on executors (propagated via {@code SparkAppConfig}).
+   * <p>
+   * The default implementation returns an empty map (no additional properties).
+   *
+   * @return an unmodifiable map of property key-value pairs (never null)
+   * @since 4.4.0
+   */
+  default Map<String, String> additionalSparkProperties() {
+    return Map.of();
+  }
+
+  /**
    * Releases any resources held by this provider (e.g., HTTP clients, connection pools).
    * <p>
    * Called by the credential management layer during shutdown. The default implementation

--- a/core/src/main/java/org/apache/spark/security/CredentialProvider.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProvider.java
@@ -106,14 +106,20 @@ public interface CredentialProvider extends AutoCloseable {
    * Returns additional Spark configuration properties that should be set when this
    * provider is active.
    * <p>
+   * This method is called after {@link #init(Map)} and a successful
+   * {@link #resolve(UserContext, URI)} invocation. Implementations may
+   * assume that provider state is fully initialized when this is called.
+   * <p>
    * The credential management layer applies these entries to {@code SparkConf} after
    * successful startup, only if the user has not already set them explicitly. This
    * allows provider modules to declare executor-side wiring (e.g., the Hadoop
    * credentials provider class for a particular filesystem scheme) without requiring
    * core to have vendor-specific knowledge.
    * <p>
-   * Keys must include the {@code spark.hadoop.} prefix if they target Hadoop
-   * configuration on executors (propagated via {@code SparkAppConfig}).
+   * Keys must use the {@code spark.} prefix to be effective (SparkConf convention).
+   * Keys with the {@code spark.hadoop.} prefix are propagated to executor-side
+   * Hadoop {@code Configuration} with the prefix stripped. Other {@code spark.*}
+   * keys are applied as Spark-internal configuration.
    * <p>
    * The default implementation returns an empty map (no additional properties).
    *

--- a/core/src/main/java/org/apache/spark/security/CredentialProvider.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProvider.java
@@ -123,7 +123,8 @@ public interface CredentialProvider extends AutoCloseable {
    * <p>
    * The default implementation returns an empty map (no additional properties).
    *
-   * @return an unmodifiable map of property key-value pairs (never null)
+   * @return an unmodifiable map of property key-value pairs (never null).
+   *         Keys and values within the map must not be {@code null}.
    * @since 4.4.0
    */
   default Map<String, String> additionalSparkProperties() {

--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -252,20 +252,6 @@ public final class CredentialProviderLoader {
   }
 
   /**
-   * Returns all registered providers discovered via ServiceLoader.
-   * <p>
-   * Unlike {@link #providerFor(String, Map)}, this does not initialize providers.
-   * It is intended for querying provider metadata (e.g.,
-   * {@link CredentialProvider#additionalSparkProperties()}).
-   *
-   * @return an unmodifiable list of all discovered providers
-   * @since 4.4.0
-   */
-  public static List<CredentialProvider> discoverAllProviders() {
-    return Collections.unmodifiableList(getProviders());
-  }
-
-  /**
    * Closes all initialized providers, suppressing individual close exceptions.
    * <p>
    * This method iterates over all providers that have been initialized via

--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -252,6 +252,20 @@ public final class CredentialProviderLoader {
   }
 
   /**
+   * Returns all registered providers discovered via ServiceLoader.
+   * <p>
+   * Unlike {@link #providerFor(String, Map)}, this does not initialize providers.
+   * It is intended for querying provider metadata (e.g.,
+   * {@link CredentialProvider#additionalSparkProperties()}).
+   *
+   * @return an unmodifiable list of all discovered providers
+   * @since 4.4.0
+   */
+  public static List<CredentialProvider> discoverAllProviders() {
+    return Collections.unmodifiableList(getProviders());
+  }
+
+  /**
    * Closes all initialized providers, suppressing individual close exceptions.
    * <p>
    * This method iterates over all providers that have been initialized via

--- a/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
@@ -112,7 +112,7 @@ private[spark] class UserCredentialManager(
       log"${MDC(LogKeys.PRINCIPAL, ctx.getPrincipal)} " +
       log"(issuer: ${MDC(LogKeys.URI, ctx.getIssuer)})")
 
-    val (credentials, earliestExpiry) = resolveCredentials(ctx)
+    val (credentials, earliestExpiry, activeProviders) = resolveCredentials(ctx)
     val serialized = UserCredentialManager.serializeUserCredentials(credentials)
     val version = credentialVersion.incrementAndGet()
 
@@ -133,17 +133,32 @@ private[spark] class UserCredentialManager(
       log"${MDC(LogKeys.TIME_UNITS, UIUtils.formatDuration(renewalDelay))}.")
 
     // Apply additional Spark properties declared by active providers.
+    // Only providers that successfully resolved credentials contribute properties.
     // This allows provider modules to wire executor-side configuration
     // (e.g., fs.s3a.aws.credentials.provider) without core having
     // vendor-specific knowledge. Properties are only set if the user
     // has not already configured them explicitly.
-    CredentialProviderLoader.discoverAllProviders().forEach { provider =>
-      provider.additionalSparkProperties().forEach { (key, value) =>
-        if (!sparkConf.contains(key)) {
-          sparkConf.set(key, value)
-          logInfo(log"Auto-configured ${MDC(LogKeys.CONFIG, key)} from " +
-            log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)}")
+    for (provider <- activeProviders) {
+      try {
+        val props = provider.additionalSparkProperties()
+        if (props != null) {
+          props.forEach { (key, value) =>
+            if (!sparkConf.contains(key)) {
+              sparkConf.set(key, value)
+              logInfo(log"Auto-configured ${MDC(LogKeys.CONFIG, key)} from " +
+                log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)}")
+            } else {
+              logDebug(log"Skipped ${MDC(LogKeys.CONFIG, key)} from " +
+                log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)} " +
+                log"(already configured)")
+            }
+          }
         }
+      } catch {
+        case scala.util.control.NonFatal(e) =>
+          logWarning(log"Failed to apply additionalSparkProperties from " +
+            log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)}. " +
+            log"Skipping.", e)
       }
     }
 
@@ -186,7 +201,7 @@ private[spark] class UserCredentialManager(
         log"${MDC(LogKeys.PRINCIPAL, ctx.getPrincipal)} " +
         log"(issuer: ${MDC(LogKeys.URI, ctx.getIssuer)})")
 
-      val (credentials, earliestExpiry) = resolveCredentials(ctx)
+      val (credentials, earliestExpiry, _) = resolveCredentials(ctx)
       val serialized = UserCredentialManager.serializeUserCredentials(credentials)
       val version = credentialVersion.incrementAndGet()
 
@@ -238,10 +253,11 @@ private[spark] class UserCredentialManager(
    * @return Tuple of (UserCredentials, earliest expiry across all service credentials)
    */
   private def resolveCredentials(
-      ctx: UserContext): (UserCredentials, Option[Instant]) = {
+      ctx: UserContext): (UserCredentials, Option[Instant], Seq[CredentialProvider]) = {
     val schemes = discoverSchemes()
 
     val credentialMap = new mutable.HashMap[String, ServiceCredential]()
+    val activeProviders = new mutable.ArrayBuffer[CredentialProvider]()
     var earliestExpiry: Option[Instant] = None
 
     for (scheme <- schemes) {
@@ -261,6 +277,7 @@ private[spark] class UserCredentialManager(
               log"returned null; skipping.")
           } else {
             credentialMap.put(scheme, credential)
+            activeProviders += provider
 
             val expiry = credential.getExpiresAt
             if (expiry != null) {
@@ -287,7 +304,7 @@ private[spark] class UserCredentialManager(
           "Check that providers are on the classpath and configured correctly.")
     }
 
-    (new UserCredentials(credentialMap.asJava), earliestExpiry)
+    (new UserCredentials(credentialMap.asJava), earliestExpiry, activeProviders.toSeq)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
@@ -131,6 +131,22 @@ private[spark] class UserCredentialManager(
 
     logInfo(log"Credential acquisition successful. Next renewal in " +
       log"${MDC(LogKeys.TIME_UNITS, UIUtils.formatDuration(renewalDelay))}.")
+
+    // Apply additional Spark properties declared by active providers.
+    // This allows provider modules to wire executor-side configuration
+    // (e.g., fs.s3a.aws.credentials.provider) without core having
+    // vendor-specific knowledge. Properties are only set if the user
+    // has not already configured them explicitly.
+    CredentialProviderLoader.discoverAllProviders().forEach { provider =>
+      provider.additionalSparkProperties().forEach { (key, value) =>
+        if (!sparkConf.contains(key)) {
+          sparkConf.set(key, value)
+          logInfo(log"Auto-configured ${MDC(LogKeys.CONFIG, key)} from " +
+            log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)}")
+        }
+      }
+    }
+
     (version, serialized)
   }
 

--- a/core/src/test/java/org/apache/spark/security/AnotherFakeCredentialProvider.java
+++ b/core/src/test/java/org/apache/spark/security/AnotherFakeCredentialProvider.java
@@ -31,6 +31,12 @@ public class AnotherFakeCredentialProvider implements CredentialProvider {
   /** Sentinel URI host that triggers a CredentialResolutionException. */
   public static final String ERROR_HOST = "error.example.com";
 
+  /**
+   * When set to true, {@link #additionalSparkProperties()} throws a RuntimeException.
+   * Used to test exception isolation in UserCredentialManager.
+   */
+  public static volatile boolean throwOnProperties = false;
+
   private Map<String, String> initConf;
 
   @Override
@@ -57,5 +63,13 @@ public class AnotherFakeCredentialProvider implements CredentialProvider {
   /** Returns the configuration map passed to {@link #init(Map)}, or null if not yet called. */
   public Map<String, String> getInitConf() {
     return initConf;
+  }
+
+  @Override
+  public Map<String, String> additionalSparkProperties() {
+    if (throwOnProperties) {
+      throw new RuntimeException("Simulated failure in additionalSparkProperties");
+    }
+    return Map.of();
   }
 }

--- a/core/src/test/java/org/apache/spark/security/FakeCredentialProvider.java
+++ b/core/src/test/java/org/apache/spark/security/FakeCredentialProvider.java
@@ -76,4 +76,10 @@ public class FakeCredentialProvider implements CredentialProvider {
   public int getCloseCount() {
     return closeCount.get();
   }
+
+  @Override
+  public Map<String, String> additionalSparkProperties() {
+    return Map.of("spark.hadoop.fs.fake.credentials.provider",
+        "org.apache.spark.security.FakeExecutorCredentialProvider");
+  }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
@@ -581,4 +581,32 @@ class UserCredentialManagerSuite extends SparkFunSuite {
       manager.stop()
     }
   }
+
+  test("start() succeeds when a provider throws from additionalSparkProperties") {
+    // AnotherFakeCredentialProvider is configured to throw; FakeCredentialProvider should
+    // still have its properties applied (exception isolation via NonFatal catch).
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    conf.set("spark.security.oidc.provider.shared",
+      "org.apache.spark.security.AnotherFakeCredentialProvider")
+    val ctx = createUserContext()
+
+    AnotherFakeCredentialProvider.throwOnProperties = true
+    try {
+      val manager = new UserCredentialManager(
+        conf, createIngestor(ctx), (_, _) => ())
+      try {
+        // start() must not fail even though AnotherFakeCredentialProvider throws
+        manager.start()
+        // FakeCredentialProvider's property must still be applied
+        assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
+          "org.apache.spark.security.FakeExecutorCredentialProvider")
+      } finally {
+        manager.stop()
+      }
+    } finally {
+      AnotherFakeCredentialProvider.throwOnProperties = false
+    }
+  }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
@@ -520,4 +520,65 @@ class UserCredentialManagerSuite extends SparkFunSuite {
     assert(fakeProvider.getCloseCount === 1,
       "stop() should close initialized providers exactly once")
   }
+
+  // ========== additionalSparkProperties application ==========
+
+  test("start() applies additionalSparkProperties from active providers") {
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    val ctx = createUserContext()
+
+    val manager = new UserCredentialManager(
+      conf, createIngestor(ctx), (_, _) => ())
+
+    try {
+      manager.start()
+      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
+        "org.apache.spark.security.FakeExecutorCredentialProvider")
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("start() does not overwrite user-set properties") {
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    // User explicitly sets the property before start()
+    conf.set("spark.hadoop.fs.fake.credentials.provider", "user.Custom")
+    val ctx = createUserContext()
+
+    val manager = new UserCredentialManager(
+      conf, createIngestor(ctx), (_, _) => ())
+
+    try {
+      manager.start()
+      // User-set value must NOT be overwritten
+      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") === "user.Custom")
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("start() handles provider returning null from additionalSparkProperties") {
+    // AnotherFakeCredentialProvider uses default (empty map), not null.
+    // This test verifies the defensive null check doesn't crash
+    // with a provider that inherits the default empty map.
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    val ctx = createUserContext()
+
+    val manager = new UserCredentialManager(
+      conf, createIngestor(ctx), (_, _) => ())
+
+    try {
+      // Should not throw
+      manager.start()
+      assert(conf.contains("spark.hadoop.fs.fake.credentials.provider"))
+    } finally {
+      manager.stop()
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a default method `additionalSparkProperties()` to the `CredentialProvider` interface that allows provider modules to declare Spark configuration properties needed when the provider is active. After successful credential acquisition, `UserCredentialManager.start()` iterates active providers (those that successfully resolved credentials) and applies their declared properties to `SparkConf` -- only if the user has not already set them explicitly.

`AwsStsCredentialProvider` overrides this to return `{"spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider"}`, enabling zero-config executor-side S3A credential resolution when OIDC is enabled.

### Why are the changes needed?

This is a Sub-task of the OIDC Credential Propagation SPIP. PR #57998 (`SparkOidcAwsCredentialsProvider`) originally placed auto-config logic in `CoarseGrainedSchedulerBackend`, which was a layer violation -- core referencing an optional module's class name. This PR moves the mechanism to a generic SPI where each provider module declares its own properties, keeping vendor-specific knowledge out of core.

### Does this PR introduce _any_ user-facing change?

Yes. When `spark.security.oidc.enabled=true` and `AwsStsCredentialProvider` is on the classpath, executors automatically use `SparkOidcAwsCredentialsProvider` for S3A access without requiring manual Hadoop configuration. User-provided values are never overwritten.

### How was this patch tested?

- `AwsStsCredentialProviderSuite` (56 tests) -- verifies the override returns the correct S3A mapping
- `UserCredentialManagerSuite` (24 tests) -- verifies properties are applied to SparkConf, user-set values are not overwritten, null map handling, and exception isolation (provider throwing from `additionalSparkProperties()` does not crash `start()` or block other providers)
- `OidcCredentialIntegrationSuite` (13 tests) -- exercises the full credential acquisition flow

Tested with both Maven and SBT.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Co-Authored using Claude Opus 4.8