### PR TITLE
[SPARK-58884][SS] Add stateful benchmarks for Real-Time Mode

### DIFF
--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
@@ -1,0 +1,21 @@
+================================================================================================
+RTM vs MBM Kafka dropDuplicates latency
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.16+8 on Linux 5.4.0-1161-aws-fips
+Intel(R) Xeon(R) 6975P-C
+
+Kafka-to-Kafka dropDuplicates e2e latency in milliseconds
+RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
+modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=300s recordsPerSecond=1000
+master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
+stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
+workload=dropDuplicates(key), 80% fresh keys, 20% guaranteed duplicates; samples are unique rows
+
+Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
+--------------------------------------------------------------------------------------------------------------------------------------
+RTM           5    1799964    1799964    1439972    1199964        0        0.0       26.0       46.0       48.0       50.0      610.0
+MBM       12157    1799997    1799997    1439998    1199994        0       61.0      147.0      206.0      222.0      269.0      354.0
+
+MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
+ratio                                                                       n/a      5.65x      4.48x      4.63x      5.38x      0.58x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
@@ -7,15 +7,15 @@ Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka dropDuplicates e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s firstOutputBatchFiltered=true warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 warmupFiltered=300s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=dropDuplicates(key), 80% fresh keys, 20% guaranteed duplicates; samples are unique rows
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799962    1799962    1439970    1199359        0       32.0       99.0      121.0      125.0      134.0      777.0
-MBM       10172    1799996    1799996    1439997    1199995        0      136.0      261.0      333.0      350.0      398.0      638.0
+RTM           5    1799953    1799953    1439963     958883        0       25.0       99.0      121.0      126.0      134.0      348.0
+MBM       10023    1799997    1799997    1439998    1199996        0      137.0      263.0      336.0      353.0      401.0      608.0
 
 MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
-ratio                                                                     4.25x      2.64x      2.75x      2.80x      2.97x      0.82x
+ratio                                                                     5.48x      2.66x      2.78x      2.80x      2.99x      1.75x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
@@ -7,15 +7,15 @@ Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka dropDuplicates e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s firstOutputBatchFiltered=true warmupFiltered=300s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=dropDuplicates(key), 80% fresh keys, 20% guaranteed duplicates; samples are unique rows
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799964    1799964    1439972    1199964        0        0.0       26.0       46.0       48.0       50.0      610.0
-MBM       12157    1799997    1799997    1439998    1199994        0       61.0      147.0      206.0      222.0      269.0      354.0
+RTM           5    1799962    1799962    1439970    1199359        0       32.0       99.0      121.0      125.0      134.0      777.0
+MBM       10172    1799996    1799996    1439997    1199995        0      136.0      261.0      333.0      350.0      398.0      638.0
 
 MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
-ratio                                                                       n/a      5.65x      4.48x      4.63x      5.38x      0.58x
+ratio                                                                     4.25x      2.64x      2.75x      2.80x      2.97x      0.82x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt
@@ -2,20 +2,20 @@
 RTM vs MBM Kafka dropDuplicates latency
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.16+8 on Linux 5.4.0-1161-aws-fips
+OpenJDK 64-Bit Server VM 17.0.15+6-Ubuntu-0ubuntu120.04 on Linux 5.4.0-1161-aws-fips
 Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka dropDuplicates e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=600s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=dropDuplicates(key), 80% fresh keys, 20% guaranteed duplicates; samples are unique rows
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799953    1799953    1439963     958883        0       25.0       99.0      121.0      126.0      134.0      348.0
-MBM       10023    1799997    1799997    1439998    1199996        0      137.0      263.0      336.0      353.0      401.0      608.0
+RTM           5    1799948    1799948    1439959     959870        0       36.0      100.0      122.0      127.0      136.0      400.0
+MBM        7069    1799998    1799998    1439999     959996        0      142.0      309.0      412.0      433.0      503.0      735.0
 
 MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
-ratio                                                                     5.48x      2.66x      2.78x      2.80x      2.99x      1.75x
+ratio                                                                     3.94x      3.09x      3.38x      3.41x      3.70x      1.84x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
@@ -7,15 +7,15 @@ Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka transformWithState e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s firstOutputBatchFiltered=true warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 warmupFiltered=300s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=ProcessingTime, one ValueState get/update per row, keys=50000, no registered timers or TTL; includes empty timer checks; samples are steady-state updates
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799957    1799957    1799957    1498979        0       29.0      103.0      125.0      130.0      139.0      973.0
-MBM        8054    1799997    1799997    1799997    1499994        0      148.0      294.0      383.0      396.0      418.0      580.0
+RTM           5    1799957    1799957    1799957    1198265        0       40.0      104.0      127.0      132.0      141.0      384.0
+MBM        8084    1799997    1799997    1799997    1499996        0      132.0      291.0      380.0      393.0      414.0      577.0
 
 MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
-ratio                                                                     5.10x      2.85x      3.06x      3.05x      3.01x      0.60x
+ratio                                                                     3.30x      2.80x      2.99x      2.98x      2.94x      1.50x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
@@ -1,0 +1,21 @@
+================================================================================================
+RTM vs MBM Kafka transformWithState latency
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.16+8 on Linux 5.4.0-1161-aws-fips
+Intel(R) Xeon(R) 6975P-C
+
+Kafka-to-Kafka transformWithState e2e latency in milliseconds
+RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
+modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=300s recordsPerSecond=1000
+master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
+stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
+workload=ProcessingTime, one ValueState get/update per row, keys=50000, no registered timers or TTL; includes empty timer checks; samples are steady-state updates
+
+Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
+--------------------------------------------------------------------------------------------------------------------------------------
+RTM           5    1799965    1799965    1799965    1499955        0        0.0       26.0       46.0       48.0       50.0      793.0
+MBM       12490    1799997    1799997    1799997    1499994        0       64.0      146.0      203.0      210.0      221.0      333.0
+
+MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
+ratio                                                                       n/a      5.62x      4.41x      4.38x      4.42x      0.42x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
@@ -2,20 +2,20 @@
 RTM vs MBM Kafka transformWithState latency
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.16+8 on Linux 5.4.0-1161-aws-fips
+OpenJDK 64-Bit Server VM 17.0.15+6-Ubuntu-0ubuntu120.04 on Linux 5.4.0-1161-aws-fips
 Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka transformWithState e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=600s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=ProcessingTime, one ValueState get/update per row, keys=50000, no registered timers or TTL; includes empty timer checks; samples are steady-state updates
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799957    1799957    1799957    1198265        0       40.0      104.0      127.0      132.0      141.0      384.0
-MBM        8084    1799997    1799997    1799997    1499996        0      132.0      291.0      380.0      393.0      414.0      577.0
+RTM           5    1799965    1799965    1799965    1199957        0       20.0      104.0      127.0      132.0      141.0      454.0
+MBM        6914    1799997    1799997    1799997    1199994        0      136.0      319.0      422.0      437.0      463.0      652.0
 
 MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
-ratio                                                                     3.30x      2.80x      2.99x      2.98x      2.94x      1.50x
+ratio                                                                     6.80x      3.07x      3.32x      3.31x      3.28x      1.44x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt
@@ -7,15 +7,15 @@ Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka transformWithState e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s firstOutputBatchFiltered=true warmupFiltered=300s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=ProcessingTime, one ValueState get/update per row, keys=50000, no registered timers or TTL; includes empty timer checks; samples are steady-state updates
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799965    1799965    1799965    1499955        0        0.0       26.0       46.0       48.0       50.0      793.0
-MBM       12490    1799997    1799997    1799997    1499994        0       64.0      146.0      203.0      210.0      221.0      333.0
+RTM           5    1799957    1799957    1799957    1498979        0       29.0      103.0      125.0      130.0      139.0      973.0
+MBM        8054    1799997    1799997    1799997    1499994        0      148.0      294.0      383.0      396.0      418.0      580.0
 
 MBM / RTM ratio over each mode's emitted samples (>1 means RTM has lower latency)
-ratio                                                                       n/a      5.62x      4.41x      4.38x      4.42x      0.42x
+ratio                                                                     5.10x      2.85x      3.06x      3.05x      3.01x      0.60x

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
@@ -7,14 +7,14 @@ Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka window aggregation e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s firstOutputBatchFiltered=true warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 warmupFiltered=300s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=groupBy(window=1 minute,key).count, keys=1000; native aggregate-update samples, not a per-input distribution; MBM may coalesce updates within a micro-batch
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799961    1799961    1799961    1499185        0       24.0      103.0      125.0      130.0      139.0      799.0
-MBM        7473    1799997    1799997    1799997    1499994        0      200.0      361.0      458.0      474.0      501.0      627.0
+RTM           5    1799957    1799957    1799957    1198493        0       26.0      103.0      125.0      130.0      138.0      346.0
+MBM        7574    1799997    1799997    1799997    1499996        0      201.0      358.0      453.0      468.0      492.0      651.0
 
 Percentile ratio omitted: RTM and MBM may emit different native sample populations.

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
@@ -7,14 +7,14 @@ Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka window aggregation e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s firstOutputBatchFiltered=true warmupFiltered=300s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=groupBy(window=1 minute,key).count, keys=1000; native aggregate-update samples, not a per-input distribution; MBM may coalesce updates within a micro-batch
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799959    1799959    1799959    1499950        0        0.0       25.0       46.0       48.0       50.0      740.0
-MBM       11352    1799998    1799998    1799998    1499994        0      116.0      208.0      271.0      279.0      291.0      405.0
+RTM           5    1799961    1799961    1799961    1499185        0       24.0      103.0      125.0      130.0      139.0      799.0
+MBM        7473    1799997    1799997    1799997    1499994        0      200.0      361.0      458.0      474.0      501.0      627.0
 
 Percentile ratio omitted: RTM and MBM may emit different native sample populations.

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
@@ -1,0 +1,20 @@
+================================================================================================
+RTM vs MBM Kafka window aggregation latency
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.16+8 on Linux 5.4.0-1161-aws-fips
+Intel(R) Xeon(R) 6975P-C
+
+Kafka-to-Kafka window aggregation e2e latency in milliseconds
+RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
+modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=300s recordsPerSecond=1000
+master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
+stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
+workload=groupBy(window=1 minute,key).count, keys=1000; native aggregate-update samples, not a per-input distribution; MBM may coalesce updates within a micro-batch
+
+Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
+--------------------------------------------------------------------------------------------------------------------------------------
+RTM           5    1799959    1799959    1799959    1499950        0        0.0       25.0       46.0       48.0       50.0      740.0
+MBM       11352    1799998    1799998    1799998    1499994        0      116.0      208.0      271.0      279.0      291.0      405.0
+
+Percentile ratio omitted: RTM and MBM may emit different native sample populations.

--- a/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
+++ b/connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt
@@ -2,19 +2,19 @@
 RTM vs MBM Kafka window aggregation latency
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.16+8 on Linux 5.4.0-1161-aws-fips
+OpenJDK 64-Bit Server VM 17.0.15+6-Ubuntu-0ubuntu120.04 on Linux 5.4.0-1161-aws-fips
 Intel(R) Xeon(R) 6975P-C
 
 Kafka-to-Kafka window aggregation e2e latency in milliseconds
 RTM trigger=RealTime(5m) MBM trigger=ProcessingTime(0ms)
-modeOrder=RTM,MBM observationWindow=1800s rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 warmupFiltered=300s recordsPerSecond=1000
+modeOrder=RTM,MBM observationWindow=1800s warmupFiltered=600s recordsPerSecond=1000
 master=local-cluster[3, 5, 2048] inputPartitions=5 shufflePartitions=5
 stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true trackTotalNumberOfRows=false
 workload=groupBy(window=1 minute,key).count, keys=1000; native aggregate-update samples, not a per-input distribution; MBM may coalesce updates within a micro-batch
 
 Mode   obsBatch   produced sourceRows   sinkRows    samples   tailMs         p0        p50        p90        p95        p99       p100
 --------------------------------------------------------------------------------------------------------------------------------------
-RTM           5    1799957    1799957    1799957    1198493        0       26.0      103.0      125.0      130.0      138.0      346.0
-MBM        7574    1799997    1799997    1799997    1499996        0      201.0      358.0      453.0      468.0      492.0      651.0
+RTM           5    1799959    1799959    1799959    1199950        0       34.0      103.0      126.0      131.0      139.0      467.0
+MBM        5846    1799997    1799997    1799909    1199993        0      231.0      441.0      563.0      581.0      610.0      756.0
 
 Percentile ratio omitted: RTM and MBM may emit different native sample populations.

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaDropDuplicatesBenchmark.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaDropDuplicatesBenchmark.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.benchmark
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+
+/**
+ * End-to-end latency benchmark for Kafka -> `dropDuplicates` -> Kafka in RTM and MBM.
+ *
+ * Four out of every five records have a fresh key. Every fifth record repeats the immediately
+ * preceding key, so the operator exercises both state insertion and duplicate suppression without
+ * exhausting a finite key space. Latency samples contain the emitted unique records.
+ *
+ * To run this benchmark:
+ * {{{
+ *   build/sbt "sql-kafka-0-10/Test/runMain \
+ *     org.apache.spark.sql.kafka010.benchmark.RTMKafkaDropDuplicatesBenchmark"
+ *   SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql-kafka-0-10/Test/runMain \
+ *     org.apache.spark.sql.kafka010.benchmark.RTMKafkaDropDuplicatesBenchmark"
+ * }}}
+ *
+ * Results are written to
+ * `connector/kafka-0-10-sql/benchmarks/RTMKafkaDropDuplicatesBenchmark-results.txt`.
+ */
+object RTMKafkaDropDuplicatesBenchmark extends RTMKafkaStatefulBenchmarkBase {
+
+  override protected def benchmarkName: String = "dropDuplicates"
+
+  override protected def benchmarkDetails: String =
+    "dropDuplicates(key), 80% fresh keys, 20% guaranteed duplicates; samples are unique rows"
+
+  override protected def expectedSinkRecordCount(numSourceRecords: Long): Option[Long] = {
+    Some(numSourceRecords - numSourceRecords / 5L)
+  }
+
+  override protected def inputKey(recordNumber: Long): String = {
+    val key = if (recordNumber % 5 == 0) recordNumber - 1 else recordNumber
+    key.toString
+  }
+
+  override protected def buildStatefulQuery(kafkaStream: DataFrame): DataFrame = {
+    kafkaStream
+      .select(
+        col("key").cast("STRING").as("dedupKey"),
+        col("key"),
+        col("value"),
+        toUnixMillis(col("timestamp")).as("sourceTimestampMs"))
+      .dropDuplicates("dedupKey")
+      .select(col("key"), col("value"), col("sourceTimestampMs"))
+  }
+}

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
@@ -48,15 +48,18 @@ import org.apache.spark.util.Utils
  *
  * Latency is measured in the same way as [[RTMKafkaKafkaBenchmark]]: the input Kafka record
  * timestamp is carried through the stateful operator in a `source-timestamp` header, then
- * subtracted from the output Kafka record timestamp. The first five minutes are filtered by
- * source timestamp before p0, p50, p90, p95, p99, and p100 are calculated.
+ * subtracted from the output Kafka record timestamp. The output batch timestamp is carried in a
+ * second header. Samples from the first output-producing batch and the first five minutes are
+ * filtered before p0, p50, p90, p95, p99, and p100 are calculated.
  * As in the stateless benchmark, the output timestamp is Kafka CreateTime, so the measurement ends
  * when the sink producer creates the output record rather than when a consumer can observe it.
  *
  * The default 30-minute observation window gives RTM several five-minute batch boundaries. Short
  * development runs can override the observation and warm-up windows with
  * `SPARK_RTM_STATEFUL_BENCHMARK_OBSERVATION_SECONDS` and
- * `SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS`. A published comparison should use the defaults.
+ * `SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS`. The observation window must remain longer than
+ * the five-minute RTM batch so that samples remain after the first batch is removed. A published
+ * comparison should use the defaults.
  * Input production stops at the observation deadline. The query then drains to the recorded Kafka
  * end offsets, so delayed output from those inputs remains part of the latency distribution.
  * `SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER` may be set to `MBM,RTM` to check for run-order bias.
@@ -158,6 +161,10 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     require(
       observationWindow > warmupWindow,
       s"observationWindow ($observationWindow) must exceed warmupWindow ($warmupWindow)")
+    require(
+      observationWindow > rtmBatchDuration,
+      s"observationWindow ($observationWindow) must exceed the RTM batch duration " +
+        s"($rtmBatchDuration) to retain samples after filtering the first batch")
     testUtils = new KafkaTestUtils(Map.empty)
     try {
       testUtils.setup()
@@ -264,11 +271,16 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       .load()
 
     val outputWithHeaders = buildStatefulQuery(kafkaStream)
+      .withColumn("outputBatchTimestampMs", toUnixMillis(current_timestamp()))
       .withColumn(
         "headers",
-        array(struct(
-          lit("source-timestamp").as("key"),
-          col("sourceTimestampMs").cast("STRING").cast("BINARY").as("value"))))
+        array(
+          struct(
+            lit("source-timestamp").as("key"),
+            col("sourceTimestampMs").cast("STRING").cast("BINARY").as("value")),
+          struct(
+            lit("output-batch-timestamp").as("key"),
+            col("outputBatchTimestampMs").cast("STRING").cast("BINARY").as("value"))))
       .select(
         col("key").cast("BINARY").as("key"),
         col("value").cast("BINARY").as("value"),
@@ -546,12 +558,17 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       .withColumn(
         "source-timestamp",
         col("headers-map.source-timestamp").cast("STRING").cast("BIGINT"))
+      .withColumn(
+        "output-batch-timestamp",
+        col("headers-map.output-batch-timestamp").cast("STRING").cast("BIGINT"))
       .withColumn("sink-timestamp", toUnixMillis(col("timestamp")))
 
     val sinkStats = kafkaSinkData
       .agg(
         count(lit(1)).as("num-sink-records"),
         count(col("source-timestamp")).as("num-timestamped-sink-records"),
+        count(col("output-batch-timestamp")).as("num-batch-timestamped-sink-records"),
+        min("output-batch-timestamp").as("first-output-batch-timestamp"),
         max("source-timestamp").as("maximum-processed-source-timestamp"))
       .collect()(0)
     val numRecordsInSink = sinkStats.getLong(0)
@@ -564,13 +581,19 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       numTimestampedSinkRecords == numRecordsInSink,
       s"[${run.mode.name}] $numTimestampedSinkRecords of $numRecordsInSink sink rows contain " +
         "a source timestamp")
+    val numBatchTimestampedSinkRecords = sinkStats.getLong(2)
+    require(
+      numBatchTimestampedSinkRecords == numRecordsInSink,
+      s"[${run.mode.name}] $numBatchTimestampedSinkRecords of $numRecordsInSink sink rows " +
+        "contain an output batch timestamp")
     expectedSinkRecordCount(numSourceRecords).foreach { expectedSinkRecords =>
       require(
         numRecordsInSink == expectedSinkRecords,
         s"[${run.mode.name}] sink contains $numRecordsInSink rows for $numSourceRecords inputs; " +
           s"expected exactly $expectedSinkRecords")
     }
-    val maximumProcessedSourceTimestamp = sinkStats.getLong(2)
+    val firstOutputBatchTimestamp = sinkStats.getLong(3)
+    val maximumProcessedSourceTimestamp = sinkStats.getLong(4)
     val unprocessedTailMs = maximumSourceTimestamp - maximumProcessedSourceTimestamp
     require(
       unprocessedTailMs >= 0 && unprocessedTailMs <= maximumUnprocessedTail.toMillis,
@@ -583,16 +606,20 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       kafkaSourceData,
       kafkaSinkData)
 
+    // MicroBatchExecution replaces current_timestamp() with one timestamp per executed batch.
+    val afterFirstBatch = kafkaSinkData.filter(
+      col("output-batch-timestamp") > firstOutputBatchTimestamp)
     val filteredSink = if (warmupWindow.toMillis == 0) {
-      kafkaSinkData
+      afterFirstBatch
     } else {
-      kafkaSinkData.filter(
+      afterFirstBatch.filter(
         col("source-timestamp") - minimumSourceTimestamp > warmupWindow.toMillis)
     }
     val numSamples = filteredSink.count()
     if (numSamples == 0) {
       throw new RuntimeException(
-        s"[${run.mode.name}] no records remained after filtering $warmupWindow of warm-up")
+        s"[${run.mode.name}] no records remained after filtering the first output-producing " +
+          s"batch and $warmupWindow of warm-up")
     }
 
     val percentiles = filteredSink
@@ -634,6 +661,7 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     sb.append("MBM trigger=ProcessingTime(0ms)\n")
     sb.append(s"modeOrder=${configuredModeOrder.map(_.name).mkString(",")} ")
     sb.append(s"observationWindow=${observationWindow.toSeconds}s ")
+    sb.append("firstOutputBatchFiltered=true ")
     sb.append(s"warmupFiltered=${warmupWindow.toSeconds}s ")
     sb.append(s"recordsPerSecond=$recordsPerSecond\n")
     sb.append(s"master=$sparkMaster inputPartitions=$numPartitions ")

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
@@ -49,8 +49,8 @@ import org.apache.spark.util.Utils
  * Latency is measured in the same way as [[RTMKafkaKafkaBenchmark]]: the input Kafka record
  * timestamp is carried through the stateful operator in a `source-timestamp` header, then
  * subtracted from the output Kafka record timestamp. The output batch timestamp is carried in a
- * second header. Samples from the first output-producing batch and the first five minutes are
- * filtered before p0, p50, p90, p95, p99, and p100 are calculated.
+ * second header. RTM filters the first two output-producing batches, while MBM filters the first.
+ * Both modes also filter the first five minutes before calculating latency percentiles.
  * As in the stateless benchmark, the output timestamp is Kafka CreateTime, so the measurement ends
  * when the sink producer creates the output record rather than when a consumer can observe it.
  *
@@ -58,8 +58,8 @@ import org.apache.spark.util.Utils
  * development runs can override the observation and warm-up windows with
  * `SPARK_RTM_STATEFUL_BENCHMARK_OBSERVATION_SECONDS` and
  * `SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS`. The observation window must remain longer than
- * the five-minute RTM batch so that samples remain after the first batch is removed. A published
- * comparison should use the defaults.
+ * two five-minute RTM batches so that samples remain after the initial batches are removed. A
+ * published comparison should use the defaults.
  * Input production stops at the observation deadline. The query then drains to the recorded Kafka
  * end offsets, so delayed output from those inputs remains part of the latency distribution.
  * `SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER` may be set to `MBM,RTM` to check for run-order bias.
@@ -162,9 +162,9 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       observationWindow > warmupWindow,
       s"observationWindow ($observationWindow) must exceed warmupWindow ($warmupWindow)")
     require(
-      observationWindow > rtmBatchDuration,
-      s"observationWindow ($observationWindow) must exceed the RTM batch duration " +
-        s"($rtmBatchDuration) to retain samples after filtering the first batch")
+      observationWindow > 2 * rtmBatchDuration,
+      s"observationWindow ($observationWindow) must exceed two RTM batch durations " +
+        s"(${2 * rtmBatchDuration}) to retain samples after filtering the first two batches")
     testUtils = new KafkaTestUtils(Map.empty)
     try {
       testUtils.setup()
@@ -607,19 +607,30 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       kafkaSinkData)
 
     // MicroBatchExecution replaces current_timestamp() with one timestamp per executed batch.
-    val afterFirstBatch = kafkaSinkData.filter(
-      col("output-batch-timestamp") > firstOutputBatchTimestamp)
-    val filteredSink = if (warmupWindow.toMillis == 0) {
-      afterFirstBatch
+    // Batch 1 includes rows queued while RTM closes its first batch, so exclude it as well.
+    val lastFilteredOutputBatchTimestamp = if (run.mode.isRtm) {
+      val secondOutputBatch = kafkaSinkData
+        .filter(col("output-batch-timestamp") > firstOutputBatchTimestamp)
+        .agg(min("output-batch-timestamp"))
+        .collect()(0)
+      require(!secondOutputBatch.isNullAt(0), "[RTM] fewer than two output-producing batches")
+      secondOutputBatch.getLong(0)
     } else {
-      afterFirstBatch.filter(
+      firstOutputBatchTimestamp
+    }
+    val afterInitialBatches = kafkaSinkData.filter(
+      col("output-batch-timestamp") > lastFilteredOutputBatchTimestamp)
+    val filteredSink = if (warmupWindow.toMillis == 0) {
+      afterInitialBatches
+    } else {
+      afterInitialBatches.filter(
         col("source-timestamp") - minimumSourceTimestamp > warmupWindow.toMillis)
     }
     val numSamples = filteredSink.count()
     if (numSamples == 0) {
       throw new RuntimeException(
-        s"[${run.mode.name}] no records remained after filtering the first output-producing " +
-          s"batch and $warmupWindow of warm-up")
+        s"[${run.mode.name}] no records remained after filtering the initial output-producing " +
+          s"batch(es) and $warmupWindow of warm-up")
     }
 
     val percentiles = filteredSink
@@ -661,7 +672,7 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     sb.append("MBM trigger=ProcessingTime(0ms)\n")
     sb.append(s"modeOrder=${configuredModeOrder.map(_.name).mkString(",")} ")
     sb.append(s"observationWindow=${observationWindow.toSeconds}s ")
-    sb.append("firstOutputBatchFiltered=true ")
+    sb.append("rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 ")
     sb.append(s"warmupFiltered=${warmupWindow.toSeconds}s ")
     sb.append(s"recordsPerSecond=$recordsPerSecond\n")
     sb.append(s"master=$sparkMaster inputPartitions=$numPartitions ")

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.kafka010.benchmark
 
 import java.io.File
 import java.time.{Duration => JavaDuration}
-import java.util.{Properties, Timer, TimerTask}
+import java.util.{Locale, Properties, Timer, TimerTask}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
 
 import scala.concurrent.duration._
@@ -48,9 +48,8 @@ import org.apache.spark.util.Utils
  *
  * Latency is measured in the same way as [[RTMKafkaKafkaBenchmark]]: the input Kafka record
  * timestamp is carried through the stateful operator in a `source-timestamp` header, then
- * subtracted from the output Kafka record timestamp. The output batch timestamp is carried in a
- * second header. RTM filters the first two output-producing batches, while MBM filters the first.
- * Both modes also filter the first five minutes before calculating latency percentiles.
+ * subtracted from the output Kafka record timestamp. Both modes filter the first ten minutes
+ * based on the source record timestamp before calculating latency percentiles.
  * As in the stateless benchmark, the output timestamp is Kafka CreateTime, so the measurement ends
  * when the sink producer creates the output record rather than when a consumer can observe it.
  *
@@ -58,8 +57,8 @@ import org.apache.spark.util.Utils
  * development runs can override the observation and warm-up windows with
  * `SPARK_RTM_STATEFUL_BENCHMARK_OBSERVATION_SECONDS` and
  * `SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS`. The observation window must remain longer than
- * two five-minute RTM batches so that samples remain after the initial batches are removed. A
- * published comparison should use the defaults.
+ * two five-minute RTM batches so that every run crosses at least two batch boundaries. A published
+ * comparison should use the defaults.
  * Input production stops at the observation deadline. The query then drains to the recorded Kafka
  * end offsets, so delayed output from those inputs remains part of the latency distribution.
  * `SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER` may be set to `MBM,RTM` to check for run-order bias.
@@ -101,7 +100,7 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     30.minutes)
   private val warmupWindow = durationFromEnv(
     "SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS",
-    5.minutes,
+    10.minutes,
     allowZero = true)
   private val maximumUnprocessedTail = 5.seconds
   private val expectedRecords = recordsPerSecond * observationWindow.toMillis / 1000L
@@ -164,7 +163,7 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     require(
       observationWindow > 2 * rtmBatchDuration,
       s"observationWindow ($observationWindow) must exceed two RTM batch durations " +
-        s"(${2 * rtmBatchDuration}) to retain samples after filtering the first two batches")
+        s"(${2 * rtmBatchDuration})")
     testUtils = new KafkaTestUtils(Map.empty)
     try {
       testUtils.setup()
@@ -222,7 +221,7 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     val names = sys.env
       .getOrElse("SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER", "RTM,MBM")
       .split(",")
-      .map(_.trim.toUpperCase)
+      .map(_.trim.toUpperCase(Locale.ROOT))
       .toSeq
     require(
       names.length == 2 && names.toSet == modesByName.keySet,
@@ -252,6 +251,14 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       s"RTM and MBM input counts differ by more than $maximumCountDifference: " +
         runs.map(run => s"${run.mode.name}=${run.recordsProduced}").mkString(", "))
     val results = runs.map(getLatencies)
+    val sampleCounts = results.map(_.numSamples)
+    val maximumSampleCountDifference = math.max(100L, sampleCounts.max / 50L)
+    if (percentileRatiosAreComparable) {
+      require(
+        sampleCounts.max - sampleCounts.min <= maximumSampleCountDifference,
+        s"RTM and MBM sample counts differ by more than $maximumSampleCountDifference: " +
+          results.map(result => s"${result.mode.name}=${result.numSamples}").mkString(", "))
+    }
     printComparison(configuredModeOrder, results)
   }
 
@@ -271,22 +278,19 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       .load()
 
     val outputWithHeaders = buildStatefulQuery(kafkaStream)
-      .withColumn("outputBatchTimestampMs", toUnixMillis(current_timestamp()))
       .withColumn(
         "headers",
         array(
           struct(
             lit("source-timestamp").as("key"),
-            col("sourceTimestampMs").cast("STRING").cast("BINARY").as("value")),
-          struct(
-            lit("output-batch-timestamp").as("key"),
-            col("outputBatchTimestampMs").cast("STRING").cast("BINARY").as("value"))))
+            col("sourceTimestampMs").cast("STRING").cast("BINARY").as("value"))))
       .select(
         col("key").cast("BINARY").as("key"),
         col("value").cast("BINARY").as("value"),
         col("headers"))
 
-    val queryName = s"${mode.name.toLowerCase}-${getClass.getSimpleName.stripSuffix("$")}"
+    val queryName =
+      s"${mode.name.toLowerCase(Locale.ROOT)}-${getClass.getSimpleName.stripSuffix("$")}"
     val writer = outputWithHeaders.writeStream
       .format("kafka")
       .option("kafka.bootstrap.servers", testUtils.brokerAddress)
@@ -319,7 +323,7 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
             case t: Throwable => producerFailure.compareAndSet(null, t)
           }
         },
-        s"${mode.name.toLowerCase}-stateful-benchmark-data-generator")
+        s"${mode.name.toLowerCase(Locale.ROOT)}-stateful-benchmark-data-generator")
       dataGenThread.setDaemon(true)
       dataGenThread.start()
 
@@ -502,13 +506,12 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
               }
             })
           currentTime = System.nanoTime()
-
-          val sleepTimeNs = math.max(0L, nextDeadline - currentTime)
-          if (sleepTimeNs > 0) {
-            val sleepTimeMs = sleepTimeNs.nanos.toMillis
-            val sleepTimeNanos = (sleepTimeNs - sleepTimeMs.millis.toNanos).toInt
-            Thread.sleep(sleepTimeMs, sleepTimeNanos)
-          }
+        }
+        val sleepTimeNs = math.max(0L, nextDeadline - currentTime)
+        if (sleepTimeNs > 0) {
+          val sleepTimeMs = sleepTimeNs.nanos.toMillis
+          val sleepTimeNanos = (sleepTimeNs - sleepTimeMs.millis.toNanos).toInt
+          Thread.sleep(sleepTimeMs, sleepTimeNanos)
         }
       }
     } catch {
@@ -558,17 +561,12 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       .withColumn(
         "source-timestamp",
         col("headers-map.source-timestamp").cast("STRING").cast("BIGINT"))
-      .withColumn(
-        "output-batch-timestamp",
-        col("headers-map.output-batch-timestamp").cast("STRING").cast("BIGINT"))
       .withColumn("sink-timestamp", toUnixMillis(col("timestamp")))
 
     val sinkStats = kafkaSinkData
       .agg(
         count(lit(1)).as("num-sink-records"),
         count(col("source-timestamp")).as("num-timestamped-sink-records"),
-        count(col("output-batch-timestamp")).as("num-batch-timestamped-sink-records"),
-        min("output-batch-timestamp").as("first-output-batch-timestamp"),
         max("source-timestamp").as("maximum-processed-source-timestamp"))
       .collect()(0)
     val numRecordsInSink = sinkStats.getLong(0)
@@ -581,19 +579,13 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       numTimestampedSinkRecords == numRecordsInSink,
       s"[${run.mode.name}] $numTimestampedSinkRecords of $numRecordsInSink sink rows contain " +
         "a source timestamp")
-    val numBatchTimestampedSinkRecords = sinkStats.getLong(2)
-    require(
-      numBatchTimestampedSinkRecords == numRecordsInSink,
-      s"[${run.mode.name}] $numBatchTimestampedSinkRecords of $numRecordsInSink sink rows " +
-        "contain an output batch timestamp")
     expectedSinkRecordCount(numSourceRecords).foreach { expectedSinkRecords =>
       require(
         numRecordsInSink == expectedSinkRecords,
         s"[${run.mode.name}] sink contains $numRecordsInSink rows for $numSourceRecords inputs; " +
           s"expected exactly $expectedSinkRecords")
     }
-    val firstOutputBatchTimestamp = sinkStats.getLong(3)
-    val maximumProcessedSourceTimestamp = sinkStats.getLong(4)
+    val maximumProcessedSourceTimestamp = sinkStats.getLong(2)
     val unprocessedTailMs = maximumSourceTimestamp - maximumProcessedSourceTimestamp
     require(
       unprocessedTailMs >= 0 && unprocessedTailMs <= maximumUnprocessedTail.toMillis,
@@ -606,31 +598,16 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
       kafkaSourceData,
       kafkaSinkData)
 
-    // MicroBatchExecution replaces current_timestamp() with one timestamp per executed batch.
-    // Batch 1 includes rows queued while RTM closes its first batch, so exclude it as well.
-    val lastFilteredOutputBatchTimestamp = if (run.mode.isRtm) {
-      val secondOutputBatch = kafkaSinkData
-        .filter(col("output-batch-timestamp") > firstOutputBatchTimestamp)
-        .agg(min("output-batch-timestamp"))
-        .collect()(0)
-      require(!secondOutputBatch.isNullAt(0), "[RTM] fewer than two output-producing batches")
-      secondOutputBatch.getLong(0)
-    } else {
-      firstOutputBatchTimestamp
-    }
-    val afterInitialBatches = kafkaSinkData.filter(
-      col("output-batch-timestamp") > lastFilteredOutputBatchTimestamp)
     val filteredSink = if (warmupWindow.toMillis == 0) {
-      afterInitialBatches
+      kafkaSinkData
     } else {
-      afterInitialBatches.filter(
+      kafkaSinkData.filter(
         col("source-timestamp") - minimumSourceTimestamp > warmupWindow.toMillis)
     }
     val numSamples = filteredSink.count()
     if (numSamples == 0) {
       throw new RuntimeException(
-        s"[${run.mode.name}] no records remained after filtering the initial output-producing " +
-          s"batch(es) and $warmupWindow of warm-up")
+        s"[${run.mode.name}] no records remained after filtering $warmupWindow of warm-up")
     }
 
     val percentiles = filteredSink
@@ -672,7 +649,6 @@ private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
     sb.append("MBM trigger=ProcessingTime(0ms)\n")
     sb.append(s"modeOrder=${configuredModeOrder.map(_.name).mkString(",")} ")
     sb.append(s"observationWindow=${observationWindow.toSeconds}s ")
-    sb.append("rtmOutputBatchesFiltered=2 mbmOutputBatchesFiltered=1 ")
     sb.append(s"warmupFiltered=${warmupWindow.toSeconds}s ")
     sb.append(s"recordsPerSecond=$recordsPerSecond\n")
     sb.append(s"master=$sparkMaster inputPartitions=$numPartitions ")

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaStatefulBenchmarkBase.scala
@@ -1,0 +1,694 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.benchmark
+
+import java.io.File
+import java.time.{Duration => JavaDuration}
+import java.util.{Properties, Timer, TimerTask}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
+
+import scala.concurrent.duration._
+
+import org.apache.kafka.clients.producer.{Callback, KafkaProducer, Producer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.TopicPartition
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import org.apache.spark.sql.execution.streaming.runtime.SerializedOffset
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.kafka010.{KafkaSourceOffset, KafkaTestUtils}
+import org.apache.spark.sql.streaming.{StreamingQuery, Trigger}
+import org.apache.spark.util.Utils
+
+/**
+ * Shared Kafka-to-Kafka latency harness for stateful Real-Time Mode benchmarks.
+ *
+ * Each concrete benchmark runs the same logical query and deterministic input pattern twice. RTM
+ * uses a five-minute batch duration and MBM uses an explicit zero-millisecond processing-time
+ * trigger. Both runs use fresh Kafka topics and checkpoint directories, but otherwise have
+ * identical Spark, Kafka, state-store, input-rate, and partition settings.
+ *
+ * Latency is measured in the same way as [[RTMKafkaKafkaBenchmark]]: the input Kafka record
+ * timestamp is carried through the stateful operator in a `source-timestamp` header, then
+ * subtracted from the output Kafka record timestamp. The first five minutes are filtered by
+ * source timestamp before p0, p50, p90, p95, p99, and p100 are calculated.
+ * As in the stateless benchmark, the output timestamp is Kafka CreateTime, so the measurement ends
+ * when the sink producer creates the output record rather than when a consumer can observe it.
+ *
+ * The default 30-minute observation window gives RTM several five-minute batch boundaries. Short
+ * development runs can override the observation and warm-up windows with
+ * `SPARK_RTM_STATEFUL_BENCHMARK_OBSERVATION_SECONDS` and
+ * `SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS`. A published comparison should use the defaults.
+ * Input production stops at the observation deadline. The query then drains to the recorded Kafka
+ * end offsets, so delayed output from those inputs remains part of the latency distribution.
+ * `SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER` may be set to `MBM,RTM` to check for run-order bias.
+ */
+private[benchmark] abstract class RTMKafkaStatefulBenchmarkBase
+    extends BenchmarkBase with Logging {
+
+  protected def benchmarkName: String
+
+  protected def benchmarkDetails: String
+
+  /** Returns key, value, and sourceTimestampMs columns for the Kafka sink preparation. */
+  protected def buildStatefulQuery(kafkaStream: DataFrame): DataFrame
+
+  /** Deterministic input key for one-based record number `recordNumber`. */
+  protected def inputKey(recordNumber: Long): String
+
+  protected def inputValue(recordNumber: Long): String = recordNumber.toString
+
+  /** Whether percentile ratios compare equivalent output populations in RTM and MBM. */
+  protected def percentileRatiosAreComparable: Boolean = true
+
+  protected def expectedSinkRecordCount(numSourceRecords: Long): Option[Long] = None
+
+  protected def validateSinkOutput(
+      isRtm: Boolean,
+      numSourceRecords: Long,
+      numSinkRecords: Long,
+      kafkaSourceData: DataFrame,
+      kafkaSinkData: DataFrame): Unit = {}
+
+  // ----- Benchmark dimensions -----
+
+  protected final val recordsPerSecond = 1000L
+
+  private val rtmBatchDuration = 5.minutes
+  private val observationWindow = durationFromEnv(
+    "SPARK_RTM_STATEFUL_BENCHMARK_OBSERVATION_SECONDS",
+    30.minutes)
+  private val warmupWindow = durationFromEnv(
+    "SPARK_RTM_STATEFUL_BENCHMARK_WARMUP_SECONDS",
+    5.minutes,
+    allowZero = true)
+  private val maximumUnprocessedTail = 5.seconds
+  private val expectedRecords = recordsPerSecond * observationWindow.toMillis / 1000L
+
+  // ----- Spark topology -----
+
+  private val sparkMaster = "local-cluster[3, 5, 2048]"
+  private val numPartitions = 5
+  private val shufflePartitions = 5
+
+  // ----- Streaming, Kafka, and state-store settings -----
+
+  private val streamingPollingDelayMs = 10
+  private val kafkaFetchMaxWaitMs = "10"
+  private val kafkaMaxPartitionFetchBytes = "10485760"
+  private val kafkaBufferMemoryBytes = "67108864"
+  private val rocksDBChangelogConf =
+    "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled"
+  private val rocksDBTrackRowsConf =
+    "spark.sql.streaming.stateStore.rocksdb.trackTotalNumberOfRows"
+
+  // ----- Mutable state -----
+
+  private val topicId = new AtomicInteger(0)
+  private var spark: SparkSession = _
+  private var testUtils: KafkaTestUtils = _
+
+  private case class BenchmarkMode(name: String, isRtm: Boolean)
+
+  private val modesByName = Map(
+    "RTM" -> BenchmarkMode("RTM", isRtm = true),
+    "MBM" -> BenchmarkMode("MBM", isRtm = false))
+
+  private case class ModeRun(
+      mode: BenchmarkMode,
+      batchesAtObservationEnd: Long,
+      recordsProduced: Long,
+      inputTopic: String,
+      outputTopic: String)
+
+  private case class Latencies(
+      mode: BenchmarkMode,
+      batchesAtObservationEnd: Long,
+      recordsProduced: Long,
+      numSourceRecords: Long,
+      numSinkRecords: Long,
+      numSamples: Long,
+      unprocessedTailMs: Long,
+      p0: Double,
+      p50: Double,
+      p90: Double,
+      p95: Double,
+      p99: Double,
+      p100: Double)
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    require(
+      observationWindow > warmupWindow,
+      s"observationWindow ($observationWindow) must exceed warmupWindow ($warmupWindow)")
+    testUtils = new KafkaTestUtils(Map.empty)
+    try {
+      testUtils.setup()
+      spark = SparkSession.builder()
+        .master(sparkMaster)
+        .appName(this.getClass.getCanonicalName)
+        .config(
+          SQLConf.STATE_STORE_PROVIDER_CLASS.key,
+          classOf[RocksDBStateStoreProvider].getName)
+        .config(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, 2)
+        .config(rocksDBChangelogConf, true)
+        .config(rocksDBTrackRowsConf, false)
+        .getOrCreate()
+      runBenchmark(s"RTM vs MBM Kafka $benchmarkName latency") {
+        benchmark()
+      }
+    } finally {
+      cleanup()
+    }
+  }
+
+  private def cleanup(): Unit = {
+    if (spark != null) {
+      try {
+        spark.stop()
+      } catch {
+        case t: Throwable => logWarning("Failed to stop SparkSession during cleanup", t)
+      }
+      spark = null
+    }
+    if (testUtils != null) {
+      try {
+        testUtils.teardown()
+      } catch {
+        case t: Throwable => logWarning("Failed to teardown KafkaTestUtils during cleanup", t)
+      }
+      testUtils = null
+    }
+  }
+
+  private def durationFromEnv(
+      name: String,
+      default: FiniteDuration,
+      allowZero: Boolean = false): FiniteDuration = {
+    sys.env.get(name).map { value =>
+      val seconds = value.toLong
+      require(
+        if (allowZero) seconds >= 0 else seconds > 0,
+        s"$name must be ${if (allowZero) "non-negative" else "positive"}: $value")
+      seconds.seconds
+    }.getOrElse(default)
+  }
+
+  private def modeOrder: Seq[BenchmarkMode] = {
+    val names = sys.env
+      .getOrElse("SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER", "RTM,MBM")
+      .split(",")
+      .map(_.trim.toUpperCase)
+      .toSeq
+    require(
+      names.length == 2 && names.toSet == modesByName.keySet,
+      "SPARK_RTM_STATEFUL_BENCHMARK_MODE_ORDER must be RTM,MBM or MBM,RTM")
+    names.map(modesByName)
+  }
+
+  private def newTopic(): String = s"topic-${topicId.getAndIncrement()}"
+
+  private def withTempDir[T](f: File => T): T = {
+    val dir = Utils.createTempDir()
+    try f(dir) finally Utils.deleteRecursively(dir)
+  }
+
+  private def benchmark(): Unit = {
+    spark.conf.set(SQLConf.STREAMING_POLLING_DELAY.key, streamingPollingDelayMs)
+    spark.conf.set(SQLConf.SHUFFLE_PARTITIONS.key, shufflePartitions)
+
+    val configuredModeOrder = modeOrder
+    // Finish both streaming runs before launching the batch queries that calculate percentiles.
+    // This avoids warming Spark's batch SQL path between the first and second streaming run.
+    val runs = configuredModeOrder.map(runOneMode)
+    val recordCounts = runs.map(_.recordsProduced)
+    val maximumCountDifference = math.max(100L, expectedRecords / 50L)
+    require(
+      recordCounts.max - recordCounts.min <= maximumCountDifference,
+      s"RTM and MBM input counts differ by more than $maximumCountDifference: " +
+        runs.map(run => s"${run.mode.name}=${run.recordsProduced}").mkString(", "))
+    val results = runs.map(getLatencies)
+    printComparison(configuredModeOrder, results)
+  }
+
+  private def runOneMode(mode: BenchmarkMode): ModeRun = withTempDir { checkpointDir =>
+    val inputTopic = newTopic()
+    val outputTopic = newTopic()
+    testUtils.createTopic(inputTopic, partitions = numPartitions)
+    testUtils.createTopic(outputTopic, partitions = numPartitions)
+
+    val kafkaStream = spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", inputTopic)
+      .option("startingOffsets", "earliest")
+      .option("kafka.fetch.max.wait.ms", kafkaFetchMaxWaitMs)
+      .option("kafka.max.partition.fetch.bytes", kafkaMaxPartitionFetchBytes)
+      .load()
+
+    val outputWithHeaders = buildStatefulQuery(kafkaStream)
+      .withColumn(
+        "headers",
+        array(struct(
+          lit("source-timestamp").as("key"),
+          col("sourceTimestampMs").cast("STRING").cast("BINARY").as("value"))))
+      .select(
+        col("key").cast("BINARY").as("key"),
+        col("value").cast("BINARY").as("value"),
+        col("headers"))
+
+    val queryName = s"${mode.name.toLowerCase}-${getClass.getSimpleName.stripSuffix("$")}"
+    val writer = outputWithHeaders.writeStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("topic", outputTopic)
+      .option("checkpointLocation", checkpointDir.getAbsolutePath)
+      .option("kafka.buffer.memory", kafkaBufferMemoryBytes)
+      .option("kafka.compression.type", "snappy")
+      .outputMode("update")
+      .queryName(queryName)
+
+    val recordsProduced = new AtomicLong(0)
+    val producerFailure = new AtomicReference[Throwable]()
+    val stopProducer = new AtomicBoolean(false)
+    var query: StreamingQuery = null
+    var dataGenThread: Thread = null
+    var batchesAtObservationEnd = 0L
+
+    try {
+      query = if (mode.isRtm) {
+        writer.trigger(Trigger.RealTime(rtmBatchDuration)).start()
+      } else {
+        writer.trigger(Trigger.ProcessingTime(0L)).start()
+      }
+
+      dataGenThread = new Thread(
+        () => {
+          try {
+            genData(mode.name, inputTopic, recordsProduced, producerFailure, stopProducer)
+          } catch {
+            case t: Throwable => producerFailure.compareAndSet(null, t)
+          }
+        },
+        s"${mode.name.toLowerCase}-stateful-benchmark-data-generator")
+      dataGenThread.setDaemon(true)
+      dataGenThread.start()
+
+      awaitObservationWindow(mode, query, producerFailure)
+      batchesAtObservationEnd = Option(query.lastProgress).map(_.batchId + 1L).getOrElse(0L)
+      stopProducer.set(true)
+      joinDataGenerator(mode, dataGenThread)
+      Option(producerFailure.get()).foreach { failure =>
+        throw new RuntimeException(s"[${mode.name}] Kafka data generator failed", failure)
+      }
+      val expectedEndOffsets = testUtils.getLatestOffsets(Set(inputTopic))
+      awaitSourceOffsets(mode, query, expectedEndOffsets, producerFailure)
+    } finally {
+      stopProducer.set(true)
+      try {
+        joinDataGenerator(mode, dataGenThread)
+      } finally {
+        if (query != null) {
+          query.stop()
+        }
+      }
+    }
+
+    Option(producerFailure.get()).foreach { failure =>
+      throw new RuntimeException(s"[${mode.name}] Kafka data generator failed", failure)
+    }
+
+    val minimumRecords = expectedRecords * 95L / 100L
+    require(
+      recordsProduced.get() >= minimumRecords,
+      s"[${mode.name}] produced only ${recordsProduced.get()} records; expected at least " +
+        s"$minimumRecords over $observationWindow")
+    val minimumCompletedRtmBatches =
+      observationWindow.toMillis / rtmBatchDuration.toMillis - 1L
+    if (mode.isRtm && minimumCompletedRtmBatches > 0) {
+      require(
+        batchesAtObservationEnd >= minimumCompletedRtmBatches,
+        s"[RTM] completed only $batchesAtObservationEnd batch(es) over $observationWindow; " +
+          s"expected at least $minimumCompletedRtmBatches")
+    }
+
+    logInfo(s"[${mode.name}] completed $batchesAtObservationEnd batch(es) during the " +
+      s"observation window and produced ${recordsProduced.get()} records")
+    ModeRun(
+      mode,
+      batchesAtObservationEnd,
+      recordsProduced.get(),
+      inputTopic,
+      outputTopic)
+  }
+
+  private def joinDataGenerator(mode: BenchmarkMode, dataGenThread: Thread): Unit = {
+    if (dataGenThread != null && dataGenThread.isAlive) {
+      dataGenThread.join(30.seconds.toMillis)
+      if (dataGenThread.isAlive) {
+        dataGenThread.interrupt()
+        dataGenThread.join(5.seconds.toMillis)
+      }
+      require(
+        !dataGenThread.isAlive,
+        s"[${mode.name}] Kafka data generator did not stop within 35 seconds")
+    }
+  }
+
+  private def querySourceOffsets(query: StreamingQuery): Option[Map[TopicPartition, Long]] = {
+    Option(query.lastProgress).flatMap { progress =>
+      progress.sources.headOption.flatMap { source =>
+        Option(source.endOffset)
+          .filter(offset => offset.nonEmpty && offset != "null")
+          .map(offset => KafkaSourceOffset(SerializedOffset(offset)).partitionToOffsets)
+      }
+    }
+  }
+
+  private def requireSourceOffsets(
+      mode: BenchmarkMode,
+      query: StreamingQuery,
+      expectedEndOffsets: Map[TopicPartition, Long]): Unit = {
+    val actualEndOffsets = querySourceOffsets(query)
+    require(
+      actualEndOffsets.contains(expectedEndOffsets),
+      s"[${mode.name}] query did not consume all input offsets: " +
+        s"expected=$expectedEndOffsets actual=$actualEndOffsets")
+  }
+
+  private def awaitSourceOffsets(
+      mode: BenchmarkMode,
+      query: StreamingQuery,
+      expectedEndOffsets: Map[TopicPartition, Long],
+      producerFailure: AtomicReference[Throwable]): Unit = {
+    val timeout = if (mode.isRtm) 2 * rtmBatchDuration + 1.minute else 1.minute
+    val deadlineNs = System.nanoTime() + timeout.toNanos
+    var terminatedEarly = false
+    while (
+        !terminatedEarly &&
+        producerFailure.get() == null &&
+        !querySourceOffsets(query).contains(expectedEndOffsets) &&
+        System.nanoTime() < deadlineNs) {
+      terminatedEarly = query.awaitTermination(1000L)
+    }
+    if (terminatedEarly) {
+      throw new RuntimeException(s"[${mode.name}] query terminated while draining input")
+    }
+    Option(producerFailure.get()).foreach { failure =>
+      throw new RuntimeException(s"[${mode.name}] Kafka data generator failed", failure)
+    }
+    requireSourceOffsets(mode, query, expectedEndOffsets)
+  }
+
+  private def awaitObservationWindow(
+      mode: BenchmarkMode,
+      query: StreamingQuery,
+      producerFailure: AtomicReference[Throwable]): Unit = {
+    val deadlineNs = System.nanoTime() + observationWindow.toNanos
+    var terminatedEarly = false
+    while (!terminatedEarly && producerFailure.get() == null && System.nanoTime() < deadlineNs) {
+      val remainingMs = math.max(1L, (deadlineNs - System.nanoTime()).nanos.toMillis)
+      terminatedEarly = query.awaitTermination(math.min(remainingMs, 1000L))
+    }
+    if (terminatedEarly) {
+      throw new RuntimeException(
+        s"[${mode.name}] query terminated before the $observationWindow observation window")
+    }
+    Option(producerFailure.get()).foreach { failure =>
+      throw new RuntimeException(s"[${mode.name}] Kafka data generator failed", failure)
+    }
+  }
+
+  private def genData(
+      mode: String,
+      topicName: String,
+      totalSuccess: AtomicLong,
+      producerFailure: AtomicReference[Throwable],
+      stopProducer: AtomicBoolean): Unit = {
+    logInfo(
+      s"[$mode] producing to ${testUtils.brokerAddress} topic $topicName at " +
+        s"$recordsPerSecond records/sec")
+
+    val props = new Properties()
+    props.put("bootstrap.servers", testUtils.brokerAddress)
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+
+    val producer: Producer[String, String] = new KafkaProducer[String, String](props)
+    val recentSuccess = new AtomicLong(0)
+    val timer = new Timer(true)
+
+    try {
+      timer.scheduleAtFixedRate(
+        new TimerTask() {
+          override def run(): Unit = {
+            logInfo(s"[$mode] throughput: ${recentSuccess.getAndSet(0)} requests/sec")
+          }
+        },
+        1000,
+        1000)
+
+      var recordNumber = 0L
+      val startTime = System.nanoTime()
+      val delayNs = (1.second.toNanos / recordsPerSecond)
+      var nextDeadline = startTime + delayNs
+      while (!stopProducer.get() && producerFailure.get() == null) {
+        var currentTime = System.nanoTime()
+        if (currentTime >= nextDeadline) {
+          recordNumber += 1
+          nextDeadline = startTime + (recordNumber + 1L) * delayNs
+          producer.send(
+            new ProducerRecord[String, String](
+              topicName,
+              inputKey(recordNumber),
+              inputValue(recordNumber)),
+            new Callback {
+              override def onCompletion(metadata: RecordMetadata, error: Exception): Unit = {
+                if (error != null) {
+                  producerFailure.compareAndSet(null, error)
+                } else {
+                  totalSuccess.incrementAndGet()
+                  recentSuccess.incrementAndGet()
+                }
+              }
+            })
+          currentTime = System.nanoTime()
+
+          val sleepTimeNs = math.max(0L, nextDeadline - currentTime)
+          if (sleepTimeNs > 0) {
+            val sleepTimeMs = sleepTimeNs.nanos.toMillis
+            val sleepTimeNanos = (sleepTimeNs - sleepTimeMs.millis.toNanos).toInt
+            Thread.sleep(sleepTimeMs, sleepTimeNanos)
+          }
+        }
+      }
+    } catch {
+      case _: InterruptedException =>
+    } finally {
+      timer.cancel()
+      producer.close(JavaDuration.ofSeconds(20))
+    }
+  }
+
+  private def getLatencies(run: ModeRun): Latencies = {
+    val kafkaSourceData = spark.read
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", run.inputTopic)
+      .option("startingOffsets", "earliest")
+      .load()
+      .select(
+        col("key"),
+        toUnixMillis(col("timestamp")).as("source-timestamp"))
+
+    val sourceStats = kafkaSourceData
+      .agg(
+        count(lit(1)).as("num-source-records"),
+        min("source-timestamp").as("minimum-source-timestamp"),
+        max("source-timestamp").as("maximum-source-timestamp"))
+      .collect()(0)
+    val numSourceRecords = sourceStats.getLong(0)
+    require(
+      numSourceRecords > 0,
+      s"[${run.mode.name}] no records found in Kafka input topic ${run.inputTopic}")
+    require(
+      numSourceRecords == run.recordsProduced,
+      s"[${run.mode.name}] Kafka input contains $numSourceRecords records, but the producer " +
+        s"acknowledged ${run.recordsProduced}")
+    val minimumSourceTimestamp = sourceStats.getLong(1)
+    val maximumSourceTimestamp = sourceStats.getLong(2)
+
+    val kafkaSinkData = spark.read
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", run.outputTopic)
+      .option("startingOffsets", "earliest")
+      .option("includeHeaders", "true")
+      .load()
+      .withColumn("headers-map", map_from_entries(col("headers")))
+      .withColumn(
+        "source-timestamp",
+        col("headers-map.source-timestamp").cast("STRING").cast("BIGINT"))
+      .withColumn("sink-timestamp", toUnixMillis(col("timestamp")))
+
+    val sinkStats = kafkaSinkData
+      .agg(
+        count(lit(1)).as("num-sink-records"),
+        count(col("source-timestamp")).as("num-timestamped-sink-records"),
+        max("source-timestamp").as("maximum-processed-source-timestamp"))
+      .collect()(0)
+    val numRecordsInSink = sinkStats.getLong(0)
+    if (numRecordsInSink == 0) {
+      throw new RuntimeException(
+        s"[${run.mode.name}] no results found in Kafka sink topic ${run.outputTopic}")
+    }
+    val numTimestampedSinkRecords = sinkStats.getLong(1)
+    require(
+      numTimestampedSinkRecords == numRecordsInSink,
+      s"[${run.mode.name}] $numTimestampedSinkRecords of $numRecordsInSink sink rows contain " +
+        "a source timestamp")
+    expectedSinkRecordCount(numSourceRecords).foreach { expectedSinkRecords =>
+      require(
+        numRecordsInSink == expectedSinkRecords,
+        s"[${run.mode.name}] sink contains $numRecordsInSink rows for $numSourceRecords inputs; " +
+          s"expected exactly $expectedSinkRecords")
+    }
+    val maximumProcessedSourceTimestamp = sinkStats.getLong(2)
+    val unprocessedTailMs = maximumSourceTimestamp - maximumProcessedSourceTimestamp
+    require(
+      unprocessedTailMs >= 0 && unprocessedTailMs <= maximumUnprocessedTail.toMillis,
+      s"[${run.mode.name}] newest sink output trails the newest input by " +
+        s"$unprocessedTailMs ms; expected at most ${maximumUnprocessedTail.toMillis} ms")
+    validateSinkOutput(
+      run.mode.isRtm,
+      numSourceRecords,
+      numRecordsInSink,
+      kafkaSourceData,
+      kafkaSinkData)
+
+    val filteredSink = if (warmupWindow.toMillis == 0) {
+      kafkaSinkData
+    } else {
+      kafkaSinkData.filter(
+        col("source-timestamp") - minimumSourceTimestamp > warmupWindow.toMillis)
+    }
+    val numSamples = filteredSink.count()
+    if (numSamples == 0) {
+      throw new RuntimeException(
+        s"[${run.mode.name}] no records remained after filtering $warmupWindow of warm-up")
+    }
+
+    val percentiles = filteredSink
+      .withColumn("e2e-latency", col("sink-timestamp") - col("source-timestamp"))
+      .selectExpr(
+        "transform(percentile_approx(`e2e-latency`, " +
+          "array(0.0, 0.5, 0.9, 0.95, 0.99, 1.0), 10000), " +
+          "x -> CAST(x AS DOUBLE)) AS p")
+      .collect()(0)
+      .getSeq[Double](0)
+
+    Latencies(
+      run.mode,
+      run.batchesAtObservationEnd,
+      run.recordsProduced,
+      numSourceRecords,
+      numRecordsInSink,
+      numSamples,
+      unprocessedTailMs,
+      percentiles(0),
+      percentiles(1),
+      percentiles(2),
+      percentiles(3),
+      percentiles(4),
+      percentiles(5))
+  }
+
+  private def printComparison(
+      configuredModeOrder: Seq[BenchmarkMode],
+      unorderedResults: Seq[Latencies]): Unit = {
+    val resultsByMode = unorderedResults.map(result => result.mode.name -> result).toMap
+    val results = Seq("RTM", "MBM").map(resultsByMode)
+    val envHeader = s"${Benchmark.getJVMOSInfo()}\n${Benchmark.getProcessorName()}\n"
+
+    val sb = new StringBuilder
+    sb.append(envHeader)
+    sb.append(s"\nKafka-to-Kafka $benchmarkName e2e latency in milliseconds\n")
+    sb.append(s"RTM trigger=RealTime(${rtmBatchDuration.toMinutes}m) ")
+    sb.append("MBM trigger=ProcessingTime(0ms)\n")
+    sb.append(s"modeOrder=${configuredModeOrder.map(_.name).mkString(",")} ")
+    sb.append(s"observationWindow=${observationWindow.toSeconds}s ")
+    sb.append(s"warmupFiltered=${warmupWindow.toSeconds}s ")
+    sb.append(s"recordsPerSecond=$recordsPerSecond\n")
+    sb.append(s"master=$sparkMaster inputPartitions=$numPartitions ")
+    sb.append(s"shufflePartitions=$shufflePartitions\n")
+    sb.append("stateStore=RocksDB checkpointFormatVersion=2 changelogCheckpointing=true ")
+    sb.append("trackTotalNumberOfRows=false\n")
+    sb.append(s"workload=$benchmarkDetails\n")
+    sb.append('\n')
+
+    val header = f"${"Mode"}%-6s ${"obsBatch"}%8s ${"produced"}%10s ${"sourceRows"}%10s " +
+      f"${"sinkRows"}%10s ${"samples"}%10s ${"tailMs"}%8s ${"p0"}%10s ${"p50"}%10s " +
+      f"${"p90"}%10s ${"p95"}%10s ${"p99"}%10s ${"p100"}%10s"
+    sb.append(header).append('\n')
+    sb.append("-" * header.length).append('\n')
+    results.foreach { result =>
+      sb.append(
+        f"${result.mode.name}%-6s ${result.batchesAtObservationEnd}%8d " +
+          f"${result.recordsProduced}%10d ${result.numSourceRecords}%10d " +
+          f"${result.numSinkRecords}%10d ${result.numSamples}%10d " +
+          f"${result.unprocessedTailMs}%8d " +
+          f"${result.p0}%10.1f ${result.p50}%10.1f ${result.p90}%10.1f " +
+          f"${result.p95}%10.1f ${result.p99}%10.1f ${result.p100}%10.1f\n")
+    }
+
+    if (percentileRatiosAreComparable) {
+      val rtm = resultsByMode("RTM")
+      val mbm = resultsByMode("MBM")
+      def ratio(mbmValue: Double, rtmValue: Double): String = {
+        if (rtmValue <= 0) "n/a" else f"${mbmValue / rtmValue}%.2fx"
+      }
+      sb.append("\nMBM / RTM ratio over each mode's emitted samples ")
+      sb.append("(>1 means RTM has lower latency)\n")
+      sb.append(
+        f"${"ratio"}%-6s ${""}%8s ${""}%10s ${""}%10s ${""}%10s ${""}%10s " +
+          f"${""}%8s ${ratio(mbm.p0, rtm.p0)}%10s ${ratio(mbm.p50, rtm.p50)}%10s " +
+          f"${ratio(mbm.p90, rtm.p90)}%10s ${ratio(mbm.p95, rtm.p95)}%10s " +
+          f"${ratio(mbm.p99, rtm.p99)}%10s ${ratio(mbm.p100, rtm.p100)}%10s")
+    } else {
+      sb.append("\nPercentile ratio omitted: RTM and MBM may emit different native sample ")
+      sb.append("populations.")
+    }
+
+    val message = sb.toString()
+    output match {
+      case Some(out) =>
+        out.write(message.getBytes)
+        // Always echo the comparison when BenchmarkBase is writing a result file.
+        // scalastyle:off println
+        println(message)
+        // scalastyle:on println
+      case None => logInfo("\n" + message)
+    }
+  }
+
+  protected final def toUnixMillis(column: Column): Column = {
+    (column.cast("timestamp").cast("double") * 1000).cast("long")
+  }
+}

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaTransformWithStateBenchmark.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaTransformWithStateBenchmark.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.benchmark
+
+import org.apache.spark.sql.{DataFrame, Encoders}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.streaming._
+
+private[benchmark] case class TransformWithStateBenchmarkRecord(
+    key: String,
+    value: Array[Byte],
+    sourceTimestampMs: Long)
+
+private[benchmark] class TransformWithStateBenchmarkProcessor
+    extends StatefulProcessor[
+      String,
+      TransformWithStateBenchmarkRecord,
+      TransformWithStateBenchmarkRecord] {
+
+  @transient private var countState: ValueState[Long] = _
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    countState = getHandle.getValueState("count", Encoders.scalaLong, TTLConfig.NONE)
+  }
+
+  override def handleInputRows(
+      _key: String,
+      inputRows: Iterator[TransformWithStateBenchmarkRecord],
+      _timerValues: TimerValues): Iterator[TransformWithStateBenchmarkRecord] = {
+    inputRows.map { row =>
+      countState.update(countState.get() + 1L)
+      row
+    }
+  }
+}
+
+/**
+ * End-to-end latency benchmark for Kafka -> JVM `transformWithState` -> Kafka in RTM and MBM.
+ *
+ * The processor uses processing-time mode and performs one ValueState read and update per input
+ * row, then emits that row unchanged. Keys repeat over a 50,000-key space, so the benchmark covers
+ * both new and existing state while keeping state size bounded. It does not register timers or use
+ * TTL, although processing-time mode still performs its empty expired-timer checks. The first pass
+ * through the key space occurs during warm-up, so reported samples measure existing-state updates.
+ * Timer registration and TTL should be measured as separate workloads.
+ *
+ * To run this benchmark:
+ * {{{
+ *   build/sbt "sql-kafka-0-10/Test/runMain \
+ *     org.apache.spark.sql.kafka010.benchmark.RTMKafkaTransformWithStateBenchmark"
+ *   SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql-kafka-0-10/Test/runMain \
+ *     org.apache.spark.sql.kafka010.benchmark.RTMKafkaTransformWithStateBenchmark"
+ * }}}
+ *
+ * Results are written to
+ * `connector/kafka-0-10-sql/benchmarks/RTMKafkaTransformWithStateBenchmark-results.txt`.
+ */
+object RTMKafkaTransformWithStateBenchmark extends RTMKafkaStatefulBenchmarkBase {
+
+  private val numKeys = 50000L
+
+  override protected def benchmarkName: String = "transformWithState"
+
+  override protected def benchmarkDetails: String =
+    s"ProcessingTime, one ValueState get/update per row, keys=$numKeys, no registered timers or " +
+      "TTL; includes empty timer checks; samples are steady-state updates"
+
+  override protected def expectedSinkRecordCount(numSourceRecords: Long): Option[Long] = {
+    Some(numSourceRecords)
+  }
+
+  override protected def inputKey(recordNumber: Long): String = {
+    (recordNumber % numKeys).toString
+  }
+
+  override protected def buildStatefulQuery(kafkaStream: DataFrame): DataFrame = {
+    val session = kafkaStream.sparkSession
+    import session.implicits._
+
+    kafkaStream
+      .select(
+        col("key").cast("STRING").as("key"),
+        col("value"),
+        toUnixMillis(col("timestamp")).as("sourceTimestampMs"))
+      .as[TransformWithStateBenchmarkRecord]
+      .groupByKey(_.key)
+      .transformWithState(
+        new TransformWithStateBenchmarkProcessor,
+        TimeMode.ProcessingTime(),
+        OutputMode.Update())
+      .toDF()
+  }
+}

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaWindowAggregationBenchmark.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/benchmark/RTMKafkaWindowAggregationBenchmark.scala
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010.benchmark
+
+import scala.concurrent.duration._
+
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.functions._
+
+/**
+ * End-to-end latency benchmark for Kafka -> windowed aggregation -> Kafka in RTM and MBM.
+ *
+ * The query groups 1000 repeated keys into one-minute tumbling windows and computes a running
+ * count. It also carries the maximum input Kafka timestamp for each update, so the reported value
+ * is aggregate-update latency for the newest reflected input. RTM emits an update per input row;
+ * MBM can coalesce updates to the same group within a micro-batch, so sample counts are reported.
+ * No watermark is used.
+ *
+ * To run this benchmark:
+ * {{{
+ *   build/sbt "sql-kafka-0-10/Test/runMain \
+ *     org.apache.spark.sql.kafka010.benchmark.RTMKafkaWindowAggregationBenchmark"
+ *   SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql-kafka-0-10/Test/runMain \
+ *     org.apache.spark.sql.kafka010.benchmark.RTMKafkaWindowAggregationBenchmark"
+ * }}}
+ *
+ * Results are written to
+ * `connector/kafka-0-10-sql/benchmarks/RTMKafkaWindowAggregationBenchmark-results.txt`.
+ */
+object RTMKafkaWindowAggregationBenchmark extends RTMKafkaStatefulBenchmarkBase {
+
+  private val numKeys = 1000L
+  private val windowDuration = 1.minute
+  private val windowDurationMs = windowDuration.toMillis
+
+  override protected def benchmarkName: String = "window aggregation"
+
+  override protected def benchmarkDetails: String =
+    s"groupBy(window=$windowDuration,key).count, keys=$numKeys; native aggregate-update samples, " +
+      "not a per-input distribution; MBM may coalesce updates within a micro-batch"
+
+  override protected def percentileRatiosAreComparable: Boolean = false
+
+  override protected def inputKey(recordNumber: Long): String = {
+    (recordNumber % numKeys).toString
+  }
+
+  override protected def buildStatefulQuery(kafkaStream: DataFrame): DataFrame = {
+    kafkaStream
+      .select(
+        col("key").cast("STRING").as("groupKey"),
+        col("timestamp"),
+        toUnixMillis(col("timestamp")).as("sourceTimestampMs"))
+      .groupBy(window(col("timestamp"), windowDuration.toString), col("groupKey"))
+      .agg(
+        count(lit(1)).as("count"),
+        max(col("sourceTimestampMs")).as("sourceTimestampMs"))
+      .select(
+        col("groupKey").as("key"),
+        col("count").cast("STRING").as("value"),
+        col("sourceTimestampMs"))
+  }
+
+  override protected def validateSinkOutput(
+      isRtm: Boolean,
+      numSourceRecords: Long,
+      numSinkRecords: Long,
+      kafkaSourceData: DataFrame,
+      kafkaSinkData: DataFrame): Unit = {
+    require(
+      numSinkRecords <= numSourceRecords,
+      s"Window aggregation emitted $numSinkRecords rows for $numSourceRecords inputs")
+    // RTM plans StatefulStreamlineAggregateExec, whose Update mode emits once per input row.
+    if (isRtm) {
+      require(
+        numSinkRecords == numSourceRecords,
+        s"RTM emitted $numSinkRecords window updates for $numSourceRecords inputs")
+    }
+
+    val sourceCounts = kafkaSourceData
+      .select(
+        col("key").cast("STRING").as("groupKey"),
+        windowStart(col("source-timestamp")).as("windowStart"))
+      .groupBy("groupKey", "windowStart")
+      .agg(count(lit(1)).as("sourceCount"))
+    val sinkUpdates = kafkaSinkData
+      .select(
+        col("key").cast("STRING").as("groupKey"),
+        windowStart(col("source-timestamp")).as("windowStart"),
+        col("value").cast("STRING").cast("LONG").as("aggregateCount"))
+    val sinkFinalCounts = sinkUpdates
+      .groupBy("groupKey", "windowStart")
+      .agg(max("aggregateCount").as("sinkCount"))
+    val hasCountMismatch = sourceCounts
+      .join(sinkFinalCounts, Seq("groupKey", "windowStart"), "full_outer")
+      .filter(!col("sourceCount").eqNullSafe(col("sinkCount")))
+      .limit(1)
+      .count() > 0
+    require(!hasCountMismatch, "Window aggregation sink does not cover every input group")
+
+    val hasDuplicateUpdate = sinkUpdates
+      .groupBy("groupKey", "windowStart", "aggregateCount")
+      .count()
+      .filter(col("count") > 1)
+      .limit(1)
+      .count() > 0
+    require(!hasDuplicateUpdate, "Window aggregation sink contains duplicate updates")
+  }
+
+  private def windowStart(timestampMs: Column): Column = {
+    timestampMs - pmod(timestampMs, lit(windowDurationMs))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

  This PR adds Kafka-to-Kafka latency benchmarks comparing Real-Time Mode (RTM) and Micro-Batch Mode (MBM) for three stateful Structured Streaming operators:

  - `dropDuplicates`
  - Grouped window aggregation
  - JVM `transformWithState`

  The shared benchmark harness uses:

  - RTM with `RealTime(5m)`
  - MBM with `ProcessingTime(0ms)`
  - 1,000 input records per second
  - Five Kafka input and shuffle partitions
  - A 30-minute observation window per mode
  - A 10-minute source-timestamp warm-up filter
  - RocksDB checkpoint format V2
  - RocksDB changelog checkpointing enabled

  End-to-end latency is calculated from the input Kafka record CreateTime propagated through the operator to the output Kafka record CreateTime. The harness validates source and sink
  counts, drains all produced input offsets, checks the unprocessed tail, and records latency percentiles in benchmark result files.

  The workloads are:

  - `dropDuplicates`: 80% fresh keys and 20% guaranteed duplicates.
  - Window aggregation: one-minute tumbling windows over 1,000 keys.
  - `transformWithState`: processing-time mode over 50,000 keys, with one `ValueState` read and update per row and no TTL or registered timers.

  ### Why are the changes needed?

  Spark already has a stateless Kafka-to-Kafka RTM latency benchmark, but it does not cover state stores or pipelined shuffles.

  These benchmarks provide reproducible RTM-versus-MBM latency measurements for representative stateful operators and can detect regressions in pipelined shuffle, state-store processing,
  and stateful RTM execution.

  ### Does this PR introduce _any_ user-facing change?

  No. This PR only adds benchmark code and generated benchmark results.

  ### How was this patch tested?

  The benchmark test sources were compiled with:

  ```bash
  build/sbt 'sql-kafka-0-10/Test/compile'

  Scala formatting and style checks were run with:

  ./dev/lint-scala

  Each benchmark was run for 30 minutes per mode:

  SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt \
    'sql-kafka-0-10/Test/runMain org.apache.spark.sql.kafka010.benchmark.RTMKafkaDropDuplicatesBenchmark'

  SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt \
    'sql-kafka-0-10/Test/runMain org.apache.spark.sql.kafka010.benchmark.RTMKafkaWindowAggregationBenchmark'

  SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt \
    'sql-kafka-0-10/Test/runMain org.apache.spark.sql.kafka010.benchmark.RTMKafkaTransformWithStateBenchmark'
```

  Recorded latency results in milliseconds:

   Benchmark             Mode    p50    p90    p95    p99    p100
  ━━━━━━━━━━━━━━━━━━━━  ━━━━━━  ━━━━━  ━━━━━  ━━━━━  ━━━━━  ━━━━━━
   dropDuplicates         RTM    100    122    127    136     400
  ────────────────────  ──────  ─────  ─────  ─────  ─────  ──────
                          MBM    309    412    433    503     735
  ────────────────────  ──────  ─────  ─────  ─────  ─────  ──────
   Window aggregation     RTM    103    126    131    139     467
  ────────────────────  ──────  ─────  ─────  ─────  ─────  ──────
                          MBM    441    563    581    610     756
  ────────────────────  ──────  ─────  ─────  ─────  ─────  ──────
   transformWithState     RTM    104    127    132    141     454
  ────────────────────  ──────  ─────  ─────  ─────  ─────  ──────
                          MBM    319    422    437    463     652

  git diff --check, Scalastyle, and Scalafmt also passed.

  ### Was this patch authored or co-authored using generative AI tooling?

Co-authored with OpenAI Codex (GPT-5)
