### PR TITLE
[SPARK-58827][DOCS] Document SPARK_LOCAL_IP for local RemoteClassLoaderError test failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,9 @@ These are combined with a base above rather than used on their own:
 
 Build and tests can take a long time. If the user explicitly asked to run tests, run them. Otherwise (you are running tests on your own to verify a change), first ask the user if they have more changes to make.
 
+For build and test setup, including how to run tests and troubleshoot common
+local failures, see `docs/building-spark.md`.
+
 Prefer SBT over Maven for faster incremental compilation. Module names are defined in `project/SparkBuild.scala`.
 
 Compile a single module:

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -278,7 +278,7 @@ non-loopback address, causing local tests to fail with errors such as
 `RemoteClassLoaderError` or Netty `Connection reset by peer`. Forcing the loopback
 interface usually resolves this:
 
-    export SPARK_LOCAL_IP=127.0.0.1
+    export SPARK_LOCAL_IP=localhost
 
 <!---
 ## Change Scala Version

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -271,6 +271,15 @@ or
 
     ./build/sbt -Pdocker-integration-tests docker-integration-tests/test
 
+## Local network binding
+
+On a machine with multiple network interfaces (for example a VPN), Spark may bind to a
+non-loopback address, causing local tests to fail with errors such as
+`RemoteClassLoaderError` or Netty `Connection reset by peer`. Forcing the loopback
+interface usually resolves this:
+
+    export SPARK_LOCAL_IP=127.0.0.1
+
 <!---
 ## Change Scala Version
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add a short **Local network binding** note near the end of Running Tests in `docs/building-spark.md`, recommending `export SPARK_LOCAL_IP=localhost` when local tests fail due to binding to a non-loopback interface (e.g. VPN).
- Add a generic pointer in `AGENTS.md` to `docs/building-spark.md` for build/test setup and troubleshooting.

### Why are the changes needed?

`SPARK_LOCAL_IP` is already listed in the Configuration Guide as a deploy-time env var, but contributor / test docs do not mention this failure mode. Local tests can fail with `RemoteClassLoaderError` or Netty `Connection reset by peer` even though the code under test is fine.

### Does this PR introduce _any_ user-facing change?

No. Documentation / agent-instructions only.

### How was this patch tested?

N/A (docs). The same `SPARK_LOCAL_IP=localhost` workaround was verified locally when running AutoCDC suites.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.5