### PR TITLE
[SPARK-58834][3.5][INFRA] Bump docker CI actions to latest ASF-allowlisted versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -308,7 +308,7 @@ jobs:
       packages: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -328,12 +328,12 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./dev/infra/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -40,18 +40,18 @@ jobs:
       - name: Checkout Spark repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
       - name: Login to DockerHub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./dev/infra/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport of [SPARK-58834](https://issues.apache.org/jira/browse/SPARK-58834) to `branch-3.5`. ASF's actions allow-list update (apache/infrastructure-actions@273b783) removed the expired docker action pins that Spark CI was using. This PR bumps the affected pins in `.github/workflows/build_and_test.yml` and `.github/workflows/build_infra_images_cache.yml` to the latest allow-listed versions:

| Action | Old | New |
|---|---|---|
| `docker/setup-buildx-action` | v4.0.0 (`4d04d5d`) | v4.2.0 (`bb05f3f`) |
| `docker/login-action` | v4.1.0 (`4907a6d`) | v4.6.0 (`dbcb813`) |
| `docker/build-push-action` | v7.1.0 (`bcafcac`) | v7.3.0 (`53b7df9`) |
| `docker/setup-qemu-action` | v4.0.0 (`ce36039`) | v4.2.0 (`96fe6ef`) |

The first three pins were removed from the allow-list; `docker/setup-qemu-action` was not removed in that commit but its v4.0.0 pin was expiring, so it is bumped in the same pass.

### Why are the changes needed?

The removed pins are no longer on the ASF actions allow-list, which would cause CI jobs that use these docker actions to fail.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI on this PR exercises the updated actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)