### PR TITLE
[SPARK-58798][SQL] Fix collated CHAR LCT and cover compare/IN/set-ops

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/CharVarcharCodegenUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/CharVarcharCodegenUtils.java
@@ -61,8 +61,14 @@ public class CharVarcharCodegenUtils {
    * characters instead of raising a right-truncation exception.
    */
   public static UTF8String charTypeCast(UTF8String inputStr, int limit) {
-    UTF8String truncated = varcharTypeCast(inputStr, limit);
-    return truncated.numChars() < limit ? truncated.rpad(limit, SPACE) : truncated;
+    int numChars = inputStr.numChars();
+    if (numChars == limit) {
+      return inputStr;
+    } else if (numChars < limit) {
+      return inputStr.rpad(limit, SPACE);
+    } else {
+      return inputStr.substring(0, limit);
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/CharVarcharCodegenUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/CharVarcharCodegenUtils.java
@@ -54,6 +54,24 @@ public class CharVarcharCodegenUtils {
     }
   }
 
+  /**
+   * Applies the SQL explicit-cast rules for a character string source and CHAR target.
+   *
+   * Unlike store assignment, an explicit character-to-character cast truncates non-space
+   * characters instead of raising a right-truncation exception.
+   */
+  public static UTF8String charTypeCast(UTF8String inputStr, int limit) {
+    UTF8String truncated = varcharTypeCast(inputStr, limit);
+    return truncated.numChars() < limit ? truncated.rpad(limit, SPACE) : truncated;
+  }
+
+  /**
+   * Applies the SQL explicit-cast rules for a character string source and VARCHAR target.
+   */
+  public static UTF8String varcharTypeCast(UTF8String inputStr, int limit) {
+    return inputStr.numChars() > limit ? inputStr.substring(0, limit) : inputStr;
+  }
+
   public static UTF8String readSidePadding(UTF8String inputStr, int limit) {
     int numChars = inputStr.numChars();
     if (numChars == limit) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.{
-  ArrayType, DataType, IndeterminateStringType, MapType, NullType, StringHelper, StringType,
-  StructType
+  ArrayType, CharType, DataType, IndeterminateStringType, MapType, NullType, StringHelper,
+  StringType, StructType
 }
 import org.apache.spark.sql.util.SchemaUtils
 
@@ -110,6 +110,11 @@ object CollationTypeCoercion extends SQLConfHelper {
 
   /**
    * Changes the data type of the expression to the given `newType`.
+   *
+   * An existing Cast is retargeted when the rewrite still materializes CHAR padding
+   * (CHAR to a wider CHAR). If the source is CHAR and the LCT is not, retargeting
+   * would skip the pad: CAST('a' AS CHAR(2)) rewritten as CAST('a' AS VARCHAR(2))
+   * is 'a', not 'a '. Nest a new Cast in that case, matching uncollated TypeCoercion.
    */
   private def changeType(expr: Expression, newType: DataType): Expression = {
     mergeTypes(expr.dataType, newType) match {
@@ -118,6 +123,8 @@ object CollationTypeCoercion extends SQLConfHelper {
 
         expr match {
           case lit: Literal => lit.copy(dataType = newDataType)
+          case cast: Cast if needsCharPaddingCast(cast.dataType, newDataType) =>
+            Cast(cast, newDataType, timeZoneId = Some(conf.sessionLocalTimeZone))
           case cast: Cast => cast.copy(dataType = newDataType)
           case subquery: SubqueryExpression =>
             changeTypeInSubquery(subquery, newType)
@@ -127,6 +134,24 @@ object CollationTypeCoercion extends SQLConfHelper {
 
       case _ =>
         expr
+    }
+  }
+
+  /**
+   * True when rewriting `from` to `to` would drop CHAR padding if an existing Cast
+   * were retargeted instead of nested.
+   */
+  private def needsCharPaddingCast(from: DataType, to: DataType): Boolean = {
+    (from, to) match {
+      case (_: CharType, t) if !t.isInstanceOf[CharType] => true
+      case (ArrayType(lf, _), ArrayType(rt, _)) => needsCharPaddingCast(lf, rt)
+      case (MapType(lk, lv, _), MapType(rk, rv, _)) =>
+        needsCharPaddingCast(lk, rk) || needsCharPaddingCast(lv, rv)
+      case (StructType(lf), StructType(rt)) =>
+        lf.zip(rt).exists { case (l, r) =>
+          needsCharPaddingCast(l.dataType, r.dataType)
+        }
+      case _ => false
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -417,7 +417,23 @@ object CollationTypeCoercion extends SQLConfHelper {
     }
   }
 
-  /** Determines the winning StringTypeWithContext based on the strength of the collation. */
+  /**
+   * Resolves collation strength independently of CHAR/VARCHAR length.
+   *
+   * This rule always runs. First-class CHAR/VARCHAR appear whenever
+   * `charVarcharFirstClassTypes` is true (`standardSemantics` or
+   * `preserveCharVarcharTypeInfo`), not only under `standardSemantics`.
+   *
+   * Same collation, including mixed strength: take the string-family LCT `max(n, m)`
+   * (pads, never truncates) and attach the stronger strength. Example:
+   * `coalesce(CAST('a' AS CHAR(2) COLLATE UTF8_LCASE),
+   * CAST(1 AS CHAR(4) COLLATE UTF8_LCASE))` is CHAR(4) COLLATE UTF8_LCASE
+   * (Implicit CHAR(2) from a string CAST vs Default CHAR(4) from a non-string CAST).
+   *
+   * Different collations at equal strength: mismatch (error if Explicit, else
+   * indeterminate). Different collations at unequal strength: the stronger operand
+   * wins in full, including its length (SQL collation precedence).
+   */
   private def getWinningStringType(
       left: StringTypeWithContext,
       right: StringTypeWithContext): StringTypeWithContext = {
@@ -430,24 +446,13 @@ object CollationTypeCoercion extends SQLConfHelper {
       }
     }
 
-    (left.strength.priority, right.strength.priority) match {
-      case (leftPriority, rightPriority) if leftPriority == rightPriority =>
-        if (left.sameType(right)) {
-          left
-        } else {
-          // Equal strength with differing types is only a real collation mismatch when the
-          // collations differ. Same-collation CHAR(2) and CHAR(4) differ only in length, so widen
-          // to the string-family LCT (max(n, m), which pads rather than truncates); a genuine
-          // collation mismatch has no LCT and falls through.
-          StringHelper.tightestCommonString(left.stringType, right.stringType) match {
-            case Some(lct) => StringTypeWithContext(lct, left.strength)
-            case None => handleMismatch()
-          }
-        }
+    val winner =
+      if (left.strength.priority <= right.strength.priority) left else right
 
-      case (leftPriority, rightPriority) =>
-        if (leftPriority < rightPriority) left
-        else right
+    StringHelper.tightestCommonString(left.stringType, right.stringType) match {
+      case Some(lct) => StringTypeWithContext(lct, winner.strength)
+      case None if left.strength.priority == right.strength.priority => handleMismatch()
+      case None => winner
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -151,8 +151,8 @@ object CollationTypeCoercion extends SQLConfHelper {
       case (MapType(fk, fv, _), MapType(tk, tv, _)) =>
         stringConstraintChanged(fk, tk) || stringConstraintChanged(fv, tv)
       case (fs: StructType, ts: StructType) if fs.length == ts.length =>
-        fs.fields.zip(ts.fields).exists { case (a, b) =>
-          stringConstraintChanged(a.dataType, b.dataType)
+        fs.fields.indices.exists { i =>
+          stringConstraintChanged(fs.fields(i).dataType, ts.fields(i).dataType)
         }
       case _ => false
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.{
-  ArrayType, CharType, DataType, IndeterminateStringType, MapType, NullType, StringHelper,
+  ArrayType, DataType, IndeterminateStringType, MapType, NullType, StringHelper,
   StringType, StructType
 }
 import org.apache.spark.sql.util.SchemaUtils
@@ -111,10 +111,9 @@ object CollationTypeCoercion extends SQLConfHelper {
   /**
    * Changes the data type of the expression to the given `newType`.
    *
-   * An existing Cast is retargeted when the rewrite still materializes CHAR padding
-   * (CHAR to a wider CHAR). If the source is CHAR and the LCT is not, retargeting
-   * would skip the pad: CAST('a' AS CHAR(2)) rewritten as CAST('a' AS VARCHAR(2))
-   * is 'a', not 'a '. Nest a new Cast in that case, matching uncollated TypeCoercion.
+   * Never retarget an existing Cast (`cast.copy(dataType = ...)`). Explicit CAST
+   * truncation / overflow (ISO 6.13) and CHAR padding must stay on the inner node;
+   * LCT is an outer Cast. Uncollated TypeCoercion already nests.
    */
   private def changeType(expr: Expression, newType: DataType): Expression = {
     mergeTypes(expr.dataType, newType) match {
@@ -123,9 +122,8 @@ object CollationTypeCoercion extends SQLConfHelper {
 
         expr match {
           case lit: Literal => lit.copy(dataType = newDataType)
-          case cast: Cast if needsCharPaddingCast(cast.dataType, newDataType) =>
+          case cast: Cast =>
             Cast(cast, newDataType, timeZoneId = Some(conf.sessionLocalTimeZone))
-          case cast: Cast => cast.copy(dataType = newDataType)
           case subquery: SubqueryExpression =>
             changeTypeInSubquery(subquery, newType)
 
@@ -134,24 +132,6 @@ object CollationTypeCoercion extends SQLConfHelper {
 
       case _ =>
         expr
-    }
-  }
-
-  /**
-   * True when rewriting `from` to `to` would drop CHAR padding if an existing Cast
-   * were retargeted instead of nested.
-   */
-  private def needsCharPaddingCast(from: DataType, to: DataType): Boolean = {
-    (from, to) match {
-      case (_: CharType, t) if !t.isInstanceOf[CharType] => true
-      case (ArrayType(lf, _), ArrayType(rt, _)) => needsCharPaddingCast(lf, rt)
-      case (MapType(lk, lv, _), MapType(rk, rv, _)) =>
-        needsCharPaddingCast(lk, rk) || needsCharPaddingCast(lv, rv)
-      case (StructType(lf), StructType(rt)) =>
-        lf.zip(rt).exists { case (l, r) =>
-          needsCharPaddingCast(l.dataType, r.dataType)
-        }
-      case _ => false
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -114,6 +114,9 @@ object CollationTypeCoercion extends SQLConfHelper {
    * Never retarget an existing Cast (`cast.copy(dataType = ...)`). Explicit CAST
    * truncation / overflow (ISO 6.13) and CHAR padding must stay on the inner node;
    * LCT is an outer Cast. Uncollated TypeCoercion already nests.
+   *
+   * Literals: `copy(dataType)` is enough when only collation changes. When a string
+   * constraint changes (CHAR(2) to CHAR(4)), wrap in Cast so padding is re-applied.
    */
   private def changeType(expr: Expression, newType: DataType): Expression = {
     mergeTypes(expr.dataType, newType) match {
@@ -121,6 +124,8 @@ object CollationTypeCoercion extends SQLConfHelper {
         assert(!newDataType.existsRecursively(_.isInstanceOf[StringTypeWithContext]))
 
         expr match {
+          case lit: Literal if stringConstraintChanged(lit.dataType, newDataType) =>
+            Cast(lit, newDataType, timeZoneId = Some(conf.sessionLocalTimeZone))
           case lit: Literal => lit.copy(dataType = newDataType)
           case cast: Cast =>
             Cast(cast, newDataType, timeZoneId = Some(conf.sessionLocalTimeZone))
@@ -132,6 +137,24 @@ object CollationTypeCoercion extends SQLConfHelper {
 
       case _ =>
         expr
+    }
+  }
+
+  /**
+   * True when CHAR/VARCHAR length (or nested length) differs between `from` and `to`.
+   * Collation-only differences are not a constraint change.
+   */
+  private def stringConstraintChanged(from: DataType, to: DataType): Boolean = {
+    (from, to) match {
+      case (f: StringType, t: StringType) => f.constraint != t.constraint
+      case (ArrayType(fe, _), ArrayType(te, _)) => stringConstraintChanged(fe, te)
+      case (MapType(fk, fv, _), MapType(tk, tv, _)) =>
+        stringConstraintChanged(fk, tk) || stringConstraintChanged(fv, tv)
+      case (fs: StructType, ts: StructType) if fs.length == ts.length =>
+        fs.fields.zip(ts.fields).exists { case (a, b) =>
+          stringConstraintChanged(a.dataType, b.dataType)
+        }
+      case _ => false
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -25,7 +25,10 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Proj
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{ArrayType, DataType, IndeterminateStringType, MapType, NullType, StringType, StructType}
+import org.apache.spark.sql.types.{
+  ArrayType, DataType, IndeterminateStringType, MapType, NullType, StringHelper, StringType,
+  StructType
+}
 import org.apache.spark.sql.util.SchemaUtils
 
 /**
@@ -429,8 +432,18 @@ object CollationTypeCoercion extends SQLConfHelper {
 
     (left.strength.priority, right.strength.priority) match {
       case (leftPriority, rightPriority) if leftPriority == rightPriority =>
-        if (left.sameType(right)) left
-        else handleMismatch()
+        if (left.sameType(right)) {
+          left
+        } else {
+          // Equal strength with differing types is only a real collation mismatch when the
+          // collations differ. Same-collation CHAR(2) and CHAR(4) differ only in length, so widen
+          // to the string-family LCT (max(n, m), which pads rather than truncates); a genuine
+          // collation mismatch has no LCT and falls through.
+          StringHelper.tightestCommonString(left.stringType, right.stringType) match {
+            case Some(lct) => StringTypeWithContext(lct, left.strength)
+            case None => handleMismatch()
+          }
+        }
 
       case (leftPriority, rightPriority) =>
         if (leftPriority < rightPriority) left

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -236,7 +236,8 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     if (canWriteValue) {
       val nullCheckedValue = checkNullability(value, attr, conf, colPath)
       val casted = cast(nullCheckedValue, attrTypeWithoutCharVarchar, conf, colPath.quoted)
-      val exprWithStrLenCheck = if (conf.charVarcharAsString || !attrTypeHasCharVarchar) {
+      val exprWithStrLenCheck = if (!attrTypeHasCharVarchar ||
+          !CharVarcharUtils.shouldApplyWriteSideLengthCheck(conf)) {
         casted
       } else {
         CharVarcharUtils.stringLengthCheck(casted, attr.dataType)
@@ -333,7 +334,8 @@ object TableOutputResolver extends SQLConfHelper with Logging {
       expectedCol: Attribute,
       conf: SQLConf): NamedExpression = {
     val rawType = CharVarcharUtils.getRawType(expectedCol.metadata).getOrElse(expectedCol.dataType)
-    val checked = if (!conf.charVarcharAsString && CharVarcharUtils.hasCharVarchar(rawType)) {
+    val checked = if (CharVarcharUtils.hasCharVarchar(rawType) &&
+        CharVarcharUtils.shouldApplyWriteSideLengthCheck(conf)) {
       val value = defaultExpr match {
         case a: Alias => a.child
         case other => other
@@ -854,7 +856,8 @@ object TableOutputResolver extends SQLConfHelper with Logging {
         } else {
           val udtUnwrapped = unwrapUDT(queryExpr)
           val casted = cast(udtUnwrapped, attrTypeWithoutCharVarchar, conf, colPath.quoted)
-          if (conf.charVarcharAsString || !attrTypeHasCharVarchar) {
+          if (!attrTypeHasCharVarchar ||
+              !CharVarcharUtils.shouldApplyWriteSideLengthCheck(conf)) {
             casted
           } else {
             CharVarcharUtils.stringLengthCheck(casted, tableAttr.dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -692,6 +692,10 @@ case class Cast(
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
 
+  // Parser, Column.cast, and Connect set USER_SPECIFIED_CAST. Analyzer-inserted Casts do not.
+  override protected def truncateCharVarcharOnCast: Boolean =
+    containsTag(Cast.USER_SPECIFIED_CAST)
+
   override protected def withNewChildInternal(newChild: Expression): Cast = copy(child = newChild)
 
   // CAST_TO_TIMESTAMP must be set on a superset of the targets accepted by

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -58,12 +58,16 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
   // Returns a function to convert a value to pretty string. The function assumes input is not null.
   protected final def castToString(
       from: DataType, to: StringConstraint = NoConstraint): Any => UTF8String =
-    to match {
-      case FixedLength(length) =>
+    (to, from) match {
+      case (FixedLength(length), _: StringType) if SQLConf.get.charVarcharStandardSemantics =>
+        s => CharVarcharCodegenUtils.charTypeCast(castToString(from)(s), length)
+      case (MaxLength(length), _: StringType) if SQLConf.get.charVarcharStandardSemantics =>
+        s => CharVarcharCodegenUtils.varcharTypeCast(castToString(from)(s), length)
+      case (FixedLength(length), _) =>
         s => CharVarcharCodegenUtils.charTypeWriteSideCheck(castToString(from)(s), length)
-      case MaxLength(length) =>
+      case (MaxLength(length), _) =>
         s => CharVarcharCodegenUtils.varcharTypeWriteSideCheck(castToString(from)(s), length)
-      case NoConstraint => castToString(from)
+      case (NoConstraint, _) => castToString(from)
     }
 
   // The Types Framework is the single integration point for framework types' cast-to-string, via
@@ -196,14 +200,22 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
     (c, evPrim) => {
       val tmpVar = ctx.freshVariable("tmp", classOf[UTF8String])
       val castToString = castToStringCode(from, ctx)(c, tmpVar)
-      val maintainConstraint = to match {
-        case FixedLength(length) =>
+      val maintainConstraint = (to, from) match {
+        case (FixedLength(length), _: StringType)
+            if SQLConf.get.charVarcharStandardSemantics =>
+          code"""$evPrim = org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
+                .charTypeCast($tmpVar, $length);""".stripMargin
+        case (MaxLength(length), _: StringType)
+            if SQLConf.get.charVarcharStandardSemantics =>
+          code"""$evPrim = org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
+                .varcharTypeCast($tmpVar, $length);""".stripMargin
+        case (FixedLength(length), _) =>
           code"""$evPrim = org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
                 .charTypeWriteSideCheck($tmpVar, $length);""".stripMargin
-        case MaxLength(length) =>
+        case (MaxLength(length), _) =>
           code"""$evPrim = org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
                 .varcharTypeWriteSideCheck($tmpVar, $length);""".stripMargin
-        case NoConstraint => code"$evPrim = $tmpVar;"
+        case (NoConstraint, _) => code"$evPrim = $tmpVar;"
       }
       code"""
             UTF8String $tmpVar;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -35,6 +35,13 @@ import org.apache.spark.util.SparkStringUtils
 
 trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
 
+  /**
+   * ISO 6.13 truncation applies only to user-written CAST / TRY_CAST. Implicit and
+   * store-assignment Casts keep the write-side length check. [[ToPrettyString]] is never
+   * a CAST, so it stays false.
+   */
+  protected def truncateCharVarcharOnCast: Boolean = false
+
   private lazy val dateFormatter = DateFormatter()
   private lazy val timeFormatter = new FractionTimeFormatter()
   private lazy val timestampFormatter = TimestampFormatter.getFractionFormatter(zoneId)
@@ -59,9 +66,11 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
   protected final def castToString(
       from: DataType, to: StringConstraint = NoConstraint): Any => UTF8String =
     (to, from) match {
-      case (FixedLength(length), _: StringType) if SQLConf.get.charVarcharStandardSemantics =>
+      case (FixedLength(length), _: StringType)
+          if SQLConf.get.charVarcharStandardSemantics && truncateCharVarcharOnCast =>
         s => CharVarcharCodegenUtils.charTypeCast(castToString(from)(s), length)
-      case (MaxLength(length), _: StringType) if SQLConf.get.charVarcharStandardSemantics =>
+      case (MaxLength(length), _: StringType)
+          if SQLConf.get.charVarcharStandardSemantics && truncateCharVarcharOnCast =>
         s => CharVarcharCodegenUtils.varcharTypeCast(castToString(from)(s), length)
       case (FixedLength(length), _) =>
         s => CharVarcharCodegenUtils.charTypeWriteSideCheck(castToString(from)(s), length)
@@ -202,11 +211,11 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
       val castToString = castToStringCode(from, ctx)(c, tmpVar)
       val maintainConstraint = (to, from) match {
         case (FixedLength(length), _: StringType)
-            if SQLConf.get.charVarcharStandardSemantics =>
+            if SQLConf.get.charVarcharStandardSemantics && truncateCharVarcharOnCast =>
           code"""$evPrim = org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
                 .charTypeCast($tmpVar, $length);""".stripMargin
         case (MaxLength(length), _: StringType)
-            if SQLConf.get.charVarcharStandardSemantics =>
+            if SQLConf.get.charVarcharStandardSemantics && truncateCharVarcharOnCast =>
           code"""$evPrim = org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
                 .varcharTypeCast($tmpVar, $length);""".stripMargin
         case (FixedLength(length), _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -64,20 +64,22 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
 
   // Returns a function to convert a value to pretty string. The function assumes input is not null.
   protected final def castToString(
-      from: DataType, to: StringConstraint = NoConstraint): Any => UTF8String =
+      from: DataType, to: StringConstraint = NoConstraint): Any => UTF8String = {
+    val toUTF8String = castToString(from)
     (to, from) match {
       case (FixedLength(length), _: StringType)
           if SQLConf.get.charVarcharStandardSemantics && truncateCharVarcharOnCast =>
-        s => CharVarcharCodegenUtils.charTypeCast(castToString(from)(s), length)
+        s => CharVarcharCodegenUtils.charTypeCast(toUTF8String(s), length)
       case (MaxLength(length), _: StringType)
           if SQLConf.get.charVarcharStandardSemantics && truncateCharVarcharOnCast =>
-        s => CharVarcharCodegenUtils.varcharTypeCast(castToString(from)(s), length)
+        s => CharVarcharCodegenUtils.varcharTypeCast(toUTF8String(s), length)
       case (FixedLength(length), _) =>
-        s => CharVarcharCodegenUtils.charTypeWriteSideCheck(castToString(from)(s), length)
+        s => CharVarcharCodegenUtils.charTypeWriteSideCheck(toUTF8String(s), length)
       case (MaxLength(length), _) =>
-        s => CharVarcharCodegenUtils.varcharTypeWriteSideCheck(castToString(from)(s), length)
-      case (NoConstraint, _) => castToString(from)
+        s => CharVarcharCodegenUtils.varcharTypeWriteSideCheck(toUTF8String(s), length)
+      case (NoConstraint, _) => toUTF8String
     }
+  }
 
   // The Types Framework is the single integration point for framework types' cast-to-string, via
   // the zone-less formatUTF8. The cast's session zone is threaded into the lookup so TIMESTAMP_LTZ

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -191,9 +191,14 @@ object Project {
     }
   }
 
-  // Store assignment must not use character-to-character CAST truncation (ISO 6.13).
-  // Cast to unconstrained STRING first, then apply the write-side length check.
-  // Avoid replaceCharVarcharWithString: first-class types keep CHAR/VARCHAR.
+  /**
+   * Cast `col` for ANSI store assignment without using character-to-character CAST
+   * truncation (ISO 6.13).
+   *
+   * For CHAR/VARCHAR targets the plan is Cast to unconstrained STRING, then
+   * `stringLengthCheck` (write-side overflow). Avoid replaceCharVarcharWithString
+   * so first-class types stay CHAR/VARCHAR.
+   */
   private def storeAssignCast(
       col: Expression,
       other: DataType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -184,7 +184,24 @@ object Project {
         if (other == target) {
           col
         } else if (Cast.canANSIStoreAssign(other, target)) {
-          Cast(col, target, Option(conf.sessionLocalTimeZone), ansiEnabled = true)
+          // Store assignment must not use character-to-character CAST truncation (ISO 6.13).
+          // Cast to unconstrained STRING first, then apply the write-side length check.
+          // Avoid replaceCharVarcharWithString: first-class types keep CHAR/VARCHAR.
+          val (castTarget, lengthCheckType) = target match {
+            case c: CharType => (c.toStringType, Some(c: DataType))
+            case v: VarcharType => (v.toStringType, Some(v: DataType))
+            case otherType => (otherType, None)
+          }
+          val casted = if (other == castTarget) {
+            col
+          } else {
+            Cast(col, castTarget, Option(conf.sessionLocalTimeZone), ansiEnabled = true)
+          }
+          if (lengthCheckType.isDefined && !conf.charVarcharAsString) {
+            CharVarcharUtils.stringLengthCheck(casted, lengthCheckType.get)
+          } else {
+            casted
+          }
         } else {
           throw QueryCompilationErrors.invalidColumnOrFieldDataTypeError(columnPath, other, target)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -184,27 +184,36 @@ object Project {
         if (other == target) {
           col
         } else if (Cast.canANSIStoreAssign(other, target)) {
-          // Store assignment must not use character-to-character CAST truncation (ISO 6.13).
-          // Cast to unconstrained STRING first, then apply the write-side length check.
-          // Avoid replaceCharVarcharWithString: first-class types keep CHAR/VARCHAR.
-          val (castTarget, lengthCheckType) = target match {
-            case c: CharType => (c.toStringType, Some(c: DataType))
-            case v: VarcharType => (v.toStringType, Some(v: DataType))
-            case otherType => (otherType, None)
-          }
-          val casted = if (other == castTarget) {
-            col
-          } else {
-            Cast(col, castTarget, Option(conf.sessionLocalTimeZone), ansiEnabled = true)
-          }
-          if (lengthCheckType.isDefined && !conf.charVarcharAsString) {
-            CharVarcharUtils.stringLengthCheck(casted, lengthCheckType.get)
-          } else {
-            casted
-          }
+          storeAssignCast(col, other, target, conf)
         } else {
           throw QueryCompilationErrors.invalidColumnOrFieldDataTypeError(columnPath, other, target)
         }
+    }
+  }
+
+  // Store assignment must not use character-to-character CAST truncation (ISO 6.13).
+  // Cast to unconstrained STRING first, then apply the write-side length check.
+  // Avoid replaceCharVarcharWithString: first-class types keep CHAR/VARCHAR.
+  private def storeAssignCast(
+      col: Expression,
+      other: DataType,
+      target: DataType,
+      conf: SQLConf): Expression = {
+    val (castTarget, lengthCheckType) = target match {
+      case c: CharType => (c.toStringType, Some(c: DataType))
+      case v: VarcharType => (v.toStringType, Some(v: DataType))
+      case otherType => (otherType, None)
+    }
+    val casted = if (other == castTarget) {
+      col
+    } else {
+      Cast(col, castTarget, Option(conf.sessionLocalTimeZone), ansiEnabled = true)
+    }
+    lengthCheckType match {
+      case Some(dt) if CharVarcharUtils.shouldApplyWriteSideLengthCheck(conf) =>
+        CharVarcharUtils.stringLengthCheck(casted, dt)
+      case _ =>
+        casted
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -167,6 +167,15 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
     }.getOrElse(expr)
   }
 
+  /**
+   * Write-side CHAR/VARCHAR length checks apply unless the session is on the legacy
+   * `charVarcharAsString` path with no first-class types. `standardSemantics` and
+   * `preserveCharVarcharTypeInfo` keep first-class types even if the legacy flag is also on.
+   */
+  def shouldApplyWriteSideLengthCheck(conf: SQLConf): Boolean = {
+    !conf.charVarcharAsString || conf.charVarcharFirstClassTypes
+  }
+
   def stringLengthCheck(expr: Expression, dt: DataType): Expression = {
     processStringForCharVarchar(
       expr,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -439,7 +439,8 @@ object ResolveDefaultColumns extends QueryErrorsBase
           throw QueryCompilationErrors.defaultValuesDataTypeError(
             statementType, colName, defaultSQL, dataType, other.dataType))
     }
-    if (!conf.charVarcharAsString && CharVarcharUtils.hasCharVarchar(dataType) && ret.foldable) {
+    if (CharVarcharUtils.hasCharVarchar(dataType) &&
+        CharVarcharUtils.shouldApplyWriteSideLengthCheck(conf) && ret.foldable) {
       CharVarcharUtils.stringLengthCheck(ret, dataType).eval(EmptyRow)
     }
     ret

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
@@ -396,10 +396,10 @@ Project [typeof(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) c
 
 
 -- !query
-SELECT concat('<', coalesce(
-  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+SELECT hex(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query analysis
-Project [concat(<, coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
+Project [hex(cast(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE)) as string collate UTF8_LCASE)) AS hex(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 
@@ -421,11 +421,11 @@ Project [typeof(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) c
 
 
 -- !query
-SELECT concat('<', coalesce(
+SELECT hex(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
-  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query analysis
-Project [concat(<, coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
+Project [hex(cast(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE)) as string collate UTF8_LCASE)) AS hex(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 
@@ -650,7 +650,7 @@ Project [(cast(cast(a as char(2)) as string collate UTF8_BINARY) = a ) AS (CAST(
 -- !query
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a'
 -- !query analysis
-Project [(cast(a as char(2) collate UTF8_BINARY_RTRIM) = a) AS (CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a' collate UTF8_BINARY_RTRIM)#x]
+Project [(cast(a as char(2) collate UTF8_BINARY_RTRIM) = cast(a as char(2) collate UTF8_BINARY_RTRIM)) AS (CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = a)#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
@@ -56,6 +56,27 @@ Project [try_cast(abcdef as varchar(2)) AS TRY_CAST(abcdef AS VARCHAR(2))#x]
 
 
 -- !query
+SELECT CAST(12345 AS VARCHAR(4))
+-- !query analysis
+Project [cast(12345 as varchar(4)) AS CAST(12345 AS VARCHAR(4))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST(12345 AS VARCHAR(5))
+-- !query analysis
+Project [cast(12345 as varchar(5)) AS CAST(12345 AS VARCHAR(5))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_cast(12345 AS VARCHAR(4))
+-- !query analysis
+Project [try_cast(12345 as varchar(4)) AS TRY_CAST(12345 AS VARCHAR(4))#x]
++- OneRowRelation
+
+
+-- !query
 SELECT typeof(coalesce(cast('hello' AS VARCHAR(5)), cast('world' AS VARCHAR(10))))
 -- !query analysis
 Project [typeof(coalesce(cast(cast(hello as varchar(5)) as varchar(10)), cast(world as varchar(10)))) AS typeof(coalesce(CAST(hello AS VARCHAR(5)), CAST(world AS VARCHAR(10))))#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
@@ -77,6 +77,50 @@ Project [try_cast(12345 as varchar(4)) AS TRY_CAST(12345 AS VARCHAR(4))#x]
 
 
 -- !query
+SELECT coalesce(CAST('abcdef' AS VARCHAR(2)), CAST('x' AS VARCHAR(4)))
+-- !query analysis
+Project [coalesce(cast(cast(abcdef as varchar(2)) as varchar(4)), cast(x as varchar(4))) AS coalesce(CAST(abcdef AS VARCHAR(2)), CAST(x AS VARCHAR(4)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CASE WHEN true THEN CAST('abcdef' AS VARCHAR(2)) ELSE CAST('x' AS VARCHAR(4)) END
+-- !query analysis
+Project [CASE WHEN true THEN cast(cast(abcdef as varchar(2)) as varchar(4)) ELSE cast(x as varchar(4)) END AS CASE WHEN true THEN CAST(abcdef AS VARCHAR(2)) ELSE CAST(x AS VARCHAR(4)) END#x]
++- OneRowRelation
+
+
+-- !query
+SELECT CAST('abcdef' AS VARCHAR(2)) IN (CAST('ab' AS VARCHAR(4)))
+-- !query analysis
+Project [cast(cast(abcdef as varchar(2)) as varchar(4)) IN (cast(cast(ab as varchar(4)) as varchar(4))) AS (CAST(abcdef AS VARCHAR(2)) IN (CAST(ab AS VARCHAR(4))))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(
+  CAST('abcdef' AS VARCHAR(2) COLLATE UTF8_LCASE),
+  CAST('x' AS VARCHAR(4) COLLATE UTF8_LCASE))
+-- !query analysis
+Project [coalesce(cast(cast(abcdef as varchar(2) collate UTF8_LCASE) as varchar(4) collate UTF8_LCASE), cast(x as varchar(4) collate UTF8_LCASE)) AS coalesce(CAST(abcdef AS VARCHAR(2) COLLATE UTF8_LCASE), CAST(x AS VARCHAR(4) COLLATE UTF8_LCASE))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(try_cast(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)))
+-- !query analysis
+Project [coalesce(cast(try_cast(12345 as varchar(4)) as varchar(5)), cast(x as varchar(5))) AS coalesce(TRY_CAST(12345 AS VARCHAR(4)), CAST(x AS VARCHAR(5)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(CAST(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)))
+-- !query analysis
+Project [coalesce(cast(cast(12345 as varchar(4)) as varchar(5)), cast(x as varchar(5))) AS coalesce(CAST(12345 AS VARCHAR(4)), CAST(x AS VARCHAR(5)))#x]
++- OneRowRelation
+
+
+-- !query
 SELECT typeof(coalesce(cast('hello' AS VARCHAR(5)), cast('world' AS VARCHAR(10))))
 -- !query analysis
 Project [typeof(coalesce(cast(cast(hello as varchar(5)) as varchar(10)), cast(world as varchar(10)))) AS typeof(coalesce(CAST(hello AS VARCHAR(5)), CAST(world AS VARCHAR(10))))#x]
@@ -347,7 +391,7 @@ Project [typeof(coalesce(cast(a as char(2) collate UTF8_LCASE), cast(bb as char(
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query analysis
-Project [typeof(coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE))) AS typeof(coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)))#x]
+Project [typeof(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE))) AS typeof(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 
@@ -355,7 +399,7 @@ Project [typeof(coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as char(
 SELECT concat('<', coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>')
 -- !query analysis
-Project [concat(<, coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
+Project [concat(<, coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
 +- OneRowRelation
 
 
@@ -372,7 +416,7 @@ SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
   cast(1 AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query analysis
-Project [typeof(coalesce(cast(a as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE))) AS typeof(coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)))#x]
+Project [typeof(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE))) AS typeof(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 
@@ -381,7 +425,7 @@ SELECT concat('<', coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
   cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>')
 -- !query analysis
-Project [concat(<, coalesce(cast(a as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
+Project [concat(<, coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
 +- OneRowRelation
 
 
@@ -614,7 +658,7 @@ Project [(cast(a as char(2) collate UTF8_BINARY_RTRIM) = a) AS (CAST(a AS CHAR(2
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
   cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)
 -- !query analysis
-Project [(cast(a as char(4) collate UTF8_BINARY_RTRIM) = cast(a as char(4) collate UTF8_BINARY_RTRIM)) AS (a = CAST(a AS CHAR(4) COLLATE UTF8_BINARY_RTRIM))#x]
+Project [(cast(cast(a as char(2) collate UTF8_BINARY_RTRIM) as char(4) collate UTF8_BINARY_RTRIM) = cast(a as char(4) collate UTF8_BINARY_RTRIM)) AS (CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = CAST(a AS CHAR(4) COLLATE UTF8_BINARY_RTRIM))#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
@@ -342,7 +342,7 @@ Project [concat(<, coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as ch
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS VARCHAR(4) COLLATE UTF8_LCASE)))
 -- !query analysis
-Project [typeof(coalesce(cast(a as varchar(4) collate UTF8_LCASE), cast(bb as varchar(4) collate UTF8_LCASE))) AS typeof(coalesce(a, CAST(bb AS VARCHAR(4) COLLATE UTF8_LCASE)))#x]
+Project [typeof(coalesce(cast(cast(a as char(2) collate UTF8_LCASE) as varchar(4) collate UTF8_LCASE), cast(bb as varchar(4) collate UTF8_LCASE))) AS typeof(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS VARCHAR(4) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 
@@ -642,14 +642,14 @@ Project [cast(cast(a as char(2)) as varchar(4)) IN (cast(cast(a as char(4)) as v
 -- !query
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) = cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE)
 -- !query analysis
-Project [(cast(a as varchar(2) collate UTF8_LCASE) = cast(a as varchar(2) collate UTF8_LCASE)) AS (a = CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE))#x]
+Project [(cast(cast(a as char(2) collate UTF8_LCASE) as varchar(2) collate UTF8_LCASE) = cast(a as varchar(2) collate UTF8_LCASE)) AS (CAST(a AS CHAR(2) COLLATE UTF8_LCASE) = CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE))#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) IN (cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE))
 -- !query analysis
-Project [cast(a as varchar(2) collate UTF8_LCASE) IN (cast(a as varchar(2) collate UTF8_LCASE)) AS (a IN (CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE)))#x]
+Project [cast(cast(a as char(2) collate UTF8_LCASE) as varchar(2) collate UTF8_LCASE) IN (cast(a as varchar(2) collate UTF8_LCASE)) AS (CAST(a AS CHAR(2) COLLATE UTF8_LCASE) IN (CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
@@ -339,6 +339,32 @@ Project [concat(<, coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as ch
 
 
 -- !query
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS VARCHAR(4) COLLATE UTF8_LCASE)))
+-- !query analysis
+Project [typeof(coalesce(cast(a as varchar(4) collate UTF8_LCASE), cast(bb as varchar(4) collate UTF8_LCASE))) AS typeof(coalesce(a, CAST(bb AS VARCHAR(4) COLLATE UTF8_LCASE)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)))
+-- !query analysis
+Project [typeof(coalesce(cast(a as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE))) AS typeof(coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT concat('<', coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+-- !query analysis
+Project [concat(<, coalesce(cast(a as char(4) collate UTF8_LCASE), cast(1 as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT typeof(c) FROM (
   SELECT cast('a' AS VARCHAR(3)) AS c
   UNION ALL
@@ -355,6 +381,42 @@ GlobalLimit 1
             :     +- OneRowRelation
             +- Project [cast(abcd as varchar(8)) AS c#x]
                +- OneRowRelation
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION ALL
+  SELECT cast('bb' AS CHAR(4)) AS c
+) t LIMIT 1
+-- !query analysis
+GlobalLimit 1
++- LocalLimit 1
+   +- Project [typeof(c#x) AS typeof(c)#x]
+      +- SubqueryAlias t
+         +- Union false, false
+            :- Project [cast(c#x as char(4)) AS c#x]
+            :  +- Project [cast(a as char(2)) AS c#x]
+            :     +- OneRowRelation
+            +- Project [cast(bb as char(4)) AS c#x]
+               +- OneRowRelation
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION ALL
+  SELECT cast('bb' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [concat(<, cast(c#x as string), >) AS concat(<, c, >)#x]
++- SubqueryAlias t
+   +- Union false, false
+      :- Project [cast(c#x as char(4)) AS c#x]
+      :  +- Project [cast(a as char(2)) AS c#x]
+      :     +- OneRowRelation
+      +- Project [cast(bb as char(4)) AS c#x]
+         +- OneRowRelation
 
 
 -- !query
@@ -431,7 +493,7 @@ Project [concat(<, cast(c#x as string), >) AS concat(<, c, >)#x]
 SELECT typeof(c) FROM (
   SELECT cast('ab' AS CHAR(2)) AS c
   EXCEPT
-  SELECT cast('ab' AS CHAR(4)) AS c
+  SELECT cast('xy' AS CHAR(4)) AS c
 ) t
 -- !query analysis
 Project [typeof(c#x) AS typeof(c)#x]
@@ -440,7 +502,24 @@ Project [typeof(c#x) AS typeof(c)#x]
       :- Project [cast(c#x as char(4)) AS c#x]
       :  +- Project [cast(ab as char(2)) AS c#x]
       :     +- OneRowRelation
-      +- Project [cast(ab as char(4)) AS c#x]
+      +- Project [cast(xy as char(4)) AS c#x]
+         +- OneRowRelation
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  EXCEPT
+  SELECT cast('xy' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [concat(<, cast(c#x as string), >) AS concat(<, c, >)#x]
++- SubqueryAlias t
+   +- Except false
+      :- Project [cast(c#x as char(4)) AS c#x]
+      :  +- Project [cast(ab as char(2)) AS c#x]
+      :     +- OneRowRelation
+      +- Project [cast(xy as char(4)) AS c#x]
          +- OneRowRelation
 
 
@@ -550,6 +629,27 @@ Project [cast(cast(a as char(2)) as string collate UTF8_BINARY) IN (cast(a as st
 SELECT cast('a' AS CHAR(2)) IN ('a ', 'b')
 -- !query analysis
 Project [cast(cast(a as char(2)) as string collate UTF8_BINARY) IN (cast(a  as string collate UTF8_BINARY),cast(b as string collate UTF8_BINARY)) AS (CAST(a AS CHAR(2)) IN (a , b))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)))
+-- !query analysis
+Project [cast(cast(a as char(2)) as varchar(4)) IN (cast(cast(a as char(4)) as varchar(4)),cast(cast(b as varchar(3)) as varchar(4))) AS (CAST(a AS CHAR(2)) IN (CAST(a AS CHAR(4)), CAST(b AS VARCHAR(3))))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) = cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE)
+-- !query analysis
+Project [(cast(a as varchar(2) collate UTF8_LCASE) = cast(a as varchar(2) collate UTF8_LCASE)) AS (a = CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) IN (cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE))
+-- !query analysis
+Project [cast(a as varchar(2) collate UTF8_LCASE) IN (cast(a as varchar(2) collate UTF8_LCASE)) AS (a IN (CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE)))#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar-standard-semantics.sql.out
@@ -323,6 +323,22 @@ Project [typeof(coalesce(cast(a as char(2) collate UTF8_LCASE), cast(bb as char(
 
 
 -- !query
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)))
+-- !query analysis
+Project [typeof(coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE))) AS typeof(coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT concat('<', coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+-- !query analysis
+Project [concat(<, coalesce(cast(a as char(4) collate UTF8_LCASE), cast(bb as char(4) collate UTF8_LCASE)), >) AS concat('<' collate UTF8_LCASE, coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT typeof(c) FROM (
   SELECT cast('a' AS VARCHAR(3)) AS c
   UNION ALL
@@ -339,6 +355,202 @@ GlobalLimit 1
             :     +- OneRowRelation
             +- Project [cast(abcd as varchar(8)) AS c#x]
                +- OneRowRelation
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION
+  SELECT cast('a' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [typeof(c#x) AS typeof(c)#x]
++- SubqueryAlias t
+   +- Distinct
+      +- Union false, false
+         :- Project [cast(c#x as char(4)) AS c#x]
+         :  +- Project [cast(a as char(2)) AS c#x]
+         :     +- OneRowRelation
+         +- Project [cast(a as char(4)) AS c#x]
+            +- OneRowRelation
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION
+  SELECT cast('a' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [concat(<, cast(c#x as string), >) AS concat(<, c, >)#x]
++- SubqueryAlias t
+   +- Distinct
+      +- Union false, false
+         :- Project [cast(c#x as char(4)) AS c#x]
+         :  +- Project [cast(a as char(2)) AS c#x]
+         :     +- OneRowRelation
+         +- Project [cast(a as char(4)) AS c#x]
+            +- OneRowRelation
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  INTERSECT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [typeof(c#x) AS typeof(c)#x]
++- SubqueryAlias t
+   +- Intersect false
+      :- Project [cast(c#x as char(4)) AS c#x]
+      :  +- Project [cast(ab as char(2)) AS c#x]
+      :     +- OneRowRelation
+      +- Project [cast(ab as char(4)) AS c#x]
+         +- OneRowRelation
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  INTERSECT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [concat(<, cast(c#x as string), >) AS concat(<, c, >)#x]
++- SubqueryAlias t
+   +- Intersect false
+      :- Project [cast(c#x as char(4)) AS c#x]
+      :  +- Project [cast(ab as char(2)) AS c#x]
+      :     +- OneRowRelation
+      +- Project [cast(ab as char(4)) AS c#x]
+         +- OneRowRelation
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  EXCEPT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t
+-- !query analysis
+Project [typeof(c#x) AS typeof(c)#x]
++- SubqueryAlias t
+   +- Except false
+      :- Project [cast(c#x as char(4)) AS c#x]
+      :  +- Project [cast(ab as char(2)) AS c#x]
+      :     +- OneRowRelation
+      +- Project [cast(ab as char(4)) AS c#x]
+         +- OneRowRelation
+
+
+-- !query
+SELECT typeof(c) FROM (VALUES
+  (cast('a' AS CHAR(2))),
+  (cast('bb' AS CHAR(4)))
+) t(c)
+-- !query analysis
+Project [typeof(c#x) AS typeof(c)#x]
++- SubqueryAlias t
+   +- Project [col1#x AS c#x]
+      +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (VALUES
+  (cast('a' AS CHAR(2))),
+  (cast('bb' AS CHAR(4)))
+) t(c)
+-- !query analysis
+Project [concat(<, cast(c#x as string), >) AS concat(<, c, >)#x]
++- SubqueryAlias t
+   +- Project [col1#x AS c#x]
+      +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = cast('a' AS CHAR(4))
+-- !query analysis
+Project [(cast(cast(a as char(2)) as char(4)) = cast(a as char(4))) AS (CAST(a AS CHAR(2)) = CAST(a AS CHAR(4)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = cast('a' AS VARCHAR(2))
+-- !query analysis
+Project [(cast(cast(a as char(2)) as varchar(2)) = cast(a as varchar(2))) AS (CAST(a AS CHAR(2)) = CAST(a AS VARCHAR(2)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = cast('a ' AS VARCHAR(2))
+-- !query analysis
+Project [(cast(cast(a as char(2)) as varchar(2)) = cast(a  as varchar(2))) AS (CAST(a AS CHAR(2)) = CAST(a  AS VARCHAR(2)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = 'a'
+-- !query analysis
+Project [(cast(cast(a as char(2)) as string collate UTF8_BINARY) = a) AS (CAST(a AS CHAR(2)) = a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = 'a '
+-- !query analysis
+Project [(cast(cast(a as char(2)) as string collate UTF8_BINARY) = a ) AS (CAST(a AS CHAR(2)) = a )#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a'
+-- !query analysis
+Project [(cast(a as char(2) collate UTF8_BINARY_RTRIM) = a) AS (CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a' collate UTF8_BINARY_RTRIM)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
+  cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)
+-- !query analysis
+Project [(cast(a as char(4) collate UTF8_BINARY_RTRIM) = cast(a as char(4) collate UTF8_BINARY_RTRIM)) AS (a = CAST(a AS CHAR(4) COLLATE UTF8_BINARY_RTRIM))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)))
+-- !query analysis
+Project [cast(cast(a as char(2)) as char(4)) IN (cast(cast(a as char(4)) as char(4))) AS (CAST(a AS CHAR(2)) IN (CAST(a AS CHAR(4))))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS VARCHAR(2)))
+-- !query analysis
+Project [cast(cast(a as char(2)) as varchar(2)) IN (cast(cast(a as varchar(2)) as varchar(2))) AS (CAST(a AS CHAR(2)) IN (CAST(a AS VARCHAR(2))))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a ' AS VARCHAR(2)))
+-- !query analysis
+Project [cast(cast(a as char(2)) as varchar(2)) IN (cast(cast(a  as varchar(2)) as varchar(2))) AS (CAST(a AS CHAR(2)) IN (CAST(a  AS VARCHAR(2))))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN ('a', 'b')
+-- !query analysis
+Project [cast(cast(a as char(2)) as string collate UTF8_BINARY) IN (cast(a as string collate UTF8_BINARY),cast(b as string collate UTF8_BINARY)) AS (CAST(a AS CHAR(2)) IN (a, b))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN ('a ', 'b')
+-- !query analysis
+Project [cast(cast(a as char(2)) as string collate UTF8_BINARY) IN (cast(a  as string collate UTF8_BINARY),cast(b as string collate UTF8_BINARY)) AS (CAST(a AS CHAR(2)) IN (a , b))#x]
++- OneRowRelation
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -66,22 +66,74 @@ SELECT typeof(reverse(array(1, 2)));
 SELECT typeof(str_to_map(cast('a:1,b:2' AS CHAR(7))));
 SELECT typeof(c0) FROM (SELECT json_tuple(cast('{"a":"1"}' AS CHAR(9)), 'a') AS c0);
 
--- R2 with collation. A declared collation survives the CAST and an LCT over equally constrained
--- operands. The mixed-length case (CHAR(2) with CHAR(4), same collation) is deliberately not
--- covered here: CollationTypeCoercion reads the differing lengths as a collation mismatch and
--- yields an indeterminate collation. That predates this change (it reproduces under
--- spark.sql.preserveCharVarcharTypeInfo) and is tracked separately, so goldening it would
--- normalize the bug.
+-- Collation survives CAST and LCT. Mixed lengths with the same collation widen to max(n, m);
+-- they must not collapse to an indeterminate collation.
 SELECT typeof(cast('a' AS CHAR(2) COLLATE UTF8_LCASE));
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(2) COLLATE UTF8_LCASE)));
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)));
+SELECT concat('<', coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>');
 
--- UNION LCT
+-- Set operations and multi-row VALUES share the same LCT as COALESCE.
 SELECT typeof(c) FROM (
   SELECT cast('a' AS VARCHAR(3)) AS c
   UNION ALL
   SELECT cast('abcd' AS VARCHAR(8)) AS c
 ) t LIMIT 1;
+SELECT typeof(c) FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION
+  SELECT cast('a' AS CHAR(4)) AS c
+) t;
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION
+  SELECT cast('a' AS CHAR(4)) AS c
+) t;
+SELECT typeof(c) FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  INTERSECT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t;
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  INTERSECT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t;
+SELECT typeof(c) FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  EXCEPT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t;
+SELECT typeof(c) FROM (VALUES
+  (cast('a' AS CHAR(2))),
+  (cast('bb' AS CHAR(4)))
+) t(c);
+SELECT concat('<', c, '>') FROM (VALUES
+  (cast('a' AS CHAR(2))),
+  (cast('bb' AS CHAR(4)))
+) t(c);
+
+-- Comparison and IN: both sides (including the IN left-hand side) are cast to the LCT of all
+-- participants. Casting to CHAR pads, so CHAR vs CHAR of different lengths compares equal after
+-- widen; casting to VARCHAR/STRING keeps the CHAR pad, so CHAR 'a' (stored as 'a ') is not equal
+-- to VARCHAR/STRING 'a' unless the other side carries the same trailing blank. Trailing-blank
+-- ignoring is a collation concern (RTRIM), not a type-level PAD SPACE policy.
+SELECT cast('a' AS CHAR(2)) = cast('a' AS CHAR(4));
+SELECT cast('a' AS CHAR(2)) = cast('a' AS VARCHAR(2));
+SELECT cast('a' AS CHAR(2)) = cast('a ' AS VARCHAR(2));
+SELECT cast('a' AS CHAR(2)) = 'a';
+SELECT cast('a' AS CHAR(2)) = 'a ';
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a';
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
+  cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM);
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)));
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS VARCHAR(2)));
+SELECT cast('a' AS CHAR(2)) IN (cast('a ' AS VARCHAR(2)));
+SELECT cast('a' AS CHAR(2)) IN ('a', 'b');
+SELECT cast('a' AS CHAR(2)) IN ('a ', 'b');
 
 -- Nested types keep CHAR/VARCHAR
 SELECT typeof(array(cast('a' AS CHAR(2)), cast('bb' AS CHAR(3))));

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -158,7 +158,7 @@ SELECT concat('<', c, '>') FROM (VALUES
 
 -- Comparison and IN: both sides (including the IN left-hand side) are cast to the LCT of all
 -- participants. Casting to CHAR pads, so CHAR vs CHAR of different lengths compares equal after
--- widen; casting to VARCHAR/STRING keeps the CHAR pad, so CHAR 'a' (stored as 'a ') is not equal
+-- widening; casting to VARCHAR/STRING keeps the CHAR pad, so CHAR 'a' (stored as 'a ') is not equal
 -- to VARCHAR/STRING 'a' unless the other side carries the same trailing blank. Trailing-blank
 -- ignoring is a collation concern (RTRIM), not a type-level PAD SPACE policy.
 SELECT cast('a' AS CHAR(2)) = cast('a' AS CHAR(4));

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -75,6 +75,17 @@ SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)));
 SELECT concat('<', coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>');
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS VARCHAR(4) COLLATE UTF8_LCASE)));
+-- Mixed strength, same collation: Implicit string CAST CHAR(2) vs Default
+-- non-string CAST CHAR(4). Length still widens to max(n, m); the COLLATE
+-- operator itself is STRING, so it is not used here.
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)));
+SELECT concat('<', coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>');
 
 -- Set operations and multi-row VALUES share the same LCT as COALESCE.
 SELECT typeof(c) FROM (
@@ -84,6 +95,16 @@ SELECT typeof(c) FROM (
 ) t LIMIT 1;
 SELECT typeof(c) FROM (
   SELECT cast('a' AS CHAR(2)) AS c
+  UNION ALL
+  SELECT cast('bb' AS CHAR(4)) AS c
+) t LIMIT 1;
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION ALL
+  SELECT cast('bb' AS CHAR(4)) AS c
+) t;
+SELECT typeof(c) FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
   UNION
   SELECT cast('a' AS CHAR(4)) AS c
 ) t;
@@ -102,10 +123,16 @@ SELECT concat('<', c, '>') FROM (
   INTERSECT
   SELECT cast('ab' AS CHAR(4)) AS c
 ) t;
+-- Non-empty EXCEPT: after widen, 'ab  ' is not 'xy  '.
 SELECT typeof(c) FROM (
   SELECT cast('ab' AS CHAR(2)) AS c
   EXCEPT
-  SELECT cast('ab' AS CHAR(4)) AS c
+  SELECT cast('xy' AS CHAR(4)) AS c
+) t;
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  EXCEPT
+  SELECT cast('xy' AS CHAR(4)) AS c
 ) t;
 SELECT typeof(c) FROM (VALUES
   (cast('a' AS CHAR(2))),
@@ -134,6 +161,10 @@ SELECT cast('a' AS CHAR(2)) IN (cast('a' AS VARCHAR(2)));
 SELECT cast('a' AS CHAR(2)) IN (cast('a ' AS VARCHAR(2)));
 SELECT cast('a' AS CHAR(2)) IN ('a', 'b');
 SELECT cast('a' AS CHAR(2)) IN ('a ', 'b');
+-- Three-part IN: LHS CHAR(2) and list CHAR(4)/VARCHAR(3) all widen to VARCHAR(4).
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)));
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) = cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE);
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) IN (cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE));
 
 -- Nested types keep CHAR/VARCHAR
 SELECT typeof(array(cast('a' AS CHAR(2)), cast('bb' AS CHAR(3))));

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -136,7 +136,7 @@ SELECT concat('<', c, '>') FROM (
   INTERSECT
   SELECT cast('ab' AS CHAR(4)) AS c
 ) t;
--- Non-empty EXCEPT: after widen, 'ab  ' is not 'xy  '.
+-- Non-empty EXCEPT: after widening, 'ab  ' is not 'xy  '.
 SELECT typeof(c) FROM (
   SELECT cast('ab' AS CHAR(2)) AS c
   EXCEPT

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -15,6 +15,16 @@ SELECT CAST(12345 AS VARCHAR(4));
 SELECT CAST(12345 AS VARCHAR(5));
 SELECT try_cast(12345 AS VARCHAR(4));
 
+-- Explicit CAST inside LCT must keep inner truncation / overflow (do not retarget).
+SELECT coalesce(CAST('abcdef' AS VARCHAR(2)), CAST('x' AS VARCHAR(4)));
+SELECT CASE WHEN true THEN CAST('abcdef' AS VARCHAR(2)) ELSE CAST('x' AS VARCHAR(4)) END;
+SELECT CAST('abcdef' AS VARCHAR(2)) IN (CAST('ab' AS VARCHAR(4)));
+SELECT coalesce(
+  CAST('abcdef' AS VARCHAR(2) COLLATE UTF8_LCASE),
+  CAST('x' AS VARCHAR(4) COLLATE UTF8_LCASE));
+SELECT coalesce(try_cast(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)));
+SELECT coalesce(CAST(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)));
+
 -- R2: least common type (COALESCE / CASE)
 SELECT typeof(coalesce(cast('hello' AS VARCHAR(5)), cast('world' AS VARCHAR(10))));
 SELECT typeof(coalesce(cast('hello' AS VARCHAR(5)), cast('world!' AS CHAR(6))));

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -86,8 +86,8 @@ SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(2) COLLATE UTF8_LCASE)));
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)));
-SELECT concat('<', coalesce(
-  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>');
+SELECT hex(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)));
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS VARCHAR(4) COLLATE UTF8_LCASE)));
 -- Mixed strength, same collation: Implicit string CAST CHAR(2) vs Default
@@ -96,9 +96,9 @@ SELECT typeof(coalesce(
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
   cast(1 AS CHAR(4) COLLATE UTF8_LCASE)));
-SELECT concat('<', coalesce(
+SELECT hex(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
-  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>');
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)));
 
 -- Set operations and multi-row VALUES share the same LCT as COALESCE.
 SELECT typeof(c) FROM (

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -5,12 +5,15 @@ SELECT typeof(CAST('ab' AS CHAR(5)));
 SELECT typeof(CAST('hello' AS VARCHAR(5)));
 SELECT 'X' || CAST('5' AS CHAR(5)) || 'X';
 
--- CAST length enforcement: trailing spaces are trimmed, real overflow errors
+-- CAST length: character-to-character truncates (ISO 6.13); numeric overflow errors
 SELECT CAST('ab   ' AS CHAR(2));
 SELECT CAST('abcdef' AS CHAR(2));
 SELECT CAST('abcdef' AS VARCHAR(2));
 SELECT try_cast('abcdef' AS CHAR(2));
 SELECT try_cast('abcdef' AS VARCHAR(2));
+SELECT CAST(12345 AS VARCHAR(4));
+SELECT CAST(12345 AS VARCHAR(5));
+SELECT try_cast(12345 AS VARCHAR(4));
 
 -- R2: least common type (COALESCE / CASE)
 SELECT typeof(coalesce(cast('hello' AS VARCHAR(5)), cast('world' AS VARCHAR(10))));

--- a/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/charvarchar-standard-semantics.sql
@@ -163,6 +163,9 @@ SELECT cast('a' AS CHAR(2)) IN ('a', 'b');
 SELECT cast('a' AS CHAR(2)) IN ('a ', 'b');
 -- Three-part IN: LHS CHAR(2) and list CHAR(4)/VARCHAR(3) all widen to VARCHAR(4).
 SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)));
+-- Same CHAR-pad rule under a non-RTRIM collation: UTF8_LCASE must not make
+-- CHAR 'a' equal VARCHAR 'a'. The analyzer must nest CHAR then VARCHAR, not
+-- retarget CAST('a' AS CHAR(2) COLLATE UTF8_LCASE) to VARCHAR(2).
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) = cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE);
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) IN (cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE));
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
@@ -376,6 +376,24 @@ char(2) collate UTF8_LCASE
 
 
 -- !query
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)))
+-- !query schema
+struct<typeof(coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE))):string>
+-- !query output
+char(4) collate UTF8_LCASE
+
+
+-- !query
+SELECT concat('<', coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+-- !query schema
+struct<concat('<' collate UTF8_LCASE, coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
+-- !query output
+<a   >
+
+
+-- !query
 SELECT typeof(c) FROM (
   SELECT cast('a' AS VARCHAR(3)) AS c
   UNION ALL
@@ -385,6 +403,187 @@ SELECT typeof(c) FROM (
 struct<typeof(c):string>
 -- !query output
 varchar(8)
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION
+  SELECT cast('a' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<typeof(c):string>
+-- !query output
+char(4)
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION
+  SELECT cast('a' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<concat(<, c, >):string>
+-- !query output
+<a   >
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  INTERSECT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<typeof(c):string>
+-- !query output
+char(4)
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  INTERSECT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<concat(<, c, >):string>
+-- !query output
+<ab  >
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  EXCEPT
+  SELECT cast('ab' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<typeof(c):string>
+-- !query output
+
+
+
+-- !query
+SELECT typeof(c) FROM (VALUES
+  (cast('a' AS CHAR(2))),
+  (cast('bb' AS CHAR(4)))
+) t(c)
+-- !query schema
+struct<typeof(c):string>
+-- !query output
+char(4)
+char(4)
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (VALUES
+  (cast('a' AS CHAR(2))),
+  (cast('bb' AS CHAR(4)))
+) t(c)
+-- !query schema
+struct<concat(<, c, >):string>
+-- !query output
+<a   >
+<bb  >
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = cast('a' AS CHAR(4))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) = CAST(a AS CHAR(4))):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = cast('a' AS VARCHAR(2))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) = CAST(a AS VARCHAR(2))):boolean>
+-- !query output
+false
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = cast('a ' AS VARCHAR(2))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) = CAST(a  AS VARCHAR(2))):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = 'a'
+-- !query schema
+struct<(CAST(a AS CHAR(2)) = a):boolean>
+-- !query output
+false
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) = 'a '
+-- !query schema
+struct<(CAST(a AS CHAR(2)) = a ):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a'
+-- !query schema
+struct<(CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a' collate UTF8_BINARY_RTRIM):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
+  cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)
+-- !query schema
+struct<(a = CAST(a AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) IN (CAST(a AS CHAR(4)))):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS VARCHAR(2)))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) IN (CAST(a AS VARCHAR(2)))):boolean>
+-- !query output
+false
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a ' AS VARCHAR(2)))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) IN (CAST(a  AS VARCHAR(2)))):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN ('a', 'b')
+-- !query schema
+struct<(CAST(a AS CHAR(2)) IN (a, b)):boolean>
+-- !query output
+false
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN ('a ', 'b')
+-- !query schema
+struct<(CAST(a AS CHAR(2)) IN (a , b)):boolean>
+-- !query output
+true
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
@@ -394,6 +394,35 @@ struct<concat('<' collate UTF8_LCASE, coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF
 
 
 -- !query
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS VARCHAR(4) COLLATE UTF8_LCASE)))
+-- !query schema
+struct<typeof(coalesce(a, CAST(bb AS VARCHAR(4) COLLATE UTF8_LCASE))):string>
+-- !query output
+varchar(4) collate UTF8_LCASE
+
+
+-- !query
+SELECT typeof(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)))
+-- !query schema
+struct<typeof(coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE))):string>
+-- !query output
+char(4) collate UTF8_LCASE
+
+
+-- !query
+SELECT concat('<', coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+-- !query schema
+struct<concat('<' collate UTF8_LCASE, coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
+-- !query output
+<a   >
+
+
+-- !query
 SELECT typeof(c) FROM (
   SELECT cast('a' AS VARCHAR(3)) AS c
   UNION ALL
@@ -403,6 +432,31 @@ SELECT typeof(c) FROM (
 struct<typeof(c):string>
 -- !query output
 varchar(8)
+
+
+-- !query
+SELECT typeof(c) FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION ALL
+  SELECT cast('bb' AS CHAR(4)) AS c
+) t LIMIT 1
+-- !query schema
+struct<typeof(c):string>
+-- !query output
+char(4)
+
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('a' AS CHAR(2)) AS c
+  UNION ALL
+  SELECT cast('bb' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<concat(<, c, >):string>
+-- !query output
+<a   >
+<bb  >
 
 
 -- !query
@@ -457,12 +511,24 @@ struct<concat(<, c, >):string>
 SELECT typeof(c) FROM (
   SELECT cast('ab' AS CHAR(2)) AS c
   EXCEPT
-  SELECT cast('ab' AS CHAR(4)) AS c
+  SELECT cast('xy' AS CHAR(4)) AS c
 ) t
 -- !query schema
 struct<typeof(c):string>
 -- !query output
+char(4)
 
+
+-- !query
+SELECT concat('<', c, '>') FROM (
+  SELECT cast('ab' AS CHAR(2)) AS c
+  EXCEPT
+  SELECT cast('xy' AS CHAR(4)) AS c
+) t
+-- !query schema
+struct<concat(<, c, >):string>
+-- !query output
+<ab  >
 
 
 -- !query
@@ -582,6 +648,30 @@ false
 SELECT cast('a' AS CHAR(2)) IN ('a ', 'b')
 -- !query schema
 struct<(CAST(a AS CHAR(2)) IN (a , b)):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)))
+-- !query schema
+struct<(CAST(a AS CHAR(2)) IN (CAST(a AS CHAR(4)), CAST(b AS VARCHAR(3)))):boolean>
+-- !query output
+false
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) = cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE)
+-- !query schema
+struct<(a = CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE)):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) IN (cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE))
+-- !query schema
+struct<(a IN (CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE))):boolean>
 -- !query output
 true
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
@@ -95,6 +95,63 @@ NULL
 
 
 -- !query
+SELECT coalesce(CAST('abcdef' AS VARCHAR(2)), CAST('x' AS VARCHAR(4)))
+-- !query schema
+struct<coalesce(CAST(abcdef AS VARCHAR(2)), CAST(x AS VARCHAR(4))):varchar(4)>
+-- !query output
+ab
+
+
+-- !query
+SELECT CASE WHEN true THEN CAST('abcdef' AS VARCHAR(2)) ELSE CAST('x' AS VARCHAR(4)) END
+-- !query schema
+struct<CASE WHEN true THEN CAST(abcdef AS VARCHAR(2)) ELSE CAST(x AS VARCHAR(4)) END:varchar(4)>
+-- !query output
+ab
+
+
+-- !query
+SELECT CAST('abcdef' AS VARCHAR(2)) IN (CAST('ab' AS VARCHAR(4)))
+-- !query schema
+struct<(CAST(abcdef AS VARCHAR(2)) IN (CAST(ab AS VARCHAR(4)))):boolean>
+-- !query output
+true
+
+
+-- !query
+SELECT coalesce(
+  CAST('abcdef' AS VARCHAR(2) COLLATE UTF8_LCASE),
+  CAST('x' AS VARCHAR(4) COLLATE UTF8_LCASE))
+-- !query schema
+struct<coalesce(CAST(abcdef AS VARCHAR(2) COLLATE UTF8_LCASE), CAST(x AS VARCHAR(4) COLLATE UTF8_LCASE)):varchar(4) collate UTF8_LCASE>
+-- !query output
+ab
+
+
+-- !query
+SELECT coalesce(try_cast(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)))
+-- !query schema
+struct<coalesce(TRY_CAST(12345 AS VARCHAR(4)), CAST(x AS VARCHAR(5))):varchar(5)>
+-- !query output
+x
+
+
+-- !query
+SELECT coalesce(CAST(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)))
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "EXCEED_LIMIT_LENGTH",
+  "sqlState" : "54006",
+  "messageParameters" : {
+    "limit" : "4"
+  }
+}
+
+
+-- !query
 SELECT typeof(coalesce(cast('hello' AS VARCHAR(5)), cast('world' AS VARCHAR(10))))
 -- !query schema
 struct<typeof(coalesce(CAST(hello AS VARCHAR(5)), CAST(world AS VARCHAR(10)))):string>
@@ -396,7 +453,7 @@ char(2) collate UTF8_LCASE
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query schema
-struct<typeof(coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE))):string>
+struct<typeof(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE))):string>
 -- !query output
 char(4) collate UTF8_LCASE
 
@@ -405,7 +462,7 @@ char(4) collate UTF8_LCASE
 SELECT concat('<', coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>')
 -- !query schema
-struct<concat('<' collate UTF8_LCASE, coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
+struct<concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
 -- !query output
 <a   >
 
@@ -424,7 +481,7 @@ SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
   cast(1 AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query schema
-struct<typeof(coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE))):string>
+struct<typeof(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE))):string>
 -- !query output
 char(4) collate UTF8_LCASE
 
@@ -434,7 +491,7 @@ SELECT concat('<', coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
   cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>')
 -- !query schema
-struct<concat('<' collate UTF8_LCASE, coalesce(a, CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
+struct<concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
 -- !query output
 <a   >
 
@@ -624,7 +681,7 @@ true
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
   cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)
 -- !query schema
-struct<(a = CAST(a AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)):boolean>
+struct<(CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = CAST(a AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)):boolean>
 -- !query output
 true
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
@@ -459,12 +459,12 @@ char(4) collate UTF8_LCASE
 
 
 -- !query
-SELECT concat('<', coalesce(
-  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+SELECT hex(coalesce(
+  cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query schema
-struct<concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
+struct<hex(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS CHAR(4) COLLATE UTF8_LCASE))):string collate UTF8_LCASE>
 -- !query output
-<a   >
+61202020
 
 
 -- !query
@@ -487,13 +487,13 @@ char(4) collate UTF8_LCASE
 
 
 -- !query
-SELECT concat('<', coalesce(
+SELECT hex(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
-  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>')
+  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)))
 -- !query schema
-struct<concat('<' collate UTF8_LCASE, coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)), '>' collate UTF8_LCASE):string collate UTF8_LCASE>
+struct<hex(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(1 AS CHAR(4) COLLATE UTF8_LCASE))):string collate UTF8_LCASE>
 -- !query output
-<a   >
+61202020
 
 
 -- !query
@@ -672,7 +672,7 @@ true
 -- !query
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a'
 -- !query schema
-struct<(CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a' collate UTF8_BINARY_RTRIM):boolean>
+struct<(CAST(a AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = a):boolean>
 -- !query output
 true
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
@@ -34,31 +34,17 @@ ab
 -- !query
 SELECT CAST('abcdef' AS CHAR(2))
 -- !query schema
-struct<>
+struct<CAST(abcdef AS CHAR(2)):char(2)>
 -- !query output
-org.apache.spark.SparkRuntimeException
-{
-  "errorClass" : "EXCEED_LIMIT_LENGTH",
-  "sqlState" : "54006",
-  "messageParameters" : {
-    "limit" : "2"
-  }
-}
+ab
 
 
 -- !query
 SELECT CAST('abcdef' AS VARCHAR(2))
 -- !query schema
-struct<>
+struct<CAST(abcdef AS VARCHAR(2)):varchar(2)>
 -- !query output
-org.apache.spark.SparkRuntimeException
-{
-  "errorClass" : "EXCEED_LIMIT_LENGTH",
-  "sqlState" : "54006",
-  "messageParameters" : {
-    "limit" : "2"
-  }
-}
+ab
 
 
 -- !query
@@ -66,13 +52,44 @@ SELECT try_cast('abcdef' AS CHAR(2))
 -- !query schema
 struct<TRY_CAST(abcdef AS CHAR(2)):char(2)>
 -- !query output
-NULL
+ab
 
 
 -- !query
 SELECT try_cast('abcdef' AS VARCHAR(2))
 -- !query schema
 struct<TRY_CAST(abcdef AS VARCHAR(2)):varchar(2)>
+-- !query output
+ab
+
+
+-- !query
+SELECT CAST(12345 AS VARCHAR(4))
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "EXCEED_LIMIT_LENGTH",
+  "sqlState" : "54006",
+  "messageParameters" : {
+    "limit" : "4"
+  }
+}
+
+
+-- !query
+SELECT CAST(12345 AS VARCHAR(5))
+-- !query schema
+struct<CAST(12345 AS VARCHAR(5)):varchar(5)>
+-- !query output
+12345
+
+
+-- !query
+SELECT try_cast(12345 AS VARCHAR(4))
+-- !query schema
+struct<TRY_CAST(12345 AS VARCHAR(4)):varchar(4)>
 -- !query output
 NULL
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar-standard-semantics.sql.out
@@ -397,7 +397,7 @@ struct<concat('<' collate UTF8_LCASE, coalesce(a, CAST(bb AS CHAR(4) COLLATE UTF
 SELECT typeof(coalesce(
   cast('a' AS CHAR(2) COLLATE UTF8_LCASE), cast('bb' AS VARCHAR(4) COLLATE UTF8_LCASE)))
 -- !query schema
-struct<typeof(coalesce(a, CAST(bb AS VARCHAR(4) COLLATE UTF8_LCASE))):string>
+struct<typeof(coalesce(CAST(a AS CHAR(2) COLLATE UTF8_LCASE), CAST(bb AS VARCHAR(4) COLLATE UTF8_LCASE))):string>
 -- !query output
 varchar(4) collate UTF8_LCASE
 
@@ -663,17 +663,17 @@ false
 -- !query
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) = cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE)
 -- !query schema
-struct<(a = CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE)):boolean>
+struct<(CAST(a AS CHAR(2) COLLATE UTF8_LCASE) = CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE)):boolean>
 -- !query output
-true
+false
 
 
 -- !query
 SELECT cast('a' AS CHAR(2) COLLATE UTF8_LCASE) IN (cast('a' AS VARCHAR(2) COLLATE UTF8_LCASE))
 -- !query schema
-struct<(a IN (CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE))):boolean>
+struct<(CAST(a AS CHAR(2) COLLATE UTF8_LCASE) IN (CAST(a AS VARCHAR(2) COLLATE UTF8_LCASE))):boolean>
 -- !query output
-true
+false
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.{Attribute, EqualTo, GreaterThan, ScalarSubquery, StringRPad}
 import org.apache.spark.sql.catalyst.expressions.Cast.toSQLId
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Project}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.SchemaRequiredDataSource
@@ -1265,6 +1265,41 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       assert(sql(
         """SELECT c FROM (VALUES (cast('a' AS CHAR(2))), (cast('bb' AS CHAR(4)))) t(c)""")
         .schema.head.dataType === CharType(4))
+    }
+  }
+
+  test("SPARK-58794: parameterized CHAR/VARCHAR lengths under standardSemantics") {
+    // Length positions accept parameter markers (`integerValue` -> `parameterMarker`). Under
+    // standardSemantics the bound type stays first-class: CAST keeps CHAR/VARCHAR, pads and
+    // enforces length, and DDL schemas retain the substituted n.
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val charDf = spark.sql("SELECT cast('ab' AS CHAR(:n)) AS c", Map("n" -> 5))
+      assert(charDf.schema.head.dataType === CharType(5))
+      checkAnswer(
+        spark.sql("SELECT concat('<', cast('ab' AS CHAR(:n)), '>')", Map("n" -> 5)),
+        Row("<ab   >"))
+
+      val varcharDf = spark.sql("SELECT cast('hello' AS VARCHAR(?)) AS c", Array(5))
+      assert(varcharDf.schema.head.dataType === VarcharType(5))
+      intercept[SparkRuntimeException] {
+        spark.sql("SELECT cast('abcdef' AS VARCHAR(?))", Array(2)).collect()
+      }
+
+      withTable("param_varchar", "param_char") {
+        spark.sql(
+          "CREATE TABLE param_varchar (c VARCHAR(:n)) USING parquet", Map("n" -> 7))
+        assert(spark.table("param_varchar").schema.head.dataType === VarcharType(7))
+        spark.sql("CREATE TABLE param_char (c CHAR(?)) USING parquet", Array(4))
+        assert(spark.table("param_char").schema.head.dataType === CharType(4))
+      }
+
+      // Non-integral / negative lengths fail when substituted into the length position.
+      intercept[ParseException] {
+        spark.sql("SELECT cast('a' AS CHAR(:n))", Map("n" -> -1)).collect()
+      }
+      intercept[ParseException] {
+        spark.sql("SELECT cast('a' AS CHAR(:n))", Map("n" -> 1.5)).collect()
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -21,7 +21,7 @@ import scala.util.Try
 
 import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.expressions.{Attribute, EqualTo, GreaterThan, ScalarSubquery, StringRPad}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, EqualTo, GreaterThan, Literal, ScalarSubquery, StringRPad}
 import org.apache.spark.sql.catalyst.expressions.Cast.toSQLId
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Project}
@@ -1275,6 +1275,20 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         assert(sql(mixedStrength).schema.head.dataType === CharType(4, "UTF8_LCASE"),
           s"$key=$value Implicit CHAR(2) vs Default CHAR(4) must widen, not narrow")
       }
+    }
+  }
+
+  test("SPARK-58794: typed CHAR Literal is re-padded when LCT widens the length") {
+    // CollationTypeCoercion.changeType used to `copy(dataType)` on Literal, which would
+    // leave CHAR(2) "a " as a CHAR(4) value without the extra pad. SQL CAST is a Cast
+    // node so goldens do not cover this; Literal.create does.
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val c2 = Column(Literal.create("a", CharType(2, "UTF8_LCASE")))
+      val c4 = Column(Literal.create("bb", CharType(4, "UTF8_LCASE")))
+      val coalesced = functions.coalesce(c2, c4)
+      val df = spark.range(1).select(coalesced.as("c"))
+      assert(df.schema.head.dataType === CharType(4, "UTF8_LCASE"))
+      checkAnswer(df, Row("a   "))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -891,6 +891,57 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       )
       checkAnswer(sql("SELECT CAST(12345 AS VARCHAR(5)) AS v"), Row("12345"))
       checkAnswer(sql("SELECT try_cast(12345 AS VARCHAR(4)) AS v"), Row(null))
+
+      // LCT must wrap the inner CAST, not retarget it (truncation / overflow stay).
+      checkAnswer(
+        sql("SELECT coalesce(CAST('abcdef' AS VARCHAR(2)), CAST('x' AS VARCHAR(4))) AS c"),
+        Row("ab"))
+      checkAnswer(
+        sql("""SELECT CASE WHEN true THEN CAST('abcdef' AS VARCHAR(2))
+          |ELSE CAST('x' AS VARCHAR(4)) END AS c""".stripMargin),
+        Row("ab"))
+      checkAnswer(
+        sql("SELECT CAST('abcdef' AS VARCHAR(2)) IN (CAST('ab' AS VARCHAR(4)))"),
+        Row(true))
+      checkAnswer(
+        sql("""SELECT coalesce(
+          |  CAST('abcdef' AS VARCHAR(2) COLLATE UTF8_LCASE),
+          |  CAST('x' AS VARCHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin),
+        Row("ab"))
+      checkAnswer(
+        sql("SELECT coalesce(try_cast(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5))) AS c"),
+        Row("x"))
+      checkError(
+        exception = intercept[SparkRuntimeException] {
+          sql("SELECT coalesce(CAST(12345 AS VARCHAR(4)), CAST('x' AS VARCHAR(5)))").collect()
+        },
+        condition = "EXCEED_LIMIT_LENGTH",
+        parameters = Map("limit" -> "4")
+      )
+    }
+  }
+
+  test("SPARK-58797: store assignment with standardSemantics and charVarcharAsString") {
+    withSQLConf(
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true",
+        SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING.key -> "true") {
+      val wide = new StructType().add("c", CharType(10))
+      val df = spark.createDataFrame(java.util.Arrays.asList(Row("spark")), wide)
+      checkError(
+        exception = intercept[SparkRuntimeException] {
+          df.to(new StructType().add("c", CharType(3))).collect()
+        },
+        condition = "EXCEED_LIMIT_LENGTH",
+        parameters = Map("limit" -> "3"))
+      withTable("std_and_as_string") {
+        sql("CREATE TABLE std_and_as_string (v VARCHAR(2)) USING parquet")
+        checkError(
+          exception = intercept[SparkRuntimeException] {
+            sql("INSERT INTO std_and_as_string VALUES ('abc')")
+          },
+          condition = "EXCEED_LIMIT_LENGTH",
+          parameters = Map("limit" -> "2"))
+      }
     }
   }
 
@@ -1295,6 +1346,17 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       assert(sql("SELECT try_cast('abcdef' AS CHAR(2)) AS c").schema.head.dataType ===
         CharType(2))
       checkAnswer(sql("SELECT try_cast('abcdef' AS VARCHAR(2)) AS c"), Row("ab"))
+      checkAnswer(
+        sql("SELECT coalesce(CAST('abcdef' AS VARCHAR(2)), CAST('x' AS VARCHAR(4))) AS c"),
+        Row("ab"))
+      checkAnswer(
+        sql("SELECT CAST('abcdef' AS VARCHAR(2)) IN (CAST('ab' AS VARCHAR(4)))"),
+        Row(true))
+      checkAnswer(
+        sql("""SELECT coalesce(
+          |  CAST('abcdef' AS VARCHAR(2) COLLATE UTF8_LCASE),
+          |  CAST('x' AS VARCHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin),
+        Row("ab"))
 
       // Least common type (R2): COALESCE / CASE / NULL / CHAR+VARCHAR / CHAR+STRING.
       assert(sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1212,7 +1212,7 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = 'a'"), Row(false))
       checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = 'a '"), Row(true))
 
-      // INTypeCoercion uses findWiderCommonType over (lhs +: list), then casts every child —
+      // INTypeCoercion uses findWiderCommonType over (lhs +: list), then casts every child:
       // the left-hand side is not exempt.
       val inAnalyzed = sql(
         "SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)))")

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -868,25 +868,29 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       assert(varcharDf.schema.head.dataType === VarcharType(5))
       checkAnswer(varcharDf, Row("hello"))
 
-      checkError(
-        exception = intercept[SparkRuntimeException] {
-          sql("SELECT CAST('hello!' AS VARCHAR(5))").collect()
-        },
-        condition = "EXCEED_LIMIT_LENGTH",
-        parameters = Map("limit" -> "5")
-      )
+      // ISO 6.13: character-to-character CAST truncates rather than erroring.
+      checkAnswer(sql("SELECT CAST('hello!' AS VARCHAR(5)) AS v"), Row("hello"))
+      checkAnswer(sql("SELECT CAST('abcdef' AS CHAR(2)) AS c"), Row("ab"))
+      checkAnswer(sql("SELECT CAST('abcdef' AS VARCHAR(2)) AS v"), Row("ab"))
+      checkAnswer(sql("SELECT try_cast('abcdef' AS CHAR(2)) AS c"), Row("ab"))
+      checkAnswer(sql("SELECT try_cast('abcdef' AS VARCHAR(2)) AS v"), Row("ab"))
 
       // Multi-byte characters: length is in characters, not octets.
       // scalastyle:off nonascii
       checkAnswer(sql("SELECT CAST('你好' AS VARCHAR(2)) AS v"), Row("你好"))
+      checkAnswer(sql("SELECT CAST('你好啊' AS VARCHAR(2)) AS v"), Row("你好"))
+      // scalastyle:on nonascii
+
+      // ISO 6.13 numeric-to-character CAST still errors when the literal does not fit.
       checkError(
         exception = intercept[SparkRuntimeException] {
-          sql("SELECT CAST('你好啊' AS VARCHAR(2))").collect()
+          sql("SELECT CAST(12345 AS VARCHAR(4))").collect()
         },
         condition = "EXCEED_LIMIT_LENGTH",
-        parameters = Map("limit" -> "2")
+        parameters = Map("limit" -> "4")
       )
-      // scalastyle:on nonascii
+      checkAnswer(sql("SELECT CAST(12345 AS VARCHAR(5)) AS v"), Row("12345"))
+      checkAnswer(sql("SELECT try_cast(12345 AS VARCHAR(4)) AS v"), Row(null))
     }
   }
 
@@ -1236,12 +1240,9 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
 
       val varcharDf = spark.sql("SELECT cast('hello' AS VARCHAR(?)) AS c", Array(5))
       assert(varcharDf.schema.head.dataType === VarcharType(5))
-      checkError(
-        exception = intercept[SparkRuntimeException] {
-          spark.sql("SELECT cast('abcdef' AS VARCHAR(?))", Array(2)).collect()
-        },
-        condition = "EXCEED_LIMIT_LENGTH",
-        parameters = Map("limit" -> "2"))
+      checkAnswer(
+        spark.sql("SELECT cast('abcdef' AS VARCHAR(?))", Array(2)),
+        Row("ab"))
 
       withTable("param_varchar", "param_char") {
         spark.sql(
@@ -1293,7 +1294,7 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         VarcharType(5))
       assert(sql("SELECT try_cast('abcdef' AS CHAR(2)) AS c").schema.head.dataType ===
         CharType(2))
-      checkAnswer(sql("SELECT try_cast('abcdef' AS VARCHAR(2)) AS c"), Row(null))
+      checkAnswer(sql("SELECT try_cast('abcdef' AS VARCHAR(2)) AS c"), Row("ab"))
 
       // Least common type (R2): COALESCE / CASE / NULL / CHAR+VARCHAR / CHAR+STRING.
       assert(sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1201,6 +1201,73 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-58794: compare, IN and set-ops cast every participant to the string LCT") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      // Comparison and IN cast both sides (including the IN left-hand side) to the LCT of all
+      // participants. Casting to CHAR pads, so unequal CHAR lengths compare equal after widen;
+      // casting to VARCHAR/STRING keeps the CHAR pad, so equality needs a matching blank.
+      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = cast('a' AS CHAR(4))"), Row(true))
+      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = cast('a' AS VARCHAR(2))"), Row(false))
+      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = cast('a ' AS VARCHAR(2))"), Row(true))
+      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = 'a'"), Row(false))
+      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = 'a '"), Row(true))
+
+      // INTypeCoercion uses findWiderCommonType over (lhs +: list), then casts every child —
+      // the left-hand side is not exempt.
+      val inAnalyzed = sql(
+        "SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)))")
+        .queryExecution.analyzed
+      assert(inAnalyzed.toString.contains("as varchar(4)"),
+        s"LHS and list should all widen to VARCHAR(4), got:\n$inAnalyzed")
+      checkAnswer(
+        sql("SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)))"), Row(true))
+      checkAnswer(
+        sql("SELECT cast('a' AS CHAR(2)) IN (cast('a' AS VARCHAR(2)))"), Row(false))
+      checkAnswer(
+        sql("SELECT cast('a' AS CHAR(2)) IN (cast('a ' AS VARCHAR(2)))"), Row(true))
+
+      // RTRIM ignores trailing blanks for CHAR vs STRING and for mixed CHAR lengths.
+      checkAnswer(
+        sql("SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a'"), Row(true))
+      checkAnswer(
+        sql("""SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
+              |  cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)""".stripMargin),
+        Row(true))
+
+      // Collated LCT must keep the collation and take max(n, m), not become indeterminate.
+      assert(sql(
+        """SELECT coalesce(
+          |  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+          |  cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin)
+        .schema.head.dataType === CharType(4, "UTF8_LCASE"))
+
+      // Set ops and multi-row VALUES share the same LCT.
+      assert(sql(
+        """SELECT c FROM (
+          |  SELECT cast('a' AS CHAR(2)) AS c UNION SELECT cast('a' AS CHAR(4)) AS c) t"""
+          .stripMargin)
+        .schema.head.dataType === CharType(4))
+      checkAnswer(
+        sql("""SELECT c FROM (
+              |  SELECT cast('a' AS CHAR(2)) AS c UNION SELECT cast('a' AS CHAR(4)) AS c) t"""
+          .stripMargin),
+        Row("a   "))
+      checkAnswer(
+        sql("""SELECT c FROM (
+              |  SELECT cast('ab' AS CHAR(2)) AS c INTERSECT
+              |  SELECT cast('ab' AS CHAR(4)) AS c) t""".stripMargin),
+        Row("ab  "))
+      checkAnswer(
+        sql("""SELECT c FROM (
+              |  SELECT cast('ab' AS CHAR(2)) AS c EXCEPT
+              |  SELECT cast('ab' AS CHAR(4)) AS c) t""".stripMargin),
+        Seq.empty)
+      assert(sql(
+        """SELECT c FROM (VALUES (cast('a' AS CHAR(2))), (cast('bb' AS CHAR(4)))) t(c)""")
+        .schema.head.dataType === CharType(4))
+    }
+  }
+
   test("SPARK-58802: single-pass resolver agrees with fixed-point under standardSemantics") {
     // Dual run defaults to on under tests, but pin it explicitly so this coverage cannot be
     // silently lost: the HybridAnalyzer compares output schema and normalized plan across the

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1383,6 +1383,14 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         sql("SELECT CAST('a' AS CHAR(2) COLLATE UTF8_LCASE) IN " +
           "(CAST('a' AS CHAR(4) COLLATE UTF8_LCASE))"),
         Row(true))
+      checkAnswer(
+        sql("SELECT CAST('a' AS CHAR(2) COLLATE UTF8_LCASE) = " +
+          "CAST('a' AS VARCHAR(2) COLLATE UTF8_LCASE)"),
+        Row(false))
+      checkAnswer(
+        sql("SELECT CAST('a' AS CHAR(2) COLLATE UTF8_LCASE) IN " +
+          "(CAST('a' AS VARCHAR(2) COLLATE UTF8_LCASE))"),
+        Row(false))
 
       val mixedCharUnion = sql(
         """SELECT CAST('a' AS CHAR(2)) AS c

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1201,70 +1201,25 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
     }
   }
 
-  test("SPARK-58794: compare, IN and set-ops cast every participant to the string LCT") {
-    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
-      // Comparison and IN cast both sides (including the IN left-hand side) to the LCT of all
-      // participants. Casting to CHAR pads, so unequal CHAR lengths compare equal after widen;
-      // casting to VARCHAR/STRING keeps the CHAR pad, so equality needs a matching blank.
-      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = cast('a' AS CHAR(4))"), Row(true))
-      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = cast('a' AS VARCHAR(2))"), Row(false))
-      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = cast('a ' AS VARCHAR(2))"), Row(true))
-      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = 'a'"), Row(false))
-      checkAnswer(sql("SELECT cast('a' AS CHAR(2)) = 'a '"), Row(true))
+  test("SPARK-58794: collated mixed-length LCT ignores collation strength for length") {
+    val mixedLength =
+      """SELECT coalesce(
+        |  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+        |  cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin
+    val mixedStrength =
+      """SELECT coalesce(
+        |  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
+        |  cast(1 AS CHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin
 
-      // INTypeCoercion uses findWiderCommonType over (lhs +: list), then casts every child:
-      // the left-hand side is not exempt.
-      val inAnalyzed = sql(
-        "SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)), cast('b' AS VARCHAR(3)))")
-        .queryExecution.analyzed
-      assert(inAnalyzed.toString.contains("as varchar(4)"),
-        s"LHS and list should all widen to VARCHAR(4), got:\n$inAnalyzed")
-      checkAnswer(
-        sql("SELECT cast('a' AS CHAR(2)) IN (cast('a' AS CHAR(4)))"), Row(true))
-      checkAnswer(
-        sql("SELECT cast('a' AS CHAR(2)) IN (cast('a' AS VARCHAR(2)))"), Row(false))
-      checkAnswer(
-        sql("SELECT cast('a' AS CHAR(2)) IN (cast('a ' AS VARCHAR(2)))"), Row(true))
-
-      // RTRIM ignores trailing blanks for CHAR vs STRING and for mixed CHAR lengths.
-      checkAnswer(
-        sql("SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) = 'a'"), Row(true))
-      checkAnswer(
-        sql("""SELECT cast('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
-              |  cast('a' AS CHAR(4) COLLATE UTF8_BINARY_RTRIM)""".stripMargin),
-        Row(true))
-
-      // Collated LCT must keep the collation and take max(n, m), not become indeterminate.
-      assert(sql(
-        """SELECT coalesce(
-          |  cast('a' AS CHAR(2) COLLATE UTF8_LCASE),
-          |  cast('bb' AS CHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin)
-        .schema.head.dataType === CharType(4, "UTF8_LCASE"))
-
-      // Set ops and multi-row VALUES share the same LCT.
-      assert(sql(
-        """SELECT c FROM (
-          |  SELECT cast('a' AS CHAR(2)) AS c UNION SELECT cast('a' AS CHAR(4)) AS c) t"""
-          .stripMargin)
-        .schema.head.dataType === CharType(4))
-      checkAnswer(
-        sql("""SELECT c FROM (
-              |  SELECT cast('a' AS CHAR(2)) AS c UNION SELECT cast('a' AS CHAR(4)) AS c) t"""
-          .stripMargin),
-        Row("a   "))
-      checkAnswer(
-        sql("""SELECT c FROM (
-              |  SELECT cast('ab' AS CHAR(2)) AS c INTERSECT
-              |  SELECT cast('ab' AS CHAR(4)) AS c) t""".stripMargin),
-        Row("ab  "))
-      checkAnswer(
-        sql("""SELECT c FROM (
-              |  SELECT cast('ab' AS CHAR(2)) AS c EXCEPT
-              |  SELECT cast('ab' AS CHAR(4)) AS c) t""".stripMargin),
-        Seq.empty)
-      assert(sql(
-        """SELECT c FROM (VALUES (cast('a' AS CHAR(2))), (cast('bb' AS CHAR(4)))) t(c)""")
-        .schema.head.dataType === CharType(4))
+    Seq(
+      SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true",
+      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true").foreach { case (key, value) =>
+      withSQLConf(key -> value) {
+        assert(sql(mixedLength).schema.head.dataType === CharType(4, "UTF8_LCASE"),
+          s"$key=$value same-strength mixed CHAR lengths")
+        assert(sql(mixedStrength).schema.head.dataType === CharType(4, "UTF8_LCASE"),
+          s"$key=$value Implicit CHAR(2) vs Default CHAR(4) must widen, not narrow")
+      }
     }
   }
 
@@ -1281,9 +1236,12 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
 
       val varcharDf = spark.sql("SELECT cast('hello' AS VARCHAR(?)) AS c", Array(5))
       assert(varcharDf.schema.head.dataType === VarcharType(5))
-      intercept[SparkRuntimeException] {
-        spark.sql("SELECT cast('abcdef' AS VARCHAR(?))", Array(2)).collect()
-      }
+      checkError(
+        exception = intercept[SparkRuntimeException] {
+          spark.sql("SELECT cast('abcdef' AS VARCHAR(?))", Array(2)).collect()
+        },
+        condition = "EXCEED_LIMIT_LENGTH",
+        parameters = Map("limit" -> "2"))
 
       withTable("param_varchar", "param_char") {
         spark.sql(
@@ -1294,12 +1252,26 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       }
 
       // Non-integral / negative lengths fail when substituted into the length position.
-      intercept[ParseException] {
-        spark.sql("SELECT cast('a' AS CHAR(:n))", Map("n" -> -1)).collect()
-      }
-      intercept[ParseException] {
-        spark.sql("SELECT cast('a' AS CHAR(:n))", Map("n" -> 1.5)).collect()
-      }
+      checkError(
+        exception = intercept[ParseException] {
+          spark.sql("SELECT cast('a' AS CHAR(:n))", Map("n" -> -1))
+        },
+        condition = "PARSE_SYNTAX_ERROR",
+        parameters = Map("error" -> "'-'", "hint" -> ""),
+        context = ExpectedContext(
+          fragment = "SELECT cast('a' AS CHAR(:n))",
+          start = 0,
+          stop = 27))
+      checkError(
+        exception = intercept[ParseException] {
+          spark.sql("SELECT cast('a' AS CHAR(:n))", Map("n" -> 1.5))
+        },
+        condition = "PARSE_SYNTAX_ERROR",
+        parameters = Map("error" -> "'1.5D'", "hint" -> ""),
+        context = ExpectedContext(
+          fragment = "SELECT cast('a' AS CHAR(:n))",
+          start = 0,
+          stop = 27))
     }
   }
 
@@ -1391,9 +1363,33 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         .schema.head.dataType ===
         StructType(Seq(StructField("f", CharType(2), nullable = false))))
 
-      // Collated CAST keeps the declared collation under both analyzers.
-      assert(sql("SELECT CAST('ab' AS CHAR(2) COLLATE UTF8_LCASE) AS c")
-        .schema.head.dataType === CharType(2, "UTF8_LCASE"))
+      // Collated mixed-length LCT (the CollationTypeCoercion equal-strength and
+      // mixed-strength paths). Set ops have a separate resolver path.
+      assert(sql(
+        """SELECT coalesce(
+          |  CAST('a' AS CHAR(2) COLLATE UTF8_LCASE),
+          |  CAST('bb' AS CHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin)
+        .schema.head.dataType === CharType(4, "UTF8_LCASE"))
+      assert(sql(
+        """SELECT coalesce(
+          |  CAST('a' AS CHAR(2) COLLATE UTF8_LCASE),
+          |  CAST(1 AS CHAR(4) COLLATE UTF8_LCASE)) AS c""".stripMargin)
+        .schema.head.dataType === CharType(4, "UTF8_LCASE"))
+      checkAnswer(
+        sql("SELECT CAST('a' AS CHAR(2) COLLATE UTF8_LCASE) = " +
+          "CAST('a' AS CHAR(4) COLLATE UTF8_LCASE)"),
+        Row(true))
+      checkAnswer(
+        sql("SELECT CAST('a' AS CHAR(2) COLLATE UTF8_LCASE) IN " +
+          "(CAST('a' AS CHAR(4) COLLATE UTF8_LCASE))"),
+        Row(true))
+
+      val mixedCharUnion = sql(
+        """SELECT CAST('a' AS CHAR(2)) AS c
+          |UNION ALL
+          |SELECT CAST('bb' AS CHAR(4)) AS c""".stripMargin)
+      assert(mixedCharUnion.schema.head.dataType === CharType(4))
+      checkAnswer(mixedCharUnion, Seq(Row("a   "), Row("bb  ")))
 
       // Bare column references keep the declared type (R3) through dual-run analysis.
       withTable("char_varchar_dual_run") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Covers the string-family LCT lattice ([SPARK-58798](https://issues.apache.org/jira/browse/SPARK-58798)). Parent: [SPARK-58794](https://issues.apache.org/jira/browse/SPARK-58794). Also includes explicit character CAST truncation ([SPARK-58797](https://issues.apache.org/jira/browse/SPARK-58797)).

Rebased onto `master` after #58033 merged. Unique commits vs master: https://github.com/srielau/spark/compare/master...SPARK-58794-lct-compare

Follow-up that drills into least-common-type, comparison, and `IN` under `spark.sql.charVarchar.standardSemantics.enabled`.

`CollationTypeCoercion` is not gated on `standardSemantics` alone (`charVarcharFirstClassTypes` is also true under `preserveCharVarcharTypeInfo`). The equal-collation length LCT therefore applies in preserve-only mode as well; tests cover both flags.

**Bug fix.** `CollationTypeCoercion.getWinningStringType` required `sameType` at equal collation strength. Same-collation `CHAR(2)` and `CHAR(4)` therefore looked like a collation mismatch and became `IndeterminateStringType` (`string collate null`). At equal strength, take `StringHelper.tightestCommonString` instead so every child is cast to `max(n, m)` (padding, never truncating).

**Explicit CAST vs store assignment (ISO 6.13 / 9.2).** Under the flag:

- Character-to-`CHAR`/`VARCHAR` `CAST` / `TRY_CAST` **truncates** to `n` characters (then `CHAR` pads). Example: `CAST('abcdef' AS VARCHAR(2))` is `'ab'`, not `EXCEED_LIMIT_LENGTH`.
- Numeric (and other non-string) `CAST` to `CHAR`/`VARCHAR` still **errors** when the formatted literal does not fit (`CAST(12345 AS VARCHAR(4))` -> `EXCEED_LIMIT_LENGTH` / 54006). That matches ISO 22001, not silent digit clipping.
- Store assignment (`INSERT`, `Dataset.to`, encoder write-side) is unchanged: non-space overflow still errors. Project store-assignment casts to unconstrained `STRING` then `stringLengthCheck`, so they do not inherit CAST truncation.

**Coverage / pinned behavior.**

- Set ops: `UNION` / `UNION ALL` / `INTERSECT` / `EXCEPT`, plus multi-row `VALUES`, all share the string-family LCT.
- Comparison and `IN`: every participant is cast to that LCT, including the `IN` left-hand side (`InTypeCoercion` uses `findWiderCommonType` over `value +: list`). Casting to `CHAR` pads, so unequal `CHAR` lengths compare equal after widen; casting to `VARCHAR`/`STRING` keeps the `CHAR` pad, so `CHAR 'a'` (stored as `'a '`) is not equal to `VARCHAR`/`STRING 'a'` unless the other side carries the same trailing blank. Ignoring trailing blanks is a collation concern (`RTRIM`), not a type-level `PAD SPACE` policy (design D17).
- Parameterized lengths (`CHAR(:n)` / `VARCHAR(?)`): markers in length position already bind through the parser; under the flag, character CAST truncates to the bound `n`, numeric CAST still errors if it does not fit, and DDL keeps the bound `n`. Negative / non-integral lengths fail at parse after substitution.

### Why are the changes needed?

#58033 left the collated mixed-length LCT gap as a known issue, and had only thin coverage of `UNION ALL` / `INTERSECT` with no compare / `IN`-LHS / `VALUES` / `EXCEPT` matrix. Without pinning the LCT-cast rule, CHAR vs CHAR vs VARCHAR equality is easy to misread as PAD SPACE.

Explicit character CAST was still using the write-side length check, so `CAST('abcdef' AS VARCHAR(2))` failed the same way as `INSERT`. ISO 6.13 truncates that CAST; 9.2 keeps the INSERT error. Numeric CAST must still fail when the literal does not fit (ISO 22001).

### Does this PR introduce _any_ user-facing change?

Yes, when the flag is on:

- Collated `CHAR`/`VARCHAR` values of different lengths but the same collation now widen to `CHAR`/`VARCHAR(max(n,m))` instead of an indeterminate collation. Compare / `IN` / set-op results for mixed `CHAR` lengths follow the LCT-cast rule above (this matches what the engine already did for non-collated paths; the new tests lock it in).
- Explicit character-to-`CHAR`/`VARCHAR` CAST truncates instead of raising `EXCEED_LIMIT_LENGTH`. `INSERT` / encoder overflow and numeric CAST overflow still error.

### How was this patch tested?

- New `BasicCharVarcharTestSuite` cases covering compare, `IN` (including analyzed-plan assertion that the LHS widens), `RTRIM`, collated LCT, `UNION` / `INTERSECT` / `EXCEPT`, multi-row `VALUES`, parameterized `CHAR`/`VARCHAR` lengths, character CAST truncation, and numeric CAST overflow under the flag.
- Expanded golden file `charvarchar-standard-semantics.sql`.
- Locally: `BasicCharVarcharTestSuite` and the golden file regeneration/run.
