### PR TITLE
[SPARK-58383][SQL] Bind the right filter by expression id in ReplaceExceptWithFilter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExceptWithFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExceptWithFilter.scala
@@ -103,11 +103,10 @@ object ReplaceExceptWithFilter extends Rule[LogicalPlan] {
     val leftProjectList = projectList(left)
     val rightProjectList = projectList(right)
 
-    left.output.size == left.output.map(_.name).distinct.size &&
-      !left.exists(_.expressions.exists(SubqueryExpression.hasSubquery)) &&
-        !right.exists(_.expressions.exists(SubqueryExpression.hasSubquery)) &&
-          Project(leftProjectList, nonFilterChild(skipProject(left))).sameResult(
-            Project(rightProjectList, nonFilterChild(skipProject(right))))
+    !left.exists(_.expressions.exists(SubqueryExpression.hasSubquery)) &&
+      !right.exists(_.expressions.exists(SubqueryExpression.hasSubquery)) &&
+        Project(leftProjectList, nonFilterChild(skipProject(left))).sameResult(
+          Project(rightProjectList, nonFilterChild(skipProject(right))))
   }
 
   private def projectList(node: LogicalPlan): Seq[NamedExpression] = node match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExceptWithFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExceptWithFilter.scala
@@ -52,7 +52,7 @@ object ReplaceExceptWithFilter extends Rule[LogicalPlan] {
       case e @ Except(left, right, false) if isEligible(left, right) =>
         val filterCondition = combineFilters(skipProject(right)).asInstanceOf[Filter].condition
         if (filterCondition.deterministic) {
-          transformCondition(left, filterCondition).map { c =>
+          transformCondition(left, right, filterCondition).map { c =>
             Distinct(Filter(Not(c), left))
           }.getOrElse {
             e
@@ -63,11 +63,27 @@ object ReplaceExceptWithFilter extends Rule[LogicalPlan] {
     }
   }
 
-  private def transformCondition(plan: LogicalPlan, condition: Expression): Option[Expression] = {
-    val attributeNameMap: Map[String, Attribute] = plan.output.map(x => (x.name, x)).toMap
-    if (condition.references.forall(r => attributeNameMap.contains(r.name))) {
+  private def transformCondition(
+      left: LogicalPlan,
+      right: LogicalPlan,
+      condition: Expression): Option[Expression] = {
+    // The condition references the attributes of the right side's base relation, below the right
+    // projection. That base relation is known to produce the same result as the left side's one
+    // (see `verifyConditions`), so the two outputs correspond to each other positionally.
+    val baseMap = AttributeMap(
+      nonFilterChild(skipProject(right)).output.zip(nonFilterChild(skipProject(left)).output))
+    // The rewritten condition is applied on top of the left plan, so it can only reference the
+    // left output. A left base attribute reaches that output either directly or through an alias.
+    val leftOutputMap = AttributeMap(projectList(left).collect {
+      case a: Attribute => a -> a
+      case a @ Alias(child: Attribute, _) => child -> a.toAttribute
+    })
+    // Bail out and keep the anti-join when a reference cannot be traced to the left output. Note
+    // that the attributes are matched by expression id rather than by name: an alias on the left
+    // side may reuse the name of an unrelated base column that the right condition references.
+    if (condition.references.forall(r => baseMap.get(r).exists(leftOutputMap.contains))) {
       val rewrittenCondition = condition.transform {
-        case a: AttributeReference => attributeNameMap(a.name)
+        case a: AttributeReference => leftOutputMap(baseMap(a))
       }
       // We need to consider as False when the condition is NULL, otherwise we do not return those
       // rows containing NULL which are instead filtered in the Except right plan

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
@@ -266,6 +266,22 @@ class ReplaceOperatorSuite extends PlanTest {
     comparePlans(result, correctAnswer)
   }
 
+  test("SPARK-58383: ReplaceExceptWithFilter should not bind the right condition by name") {
+    val table = LocalRelation(Seq($"id".int, $"val".int))
+    // The left side aliases `val` to `id`, which collides with the name of the base column that
+    // the right side's filter references. The filter is not expressible over the left output, so
+    // the rewrite must be skipped instead of binding the condition to the alias.
+    val basePlan = table.select($"val".as("id"))
+    val otherPlan = table.where($"id" === 1).select($"val".as("v"))
+    val except = Except(basePlan, otherPlan, false)
+    val result = Optimize.execute(except.analyze)
+    val condition = basePlan.output.zip(otherPlan.output).map { case (a1, a2) =>
+      a1 <=> a2 }.reduce( _ && _)
+    val correctAnswer = Aggregate(basePlan.output, basePlan.output,
+      Join(basePlan, otherPlan, LeftAnti, Option(condition), JoinHint.NONE)).analyze
+    comparePlans(result, correctAnswer)
+  }
+
   test("SPARK-46763: ReplaceDeduplicateWithAggregate non-grouping keys with duplicate attributes") {
     val a = $"a".int
     val b = $"b".int

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3065,6 +3065,26 @@ class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
+  test("SPARK-58383: EXCEPT when a left alias reuses the name of a base column") {
+    withTable("repro_t") {
+      sql("CREATE TABLE repro_t(id INT, val INT) USING parquet")
+      sql("INSERT INTO repro_t VALUES (1, 10), (2, 20)")
+      // The right side filters the base column `id`, while the left side aliases `val` to `id`.
+      // ReplaceExceptWithFilter must not port the filter onto that alias.
+      val query =
+        """
+          |(SELECT val AS id FROM repro_t)
+          |EXCEPT
+          |(SELECT val AS v FROM repro_t WHERE id = 1)
+        """.stripMargin
+      Seq(true, false).foreach { enabled =>
+        withSQLConf(SQLConf.REPLACE_EXCEPT_WITH_FILTER.key -> enabled.toString) {
+          checkAnswer(sql(query), Row(20) :: Nil)
+        }
+      }
+    }
+  }
+
   test("SPARK-26402: accessing nested fields with different cases in case insensitive mode") {
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
       checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3077,9 +3077,18 @@ class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
           |EXCEPT
           |(SELECT val AS v FROM repro_t WHERE id = 1)
         """.stripMargin
+      // Duplicate names in the left output are matched by expression id, so the rewrite applies
+      // and still binds the condition to the base column that the right side filters.
+      val duplicateNamesQuery =
+        """
+          |(SELECT id AS x, val AS x FROM repro_t)
+          |EXCEPT
+          |(SELECT id AS x, val AS x FROM repro_t WHERE id = 1)
+        """.stripMargin
       Seq(true, false).foreach { enabled =>
         withSQLConf(SQLConf.REPLACE_EXCEPT_WITH_FILTER.key -> enabled.toString) {
           checkAnswer(sql(query), Row(20) :: Nil)
+          checkAnswer(sql(duplicateNamesQuery), Row(2, 20) :: Nil)
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ReplaceExceptWithFilter` rewrites `left EXCEPT right` into `Distinct(Filter(NOT coalesce(cond, false), left))` when the right side is the same relation and projection as the left plus an additional filter.

The filter condition references the base columns *below* the right projection, but `transformCondition` remapped it onto `left.output` by attribute **name**:

```scala
val attributeNameMap: Map[String, Attribute] = plan.output.map(x => (x.name, x)).toMap
if (condition.references.forall(r => attributeNameMap.contains(r.name))) {
  val rewrittenCondition = condition.transform {
    case a: AttributeReference => attributeNameMap(a.name)
  }
```

When a left alias reuses the name of an unrelated base column, the injected predicate binds to the wrong column.

This PR maps the condition through the base relations instead:

1. The left and right base relations are already known to be `sameResult` (checked by `verifyConditions`), so their outputs correspond positionally — that gives right-base attribute -> left-base attribute.
2. The left base attributes are then translated into `left.output` through the left project list by expression id, either directly or through an alias.
3. If any reference cannot be traced, the rewrite is skipped and the plan keeps the anti-join.

This replaces the name-presence check added by SPARK-23274, and also lets the left-output-name-distinctness guard from the original SPARK-22181 commit go away: it existed because the name-keyed map silently collapsed duplicate names, which expression-id matching cannot do.

### Why are the changes needed?

It is a correctness bug: the query returns wrong results. Present since Spark 2.3.0, when the rule was introduced.

```sql
CREATE TABLE repro_t(id INT, val INT) USING parquet;
INSERT INTO repro_t VALUES (1, 10), (2, 20);

(SELECT val AS id FROM repro_t)
EXCEPT
(SELECT val AS v FROM repro_t WHERE id = 1);
```

The right side contains no alias named `id`, so its `WHERE id = 1` unambiguously references the base column. But the condition is ported onto the left output by name and lands on the left's alias of `val`:

```
== Optimized Logical Plan ==
Aggregate [id#12239], [id#12239]
+- Project [val#12251 AS id#12239]
   +- Filter NOT coalesce((val#12251 = 1), false)
      +- Relation default.repro_t[id#12250,val#12251] parquet
```

| | before | after |
|---|---|---|
| result | `[10]`, `[20]` | `[20]` |

`SPARK-23274` added a check that every reference in the condition is present among the left output names, but that does not catch this case: here the name *is* present, it just belongs to an unrelated column. The collision is between a left alias and a right *base* column. Note that alias names are erased during canonicalization (`QueryPlan#doCanonicalize` rewrites `Alias(child, name)` to `Alias(normalizedChild, "")`), which is why `val AS id` and `val AS v` compare as `sameResult` and the rule fires in the first place.

The existing workaround is `SET spark.sql.optimizer.replaceExceptWithFilter=false`.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes wrong results for the queries described above. Affected queries now return the correct answer.

There is also a secondary plan change. Because references are now traced by expression id rather than by name, the rule can apply in a case where it previously bailed out — when the right condition references a base column that the left side exposes under a *different* name, e.g.

```sql
(SELECT val AS v FROM t) EXCEPT (SELECT val AS v FROM t WHERE val = 1)
```

Previously `val` was not found among the left output names (`v`) and the plan fell back to the anti-join; it is now rewritten to the filter form.

Dropping the name-distinctness guard widens the rule the same way for a left side with duplicate output names, e.g. `SELECT id AS x, val AS x FROM t`, which previously always fell back to the anti-join.

In both cases the results are unchanged — these are plan/performance changes only.

### How was this patch tested?

New tests, both of which fail without the rule change and pass with it:

- `ReplaceOperatorSuite`: `SPARK-58383: ReplaceExceptWithFilter should not bind the right condition by name` — asserts the rewrite is skipped and the anti-join is kept.
- `SQLQuerySuite`: `SPARK-58383: EXCEPT when a left alias reuses the name of a base column` — end-to-end version of the reported repro, plus a duplicate-left-output-name query covering the path opened up by removing the distinctness guard. Both run with `spark.sql.optimizer.replaceExceptWithFilter` enabled and disabled.

Verified the end-to-end test catches the bug by reverting only the rule change and re-running it: it returned 2 rows instead of 1, with `DataFilters: [NOT coalesce((val#87 = 1), false)]` on the scan.

Existing suites, all passing:

```
build/sbt 'catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.*'
build/sbt 'sql/testOnly org.apache.spark.sql.SQLQuerySuite'
build/sbt 'sql/testOnly org.apache.spark.sql.DataFrameSetOperationsSuite'
build/sbt 'sql/testOnly *SQLQueryTestSuite -- -z except'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
