### PR TITLE
[SPARK-58859][PYSPARK][TESTS] Add BarrierTaskContext negative tests for SQL map APIs

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -191,12 +191,10 @@ class MapInArrowTestsMixin:
             tc = TaskContext.get()
             assert tc is not None
             assert not isinstance(tc, BarrierTaskContext)
-            BarrierTaskContext.get()
             for batch in iterator:
                 yield batch
 
-        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInArrow(func1, "id long", False).collect()
+        df.mapInArrow(func1, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext
@@ -208,6 +206,19 @@ class MapInArrowTestsMixin:
                 yield batch
 
         df.mapInArrow(func2, "id long", True).collect()
+
+    def test_barrier_task_context_get_without_barrier_mode(self):
+        df = self.spark.range(10)
+
+        def func(iterator):
+            from pyspark import BarrierTaskContext
+
+            BarrierTaskContext.get()
+            for batch in iterator:
+                yield batch
+
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInArrow(func, "id long", False).collect()
 
     def test_negative_and_zero_batch_size(self):
         for batch_size in [0, -1]:

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -196,7 +196,7 @@ class MapInArrowTestsMixin:
 
         df.mapInArrow(func1, "id long", False).collect()
 
-        def func1_barrier_context_get(iterator):
+        def func0(iterator):
             from pyspark import BarrierTaskContext
 
             BarrierTaskContext.get()
@@ -204,7 +204,7 @@ class MapInArrowTestsMixin:
                 yield batch
 
         with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInArrow(func1_barrier_context_get, "id long", False).collect()
+            df.mapInArrow(func0, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -191,6 +191,12 @@ class MapInArrowTestsMixin:
             tc = TaskContext.get()
             assert tc is not None
             assert not isinstance(tc, BarrierTaskContext)
+            try:
+                BarrierTaskContext.get()
+            except Exception:
+                pass
+            else:
+                raise AssertionError("BarrierTaskContext.get() should fail outside barrier mode")
             for batch in iterator:
                 yield batch
 

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -196,6 +196,16 @@ class MapInArrowTestsMixin:
 
         df.mapInArrow(func1, "id long", False).collect()
 
+        def func1_barrier_context_get(iterator):
+            from pyspark import BarrierTaskContext
+
+            BarrierTaskContext.get()
+            for batch in iterator:
+                yield batch
+
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInArrow(func1_barrier_context_get, "id long", False).collect()
+
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext
 
@@ -206,19 +216,6 @@ class MapInArrowTestsMixin:
                 yield batch
 
         df.mapInArrow(func2, "id long", True).collect()
-
-    def test_barrier_task_context_get_without_barrier_mode(self):
-        df = self.spark.range(10)
-
-        def func(iterator):
-            from pyspark import BarrierTaskContext
-
-            BarrierTaskContext.get()
-            for batch in iterator:
-                yield batch
-
-        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInArrow(func, "id long", False).collect()
 
     def test_negative_and_zero_batch_size(self):
         for batch_size in [0, -1]:

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -191,16 +191,12 @@ class MapInArrowTestsMixin:
             tc = TaskContext.get()
             assert tc is not None
             assert not isinstance(tc, BarrierTaskContext)
-            try:
-                BarrierTaskContext.get()
-            except Exception:
-                pass
-            else:
-                raise AssertionError("BarrierTaskContext.get() should fail outside barrier mode")
+            BarrierTaskContext.get()
             for batch in iterator:
                 yield batch
 
-        df.mapInArrow(func1, "id long", False).collect()
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInArrow(func1, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -185,6 +185,16 @@ class MapInArrowTestsMixin:
     def test_map_in_arrow_with_barrier_mode(self):
         df = self.spark.range(10)
 
+        def func0(iterator):
+            from pyspark import BarrierTaskContext
+
+            BarrierTaskContext.get()
+            for batch in iterator:
+                yield batch
+
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInArrow(func0, "id long", False).collect()
+
         def func1(iterator):
             from pyspark import TaskContext, BarrierTaskContext
 
@@ -195,16 +205,6 @@ class MapInArrowTestsMixin:
                 yield batch
 
         df.mapInArrow(func1, "id long", False).collect()
-
-        def func0(iterator):
-            from pyspark import BarrierTaskContext
-
-            BarrierTaskContext.get()
-            for batch in iterator:
-                yield batch
-
-        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInArrow(func0, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -459,6 +459,16 @@ class MapInPandasTestsMixin:
     def test_map_in_pandas_with_barrier_mode(self):
         df = self.spark.range(10)
 
+        def func0(iterator):
+            from pyspark import BarrierTaskContext
+
+            BarrierTaskContext.get()
+            for batch in iterator:
+                yield batch
+
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInPandas(func0, "id long", False).collect()
+
         def func1(iterator):
             from pyspark import TaskContext, BarrierTaskContext
 
@@ -469,16 +479,6 @@ class MapInPandasTestsMixin:
                 yield batch
 
         df.mapInPandas(func1, "id long", False).collect()
-
-        def func0(iterator):
-            from pyspark import BarrierTaskContext
-
-            BarrierTaskContext.get()
-            for batch in iterator:
-                yield batch
-
-        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInPandas(func0, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -465,12 +465,10 @@ class MapInPandasTestsMixin:
             tc = TaskContext.get()
             assert tc is not None
             assert not isinstance(tc, BarrierTaskContext)
-            BarrierTaskContext.get()
             for batch in iterator:
                 yield batch
 
-        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInPandas(func1, "id long", False).collect()
+        df.mapInPandas(func1, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext
@@ -482,6 +480,19 @@ class MapInPandasTestsMixin:
                 yield batch
 
         df.mapInPandas(func2, "id long", True).collect()
+
+    def test_barrier_task_context_get_without_barrier_mode(self):
+        df = self.spark.range(10)
+
+        def func(iterator):
+            from pyspark import BarrierTaskContext
+
+            BarrierTaskContext.get()
+            for batch in iterator:
+                yield batch
+
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInPandas(func, "id long", False).collect()
 
     def test_map_in_pandas_type_mismatch(self):
         def func(iterator):

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -465,6 +465,12 @@ class MapInPandasTestsMixin:
             tc = TaskContext.get()
             assert tc is not None
             assert not isinstance(tc, BarrierTaskContext)
+            try:
+                BarrierTaskContext.get()
+            except Exception:
+                pass
+            else:
+                raise AssertionError("BarrierTaskContext.get() should fail outside barrier mode")
             for batch in iterator:
                 yield batch
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -465,16 +465,12 @@ class MapInPandasTestsMixin:
             tc = TaskContext.get()
             assert tc is not None
             assert not isinstance(tc, BarrierTaskContext)
-            try:
-                BarrierTaskContext.get()
-            except Exception:
-                pass
-            else:
-                raise AssertionError("BarrierTaskContext.get() should fail outside barrier mode")
+            BarrierTaskContext.get()
             for batch in iterator:
                 yield batch
 
-        df.mapInPandas(func1, "id long", False).collect()
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInPandas(func1, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -470,7 +470,7 @@ class MapInPandasTestsMixin:
 
         df.mapInPandas(func1, "id long", False).collect()
 
-        def func1_barrier_context_get(iterator):
+        def func0(iterator):
             from pyspark import BarrierTaskContext
 
             BarrierTaskContext.get()
@@ -478,7 +478,7 @@ class MapInPandasTestsMixin:
                 yield batch
 
         with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInPandas(func1_barrier_context_get, "id long", False).collect()
+            df.mapInPandas(func0, "id long", False).collect()
 
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -470,6 +470,16 @@ class MapInPandasTestsMixin:
 
         df.mapInPandas(func1, "id long", False).collect()
 
+        def func1_barrier_context_get(iterator):
+            from pyspark import BarrierTaskContext
+
+            BarrierTaskContext.get()
+            for batch in iterator:
+                yield batch
+
+        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
+            df.mapInPandas(func1_barrier_context_get, "id long", False).collect()
+
         def func2(iterator):
             from pyspark import TaskContext, BarrierTaskContext
 
@@ -480,19 +490,6 @@ class MapInPandasTestsMixin:
                 yield batch
 
         df.mapInPandas(func2, "id long", True).collect()
-
-    def test_barrier_task_context_get_without_barrier_mode(self):
-        df = self.spark.range(10)
-
-        def func(iterator):
-            from pyspark import BarrierTaskContext
-
-            BarrierTaskContext.get()
-            for batch in iterator:
-                yield batch
-
-        with self.assertRaisesRegex(PythonException, "\\[NOT_IN_BARRIER_STAGE\\]"):
-            df.mapInPandas(func, "id long", False).collect()
 
     def test_map_in_pandas_type_mismatch(self):
         def func(iterator):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR strengthens the existing `mapInPandas` and `mapInArrow` barrier-mode tests.

For the non-barrier case, the tests now call `BarrierTaskContext.get()` directly and assert
that it fails. The existing checks continue to verify that `TaskContext.get()` is present and
is not a `BarrierTaskContext` outside barrier mode.

### Why are the changes needed?

`BarrierTaskContext` should only be available in barrier execution. The existing SQL map API
tests checked the `TaskContext.get()` type in both modes, but they did not directly verify that
`BarrierTaskContext.get()` fails when `barrier=False`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added negative coverage to existing PySpark SQL tests:

- `MapInPandasTestsMixin.test_map_in_pandas_with_barrier_mode`
- `MapInArrowTestsMixin.test_map_in_arrow_with_barrier_mode`

Local checks:

- `git diff --check`
- ASCII and line-length scans on changed files

Focused PySpark suites were not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
