### PR TITLE
[MINOR][INFRA] Add Cursor Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Apache Spark",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Cloud Agent install script for Apache Spark.
+#
+# Idempotent: prepares the Python tooling PySpark needs, installs PySpark's
+# runtime Python dependencies, and builds the Spark assembly + examples (and
+# every module they depend on) so that bin/spark-shell, bin/pyspark and
+# bin/run-example work out of the box.
+#
+# Heavy, source-derived work belongs here (it runs once to create the
+# environment build snapshot). No long-running service is required, so there
+# is no `start` phase.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Some Spark dev scripts invoke `python`; make sure it resolves to python3.
+if ! command -v python >/dev/null 2>&1; then
+  sudo apt-get update -y
+  sudo apt-get install -y python-is-python3
+fi
+
+# PySpark runtime dependencies. Versions mirror the minimums declared in
+# python/packaging/classic/setup.py. Installed to the user site so they persist
+# in the snapshot without needing a virtualenv on PATH.
+python3 -m pip install --break-system-packages --user \
+  "py4j==0.10.9.9" \
+  "numpy>=1.21" \
+  "pandas>=2.2.0" \
+  "pyarrow>=15.0.0" \
+  "grpcio>=1.67.0" \
+  "grpcio-status>=1.67.0" \
+  "googleapis-common-protos>=1.65.0"
+
+# Build the Spark assembly + examples (and their upstream modules). The
+# build/mvn wrapper downloads the pinned Maven version into build/ automatically.
+# JAVA_HOME is derived from javac by the wrapper; java 21 is on PATH at runtime.
+export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx6g -XX:ReservedCodeCacheSize=256m}"
+./build/mvn -DskipTests -pl assembly,examples -am package


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a Cursor Cloud Agent environment so a Spark checkout can be used without a manual bootstrap:

- `.cursor/environment.json` — environment name, `ubuntu` user, and `install` hook
- `.cursor/install.sh` — idempotent install that:
  - makes `python` resolve to `python3` (`python-is-python3`)
  - pip-installs PySpark runtime deps matching the minimums in `python/packaging/classic/setup.py`
  - builds with the pinned Maven wrapper: `./build/mvn -DskipTests -pl assembly,examples -am package`

`install.sh` includes the standard ASF license header so `dev/check-license` can pass. No `start` phase: Spark is a library/CLI here, not a long-running service.

### Why are the changes needed?
Cursor Cloud Agents need a deterministic, source-derived install. Without these files, each agent or contributor repeats Java / Python / Maven setup by hand, and `bin/spark-shell`, `bin/pyspark`, and `bin/run-example` are not ready after clone.

This does not change Spark's runtime, APIs, or build for users who ignore `.cursor/`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The same install was previously validated on a Cloud Agent VM (Java 21, 4 cores, 15 GB RAM):

| Check | Result |
| --- | --- |
| `bin/run-example SparkPi 10` | `Pi is roughly 3.14446...` |
| Scala `spark-shell` `spark.range(1e9).count()` | `1000000000` |
| PySpark `spark-submit` (range count + aggregation) | `1000000000`, `sum_id=6` |
| Maven `assembly,examples -am` | `BUILD SUCCESS`, 33/33 modules |
| Install idempotence | Passed on a second run |

No unit tests: these files are contributor-environment setup, not Spark runtime code.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor Grok 4.6

cc @HyukjinKwon @dongjoon-hyun @nchammas