### PR TITLE
[MINOR][DOC] Fix broken submitting-applications link in Kafka guide

### DIFF
--- a/docs/streaming/structured-streaming-kafka-integration.md
+++ b/docs/streaming/structured-streaming-kafka-integration.md
@@ -1045,7 +1045,7 @@ For experimenting on `spark-shell`, you can also use `--packages` to add `spark-
 
     ./bin/spark-shell --packages org.apache.spark:spark-sql-kafka-0-10_{{site.SCALA_BINARY_VERSION}}:{{site.SPARK_VERSION_SHORT}} ...
 
-See [Application Submission Guide](submitting-applications.html) for more details about submitting
+See [Application Submission Guide](../submitting-applications.html) for more details about submitting
 applications with external dependencies.
 
 ## Security


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a broken relative link in the Structured Streaming Kafka integration guide. `docs/streaming/structured-streaming-kafka-integration.md` pointed at `submitting-applications.html` with no `../` prefix, so the rendered page 404s. The target file is `docs/submitting-applications.md`. Sibling pages under `docs/streaming/` already use `../` for parent-directory docs.

### Why are the changes needed?

The Application Submission Guide link in the Deploying section of the Kafka guide is broken.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Confirmed `docs/submitting-applications.md` exists one directory above `docs/streaming/`. The corrected href matches the `../` convention already used by sibling pages such as `docs/streaming/ss-migration-guide.md` (`../sql-migration-guide.html`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6
