### PR TITLE
[SPARK-58834][4.2][FOLLOWUP][INFRA] Bump remaining docker build-push-action pins to allowlisted version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -498,7 +498,7 @@ jobs:
       - name: Build and push for branch-3.5
         if: inputs.branch == 'branch-3.5'
         id: docker_build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./dev/infra/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build and push
         id: docker_build
         continue-on-error: true
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./dev/infra/
           push: true
@@ -134,7 +134,7 @@ jobs:
         if: hashFiles('dev/spark-test-image/python-310/Dockerfile') != ''
         id: docker_build_pyspark_python_310
         continue-on-error: true
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./dev/spark-test-image/python-310/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to [SPARK-58834](https://issues.apache.org/jira/browse/SPARK-58834) on `branch-4.2`. The earlier backport to this branch updated most of the docker action pins but missed a few `docker/build-push-action` references that were still on the removed v7.1.0 (`bcafcac`). This PR bumps the remaining 3 occurrences to v7.3.0 (`53b7df9`) so the whole branch is consistent and off the removed pin.

### Why are the changes needed?

The v7.1.0 (`bcafcac`) pin was removed from the ASF actions allow-list (apache/infrastructure-actions@273b783), so any workflow still referencing it would fail the allow-list check.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI on this PR exercises the updated action.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)