### PR TITLE
[SPARK-57696][PYTHON] Preserve TIME precision in the PySpark Arrow/pandas type mapping

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -75,6 +75,8 @@ if TYPE_CHECKING:
 
 # Should keep in line with org.apache.spark.sql.util.ArrowUtils.metadataKey
 metadata_key = b"SPARK::metadata::json"
+# Keep in line with org.apache.spark.sql.util.ArrowUtils.timePrecisionKey
+time_precision_key = b"SPARK::time::precision"
 
 
 def to_arrow_metadata(metadata: Optional[Dict[str, Any]] = None) -> Optional[Dict[bytes, bytes]]:
@@ -89,6 +91,35 @@ def from_arrow_metadata(metadata: Optional[Dict[bytes, bytes]]) -> Optional[Dict
         return json.loads(metadata[metadata_key].decode("utf-8"))
     else:
         return None
+
+
+def _to_arrow_field_metadata(
+    dt: DataType,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[bytes, bytes]]:
+    """Merge user metadata with the TIME precision tag when ``dt`` is TimeType."""
+    arrow_meta = to_arrow_metadata(metadata)
+    if not isinstance(dt, TimeType):
+        return arrow_meta
+    tagged: Dict[bytes, bytes] = {time_precision_key: str(dt.precision).encode("utf-8")}
+    if arrow_meta is not None:
+        tagged = {**arrow_meta, **tagged}
+    return tagged
+
+
+def _time_type_from_arrow_metadata(
+    metadata: Optional[Dict[bytes, bytes]],
+) -> TimeType:
+    """Parse SPARK::time::precision; missing or invalid values become TimeType()."""
+    if metadata is None or time_precision_key not in metadata:
+        return TimeType()
+    try:
+        precision = int(metadata[time_precision_key])
+    except (TypeError, ValueError):
+        return TimeType()
+    if 0 <= precision <= 9:
+        return TimeType(precision)
+    return TimeType()
 
 
 def to_arrow_type(
@@ -158,6 +189,7 @@ def to_arrow_type(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=dt.containsNull,
+            metadata=_to_arrow_field_metadata(dt.elementType),
         )
         arrow_type = pa.list_(field)
     elif isinstance(dt, MapType):
@@ -170,6 +202,7 @@ def to_arrow_type(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=False,
+            metadata=_to_arrow_field_metadata(dt.keyType),
         )
         value_field = pa.field(
             "value",
@@ -180,6 +213,7 @@ def to_arrow_type(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=dt.valueContainsNull,
+            metadata=_to_arrow_field_metadata(dt.valueType),
         )
         arrow_type = pa.map_(key_field, value_field)
     elif isinstance(dt, StructType):
@@ -199,7 +233,7 @@ def to_arrow_type(
                     prefers_large_types=prefers_large_types,
                 ),
                 nullable=field.nullable,
-                metadata=to_arrow_metadata(field.metadata),
+                metadata=_to_arrow_field_metadata(field.dataType, field.metadata),
             )
             for field in dt
         ]
@@ -287,7 +321,7 @@ def to_arrow_schema(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=field.nullable,
-            metadata=to_arrow_metadata(field.metadata),
+            metadata=_to_arrow_field_metadata(field.dataType, field.metadata),
         )
         for field in schema
     ]
@@ -403,6 +437,8 @@ def from_arrow_type(
     elif types.is_date32(at):
         spark_type = DateType()
     elif types.is_time64(at):
+        # Precision lives on the Arrow field (see _from_arrow_field). Bare time64
+        # without field metadata falls back to the default TIME(6).
         spark_type = TimeType()
     elif types.is_timestamp(at):
         if at.tz is None and prefer_timestamp_ntz:
@@ -420,23 +456,23 @@ def from_arrow_type(
         spark_type = YearMonthIntervalType()
     elif types.is_list(at):
         spark_type = ArrayType(
-            elementType=from_arrow_type(at.value_type, prefer_timestamp_ntz),
+            elementType=_from_arrow_field(at.value_field, prefer_timestamp_ntz),
             containsNull=at.value_field.nullable,
         )
     elif types.is_fixed_size_list(at):
         spark_type = ArrayType(
-            elementType=from_arrow_type(at.value_type, prefer_timestamp_ntz),
+            elementType=_from_arrow_field(at.value_field, prefer_timestamp_ntz),
             containsNull=at.value_field.nullable,
         )
     elif types.is_large_list(at):
         spark_type = ArrayType(
-            elementType=from_arrow_type(at.value_type, prefer_timestamp_ntz),
+            elementType=_from_arrow_field(at.value_field, prefer_timestamp_ntz),
             containsNull=at.value_field.nullable,
         )
     elif types.is_map(at):
         spark_type = MapType(
-            keyType=from_arrow_type(at.key_type, prefer_timestamp_ntz),
-            valueType=from_arrow_type(at.item_type, prefer_timestamp_ntz),
+            keyType=_from_arrow_field(at.key_field, prefer_timestamp_ntz),
+            valueType=_from_arrow_field(at.item_field, prefer_timestamp_ntz),
             valueContainsNull=at.item_field.nullable,
         )
     elif types.is_struct(at):
@@ -458,7 +494,7 @@ def from_arrow_type(
             [
                 StructField(
                     field.name,
-                    from_arrow_type(field.type, prefer_timestamp_ntz),
+                    _from_arrow_field(field, prefer_timestamp_ntz),
                     nullable=field.nullable,
                     metadata=from_arrow_metadata(field.metadata),
                 )
@@ -477,6 +513,18 @@ def from_arrow_type(
     return spark_type
 
 
+def _from_arrow_field(
+    field: "pa.Field",
+    prefer_timestamp_ntz: bool = True,
+) -> DataType:
+    """Convert a PyArrow field to a Spark type, recovering TIME precision from metadata."""
+    import pyarrow.types as types
+
+    if types.is_time64(field.type):
+        return _time_type_from_arrow_metadata(field.metadata)
+    return from_arrow_type(field.type, prefer_timestamp_ntz)
+
+
 def from_arrow_schema(
     arrow_schema: "pa.Schema",
     prefer_timestamp_ntz: bool = True,
@@ -486,7 +534,7 @@ def from_arrow_schema(
         [
             StructField(
                 field.name,
-                from_arrow_type(field.type, prefer_timestamp_ntz),
+                _from_arrow_field(field, prefer_timestamp_ntz),
                 nullable=field.nullable,
                 metadata=from_arrow_metadata(field.metadata),
             )

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -114,7 +114,8 @@ def _time_type_from_arrow_metadata(
     if metadata is None or time_precision_key not in metadata:
         return TimeType()
     try:
-        precision = int(metadata[time_precision_key])
+        # Base 10 accepts PyArrow bytes values and str, matching JVM Integer.parse.
+        precision = int(metadata[time_precision_key], 10)
     except (TypeError, ValueError):
         return TimeType()
     if 0 <= precision <= 9:
@@ -520,7 +521,9 @@ def _from_arrow_field(
     """Convert a PyArrow field to a Spark type, recovering TIME precision from metadata."""
     import pyarrow.types as types
 
-    if types.is_time64(field.type):
+    # JVM ArrowUtils.fromArrowField only reads SPARK::time::precision on Time(NANOSECOND).
+    # Foreign time64[us] stays TIME(6); do not invent precision from the Arrow unit.
+    if types.is_time64(field.type) and field.type.unit == "ns":
         return _time_type_from_arrow_metadata(field.metadata)
     return from_arrow_type(field.type, prefer_timestamp_ntz)
 

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -871,7 +871,7 @@ class ArrowTestsMixin:
         # SPARK-57696: TIME(p) precision is stored on the Arrow field, not the type.
         import pyarrow.types as types
 
-        for precision in (0, 3, 6, 9):
+        for precision in (0, 3, 6, 7, 9):
             with self.subTest(precision=precision):
                 schema = StructType([StructField("t", TimeType(precision))])
                 arrow_schema = to_arrow_schema(schema)
@@ -885,9 +885,18 @@ class ArrowTestsMixin:
 
         # Bare time64 with no precision key maps to the default TIME(6).
         self.assertEqual(from_arrow_type(pa.time64("ns")), TimeType())
+        self.assertEqual(from_arrow_type(pa.time64("us")), TimeType())
         untagged = pa.schema([pa.field("t", pa.time64("ns"))])
         self.assertEqual(
             from_arrow_schema(untagged), StructType([StructField("t", TimeType())])
+        )
+        # Foreign time64[us] stays TIME(6) even if a precision key is present.
+        # JVM fromArrowField only honors the key on Time(NANOSECOND).
+        us_tagged = pa.schema(
+            [pa.field("t", pa.time64("us"), metadata={time_precision_key: b"3"})]
+        )
+        self.assertEqual(
+            from_arrow_schema(us_tagged), StructType([StructField("t", TimeType())])
         )
 
         # Present-but-invalid keys also fall back to TIME(6), matching the JVM.

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -54,6 +54,7 @@ from pyspark.sql.pandas.types import (
     to_arrow_type,
     from_arrow_schema,
     to_arrow_schema,
+    time_precision_key,
 )
 from pyspark.testing.objects import ExamplePoint, ExamplePointUDT
 from pyspark.testing.sqlutils import ReusedSQLTestCase
@@ -865,6 +866,61 @@ class ArrowTestsMixin:
                     pa_schema2 = to_arrow_schema(t, timezone="UTC", prefers_large_types=True)
                     schema3 = from_arrow_schema(pa_schema2)
                     self.assertEqual(t, schema3)
+
+    def test_time_precision_arrow_round_trip(self):
+        # SPARK-57696: TIME(p) precision is stored on the Arrow field, not the type.
+        import pyarrow.types as types
+
+        for precision in (0, 3, 6, 9):
+            with self.subTest(precision=precision):
+                schema = StructType([StructField("t", TimeType(precision))])
+                arrow_schema = to_arrow_schema(schema)
+                field = arrow_schema.field("t")
+                self.assertTrue(types.is_time64(field.type))
+                self.assertEqual(field.type.unit, "ns")
+                self.assertEqual(
+                    field.metadata[time_precision_key], str(precision).encode("utf-8")
+                )
+                self.assertEqual(from_arrow_schema(arrow_schema), schema)
+
+        # Bare time64 with no precision key maps to the default TIME(6).
+        self.assertEqual(from_arrow_type(pa.time64("ns")), TimeType())
+        untagged = pa.schema([pa.field("t", pa.time64("ns"))])
+        self.assertEqual(
+            from_arrow_schema(untagged), StructType([StructField("t", TimeType())])
+        )
+
+        # Present-but-invalid keys also fall back to TIME(6), matching the JVM.
+        for raw in (b"-1", b"10", b"x"):
+            with self.subTest(raw=raw):
+                arrow_schema = pa.schema(
+                    [pa.field("t", pa.time64("ns"), metadata={time_precision_key: raw})]
+                )
+                self.assertEqual(
+                    from_arrow_schema(arrow_schema),
+                    StructType([StructField("t", TimeType())]),
+                )
+
+        # The precision key must not leak into reconstructed column metadata.
+        schema = StructType([StructField("t", TimeType(3), True, {"city": "beijing"})])
+        schema_rt = from_arrow_schema(to_arrow_schema(schema))
+        self.assertEqual(schema_rt, schema)
+        self.assertEqual(schema_rt["t"].metadata, {"city": "beijing"})
+        self.assertIn(time_precision_key, to_arrow_schema(schema).field("t").metadata)
+
+        # Nested array / struct / map fields must keep precision (JVM toArrowField is recursive).
+        nested = StructType(
+            [
+                StructField("s", StructType([StructField("inner", TimeType(3))])),
+                StructField("arr", ArrayType(TimeType(3))),
+                StructField("m", MapType(StringType(), TimeType(9))),
+            ]
+        )
+        self.assertEqual(from_arrow_schema(to_arrow_schema(nested)), nested)
+        self.assertEqual(
+            from_arrow_type(to_arrow_type(ArrayType(TimeType(3)))),
+            ArrayType(TimeType(3)),
+        )
 
     def test_createDataFrame_with_ndarray(self):
         for arrow_enabled in [True, False]:

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -958,8 +958,8 @@ class ArrowTestsMixin:
                 rows_df = self.spark.createDataFrame([(expected,)], schema)
                 self._assert_time_precision_df(rows_df, precision, expected)
 
-                pdf = pd.DataFrame({"t": [expected]})
-                pandas_df = self.spark.createDataFrame(pdf, schema)
+                # toPandas then createDataFrame must keep the declared TIME(p).
+                pandas_df = self.spark.createDataFrame(sql_df.toPandas(), schema)
                 self._assert_time_precision_df(pandas_df, precision, expected)
 
                 table = sql_df.toArrow()

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -967,7 +967,9 @@ class ArrowTestsMixin:
                     table.schema.field("t").metadata[time_precision_key],
                     str(precision).encode("utf-8"),
                 )
-                self.assertEqual(from_arrow_schema(table.schema), schema)
+                self.assertEqual(
+                    from_arrow_schema(table.schema)["t"].dataType, TimeType(precision)
+                )
                 arrow_df = self.spark.createDataFrame(table)
                 self._assert_time_precision_df(arrow_df, precision, expected)
 

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -931,6 +931,54 @@ class ArrowTestsMixin:
             ArrayType(TimeType(3)),
         )
 
+    def _time_precision_e2e_cases(self):
+        # Python datetime.time stores microseconds only, so TIME(9) collects as us.
+        return (
+            ("12:34:56", 0, datetime.time(12, 34, 56)),
+            ("12:34:56.123", 3, datetime.time(12, 34, 56, 123000)),
+            ("12:34:56.123456", 6, datetime.time(12, 34, 56, 123456)),
+            ("12:34:56.123456789", 9, datetime.time(12, 34, 56, 123456)),
+        )
+
+    def _assert_time_precision_df(self, df, precision, expected):
+        self.assertEqual(df.schema["t"].dataType, TimeType(precision))
+        self.assertEqual(df.collect(), [Row(t=expected)])
+
+    def test_time_precision_e2e_createDataFrame_collect(self):
+        # SPARK-57696: createDataFrame / collect / toArrow keep TIME(p) end-to-end.
+        # ArrowParityTests runs this on Spark Connect as well.
+        for literal, precision, expected in self._time_precision_e2e_cases():
+            with self.subTest(precision=precision):
+                schema = StructType([StructField("t", TimeType(precision))])
+                sql_df = self.spark.sql(
+                    "SELECT CAST('%s' AS TIME(%d)) AS t" % (literal, precision)
+                )
+                self._assert_time_precision_df(sql_df, precision, expected)
+
+                rows_df = self.spark.createDataFrame([(expected,)], schema)
+                self._assert_time_precision_df(rows_df, precision, expected)
+
+                pdf = pd.DataFrame({"t": [expected]})
+                pandas_df = self.spark.createDataFrame(pdf, schema)
+                self._assert_time_precision_df(pandas_df, precision, expected)
+
+                table = sql_df.toArrow()
+                self.assertEqual(
+                    table.schema.field("t").metadata[time_precision_key],
+                    str(precision).encode("utf-8"),
+                )
+                self.assertEqual(from_arrow_schema(table.schema), schema)
+                arrow_df = self.spark.createDataFrame(table)
+                self._assert_time_precision_df(arrow_df, precision, expected)
+
+                # Untagged time64 has no precision key, so inference stays TIME(6).
+                if precision != 6:
+                    untagged = pa.table(
+                        {"t": pa.array([expected], type=pa.time64("ns"))}
+                    )
+                    inferred = self.spark.createDataFrame(untagged)
+                    self.assertEqual(inferred.schema["t"].dataType, TimeType())
+
     def test_createDataFrame_with_ndarray(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 import os
 import time
 import unittest
@@ -22,6 +23,7 @@ import logging
 from pyspark.sql.utils import PythonException
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.sql import Row
+from pyspark.sql.types import TimeType
 from pyspark.testing.utils import (
     assertDataFrameEqual,
     have_pandas,
@@ -54,6 +56,40 @@ class MapInArrowTestsMixin:
         actual = df.mapInArrow(func, "id long").collect()
         expected = df.collect()
         self.assertEqual(actual, expected)
+
+    def test_time_precision_map_in_arrow(self):
+        # SPARK-57696: mapInArrow identity keeps TIME(p) on input metadata and output schema.
+        cases = (
+            ("12:34:56", 0, datetime.time(12, 34, 56)),
+            ("12:34:56.123", 3, datetime.time(12, 34, 56, 123000)),
+            ("12:34:56.123456", 6, datetime.time(12, 34, 56, 123456)),
+            ("12:34:56.123456789", 9, datetime.time(12, 34, 56, 123456)),
+        )
+
+        def identity(iterator):
+            for batch in iterator:
+                yield batch
+
+        for literal, precision, expected in cases:
+            with self.subTest(precision=precision):
+                df = self.spark.sql(
+                    "SELECT CAST('%s' AS TIME(%d)) AS t" % (literal, precision)
+                )
+
+                def check_metadata(iterator):
+                    key = b"SPARK::time::precision"
+                    tagged = str(precision).encode("utf-8")
+                    for batch in iterator:
+                        assert batch.schema.field("t").metadata[key] == tagged
+                        yield batch
+
+                out = df.mapInArrow(identity, df.schema)
+                self.assertEqual(out.schema["t"].dataType, TimeType(precision))
+                self.assertEqual(out.collect(), [Row(t=expected)])
+
+                checked = df.mapInArrow(check_metadata, "t time(%d)" % precision)
+                self.assertEqual(checked.schema["t"].dataType, TimeType(precision))
+                self.assertEqual(checked.collect(), [Row(t=expected)])
 
     def test_map_in_arrow_with_limit(self):
         def get_size(iterator):

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -16,6 +16,7 @@
 #
 
 from decimal import Decimal
+import datetime
 import unittest
 
 from pyspark.errors import AnalysisException, PythonException, PySparkNotImplementedError
@@ -32,6 +33,7 @@ from pyspark.sql.types import (
     StringType,
     StructField,
     StructType,
+    TimeType,
     VarcharType,
 )
 from pyspark.testing.sqlutils import ReusedSQLTestCase
@@ -269,6 +271,25 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
 
             rounded = df.select(f("v").alias("d")).first().d
             self.assertEqual(rounded, Decimal("1.233999999999999986"))
+
+    def test_time_precision_python_udf(self):
+        # SPARK-57696: Arrow and pickled Python UDFs keep TIME(p) through collect.
+        cases = (
+            ("12:34:56", 0, datetime.time(12, 34, 56)),
+            ("12:34:56.123", 3, datetime.time(12, 34, 56, 123000)),
+            ("12:34:56.123456", 6, datetime.time(12, 34, 56, 123456)),
+            ("12:34:56.123456789", 9, datetime.time(12, 34, 56, 123456)),
+        )
+        for literal, precision, expected in cases:
+            for use_arrow in (True, False):
+                with self.subTest(precision=precision, use_arrow=use_arrow):
+                    df = self.spark.sql(
+                        "SELECT CAST('%s' AS TIME(%d)) AS t" % (literal, precision)
+                    )
+                    ident = udf(lambda t: t, TimeType(precision), useArrow=use_arrow)
+                    out = df.select(ident("t").alias("t"))
+                    self.assertEqual(out.schema["t"].dataType, TimeType(precision))
+                    self.assertEqual(out.collect(), [Row(t=expected)])
 
     def test_err_return_type(self):
         with self.assertRaises(PySparkNotImplementedError) as pe:

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -45,6 +45,7 @@ from pyspark.sql.types import (
     MapType,
     BinaryType,
     YearMonthIntervalType,
+    TimeType,
 )
 from pyspark.errors import AnalysisException, PythonException
 from pyspark.testing.utils import (
@@ -479,6 +480,31 @@ class ScalarArrowUDFTestsMixin:
             ],
             result.collect(),
         )
+
+    def test_arrow_udf_time_precision(self):
+        # SPARK-57696: scalar Arrow UDF return type keeps TIME(p) through collect.
+        import pyarrow as pa
+
+        cases = (
+            ("12:34:56", 0, datetime.time(12, 34, 56)),
+            ("12:34:56.123", 3, datetime.time(12, 34, 56, 123000)),
+            ("12:34:56.123456", 6, datetime.time(12, 34, 56, 123456)),
+            ("12:34:56.123456789", 9, datetime.time(12, 34, 56, 123456)),
+        )
+        for literal, precision, expected in cases:
+            with self.subTest(precision=precision):
+                df = self.spark.sql(
+                    "SELECT CAST('%s' AS TIME(%d)) AS t" % (literal, precision)
+                )
+
+                @arrow_udf(TimeType(precision))
+                def ident(v):
+                    assert isinstance(v, pa.Time64Array)
+                    return v
+
+                out = df.select(ident("t").alias("t"))
+                self.assertEqual(out.schema["t"].dataType, TimeType(precision))
+                self.assertEqual(out.collect(), [Row(t=expected)])
 
     def test_arrow_udf_input_variant(self):
         import pyarrow as pa


### PR DESCRIPTION
### What changes were proposed in this pull request?
Carry `TimeType(p)` precision across the PySpark Arrow / pandas type mapping, matching the JVM fix in SPARK-57661 (#56778).

Arrow `time64` has no fractional-precision field, so `TIME(0)`, `TIME(3)`, and `TIME(9)` all came back as `TIME(6)` after `toPandas` / `createDataFrame` / `mapInArrow`.

This PR writes and reads `SPARK::time::precision` on the Arrow field (not the Arrow type), same key as `ArrowUtils`:

- Tag every `pa.field` path in `to_arrow_schema` and the struct / array / map branches of `to_arrow_type`.
- Recover precision from field metadata in `from_arrow_schema` and the struct-fields loop in `from_arrow_type`. Accept `[0, 9]`. Missing, non-numeric, or out-of-range values (`-1`, `10`) fall back to `TimeType()` (precision 6).
- Bare `from_arrow_type(time64)` stays `TimeType()` for foreign Arrow / pandas inference.
- The key does not leak into reconstructed column metadata.
- No value conversion change. Precision is a type label only. Connect proto mapping is unchanged.

### Why are the changes needed?
`python/pyspark/sql/pandas/types.py` mapped every `TimeType` to `pa.time64("ns")` and read it back as `TimeType()`, which defaults to precision 6. The JVM path already keeps `p`. PySpark did not. Dongjoon called this out on #56778, and Max filed this sibling ticket under SPARK-57550.

### Does this PR introduce _any_ user-facing change?
No. `spark.sql.timeType.enabled` stays internal and off in production. Values are already nanoseconds and are unchanged. With the flag on, a `TIME(p)` column keeps its declared precision instead of always reading back as `TIME(6)`.

### How was this patch tested?
Added `test_time_precision_arrow_round_trip` in `python/pyspark/sql/tests/arrow/test_arrow.py`:

- Round-trip `TIME(p)` for `p` in `{0, 3, 6, 9}`. Arrow type stays `time64[ns]`.
- Untagged `time64` and invalid keys (`-1`, `10`, `"x"`) fall back to `TIME(6)`.
- Precision key does not leak into `StructField.metadata`.
- Nested struct / array / map fields keep precision.

Schema-level mapping checks for those cases passed. I did not run the full `python/run-tests --testnames pyspark.sql.tests.arrow.test_arrow` suite locally (needs `build/sbt -Phive package`).

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor Grok 4.6

Made with [Cursor](https://cursor.com)