### PR TITLE
[SPARK-58792][SQL] Isolate Hive GenericUDF evaluator instances

### DIFF
--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/exec/HiveFunctionRegistryUtils.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/exec/HiveFunctionRegistryUtils.java
@@ -18,11 +18,16 @@
 package org.apache.hadoop.hive.ql.exec;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.SettableUDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBridge;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMacro;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils.PrimitiveGrouping;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.*;
+import org.apache.hadoop.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -42,6 +47,46 @@ public class HiveFunctionRegistryUtils {
 
   public static final SparkLogger LOG =
     SparkLoggerFactory.getLogger(HiveFunctionRegistryUtils.class);
+
+  /**
+   * Creates an independent copy of a GenericUDF without initializing Hive's FunctionRegistry.
+   *
+   * This is adapted from Hive's FunctionRegistry.cloneGenericUDF.
+   */
+  public static GenericUDF cloneGenericUDF(GenericUDF genericUDF) {
+    if (genericUDF == null) {
+      return null;
+    }
+
+    GenericUDF clonedUDF;
+    if (genericUDF instanceof GenericUDFBridge) {
+      GenericUDFBridge bridge = (GenericUDFBridge) genericUDF;
+      clonedUDF = new GenericUDFBridge(
+          bridge.getUdfName(), bridge.isOperator(), bridge.getUdfClassName());
+    } else if (genericUDF instanceof GenericUDFMacro) {
+      GenericUDFMacro macro = (GenericUDFMacro) genericUDF;
+      clonedUDF = new GenericUDFMacro(
+          macro.getMacroName(),
+          macro.getBody().clone(),
+          macro.getColNames(),
+          macro.getColTypes());
+    } else {
+      clonedUDF = ReflectionUtils.newInstance(genericUDF.getClass(), null);
+    }
+
+    try {
+      genericUDF.copyToNewInstance(clonedUDF);
+      if (genericUDF instanceof SettableUDF) {
+        TypeInfo typeInfo = ((SettableUDF) genericUDF).getTypeInfo();
+        if (typeInfo != null) {
+          ((SettableUDF) clonedUDF).setTypeInfo(typeInfo);
+        }
+      }
+    } catch (UDFArgumentException err) {
+      throw new IllegalArgumentException(err);
+    }
+    return clonedUDF;
+  }
 
   /**
    * This method is shared between UDFRegistry and UDAFRegistry. methodName will

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
 import org.apache.spark.sql.types.DataType
 
 abstract class HiveUDFEvaluatorBase[UDFType <: AnyRef](
-    funcWrapper: HiveFunctionWrapper, children: Seq[Expression])
+    protected val funcWrapper: HiveFunctionWrapper, children: Seq[Expression])
   extends HiveInspectors with Serializable {
 
   @transient
@@ -114,6 +114,11 @@ class HiveSimpleUDFEvaluator(
 class HiveGenericUDFEvaluator(
     funcWrapper: HiveFunctionWrapper, children: Seq[Expression])
   extends HiveUDFEvaluatorBase[GenericUDF](funcWrapper, children) {
+
+  @transient
+  override lazy val function: GenericUDF = {
+    HiveFunctionRegistryUtils.cloneGenericUDF(funcWrapper.createFunction[GenericUDF]())
+  }
 
   @transient
   private lazy val argumentInspectors = children.map(toInspector).toArray

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -29,19 +29,25 @@ import org.apache.hadoop.hive.ql.udf.{UDAFPercentile, UDFType}
 import org.apache.hadoop.hive.ql.udf.generic._
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject
 import org.apache.hadoop.hive.serde2.{AbstractSerDe, SerDeStats}
-import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, ObjectInspectorFactory}
+import org.apache.hadoop.hive.serde2.objectinspector.{
+  ConstantObjectInspector,
+  ObjectInspector,
+  ObjectInspectorFactory
+}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
 import org.apache.hadoop.io.{LongWritable, Writable}
 
 import org.apache.spark.{SparkException, SparkFiles, TestUtils}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, CodegenObjectFactoryMode, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.functions.{call_function, max}
+import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
+import org.apache.spark.sql.hive.HiveGenericUDFEvaluator
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestUDTFJar}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.TimeType
+import org.apache.spark.sql.types.{StringType, TimeType}
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
@@ -886,6 +892,23 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
     }
     hiveContext.reset()
   }
+
+  test("SPARK-58792: Hive Generic UDF evaluator copies use isolated functions") {
+    val functionWrapper = HiveFunctionWrapper(classOf[InspectorSensitiveUDF].getName)
+    val literalEvaluator = new HiveGenericUDFEvaluator(functionWrapper, Seq(Literal("literal")))
+    val attributeEvaluator = new HiveGenericUDFEvaluator(
+      functionWrapper,
+      Seq(BoundReference(0, StringType, nullable = false)))
+
+    literalEvaluator.returnType
+    attributeEvaluator.returnType
+    assert(literalEvaluator.function ne attributeEvaluator.function)
+    literalEvaluator.setArg(0, "literal")
+    attributeEvaluator.setArg(0, "attribute")
+
+    assert(literalEvaluator.evaluate().toString === "constant")
+    assert(attributeEvaluator.evaluate().toString === "non-constant")
+  }
 }
 
 class TestPair(x: Int, y: Int) extends Writable with Serializable {
@@ -949,6 +972,21 @@ class PairUDF extends GenericUDF {
   }
 
   override def getDisplayString(p1: Array[String]): String = ""
+}
+
+class InspectorSensitiveUDF extends GenericUDF {
+  private var initializedWithConstantInspector = false
+
+  override def initialize(arguments: Array[ObjectInspector]): ObjectInspector = {
+    initializedWithConstantInspector = arguments.head.isInstanceOf[ConstantObjectInspector]
+    PrimitiveObjectInspectorFactory.javaStringObjectInspector
+  }
+
+  override def evaluate(arguments: Array[DeferredObject]): AnyRef = {
+    if (initializedWithConstantInspector) "constant" else "non-constant"
+  }
+
+  override def getDisplayString(children: Array[String]): String = "inspector_sensitive"
 }
 
 @UDFType(stateful = true)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR gives each `HiveGenericUDFEvaluator` an independent copy of the cached GenericUDF. The clone helper is adapted from Hive while avoiding `FunctionRegistry` initialization, and preserves bridge, macro, and SettableUDF state.

### Why are the changes needed?

Optimizer-created copies of a Hive GenericUDF expression can otherwise share one mutable UDF instance. Initializing copies with different object inspectors can overwrite evaluator state, producing wrong results or a ClassCastException.

### Does this PR introduce _any_ user-facing change?

Yes. Queries using optimizer-duplicated Hive GenericUDF expressions now evaluate with isolated UDF state instead of potentially returning incorrect results or failing.

### How was this patch tested?

Added `SPARK-58792: Hive Generic UDF evaluator copies use isolated functions`, which initializes two evaluators from one wrapper with constant and non-constant inspectors and verifies they keep distinct function instances and results.

Ran:

```
build/sbt 'hive/testOnly org.apache.spark.sql.hive.execution.HiveUDFSuite -- -z "SPARK-58792"'\n```\n\n### Was this patch authored or co-authored using generative AI tooling?\n\nGenerated-by: Codex for code assistance.