### PR TITLE
[SPARK-58000][CONNECT][TESTS] Increase listener events termination ti…

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
@@ -577,7 +577,7 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
       }
     } finally {
       q.stop()
-      eventually(timeout(60.seconds), interval(1.seconds)) {
+      eventually(timeout(180.seconds), interval(1.seconds)) {
         assert(!q.isActive)
         assert(listener.terminate.nonEmpty)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR increases the timeout for waiting for the `QueryTerminatedEvent` in
`ClientStreamingQuerySuite."listener events"` from 60 seconds to 180 seconds.

The test verifies that a Spark Connect streaming query listener receives start,
progress, and termination events. Since listener event delivery is asynchronous,
the termination event may take longer to be observed in slower or noisier CI
environments.

This is a minimal test-only change intended to check whether giving the
termination event more time is enough to deflake the test before considering a
larger change to the listener/test synchronization logic.


### Why are the changes needed?
`ClientStreamingQuerySuite."listener events"` is flaky in CI. The reported failure
shows that the test timed out while waiting for `listener.terminate` to become
non-empty. Increasing the timeout gives the asynchronous listener path more time to deliver the terminal event in
slow or noisy CI environments. 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
i ran `
for i in {1..100}; do
  echo "===== run $i ====="
  ./build/sbt "connect-client-jvm/testOnly org.apache.spark.sql.connect.streaming.ClientStreamingQuerySuite -- -z \"listener events\"" || break
done
`

and all the tests were successful  in my local environment.
<img width="699" height="141" alt="Screenshot 2026-08-17 at 1 53 57 PM" src="https://github.com/user-attachments/assets/51eb20c7-31fd-4d26-8ace-7e9daf33c090" />



### Was this patch authored or co-authored using generative AI tooling?
No.

