### PR TITLE
[SPARK-47397][SQL][DOCS] Document that COUNT(DISTINCT) skips nulls

### DIFF
--- a/docs/sql-ref-null-semantics.md
+++ b/docs/sql-ref-null-semantics.md
@@ -273,8 +273,8 @@ SELECT count(age) FROM person;
 |         5|
 +----------+
 
--- `count(DISTINCT age)` also skips `NULL`. A null group is not a distinct counted value.
--- This is different from GROUP BY / SELECT DISTINCT, which put all nulls in one bucket.
+-- `count(DISTINCT age)` also skips `NULL`. This is different from GROUP BY / SELECT DISTINCT,
+-- which put all nulls in one bucket.
 SELECT count(DISTINCT age) FROM person;
 +-------------------+
 |count(DISTINCT age)|
@@ -394,7 +394,7 @@ two `NULL` values are not equal. However, for the purpose of grouping and distin
 values with `NULL data`are grouped together into the same bucket. This behaviour is conformant with SQL
 standard and with other enterprise database management systems.
 
-`COUNT(DISTINCT expr)` still follows the aggregate rule above and does not count null.
+`COUNT(DISTINCT expr)` ignores `NULL` values. Only distinct non-null values are counted.
 
 **Examples**
 

--- a/docs/sql-ref-null-semantics.md
+++ b/docs/sql-ref-null-semantics.md
@@ -273,6 +273,15 @@ SELECT count(age) FROM person;
 |         5|
 +----------+
 
+-- `count(DISTINCT age)` also skips `NULL`. A null group is not a distinct counted value.
+-- This is different from GROUP BY / SELECT DISTINCT, which put all nulls in one bucket.
+SELECT count(DISTINCT age) FROM person;
++-------------------+
+|count(DISTINCT age)|
++-------------------+
+|                  3|
++-------------------+
+
 -- `count(*)` on an empty input set returns 0. This is unlike the other
 -- aggregate functions, such as `max`, which return `NULL`.
 SELECT count(*) FROM person where 1 = 0;
@@ -384,6 +393,8 @@ As discussed in the previous section [comparison operator](sql-ref-null-semantic
 two `NULL` values are not equal. However, for the purpose of grouping and distinct processing, the two or more
 values with `NULL data`are grouped together into the same bucket. This behaviour is conformant with SQL
 standard and with other enterprise database management systems.
+
+`COUNT(DISTINCT expr)` still follows the aggregate rule above and does not count null.
 
 **Examples**
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spell out that `COUNT(DISTINCT)` / `count_distinct` skips nulls, in `docs/sql-ref-null-semantics.md`.

- Add a `count(DISTINCT age)` example next to the existing `count(*)` / `count(age)` block. On the `person` table the result is 3 (ages 30, 18, 50).
- Add a one-liner in the GROUP BY / DISTINCT section: `COUNT(DISTINCT expr)` still follows the aggregate rule and does not count null.

No code change. `Count.scala`, `count.sql.out`, and `DataFrameAggregateSuite` already treat distinct count as unique non-null values. GROUP BY / SELECT DISTINCT still bucket nulls. Those are different rules.

### Why are the changes needed?
The page already states both rules, and it is easy to mix them up for `COUNT(DISTINCT)`. The ticket reporter hit that. Philipp pointed at the SQL standard. Nicholas asked to document it on this page. The implementation is already correct.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Docs only. Mentally executed on the `person` table on that page: distinct non-null ages are 30, 18, 50, so the result is 3. I did not run the Jekyll build here because Bundler was not available.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor Grok 4.6

Made with [Cursor](https://cursor.com)