### PR TITLE
[SPARK-58841][K8S][DOCS] Update `YuniKorn` docs with `1.9.0`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -2188,10 +2188,10 @@ Install Apache YuniKorn:
 ```bash
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.8.0 --create-namespace --set embedAdmissionController=false
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.9.0 --create-namespace --set embedAdmissionController=false
 ```
 
-The above steps will install YuniKorn v1.8.0 on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.9.0 on an existing Kubernetes cluster.
 
 ##### Get started
 

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -413,13 +413,13 @@ The suite is tagged with `YuniKornTag` which is excluded by default via
 
 ## Requirements
 
-- Apache YuniKorn 1.8.0.
+- Apache YuniKorn 1.9.0.
 
 ## Installation
 
     helm repo add yunikorn https://apache.github.io/yunikorn-release
     helm repo update
-    helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.8.0 \
+    helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.9.0 \
         --create-namespace --set embedAdmissionController=false
 
 ## Run tests


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recommend `YuniKorn` v1.9.0.

### Why are the changes needed?

Apache YuniKorn v1.9.0 is a new feature release with 101 patches.
- https://yunikorn.apache.org/release-announce/1.9.0 (2026-07-29)
  - [YUNIKORN-3211 Kubernetes 1.35 support](https://issues.apache.org/jira/browse/YUNIKORN-3211)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change.

### How was this patch tested?

Pass the CIs and manual test.

```
$ helm list -n yunikorn
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS  CHART            APP VERSION
yunikorn        yunikorn        1               2026-08-18 01:43:32.377388 -0700 PDT    deployedyunikorn-1.9.0
```

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.deployMode=rancher-desktop "kubernetes-integration-tests/testOnly *.YuniKornSuite" -Dtest.exclude.tags=minikube,local,decom,r -Dtest.default.exclude.tags=
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5