### PR TITLE
[SPARK-58553][PS][FOLLOWUP] Gate native fmax/fmin/reciprocal to verified platform, else pandas_udf

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import platform
 from typing import Any, Callable, no_type_check
 
 import numpy as np
@@ -23,6 +24,41 @@ from pyspark.sql import Column, functions as F
 from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.types import DoubleType, BooleanType
 from pyspark.pandas.base import IndexOpsMixin
+
+
+# For most functions the native Spark expression equals NumPy everywhere. fmax/fmin and reciprocal
+# are exceptions: the underlying operation is unspecified by C/IEEE, so NumPy's own result depends
+# on CPU architecture and NumPy version. Our native expression returns one fixed value, so it only
+# matches NumPy on the platform/version we verified; elsewhere we run real NumPy via a pandas UDF
+# (matches by construction). Each gates only on the axes that affect it -- the predicates below.
+
+# reciprocal's int 1/0 casts +inf to int -- undefined in C, resolved per CPU arch (x86-64 gives
+# INT64_MIN, aarch64 INT64_MAX). Check arch, not just OS: Linux also runs on aarch64.
+_native_platform = platform.system() == "Linux" and platform.machine() == "x86_64"
+
+# fmax/fmin's signed-zero tie is C99-unspecified; NumPy's scalar result returns the first operand
+# (what native produces) at 2.3.0+, the second below.
+_numpy_tie_returns_first = LooseVersion(np.__version__) >= LooseVersion("2.3.0")
+
+
+def _reciprocal_func(c: Column) -> Column:
+    return F.when(
+        F.typeof(c).isin("float", "double"),
+        F.when(c.isNull(), c.cast("double"))
+        .when(
+            c == 0,
+            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
+        )
+        .otherwise(F.lit(1.0) / c),
+    ).otherwise(
+        # Integer input: numpy does integer division (truncated toward zero),
+        # so casting the float quotient to long reproduces 1 -> 1, -1 -> -1,
+        # and every other magnitude -> 0. Dividing by 0 overflows to the int64
+        # minimum, matching numpy's behavior on integer arrays.
+        F.when(c == 0, F.lit(float(np.iinfo(np.int64).min))).otherwise(
+            (F.lit(1) / c).cast("long").cast("double")
+        )
+    )
 
 
 unary_np_spark_mappings = {
@@ -68,22 +104,10 @@ unary_np_spark_mappings = {
     "positive": F.positive,
     "rad2deg": F.degrees,
     "radians": F.radians,
-    "reciprocal": lambda c: F.when(
-        F.typeof(c).isin("float", "double"),
-        F.when(c.isNull(), c.cast("double"))
-        .when(
-            c == 0,
-            F.when(c.cast("string") == "-0.0", F.lit(float("-inf"))).otherwise(F.lit(float("inf"))),
-        )
-        .otherwise(F.lit(1.0) / c),
-    ).otherwise(
-        # Integer input: numpy does integer division (truncated toward zero),
-        # so casting the float quotient to long reproduces 1 -> 1, -1 -> -1,
-        # and every other magnitude -> 0. Dividing by 0 overflows to the int64
-        # minimum, matching numpy's behavior on integer arrays.
-        F.when(c == 0, F.lit(float(np.iinfo(np.int64).min))).otherwise(
-            (F.lit(1) / c).cast("long").cast("double")
-        )
+    "reciprocal": (
+        _reciprocal_func
+        if _native_platform
+        else pandas_udf(lambda s: np.reciprocal(s), DoubleType())  # type: ignore[call-overload]
     ),
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
@@ -204,27 +228,23 @@ def _floor_divide_func(c1: Column, c2: Column) -> Column:
     )
 
 
-# NumPy 2.3.0 changed how fmax/fmin break a signed-zero tie: for equal operands
-# (for example +0.0 and -0.0) it returns the first operand, while older versions
-# returned the second. Track the installed NumPy so the result keeps the matching
-# sign of zero.
-_tie_returns_first_operand = LooseVersion(np.__version__) >= LooseVersion("2.3.0")
-
-
+# fmax/fmin: when the two operands are equal (differing only in sign of zero, e.g. +0.0 vs -0.0),
+# NumPy may return either. Its scalar path returns the first operand from NumPy 2.3.0 on (and the
+# second before 2.3.0), so these helpers return the first operand (c1) to match NumPy >= 2.3.0.
+# The fmax/fmin entries below use them only where that holds (x86-64 Linux + NumPy >= 2.3.0) and
+# otherwise fall back to real NumPy; see the two predicates above.
 def _fmax_func(c1: Column, c2: Column) -> Column:
-    tie = c1 if _tie_returns_first_operand else c2
     return (
         F.when(F.isnan(c1.cast("double")), c2)
         .when(F.isnan(c2.cast("double")), c1)
-        .when(c1 == c2, tie)
+        .when(c1 == c2, c1)
         .otherwise(F.greatest(c1, c2))
         .cast("double")
     )
 
 
 def _fmin_func(c1: Column, c2: Column) -> Column:
-    tie = c1 if _tie_returns_first_operand else c2
-    return F.when(c1 == c2, tie).otherwise(F.least(c1, c2)).cast("double")
+    return F.when(c1 == c2, c1).otherwise(F.least(c1, c2)).cast("double")
 
 
 binary_np_spark_mappings = {
@@ -239,8 +259,16 @@ binary_np_spark_mappings = {
     # np.floor_divide dispatches to the pandas-on-Spark floordiv dunder operation
     # before this registry is consulted, so this mapping is not used for that case.
     "floor_divide": _floor_divide_func,
-    "fmax": _fmax_func,
-    "fmin": _fmin_func,
+    "fmax": (
+        _fmax_func
+        if _native_platform and _numpy_tie_returns_first
+        else pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType())  # type: ignore[call-overload]
+    ),
+    "fmin": (
+        _fmin_func
+        if _native_platform and _numpy_tie_returns_first
+        else pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType())  # type: ignore[call-overload]
+    ),
     "fmod": _fmod_func,
     "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),  # type: ignore[call-overload]
     "heaviside": lambda c1, c2: F.when(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to the native conversions of `fmax`/`fmin` (SPARK-58553) and `reciprocal` (SPARK-58465, SPARK-58646) in `pyspark.pandas.numpy_compat`. Those conversions replaced the `pandas_udf` fallbacks with native Spark expressions, but for these three functions the native expression reproduces behavior that C/IEEE leave unspecified, so it only matches NumPy on the platform and NumPy version where that behavior was pinned down.

This PR restricts the native path to the verified platform and otherwise falls back to the real NumPy ufunc via `pandas_udf` (which matches NumPy on any platform/version by construction). Two module-level predicates express the two independent axes of divergence:

- `_native_platform = platform.system() == "Linux" and platform.machine() == "x86_64"`
- `_numpy_tie_returns_first = LooseVersion(np.__version__) >= LooseVersion("2.3.0")`

`reciprocal` gates on `_native_platform` only (its divergence is architecture-specific, not version-specific); `fmax`/`fmin` gate on `_native_platform and _numpy_tie_returns_first`.

### Why are the changes needed?

The scheduled ARM (`ubuntu-24.04-arm`, aarch64) and macOS jobs fail on `test_np_fmax_fmin` and `test_np_reciprocal_integer`, because NumPy's own result for these operations is not portable:

- `reciprocal` of an integer `0` is computed through a float→int cast of `+inf`, which is undefined behavior in C and resolved per CPU architecture: x86-64 yields `INT64_MIN`, aarch64 yields `INT64_MAX`.
- The `fmax`/`fmin` signed-zero tie (equal operands differing only in the sign of zero, e.g. `+0.0` vs `-0.0`) is unspecified by C99. NumPy's scalar result returns the first operand from 2.3.0 on and the second before, and it also differs across architectures.

The native expressions were tuned to the x86-64 Linux / NumPy >= 2.3.0 result, so they diverge on other architectures and older NumPy. The minimum-dependencies job (older NumPy) was addressed for `fmax`/`fmin` in an earlier SPARK-58553 follow-up, but the underlying cross-platform (architecture) divergence remained on aarch64 and macOS, and `reciprocal` was affected as well.

### Does this PR introduce _any_ user-facing change?

No. On the verified platform the native expression is unchanged. On other platforms/versions the result now matches the installed NumPy (via the UDF) instead of a platform-specific value, restoring behavior-preserving parity with NumPy. There is no API change.

### How was this patch tested?

No test changes were needed: the existing `test_np_fmax_fmin`, `test_np_reciprocal_integer`, and the `NumPyCompatTests` compat sweep use the installed NumPy as the reference, so the mapping now tracks NumPy on every platform.

Verified on GitHub Actions across all affected environments — ARM (`ubuntu-24.04-arm`, aarch64), macOS (`macos-26`), the minimum-dependencies build (older NumPy), and the regular x86-64 Linux build — all green. Also ran the full `NumPyCompatTests` locally on x86-64 Linux with both the native path and the UDF fallback path exercised, both passing.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic)
