### PR TITLE
[SPARK-58021][CONNECT][FOLLOWUP] Strip launcher-owned binding address from seed configuration

### DIFF
--- a/python/pyspark/sql/connect/local_server.py
+++ b/python/pyspark/sql/connect/local_server.py
@@ -293,6 +293,7 @@ def _strip_launcher_conf(conf: Dict[str, Any]) -> Dict[str, Any]:
             "spark.api.mode",
             "spark.master",
             "spark.connect.authenticate.token",
+            "spark.connect.grpc.binding.address",
             "spark.connect.grpc.binding.port",
         ) or k.startswith("spark.local.connect."):
             stripped.pop(k)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Followup to https://github.com/apache/spark/pull/57684.

Add `spark.connect.grpc.binding.address` to the settings removed by
`_strip_launcher_conf` before writing local Connect server seed properties.

### Why are the changes needed?

The local server launcher sets the binding address explicitly on its command line. Removing the
same setting from seed properties keeps all launcher-owned settings centralized and avoids carrying
a competing value in the generated properties file.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No new test was added because this completes the existing launcher-owned configuration allowlist;
the behavior is covered by the existing seed-configuration tests from the original change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
