### PR TITLE
[SPARK-58851][SS] Add missing scaladoc for streaming progress parameters

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -60,13 +60,14 @@ import org.apache.spark.sql.streaming.SinkProgress.DEFAULT_NUM_OUTPUT_ROWS
  * @param memoryUsedBytes
  *   Memory used, in bytes, by the operator's state store.
  * @param numRowsDroppedByWatermark
- *   Number of input rows dropped because they were later than the watermark.
+ *   Number of input rows dropped because their event time was older than the watermark.
  * @param numShufflePartitions
  *   Number of shuffle partitions the operator ran with.
  * @param numStateStoreInstances
  *   Number of state store instances backing the operator.
  * @param customMetrics
- *   State store implementation specific metrics, keyed by metric name.
+ *   Custom metrics specific to the stateful operator or state store implementation, keyed by
+ *   metric name.
  */
 @Evolving
 class StateOperatorProgress private[spark] (

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -42,6 +42,31 @@ import org.apache.spark.sql.streaming.SinkProgress.DEFAULT_NUM_OUTPUT_ROWS
 
 /**
  * Information about updates made to stateful operators in a [[StreamingQuery]] during a trigger.
+ *
+ * @param operatorName
+ *   Name of the stateful operator this progress describes.
+ * @param numRowsTotal
+ *   Number of state rows held by the operator after this trigger.
+ * @param numRowsUpdated
+ *   Number of state rows updated during this trigger.
+ * @param allUpdatesTimeMs
+ *   Time taken, in milliseconds, to apply all state updates in this trigger.
+ * @param numRowsRemoved
+ *   Number of state rows removed during this trigger.
+ * @param allRemovalsTimeMs
+ *   Time taken, in milliseconds, to remove all evicted state rows in this trigger.
+ * @param commitTimeMs
+ *   Time taken, in milliseconds, to commit the state changes of this trigger.
+ * @param memoryUsedBytes
+ *   Memory used, in bytes, by the operator's state store.
+ * @param numRowsDroppedByWatermark
+ *   Number of input rows dropped because they were later than the watermark.
+ * @param numShufflePartitions
+ *   Number of shuffle partitions the operator ran with.
+ * @param numStateStoreInstances
+ *   Number of state store instances backing the operator.
+ * @param customMetrics
+ *   State store implementation specific metrics, keyed by metric name.
  */
 @Evolving
 class StateOperatorProgress private[spark] (
@@ -172,6 +197,8 @@ class StateOperatorProgress private[spark] (
  *   Information about operators in the query that store state.
  * @param sources
  *   detailed statistics on data being read from each of the streaming sources.
+ * @param sink
+ *   detailed statistics on data being written to the sink.
  * @since 2.1.0
  */
 @Evolving
@@ -354,6 +381,8 @@ class SourceProgress protected[spark] (
  * @param numOutputRows
  *   Number of rows written to the sink or -1 for Continuous Mode (temporarily) or Sink V1 (until
  *   decommissioned).
+ * @param metrics
+ *   Sink-specific metrics reported for this trigger, keyed by metric name.
  * @since 2.1.0
  */
 @Evolving


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds missing scaladoc `@param` documentation to the public Structured Streaming progress classes in `sql/api` (`org/apache/spark/sql/streaming/progress.scala`):

- `StreamingQueryProgress`: adds `@param sink`.
- `SinkProgress`: adds `@param metrics`.
- `StateOperatorProgress`: adds `@param` tags for all of its constructor parameters (`operatorName`, `numRowsTotal`, `numRowsUpdated`, `allUpdatesTimeMs`, `numRowsRemoved`, `allRemovalsTimeMs`, `commitTimeMs`, `memoryUsedBytes`, `numRowsDroppedByWatermark`, `numShufflePartitions`, `numStateStoreInstances`, `customMetrics`).

This is a documentation-only change; no code is modified.

### Why are the changes needed?

These are public, `@Evolving` API classes surfaced through the streaming query listener and `StreamingQueryProgress`. Their scaladoc omitted several `@param` entries, so the generated API docs were incomplete for fields users read when consuming progress events.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change.

### How was this patch tested?

No tests are required; the change adds scaladoc only. Each added `@param` name was verified to match a constructor parameter of its class, and each description was checked against how the field is populated (`ProgressReporter`, `statefulOperators`). Changed lines stay within 100 characters and introduce no non-ASCII characters.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
