### PR TITLE
[SPARK-58852][INFRA] Replace archived test report action

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -41,20 +41,11 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         run-id: ${{ github.event.workflow_run.id }}
         pattern: "test-*"
-    - name: Check if test results exist
-      id: check
-      run: |
-        if find . -path '*/target/test-reports/*.xml' -print -quit | grep -q .; then
-          echo "has_results=true" >> $GITHUB_OUTPUT
-        else
-          echo "No test result files found. Skipping report."
-          echo "has_results=false" >> $GITHUB_OUTPUT
-        fi
     - name: Publish test report
-      if: steps.check.outputs.has_results == 'true'
-      uses: scacap/action-surefire-report@5609ce4db72c09db044803b344a8968fd1f315da
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
       with:
         check_name: Report test results
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        report_paths: "**/target/test-reports/*.xml"
-        commit: ${{ github.event.workflow_run.head_commit.id }}
+        reporter: java-junit
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: "**/target/test-reports/*.xml"
+        fail-on-empty: false

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -42,17 +42,13 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
         pattern: "test-*"
     - name: Publish test report
-      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
+      uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
       with:
-        name: Report test results
-        reporter: java-junit
-        token: ${{ secrets.GITHUB_TOKEN }}
-        path: "**/target/test-reports/*.xml"
-        list-suites: failed
-        list-tests: failed
-        list-files: failed
-        # annotations need to be disabled so the action does not rely on the
-        # repo being existed, otherwise we need to checkout the repo
-        max-annotations: 0
-        use-actions-summary: false
-        fail-on-empty: false
+        check_name: Report test results
+        files: "**/target/test-reports/*.xml"
+        comment_mode: off
+        large_files: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        compare_to_earlier_commit: false
+        test_changes_limit: 0
+        check_run_annotations: none

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -48,5 +48,8 @@ jobs:
         reporter: java-junit
         token: ${{ secrets.GITHUB_TOKEN }}
         path: "**/target/test-reports/*.xml"
+        # annotations need to be disabled so the action does not rely on the
+        # repo being existed, otherwise we need to checkout the repo
+        max-annotations: 0
         use-actions-summary: false
         fail-on-empty: false

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -44,8 +44,9 @@ jobs:
     - name: Publish test report
       uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
       with:
-        check_name: Report test results
+        name: Report test results
         reporter: java-junit
         token: ${{ secrets.GITHUB_TOKEN }}
         path: "**/target/test-reports/*.xml"
+        use-actions-summary: false
         fail-on-empty: false

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -48,6 +48,9 @@ jobs:
         reporter: java-junit
         token: ${{ secrets.GITHUB_TOKEN }}
         path: "**/target/test-reports/*.xml"
+        list-suites: failed
+        list-tests: failed
+        list-files: failed
         # annotations need to be disabled so the action does not rely on the
         # repo being existed, otherwise we need to checkout the repo
         max-annotations: 0

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -48,6 +48,7 @@ jobs:
         files: "**/target/test-reports/*.xml"
         comment_mode: off
         large_files: true
+        commit: ${{ github.event.workflow_run.head_commit.id }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
         compare_to_earlier_commit: false
         test_changes_limit: 0

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -71,6 +71,8 @@ class BaseUDFTestsMixin:
         pudf = UserDefinedFunction(call, LongType())
         res = data.select(pudf(data["number"]).alias("plus_four"))
         self.assertEqual(res.agg({"plus_four": "sum"}).collect()[0][0], 85)
+        # TODO:REMOVE THIS!
+        self.assertEqual(1, 2)
 
     def test_udf_with_partial_function(self):
         data = self.spark.createDataFrame([(i, i**2) for i in range(10)], ["number", "squared"])

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -71,8 +71,6 @@ class BaseUDFTestsMixin:
         pudf = UserDefinedFunction(call, LongType())
         res = data.select(pudf(data["number"]).alias("plus_four"))
         self.assertEqual(res.agg({"plus_four": "sum"}).collect()[0][0], 85)
-        # TODO:REMOVE THIS!
-        self.assertEqual(1, 2)
 
     def test_udf_with_partial_function(self):
         data = self.spark.createDataFrame([(i, i**2) for i in range(10)], ["number", "squared"])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Replace `scacap/action-surefire-report` with `EnricoMi/publish-unit-test-result-action` for test reporting.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`scacap/action-surefire-report` is [archived](https://github.com/ScaCap/action-surefire-report) and removed from apache's allowlist. It has a [descendent](https://github.com/ScaCap/action-surefire-report) but none of them are used as much as `EnricoMi/publish-unit-test-result-action` , which is already listed on apache's allowlist. We should use the popular projects which is better maintained and tested. Also it saves us trouble to create a new entry for the allowed action. 

We considered `dorny/test-reporter` but we realized that the latest released version (v3.0.0) does not have the `list-files` options, which means it will always list **all** the files in the test suite and it will always overflow the buffer github allows.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, CI only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI should show this report. `test report` action on `apache/spark` has been failing for a while.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.