### PR TITLE
[SPARK-58836][WEBUI] Respect UI root when loading thread dump flame graph resources

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-/* global $, sorttable */
+/* global $, sorttable, uiRoot */
 
 import {
   createRESTEndPointForExecutorsPage, createRESTEndPointForMiscellaneousProcess, createTemplateURI,
@@ -120,15 +120,16 @@ function openDetailOffcanvas(url, title) {
 
 function initOffcanvasFlamegraph(fgData, fgChart, offcanvasEl) {
   // Load CSS
-  if (!document.querySelector('link[href="/static/d3-flamegraph.css"]')) {
+  var flamegraphCss = uiRoot + '/static/d3-flamegraph.css';
+  if (!document.querySelector('link[href="' + flamegraphCss + '"]')) {
     var link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = '/static/d3-flamegraph.css';
+    link.href = flamegraphCss;
     document.head.appendChild(link);
   }
   // Load d3 then d3-flamegraph, then render
-  loadScript('/static/d3.min.js').then(function() {
-    return loadScript('/static/d3-flamegraph.min.js');
+  loadScript(uiRoot + '/static/d3.min.js').then(function() {
+    return loadScript(uiRoot + '/static/d3-flamegraph.min.js');
   }).then(function() {
     /* global d3, flamegraph */
     var width = offcanvasEl.offsetWidth - 60;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR prefixes the static resources loaded by the executor thread dump off canvas panel with `uiRoot`.

The following resources are updated:

- `d3-flamegraph.css`
- `d3.min.js`
- `d3-flamegraph.min.js`

### Why are the changes needed?

When the Spark Web UI is accessed through a proxy, the thread dump offcanvas panel currently loads its flame graph resources from hard-coded `/static/...` paths.

For example, a Spark UI served under: `/proxy/application_1769588986968_67458200/`

incorrectly requests: `/static/d3-flamegraph.css`

instead of: `/proxy/application_1769588986968_67458200/static/d3-flamegraph.css`

The incorrect URL returns HTTP 404 and prevents the thread dump flame graph
from rendering.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Test manually:
before:
<img width="1919" height="830" alt="img_v3_0214m_7f0221aa-a915-4dfa-9e55-5a144dc6f76g" src="https://github.com/user-attachments/assets/5364b893-7806-4ed2-b9dc-56e82b708c80" />

after :
<img width="1914" height="829" alt="img_v3_0214m_7dcdc001-55db-4f0c-aa9d-bbc19526a2ag" src="https://github.com/user-attachments/assets/6ee17801-234d-4bc4-aed4-49c58ceee8a3" />


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)