### PR TITLE
[SPARK-58782][SQL] Fix DSv2 pushdown null literal serialization bug

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -388,13 +388,19 @@ private[sql] object HoursTransform {
 }
 
 private[sql] final case class LiteralValue[T](value: T, dataType: DataType) extends Literal[T] {
-  override def toString: String = dataType match {
-    case StringType => s"'${s"$value".replace("'", "''")}'"
-    case BinaryType =>
-      assert(value.isInstanceOf[Array[Byte]])
-      val bytes = value.asInstanceOf[Array[Byte]]
-      "0x" + HexFormat.of().withUpperCase().formatHex(bytes)
-    case _ => s"$value"
+  override def toString: String = {
+    if (value == null) {
+      "NULL"
+    } else {
+      dataType match {
+        case StringType => s"'${s"$value".replace("'", "''")}'"
+        case BinaryType =>
+          assert(value.isInstanceOf[Array[Byte]])
+          val bytes = value.asInstanceOf[Array[Byte]]
+          "0x" + HexFormat.of().withUpperCase().formatHex(bytes)
+        case _ => s"$value"
+      }
+    }
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/expressions/LiteralValueSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/expressions/LiteralValueSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.{BinaryType, BooleanType, IntegerType, StringType}
+
+class LiteralValueSuite extends SparkFunSuite {
+
+  test("SPARK-58782: null literals should render as NULL") {
+    assert(LiteralValue(null, StringType).toString === "NULL")
+    assert(LiteralValue(null, IntegerType).toString === "NULL")
+    assert(LiteralValue(null, BooleanType).toString === "NULL")
+    assert(LiteralValue(null, BinaryType).toString === "NULL")
+  }
+
+  test("non-null string literals should be quoted") {
+    assert(LiteralValue("test", StringType).toString === "'test'")
+    assert(LiteralValue("", StringType).toString === "''")
+    assert(LiteralValue("it's", StringType).toString === "'it''s'")
+  }
+
+  test("non-null numeric literals should not be quoted") {
+    assert(LiteralValue(42, IntegerType).toString === "42")
+    assert(LiteralValue(0, IntegerType).toString === "0")
+  }
+
+  test("non-null boolean literals should not be quoted") {
+    assert(LiteralValue(true, BooleanType).toString === "true")
+    assert(LiteralValue(false, BooleanType).toString === "false")
+  }
+
+  test("non-null binary literals should render as hex") {
+    val bytes = Array[Byte](0x12, 0x34, 0xAB.toByte, 0xCD.toByte)
+    assert(LiteralValue(bytes, BinaryType).toString === "0x1234ABCD")
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -236,6 +236,12 @@ class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
       batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES ('a a a')")
       batchStmt.addBatch("INSERT INTO \"test\".\"strings_with_nulls\" VALUES (null)")
 
+      batchStmt.addBatch(
+        "CREATE TABLE \"test\".\"null_literal\" (s TEXT(32))")
+      batchStmt.addBatch("INSERT INTO \"test\".\"null_literal\" VALUES ('keep')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"null_literal\" VALUES ('')")
+      batchStmt.addBatch("INSERT INTO \"test\".\"null_literal\" VALUES (null)")
+
       batchStmt.executeBatch()
 
       conn
@@ -1819,7 +1825,8 @@ class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
       Seq(Row("test", "address", false), Row("test", "people", false),
         Row("test", "empty_table", false), Row("test", "employee", false),
         Row("test", "item", false), Row("test", "dept", false),
-        Row("test", "person", false), Row("test", "view1", false), Row("test", "view2", false),
+        Row("test", "null_literal", false), Row("test", "person", false),
+        Row("test", "view1", false), Row("test", "view2", false),
         Row("test", "datetime", false), Row("test", "binary_tab", false),
         Row("test", "employee_bonus", false),
         Row("test", "strings_with_nulls", false)))
@@ -2515,7 +2522,7 @@ class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
     checkAggregateRemoved(df3)
     checkPushedInfo(df3,
       """
-        |PushedAggregates: [AVG(CASE WHEN BONUS IS NOT NULL THEN BONUS ELSE null END)],
+        |PushedAggregates: [AVG(CASE WHEN BONUS IS NOT NULL THEN BONUS ELSE NULL END)],
         |PushedFilters: [DEPT IS NOT NULL, DEPT > 0],
         |PushedGroupByExpressions: [DEPT],
         |""".stripMargin.replaceAll("\n", " "))
@@ -2531,7 +2538,7 @@ class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
     checkAggregateRemoved(df4)
     checkPushedInfo(df4,
       """
-        |PushedAggregates: [AVG(DISTINCT CASE WHEN BONUS IS NOT NULL THEN BONUS ELSE null END)],
+        |PushedAggregates: [AVG(DISTINCT CASE WHEN BONUS IS NOT NULL THEN BONUS ELSE NULL END)],
         |PushedFilters: [DEPT IS NOT NULL, DEPT > 0],
         |PushedGroupByExpressions: [DEPT],
         |""".stripMargin.replaceAll("\n", " "))
@@ -3174,4 +3181,17 @@ class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
 
     assertResult(expectedMetadata) { jdbcRdd.getDatabaseMetadata }
   }
+
+  test("SPARK-58782: null literal in aggregate should render as NULL not 'null'") {
+    val df = sql("SELECT NULLIF(s, '') AS g, COUNT(*) FROM h2.test.null_literal GROUP BY g")
+
+    checkAggregateRemoved(df)
+    checkPushedInfo(df,
+      "PushedAggregates: [COUNT(*)]",
+      "PushedGroupByExpressions: [CASE WHEN S = '' THEN NULL ELSE S END]")
+
+    // The '' row should collapse into the NULL group, not create a separate 'null' string group
+    checkAnswer(df, Seq(Row("keep", 1), Row(null, 2)))
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes a bug where null literals were incorrectly serialized as the string 'null' instead of the SQL keyword NULL when pushed down to external databases via DSv2 (JDBC aggregate/predicate pushdown).


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`LiteralValue.toString` - the only toString for DSv2's only concrete Literal, and the path every pushdown rendering (explain strings, generated SQL) ultimately goes through,  matched on dataType even when the value was null, instead of checking for null first. This produced two distinct, user-visible bugs:

* For StringType, a null value rendered as the quoted string 'null' instead of NULL. When pushed down (e.g. NULLIF(s, ''), which rewrites to If(s = '', null, s)), the empty-string row was grouped under the literal string "null" instead of collapsing into the real NULL group — the external database executed a different grouping key than intended, producing 3 result rows instead of 2.

* For BinaryType, the branch ran assert(value.isInstanceOf[Array[Byte]]), which fails on null and threw an AssertionError when rendering a pushed expression containing a null binary literal, rather than merely producing bad SQL.




### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes - Query results will now be correct when null literals are pushed down to external databases via JDBC.

_Before the fix:_ A query with NULLIF(col, '') in a GROUP BY would push down CASE WHEN col = '' THEN 'null' ELSE col END to the database, creating a spurious 'null' string group instead of a NULL group.

_After the fix:_ The same query pushes down CASE WHEN col = '' THEN NULL ELSE col END, correctly collapsing empty strings into the NULL group as intended. Null binary literals render as NULL without error.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

* Unit tests in LiteralValueSuite covering all data types
* End-to-end regression test in JDBCV2Suite with H2 database
* Updated existing test expectations that relied on the old (incorrect) behavior
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No