### PR TITLE
[SPARK-58847][SQL] Collation-aware hash aggregation

### DIFF
--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -88,7 +88,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
   /**
    * Creates independent key operations for a single {@link Location}, allowing each instance to
    * reuse mutable state. All instances must implement the same key semantics. Maps configured
-   * with this factory must use the key-operations lookup methods exclusively.
+   * with this factory must use the key-operations lookup methods exclusively. Callers may invoke
+   * {@link #create()} concurrently, so factory implementations must be thread-safe.
    */
   @FunctionalInterface
   public interface KeyOperationsFactory {

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -577,7 +577,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * Looks up a key and saves the result in the provided `loc`.
    *
    * This is a thread-safe version of `lookup`, provided that each thread supplies its own
-   * {@link Location}. The map must not be modified concurrently.
+   * {@link Location}. This guarantee excludes probe statistics, which may be inaccurate under
+   * concurrent lookup. The map must not be modified concurrently.
    */
   public void safeLookup(Object keyBase, long keyOffset, int keyLength, Location loc) {
     if (keyOperationsFactory == null) {
@@ -596,7 +597,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * Looks up a key with a precomputed hash and saves the result in the provided `loc`.
    *
    * The provided hash is ignored when this map has configured key operations. Each thread must
-   * supply its own {@link Location}, and the map must not be modified concurrently.
+   * supply its own {@link Location}. Probe statistics may be inaccurate under concurrent lookup,
+   * and the map must not be modified concurrently.
    */
   public void safeLookup(Object keyBase, long keyOffset, int keyLength, Location loc, int hash) {
     assert(longArray != null);
@@ -694,7 +696,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
     private int pos;
     /** True if this location points to a position where a key is defined, false otherwise */
     private boolean isDefined;
-    /** The hash code computed by the most recent lookup. */
+    /** The hash code used by the most recent lookup. */
     private int keyHashcode;
     private Object baseObject;  // the base object for key and value
     private long keyOffset;
@@ -858,8 +860,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
     /**
      * Append a new value for the key. This method could be called multiple times for a given key.
-     * The return value indicates whether the put succeeded or whether it failed because additional
-     * memory could not be acquired.
+     * The return value indicates whether the put succeeded or whether it failed because the map
+     * reached its capacity or additional memory could not be acquired.
      * <p>
      * It is only valid to call this method immediately after looking up the same key.
      * </p>
@@ -885,8 +887,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
      * Unspecified behavior if the key is not defined.
      * </p>
      *
-     * @return true if the put() was successful and false if the put() failed because memory could
-     *         not be acquired.
+     * @return true if the put() was successful and false if the map reached its capacity or memory
+     *         could not be acquired.
      */
     public boolean append(Object kbase, long koff, int klen, Object vbase, long voff, int vlen) {
       assert (klen % 8 == 0);
@@ -1082,6 +1084,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
   /**
    * Returns the average number of probes per key lookup.
+   *
+   * This statistic may be inaccurate if lookups are performed concurrently.
    */
   public double getAvgHashProbesPerKey() {
     return (1.0 * numProbes) / numKeyLookups;

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -551,14 +551,11 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * Looks up a key, and return a {@link Location} handle that can be used to test existence
    * and read/write values.
    *
-   * This method is only valid for maps without configured key operations.
-   *
    * This function always returns the same {@link Location} instance to avoid object allocation.
    * This function is not thread-safe.
    */
   public Location lookup(Object keyBase, long keyOffset, int keyLength) {
-    safeLookup(keyBase, keyOffset, keyLength, loc,
-      Murmur3_x86_32.hashUnsafeWords(keyBase, keyOffset, keyLength, 42));
+    safeLookup(keyBase, keyOffset, keyLength, loc);
     return loc;
   }
 
@@ -566,7 +563,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * Looks up a key, and return a {@link Location} handle that can be used to test existence
    * and read/write values.
    *
-   * This method is only valid for maps without configured key operations.
+   * The provided hash is ignored when this map has configured key operations.
    *
    * This function always returns the same {@link Location} instance to avoid object allocation.
    * This function is not thread-safe.
@@ -577,16 +574,36 @@ public final class BytesToBytesMap extends MemoryConsumer {
   }
 
   /**
-   * Looks up a key, and saves the result in provided `loc`.
-   *
-   * This method is only valid for maps without configured key operations.
+   * Looks up a key and saves the result in the provided `loc`.
    *
    * This is a thread-safe version of `lookup`, provided that each thread supplies its own
    * {@link Location}. The map must not be modified concurrently.
    */
+  public void safeLookup(Object keyBase, long keyOffset, int keyLength, Location loc) {
+    if (keyOperationsFactory == null) {
+      safeLookup(
+        keyBase,
+        keyOffset,
+        keyLength,
+        loc,
+        Murmur3_x86_32.hashUnsafeWords(keyBase, keyOffset, keyLength, 42));
+    } else {
+      safeLookupWithKeyOperations(keyBase, keyOffset, keyLength, loc);
+    }
+  }
+
+  /**
+   * Looks up a key with a precomputed hash and saves the result in the provided `loc`.
+   *
+   * The provided hash is ignored when this map has configured key operations. Each thread must
+   * supply its own {@link Location}, and the map must not be modified concurrently.
+   */
   public void safeLookup(Object keyBase, long keyOffset, int keyLength, Location loc, int hash) {
     assert(longArray != null);
-    assert(keyOperationsFactory == null);
+    if (keyOperationsFactory != null) {
+      safeLookupWithKeyOperations(keyBase, keyOffset, keyLength, loc);
+      return;
+    }
 
     numKeyLookups++;
 
@@ -622,24 +639,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
     }
   }
 
-  /**
-   * Looks up a key using the configured semantic key operations.
-   *
-   * This function always returns the same {@link Location} instance to avoid object allocation.
-   * This function is not thread-safe.
-   */
-  public Location lookupWithKeyOperations(Object keyBase, long keyOffset, int keyLength) {
-    safeLookupWithKeyOperations(keyBase, keyOffset, keyLength, loc);
-    return loc;
-  }
-
-  /**
-   * Looks up a key using the configured semantic key operations and saves the result in `loc`.
-   *
-   * Each thread must supply its own {@link Location}, and the map must not be modified
-   * concurrently.
-   */
-  public void safeLookupWithKeyOperations(
+  private void safeLookupWithKeyOperations(
       Object keyBase, long keyOffset, int keyLength, Location loc) {
     assert(longArray != null);
     assert(keyOperationsFactory != null);
@@ -688,19 +688,13 @@ public final class BytesToBytesMap extends MemoryConsumer {
     }
   }
 
-  /**
-   * Handle returned by {@link BytesToBytesMap#lookup(Object, long, int)} function.
-   */
+  /** Handle returned by this map's lookup methods. */
   public final class Location {
     /** An index into the hash map's Long array */
     private int pos;
     /** True if this location points to a position where a key is defined, false otherwise */
     private boolean isDefined;
-    /**
-     * The hashcode of the most recent key passed to
-     * {@link BytesToBytesMap#lookup(Object, long, int, int)}. Caching this hashcode here allows us
-     * to avoid re-hashing the key when storing a value for that key.
-     */
+    /** The hash code computed by the most recent lookup. */
     private int keyHashcode;
     private Object baseObject;  // the base object for key and value
     private long keyOffset;
@@ -867,7 +861,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
      * The return value indicates whether the put succeeded or whether it failed because additional
      * memory could not be acquired.
      * <p>
-     * It is only valid to call this method immediately after calling `lookup()` using the same key.
+     * It is only valid to call this method immediately after looking up the same key.
      * </p>
      * <p>
      * The key and value must be word-aligned (that is, their sizes must be a multiple of 8).

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -70,7 +70,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
   /**
    * Hashes and compares keys whose semantics cannot be determined from their raw bytes.
-   * Implementations must assign the same hash code to equal keys.
+   * Implementations must assign the same hash code to equal keys, and byte-identical keys must
+   * compare equal.
    */
   public interface KeyOperations {
     int hash(Object base, long offset, int length);
@@ -86,7 +87,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
   /**
    * Creates independent key operations for a single {@link Location}, allowing each instance to
-   * reuse mutable state.
+   * reuse mutable state. All instances must implement the same key semantics. Maps configured
+   * with this factory must use the key-operations lookup methods exclusively.
    */
   @FunctionalInterface
   public interface KeyOperationsFactory {
@@ -549,13 +551,14 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * Looks up a key, and return a {@link Location} handle that can be used to test existence
    * and read/write values.
    *
+   * This method is only valid for maps without configured key operations.
+   *
    * This function always returns the same {@link Location} instance to avoid object allocation.
    * This function is not thread-safe.
    */
   public Location lookup(Object keyBase, long keyOffset, int keyLength) {
-    final int hash = keyOperationsFactory == null ?
-      Murmur3_x86_32.hashUnsafeWords(keyBase, keyOffset, keyLength, 42) : 0;
-    safeLookup(keyBase, keyOffset, keyLength, loc, hash);
+    safeLookup(keyBase, keyOffset, keyLength, loc,
+      Murmur3_x86_32.hashUnsafeWords(keyBase, keyOffset, keyLength, 42));
     return loc;
   }
 
@@ -563,9 +566,10 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * Looks up a key, and return a {@link Location} handle that can be used to test existence
    * and read/write values.
    *
+   * This method is only valid for maps without configured key operations.
+   *
    * This function always returns the same {@link Location} instance to avoid object allocation.
-   * This function is not thread-safe. If key operations are configured, the supplied hash is
-   * ignored and recomputed by those operations.
+   * This function is not thread-safe.
    */
   public Location lookup(Object keyBase, long keyOffset, int keyLength, int hash) {
     safeLookup(keyBase, keyOffset, keyLength, loc, hash);
@@ -575,17 +579,14 @@ public final class BytesToBytesMap extends MemoryConsumer {
   /**
    * Looks up a key, and saves the result in provided `loc`.
    *
+   * This method is only valid for maps without configured key operations.
+   *
    * This is a thread-safe version of `lookup`, provided that each thread supplies its own
-   * {@link Location}. The map must not be modified concurrently. If key operations are configured,
-   * the supplied hash is ignored and recomputed by those operations.
+   * {@link Location}. The map must not be modified concurrently.
    */
   public void safeLookup(Object keyBase, long keyOffset, int keyLength, Location loc, int hash) {
     assert(longArray != null);
-
-    final KeyOperations keyOperations = loc.getKeyOperations();
-    if (keyOperations != null) {
-      hash = keyOperations.hash(keyBase, keyOffset, keyLength);
-    }
+    assert(keyOperationsFactory == null);
 
     numKeyLookups++;
 
@@ -602,16 +603,76 @@ public final class BytesToBytesMap extends MemoryConsumer {
         if ((int) (stored) == hash) {
           // Full hash code matches.  Let's compare the keys for equality.
           loc.with(pos, hash, true);
-          if (loc.getKeyLength() == keyLength &&
-              ByteArrayMethods.arrayEquals(
+          if (loc.getKeyLength() == keyLength) {
+            final boolean areEqual = ByteArrayMethods.arrayEquals(
               keyBase,
               keyOffset,
               loc.getKeyBase(),
               loc.getKeyOffset(),
-              keyLength)) {
+              keyLength
+            );
+            if (areEqual) {
+              return;
+            }
+          }
+        }
+      }
+      pos = (pos + step) & mask;
+      step++;
+    }
+  }
+
+  /**
+   * Looks up a key using the configured semantic key operations.
+   *
+   * This function always returns the same {@link Location} instance to avoid object allocation.
+   * This function is not thread-safe.
+   */
+  public Location lookupWithKeyOperations(Object keyBase, long keyOffset, int keyLength) {
+    safeLookupWithKeyOperations(keyBase, keyOffset, keyLength, loc);
+    return loc;
+  }
+
+  /**
+   * Looks up a key using the configured semantic key operations and saves the result in `loc`.
+   *
+   * Each thread must supply its own {@link Location}, and the map must not be modified
+   * concurrently.
+   */
+  public void safeLookupWithKeyOperations(
+      Object keyBase, long keyOffset, int keyLength, Location loc) {
+    assert(longArray != null);
+    assert(keyOperationsFactory != null);
+
+    final KeyOperations keyOperations = loc.getKeyOperations();
+    assert(keyOperations != null);
+    final int hash = keyOperations.hash(keyBase, keyOffset, keyLength);
+
+    numKeyLookups++;
+
+    int pos = hash & mask;
+    int step = 1;
+    while (true) {
+      numProbes++;
+      if (longArray.get(pos * 2) == 0) {
+        // This is a new key.
+        loc.with(pos, hash, false);
+        return;
+      } else {
+        long stored = longArray.get(pos * 2 + 1);
+        if ((int) (stored) == hash) {
+          // Full hash code matches. Let's compare the keys for equality.
+          loc.with(pos, hash, true);
+          if (loc.getKeyLength() == keyLength &&
+              ByteArrayMethods.arrayEquals(
+                keyBase,
+                keyOffset,
+                loc.getKeyBase(),
+                loc.getKeyOffset(),
+                keyLength)) {
             return;
           }
-          if (keyOperations != null && keyOperations.equals(
+          if (keyOperations.equals(
               keyBase,
               keyOffset,
               keyLength,

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -68,6 +68,31 @@ import org.apache.spark.util.collection.unsafe.sort.UnsafeSorterSpillWriter;
  */
 public final class BytesToBytesMap extends MemoryConsumer {
 
+  /**
+   * Hashes and compares keys whose semantics cannot be determined from their raw bytes.
+   * Implementations must assign the same hash code to equal keys.
+   */
+  public interface KeyOperations {
+    int hash(Object base, long offset, int length);
+
+    boolean equals(
+      Object leftBase,
+      long leftOffset,
+      int leftLength,
+      Object rightBase,
+      long rightOffset,
+      int rightLength);
+  }
+
+  /**
+   * Creates independent key operations for a single {@link Location}, allowing each instance to
+   * reuse mutable state.
+   */
+  @FunctionalInterface
+  public interface KeyOperationsFactory {
+    KeyOperations create();
+  }
+
   private static final SparkLogger logger = SparkLoggerFactory.getLogger(BytesToBytesMap.class);
 
   private static final HashMapGrowthStrategy growthStrategy = HashMapGrowthStrategy.DOUBLING;
@@ -127,6 +152,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
   private final double loadFactor;
 
+  @Nullable private final KeyOperationsFactory keyOperationsFactory;
+
   /**
    * The size of the data pages that hold key and value data. Map entries cannot span multiple
    * pages, so this limits the maximum entry size.
@@ -180,11 +207,30 @@ public final class BytesToBytesMap extends MemoryConsumer {
       int initialCapacity,
       double loadFactor,
       long pageSizeBytes) {
+    this(
+      taskMemoryManager,
+      blockManager,
+      serializerManager,
+      initialCapacity,
+      loadFactor,
+      pageSizeBytes,
+      null);
+  }
+
+  public BytesToBytesMap(
+      TaskMemoryManager taskMemoryManager,
+      BlockManager blockManager,
+      SerializerManager serializerManager,
+      int initialCapacity,
+      double loadFactor,
+      long pageSizeBytes,
+      @Nullable KeyOperationsFactory keyOperationsFactory) {
     super(taskMemoryManager, pageSizeBytes, taskMemoryManager.getTungstenMemoryMode());
     this.taskMemoryManager = taskMemoryManager;
     this.blockManager = blockManager;
     this.serializerManager = serializerManager;
     this.loadFactor = loadFactor;
+    this.keyOperationsFactory = keyOperationsFactory;
     this.loc = new Location();
     this.pageSizeBytes = pageSizeBytes;
     if (initialCapacity <= 0) {
@@ -206,6 +252,14 @@ public final class BytesToBytesMap extends MemoryConsumer {
       TaskMemoryManager taskMemoryManager,
       int initialCapacity,
       long pageSizeBytes) {
+    this(taskMemoryManager, initialCapacity, pageSizeBytes, null);
+  }
+
+  public BytesToBytesMap(
+      TaskMemoryManager taskMemoryManager,
+      int initialCapacity,
+      long pageSizeBytes,
+      @Nullable KeyOperationsFactory keyOperationsFactory) {
     this(
       taskMemoryManager,
       SparkEnv.get() != null ? SparkEnv.get().blockManager() :  null,
@@ -213,7 +267,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
       initialCapacity,
       // In order to re-use the longArray for sorting, the load factor cannot be larger than 0.5.
       0.5,
-      pageSizeBytes);
+      pageSizeBytes,
+      keyOperationsFactory);
   }
 
   /**
@@ -498,8 +553,9 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * This function is not thread-safe.
    */
   public Location lookup(Object keyBase, long keyOffset, int keyLength) {
-    safeLookup(keyBase, keyOffset, keyLength, loc,
-      Murmur3_x86_32.hashUnsafeWords(keyBase, keyOffset, keyLength, 42));
+    final int hash = keyOperationsFactory == null ?
+      Murmur3_x86_32.hashUnsafeWords(keyBase, keyOffset, keyLength, 42) : 0;
+    safeLookup(keyBase, keyOffset, keyLength, loc, hash);
     return loc;
   }
 
@@ -508,7 +564,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * and read/write values.
    *
    * This function always returns the same {@link Location} instance to avoid object allocation.
-   * This function is not thread-safe.
+   * This function is not thread-safe. If key operations are configured, the supplied hash is
+   * ignored and recomputed by those operations.
    */
   public Location lookup(Object keyBase, long keyOffset, int keyLength, int hash) {
     safeLookup(keyBase, keyOffset, keyLength, loc, hash);
@@ -518,10 +575,17 @@ public final class BytesToBytesMap extends MemoryConsumer {
   /**
    * Looks up a key, and saves the result in provided `loc`.
    *
-   * This is a thread-safe version of `lookup`, could be used by multiple threads.
+   * This is a thread-safe version of `lookup`, provided that each thread supplies its own
+   * {@link Location}. The map must not be modified concurrently. If key operations are configured,
+   * the supplied hash is ignored and recomputed by those operations.
    */
   public void safeLookup(Object keyBase, long keyOffset, int keyLength, Location loc, int hash) {
     assert(longArray != null);
+
+    final KeyOperations keyOperations = loc.getKeyOperations();
+    if (keyOperations != null) {
+      hash = keyOperations.hash(keyBase, keyOffset, keyLength);
+    }
 
     numKeyLookups++;
 
@@ -538,17 +602,23 @@ public final class BytesToBytesMap extends MemoryConsumer {
         if ((int) (stored) == hash) {
           // Full hash code matches.  Let's compare the keys for equality.
           loc.with(pos, hash, true);
-          if (loc.getKeyLength() == keyLength) {
-            final boolean areEqual = ByteArrayMethods.arrayEquals(
+          if (loc.getKeyLength() == keyLength &&
+              ByteArrayMethods.arrayEquals(
               keyBase,
               keyOffset,
               loc.getKeyBase(),
               loc.getKeyOffset(),
-              keyLength
-            );
-            if (areEqual) {
-              return;
-            }
+              keyLength)) {
+            return;
+          }
+          if (keyOperations != null && keyOperations.equals(
+              keyBase,
+              keyOffset,
+              keyLength,
+              loc.getKeyBase(),
+              loc.getKeyOffset(),
+              loc.getKeyLength())) {
+            return;
           }
         }
       }
@@ -577,10 +647,20 @@ public final class BytesToBytesMap extends MemoryConsumer {
     private long valueOffset;
     private int valueLength;
 
+    @Nullable private KeyOperations keyOperations;
+
     /**
      * Memory page containing the record. Only set if created by {@link BytesToBytesMap#iterator()}.
      */
     @Nullable private MemoryBlock memoryPage;
+
+    @Nullable
+    private KeyOperations getKeyOperations() {
+      if (keyOperations == null && keyOperationsFactory != null) {
+        keyOperations = keyOperationsFactory.create();
+      }
+      return keyOperations;
+    }
 
     private void updateAddressesAndSizes(long fullKeyAddress) {
       updateAddressesAndSizes(

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -138,7 +138,7 @@ public abstract class AbstractBytesToBytesMapSuite {
   @Test
   public void supportsSemanticKeyOperations() throws Exception {
     AtomicInteger operationsCreated = new AtomicInteger();
-    BytesToBytesMap.KeyOperationsFactory firstByteCaseInsensitive = () -> {
+    BytesToBytesMap.KeyOperationsFactory caseInsensitiveWithConstantHash = () -> {
       operationsCreated.incrementAndGet();
       return new BytesToBytesMap.KeyOperations() {
         private final AtomicReference<Thread> owner = new AtomicReference<>();
@@ -152,7 +152,7 @@ public abstract class AbstractBytesToBytesMapSuite {
         @Override
         public int hash(Object base, long offset, int length) {
           assertThreadOwnership();
-          return Character.toLowerCase(Platform.getByte(base, offset));
+          return 0;
         }
 
         @Override
@@ -170,39 +170,64 @@ public abstract class AbstractBytesToBytesMapSuite {
       };
     };
     BytesToBytesMap map = new BytesToBytesMap(
-      taskMemoryManager, 64, PAGE_SIZE_BYTES, firstByteCaseInsensitive);
+      taskMemoryManager, 64, PAGE_SIZE_BYTES, caseInsensitiveWithConstantHash);
     ExecutorService executor = Executors.newFixedThreadPool(2);
 
-    byte[] storedKey = new byte[8];
-    storedKey[0] = 'A';
-    byte[] equivalentKey = new byte[16];
-    equivalentKey[0] = 'a';
-    byte[] value = new byte[8];
+    byte[] firstStoredKey = new byte[8];
+    firstStoredKey[0] = 'A';
+    byte[] firstEquivalentKey = new byte[16];
+    firstEquivalentKey[0] = 'a';
+    byte[] firstValue = new byte[8];
+    Platform.putLong(firstValue, Platform.BYTE_ARRAY_OFFSET, 1L);
+    byte[] secondStoredKey = new byte[8];
+    secondStoredKey[0] = 'B';
+    byte[] secondEquivalentKey = new byte[16];
+    secondEquivalentKey[0] = 'b';
+    byte[] secondValue = new byte[8];
+    Platform.putLong(secondValue, Platform.BYTE_ARRAY_OFFSET, 2L);
 
     try {
       BytesToBytesMap.Location location = map.lookup(
-        storedKey, Platform.BYTE_ARRAY_OFFSET, storedKey.length);
+        firstStoredKey, Platform.BYTE_ARRAY_OFFSET, firstStoredKey.length);
       assertFalse(location.isDefined());
       assertTrue(location.append(
-        storedKey,
+        firstStoredKey,
         Platform.BYTE_ARRAY_OFFSET,
-        storedKey.length,
-        value,
+        firstStoredKey.length,
+        firstValue,
         Platform.BYTE_ARRAY_OFFSET,
-        value.length));
+        firstValue.length));
 
       location = map.lookup(
-        equivalentKey, Platform.BYTE_ARRAY_OFFSET, equivalentKey.length);
+        secondStoredKey, Platform.BYTE_ARRAY_OFFSET, secondStoredKey.length);
+      assertFalse(location.isDefined());
+      assertTrue(location.append(
+        secondStoredKey,
+        Platform.BYTE_ARRAY_OFFSET,
+        secondStoredKey.length,
+        secondValue,
+        Platform.BYTE_ARRAY_OFFSET,
+        secondValue.length));
+
+      location = map.lookup(
+        firstEquivalentKey, Platform.BYTE_ARRAY_OFFSET, firstEquivalentKey.length);
       assertTrue(location.isDefined());
-      assertEquals(storedKey.length, location.getKeyLength());
+      assertEquals(firstStoredKey.length, location.getKeyLength());
+      assertEquals(1L, Platform.getLong(location.getValueBase(), location.getValueOffset()));
 
       location = map.lookup(
-        equivalentKey,
+        secondEquivalentKey, Platform.BYTE_ARRAY_OFFSET, secondEquivalentKey.length);
+      assertTrue(location.isDefined());
+      assertEquals(secondStoredKey.length, location.getKeyLength());
+      assertEquals(2L, Platform.getLong(location.getValueBase(), location.getValueOffset()));
+
+      location = map.lookup(
+        firstEquivalentKey,
         Platform.BYTE_ARRAY_OFFSET,
-        equivalentKey.length,
+        firstEquivalentKey.length,
         Integer.MAX_VALUE);
       assertTrue(location.isDefined());
-      assertEquals(1, map.numKeys());
+      assertEquals(2, map.numKeys());
 
       CountDownLatch ready = new CountDownLatch(2);
       CountDownLatch start = new CountDownLatch(1);
@@ -212,9 +237,9 @@ public abstract class AbstractBytesToBytesMapSuite {
         start.await();
         for (int i = 0; i < 100; i++) {
           map.safeLookup(
-            equivalentKey,
+            firstEquivalentKey,
             Platform.BYTE_ARRAY_OFFSET,
-            equivalentKey.length,
+            firstEquivalentKey.length,
             threadLocation);
           assertTrue(threadLocation.isDefined());
         }

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -180,7 +180,7 @@ public abstract class AbstractBytesToBytesMapSuite {
     byte[] value = new byte[8];
 
     try {
-      BytesToBytesMap.Location location = map.lookupWithKeyOperations(
+      BytesToBytesMap.Location location = map.lookup(
         storedKey, Platform.BYTE_ARRAY_OFFSET, storedKey.length);
       assertFalse(location.isDefined());
       assertTrue(location.append(
@@ -191,16 +191,17 @@ public abstract class AbstractBytesToBytesMapSuite {
         Platform.BYTE_ARRAY_OFFSET,
         value.length));
 
-      location = map.lookupWithKeyOperations(
+      location = map.lookup(
         equivalentKey, Platform.BYTE_ARRAY_OFFSET, equivalentKey.length);
       assertTrue(location.isDefined());
       assertEquals(storedKey.length, location.getKeyLength());
 
-      assertThrows(AssertionError.class, () -> map.lookup(
+      location = map.lookup(
         equivalentKey,
         Platform.BYTE_ARRAY_OFFSET,
         equivalentKey.length,
-        Integer.MAX_VALUE));
+        Integer.MAX_VALUE);
+      assertTrue(location.isDefined());
       assertEquals(1, map.numKeys());
 
       CountDownLatch ready = new CountDownLatch(2);
@@ -210,7 +211,7 @@ public abstract class AbstractBytesToBytesMapSuite {
         ready.countDown();
         start.await();
         for (int i = 0; i < 100; i++) {
-          map.safeLookupWithKeyOperations(
+          map.safeLookup(
             equivalentKey,
             Platform.BYTE_ARRAY_OFFSET,
             equivalentKey.length,

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -21,6 +21,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import scala.Tuple2$;
 
@@ -127,6 +134,102 @@ public abstract class AbstractBytesToBytesMapSuite {
   }
 
   protected abstract boolean useOffHeapMemoryAllocator();
+
+  @Test
+  public void supportsSemanticKeyOperations() throws Exception {
+    AtomicInteger operationsCreated = new AtomicInteger();
+    BytesToBytesMap.KeyOperationsFactory firstByteCaseInsensitive = () -> {
+      operationsCreated.incrementAndGet();
+      return new BytesToBytesMap.KeyOperations() {
+        private final AtomicReference<Thread> owner = new AtomicReference<>();
+
+        private void assertThreadOwnership() {
+          final Thread currentThread = Thread.currentThread();
+          owner.compareAndSet(null, currentThread);
+          assertSame(currentThread, owner.get());
+        }
+
+        @Override
+        public int hash(Object base, long offset, int length) {
+          assertThreadOwnership();
+          return Character.toLowerCase(Platform.getByte(base, offset));
+        }
+
+        @Override
+        public boolean equals(
+            Object leftBase,
+            long leftOffset,
+            int leftLength,
+            Object rightBase,
+            long rightOffset,
+            int rightLength) {
+          assertThreadOwnership();
+          return Character.toLowerCase(Platform.getByte(leftBase, leftOffset)) ==
+            Character.toLowerCase(Platform.getByte(rightBase, rightOffset));
+        }
+      };
+    };
+    BytesToBytesMap map = new BytesToBytesMap(
+      taskMemoryManager, 64, PAGE_SIZE_BYTES, firstByteCaseInsensitive);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    byte[] storedKey = new byte[8];
+    storedKey[0] = 'A';
+    byte[] equivalentKey = new byte[16];
+    equivalentKey[0] = 'a';
+    byte[] value = new byte[8];
+
+    try {
+      BytesToBytesMap.Location location = map.lookup(
+        storedKey, Platform.BYTE_ARRAY_OFFSET, storedKey.length);
+      assertFalse(location.isDefined());
+      assertTrue(location.append(
+        storedKey,
+        Platform.BYTE_ARRAY_OFFSET,
+        storedKey.length,
+        value,
+        Platform.BYTE_ARRAY_OFFSET,
+        value.length));
+
+      location = map.lookup(
+        equivalentKey, Platform.BYTE_ARRAY_OFFSET, equivalentKey.length);
+      assertTrue(location.isDefined());
+      assertEquals(storedKey.length, location.getKeyLength());
+
+      location = map.lookup(
+        equivalentKey, Platform.BYTE_ARRAY_OFFSET, equivalentKey.length, Integer.MAX_VALUE);
+      assertTrue(location.isDefined());
+      assertEquals(1, map.numKeys());
+
+      CountDownLatch ready = new CountDownLatch(2);
+      CountDownLatch start = new CountDownLatch(1);
+      Callable<Void> concurrentLookup = () -> {
+        BytesToBytesMap.Location threadLocation = map.new Location();
+        ready.countDown();
+        start.await();
+        for (int i = 0; i < 100; i++) {
+          map.safeLookup(
+            equivalentKey,
+            Platform.BYTE_ARRAY_OFFSET,
+            equivalentKey.length,
+            threadLocation,
+            i);
+          assertTrue(threadLocation.isDefined());
+        }
+        return null;
+      };
+      Future<Void> firstLookup = executor.submit(concurrentLookup);
+      Future<Void> secondLookup = executor.submit(concurrentLookup);
+      ready.await();
+      start.countDown();
+      firstLookup.get();
+      secondLookup.get();
+      assertEquals(3, operationsCreated.get());
+    } finally {
+      executor.shutdownNow();
+      map.free();
+    }
+  }
 
   private static byte[] getByteArray(Object base, long offset, int size) {
     final byte[] arr = new byte[size];

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -180,7 +180,7 @@ public abstract class AbstractBytesToBytesMapSuite {
     byte[] value = new byte[8];
 
     try {
-      BytesToBytesMap.Location location = map.lookup(
+      BytesToBytesMap.Location location = map.lookupWithKeyOperations(
         storedKey, Platform.BYTE_ARRAY_OFFSET, storedKey.length);
       assertFalse(location.isDefined());
       assertTrue(location.append(
@@ -191,14 +191,16 @@ public abstract class AbstractBytesToBytesMapSuite {
         Platform.BYTE_ARRAY_OFFSET,
         value.length));
 
-      location = map.lookup(
+      location = map.lookupWithKeyOperations(
         equivalentKey, Platform.BYTE_ARRAY_OFFSET, equivalentKey.length);
       assertTrue(location.isDefined());
       assertEquals(storedKey.length, location.getKeyLength());
 
-      location = map.lookup(
-        equivalentKey, Platform.BYTE_ARRAY_OFFSET, equivalentKey.length, Integer.MAX_VALUE);
-      assertTrue(location.isDefined());
+      assertThrows(AssertionError.class, () -> map.lookup(
+        equivalentKey,
+        Platform.BYTE_ARRAY_OFFSET,
+        equivalentKey.length,
+        Integer.MAX_VALUE));
       assertEquals(1, map.numKeys());
 
       CountDownLatch ready = new CountDownLatch(2);
@@ -208,12 +210,11 @@ public abstract class AbstractBytesToBytesMapSuite {
         ready.countDown();
         start.await();
         for (int i = 0; i < 100; i++) {
-          map.safeLookup(
+          map.safeLookupWithKeyOperations(
             equivalentKey,
             Platform.BYTE_ARRAY_OFFSET,
             equivalentKey.length,
-            threadLocation,
-            i);
+            threadLocation);
           assertTrue(threadLocation.isDefined());
         }
         return null;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1296,15 +1296,7 @@ object Aggregate {
    * operations in hash aggregation.
    */
   def supportsHashAggregateGroupingKey(dataType: DataType): Boolean = {
-    def supportsSemanticEquality(dataType: DataType): Boolean = dataType match {
-      case _: StringType => true
-      case _: MapType => false
-      case ArrayType(elementType, _) => supportsSemanticEquality(elementType)
-      case StructType(fields) => fields.forall(f => supportsSemanticEquality(f.dataType))
-      case other => UnsafeRowUtils.isBinaryStable(other)
-    }
-
-    UnsafeRowUtils.isBinaryStable(dataType) || supportsSemanticEquality(dataType)
+    UnsafeRowKeyOperations.supportsDataType(dataType)
   }
 
   def supportsHashAggregate(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1291,18 +1291,34 @@ object Aggregate {
     schema.forall(f => UnsafeRow.isMutable(f.dataType))
   }
 
+  /**
+   * Returns whether hash aggregation can compare grouping keys of this type. Binary-stable types
+   * retain their raw UnsafeRow path. For binary-unstable types, only collated strings and nested
+   * arrays or structs containing them have semantic key operations.
+   */
+  def supportsHashAggregateGroupingKey(dataType: DataType): Boolean = {
+    def supportsSemanticEquality(dataType: DataType): Boolean = dataType match {
+      case _: StringType => true
+      case _: MapType => false
+      case ArrayType(elementType, _) => supportsSemanticEquality(elementType)
+      case StructType(fields) => fields.forall(f => supportsSemanticEquality(f.dataType))
+      case other => UnsafeRowUtils.isBinaryStable(other)
+    }
+
+    UnsafeRowUtils.isBinaryStable(dataType) || supportsSemanticEquality(dataType)
+  }
+
   def supportsHashAggregate(
       aggregateBufferAttributes: Seq[Attribute], groupingExpression: Seq[Expression]): Boolean = {
     val aggregationBufferSchema = DataTypeUtils.fromAttributes(aggregateBufferAttributes)
     isAggregateBufferMutable(aggregationBufferSchema) &&
-      groupingExpression.forall(e => UnsafeRowUtils.isBinaryStable(e.dataType))
+      groupingExpression.forall(e => supportsHashAggregateGroupingKey(e.dataType))
   }
 
   def supportsObjectHashAggregate(
       aggregateExpressions: Seq[AggregateExpression],
       groupingExpressions: Seq[Expression]): Boolean = {
-    // We should not use hash aggregation on binary unstable types.
-    if (groupingExpressions.exists(e => !UnsafeRowUtils.isBinaryStable(e.dataType))) {
+    if (groupingExpressions.exists(e => !supportsHashAggregateGroupingKey(e.dataType))) {
       return false
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1292,9 +1292,8 @@ object Aggregate {
   }
 
   /**
-   * Returns whether hash aggregation can compare grouping keys of this type. Binary-stable types
-   * retain their raw UnsafeRow path. For binary-unstable types, only collated strings and nested
-   * arrays or structs containing them have semantic key operations.
+   * Returns whether grouping keys of this type can use raw binary equality or schema-aware key
+   * operations in hash aggregation.
    */
   def supportsHashAggregateGroupingKey(dataType: DataType): Boolean = {
     def supportsSemanticEquality(dataType: DataType): Boolean = dataType match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.util
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Expression, Murmur3HashFunction, RowOrdering}
+import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Expression}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition}
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.util.NonFateSharingCache
@@ -34,8 +34,10 @@ import org.apache.spark.util.NonFateSharingCache
 class InternalRowComparableWrapper private (
     val row: InternalRow,
     val dataTypes: Seq[DataType],
-    val structType: StructType,
-    val ordering: BaseOrdering) {
+    val keyOperations: UnsafeRowKeyOperations) {
+
+  val structType: StructType = keyOperations.schema
+  val ordering: BaseOrdering = keyOperations.ordering
 
   /**
    * Previous constructor for binary compatibility. Prefer using
@@ -46,16 +48,9 @@ class InternalRowComparableWrapper private (
   def this(row: InternalRow, dataTypes: Seq[DataType]) = this(
     row,
     dataTypes,
-    InternalRowComparableWrapper.structTypeCache.get(dataTypes),
-    InternalRowComparableWrapper.orderingCache.get(dataTypes))
+    InternalRowComparableWrapper.keyOperationsCache.get(dataTypes))
 
-  override def hashCode(): Int = Murmur3HashFunction.hash(
-    row,
-    structType,
-    42L,
-    isCollationAware = true,
-    // legacyCollationAwareHashing only matters when isCollationAware is false.
-    legacyCollationAwareHashing = false).toInt
+  override def hashCode(): Int = keyOperations.hash(row)
 
   override def equals(other: Any): Boolean = {
     if (!other.isInstanceOf[InternalRowComparableWrapper]) {
@@ -65,23 +60,16 @@ class InternalRowComparableWrapper private (
     if (!otherWrapper.dataTypes.equals(this.dataTypes)) {
       return false
     }
-    ordering.compare(row, otherWrapper.row) == 0
+    keyOperations.areEqual(row, otherWrapper.row)
   }
 }
 
 object InternalRowComparableWrapper {
   private final val MAX_CACHE_ENTRIES = 1024
 
-  private val orderingCache = {
+  private val keyOperationsCache = {
     val loadFunc = (dataTypes: Seq[DataType]) => {
-      RowOrdering.createNaturalAscendingOrdering(dataTypes)
-    }
-    NonFateSharingCache(loadFunc, MAX_CACHE_ENTRIES)
-  }
-
-  private val structTypeCache = {
-    val loadFunc = (dataTypes: Seq[DataType]) => {
-      StructType(dataTypes.map(t => StructField("f", t)))
+      new UnsafeRowKeyOperations(StructType(dataTypes.map(t => StructField("f", t))))
     }
     NonFateSharingCache(loadFunc, MAX_CACHE_ENTRIES)
   }
@@ -102,8 +90,7 @@ object InternalRowComparableWrapper {
   /** Creates a shared factory method for a given row schema to avoid excessive cache lookups. */
   def getInternalRowComparableWrapperFactory(
       dataTypes: Seq[DataType]): InternalRow => InternalRowComparableWrapper = {
-    val structType = structTypeCache.get(dataTypes)
-    val ordering = orderingCache.get(dataTypes)
-    row: InternalRow => new InternalRowComparableWrapper(row, dataTypes, structType, ordering)
+    val keyOperations = keyOperationsCache.get(dataTypes)
+    row: InternalRow => new InternalRowComparableWrapper(row, dataTypes, keyOperations)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.util
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Expression}
+import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Expression, Murmur3HashFunction, RowOrdering}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition}
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.util.NonFateSharingCache
@@ -34,10 +34,8 @@ import org.apache.spark.util.NonFateSharingCache
 class InternalRowComparableWrapper private (
     val row: InternalRow,
     val dataTypes: Seq[DataType],
-    val keyOperations: UnsafeRowKeyOperations) {
-
-  val structType: StructType = keyOperations.schema
-  val ordering: BaseOrdering = keyOperations.ordering
+    val structType: StructType,
+    val ordering: BaseOrdering) {
 
   /**
    * Previous constructor for binary compatibility. Prefer using
@@ -48,9 +46,16 @@ class InternalRowComparableWrapper private (
   def this(row: InternalRow, dataTypes: Seq[DataType]) = this(
     row,
     dataTypes,
-    InternalRowComparableWrapper.keyOperationsCache.get(dataTypes))
+    InternalRowComparableWrapper.structTypeCache.get(dataTypes),
+    InternalRowComparableWrapper.orderingCache.get(dataTypes))
 
-  override def hashCode(): Int = keyOperations.hash(row)
+  override def hashCode(): Int = Murmur3HashFunction.hash(
+    row,
+    structType,
+    42L,
+    isCollationAware = true,
+    // legacyCollationAwareHashing only matters when isCollationAware is false.
+    legacyCollationAwareHashing = false).toInt
 
   override def equals(other: Any): Boolean = {
     if (!other.isInstanceOf[InternalRowComparableWrapper]) {
@@ -60,16 +65,23 @@ class InternalRowComparableWrapper private (
     if (!otherWrapper.dataTypes.equals(this.dataTypes)) {
       return false
     }
-    keyOperations.areEqual(row, otherWrapper.row)
+    ordering.compare(row, otherWrapper.row) == 0
   }
 }
 
 object InternalRowComparableWrapper {
   private final val MAX_CACHE_ENTRIES = 1024
 
-  private val keyOperationsCache = {
+  private val orderingCache = {
     val loadFunc = (dataTypes: Seq[DataType]) => {
-      new UnsafeRowKeyOperations(StructType(dataTypes.map(t => StructField("f", t))))
+      RowOrdering.createNaturalAscendingOrdering(dataTypes)
+    }
+    NonFateSharingCache(loadFunc, MAX_CACHE_ENTRIES)
+  }
+
+  private val structTypeCache = {
+    val loadFunc = (dataTypes: Seq[DataType]) => {
+      StructType(dataTypes.map(t => StructField("f", t)))
     }
     NonFateSharingCache(loadFunc, MAX_CACHE_ENTRIES)
   }
@@ -90,7 +102,8 @@ object InternalRowComparableWrapper {
   /** Creates a shared factory method for a given row schema to avoid excessive cache lookups. */
   def getInternalRowComparableWrapperFactory(
       dataTypes: Seq[DataType]): InternalRow => InternalRowComparableWrapper = {
-    val keyOperations = keyOperationsCache.get(dataTypes)
-    row: InternalRow => new InternalRowComparableWrapper(row, dataTypes, keyOperations)
+    val structType = structTypeCache.get(dataTypes)
+    val ordering = orderingCache.get(dataTypes)
+    row: InternalRow => new InternalRowComparableWrapper(row, dataTypes, structType, ordering)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
@@ -21,7 +21,7 @@ import com.ibm.icu.text.RawCollationKey
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeArrayData, UnsafeRow}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.array.ByteArrayMethods
@@ -223,14 +223,17 @@ object UnsafeRowKeyOperations {
       elementType: DataType,
       hashScratch: HashScratch) extends FieldOperations {
     private val elementOperations = createFieldOperations(elementType, hashScratch)
+    private val hashArray = new UnsafeArrayData
+    private val leftArray = new UnsafeArrayData
+    private val rightArray = new UnsafeArrayData
 
     override protected def hashNonNull(
         input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
-      val array = input.getArray(ordinal)
+      pointToArray(input, ordinal, hashArray)
       var result = seed
       var index = 0
-      while (index < array.numElements()) {
-        result = elementOperations.hash(array, index, result)
+      while (index < hashArray.numElements()) {
+        result = elementOperations.hash(hashArray, index, result)
         index += 1
       }
       result
@@ -241,8 +244,8 @@ object UnsafeRowKeyOperations {
         leftOrdinal: Int,
         right: SpecializedGetters,
         rightOrdinal: Int): Boolean = {
-      val leftArray = left.getArray(leftOrdinal)
-      val rightArray = right.getArray(rightOrdinal)
+      pointToArray(left, leftOrdinal, leftArray)
+      pointToArray(right, rightOrdinal, rightArray)
       if (leftArray.numElements() != rightArray.numElements()) {
         return false
       }
@@ -261,10 +264,14 @@ object UnsafeRowKeyOperations {
       dataType: StructType,
       hashScratch: HashScratch) extends FieldOperations {
     private val operations = new RowOperations(dataType, hashScratch)
+    private val hashRow = new UnsafeRow(dataType.length)
+    private val leftRow = new UnsafeRow(dataType.length)
+    private val rightRow = new UnsafeRow(dataType.length)
 
     override protected def hashNonNull(
         input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
-      operations.hash(input.getStruct(ordinal, dataType.length), seed)
+      pointToStruct(input, ordinal, hashRow)
+      operations.hash(hashRow, seed)
     }
 
     override protected def areEqualNonNull(
@@ -272,9 +279,9 @@ object UnsafeRowKeyOperations {
         leftOrdinal: Int,
         right: SpecializedGetters,
         rightOrdinal: Int): Boolean = {
-      operations.areEqual(
-        left.getStruct(leftOrdinal, dataType.length),
-        right.getStruct(rightOrdinal, dataType.length))
+      pointToStruct(left, leftOrdinal, leftRow)
+      pointToStruct(right, rightOrdinal, rightRow)
+      operations.areEqual(leftRow, rightRow)
     }
   }
 
@@ -324,5 +331,53 @@ object UnsafeRowKeyOperations {
       baseOffset: Long, offsetAndSize: Long, region: BinaryRegion): Unit = {
     region.offset = baseOffset + (offsetAndSize >> 32).toInt
     region.length = offsetAndSize.toInt
+  }
+
+  private def pointToArray(
+      input: SpecializedGetters,
+      ordinal: Int,
+      target: UnsafeArrayData): Unit = input match {
+    case row: UnsafeRow =>
+      pointToArray(row.getBaseObject, row.getBaseOffset, row.getLong(ordinal), target)
+    case array: UnsafeArrayData =>
+      pointToArray(array.getBaseObject, array.getBaseOffset, array.getLong(ordinal), target)
+    case other =>
+      throw SparkException.internalError(
+        s"Expected unsafe grouping-key storage, found ${other.getClass.getName}")
+  }
+
+  private def pointToArray(
+      base: AnyRef,
+      baseOffset: Long,
+      offsetAndSize: Long,
+      target: UnsafeArrayData): Unit = {
+    target.pointTo(
+      base,
+      baseOffset + (offsetAndSize >> 32).toInt,
+      offsetAndSize.toInt)
+  }
+
+  private def pointToStruct(
+      input: SpecializedGetters,
+      ordinal: Int,
+      target: UnsafeRow): Unit = input match {
+    case row: UnsafeRow =>
+      pointToStruct(row.getBaseObject, row.getBaseOffset, row.getLong(ordinal), target)
+    case array: UnsafeArrayData =>
+      pointToStruct(array.getBaseObject, array.getBaseOffset, array.getLong(ordinal), target)
+    case other =>
+      throw SparkException.internalError(
+        s"Expected unsafe grouping-key storage, found ${other.getClass.getName}")
+  }
+
+  private def pointToStruct(
+      base: AnyRef,
+      baseOffset: Long,
+      offsetAndSize: Long,
+      target: UnsafeRow): Unit = {
+    target.pointTo(
+      base,
+      baseOffset + (offsetAndSize >> 32).toInt,
+      offsetAndSize.toInt)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
@@ -17,44 +17,40 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Murmur3HashFunction, RowOrdering, UnsafeRow}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeRow}
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.array.ByteArrayMethods
+import org.apache.spark.unsafe.hash.Murmur3_x86_32
 import org.apache.spark.unsafe.map.BytesToBytesMap
 
-/** Schema-aware hashing and equality operations for row keys. */
+/** Hashes and compares unsafe grouping keys containing non-binary collated strings. */
 final class UnsafeRowKeyOperations(val schema: StructType)
     extends BytesToBytesMap.KeyOperationsFactory {
+  import UnsafeRowKeyOperations._
 
-  private def createOrdering(): BaseOrdering = {
-    RowOrdering.createNaturalAscendingOrdering(schema.map(_.dataType).toSeq)
-  }
+  require(
+    schema.forall(field => supportsDataType(field.dataType)),
+    s"Unsupported grouping key schema: $schema")
 
-  val ordering: BaseOrdering =
-    createOrdering()
+  private val operations = new RowOperations(schema)
 
-  def hash(row: InternalRow): Int = {
-    Murmur3HashFunction.hash(
-      row,
-      schema,
-      42L,
-      isCollationAware = true,
-      // This flag only affects hashing when isCollationAware is false.
-      legacyCollationAwareHashing = false).toInt
-  }
+  def hash(row: UnsafeRow): Int = operations.hash(row, HASH_SEED)
 
-  def areEqual(left: InternalRow, right: InternalRow): Boolean = {
-    ordering.compare(left, right) == 0
+  def areEqual(left: UnsafeRow, right: UnsafeRow): Boolean = {
+    operations.areEqual(left, right)
   }
 
   override def create(): BytesToBytesMap.KeyOperations = new BytesToBytesMap.KeyOperations {
-    private val localOrdering = createOrdering()
+    private val localOperations = new RowOperations(schema)
     private val left = new UnsafeRow(schema.length)
     private val right = new UnsafeRow(schema.length)
 
     override def hash(base: AnyRef, offset: Long, length: Int): Int = {
       left.pointTo(base, offset, length)
-      UnsafeRowKeyOperations.this.hash(left)
+      localOperations.hash(left, HASH_SEED)
     }
 
     override def equals(
@@ -66,7 +62,223 @@ final class UnsafeRowKeyOperations(val schema: StructType)
         rightLength: Int): Boolean = {
       left.pointTo(leftBase, leftOffset, leftLength)
       right.pointTo(rightBase, rightOffset, rightLength)
-      localOrdering.compare(left, right) == 0
+      localOperations.areEqual(left, right)
     }
+  }
+}
+
+object UnsafeRowKeyOperations {
+  private val HASH_SEED = 42
+
+  /** Returns whether this type can be hashed and compared as part of an unsafe row key. */
+  def supportsDataType(dataType: DataType): Boolean = {
+    if (UnsafeRowUtils.isBinaryStable(dataType)) {
+      true
+    } else {
+      dataType match {
+        case st: StringType => !st.supportsBinaryEquality
+        case ArrayType(elementType, _) => supportsDataType(elementType)
+        case StructType(fields) => fields.forall(field => supportsDataType(field.dataType))
+        case _ => false
+      }
+    }
+  }
+
+  private final class BinaryRegion {
+    var base: AnyRef = _
+    var offset: Long = 0L
+    var length: Int = 0
+  }
+
+  private sealed trait FieldOperations {
+    final def hash(input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
+      if (input.isNullAt(ordinal)) seed else hashNonNull(input, ordinal, seed)
+    }
+
+    final def areEqual(
+        left: SpecializedGetters,
+        leftOrdinal: Int,
+        right: SpecializedGetters,
+        rightOrdinal: Int): Boolean = {
+      val leftIsNull = left.isNullAt(leftOrdinal)
+      val rightIsNull = right.isNullAt(rightOrdinal)
+      if (leftIsNull || rightIsNull) {
+        leftIsNull == rightIsNull
+      } else {
+        areEqualNonNull(left, leftOrdinal, right, rightOrdinal)
+      }
+    }
+
+    protected def hashNonNull(input: SpecializedGetters, ordinal: Int, seed: Int): Int
+
+    protected def areEqualNonNull(
+        left: SpecializedGetters,
+        leftOrdinal: Int,
+        right: SpecializedGetters,
+        rightOrdinal: Int): Boolean
+  }
+
+  private final class BinaryStableOperations(dataType: DataType) extends FieldOperations {
+    private val leftRegion = new BinaryRegion
+    private val rightRegion = new BinaryRegion
+
+    override protected def hashNonNull(
+        input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
+      setRegion(input, ordinal, leftRegion)
+      Murmur3_x86_32.hashUnsafeBytes(
+        leftRegion.base, leftRegion.offset, leftRegion.length, seed)
+    }
+
+    override protected def areEqualNonNull(
+        left: SpecializedGetters,
+        leftOrdinal: Int,
+        right: SpecializedGetters,
+        rightOrdinal: Int): Boolean = {
+      setRegion(left, leftOrdinal, leftRegion)
+      setRegion(right, rightOrdinal, rightRegion)
+      leftRegion.length == rightRegion.length && ByteArrayMethods.arrayEquals(
+        leftRegion.base,
+        leftRegion.offset,
+        rightRegion.base,
+        rightRegion.offset,
+        leftRegion.length)
+    }
+
+    private def setRegion(
+        input: SpecializedGetters, ordinal: Int, region: BinaryRegion): Unit = input match {
+      case row: UnsafeRow =>
+        region.base = row.getBaseObject
+        if (UnsafeRow.isFixedLength(dataType)) {
+          region.offset = row.getBaseOffset +
+            UnsafeRow.calculateBitSetWidthInBytes(row.numFields()) + ordinal * 8L
+          region.length = 8
+        } else {
+          setVariableLengthRegion(row.getBaseOffset, row.getLong(ordinal), region)
+        }
+
+      case other =>
+        throw SparkException.internalError(
+          s"Expected unsafe grouping-key storage, found ${other.getClass.getName}")
+    }
+  }
+
+  private final class CollatedStringOperations(dataType: StringType) extends FieldOperations {
+    private val collation = CollationFactory.fetchCollation(dataType.collationId)
+
+    override protected def hashNonNull(
+        input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
+      val key = collation.sortKeyFunction.apply(input.getUTF8String(ordinal))
+      Murmur3_x86_32.hashUnsafeBytes(key, Platform.BYTE_ARRAY_OFFSET, key.length, seed)
+    }
+
+    override protected def areEqualNonNull(
+        left: SpecializedGetters,
+        leftOrdinal: Int,
+        right: SpecializedGetters,
+        rightOrdinal: Int): Boolean = {
+      collation.equalsFunction.apply(
+        left.getUTF8String(leftOrdinal), right.getUTF8String(rightOrdinal))
+    }
+  }
+
+  private final class ArrayOperations(elementType: DataType) extends FieldOperations {
+    private val elementOperations = createFieldOperations(elementType)
+
+    override protected def hashNonNull(
+        input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
+      val array = input.getArray(ordinal)
+      var result = seed
+      var index = 0
+      while (index < array.numElements()) {
+        result = elementOperations.hash(array, index, result)
+        index += 1
+      }
+      result
+    }
+
+    override protected def areEqualNonNull(
+        left: SpecializedGetters,
+        leftOrdinal: Int,
+        right: SpecializedGetters,
+        rightOrdinal: Int): Boolean = {
+      val leftArray = left.getArray(leftOrdinal)
+      val rightArray = right.getArray(rightOrdinal)
+      if (leftArray.numElements() != rightArray.numElements()) {
+        return false
+      }
+      var index = 0
+      while (index < leftArray.numElements()) {
+        if (!elementOperations.areEqual(leftArray, index, rightArray, index)) {
+          return false
+        }
+        index += 1
+      }
+      true
+    }
+  }
+
+  private final class StructOperations(dataType: StructType) extends FieldOperations {
+    private val operations = new RowOperations(dataType)
+
+    override protected def hashNonNull(
+        input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
+      operations.hash(input.getStruct(ordinal, dataType.length), seed)
+    }
+
+    override protected def areEqualNonNull(
+        left: SpecializedGetters,
+        leftOrdinal: Int,
+        right: SpecializedGetters,
+        rightOrdinal: Int): Boolean = {
+      operations.areEqual(
+        left.getStruct(leftOrdinal, dataType.length),
+        right.getStruct(rightOrdinal, dataType.length))
+    }
+  }
+
+  private final class RowOperations(dataType: StructType) {
+    private val fieldOperations =
+      dataType.fields.map(field => createFieldOperations(field.dataType))
+
+    def hash(row: InternalRow, seed: Int): Int = {
+      var result = seed
+      var ordinal = 0
+      while (ordinal < fieldOperations.length) {
+        result = fieldOperations(ordinal).hash(row, ordinal, result)
+        ordinal += 1
+      }
+      result
+    }
+
+    def areEqual(left: InternalRow, right: InternalRow): Boolean = {
+      var ordinal = 0
+      while (ordinal < fieldOperations.length) {
+        if (!fieldOperations(ordinal).areEqual(left, ordinal, right, ordinal)) {
+          return false
+        }
+        ordinal += 1
+      }
+      true
+    }
+  }
+
+  private def createFieldOperations(dataType: DataType): FieldOperations = {
+    if (UnsafeRowUtils.isBinaryStable(dataType)) {
+      new BinaryStableOperations(dataType)
+    } else {
+      dataType match {
+        case stringType: StringType => new CollatedStringOperations(stringType)
+        case ArrayType(elementType, _) => new ArrayOperations(elementType)
+        case structType: StructType => new StructOperations(structType)
+        case _ =>
+          throw SparkException.internalError(s"Unsupported grouping key type: $dataType")
+      }
+    }
+  }
+
+  private def setVariableLengthRegion(
+      baseOffset: Long, offsetAndSize: Long, region: BinaryRegion): Unit = {
+    region.offset = baseOffset + (offsetAndSize >> 32).toInt
+    region.length = offsetAndSize.toInt
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import com.ibm.icu.text.RawCollationKey
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeRow}
@@ -25,6 +27,7 @@ import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.hash.Murmur3_x86_32
 import org.apache.spark.unsafe.map.BytesToBytesMap
+import org.apache.spark.unsafe.types.UTF8String
 
 /** Hashes and compares unsafe grouping keys containing non-binary collated strings. */
 final class UnsafeRowKeyOperations(val schema: StructType)
@@ -35,7 +38,7 @@ final class UnsafeRowKeyOperations(val schema: StructType)
     schema.forall(field => supportsDataType(field.dataType)),
     s"Unsupported grouping key schema: $schema")
 
-  private val operations = new RowOperations(schema)
+  private val operations = new RowOperations(schema, new HashScratch)
 
   def hash(row: UnsafeRow): Int = operations.hash(row, HASH_SEED)
 
@@ -44,7 +47,7 @@ final class UnsafeRowKeyOperations(val schema: StructType)
   }
 
   override def create(): BytesToBytesMap.KeyOperations = new BytesToBytesMap.KeyOperations {
-    private val localOperations = new RowOperations(schema)
+    private val localOperations = new RowOperations(schema, new HashScratch)
     private val left = new UnsafeRow(schema.length)
     private val right = new UnsafeRow(schema.length)
 
@@ -88,6 +91,17 @@ object UnsafeRowKeyOperations {
     var base: AnyRef = _
     var offset: Long = 0L
     var length: Int = 0
+  }
+
+  private final class HashScratch {
+    private var reusableRawCollationKey: RawCollationKey = _
+
+    def rawCollationKey: RawCollationKey = {
+      if (reusableRawCollationKey == null) {
+        reusableRawCollationKey = new RawCollationKey()
+      }
+      reusableRawCollationKey
+    }
   }
 
   private sealed trait FieldOperations {
@@ -162,13 +176,37 @@ object UnsafeRowKeyOperations {
     }
   }
 
-  private final class CollatedStringOperations(dataType: StringType) extends FieldOperations {
+  private final class CollatedStringOperations(
+      dataType: StringType,
+      hashScratch: HashScratch) extends FieldOperations {
     private val collation = CollationFactory.fetchCollation(dataType.collationId)
+    private val useRawCollationKey = collation.provider == CollationFactory.PROVIDER_ICU
 
     override protected def hashNonNull(
         input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
-      val key = collation.sortKeyFunction.apply(input.getUTF8String(ordinal))
-      Murmur3_x86_32.hashUnsafeBytes(key, Platform.BYTE_ARRAY_OFFSET, key.length, seed)
+      val value = input.getUTF8String(ordinal)
+      if (useRawCollationKey) {
+        hashICUCollationKey(value, seed)
+      } else {
+        val key = collation.sortKeyFunction.apply(value)
+        Murmur3_x86_32.hashUnsafeBytes(key, Platform.BYTE_ARRAY_OFFSET, key.length, seed)
+      }
+    }
+
+    /**
+     * Hashes an ICU sort key from a reusable buffer after applying configured space trimming.
+     * `toValidString` applies Spark's replacement policy for malformed UTF-8 before calling ICU.
+     */
+    private def hashICUCollationKey(value: UTF8String, seed: Int): Int = {
+      val normalizedValue = if (collation.supportsSpaceTrimming) {
+        CollationFactory.applyTrimmingPolicy(value, dataType.collationId)
+      } else {
+        value
+      }
+      val key = collation.getCollator.getRawCollationKey(
+        normalizedValue.toValidString, hashScratch.rawCollationKey)
+      Murmur3_x86_32.hashUnsafeBytes(
+        key.bytes, Platform.BYTE_ARRAY_OFFSET, key.size, seed)
     }
 
     override protected def areEqualNonNull(
@@ -181,8 +219,10 @@ object UnsafeRowKeyOperations {
     }
   }
 
-  private final class ArrayOperations(elementType: DataType) extends FieldOperations {
-    private val elementOperations = createFieldOperations(elementType)
+  private final class ArrayOperations(
+      elementType: DataType,
+      hashScratch: HashScratch) extends FieldOperations {
+    private val elementOperations = createFieldOperations(elementType, hashScratch)
 
     override protected def hashNonNull(
         input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
@@ -217,8 +257,10 @@ object UnsafeRowKeyOperations {
     }
   }
 
-  private final class StructOperations(dataType: StructType) extends FieldOperations {
-    private val operations = new RowOperations(dataType)
+  private final class StructOperations(
+      dataType: StructType,
+      hashScratch: HashScratch) extends FieldOperations {
+    private val operations = new RowOperations(dataType, hashScratch)
 
     override protected def hashNonNull(
         input: SpecializedGetters, ordinal: Int, seed: Int): Int = {
@@ -236,9 +278,9 @@ object UnsafeRowKeyOperations {
     }
   }
 
-  private final class RowOperations(dataType: StructType) {
+  private final class RowOperations(dataType: StructType, hashScratch: HashScratch) {
     private val fieldOperations =
-      dataType.fields.map(field => createFieldOperations(field.dataType))
+      dataType.fields.map(field => createFieldOperations(field.dataType, hashScratch))
 
     def hash(row: InternalRow, seed: Int): Int = {
       var result = seed
@@ -262,14 +304,16 @@ object UnsafeRowKeyOperations {
     }
   }
 
-  private def createFieldOperations(dataType: DataType): FieldOperations = {
+  private def createFieldOperations(
+      dataType: DataType,
+      hashScratch: HashScratch): FieldOperations = {
     if (UnsafeRowUtils.isBinaryStable(dataType)) {
       new BinaryStableOperations(dataType)
     } else {
       dataType match {
-        case stringType: StringType => new CollatedStringOperations(stringType)
-        case ArrayType(elementType, _) => new ArrayOperations(elementType)
-        case structType: StructType => new StructOperations(structType)
+        case stringType: StringType => new CollatedStringOperations(stringType, hashScratch)
+        case ArrayType(elementType, _) => new ArrayOperations(elementType, hashScratch)
+        case structType: StructType => new StructOperations(structType, hashScratch)
         case _ =>
           throw SparkException.internalError(s"Unsupported grouping key type: $dataType")
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Murmur3HashFunct
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.map.BytesToBytesMap
 
-/** Hashing and equality operations for rows whose schema may contain collated strings. */
+/** Schema-aware hashing and equality operations for row keys. */
 final class UnsafeRowKeyOperations(val schema: StructType)
     extends BytesToBytesMap.KeyOperationsFactory {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowKeyOperations.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Murmur3HashFunction, RowOrdering, UnsafeRow}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.unsafe.map.BytesToBytesMap
+
+/** Hashing and equality operations for rows whose schema may contain collated strings. */
+final class UnsafeRowKeyOperations(val schema: StructType)
+    extends BytesToBytesMap.KeyOperationsFactory {
+
+  private def createOrdering(): BaseOrdering = {
+    RowOrdering.createNaturalAscendingOrdering(schema.map(_.dataType).toSeq)
+  }
+
+  val ordering: BaseOrdering =
+    createOrdering()
+
+  def hash(row: InternalRow): Int = {
+    Murmur3HashFunction.hash(
+      row,
+      schema,
+      42L,
+      isCollationAware = true,
+      // This flag only affects hashing when isCollationAware is false.
+      legacyCollationAwareHashing = false).toInt
+  }
+
+  def areEqual(left: InternalRow, right: InternalRow): Boolean = {
+    ordering.compare(left, right) == 0
+  }
+
+  override def create(): BytesToBytesMap.KeyOperations = new BytesToBytesMap.KeyOperations {
+    private val localOrdering = createOrdering()
+    private val left = new UnsafeRow(schema.length)
+    private val right = new UnsafeRow(schema.length)
+
+    override def hash(base: AnyRef, offset: Long, length: Int): Int = {
+      left.pointTo(base, offset, length)
+      UnsafeRowKeyOperations.this.hash(left)
+    }
+
+    override def equals(
+        leftBase: AnyRef,
+        leftOffset: Long,
+        leftLength: Int,
+        rightBase: AnyRef,
+        rightOffset: Long,
+        rightLength: Int): Boolean = {
+      left.pointTo(leftBase, leftOffset, leftLength)
+      right.pointTo(rightBase, rightOffset, rightLength)
+      localOrdering.compare(left, right) == 0
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -231,11 +231,23 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
         InternalRow(array(utf8("hello"), null, utf8("world"))),
         InternalRow(array(utf8("hello"), null, utf8("other")))),
       KeyContractCase(
+        "nested array with ICU collation",
+        StructType(StructField("a", ArrayType(ArrayType(unicodeCI))) :: Nil),
+        InternalRow(array(array(utf8("HELLO")), array(utf8("WORLD")))),
+        InternalRow(array(array(utf8("hello")), array(utf8("world")))),
+        InternalRow(array(array(utf8("hello")), array(utf8("other"))))),
+      KeyContractCase(
         "nested struct with LCASE RTRIM collation",
         StructType(StructField("nested", nestedType) :: Nil),
         InternalRow(InternalRow(7, utf8("VALUE"))),
         InternalRow(InternalRow(7, utf8("value   "))),
         InternalRow(InternalRow(8, utf8("value")))),
+      KeyContractCase(
+        "array of structs with LCASE RTRIM collation",
+        StructType(StructField("a", ArrayType(nestedType)) :: Nil),
+        InternalRow(array(InternalRow(7, utf8("VALUE")))),
+        InternalRow(array(InternalRow(7, utf8("value   ")))),
+        InternalRow(array(InternalRow(8, utf8("value"))))),
       KeyContractCase(
         "binary RTRIM string with different lengths",
         StructType(StructField("s", binaryRtrim) :: Nil),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -237,6 +237,18 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
         InternalRow(array(array(utf8("hello")), array(utf8("world")))),
         InternalRow(array(array(utf8("hello")), array(utf8("other"))))),
       KeyContractCase(
+        "nested array with unequal lengths",
+        StructType(StructField("a", ArrayType(ArrayType(unicodeCI))) :: Nil),
+        InternalRow(array(array(utf8("HELLO")))),
+        InternalRow(array(array(utf8("hello")))),
+        InternalRow(array(array(utf8("hello"), utf8("world"))))),
+      KeyContractCase(
+        "nested empty and non-empty arrays",
+        StructType(StructField("a", ArrayType(ArrayType(unicodeCI))) :: Nil),
+        InternalRow(array(array())),
+        InternalRow(array(array())),
+        InternalRow(array(array(utf8("value"))))),
+      KeyContractCase(
         "nested struct with LCASE RTRIM collation",
         StructType(StructField("nested", nestedType) :: Nil),
         InternalRow(InternalRow(7, utf8("VALUE"))),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -328,12 +328,14 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
   }
 
   test("UnsafeRowKeyOperations raw ICU keys match materialized sort-key hashes") {
+    // scalastyle:off nonascii
     val values = Seq(
       "a" * 4096,
       "short",
-      "R\u00e9sum\u00e9",
+      "Résumé",
       "resume   ",
       "")
+    // scalastyle:on nonascii
 
     Seq("UNICODE", "UNICODE_CI", "UNICODE_RTRIM", "UNICODE_CI_RTRIM").foreach {
       collationName =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.catalyst.expressions.{CodegenObjectFactoryMode, Spec
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, CalendarIntervalType, Decimal, DecimalType, GeographyType, GeometryType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.hash.Murmur3_x86_32
 import org.apache.spark.unsafe.types.{BinaryView, CalendarInterval, UTF8String}
 
 class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
@@ -320,6 +322,43 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
                 right.getBaseOffset,
                 right.getSizeInBytes))
             }
+          }
+        }
+    }
+  }
+
+  test("UnsafeRowKeyOperations raw ICU keys match materialized sort-key hashes") {
+    val values = Seq(
+      "a" * 4096,
+      "short",
+      "R\u00e9sum\u00e9",
+      "resume   ",
+      "")
+
+    Seq("UNICODE", "UNICODE_CI", "UNICODE_RTRIM", "UNICODE_CI_RTRIM").foreach {
+      collationName =>
+        val stringType = StringType(CollationFactory.collationNameToId(collationName))
+        val schema = StructType(StructField("value", stringType) :: Nil)
+        val projection = UnsafeProjection.create(schema)
+        val keyOperations = new UnsafeRowKeyOperations(schema)
+        val serializedOperations = keyOperations.create()
+        val collation = CollationFactory.fetchCollation(stringType.collationId)
+
+        values.foreach { value =>
+          val row = projection(InternalRow(UTF8String.fromString(value))).copy()
+          val materializedKey = collation.sortKeyFunction.apply(row.getUTF8String(0))
+          val expectedHash = Murmur3_x86_32.hashUnsafeBytes(
+            materializedKey,
+            Platform.BYTE_ARRAY_OFFSET,
+            materializedKey.length,
+            42)
+
+          withClue(s"$collationName: $value: ") {
+            assert(keyOperations.hash(row) == expectedHash)
+            assert(serializedOperations.hash(
+              row.getBaseObject,
+              row.getBaseOffset,
+              row.getSizeInBytes) == expectedHash)
           }
         }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -25,8 +25,8 @@ import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.expressions.{CodegenObjectFactoryMode, SpecificInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, BooleanType, Decimal, DecimalType, IntegerType, LongType, MapType, StringType, StructField, StructType}
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, CalendarIntervalType, Decimal, DecimalType, GeographyType, GeometryType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.{BinaryView, CalendarInterval, UTF8String}
 
 class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
 
@@ -171,9 +171,12 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
     assert(Aggregate.supportsHashAggregateGroupingKey(
       StructType(StructField("s", collatedString) :: Nil)))
     assert(!Aggregate.supportsHashAggregateGroupingKey(MapType(collatedString, IntegerType)))
-    assert(!Aggregate.supportsHashAggregateGroupingKey(StructType(Seq(
+    assert(Aggregate.supportsHashAggregateGroupingKey(StructType(Seq(
       StructField("s", collatedString),
       StructField("m", MapType(StringType, IntegerType))))))
+    assert(!Aggregate.supportsHashAggregateGroupingKey(StructType(Seq(
+      StructField("s", collatedString),
+      StructField("m", MapType(collatedString, IntegerType))))))
   }
 
   test("UnsafeRowKeyOperations equality and hash contract") {
@@ -196,6 +199,8 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
     val unicodeCI = collatedString("UNICODE_CI")
     val binaryRtrim = collatedString("UTF8_BINARY_RTRIM")
     val lcaseRtrim = collatedString("UTF8_LCASE_RTRIM")
+    val geometry = GeometryType(4326)
+    val geography = GeographyType(4326)
     val nestedType = StructType(Seq(
       StructField("id", IntegerType),
       StructField("label", lcaseRtrim)))
@@ -240,7 +245,33 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
         StructType(Seq(StructField("s", unicodeCI), StructField("id", IntegerType))),
         InternalRow(null, 1),
         InternalRow(null, 1),
-        InternalRow(utf8("value"), 1)))
+        InternalRow(utf8("value"), 1)),
+      KeyContractCase(
+        "collated string with opaque binary-stable fields",
+        StructType(Seq(
+          StructField("s", lcase),
+          StructField("interval", CalendarIntervalType),
+          StructField("geometry", geometry),
+          StructField("geography", geography),
+          StructField("payload", BinaryType))),
+        InternalRow(
+          utf8("HELLO"),
+          new CalendarInterval(1, 2, 3),
+          BinaryView.fromBytes(Array[Byte](1, 2, 3)),
+          BinaryView.fromBytes(Array[Byte](4, 5, 6)),
+          Array[Byte](7, 8, 9)),
+        InternalRow(
+          utf8("hello"),
+          new CalendarInterval(1, 2, 3),
+          BinaryView.fromBytes(Array[Byte](1, 2, 3)),
+          BinaryView.fromBytes(Array[Byte](4, 5, 6)),
+          Array[Byte](7, 8, 9)),
+        InternalRow(
+          utf8("hello"),
+          new CalendarInterval(1, 2, 4),
+          BinaryView.fromBytes(Array[Byte](1, 2, 3)),
+          BinaryView.fromBytes(Array[Byte](4, 5, 6)),
+          Array[Byte](7, 8, 9))))
 
     Seq(CodegenObjectFactoryMode.CODEGEN_ONLY, CodegenObjectFactoryMode.NO_CODEGEN).foreach {
       codegenMode =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -163,7 +163,7 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
         StructType(StructField("sub", nonBinaryStringType) :: Nil)) :: Nil)))
   }
 
-  test("hash aggregate grouping key support is limited to collated arrays and structs") {
+  test("hash aggregate grouping key support for binary-unstable types") {
     val collatedString = StringType(CollationFactory.collationNameToId("UTF8_LCASE"))
 
     assert(Aggregate.supportsHashAggregateGroupingKey(collatedString))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -21,10 +21,14 @@ import java.math.{BigDecimal => JavaBigDecimal}
 import java.nio.ByteOrder.{nativeOrder, BIG_ENDIAN}
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeProjection, UnsafeRow}
-import org.apache.spark.sql.types.{ArrayType, Decimal, DecimalType, IntegerType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
+import org.apache.spark.sql.catalyst.expressions.{CodegenObjectFactoryMode, SpecificInternalRow, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{ArrayType, BooleanType, Decimal, DecimalType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 
-class UnsafeRowUtilsSuite extends SparkFunSuite {
+class UnsafeRowUtilsSuite extends SparkFunSuite with SQLConfHelper {
 
   val testKeys: Seq[String] = Seq("key1", "key2")
   val testValues: Seq[String] = Seq("sum(key1)", "sum(key2)")
@@ -157,6 +161,137 @@ class UnsafeRowUtilsSuite extends SparkFunSuite {
     assert(!UnsafeRowUtils.isBinaryStable(
       StructType(StructField("field",
         StructType(StructField("sub", nonBinaryStringType) :: Nil)) :: Nil)))
+  }
+
+  test("hash aggregate grouping key support is limited to collated arrays and structs") {
+    val collatedString = StringType(CollationFactory.collationNameToId("UTF8_LCASE"))
+
+    assert(Aggregate.supportsHashAggregateGroupingKey(collatedString))
+    assert(Aggregate.supportsHashAggregateGroupingKey(ArrayType(collatedString)))
+    assert(Aggregate.supportsHashAggregateGroupingKey(
+      StructType(StructField("s", collatedString) :: Nil)))
+    assert(!Aggregate.supportsHashAggregateGroupingKey(MapType(collatedString, IntegerType)))
+    assert(!Aggregate.supportsHashAggregateGroupingKey(StructType(Seq(
+      StructField("s", collatedString),
+      StructField("m", MapType(StringType, IntegerType))))))
+  }
+
+  test("UnsafeRowKeyOperations equality and hash contract") {
+    case class KeyContractCase(
+        name: String,
+        schema: StructType,
+        left: InternalRow,
+        right: InternalRow,
+        different: InternalRow)
+
+    def collatedString(collationName: String): StringType = {
+      StringType(CollationFactory.collationNameToId(collationName))
+    }
+
+    def utf8(value: String): UTF8String = UTF8String.fromString(value)
+
+    def array(values: Any*): GenericArrayData = new GenericArrayData(values.toArray)
+
+    val lcase = collatedString("UTF8_LCASE")
+    val unicodeCI = collatedString("UNICODE_CI")
+    val binaryRtrim = collatedString("UTF8_BINARY_RTRIM")
+    val lcaseRtrim = collatedString("UTF8_LCASE_RTRIM")
+    val nestedType = StructType(Seq(
+      StructField("id", IntegerType),
+      StructField("label", lcaseRtrim)))
+
+    val testCases = Seq(
+      KeyContractCase(
+        "scalar LCASE string",
+        StructType(StructField("s", lcase) :: Nil),
+        InternalRow(utf8("AAA")),
+        InternalRow(utf8("aaa")),
+        InternalRow(utf8("bbb"))),
+      KeyContractCase(
+        "mixed primitive fields",
+        StructType(Seq(
+          StructField("id", IntegerType),
+          StructField("s", lcase),
+          StructField("flag", BooleanType),
+          StructField("count", LongType))),
+        InternalRow(1, utf8("HELLO"), true, 10L),
+        InternalRow(1, utf8("hello"), true, 10L),
+        InternalRow(2, utf8("hello"), true, 10L)),
+      KeyContractCase(
+        "array with ICU collation and null element",
+        StructType(StructField("a", ArrayType(unicodeCI)) :: Nil),
+        InternalRow(array(utf8("HELLO"), null, utf8("WORLD"))),
+        InternalRow(array(utf8("hello"), null, utf8("world"))),
+        InternalRow(array(utf8("hello"), null, utf8("other")))),
+      KeyContractCase(
+        "nested struct with LCASE RTRIM collation",
+        StructType(StructField("nested", nestedType) :: Nil),
+        InternalRow(InternalRow(7, utf8("VALUE"))),
+        InternalRow(InternalRow(7, utf8("value   "))),
+        InternalRow(InternalRow(8, utf8("value")))),
+      KeyContractCase(
+        "binary RTRIM string with different lengths",
+        StructType(StructField("s", binaryRtrim) :: Nil),
+        InternalRow(utf8("value")),
+        InternalRow(utf8("value   ")),
+        InternalRow(utf8("VALUE"))),
+      KeyContractCase(
+        "null collated field",
+        StructType(Seq(StructField("s", unicodeCI), StructField("id", IntegerType))),
+        InternalRow(null, 1),
+        InternalRow(null, 1),
+        InternalRow(utf8("value"), 1)))
+
+    Seq(CodegenObjectFactoryMode.CODEGEN_ONLY, CodegenObjectFactoryMode.NO_CODEGEN).foreach {
+      codegenMode =>
+        withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenMode.toString) {
+          testCases.foreach { testCase =>
+            withClue(s"$codegenMode: ${testCase.name}: ") {
+              val projection = UnsafeProjection.create(testCase.schema)
+              val left = projection(testCase.left).copy()
+              val right = projection(testCase.right).copy()
+              val different = projection(testCase.different).copy()
+              val keyOperations = new UnsafeRowKeyOperations(testCase.schema)
+
+              assert(keyOperations.areEqual(left, right))
+              assert(keyOperations.areEqual(right, left))
+              assert(!keyOperations.areEqual(left, different))
+              assert(!keyOperations.areEqual(different, left))
+              assert(keyOperations.hash(left) == keyOperations.hash(right))
+
+              val serializedOperations = keyOperations.create()
+              assert(serializedOperations.equals(
+                left.getBaseObject,
+                left.getBaseOffset,
+                left.getSizeInBytes,
+                right.getBaseObject,
+                right.getBaseOffset,
+                right.getSizeInBytes))
+              assert(serializedOperations.equals(
+                right.getBaseObject,
+                right.getBaseOffset,
+                right.getSizeInBytes,
+                left.getBaseObject,
+                left.getBaseOffset,
+                left.getSizeInBytes))
+              assert(!serializedOperations.equals(
+                left.getBaseObject,
+                left.getBaseOffset,
+                left.getSizeInBytes,
+                different.getBaseObject,
+                different.getBaseOffset,
+                different.getSizeInBytes))
+              assert(serializedOperations.hash(
+                left.getBaseObject,
+                left.getBaseOffset,
+                left.getSizeInBytes) == serializedOperations.hash(
+                right.getBaseObject,
+                right.getBaseOffset,
+                right.getSizeInBytes))
+            }
+          }
+        }
+    }
   }
 
   test("PaddingProvider handles endianness") {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -130,7 +130,10 @@ public final class UnsafeFixedWidthAggregationMap {
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow key) {
     return keyOperations == null ?
       getAggregationBufferFromUnsafeRow(key, key.hashCode()) :
-      getAggregationBufferFromUnsafeRowWithKeyOperations(key);
+      getAggregationBufferFromLocation(key, map.lookup(
+        key.getBaseObject(),
+        key.getBaseOffset(),
+        key.getSizeInBytes()));
   }
 
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow key, int hash) {
@@ -140,14 +143,6 @@ public final class UnsafeFixedWidthAggregationMap {
       key.getBaseOffset(),
       key.getSizeInBytes(),
       hash);
-    return getAggregationBufferFromLocation(key, loc);
-  }
-
-  public UnsafeRow getAggregationBufferFromUnsafeRowWithKeyOperations(UnsafeRow key) {
-    final BytesToBytesMap.Location loc = map.lookupWithKeyOperations(
-      key.getBaseObject(),
-      key.getBaseOffset(),
-      key.getSizeInBytes());
     return getAggregationBufferFromLocation(key, loc);
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -26,6 +26,8 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate$;
+import org.apache.spark.sql.catalyst.util.UnsafeRowKeyOperations;
+import org.apache.spark.sql.catalyst.util.UnsafeRowUtils$;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.KVIterator;
 import org.apache.spark.unsafe.Platform;
@@ -52,6 +54,9 @@ public final class UnsafeFixedWidthAggregationMap {
    * Encodes grouping keys as UnsafeRows.
    */
   private final UnsafeProjection groupingKeyProjection;
+
+  /** Semantic key operations for grouping schemas containing collated strings. */
+  private final UnsafeRowKeyOperations keyOperations;
 
   /**
    * A hashmap which maps from opaque bytearray keys to bytearray values.
@@ -92,8 +97,13 @@ public final class UnsafeFixedWidthAggregationMap {
     this.currentAggregationBuffer = new UnsafeRow(aggregationBufferSchema.length());
     this.groupingKeyProjection = UnsafeProjection.create(groupingKeySchema);
     this.groupingKeySchema = groupingKeySchema;
+    this.keyOperations = UnsafeRowUtils$.MODULE$.isBinaryStable(groupingKeySchema) ?
+      null : new UnsafeRowKeyOperations(groupingKeySchema);
     this.map = new BytesToBytesMap(
-      taskContext.taskMemoryManager(), initialCapacity, pageSizeBytes);
+      taskContext.taskMemoryManager(),
+      initialCapacity,
+      pageSizeBytes,
+      keyOperations);
 
     // Initialize the buffer for aggregation value
     final UnsafeProjection valueProjection = UnsafeProjection.create(aggregationBufferSchema);
@@ -119,16 +129,15 @@ public final class UnsafeFixedWidthAggregationMap {
   }
 
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow key) {
-    return getAggregationBufferFromUnsafeRow(key, key.hashCode());
+    return getAggregationBufferFromUnsafeRow(
+      key, keyOperations == null ? key.hashCode() : 0);
   }
 
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow key, int hash) {
     // Probe our map using the serialized key
-    final BytesToBytesMap.Location loc = map.lookup(
-      key.getBaseObject(),
-      key.getBaseOffset(),
-      key.getSizeInBytes(),
-      hash);
+    final BytesToBytesMap.Location loc = keyOperations == null ?
+      map.lookup(key.getBaseObject(), key.getBaseOffset(), key.getSizeInBytes(), hash) :
+      map.lookup(key.getBaseObject(), key.getBaseOffset(), key.getSizeInBytes());
     if (!loc.isDefined()) {
       // This is the first time that we've seen this grouping key, so we'll insert a copy of the
       // empty aggregation buffer into the map:
@@ -233,6 +242,11 @@ public final class UnsafeFixedWidthAggregationMap {
    */
   public int getNumKeys() {
     return map.numKeys();
+  }
+
+  /** Returns whether two grouping keys are semantically equal. */
+  public boolean keysEqual(UnsafeRow left, UnsafeRow right) {
+    return keyOperations == null ? left.equals(right) : keyOperations.areEqual(left, right);
   }
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -55,7 +55,6 @@ public final class UnsafeFixedWidthAggregationMap {
    */
   private final UnsafeProjection groupingKeyProjection;
 
-  /** Semantic key operations for grouping schemas containing collated strings. */
   private final UnsafeRowKeyOperations keyOperations;
 
   /**
@@ -129,15 +128,31 @@ public final class UnsafeFixedWidthAggregationMap {
   }
 
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow key) {
-    return getAggregationBufferFromUnsafeRow(
-      key, keyOperations == null ? key.hashCode() : 0);
+    return keyOperations == null ?
+      getAggregationBufferFromUnsafeRow(key, key.hashCode()) :
+      getAggregationBufferFromUnsafeRowWithKeyOperations(key);
   }
 
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow key, int hash) {
     // Probe our map using the serialized key
-    final BytesToBytesMap.Location loc = keyOperations == null ?
-      map.lookup(key.getBaseObject(), key.getBaseOffset(), key.getSizeInBytes(), hash) :
-      map.lookup(key.getBaseObject(), key.getBaseOffset(), key.getSizeInBytes());
+    final BytesToBytesMap.Location loc = map.lookup(
+      key.getBaseObject(),
+      key.getBaseOffset(),
+      key.getSizeInBytes(),
+      hash);
+    return getAggregationBufferFromLocation(key, loc);
+  }
+
+  public UnsafeRow getAggregationBufferFromUnsafeRowWithKeyOperations(UnsafeRow key) {
+    final BytesToBytesMap.Location loc = map.lookupWithKeyOperations(
+      key.getBaseObject(),
+      key.getBaseOffset(),
+      key.getSizeInBytes());
+    return getAggregationBufferFromLocation(key, loc);
+  }
+
+  private UnsafeRow getAggregationBufferFromLocation(
+      UnsafeRow key, BytesToBytesMap.Location loc) {
     if (!loc.isDefined()) {
       // This is the first time that we've seen this grouping key, so we'll insert a copy of the
       // empty aggregation buffer into the map:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.streaming.{ProjectAggregationBufferExec, StatefulStreamlineAggregateExec}
 import org.apache.spark.sql.execution.streaming.operators.stateful._
@@ -76,8 +77,12 @@ object AggUtils {
       initialInputBufferOffset: Int = 0,
       resultExpressions: Seq[NamedExpression] = Nil,
       child: SparkPlan): SparkPlan = {
-    val useHash = child.conf.useHashAggregation && Aggregate.supportsHashAggregate(
-      aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes), groupingExpressions)
+    val supportsStreamingGroupingKeys = !isStreaming ||
+      groupingExpressions.forall(e => UnsafeRowUtils.isBinaryStable(e.dataType))
+    val useHash = child.conf.useHashAggregation && supportsStreamingGroupingKeys &&
+      Aggregate.supportsHashAggregate(
+        aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes),
+        groupingExpressions)
 
     val forceObjHashAggregate = forceApplyObjectHashAggregate(child.conf)
 
@@ -94,8 +99,8 @@ object AggUtils {
         child = child)
     } else {
       val objectHashEnabled = child.conf.useObjectHashAggregation
-      val useObjectHash = Aggregate.supportsObjectHashAggregate(
-        aggregateExpressions, groupingExpressions)
+      val useObjectHash = supportsStreamingGroupingKeys &&
+        Aggregate.supportsObjectHashAggregate(aggregateExpressions, groupingExpressions)
 
       if (forceObjHashAggregate || (objectHashEnabled && useObjectHash)) {
         ObjectHashAggregateExec(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -901,7 +901,6 @@ case class HashAggregateExec(
     val fastRowKeys = ctx.generateExpressions(
       bindReferences[Expression](groupingExpressions, child.output))
     val unsafeRowKeys = unsafeRowKeyCode.value
-    val unsafeRowKeyHash = ctx.freshName("unsafeRowKeyHash")
     val unsafeRowBuffer = ctx.freshName("unsafeRowAggBuffer")
     val fastRowBuffer = ctx.freshName("fastAggBuffer")
 
@@ -960,13 +959,22 @@ case class HashAggregateExec(
       // per regular-map row (see below); emitting it in more than one runtime branch is unsafe
       // because the projection's subexpression/writer state assigned in one branch would be read
       // stale from another (e.g. the adaptive pass-through path would reuse the last probed key).
+      val (computeKeyHash, lookupBuffer) =
+        if (UnsafeRowUtils.isBinaryStable(groupingKeySchema)) {
+          val unsafeRowKeyHash = ctx.freshName("unsafeRowKeyHash")
+          (s"int $unsafeRowKeyHash = ${unsafeRowKeyCode.value}.hashCode();",
+            s"$hashMapTerm.getAggregationBufferFromUnsafeRow(" +
+              s"$unsafeRowKeys, $unsafeRowKeyHash)")
+        } else {
+          ("", s"$hashMapTerm.getAggregationBufferFromUnsafeRowWithKeyOperations(" +
+            s"$unsafeRowKeys)")
+        }
       val probeRegularMap =
         s"""
-           |int $unsafeRowKeyHash = ${unsafeRowKeyCode.value}.hashCode();
+           |$computeKeyHash
            |if ($checkFallbackForBytesToBytesMap) {
            |  // try to get the buffer from hash map
-           |  $unsafeRowBuffer =
-           |    $hashMapTerm.getAggregationBufferFromUnsafeRow($unsafeRowKeys, $unsafeRowKeyHash);
+           |  $unsafeRowBuffer = $lookupBuffer;
            |}
          """.stripMargin
 
@@ -980,8 +988,7 @@ case class HashAggregateExec(
            |$resetCounter
            |// the hash map had been spilled, so it should have enough memory now,
            |// try to allocate buffer again.
-           |$unsafeRowBuffer = $hashMapTerm.getAggregationBufferFromUnsafeRow(
-           |  $unsafeRowKeys, $unsafeRowKeyHash);
+           |$unsafeRowBuffer = $lookupBuffer;
            |if ($unsafeRowBuffer == null) {
            |  // failed to allocate the first page
            |  throw QueryExecutionErrors.aggregateOutOfMemoryError();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.catalyst.util.{truncatedString, UnsafeRowUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_MILLIS
-import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.vectorized.MutableColumnarRow
@@ -60,6 +60,8 @@ case class HashAggregateExec(
   extends AggregateCodegenSupport {
 
   require(Aggregate.supportsHashAggregate(aggregateBufferAttributes, groupingExpressions))
+  require(!isStreaming ||
+    groupingExpressions.forall(e => UnsafeRowUtils.isBinaryStable(e.dataType)))
 
   override def allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
@@ -363,7 +365,7 @@ case class HashAggregateExec(
           var findNextGroup = false
           while (!findNextGroup && sortedIter.next()) {
             val key = sortedIter.getKey
-            if (currentKey.equals(key)) {
+            if (hashMap.keysEqual(currentKey, key)) {
               mergeProjection(joinedRow(currentRow, sortedIter.getValue))
             } else {
               // We find a new group.
@@ -494,6 +496,7 @@ case class HashAggregateExec(
    */
   private def checkIfFastHashMapSupported(): Boolean = {
     val isSupported =
+      groupingExpressions.forall(e => UnsafeRowUtils.isBinaryStable(e.dataType)) &&
       (groupingKeySchema ++ bufferSchema).forall(f => CodeGenerator.isPrimitiveType(f.dataType) ||
         f.dataType.isInstanceOf[DecimalType] || f.dataType.isInstanceOf[StringType] ||
         f.dataType.isInstanceOf[CalendarIntervalType])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -966,8 +966,7 @@ case class HashAggregateExec(
             s"$hashMapTerm.getAggregationBufferFromUnsafeRow(" +
               s"$unsafeRowKeys, $unsafeRowKeyHash)")
         } else {
-          ("", s"$hashMapTerm.getAggregationBufferFromUnsafeRowWithKeyOperations(" +
-            s"$unsafeRowKeys)")
+          ("", s"$hashMapTerm.getAggregationBufferFromUnsafeRow($unsafeRowKeys)")
         }
       val probeRegularMap =
         s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
@@ -140,7 +140,7 @@ class ObjectAggregationIterator(
 
     if (aggBuffer == null) {
       aggBuffer = createNewAggregationBuffer()
-      hashMap.putAggregationBuffer(groupingKey, aggBuffer)
+      hashMap.putAggregationBuffer(groupingKey.copy(), aggBuffer)
     }
 
     aggBuffer
@@ -153,7 +153,7 @@ class ObjectAggregationIterator(
   private def processInputs(): Unit = {
     // In-memory map to store aggregation buffer for hash-based aggregation.
     val groupingSchema = DataTypeUtils.fromAttributes(groupingExpressions.map(_.toAttribute))
-    val hashMap = new ObjectAggregationMap(groupingSchema)
+    val hashMap = ObjectAggregationMap.create(groupingSchema)
 
     // If in-memory map is unable to stores all aggregation buffer, fallback to sort-based
     // aggregation backed by sorted physical storage.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
@@ -140,7 +140,7 @@ class ObjectAggregationIterator(
 
     if (aggBuffer == null) {
       aggBuffer = createNewAggregationBuffer()
-      hashMap.putAggregationBuffer(groupingKey.copy(), aggBuffer)
+      hashMap.putAggregationBuffer(groupingKey, aggBuffer)
     }
 
     aggBuffer
@@ -152,7 +152,8 @@ class ObjectAggregationIterator(
   // spills are merged together for sort-based aggregation.
   private def processInputs(): Unit = {
     // In-memory map to store aggregation buffer for hash-based aggregation.
-    val hashMap = new ObjectAggregationMap()
+    val groupingSchema = DataTypeUtils.fromAttributes(groupingExpressions.map(_.toAttribute))
+    val hashMap = new ObjectAggregationMap(groupingSchema)
 
     // If in-memory map is unable to stores all aggregation buffer, fallback to sort-based
     // aggregation backed by sorted physical storage.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationMap.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationMap.scala
@@ -36,7 +36,7 @@ private[aggregate] object ObjectAggregationMap {
     override def hashCode(): Int = keyOperations.hash(row)
 
     override def equals(other: Any): Boolean = other match {
-      case that: SemanticKey => keyOperations.areEqual(row, that.row)
+      case that: SemanticKey => row.equals(that.row) || keyOperations.areEqual(row, that.row)
       case _ => false
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationMap.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationMap.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.util.{UnsafeRowKeyOperations, UnsafeRowUtil
 import org.apache.spark.sql.execution.UnsafeKVExternalSorter
 import org.apache.spark.sql.types.StructType
 
-private object ObjectAggregationMap {
+private[aggregate] object ObjectAggregationMap {
   private final class SemanticKey(
       val keyOperations: UnsafeRowKeyOperations,
       var row: UnsafeRow) {
@@ -40,6 +40,49 @@ private object ObjectAggregationMap {
       case _ => false
     }
   }
+
+  def create(groupingSchema: StructType): ObjectAggregationMap = {
+    if (UnsafeRowUtils.isBinaryStable(groupingSchema)) {
+      new ObjectAggregationMap()
+    } else {
+      new SemanticObjectAggregationMap(groupingSchema)
+    }
+  }
+
+  private final class SemanticObjectAggregationMap(groupingSchema: StructType)
+      extends ObjectAggregationMap {
+    private val keyOperations = new UnsafeRowKeyOperations(groupingSchema)
+    private val hashMap = new ju.LinkedHashMap[SemanticKey, InternalRow]
+    private val reusableLookupKey = new SemanticKey(keyOperations, null)
+
+    override def getAggregationBuffer(groupingKey: UnsafeRow): InternalRow = {
+      reusableLookupKey.row = groupingKey
+      hashMap.get(reusableLookupKey)
+    }
+
+    override def putAggregationBuffer(groupingKey: UnsafeRow, aggBuffer: InternalRow): Unit = {
+      hashMap.put(new SemanticKey(keyOperations, groupingKey), aggBuffer)
+    }
+
+    override def size: Int = hashMap.size()
+
+    override def destructiveIterator(): Iterator[AggregationBufferEntry] = {
+      val iter = hashMap.entrySet().iterator()
+      new Iterator[AggregationBufferEntry] {
+        override def hasNext: Boolean = iter.hasNext
+
+        override def next(): AggregationBufferEntry = {
+          val entry = iter.next()
+          iter.remove()
+          new AggregationBufferEntry(entry.getKey.row, entry.getValue)
+        }
+      }
+    }
+
+    override def clear(): Unit = {
+      hashMap.clear()
+    }
+  }
 }
 
 /**
@@ -47,47 +90,15 @@ private object ObjectAggregationMap {
  * we can support storing arbitrary Java objects as aggregate function states in the aggregation
  * buffers. This class is only used together with [[ObjectHashAggregateExec]].
  */
-class ObjectAggregationMap(groupingSchema: StructType) {
-  import ObjectAggregationMap.SemanticKey
-
-  def this() = this(StructType(Nil))
-
-  private val keyOperations = if (UnsafeRowUtils.isBinaryStable(groupingSchema)) {
-    None
-  } else {
-    Some(new UnsafeRowKeyOperations(groupingSchema))
-  }
-
-  private val hashMap = new ju.LinkedHashMap[AnyRef, InternalRow]
-  private val reusableLookupKey =
-    keyOperations.map(operations => new SemanticKey(operations, null))
-
-  private def lookupKey(groupingKey: UnsafeRow): AnyRef = reusableLookupKey match {
-    case Some(key) =>
-      key.row = groupingKey
-      key
-    case None => groupingKey
-  }
-
-  private def storedKey(groupingKey: UnsafeRow): AnyRef = {
-    val copiedKey = groupingKey.copy()
-    keyOperations match {
-      case Some(operations) => new SemanticKey(operations, copiedKey)
-      case None => copiedKey
-    }
-  }
-
-  private def groupingKey(mapKey: AnyRef): UnsafeRow = mapKey match {
-    case key: SemanticKey => key.row
-    case key: UnsafeRow => key
-  }
+class ObjectAggregationMap() {
+  private[this] val hashMap = new ju.LinkedHashMap[UnsafeRow, InternalRow]
 
   def getAggregationBuffer(groupingKey: UnsafeRow): InternalRow = {
-    hashMap.get(lookupKey(groupingKey))
+    hashMap.get(groupingKey)
   }
 
   def putAggregationBuffer(groupingKey: UnsafeRow, aggBuffer: InternalRow): Unit = {
-    hashMap.put(storedKey(groupingKey), aggBuffer)
+    hashMap.put(groupingKey, aggBuffer)
   }
 
   def size: Int = hashMap.size()
@@ -106,7 +117,7 @@ class ObjectAggregationMap(groupingSchema: StructType) {
       override def next(): AggregationBufferEntry = {
         val entry = iter.next()
         iter.remove()
-        new AggregationBufferEntry(groupingKey(entry.getKey), entry.getValue)
+        new AggregationBufferEntry(entry.getKey, entry.getValue)
       }
     }
   }
@@ -148,7 +159,7 @@ class ObjectAggregationMap(groupingSchema: StructType) {
       )
     }
 
-    hashMap.clear()
+    clear()
     sorter
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationMap.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationMap.scala
@@ -25,22 +25,69 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.catalyst.util.{UnsafeRowKeyOperations, UnsafeRowUtils}
 import org.apache.spark.sql.execution.UnsafeKVExternalSorter
+import org.apache.spark.sql.types.StructType
+
+private object ObjectAggregationMap {
+  private final class SemanticKey(
+      val keyOperations: UnsafeRowKeyOperations,
+      var row: UnsafeRow) {
+    override def hashCode(): Int = keyOperations.hash(row)
+
+    override def equals(other: Any): Boolean = other match {
+      case that: SemanticKey => keyOperations.areEqual(row, that.row)
+      case _ => false
+    }
+  }
+}
 
 /**
  * An aggregation map that supports using safe `SpecificInternalRow`s aggregation buffers, so that
  * we can support storing arbitrary Java objects as aggregate function states in the aggregation
  * buffers. This class is only used together with [[ObjectHashAggregateExec]].
  */
-class ObjectAggregationMap() {
-  private[this] val hashMap = new ju.LinkedHashMap[UnsafeRow, InternalRow]
+class ObjectAggregationMap(groupingSchema: StructType) {
+  import ObjectAggregationMap.SemanticKey
+
+  def this() = this(StructType(Nil))
+
+  private val keyOperations = if (UnsafeRowUtils.isBinaryStable(groupingSchema)) {
+    None
+  } else {
+    Some(new UnsafeRowKeyOperations(groupingSchema))
+  }
+
+  private val hashMap = new ju.LinkedHashMap[AnyRef, InternalRow]
+  private val reusableLookupKey =
+    keyOperations.map(operations => new SemanticKey(operations, null))
+
+  private def lookupKey(groupingKey: UnsafeRow): AnyRef = reusableLookupKey match {
+    case Some(key) =>
+      key.row = groupingKey
+      key
+    case None => groupingKey
+  }
+
+  private def storedKey(groupingKey: UnsafeRow): AnyRef = {
+    val copiedKey = groupingKey.copy()
+    keyOperations match {
+      case Some(operations) => new SemanticKey(operations, copiedKey)
+      case None => copiedKey
+    }
+  }
+
+  private def groupingKey(mapKey: AnyRef): UnsafeRow = mapKey match {
+    case key: SemanticKey => key.row
+    case key: UnsafeRow => key
+  }
 
   def getAggregationBuffer(groupingKey: UnsafeRow): InternalRow = {
-    hashMap.get(groupingKey)
+    hashMap.get(lookupKey(groupingKey))
   }
 
   def putAggregationBuffer(groupingKey: UnsafeRow, aggBuffer: InternalRow): Unit = {
-    hashMap.put(groupingKey, aggBuffer)
+    hashMap.put(storedKey(groupingKey), aggBuffer)
   }
 
   def size: Int = hashMap.size()
@@ -59,7 +106,7 @@ class ObjectAggregationMap() {
       override def next(): AggregationBufferEntry = {
         val entry = iter.next()
         iter.remove()
-        new AggregationBufferEntry(entry.getKey, entry.getValue)
+        new AggregationBufferEntry(groupingKey(entry.getKey), entry.getValue)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -396,7 +396,7 @@ class TungstenAggregationIterator(
       val inputAggregationBuffer = sortedKVIterator.getValue
 
       // Check if the current row belongs the current input row.
-      if (currentGroupingKey.equals(groupingKey)) {
+      if (hashMap.keysEqual(currentGroupingKey, groupingKey)) {
         sortBasedProcessRow(sortBasedAggregationBuffer, inputAggregationBuffer)
 
         hasNext = sortedKVIterator.next()

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -193,21 +193,27 @@ class CollationAggregationSuite
           |AS data(key, value)
           |""".stripMargin).createOrReplaceTempView("spill_keys")
 
-      withSQLConf("spark.sql.TungstenAggregate.testFallbackStartsAt" -> "0, 1") {
-        val result = sql(
-          """
-            |SELECT LOWER(RTRIM(key)) AS normalized_key, SUM(value) AS total
-            |FROM spill_keys
-            |GROUP BY key
-            |ORDER BY normalized_key
-            |""".stripMargin)
-        assertUsesHashAggregate(result)
-        checkAnswer(result, Seq(Row("hello", 6L), Row("world", 15L)))
-        assert(exists(result.queryExecution.executedPlan) {
-          case aggregate: HashAggregateExec =>
-            aggregate.metrics("numTasksFallBacked").value > 0
-          case _ => false
-        })
+      Seq(true, false).foreach { wholeStage =>
+        withSQLConf(
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> wholeStage.toString,
+          "spark.sql.TungstenAggregate.testFallbackStartsAt" -> "0, 1") {
+          withClue(s"wholeStage=$wholeStage: ") {
+            val result = sql(
+              """
+                |SELECT LOWER(RTRIM(key)) AS normalized_key, SUM(value) AS total
+                |FROM spill_keys
+                |GROUP BY key
+                |ORDER BY normalized_key
+                |""".stripMargin)
+            assertUsesHashAggregate(result)
+            checkAnswer(result, Seq(Row("hello", 6L), Row("world", 15L)))
+            assert(exists(result.queryExecution.executedPlan) {
+              case aggregate: HashAggregateExec =>
+                aggregate.metrics("numTasksFallBacked").value > 0
+              case _ => false
+            })
+          }
+        }
       }
     }
   }
@@ -223,7 +229,9 @@ class CollationAggregationSuite
           |""".stripMargin)
       assertUsesHashAggregate(binary)
       checkAnswer(binary, Seq(Row("a", 3L), Row("b", 3L)))
-      assert(generatedCode(binary).contains("FastHashMap"))
+      val binaryCode = generatedCode(binary)
+      assert(binaryCode.contains("FastHashMap"))
+      assert(!binaryCode.contains("getAggregationBufferFromUnsafeRowWithKeyOperations"))
 
       val collated = sql(
         """
@@ -236,7 +244,9 @@ class CollationAggregationSuite
           |""".stripMargin)
       assertUsesHashAggregate(collated)
       checkAnswer(collated, Row("a", 3L))
-      assert(!generatedCode(collated).contains("FastHashMap"))
+      val collatedCode = generatedCode(collated)
+      assert(!collatedCode.contains("FastHashMap"))
+      assert(collatedCode.contains("getAggregationBufferFromUnsafeRowWithKeyOperations"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -17,73 +17,248 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class CollationAggregationSuite
-  extends SharedSparkSession
+  extends QueryTest
+  with SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
-  test("group by collated column doesn't work with obj hash aggregate") {
-    val tblName = "grp_by_tbl"
-    withTable(tblName) {
-      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE, c2 INT) USING PARQUET")
-      sql(s"INSERT INTO $tblName VALUES ('hello', 1), ('HELLO', 2), ('HeLlO', 3)")
+  private def assertUsesHashAggregate(df: DataFrame): Unit = {
+    val plan = df.queryExecution.executedPlan
+    assert(exists(plan)(_.isInstanceOf[HashAggregateExec]), plan.toString)
+    assert(!exists(plan)(_.isInstanceOf[SortAggregateExec]), plan.toString)
+  }
 
-      // Result is correct without forcing object hash aggregate.
-      checkAnswer(
-        sql(s"SELECT COUNT(*) FROM $tblName GROUP BY c1"),
-        Seq(Row(3)))
+  private def assertUsesObjectHashAggregate(df: DataFrame): Unit = {
+    val plan = df.queryExecution.executedPlan
+    assert(exists(plan)(_.isInstanceOf[ObjectHashAggregateExec]), plan.toString)
+    assert(!exists(plan)(_.isInstanceOf[SortAggregateExec]), plan.toString)
+  }
 
-      withSQLConf("spark.sql.test.forceApplyObjectHashAggregate" -> true.toString) {
-        checkAnswer(
-          sql(s"SELECT COUNT(*) FROM $tblName GROUP BY c1"),
-          Seq(Row(1), Row(1), Row(1)))
+  private def assertUsesSortAggregate(df: DataFrame): Unit = {
+    val plan = df.queryExecution.executedPlan
+    assert(exists(plan)(_.isInstanceOf[SortAggregateExec]), plan.toString)
+    assert(!exists(plan)(_.isInstanceOf[HashAggregateExec]), plan.toString)
+    assert(!exists(plan)(_.isInstanceOf[ObjectHashAggregateExec]), plan.toString)
+  }
 
-        checkAnswer(
-          sql(s"SELECT COLLECT_LIST(c2) AS c3 FROM $tblName GROUP BY c1 ORDER BY c3"),
-          Seq(Row(Seq(1)), Row(Seq(2)), Row(Seq(3))))
+  private def generatedCode(df: DataFrame): String = {
+    flatMap(df.queryExecution.executedPlan) {
+      case stage: WholeStageCodegenExec => Seq(stage.doCodeGen()._2.body)
+      case _ => Nil
+    }.mkString("\n")
+  }
+
+  test("HashAggregateExec groups collated string keys") {
+    val testCases = Seq(
+      "UTF8_LCASE" -> Seq("hello", "HELLO", "HeLlO"),
+      "UNICODE_CI" -> Seq("hello", "HELLO", "HeLlO"),
+      "UTF8_BINARY_RTRIM" -> Seq("hello", "hello ", "hello  "))
+
+    testCases.foreach { case (collation, spellings) =>
+      withTempView("collated_keys") {
+        val values = spellings.zipWithIndex
+          .map { case (key, index) => s"('$key', ${index + 1})" }
+          .mkString(", ")
+        sql(
+          s"""
+             |SELECT CAST(key AS STRING COLLATE $collation) AS key, value
+             |FROM VALUES $values, (NULL, 4) AS data(key, value)
+             |""".stripMargin).createOrReplaceTempView("collated_keys")
+
+        val result = sql(
+          """
+            |SELECT LOWER(RTRIM(key)) AS normalized_key, SUM(value) AS total
+            |FROM collated_keys
+            |GROUP BY key
+            |ORDER BY normalized_key NULLS LAST
+            |""".stripMargin)
+        assertUsesHashAggregate(result)
+        checkAnswer(result, Seq(Row("hello", 6L), Row(null, 4L)))
       }
     }
   }
 
-  test("imperative aggregate fn does not use objectHashAggregate when group by collated column") {
-    val tblName = "imp_agg"
-    Seq(true, false).foreach { useObjHashAgg =>
-      withTable(tblName) {
-        withSQLConf("spark.sql.execution.useObjectHashAggregateExec" -> useObjHashAgg.toString) {
-          sql(
-            s"""
-               |CREATE TABLE $tblName (
-               |  c1 STRING COLLATE UTF8_LCASE,
-               |  c2 INT
-               |) USING PARQUET
-               |""".stripMargin)
-          sql(s"INSERT INTO $tblName VALUES ('HELLO', 1), ('hello', 2), ('HeLlO', 3)")
+  test("nested and distinct collated grouping works across partial and final aggregation") {
+    withTempView("nested_keys") {
+      sql(
+        """
+          |SELECT id, CAST(key AS STRING COLLATE UTF8_LCASE) AS key, bucket, value
+          |FROM VALUES
+          |  (1, 'alpha', 0, 10),
+          |  (2, 'ALPHA', 0, 20),
+          |  (3, 'beta', 1, 30),
+          |  (4, 'BETA', 1, 40),
+          |  (5, NULL, 2, 50),
+          |  (6, NULL, 2, 60)
+          |AS data(id, key, bucket, value)
+          |""".stripMargin)
+        .repartition(4)
+        .createOrReplaceTempView("nested_keys")
 
-          val df = sql(s"SELECT COLLECT_LIST(c2) as list FROM $tblName GROUP BY c1")
-          val executedPlan = df.queryExecution.executedPlan
+      val distinctKeys = sql(
+        """
+          |SELECT LOWER(key) AS normalized_key
+          |FROM (SELECT DISTINCT key FROM nested_keys)
+          |ORDER BY normalized_key NULLS LAST
+          |""".stripMargin)
+      assertUsesHashAggregate(distinctKeys)
+      checkAnswer(distinctKeys, Seq(Row("alpha"), Row("beta"), Row(null)))
 
-          // Plan should not have any hash aggregate nodes.
-          collectFirst(executedPlan) {
-            case _: ObjectHashAggregateExec => fail("ObjectHashAggregateExec should not be used.")
-            case _: HashAggregateExec => fail("HashAggregateExec should not be used.")
+      val result = sql(
+        """
+          |SELECT
+          |  LOWER(array_key[0]) AS array_key,
+          |  LOWER(struct_key.s) AS struct_key,
+          |  bucket,
+          |  distinct_ids,
+          |  total
+          |FROM (
+          |  SELECT
+          |    ARRAY(key) AS array_key,
+          |    NAMED_STRUCT('s', key) AS struct_key,
+          |    bucket,
+          |    COUNT(DISTINCT id) AS distinct_ids,
+          |    SUM(value) AS total
+          |  FROM nested_keys
+          |  GROUP BY ARRAY(key), NAMED_STRUCT('s', key), bucket
+          |)
+          |ORDER BY bucket
+          |""".stripMargin)
+      assertUsesHashAggregate(result)
+      checkAnswer(result, Seq(
+        Row("alpha", "alpha", 0, 2L, 30L),
+        Row("beta", "beta", 1, 2L, 70L),
+        Row(null, null, 2, 2L, 110L)))
+    }
+  }
+
+  test("ObjectHashAggregateExec groups collated keys before and after sort fallback") {
+    withTempView("object_keys") {
+      sql(
+        """
+          |SELECT CAST(key AS STRING COLLATE UTF8_LCASE) AS key, value
+          |FROM VALUES
+          |  ('hello', 1), ('world', 4),
+          |  ('HELLO', 2), ('WORLD', 5),
+          |  ('HeLlO', 3), ('WoRlD', 6)
+          |AS data(key, value)
+          |""".stripMargin).createOrReplaceTempView("object_keys")
+
+      Seq(Int.MaxValue.toString, "1").foreach { fallbackThreshold =>
+        withSQLConf(
+          SQLConf.OBJECT_AGG_SORT_BASED_FALLBACK_THRESHOLD.key -> fallbackThreshold) {
+          val result = sql(
+            """
+              |SELECT
+              |  LOWER(key) AS normalized_key,
+              |  ARRAY_SORT(COLLECT_LIST(value)) AS collected_list,
+              |  ARRAY_SORT(COLLECT_SET(value)) AS collected_set
+              |FROM object_keys
+              |GROUP BY key
+              |ORDER BY normalized_key
+              |""".stripMargin)
+          assertUsesObjectHashAggregate(result)
+          checkAnswer(result, Seq(
+            Row("hello", Seq(1, 2, 3), Seq(1, 2, 3)),
+            Row("world", Seq(4, 5, 6), Seq(4, 5, 6))))
+
+          if (fallbackThreshold == "1") {
+            assert(exists(result.queryExecution.executedPlan) {
+              case aggregate: ObjectHashAggregateExec =>
+                aggregate.metrics("numTasksFallBacked").value > 0
+              case _ => false
+            })
           }
-
-          // Plan should have a [[SortAggregateExec]] node.
-          assert(collectFirst(executedPlan) {
-            case _: SortAggregateExec => true
-          }.nonEmpty)
-
-          checkAnswer(
-            // Sort the values to get deterministic output.
-            df.selectExpr("array_sort(list)"),
-            Seq(Row(Seq(1, 2, 3)))
-          )
         }
       }
+    }
+  }
+
+  test("HashAggregateExec spill merges collation-equivalent keys") {
+    withTempView("spill_keys") {
+      sql(
+        """
+          |SELECT CAST(key AS STRING COLLATE UTF8_LCASE_RTRIM) AS key, value
+          |FROM VALUES
+          |  ('hello', 1), ('world', 4),
+          |  ('HELLO ', 2), ('WORLD ', 5),
+          |  ('HeLlO  ', 3), ('WoRlD  ', 6)
+          |AS data(key, value)
+          |""".stripMargin).createOrReplaceTempView("spill_keys")
+
+      withSQLConf("spark.sql.TungstenAggregate.testFallbackStartsAt" -> "0, 1") {
+        val result = sql(
+          """
+            |SELECT LOWER(RTRIM(key)) AS normalized_key, SUM(value) AS total
+            |FROM spill_keys
+            |GROUP BY key
+            |ORDER BY normalized_key
+            |""".stripMargin)
+        assertUsesHashAggregate(result)
+        checkAnswer(result, Seq(Row("hello", 6L), Row("world", 15L)))
+        assert(exists(result.queryExecution.executedPlan) {
+          case aggregate: HashAggregateExec =>
+            aggregate.metrics("numTasksFallBacked").value > 0
+          case _ => false
+        })
+      }
+    }
+  }
+
+  test("two-level aggregation remains enabled only for binary-stable grouping keys") {
+    withSQLConf(SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key -> "true") {
+      val binary = sql(
+        """
+          |SELECT key, SUM(value)
+          |FROM VALUES ('a', 1), ('a', 2), ('b', 3) AS data(key, value)
+          |GROUP BY key
+          |ORDER BY key
+          |""".stripMargin)
+      assertUsesHashAggregate(binary)
+      checkAnswer(binary, Seq(Row("a", 3L), Row("b", 3L)))
+      assert(generatedCode(binary).contains("FastHashMap"))
+
+      val collated = sql(
+        """
+          |SELECT LOWER(key) AS normalized_key, SUM(value)
+          |FROM (
+          |  SELECT CAST(key AS STRING COLLATE UTF8_LCASE) AS key, value
+          |  FROM VALUES ('a', 1), ('A', 2) AS data(key, value)
+          |)
+          |GROUP BY key
+          |""".stripMargin)
+      assertUsesHashAggregate(collated)
+      checkAnswer(collated, Row("a", 3L))
+      assert(!generatedCode(collated).contains("FastHashMap"))
+    }
+  }
+
+  test("SortAggregateExec groups collated keys when hash aggregation is disabled") {
+    withSQLConf(
+      SQLConf.USE_HASH_AGG.key -> "false",
+      SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+      val result = sql(
+        """
+          |SELECT LOWER(key) AS normalized_key, SUM(value) AS total
+          |FROM (
+          |  SELECT CAST(key AS STRING COLLATE UTF8_LCASE) AS key, value
+          |  FROM VALUES
+          |    ('hello', 1), ('HELLO', 2),
+          |    ('world', 4), ('WORLD', 5)
+          |  AS data(key, value)
+          |)
+          |GROUP BY key
+          |ORDER BY normalized_key
+          |""".stripMargin)
+      assertUsesSortAggregate(result)
+      checkAnswer(result, Seq(Row("hello", 3L), Row("world", 9L)))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -18,16 +18,20 @@
 package org.apache.spark.sql.collation
 
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.unsafe.types.CalendarInterval
 
 class CollationAggregationSuite
   extends QueryTest
   with SharedSparkSession
   with AdaptiveSparkPlanHelper {
+
+  import testImplicits._
 
   private def assertUsesHashAggregate(df: DataFrame): Unit = {
     val plan = df.queryExecution.executedPlan
@@ -82,6 +86,67 @@ class CollationAggregationSuite
         assertUsesHashAggregate(result)
         checkAnswer(result, Seq(Row("hello", 6L), Row(null, 4L)))
       }
+    }
+  }
+
+  test("HashAggregateExec preserves binary semantics for stable sibling keys") {
+    withTempView("interval_keys") {
+      Seq(
+        ("hello", new CalendarInterval(1, 2, 3), 1),
+        ("HELLO", new CalendarInterval(1, 2, 3), 2))
+        .toDF("key", "calendar_interval", "value")
+        .selectExpr(
+          "CAST(key AS STRING COLLATE UTF8_LCASE) AS key",
+          "calendar_interval",
+          "value")
+        .repartition(1)
+        .createOrReplaceTempView("interval_keys")
+
+      withSQLConf(
+        SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.NO_CODEGEN.toString) {
+        val result = sql(
+          """
+            |SELECT LOWER(key) AS normalized_key, SUM(value) AS total
+            |FROM interval_keys
+            |GROUP BY key, calendar_interval
+            |""".stripMargin)
+        assertUsesHashAggregate(result)
+        checkAnswer(result, Row("hello", 3L))
+
+        val objectResult = sql(
+          """
+            |SELECT LOWER(key) AS normalized_key, ARRAY_SORT(COLLECT_LIST(value)) AS values
+            |FROM interval_keys
+            |GROUP BY key, calendar_interval
+            |""".stripMargin)
+        assertUsesObjectHashAggregate(objectResult)
+        checkAnswer(objectResult, Row("hello", Seq(1, 2)))
+      }
+    }
+
+    withTempView("geometry_keys") {
+      sql(
+        """
+          |SELECT
+          |  CAST(key AS STRING COLLATE UTF8_LCASE) AS key,
+          |  ST_GeomFromWKB(wkb) AS geometry,
+          |  value
+          |FROM VALUES
+          |  ('hello', X'0101000000000000000000F03F0000000000000040', 1),
+          |  ('HELLO', X'0101000000000000000000F03F0000000000000040', 2)
+          |AS data(key, wkb, value)
+          |""".stripMargin)
+        .repartition(1)
+        .createOrReplaceTempView("geometry_keys")
+
+      val result = sql(
+        """
+          |SELECT LOWER(key) AS normalized_key, SUM(value) AS total
+          |FROM geometry_keys
+          |GROUP BY key, geometry
+          |""".stripMargin)
+      assertUsesHashAggregate(result)
+      checkAnswer(result, Row("hello", 3L))
     }
   }
 
@@ -231,7 +296,6 @@ class CollationAggregationSuite
       checkAnswer(binary, Seq(Row("a", 3L), Row("b", 3L)))
       val binaryCode = generatedCode(binary)
       assert(binaryCode.contains("FastHashMap"))
-      assert(!binaryCode.contains("getAggregationBufferFromUnsafeRowWithKeyOperations"))
 
       val collated = sql(
         """
@@ -246,7 +310,7 @@ class CollationAggregationSuite
       checkAnswer(collated, Row("a", 3L))
       val collatedCode = generatedCode(collated)
       assert(!collatedCode.contains("FastHashMap"))
-      assert(collatedCode.contains("getAggregationBufferFromUnsafeRowWithKeyOperations"))
+      assert(collatedCode.contains("getAggregationBufferFromUnsafeRow"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -453,7 +453,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("hash agg is not used for non binary collations") {
+  test("hash agg is used for binary and non-binary collations") {
     val tableNameNonBinary = "T_NON_BINARY"
     val tableNameBinary = "T_BINARY"
     withTable(tableNameNonBinary) {
@@ -466,7 +466,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         val dfNonBinary = sql(s"SELECT COUNT(*), c FROM $tableNameNonBinary GROUP BY c")
         assert(collectFirst(dfNonBinary.queryExecution.executedPlan) {
           case _: HashAggregateExec | _: ObjectHashAggregateExec => ()
-        }.isEmpty)
+        }.nonEmpty)
 
         val dfBinary = sql(s"SELECT COUNT(*), c FROM $tableNameBinary GROUP BY c")
         assert(collectFirst(dfBinary.queryExecution.executedPlan) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptivePartialAggregationSuite.scala
@@ -315,6 +315,27 @@ class AdaptivePartialAggregationSuite extends QueryTest with SharedSparkSession
     }
   }
 
+  test("collation-equivalent keys across the bypass cutoff stay in one group") {
+    forEachCodegenAndMap() { clue =>
+      // The first eight rows are distinct, so the eighth row flips pass-through on. Its key is
+      // already in the frozen map when the equivalent spelling on the ninth row bypasses it.
+      val df = () => spark.range(0, 200, 1, 1)
+        .selectExpr(
+          """CAST(CASE
+            |  WHEN id = 7 THEN 'COLLATED'
+            |  WHEN id = 8 THEN 'collated'
+            |  ELSE CONCAT('key-', id)
+            |END AS STRING COLLATE UTF8_LCASE) AS k""".stripMargin,
+          "id AS v")
+        .groupBy($"k")
+        .agg(sum($"v") as "s", count(lit(1)) as "c")
+      withClue(clue) {
+        assert(numBypassingRows(df) > 0,
+          "expected the equivalent spelling after the cutoff to bypass partial aggregation")
+      }
+    }
+  }
+
   test("results unchanged with nullable grouping keys") {
     // Nulls are sparse enough (1 in 40) that the keys stay close to unique and the input really
     // does bypass; a denser null key would lift the compaction ratio above the threshold and the


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Implementing support for binary unstable types (eg collated strings) in hash aggregators (both `HashAggregate` and `ObjectHashAggregate`). Binary unstable types are types for whom we can't derive equality / ordering by their bytes representations alone (eg `a` and `A` are equal in any case-insensitive collation).

### Why are the changes needed?
Hash aggregation is the default aggregation mode in spark, and we've seen regressions in queries after moving from `UTF8_BINARY` to other collations as they would have to fall back to `SortAggregate`.


## Benchmark results

4.2M rows, three runs per case:

| Collation | Groups | HashAggregate | SortAggregate | Speedup |
|---|---:|---:|---:|---:|
| `UTF8_LCASE` | 4K | 1.30s | 6.35s | 4.9x |
| `UNICODE_CI` | 4K | 2.89s | 9.23s | 3.2x |
| `UTF8_LCASE` | 1M | 5.72s | 9.08s | 1.6x |
| `UNICODE_CI` | 1M | 9.46s | 12.49s | 1.3x |

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit and query-level tests.


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: gpt-5.6-sol
