### PR TITLE
[SPARK-58673][BUILD] Upgrade Avro to 1.12.2

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -292,12 +292,15 @@ class AvroFunctionsSuite extends SharedSparkSession {
       df.write.format("avro").save(dir.getCanonicalPath)
       checkAnswer(spark.read.schema(sparkSchema).format("avro").load(dir.getCanonicalPath), df)
 
-      val msg = intercept[SparkException] {
-        spark.read.option("avroSchema", avroTypeStruct).format("avro")
-          .load(dir.getCanonicalPath)
-          .collect()
-      }.getCause.getMessage
-      assert(msg.contains("Invalid default for field id: null not a \"long\""))
+      // Reading with the `avroSchema` option also succeeds. The invalid `null` default is never
+      // materialized because every record carries `id`. Since Avro 1.12.2 (AVRO-4257), a `Schema`
+      // deserialized on the executors is parsed with the non-validating internal parser, so the
+      // reader schema is no longer re-validated after being shipped from the driver, and no error
+      // is raised. This is consistent with the goal of SPARK-39775: schemas that carry invalid but
+      // unused defaults must remain usable end to end.
+      checkAnswer(
+        spark.read.option("avroSchema", avroTypeStruct).format("avro").load(dir.getCanonicalPath),
+        df)
     }
   }
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -31,9 +31,9 @@ arrow-memory-netty/19.0.0//arrow-memory-netty-19.0.0.jar
 arrow-vector/19.0.0//arrow-vector-19.0.0.jar
 audience-annotations/0.12.0//audience-annotations-0.12.0.jar
 auth/2.35.4//auth-2.35.4.jar
-avro-ipc/1.12.1//avro-ipc-1.12.1.jar
-avro-mapred/1.12.1//avro-mapred-1.12.1.jar
-avro/1.12.1//avro-1.12.1.jar
+avro-ipc/1.12.2//avro-ipc-1.12.2.jar
+avro-mapred/1.12.2//avro-mapred-1.12.2.jar
+avro/1.12.2//avro-1.12.2.jar
 aws-core/2.35.4//aws-core-2.35.4.jar
 aws-query-protocol/2.35.4//aws-query-protocol-2.35.4.jar
 azure-data-lake-store-sdk/2.3.9//azure-data-lake-store-sdk-2.3.9.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -28,9 +28,9 @@ arrow-memory-netty-buffer-patch/19.0.0//arrow-memory-netty-buffer-patch-19.0.0.j
 arrow-memory-netty/19.0.0//arrow-memory-netty-19.0.0.jar
 arrow-vector/19.0.0//arrow-vector-19.0.0.jar
 audience-annotations/0.12.0//audience-annotations-0.12.0.jar
-avro-ipc/1.12.1//avro-ipc-1.12.1.jar
-avro-mapred/1.12.1//avro-mapred-1.12.1.jar
-avro/1.12.1//avro-1.12.1.jar
+avro-ipc/1.12.2//avro-ipc-1.12.2.jar
+avro-mapred/1.12.2//avro-mapred-1.12.2.jar
+avro/1.12.2//avro-1.12.2.jar
 azure-data-lake-store-sdk/2.3.9//azure-data-lake-store-sdk-2.3.9.jar
 azure-keyvault-core/1.0.0//azure-keyvault-core-1.0.0.jar
 azure-storage/7.0.1//azure-storage-7.0.1.jar

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -477,7 +477,7 @@ Submission Guide for more details.
 [adm]: submitting-applications.html#advanced-dependency-management
 
 ## Supported types for Avro -> Spark SQL conversion
-Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.12.1/specification/#primitive-types) and [complex types](https://avro.apache.org/docs/1.12.1/specification/#complex-types) under records of Avro.
+Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.12.2/specification/#primitive-types) and [complex types](https://avro.apache.org/docs/1.12.2/specification/#complex-types) under records of Avro.
 <table>
   <thead><tr><th><b>Avro type</b></th><th><b>Spark SQL type</b></th></tr></thead>
   <tr>
@@ -541,7 +541,7 @@ In addition to the types listed above, it supports reading `union` types. The fo
 3. `union(something, null)`, where something is any supported Avro type. This will be mapped to the same Spark SQL type as that of something, with nullable set to true.
 All other union types are considered complex. They will be mapped to StructType where field names are member0, member1, etc., in accordance with members of the union. This is consistent with the behavior when converting between Avro and Parquet.
 
-It also supports reading the following Avro [logical types](https://avro.apache.org/docs/1.12.1/specification/#logical-types):
+It also supports reading the following Avro [logical types](https://avro.apache.org/docs/1.12.2/specification/#logical-types):
 
 <table>
   <thead><tr><th><b>Avro logical type</b></th><th><b>Avro type</b></th><th><b>Spark SQL type</b></th></tr></thead>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     -->
     <codahale.metrics.version>4.2.37</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
-    <avro.version>1.12.1</avro.version>
+    <avro.version>1.12.2</avro.version>
     <aws.kinesis.client.version>2.7.2</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.v2.version>2.35.4</aws.java.sdk.v2.version>
@@ -2906,6 +2906,7 @@
               <!-- Needed by sql/hive tests. -->
               <test.src.tables>src</test.src.tables>
               <hive.conf.validation>false</hive.conf.validation>
+              <org.apache.avro.SERIALIZABLE_PACKAGES>org.apache.spark</org.apache.avro.SERIALIZABLE_PACKAGES>
             </systemPropertyVariables>
             <failIfNoTests>false</failIfNoTests>
             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
@@ -2961,6 +2962,7 @@
               <spark.test.docker.removePulledImage>${spark.test.docker.removePulledImage}</spark.test.docker.removePulledImage>
               <!-- Needed by sql/hive tests. -->
               <test.src.tables>__not_used__</test.src.tables>
+              <org.apache.avro.SERIALIZABLE_PACKAGES>org.apache.spark</org.apache.avro.SERIALIZABLE_PACKAGES>
             </systemProperties>
             <tagsToExclude>${test.exclude.tags},${test.default.exclude.tags}</tagsToExclude>
             <tagsToInclude>${test.include.tags}</tagsToInclude>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -2038,6 +2038,7 @@ object TestSettings {
     (Test / javaOptions) += "-Dhive.conf.validation=false",
     (Test / javaOptions) += "-Dsun.io.serialization.extendedDebugInfo=false",
     (Test / javaOptions) += "-Dderby.system.durability=test",
+    (Test / javaOptions) += "-Dorg.apache.avro.SERIALIZABLE_PACKAGES=org.apache.spark",
     (Test / javaOptions) ++= {
       if ("true".equals(System.getProperty("java.net.preferIPv6Addresses"))) {
         Seq("-Djava.net.preferIPv6Addresses=true")

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -97,14 +97,14 @@ private[sql] class AvroOptions(
 
   /**
    * Top level record name in write result, which is required in Avro spec.
-   * See https://avro.apache.org/docs/1.12.1/specification/#schema-record .
+   * See https://avro.apache.org/docs/1.12.2/specification/#schema-record .
    * Default value is "topLevelRecord"
    */
   val recordName: String = parameters.getOrElse(RECORD_NAME, "topLevelRecord")
 
   /**
    * Record namespace in write result. Default value is "".
-   * See Avro spec for details: https://avro.apache.org/docs/1.12.1/specification/#schema-record .
+   * See Avro spec for details: https://avro.apache.org/docs/1.12.2/specification/#schema-record .
    */
   val recordNamespace: String = parameters.getOrElse(RECORD_NAMESPACE, "")
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -828,7 +828,7 @@ class HiveClientSuite(version: String) extends HiveVersionSuite(version) {
   test("Decimal support of Avro Hive serde") {
     val tableName = "tab1"
     // TODO: add the other logical types. For details, see the link:
-    // https://avro.apache.org/docs/1.12.1/specification/#logical-types
+    // https://avro.apache.org/docs/1.12.2/specification/#logical-types
     val avroSchema =
     """{
       |  "name": "test_record",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache Avro from 1.12.1 to 1.12.2. This bumps `avro.version` in `pom.xml`, `SparkBuild.scala`, and the Hadoop 3 deps manifest, and updates the versioned links in the Avro docs/options.

Avro 1.12.2 hardens deserialization of `Schema` objects behind an allow-list (`org.apache.avro.SERIALIZABLE_PACKAGES`), so the build now sets that system property to `org.apache.spark` for tests (Maven surefire/scalatest and SBT).

`AvroFunctionsSuite` is updated: since AVRO-4257, a `Schema` deserialized on executors is parsed with the non-validating internal parser, so a reader schema carrying an unused invalid default is no longer re-validated and the read now succeeds. This is consistent with SPARK-39775.

### Why are the changes needed?
Keep the Avro dependency current with the latest 1.12.x patch release.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing Avro/Hive test suites.

### Was this patch authored or co-authored using generative AI tooling?
No.
