### PR TITLE
[SPARK-58843][DOCS] Fix grammar errors in the SQL tuning, GraphX and MLlib clustering guides

### DIFF
--- a/docs/graphx-programming-guide.md
+++ b/docs/graphx-programming-guide.md
@@ -189,7 +189,7 @@ val users: RDD[(VertexId, (String, String))] =
 val relationships: RDD[Edge[String]] =
   sc.parallelize(Seq(Edge(3L, 7L, "collab"),    Edge(5L, 3L, "advisor"),
                        Edge(2L, 5L, "colleague"), Edge(5L, 7L, "pi")))
-// Define a default user in case there are relationship with missing user
+// Define a default user in case there is a relationship with a missing user
 val defaultUser = ("John Doe", "Missing")
 // Build the initial Graph
 val graph = Graph(users, relationships, defaultUser)
@@ -413,7 +413,7 @@ implemented efficiently without data movement or duplication.
 The [`subgraph`][Graph.subgraph] operator takes vertex and edge predicates and returns the graph
 containing only the vertices that satisfy the vertex predicate (evaluate to true) and edges that
 satisfy the edge predicate *and connect vertices that satisfy the vertex predicate*.  The `subgraph`
-operator can be used in number of situations to restrict the graph to the vertices and edges of
+operator can be used in a number of situations to restrict the graph to the vertices and edges of
 interest or eliminate broken links. For example in the following code we remove broken links:
 
 
@@ -428,7 +428,7 @@ val relationships: RDD[Edge[String]] =
   sc.parallelize(Seq(Edge(3L, 7L, "collab"),    Edge(5L, 3L, "advisor"),
                        Edge(2L, 5L, "colleague"), Edge(5L, 7L, "pi"),
                        Edge(4L, 0L, "student"),   Edge(5L, 0L, "colleague")))
-// Define a default user in case there are relationship with missing user
+// Define a default user in case there is a relationship with a missing user
 val defaultUser = ("John Doe", "Missing")
 // Build the initial Graph
 val graph = Graph(users, relationships, defaultUser)

--- a/docs/mllib-clustering.md
+++ b/docs/mllib-clustering.md
@@ -384,7 +384,7 @@ Refer to the [`LDA` Java docs](api/java/org/apache/spark/mllib/clustering/LDA.ht
 Bisecting K-means can often be much faster than regular K-means, but it will generally produce a different clustering.
 
 Bisecting k-means is a kind of [hierarchical clustering](https://en.wikipedia.org/wiki/Hierarchical_clustering).
-Hierarchical clustering is one of the most commonly used  method of cluster analysis which seeks to build a hierarchy of clusters.
+Hierarchical clustering is one of the most commonly used methods of cluster analysis which seeks to build a hierarchy of clusters.
 Strategies for hierarchical clustering generally fall into two types:
 
 - Agglomerative: This is a "bottom up" approach: each observation starts in its own cluster, and pairs of clusters are merged as one moves up the hierarchy.

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -101,7 +101,7 @@ Configuration of in-memory caching can be done via `spark.conf.set` or by runnin
     <td>None</td>
     <td>
       The suggested (not guaranteed) maximum number of split file partitions. If it is set,
-      Spark will rescale each partition to make the number of partitions is close to this
+      Spark will rescale each partition to make the number of partitions close to this
       value if the initial number of partitions exceeds this value. This configuration is
       effective only when using file-based sources such as Parquet, JSON and ORC.
     </td>
@@ -429,7 +429,7 @@ This feature coalesces the post shuffle partitions based on the map output stati
      <td><code>spark.sql.adaptive.coalescePartitions.parallelismFirst</code></td>
      <td>true</td>
      <td>
-       When true, Spark ignores the target size specified by <code>spark.sql.adaptive.advisoryPartitionSizeInBytes</code> (default 64MB) when coalescing contiguous shuffle partitions, and only respect the minimum partition size specified by <code>spark.sql.adaptive.coalescePartitions.minPartitionSize</code> (default 1MB), to maximize the parallelism. This is to avoid performance regressions when enabling adaptive query execution. It's recommended to set this config to false on a busy cluster to make resource utilization more efficient (not many small tasks).
+       When true, Spark ignores the target size specified by <code>spark.sql.adaptive.advisoryPartitionSizeInBytes</code> (default 64MB) when coalescing contiguous shuffle partitions, and only respects the minimum partition size specified by <code>spark.sql.adaptive.coalescePartitions.minPartitionSize</code> (default 1MB), to maximize the parallelism. This is to avoid performance regressions when enabling adaptive query execution. It's recommended to set this config to false on a busy cluster to make resource utilization more efficient (not many small tasks).
      </td>
      <td>3.2.0</td>
    </tr>
@@ -482,7 +482,7 @@ This feature coalesces the post shuffle partitions based on the map output stati
      <td><code>spark.sql.adaptive.rebalancePartitionsSmallPartitionFactor</code></td>
      <td>0.2</td>
      <td>
-       A partition will be merged during splitting if its size is small than this factor multiply <code>spark.sql.adaptive.advisoryPartitionSizeInBytes</code>.
+       A partition will be merged during splitting if its size is smaller than this factor multiplying <code>spark.sql.adaptive.advisoryPartitionSizeInBytes</code>.
      </td>
      <td>3.3.0</td>
    </tr>
@@ -622,7 +622,7 @@ You can control the details of how AQE works by providing your own cost evaluato
 
 ## Storage Partition Join
 
-Storage Partition Join (SPJ) is an optimization technique in Spark SQL that makes use the existing storage layout to avoid the shuffle phase.
+Storage Partition Join (SPJ) is an optimization technique in Spark SQL that makes use of the existing storage layout to avoid the shuffle phase.
 
 This is a generalization of the concept of Bucket Joins, which is only applicable for [bucketed](sql-data-sources-load-save-functions.html#bucketing-sorting-and-partitioning) tables, to tables partitioned by functions registered in FunctionCatalog. Storage Partition Joins are currently supported for compatible V2 DataSources.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes eight grammatical errors across three documentation guides:

- `sql-performance-tuning.md`: `partitions is close` to `partitions close`; `only respect` to `only respects`; `is small than this factor multiply` to `is smaller than this factor multiplying`; `makes use the` to `makes use of the`
- `graphx-programming-guide.md`: `there are relationship with missing user` to `there is a relationship with a missing user` (twice); `in number of situations` to `in a number of situations`
- `mllib-clustering.md`: `most commonly used  method` to `most commonly used methods`

### Why are the changes needed?

Each is a plain grammatical error. Several are proven by the same file writing the phrase correctly elsewhere: `sql-performance-tuning.md` already has `if its size is larger than this factor multiplying` and `makes use of the runtime statistics`.

### Does this PR introduce _any_ user-facing change?

No, other than the corrected documentation.

### How was this patch tested?

Documentation only. No code sample, config name, or expected output is touched.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
