### PR TITLE
[SPARK-58387][SQL] Do not pre-aggregate under an Expand when a duplicate-sensitive aggregate is present

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeExpand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeExpand.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.AGGREGATE
@@ -42,7 +43,9 @@ import org.apache.spark.sql.internal.SQLConf
  *  - Expand projection count >= configured threshold
  *  - No non-distinct aggregates or FILTER clauses on distinct
  *    aggregates (checked via `expand.producedAttributes` being
- *    a subset of the inner aggregate's GROUP BY)
+ *    a subset of the inner aggregate's GROUP BY, plus a direct
+ *    check for duplicate-sensitive aggregates such as `count(1)`
+ *    that reference no attribute)
  *  - The pre-aggregate's group-by column count does not exceed
  *    the inner aggregate's (minus gid), which rejects composite
  *    distinct expressions (e.g. `col1 + col2`) that introduce
@@ -86,7 +89,10 @@ object OptimizeExpand extends Rule[LogicalPlan] {
    *  1. The Expand is produced by [[RewriteDistinctAggregates]]
    *     (gid present in inner GROUP BY).
    *  2. All Expand-produced attributes are consumed by the inner
-   *     GROUP BY (rejects non-distinct aggs and FILTER clauses).
+   *     GROUP BY (rejects non-distinct aggs and FILTER clauses),
+   *     and the inner aggregate holds no duplicate-sensitive
+   *     aggregate (rejects `count(1)`, which the check above
+   *     cannot see because it references no attribute).
    *  3. The pre-aggregate's group-by column count does not exceed
    *     the inner aggregate's (minus gid). Composite distinct
    *     expressions like `col1 + col2` fan out into more leaf
@@ -106,6 +112,18 @@ object OptimizeExpand extends Rule[LogicalPlan] {
     val innerGroupByAttrs = AttributeSet(
       innerAgg.groupingExpressions.flatMap(_.references))
     if (!expand.producedAttributes.subsetOf(innerGroupByAttrs)) return false
+
+    // Check 2b: an aggregate that references no attribute, such as count(1)
+    // from COUNT(1) or COUNT(*), gets no dedicated Expand output column and so
+    // passes the check above. Pre-aggregating would make it count the distinct
+    // rows rather than the base rows, so reject any duplicate-sensitive
+    // aggregate directly.
+    val hasDuplicateSensitiveAgg = innerAgg.aggregateExpressions.exists(_.exists {
+      case ae: AggregateExpression =>
+        !ae.isDistinct && !EliminateDistinct.isDuplicateAgnostic(ae.aggregateFunction)
+      case _ => false
+    })
+    if (hasDuplicateSensitiveAgg) return false
 
     // Check 3: composite expressions like col1 + col2 fan out into
     // more leaf attributes than inner group-by slots, making the

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeExpandSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeExpandSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
@@ -159,6 +159,23 @@ class OptimizeExpandSuite extends PlanTest {
         "Pre-aggregate should include distinct col1")
       assert(groupByNames.contains("col2"),
         "Pre-aggregate should include distinct col2")
+    }
+  }
+
+  test("SPARK-58387: skips when a non-distinct count(1) is present") {
+    // count(1) references no attribute, so it does not force an Expand output
+    // column outside the inner GROUP BY, but it is duplicate sensitive: the
+    // pre-aggregate would make it count distinct rows instead of base rows.
+    withSQLConf(SQLConf.OPTIMIZE_EXPAND_RATIO.key -> "2") {
+      val query = testRelation
+        .groupBy($"key")(
+          countDistinct($"col1").as("cd1"),
+          countDistinct($"col2").as("cd2"),
+          count(Literal(1)).as("cnt"))
+        .analyze
+      val optimized = Optimize.execute(query)
+      assert(!hasPreAggBeforeExpand(optimized),
+        "Should skip when a non-distinct count(1) is present")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/OptimizeExpandQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/OptimizeExpandQuerySuite.scala
@@ -177,6 +177,33 @@ class OptimizeExpandQuerySuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-58387: correctness: count distinct with a non-distinct count(1)") {
+    withTempView("t") {
+      spark.sql(
+        """SELECT * FROM VALUES
+          |  (1, 5, 7), (1, 5, 7), (1, 5, 7), (1, 6, 8), (2, 9, 9)
+          |AS t(k, a, b)""".stripMargin)
+        .createOrReplaceTempView("t")
+
+      val sqlText =
+        """SELECT k, count(distinct a), count(distinct b), count(1)
+          |FROM t GROUP BY k""".stripMargin
+
+      withSQLConf(SQLConf.OPTIMIZE_EXPAND_RATIO.key -> "2") {
+        checkAnswer(spark.sql(sqlText), Seq(Row(1, 2, 2, 4), Row(2, 1, 1, 1)))
+      }
+    }
+  }
+
+  test("SPARK-58387: correctness: count distinct with a non-distinct count(*)") {
+    checkOptimizationCorrectness(
+      """SELECT key,
+        |  count(distinct col1),
+        |  count(distinct col2),
+        |  count(*)
+        |FROM t GROUP BY key""".stripMargin)
+  }
+
   test("skips optimization for expression-based distinct (col1 + col2)") {
     withTempView("t") {
       spark.range(10000)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`OptimizeExpand` (added by SPARK-56315, gated by the internal conf `spark.sql.optimizer.optimizeExpandRatio`, default `-1` = disabled) inserts a de-duplicating `Aggregate` beneath the `Expand` produced by `RewriteDistinctAggregates`. That de-duplication is sound only for pure distinct aggregates, and [the conf's own doc](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala) states the precondition: *"Only applies to pure distinct aggregates without non-distinct aggregates or FILTER clauses."*

The guard implementing that precondition tested *attributes* rather than *aggregate functions*:

```scala
val innerGroupByAttrs = AttributeSet(innerAgg.groupingExpressions.flatMap(_.references))
if (!expand.producedAttributes.subsetOf(innerGroupByAttrs)) return false
```

The reasoning is that a non-distinct aggregate forces an `Expand` output column outside the inner `GROUP BY`. That only holds for aggregates to which `RewriteDistinctAggregates` assigns a dedicated `Expand` slot. An aggregate that reaches the inner `Aggregate` as `count(1)` — from `COUNT(1)` or `COUNT(*)` — references no attribute at all, so it always passes the guard.

This PR rejects duplicate-sensitive aggregates directly, by checking the inner aggregate's aggregate expressions with `EliminateDistinct.isDuplicateAgnostic` — the same soundness check `RemoveRedundantAggregates` uses for the same question:

```scala
val hasDuplicateSensitiveAgg = innerAgg.aggregateExpressions.exists(_.exists {
  case ae: AggregateExpression =>
    !ae.isDistinct && !EliminateDistinct.isDuplicateAgnostic(ae.aggregateFunction)
  case _ => false
})
if (hasDuplicateSensitiveAgg) return false
```

### Why are the changes needed?

It is a correctness bug: the query returns the count of distinct rows where it must return the count of base rows.

```sql
CREATE TABLE oe USING parquet AS SELECT * FROM VALUES (1,5,7),(1,5,7),(1,5,7),(1,6,8),(2,9,9) AS t(k,a,b);

SET spark.sql.optimizer.optimizeExpandRatio=2;

SELECT k, COUNT(DISTINCT a), COUNT(DISTINCT b), COUNT(1) FROM oe GROUP BY k ORDER BY k;
-- before: [1,2,2,2], [2,1,1,1]   WRONG
-- after:  [1,2,2,4], [2,1,1,1]   k=1 has four rows
```

`COUNT(*)` behaves identically. The optimized plan before the fix shows the inserted pre-aggregate feeding the `Expand` whose downstream `count(1)` was supposed to count base rows:

```
Aggregate [k], [k, count(a) FILTER (gid=1), count(b) FILTER (gid=2),
                coalesce(first(count(1)) FILTER (gid=0), 0)]
+- Aggregate [k, a, b, gid], [k, a, b, gid, count(1)]
   +- Expand [[k,null,null,0], [k,a,null,1], [k,null,b,2]], [k, a, b, gid]
      +- Aggregate [k, a, b], [k, a, b]          <- inserted by OptimizeExpand
         +- Relation oe[k,a,b] parquet
```

Note on the JIRA: it also lists `COUNT(a)` on a non-nullable column as affected, on the grounds that the rewrite normalizes it to `count(1)`. That does not reproduce on master — no such normalization happens, `RewriteDistinctAggregates` gives it its own `Expand` slot, and the existing attribute check already rejects it. A test for that case was written and passed before the fix, so it was dropped rather than added as a non-regression test.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes wrong results for the queries above. Only when `spark.sql.optimizer.optimizeExpandRatio` is explicitly set, since the rule is disabled by default.

### How was this patch tested?

New tests, verified failing before the fix and passing after:

- `OptimizeExpandSuite` — "SPARK-58387: skips when a non-distinct count(1) is present": asserts no pre-aggregate is inserted.
- `OptimizeExpandQuerySuite` — "SPARK-58387: correctness: count distinct with a non-distinct count(1)": the JIRA repro, checked against the expected answer.
- `OptimizeExpandQuerySuite` — "SPARK-58387: correctness: count distinct with a non-distinct count(*)": checked against the rule-disabled result.

Full suites pass: `OptimizeExpandSuite` (9 tests) and `OptimizeExpandQuerySuite` (10 tests).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
