### PR TITLE
[SPARK-58830][CORE] Add MapStatus checksum to detect metadata corruption between mapper and reducer

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -39,8 +39,8 @@ import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.config._
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
-import org.apache.spark.scheduler.{MapStatus, MergeStatus, ShuffleOutputStatus}
-import org.apache.spark.shuffle.MetadataFetchFailedException
+import org.apache.spark.scheduler.{MapStatus, MapStatusChecksum, MergeStatus, ShuffleOutputStatus}
+import org.apache.spark.shuffle.{FetchFailedException, MetadataFetchFailedException}
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockId, ShuffleMergedBlockId}
 import org.apache.spark.util._
 import org.apache.spark.util.ArrayImplicits._
@@ -1880,6 +1880,14 @@ private[spark] object MapOutputTracker extends Logging {
     assert (mapStatuses != null)
     val splitsByAddress = new HashMap[BlockManagerId, ListBuffer[(BlockId, Long, Int)]]
     var enableBatchFetch = true
+    val checksumConf = Option(SparkEnv.get).map(_.conf).orNull
+    val checksumEnabled =
+      checksumConf != null && checksumConf.get(SHUFFLE_MAP_STATUS_CHECKSUM_ENABLED)
+    val checksumAlgorithm = if (checksumEnabled) {
+      checksumConf.get(SHUFFLE_MAP_STATUS_CHECKSUM_ALGORITHM)
+    } else {
+      null
+    }
     // Only use MergeStatus for reduce tasks that fetch all map outputs. Since a merged shuffle
     // partition consists of blocks merged in random order, we are unable to serve map index
     // subrange requests. However, when a reduce task needs to fetch blocks from a subrange of
@@ -1908,6 +1916,9 @@ private[spark] object MapOutputTracker extends Logging {
       // Add location for the mapper shuffle partition blocks
       for ((mapStatus, mapIndex) <- mapStatuses.iterator.zipWithIndex) {
         validateStatus(mapStatus, shuffleId, startPartition)
+        if (checksumEnabled) {
+          verifyChecksumOrFail(mapStatus, shuffleId, startPartition, checksumAlgorithm)
+        }
         for (partId <- startPartition until endPartition) {
           // For the "holes" in this pre-merged shuffle partition, i.e., unmerged mapper
           // shuffle partition blocks, fetch the original map produced shuffle partition blocks
@@ -1926,6 +1937,9 @@ private[spark] object MapOutputTracker extends Logging {
       val iter = mapStatuses.iterator.zipWithIndex
       for ((status, mapIndex) <- iter.slice(startMapIndex, endMapIndex)) {
         validateStatus(status, shuffleId, startPartition)
+        if (checksumEnabled) {
+          verifyChecksumOrFail(status, shuffleId, startPartition, checksumAlgorithm)
+        }
         for (part <- startPartition until endPartition) {
           val size = status.getSizeForBlock(part)
           if (size != 0) {
@@ -1962,10 +1976,21 @@ private[spark] object MapOutputTracker extends Logging {
       tracker: RoaringBitmap): Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])] = {
     assert (mapStatuses != null && tracker != null)
     val splitsByAddress = new HashMap[BlockManagerId, ListBuffer[(BlockId, Long, Int)]]
+    val checksumConf = Option(SparkEnv.get).map(_.conf).orNull
+    val checksumEnabled =
+      checksumConf != null && checksumConf.get(SHUFFLE_MAP_STATUS_CHECKSUM_ENABLED)
+    val checksumAlgorithm = if (checksumEnabled) {
+      checksumConf.get(SHUFFLE_MAP_STATUS_CHECKSUM_ALGORITHM)
+    } else {
+      null
+    }
     for ((status, mapIndex) <- mapStatuses.zipWithIndex) {
       // Only add blocks that are merged
       if (tracker.contains(mapIndex)) {
         MapOutputTracker.validateStatus(status, shuffleId, partitionId)
+        if (checksumEnabled) {
+          verifyChecksumOrFail(status, shuffleId, partitionId, checksumAlgorithm)
+        }
         splitsByAddress.getOrElseUpdate(status.location, ListBuffer()) +=
           ((ShuffleBlockId(shuffleId, status.mapId, partitionId),
             status.getSizeForBlock(partitionId), mapIndex))
@@ -1981,6 +2006,35 @@ private[spark] object MapOutputTracker extends Logging {
       // scalastyle:on
       logError(errorMessage)
       throw new MetadataFetchFailedException(shuffleId, partition, errorMessage.message)
+    }
+  }
+
+  def verifyChecksumOrFail(
+      status: MapStatus,
+      shuffleId: Int,
+      reduceId: Int,
+      algorithm: String): Unit = {
+    if (status == null) return
+    status.nonEmptyChecksum.foreach { stored =>
+      val actual = MapStatusChecksum.recompute(status, algorithm)
+      if (!actual.contains(stored)) {
+        val expectedStr = f"0x$stored%08x"
+        val actualStr = actual.map(v => f"0x$v%08x").getOrElse("<empty>")
+        val message = log"MapStatus checksum verification failed for shuffle " +
+          log"${MDC(SHUFFLE_ID, shuffleId)} ${MDC(MAP_ID, status.mapId)} from mapper " +
+          log"${MDC(BLOCK_MANAGER_ID, status.location)}: expected checksum " +
+          log"${MDC(CHECKSUM, expectedStr)} but computed ${MDC(CHECKSUM, actualStr)} " +
+          log"(numPartitions=${MDC(NUM_PARTITIONS, status.numPartitions)}). This indicates " +
+          log"MapStatus metadata was corrupted in transit."
+        logError(message)
+        throw new FetchFailedException(
+          bmAddress = status.location,
+          shuffleId = shuffleId,
+          mapId = status.mapId,
+          mapIndex = -1,
+          reduceId = reduceId,
+          message = message.message)
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1997,6 +1997,31 @@ package object config {
       .checkValue(v => v > 0, "The value should be a positive integer.")
       .createWithDefault(2000)
 
+  private[spark] val SHUFFLE_MAP_STATUS_CHECKSUM_ENABLED =
+    ConfigBuilder("spark.shuffle.mapStatus.checksum.enabled")
+      .doc("When true, the mapper computes an integrity checksum over the non-empty partition " +
+        "indices of each MapStatus. Each reducer verifies the checksum on receipt; a mismatch " +
+        "raises a FetchFailedException that triggers stage retry via Spark's standard fetch-" +
+        "failure recovery path.")
+      .version("4.4.0")
+      .internal()
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val SHUFFLE_MAP_STATUS_CHECKSUM_ALGORITHM =
+    ConfigBuilder("spark.shuffle.mapStatus.checksum.algorithm")
+      .doc("The algorithm used to compute the MapStatus checksum. Currently, ADLER32 and CRC32 " +
+        "are supported. The default is CRC32. Only meaningful when " +
+        s"${SHUFFLE_MAP_STATUS_CHECKSUM_ENABLED.key} is true.")
+      .version("4.4.0")
+      .internal()
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .stringConf
+      .transform(_.toUpperCase(java.util.Locale.ROOT))
+      .checkValues(Set("ADLER32", "CRC32"))
+      .createWithDefault("CRC32")
+
   private[spark] val SHUFFLE_USE_OLD_FETCH_PROTOCOL =
     ConfigBuilder("spark.shuffle.useOldFetchProtocol")
       .doc("Whether to use the old protocol while doing the shuffle block fetching. " +

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -64,6 +64,15 @@ private[spark] sealed trait MapStatus extends ShuffleOutputStatus {
    * output data has changed across different map task retries.
    */
   def checksumValue: Long = 0
+
+  /**
+   * The checksum computed over the set of non-empty partition indices in this MapStatus, used
+   * to detect if the MapStatus metadata itself was corrupted in transit or at rest.
+   */
+  def nonEmptyChecksum: Option[Int]
+
+  /** The number of partitions tracked by this MapStatus. */
+  def numPartitions: Int
 }
 
 
@@ -82,10 +91,16 @@ private[spark] object MapStatus {
       uncompressedSizes: Array[Long],
       mapTaskId: Long,
       checksumVal: Long = 0): MapStatus = {
+    val nonEmptyChecksum = Option(SparkEnv.get) match {
+      case Some(env) if env.conf.get(config.SHUFFLE_MAP_STATUS_CHECKSUM_ENABLED) =>
+        MapStatusChecksum.compute(
+          uncompressedSizes, env.conf.get(config.SHUFFLE_MAP_STATUS_CHECKSUM_ALGORITHM))
+      case _ => None
+    }
     if (uncompressedSizes.length > minPartitionsToUseHighlyCompressMapStatus) {
-      HighlyCompressedMapStatus(loc, uncompressedSizes, mapTaskId, checksumVal)
+      HighlyCompressedMapStatus(loc, uncompressedSizes, mapTaskId, checksumVal, nonEmptyChecksum)
     } else {
-      new CompressedMapStatus(loc, uncompressedSizes, mapTaskId, checksumVal)
+      new CompressedMapStatus(loc, uncompressedSizes, mapTaskId, checksumVal, nonEmptyChecksum)
     }
   }
 
@@ -127,23 +142,27 @@ private[spark] object MapStatus {
  * @param compressedSizes size of the blocks, indexed by reduce partition id.
  * @param _mapTaskId unique task id for the task
  * @param _checksumVal the checksum value for the task
+ * @param _nonEmptyChecksum the checksum of the non-empty partition indices for the task
  */
 private[spark] class CompressedMapStatus(
     private[this] var loc: BlockManagerId,
     private[this] var compressedSizes: Array[Byte],
     private[this] var _mapTaskId: Long,
-    private[this] var _checksumVal: Long = 0)
+    private[this] var _checksumVal: Long,
+    private[this] var _nonEmptyChecksum: Option[Int])
   extends MapStatus with Externalizable {
 
   // For deserialization only
-  protected def this() = this(null, null.asInstanceOf[Array[Byte]], -1, 0)
+  protected def this() = this(null, null.asInstanceOf[Array[Byte]], -1, 0, None)
 
   def this(
       loc: BlockManagerId,
       uncompressedSizes: Array[Long],
       mapTaskId: Long,
-      checksumVal: Long) = {
-    this(loc, uncompressedSizes.map(MapStatus.compressSize), mapTaskId, checksumVal)
+      checksumVal: Long = 0,
+      nonEmptyChecksum: Option[Int] = None) = {
+    this(loc, uncompressedSizes.map(MapStatus.compressSize), mapTaskId, checksumVal,
+      nonEmptyChecksum)
   }
 
   override def location: BlockManagerId = loc
@@ -160,12 +179,23 @@ private[spark] class CompressedMapStatus(
 
   override def checksumValue: Long = _checksumVal
 
+  override def nonEmptyChecksum: Option[Int] = _nonEmptyChecksum
+
+  override def numPartitions: Int = compressedSizes.length
+
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
     loc.writeExternal(out)
     out.writeInt(compressedSizes.length)
     out.write(compressedSizes)
     out.writeLong(_mapTaskId)
     out.writeLong(_checksumVal)
+    _nonEmptyChecksum match {
+      case Some(v) =>
+        out.writeBoolean(true)
+        out.writeInt(v)
+      case None =>
+        out.writeBoolean(false)
+    }
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
@@ -175,6 +205,7 @@ private[spark] class CompressedMapStatus(
     in.readFully(compressedSizes)
     _mapTaskId = in.readLong()
     _checksumVal = in.readLong()
+    _nonEmptyChecksum = if (in.readBoolean()) Some(in.readInt()) else None
   }
 }
 
@@ -190,6 +221,8 @@ private[spark] class CompressedMapStatus(
  * @param hugeBlockSizes sizes of huge blocks by their reduceId.
  * @param _mapTaskId unique task id for the task
  * @param _checksumVal checksum value for the task
+ * @param _numPartitions the number of partitions tracked by this MapStatus
+ * @param _nonEmptyChecksum the checksum of the non-empty partition indices for the task
  */
 private[spark] class HighlyCompressedMapStatus private (
     private[this] var loc: BlockManagerId,
@@ -198,7 +231,9 @@ private[spark] class HighlyCompressedMapStatus private (
     private[this] var avgSize: Long,
     private[this] var hugeBlockSizes: scala.collection.Map[Int, Byte],
     private[this] var _mapTaskId: Long,
-    private[this] var _checksumVal: Long = 0)
+    private[this] var _checksumVal: Long = 0,
+    private[this] var _numPartitions: Int,
+    private[this] var _nonEmptyChecksum: Option[Int] = None)
   extends MapStatus with Externalizable {
 
   // loc could be null when the default constructor is called during deserialization
@@ -206,7 +241,7 @@ private[spark] class HighlyCompressedMapStatus private (
     || numNonEmptyBlocks == 0 || _mapTaskId > 0,
     "Average size can only be zero for map stages that produced no output")
 
-  protected def this() = this(null, -1, null, -1, null, -1, 0)  // For deserialization only
+  protected def this() = this(null, -1, null, -1, null, -1, 0, -1, None)  // For deserialization
 
   override def location: BlockManagerId = loc
 
@@ -230,6 +265,10 @@ private[spark] class HighlyCompressedMapStatus private (
 
   override def checksumValue: Long = _checksumVal
 
+  override def nonEmptyChecksum: Option[Int] = _nonEmptyChecksum
+
+  override def numPartitions: Int = _numPartitions
+
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
     loc.writeExternal(out)
     emptyBlocks.serialize(out)
@@ -241,6 +280,14 @@ private[spark] class HighlyCompressedMapStatus private (
     }
     out.writeLong(_mapTaskId)
     out.writeLong(_checksumVal)
+    out.writeInt(_numPartitions)
+    _nonEmptyChecksum match {
+      case Some(v) =>
+        out.writeBoolean(true)
+        out.writeInt(v)
+      case None =>
+        out.writeBoolean(false)
+    }
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
@@ -259,6 +306,8 @@ private[spark] class HighlyCompressedMapStatus private (
     hugeBlockSizes = hugeBlockSizesImpl
     _mapTaskId = in.readLong()
     _checksumVal = in.readLong()
+    _numPartitions = in.readInt()
+    _nonEmptyChecksum = if (in.readBoolean()) Some(in.readInt()) else None
   }
 }
 
@@ -267,7 +316,8 @@ private[spark] object HighlyCompressedMapStatus {
       loc: BlockManagerId,
       uncompressedSizes: Array[Long],
       mapTaskId: Long,
-      checksumVal: Long = 0): HighlyCompressedMapStatus = {
+      checksumVal: Long = 0,
+      nonEmptyChecksum: Option[Int] = None): HighlyCompressedMapStatus = {
     // We must keep track of which blocks are empty so that we don't report a zero-sized
     // block as being non-empty (or vice-versa) when using the average block size.
     var i = 0
@@ -334,6 +384,6 @@ private[spark] object HighlyCompressedMapStatus {
     emptyBlocks.trim()
     emptyBlocks.runOptimize()
     new HighlyCompressedMapStatus(loc, numNonEmptyBlocks, emptyBlocks, avgSize,
-      hugeBlockSizes, mapTaskId, checksumVal)
+      hugeBlockSizes, mapTaskId, checksumVal, uncompressedSizes.length, nonEmptyChecksum)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatusChecksum.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatusChecksum.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler
 
 import java.util.Locale
-import java.util.zip.{Adler32, CRC32, Checksum}
+import java.util.zip.{Adler32, Checksum, CRC32}
 
 /**
  * Computes integrity checksums over the set of non-empty partition indices of a MapStatus.

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatusChecksum.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatusChecksum.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.Locale
+import java.util.zip.{Adler32, CRC32, Checksum}
+
+/**
+ * Computes integrity checksums over the set of non-empty partition indices of a MapStatus.
+ * Targets metadata corruptions that flip a non-empty partition to size zero, which would cause
+ * reducers to silently skip fetching valid on-disk data.
+ */
+private[spark] object MapStatusChecksum {
+
+  val ADLER32 = "ADLER32"
+  val CRC32_ALG = "CRC32"
+
+  /** Return a fresh Checksum instance for the given algorithm name. */
+  def newChecksum(algorithm: String): Checksum = {
+    algorithm.toUpperCase(Locale.ROOT) match {
+      case ADLER32 => new Adler32
+      case CRC32_ALG => new CRC32
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported MapStatus checksum algorithm: $other")
+    }
+  }
+
+  /** Returns `None` when the array has no non-empty entries. */
+  def compute(partitionLengths: Array[Long], algorithm: String): Option[Int] = {
+    val checksum = newChecksum(algorithm)
+    val buf = new Array[Byte](4)
+    var hasNonEmpty = false
+    var i = 0
+    while (i < partitionLengths.length) {
+      if (partitionLengths(i) != 0L) {
+        writeIntBE(buf, i)
+        checksum.update(buf, 0, 4)
+        hasNonEmpty = true
+      }
+      i += 1
+    }
+    if (hasNonEmpty) Some(checksum.getValue.toInt) else None
+  }
+
+  def recompute(status: MapStatus, algorithm: String): Option[Int] = {
+    val bound = status.numPartitions
+    val checksum = newChecksum(algorithm)
+    val buf = new Array[Byte](4)
+    var hasNonEmpty = false
+    var i = 0
+    while (i < bound) {
+      if (status.getSizeForBlock(i) != 0L) {
+        writeIntBE(buf, i)
+        checksum.update(buf, 0, 4)
+        hasNonEmpty = true
+      }
+      i += 1
+    }
+    if (hasNonEmpty) Some(checksum.getValue.toInt) else None
+  }
+
+  private def writeIntBE(buf: Array[Byte], value: Int): Unit = {
+    buf(0) = (value >>> 24).toByte
+    buf(1) = (value >>> 16).toByte
+    buf(2) = (value >>>  8).toByte
+    buf(3) = value.toByte
+  }
+}

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -35,7 +35,8 @@ import org.apache.spark.internal.config.Network.{RPC_ASK_TIMEOUT, RPC_MESSAGE_MA
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.network.shuffle.ExternalBlockStoreClient
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
-import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus, MapStatus, MergeStatus}
+import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus, MapStatus,
+  MapStatusChecksum, MergeStatus}
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockManagerId, BlockManagerMasterEndpoint, ShuffleBlockId, ShuffleMergedBlockId}
 import org.apache.spark.util.collection.Utils.createArray
@@ -284,6 +285,25 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
       assert(1 == masterTracker.getNumCachedSerializedBroadcast)
       masterTracker.unregisterShuffle(20)
       assert(0 == masterTracker.getNumCachedSerializedBroadcast)
+    }
+  }
+
+  test("MapStatus checksum mismatch triggers FetchFailedException") {
+    val newConf = new SparkConf
+    newConf.set(SHUFFLE_MAP_STATUS_CHECKSUM_ENABLED, true)
+
+    withSpark(new SparkContext("local", "MapOutputTrackerSuite", newConf)) { sc =>
+      val masterTracker = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+      masterTracker.registerShuffle(30, 1, MergeStatus.SHUFFLE_PUSH_DUMMY_NUM_REDUCES)
+      val sizes = Array[Long](1000L)
+      val validChecksum = MapStatusChecksum.compute(sizes, MapStatusChecksum.CRC32_ALG)
+      val corruptedChecksum = validChecksum.map(_ + 1)
+      val status = new CompressedMapStatus(
+        BlockManagerId("a", "hostA", 1000), sizes, mapTaskId = 0L,
+        nonEmptyChecksum = corruptedChecksum)
+      masterTracker.registerMapOutput(30, 0, status)
+
+      intercept[FetchFailedException] { masterTracker.getMapSizesByExecutorId(30, 0) }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusChecksumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusChecksumSuite.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.util.zip.CRC32
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.storage.BlockManagerId
+
+class MapStatusChecksumSuite extends SparkFunSuite {
+
+  private val loc = BlockManagerId("exec-1", "host-1", 7337)
+  private val CRC32Alg = MapStatusChecksum.CRC32_ALG
+  private val ADLER32Alg = MapStatusChecksum.ADLER32
+
+  test("compute returns None when all partitions are empty") {
+    val sizes = Array.fill[Long](128)(0L)
+    assert(MapStatusChecksum.compute(sizes, CRC32Alg).isEmpty)
+  }
+
+  test("compute is invariant to size values, only depends on non-empty partition indices") {
+    val sizesA = Array[Long](0, 100, 0, 200, 0, 300)
+    val sizesB = Array[Long](0, 1, 0, 2, 0, 3)
+    assert(MapStatusChecksum.compute(sizesA, CRC32Alg) ===
+      MapStatusChecksum.compute(sizesB, CRC32Alg))
+  }
+
+  test("compute is sensitive to a single-bit change in the non-empty set") {
+    val base = Array[Long](0, 100, 0, 200, 0, 300)
+    val flipped = base.clone(); flipped(2) = 42
+    assert(MapStatusChecksum.compute(base, CRC32Alg) !==
+      MapStatusChecksum.compute(flipped, CRC32Alg))
+  }
+
+  test("compute matches an independent CRC32 reference implementation") {
+    val sizes = Array[Long](0, 1, 0, 2, 3, 0, 0, 4)
+    val expected = {
+      val crc = new CRC32()
+      val buf = new Array[Byte](4)
+      def writeIntBE(v: Int): Unit = {
+        buf(0) = (v >>> 24).toByte
+        buf(1) = (v >>> 16).toByte
+        buf(2) = (v >>>  8).toByte
+        buf(3) = v.toByte
+        crc.update(buf, 0, 4)
+      }
+      writeIntBE(1); writeIntBE(3); writeIntBE(4); writeIntBE(7)
+      crc.getValue.toInt
+    }
+    assert(MapStatusChecksum.compute(sizes, CRC32Alg) === Some(expected))
+  }
+
+  test("ADLER32 produces a different value than CRC32 for the same input") {
+    val sizes = Array[Long](0, 1, 0, 2, 3, 0, 0, 4)
+    val crc = MapStatusChecksum.compute(sizes, CRC32Alg)
+    val adler = MapStatusChecksum.compute(sizes, ADLER32Alg)
+    assert(crc.isDefined && adler.isDefined)
+    assert(crc !== adler)
+  }
+
+  test("newChecksum rejects unsupported algorithm names") {
+    intercept[IllegalArgumentException] {
+      MapStatusChecksum.newChecksum("SHA256")
+    }
+  }
+
+  test("recompute agrees with compute for the same non-empty partition set") {
+    val sizes = Array[Long](0, 100, 0, 0, 200, 0, 300)
+    val expected = MapStatusChecksum.compute(sizes, CRC32Alg)
+    val status = new CompressedMapStatus(loc, sizes, mapTaskId = 7L, nonEmptyChecksum = expected)
+    assert(MapStatusChecksum.recompute(status, CRC32Alg) === expected)
+  }
+
+  test("recompute matches the stored checksum when partitions are unchanged") {
+    val sizes = Array[Long](0, 100, 0, 200)
+    val cs = MapStatusChecksum.compute(sizes, CRC32Alg)
+    val status = new CompressedMapStatus(loc, sizes, mapTaskId = 1L, nonEmptyChecksum = cs)
+    assert(MapStatusChecksum.recompute(status, CRC32Alg) === cs)
+  }
+
+  test("recompute differs from stored checksum when the non-empty set changes") {
+    val sizes = Array[Long](0, 100, 0, 200)
+    val wrongChecksum: Int = 0x12345678
+    val status = new CompressedMapStatus(
+      loc, sizes, mapTaskId = 1L, nonEmptyChecksum = Some(wrongChecksum))
+    val actual = MapStatusChecksum.recompute(status, CRC32Alg)
+    assert(actual !== Some(wrongChecksum))
+    assert(actual === MapStatusChecksum.compute(sizes, CRC32Alg))
+  }
+
+  test("CompressedMapStatus round-trips checksum via Java serialization") {
+    val sizes = Array[Long](0, 100, 0, 200, 0, 300)
+    val cs = MapStatusChecksum.compute(sizes, CRC32Alg)
+    val original = new CompressedMapStatus(loc, sizes, mapTaskId = 42L, nonEmptyChecksum = cs)
+    val roundTripped = javaRoundTrip(original)
+    assert(roundTripped.nonEmptyChecksum === cs)
+    assert(roundTripped.mapId === 42L)
+    assert(roundTripped.location === loc)
+  }
+
+  test("HighlyCompressedMapStatus round-trips checksum via Java serialization") {
+    val sizes = Array.tabulate[Long](3000)(i => if (i % 100 == 0) i.toLong else 0L)
+    val cs = MapStatusChecksum.compute(sizes, CRC32Alg)
+    val original = HighlyCompressedMapStatus(loc, sizes, mapTaskId = 99L, nonEmptyChecksum = cs)
+    val roundTripped = javaRoundTrip(original)
+    assert(roundTripped.nonEmptyChecksum === cs)
+    assert(roundTripped.mapId === 99L)
+  }
+
+  private def javaRoundTrip[T <: MapStatus](status: T): T = {
+    val bytes = javaBytes(status)
+    val ois = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val out = ois.readObject().asInstanceOf[T]
+    ois.close()
+    out
+  }
+
+  private def javaBytes(o: Any): Array[Byte] = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(o)
+    oos.close()
+    baos.toByteArray
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an integrity checksum to `MapStatus` that covers the *set of non-empty
partition indices*, and verifies it wherever a `MapStatus` is consumed to plan shuffle
block fetches.

- A new `MapStatusChecksum` utility computes a checksum (CRC32 or Adler32) over the
  indices of non-empty partitions in a `partitionLengths` array. It returns `None` when
  there are no non-empty partitions.
- `MapStatus` (both `CompressedMapStatus` and `HighlyCompressedMapStatus`) gains a new
  `nonEmptyChecksum: Option[Int]` field, computed at construction time when enabled, and
  carried through Java (`Externalizable`) serialization via a presence flag followed by
  the value, matching the existing pattern used for other optional fields.
- `MapOutputTracker.verifyChecksumOrFail` recomputes the checksum from the `MapStatus`
  actually consumed by a reducer and compares it against the stored value. A mismatch
  throws a `FetchFailedException`, reusing Spark's existing fetch-failure / stage-retry
  recovery path instead of introducing a new failure mode.
- Two new internal, off-by-default configs:
  - `spark.shuffle.mapStatus.checksum.enabled` (default `false`)
  - `spark.shuffle.mapStatus.checksum.algorithm` (default `CRC32`, also supports `ADLER32`)

The checksum is computed over the non-empty/empty *boundary* of each partition rather
than the sizes themselves, because sizes are already lossily compressed/estimated by
`CompressedMapStatus` / `HighlyCompressedMapStatus` and can legitimately differ in
representation while still being correct. Only the non-empty/empty boundary matters for
the silent-data-loss failure mode this PR targets.

### Why are the changes needed?

`MapStatus` is the most frequently accessed piece of shuffle metadata: every mapper
produces one, the driver holds one per map task, and every reducer consults it to decide
which blocks to fetch. If a `MapStatus`'s `partitionLengths` (or its compressed
representation) is corrupted in memory or in transit between the mapper and a reducer --
e.g. due to a transient hardware fault, a JVM/memory corruption, or a serialization bug
-- a partition that actually has data on disk can appear to have size 0. Because block
fetchers are intentionally designed to skip zero-size blocks
(`MapStatus.getSizeForBlock(reduceId) == 0`), the reducer silently skips fetching that
block. The on-disk data is never read and is effectively lost, with no exception, no
failed stage, and no log signal anywhere in the pipeline.

We hit this in production: a job produced fewer output rows than an otherwise-equivalent
rerun, with no errors in the driver or executor logs. Comparing Spark UI SQL metrics for
the two runs showed shuffle "records written" and "records read" diverging by a large
margin at an Exchange node in the faulty run. Instrumenting `MapStatus` at several points
along its mapper -> driver -> reducer path showed a handful of non-empty partition
entries had been flipped to zero somewhere along that path, while the corresponding
shuffle data files on disk were complete and correct. The root cause traced back to a
hardware fault on one worker node that silently corrupted the `MapStatus` object held in
the driver's memory. Full writeup: SPARK-58830.

Existing safeguards don't catch this class of failure:

- SPARK-35276 added a checksum over shuffle *data* files, so disk/IO-level corruption of
  shuffle bytes is detectable when a reducer actually reads them. But when the corruption
  is in the *metadata* (a non-empty partition reported as empty), the reducer never
  attempts to read that block, so the data checksum path is never exercised.
- SPARK-40872 handles a related but distinct push-based-shuffle case (a merged chunk that
  is empty because it was merged by a bad node) via a fallback to fetching the original
  blocks. It doesn't cover non-empty-to-empty corruption of a mapper's own `MapStatus`
  outside push-based merging.
- SPARK-57491 handles two attempts of the same partition both completing a push under
  speculation/non-deterministic shuffle keys, where only one attempt's `MapStatus`
  should survive. It doesn't address transport/memory corruption of a single
  `MapStatus`.

None of the above detects the case where a `MapStatus` that was correct when the mapper
produced it gets corrupted before a reducer consumes it. This PR closes that gap.

### Does this PR introduce _any_ user-facing change?

No behavior change by default: both new configs are internal and `spark.shuffle.mapStatus.checksum.enabled` defaults to `false`.

When explicitly enabled, a `MapStatus` metadata checksum mismatch now surfaces as a `FetchFailedException`, which triggers Spark's standard stage-retry recovery, instead of silently under-reading shuffle data.

### How was this patch tested?

- New unit tests in `MapStatusChecksumSuite` cover: `compute`/`recompute` returning `None` for all-empty inputs, invariance to size values (only non-empty indices matter), sensitivity to a single-bit change in the non-empty set, agreement with an independent CRC32 reference implementation, ADLER32 vs CRC32 producing different values, rejection of unsupported algorithm names, `recompute` agreeing with `compute` and detecting a changed non-empty set, and Java serialization round-trips of the new field on both `CompressedMapStatus` and `HighlyCompressedMapStatus`.
- New test in `MapOutputTrackerSuite`, `"MapStatus checksum mismatch triggers FetchFailedException"`, exercises `verifyChecksumOrFail` against a real `MapOutputTrackerMaster` with a corrupted checksum and asserts a `FetchFailedException` is thrown.
- Ran both suites locally: `build/sbt 'core/testOnly *MapStatusChecksumSuite'` and `build/sbt 'core/testOnly *MapOutputTrackerSuite'` -- all tests pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Sonnet 5)
