### PR TITLE
[SPARK-58850][SQL] Update stale plan node names in AQE test comments

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -148,7 +148,7 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper
           spark.range(0, 20).selectExpr("id", "50 as cnt").collect().toImmutableArraySeq)
 
         // Then, let's look at the number of post-shuffle partitions estimated
-        // by the ExchangeCoordinator.
+        // by the CoalesceShufflePartitions rule.
         val finalPlan = stripAQEPlan(agg.queryExecution.executedPlan)
         val shuffleReads = finalPlan.collect {
           case r @ CoalescedShuffleRead() => r
@@ -193,7 +193,7 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper
           expectedAnswer.collect().toImmutableArraySeq)
 
         // Then, let's look at the number of post-shuffle partitions estimated
-        // by the ExchangeCoordinator.
+        // by the CoalesceShufflePartitions rule.
         val finalPlan = stripAQEPlan(join.queryExecution.executedPlan)
         val shuffleReads = finalPlan.collect {
           case r @ CoalescedShuffleRead() => r
@@ -248,7 +248,7 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper
           expectedAnswer.collect().toImmutableArraySeq)
 
         // Then, let's look at the number of post-shuffle partitions estimated
-        // by the ExchangeCoordinator.
+        // by the CoalesceShufflePartitions rule.
         val finalPlan = stripAQEPlan(join.queryExecution.executedPlan)
         val shuffleReads = finalPlan.collect {
           case r @ CoalescedShuffleRead() => r
@@ -298,7 +298,7 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper
           expectedAnswer.collect().toImmutableArraySeq)
 
         // Then, let's look at the number of post-shuffle partitions estimated
-        // by the ExchangeCoordinator.
+        // by the CoalesceShufflePartitions rule.
         val finalPlan = stripAQEPlan(join.queryExecution.executedPlan)
         val shuffleReads = finalPlan.collect {
           case r @ CoalescedShuffleRead() => r

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -426,19 +426,19 @@ class AdaptiveQueryExecSuite
       // A possible resulting query plan:
       // BroadcastHashJoin
       // +- BroadcastExchange
-      //    +- LocalShuffleReader*
+      //    +- AQEShuffleRead (local)*
       //       +- ShuffleExchange
       //          +- BroadcastHashJoin
       //             +- BroadcastExchange
-      //                +- LocalShuffleReader*
+      //                +- AQEShuffleRead (local)*
       //                   +- ShuffleExchange
-      //             +- LocalShuffleReader*
+      //             +- AQEShuffleRead (local)*
       //                +- ShuffleExchange
       // +- BroadcastHashJoin
-      //    +- LocalShuffleReader*
+      //    +- AQEShuffleRead (local)*
       //       +- ShuffleExchange
       //    +- BroadcastExchange
-      //       +-LocalShuffleReader*
+      //       +-AQEShuffleRead (local)*
       //             +- ShuffleExchange
 
       // After applied the 'OptimizeShuffleWithLocalRead' rule, we can convert all the four
@@ -473,20 +473,20 @@ class AdaptiveQueryExecSuite
       // A possible resulting query plan:
       // BroadcastHashJoin
       // +- BroadcastExchange
-      //    +- LocalShuffleReader*
+      //    +- AQEShuffleRead (local)*
       //       +- ShuffleExchange
       //          +- BroadcastHashJoin
       //             +- BroadcastExchange
-      //                +- LocalShuffleReader*
+      //                +- AQEShuffleRead (local)*
       //                   +- ShuffleExchange
-      //             +- LocalShuffleReader*
+      //             +- AQEShuffleRead (local)*
       //                +- ShuffleExchange
       // +- BroadcastHashJoin
-      //    +- LocalShuffleReader*
+      //    +- AQEShuffleRead (local)*
       //       +- ShuffleExchange
       //    +- BroadcastExchange
       //       +-HashAggregate
-      //          +- CoalescedShuffleReader
+      //          +- AQEShuffleRead (coalesced)
       //             +- ShuffleExchange
 
       // The shuffle added by Aggregate can't apply local read.
@@ -518,21 +518,21 @@ class AdaptiveQueryExecSuite
       // A possible resulting query plan:
       // BroadcastHashJoin
       // +- BroadcastExchange
-      //    +- LocalShuffleReader*
+      //    +- AQEShuffleRead (local)*
       //       +- ShuffleExchange
       //          +- BroadcastHashJoin
       //             +- BroadcastExchange
-      //                +- LocalShuffleReader*
+      //                +- AQEShuffleRead (local)*
       //                   +- ShuffleExchange
-      //             +- LocalShuffleReader*
+      //             +- AQEShuffleRead (local)*
       //                +- ShuffleExchange
       // +- BroadcastHashJoin
       //    +- Filter
       //       +- HashAggregate
-      //          +- CoalescedShuffleReader
+      //          +- AQEShuffleRead (coalesced)
       //             +- ShuffleExchange
       //    +- BroadcastExchange
-      //       +-LocalShuffleReader*
+      //       +-AQEShuffleRead (local)*
       //           +- ShuffleExchange
 
       // The shuffle added by Aggregate can't apply local read.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -426,19 +426,19 @@ class AdaptiveQueryExecSuite
       // A possible resulting query plan:
       // BroadcastHashJoin
       // +- BroadcastExchange
-      //    +- AQEShuffleRead (local)*
+      //    +- AQEShuffleRead local*
       //       +- ShuffleExchange
       //          +- BroadcastHashJoin
       //             +- BroadcastExchange
-      //                +- AQEShuffleRead (local)*
+      //                +- AQEShuffleRead local*
       //                   +- ShuffleExchange
-      //             +- AQEShuffleRead (local)*
+      //             +- AQEShuffleRead local*
       //                +- ShuffleExchange
       // +- BroadcastHashJoin
-      //    +- AQEShuffleRead (local)*
+      //    +- AQEShuffleRead local*
       //       +- ShuffleExchange
       //    +- BroadcastExchange
-      //       +-AQEShuffleRead (local)*
+      //       +-AQEShuffleRead local*
       //             +- ShuffleExchange
 
       // After applied the 'OptimizeShuffleWithLocalRead' rule, we can convert all the four
@@ -473,20 +473,20 @@ class AdaptiveQueryExecSuite
       // A possible resulting query plan:
       // BroadcastHashJoin
       // +- BroadcastExchange
-      //    +- AQEShuffleRead (local)*
+      //    +- AQEShuffleRead local*
       //       +- ShuffleExchange
       //          +- BroadcastHashJoin
       //             +- BroadcastExchange
-      //                +- AQEShuffleRead (local)*
+      //                +- AQEShuffleRead local*
       //                   +- ShuffleExchange
-      //             +- AQEShuffleRead (local)*
+      //             +- AQEShuffleRead local*
       //                +- ShuffleExchange
       // +- BroadcastHashJoin
-      //    +- AQEShuffleRead (local)*
+      //    +- AQEShuffleRead local*
       //       +- ShuffleExchange
       //    +- BroadcastExchange
       //       +-HashAggregate
-      //          +- AQEShuffleRead (coalesced)
+      //          +- AQEShuffleRead coalesced
       //             +- ShuffleExchange
 
       // The shuffle added by Aggregate can't apply local read.
@@ -518,21 +518,21 @@ class AdaptiveQueryExecSuite
       // A possible resulting query plan:
       // BroadcastHashJoin
       // +- BroadcastExchange
-      //    +- AQEShuffleRead (local)*
+      //    +- AQEShuffleRead local*
       //       +- ShuffleExchange
       //          +- BroadcastHashJoin
       //             +- BroadcastExchange
-      //                +- AQEShuffleRead (local)*
+      //                +- AQEShuffleRead local*
       //                   +- ShuffleExchange
-      //             +- AQEShuffleRead (local)*
+      //             +- AQEShuffleRead local*
       //                +- ShuffleExchange
       // +- BroadcastHashJoin
       //    +- Filter
       //       +- HashAggregate
-      //          +- AQEShuffleRead (coalesced)
+      //          +- AQEShuffleRead coalesced
       //             +- ShuffleExchange
       //    +- BroadcastExchange
-      //       +-AQEShuffleRead (local)*
+      //       +-AQEShuffleRead local*
       //           +- ShuffleExchange
 
       // The shuffle added by Aggregate can't apply local read.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates stale class and rule names in the adaptive query execution (AQE) test comments so they match the current planner. The referenced symbols were renamed or removed:

- `LocalShuffleReaderExec` and `CoalescedShuffleReaderExec` were consolidated into `AQEShuffleReadExec`, which renders in query plans as `AQEShuffleRead local` and `AQEShuffleRead coalesced` (see `AQEShuffleReadExec.stringArgs`). The ASCII "possible resulting query plan" comments in `AdaptiveQueryExecSuite` are updated accordingly.
- The pre-AQE `ExchangeCoordinator` was removed; post-shuffle partition coalescing is now performed by the `CoalesceShufflePartitions` rule. The comments in `CoalesceShufflePartitionsSuite` that attribute the post-shuffle partition estimate to the `ExchangeCoordinator` are retargeted to that rule.

This is a comment-only change; no code is modified.

### Why are the changes needed?

The comments reference classes that no longer exist in the codebase. `LocalShuffleReaderExec`, `CoalescedShuffleReaderExec`, and `ExchangeCoordinator` all have zero references under `sql/core/src/main`, so the comments misdescribe the plans these tests exercise and can mislead readers.

### Does this PR introduce _any_ user-facing change?

No. Test-comment-only changes.

### How was this patch tested?

No tests are required; the change touches comments only. The updated names were verified against the current source: `AQEShuffleReadExec.stringArgs` emits `local`/`coalesced`, and `CoalesceShufflePartitions` is the rule that estimates post-shuffle partition counts. Changed lines stay within 100 characters and introduce no non-ASCII characters.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

