### PR TITLE
[SPARK-58815][SQL] Handle name conflicts in row-level operations

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, EqualNullSafe, Expression, Literal, Not}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, EqualNullSafe, Expression, Literal, Not}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, Filter, LogicalPlan, Project, ReplaceData, WriteDelta}
 import org.apache.spark.sql.catalyst.trees.TreePattern.DELETE_FROM_TABLE
@@ -88,7 +88,8 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
     val query = addOperationColumn(COPY_OPERATION, remainingRowsPlan)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val projections = buildReplaceDataProjections(
+      query, relation.output, metadataAttrs, readRelation.output)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
@@ -110,12 +111,16 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
     // construct a plan that only contains records to delete
     val deletedRowsPlan = Filter(cond, readRelation)
     val operationType = Alias(Literal(DELETE_OPERATION), OPERATION_COLUMN)()
-    val requiredWriteAttrs = nullifyMetadataOnDelete(dedupAttrs(rowIdAttrs ++ metadataAttrs))
+    val sourceAttrs = dedupAttrs(rowIdAttrs ++ metadataAttrs)
+    val originalRowIdValues = buildOriginalRowIdValues(rowIdAttrs, Nil, metadataAttrs)
+    val requiredWriteAttrs = nullifyMetadataOnDelete(sourceAttrs) ++ originalRowIdValues
     val project = Project(operationType +: requiredWriteAttrs, deletedRowsPlan)
 
     // build a plan to write deletes to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(project, Nil, rowIdAttrs, metadataAttrs)
+    val originalRowIdAttrs = originalRowIdValues.map(_.child.asInstanceOf[Attribute])
+    val projections = buildWriteDeltaProjections(
+      project, Nil, rowIdAttrs, metadataAttrs, sourceAttrs, originalRowIdAttrs)
     WriteDelta(writeRelation, cond, project, relation, projections)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -43,6 +43,12 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
   private final val ROW_FROM_SOURCE = "__row_from_source"
   private final val ROW_FROM_TARGET = "__row_from_target"
 
+  private case class MergeJoin(
+      plan: LogicalPlan,
+      rowFromSource: Attribute,
+      rowFromTarget: Attribute,
+      cardinalityRowId: Option[Attribute])
+
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
     _.containsPattern(MERGE_INTO_TABLE)) {
     // aligned is false when schema evolution is pending (see ResolveRowLevelCommandAssignments)
@@ -113,7 +119,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
             matchedInstructions = Nil,
             notMatchedInstructions = notMatchedInstructions,
             notMatchedBySourceInstructions = Nil,
-            checkCardinality = false,
+            cardinalityRowId = None,
             output = generateExpandOutput(r.output, outputs),
             joinPlan)
 
@@ -168,11 +174,11 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     // use left outer join if there is no NOT MATCHED action, unmatched source rows can be discarded
     // use full outer join in all other cases, unmatched source rows may be needed
     val joinType = if (notMatchedActions.isEmpty) LeftOuter else FullOuter
-    val joinPlan = join(readRelation, source, joinType, cond, checkCardinality)
+    val mergeJoin = join(readRelation, source, joinType, cond, checkCardinality)
 
     val mergeRowsPlan = buildReplaceDataMergeRowsPlan(
-      readRelation, joinPlan, matchedActions, notMatchedActions,
-      notMatchedBySourceActions, metadataAttrs, checkCardinality)
+      readRelation, mergeJoin, matchedActions, notMatchedActions,
+      notMatchedBySourceActions, metadataAttrs)
 
     // predicates of the ON condition can be used to filter the target table (planning & runtime)
     // only if there is no NOT MATCHED BY SOURCE clause
@@ -188,18 +194,18 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(mergeRowsPlan, relation.output, metadataAttrs)
+    val projections = buildReplaceDataProjections(
+      mergeRowsPlan, relation.output, metadataAttrs, readRelation.output)
     ReplaceData(writeRelation, pushableCond, mergeRowsPlan, relation, projections, groupFilterCond)
   }
 
   private def buildReplaceDataMergeRowsPlan(
       targetTable: LogicalPlan,
-      joinPlan: LogicalPlan,
+      mergeJoin: MergeJoin,
       matchedActions: Seq[MergeAction],
       notMatchedActions: Seq[MergeAction],
       notMatchedBySourceActions: Seq[MergeAction],
-      metadataAttrs: Seq[Attribute],
-      checkCardinality: Boolean): MergeRows = {
+      metadataAttrs: Seq[Attribute]): MergeRows = {
 
     // target records that were read but did not match any MATCHED or NOT MATCHED BY SOURCE actions
     // must be copied over and included in the new state of the table as groups are being replaced
@@ -221,9 +227,6 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       toInstruction(action, metadataAttrs)
     } :+ keepCarryoverRowsInstruction
 
-    val rowFromSourceAttr = resolveAttrRef(ROW_FROM_SOURCE, joinPlan)
-    val rowFromTargetAttr = resolveAttrRef(ROW_FROM_TARGET, joinPlan)
-
     val outputs = matchedInstructions.flatMap(_.outputs) ++
       notMatchedInstructions.flatMap(_.outputs) ++
       notMatchedBySourceInstructions.flatMap(_.outputs)
@@ -232,14 +235,14 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val attrs = operationTypeAttr +: targetTable.output
 
     MergeRows(
-      isSourceRowPresent = IsNotNull(rowFromSourceAttr),
-      isTargetRowPresent = IsNotNull(rowFromTargetAttr),
+      isSourceRowPresent = IsNotNull(mergeJoin.rowFromSource),
+      isTargetRowPresent = IsNotNull(mergeJoin.rowFromTarget),
       matchedInstructions = matchedInstructions,
       notMatchedInstructions = notMatchedInstructions,
       notMatchedBySourceInstructions = notMatchedBySourceInstructions,
-      checkCardinality = checkCardinality,
+      cardinalityRowId = mergeJoin.cardinalityRowId,
       output = generateExpandOutput(attrs, outputs),
-      joinPlan)
+      mergeJoin.plan)
   }
 
   // converts a MERGE condition into an EXISTS subquery for runtime filtering
@@ -289,16 +292,34 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val checkCardinality = shouldCheckCardinality(matchedActions)
 
     val joinType = chooseWriteDeltaJoinType(notMatchedActions, notMatchedBySourceActions)
-    val joinPlan = join(filteredReadRelation, source, joinType, joinCond, checkCardinality)
+    val mergeJoin = join(filteredReadRelation, source, joinType, joinCond, checkCardinality)
+
+    val updateAssignments = if (operation.representUpdateAsDeleteAndInsert) {
+      Seq.empty
+    } else {
+      (matchedActions ++ notMatchedBySourceActions).flatMap {
+        case UpdateAction(_, assignments, _) => assignments
+        case _ => Nil
+      }
+    }
+    val originalRowIdValues =
+      buildOriginalRowIdValues(rowIdAttrs, updateAssignments, metadataAttrs)
 
     val mergeRowsPlan = buildWriteDeltaMergeRowsPlan(
-      readRelation, joinPlan, matchedActions, notMatchedActions,
-      notMatchedBySourceActions, rowIdAttrs, checkCardinality,
+      readRelation, mergeJoin, matchedActions, notMatchedActions,
+      notMatchedBySourceActions, rowIdAttrs, originalRowIdValues,
       operation.representUpdateAsDeleteAndInsert)
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(mergeRowsPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+    val originalRowIdAttrs = originalRowIdValues.map(_.child.asInstanceOf[Attribute])
+    val projections = buildWriteDeltaProjections(
+      mergeRowsPlan,
+      rowAttrs,
+      rowIdAttrs,
+      metadataAttrs,
+      readRelation.output,
+      originalRowIdAttrs)
     val groupFilterCond = if (notMatchedBySourceActions.isEmpty && groupFilterEnabled) {
       Some(toGroupFilterCondition(relation, source, cond))
     } else {
@@ -327,28 +348,16 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
   private def buildWriteDeltaMergeRowsPlan(
       targetTable: DataSourceV2Relation,
-      joinPlan: LogicalPlan,
+      mergeJoin: MergeJoin,
       matchedActions: Seq[MergeAction],
       notMatchedActions: Seq[MergeAction],
       notMatchedBySourceActions: Seq[MergeAction],
       rowIdAttrs: Seq[Attribute],
-      checkCardinality: Boolean,
+      originalRowIdValues: Seq[Alias],
       splitUpdates: Boolean): MergeRows = {
 
     val (metadataAttrs, rowAttrs) = targetTable.output.partition { attr =>
       MetadataAttribute.isValid(attr.metadata)
-    }
-
-    val originalRowIdValues = if (splitUpdates) {
-      Seq.empty
-    } else {
-      // original row ID values must be preserved and passed back to the table to encode updates
-      // if there are any assignments to row ID attributes, add extra columns for original values
-      val updateAssignments = (matchedActions ++ notMatchedBySourceActions).flatMap {
-        case UpdateAction(_, assignments, _) => assignments
-        case _ => Nil
-      }
-      buildOriginalRowIdValues(rowIdAttrs, updateAssignments)
     }
 
     val matchedInstructions = matchedActions.map { action =>
@@ -363,9 +372,6 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       toInstruction(action, rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues, splitUpdates)
     }
 
-    val rowFromSourceAttr = resolveAttrRef(ROW_FROM_SOURCE, joinPlan)
-    val rowFromTargetAttr = resolveAttrRef(ROW_FROM_TARGET, joinPlan)
-
     val outputs = matchedInstructions.flatMap(_.outputs) ++
       notMatchedInstructions.flatMap(_.outputs) ++
       notMatchedBySourceInstructions.flatMap(_.outputs)
@@ -375,14 +381,14 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     val attrs = Seq(operationTypeAttr) ++ targetTable.output ++ originalRowIdAttrs
 
     MergeRows(
-      isSourceRowPresent = IsNotNull(rowFromSourceAttr),
-      isTargetRowPresent = IsNotNull(rowFromTargetAttr),
+      isSourceRowPresent = IsNotNull(mergeJoin.rowFromSource),
+      isTargetRowPresent = IsNotNull(mergeJoin.rowFromTarget),
       matchedInstructions = matchedInstructions,
       notMatchedInstructions = notMatchedInstructions,
       notMatchedBySourceInstructions = notMatchedBySourceInstructions,
-      checkCardinality = checkCardinality,
+      cardinalityRowId = mergeJoin.cardinalityRowId,
       output = generateExpandOutput(attrs, outputs),
-      joinPlan)
+      mergeJoin.plan)
   }
 
   private def pushDownTargetPredicates(
@@ -403,17 +409,17 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       source: LogicalPlan,
       joinType: JoinType,
       joinCond: Expression,
-      checkCardinality: Boolean): LogicalPlan = {
+      checkCardinality: Boolean): MergeJoin = {
 
     // project an extra column to check if a target row exists after the join
     // if needed, project a synthetic row ID used to perform the cardinality check later
     val rowFromTarget = Alias(TrueLiteral, ROW_FROM_TARGET)()
-    val targetTableProjExprs = if (checkCardinality) {
-      val rowId = Alias(MonotonicallyIncreasingID(), ROW_ID)()
-      targetTable.output ++ Seq(rowFromTarget, rowId)
+    val cardinalityRowId = if (checkCardinality) {
+      Some(Alias(MonotonicallyIncreasingID(), ROW_ID)())
     } else {
-      targetTable.output :+ rowFromTarget
+      None
     }
+    val targetTableProjExprs = targetTable.output ++ Seq(rowFromTarget) ++ cardinalityRowId
     val targetTableProj = Project(targetTableProjExprs, targetTable)
 
     // project an extra column to check if a source row exists after the join
@@ -428,7 +434,12 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
     } else {
       JoinHint.NONE
     }
-    Join(targetTableProj, sourceTableProj, joinType, Some(joinCond), joinHint)
+    val joinPlan = Join(targetTableProj, sourceTableProj, joinType, Some(joinCond), joinHint)
+    MergeJoin(
+      joinPlan,
+      rowFromSource.toAttribute,
+      rowFromTarget.toAttribute,
+      cardinalityRowId.map(_.toAttribute))
   }
 
   // skip the cardinality check in these cases:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -21,14 +21,13 @@ import scala.collection.mutable
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.ProjectingInternalRow
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, Expression, ExprId, If, Literal, MetadataAttribute, NamedExpression, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, Expression, ExprId, If, Literal, MetadataAttribute, MetadataAttributeWithLogicalName, NamedExpression, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, LogicalPlan, MergeRows, Project, Union}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ReplaceDataProjections,
   WriteDeltaProjections}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
-import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -104,7 +103,7 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       relation: DataSourceV2Relation,
       operation: RowLevelOperation): Seq[AttributeReference] = {
 
-    V2ExpressionUtils.resolveRefs[AttributeReference](
+    V2ExpressionUtils.resolveMetadataRefs(
       operation.requiredMetadataAttributes.toImmutableArraySeq,
       relation)
   }
@@ -113,9 +112,15 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       relation: DataSourceV2Relation,
       operation: SupportsDelta): Seq[AttributeReference] = {
 
-    val rowIdAttrs = V2ExpressionUtils.resolveRefs[AttributeReference](
-      operation.rowId.toImmutableArraySeq,
-      relation)
+    val rowIdAttrs = operation.rowId.toImmutableArraySeq.map { ref =>
+      val fieldNames = ref.fieldNames.toImmutableArraySeq
+      if (fieldNames.length == 1) {
+        relation.getMetadataAttributeByNameOpt(fieldNames.head)
+          .getOrElse(V2ExpressionUtils.resolveRef[AttributeReference](ref, relation))
+      } else {
+        V2ExpressionUtils.resolveRef[AttributeReference](ref, relation)
+      }
+    }
 
     val nullableRowIdAttrs = rowIdAttrs.filter(_.nullable)
     if (nullableRowIdAttrs.nonEmpty) {
@@ -123,10 +128,6 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     }
 
     rowIdAttrs
-  }
-
-  protected def resolveAttrRef(name: String, plan: LogicalPlan): AttributeReference = {
-    V2ExpressionUtils.resolveRef[AttributeReference](FieldReference(name), plan)
   }
 
   protected def deltaDeleteOutput(
@@ -210,15 +211,17 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   protected def buildReplaceDataProjections(
       plan: LogicalPlan,
       rowAttrs: Seq[Attribute],
-      metadataAttrs: Seq[Attribute]): ReplaceDataProjections = {
+      metadataAttrs: Seq[Attribute],
+      sourceAttrs: Seq[Attribute]): ReplaceDataProjections = {
     val outputs = extractOutputs(plan)
+    val projectedAttrMap = buildProjectedAttrMap(plan, sourceAttrs)
 
     val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
-    val rowProjection = newLazyProjection(plan, outputsWithRow, rowAttrs)
+    val rowProjection = newLazyProjection(plan, outputsWithRow, rowAttrs, projectedAttrMap)
 
     val metadataProjection = if (metadataAttrs.nonEmpty) {
       val outputsWithMetadata = filterOutputs(outputs, OPERATIONS_WITH_METADATA)
-      Some(newLazyProjection(plan, outputsWithMetadata, metadataAttrs))
+      Some(newLazyProjection(plan, outputsWithMetadata, metadataAttrs, projectedAttrMap))
     } else {
       None
     }
@@ -230,22 +233,28 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       plan: LogicalPlan,
       rowAttrs: Seq[Attribute],
       rowIdAttrs: Seq[Attribute],
-      metadataAttrs: Seq[Attribute]): WriteDeltaProjections = {
+      metadataAttrs: Seq[Attribute],
+      sourceAttrs: Seq[Attribute],
+      originalRowIdAttrs: Seq[Attribute] = Nil): WriteDeltaProjections = {
     val outputs = extractOutputs(plan)
+    val projectedAttrMap = buildProjectedAttrMap(plan, sourceAttrs)
+    val originalRowIdAttrMap = buildOriginalRowIdAttrMap(
+      plan, sourceAttrs, originalRowIdAttrs)
 
     val rowProjection = if (rowAttrs.nonEmpty) {
       val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
-      Some(newLazyProjection(plan, outputsWithRow, rowAttrs))
+      Some(newLazyProjection(plan, outputsWithRow, rowAttrs, projectedAttrMap))
     } else {
       None
     }
 
     val outputsWithRowId = filterOutputs(outputs, OPERATIONS_WITH_ROW_ID)
-    val rowIdProjection = newLazyRowIdProjection(plan, outputsWithRowId, rowIdAttrs)
+    val rowIdProjection = newLazyRowIdProjection(
+      plan, outputsWithRowId, rowIdAttrs, projectedAttrMap, originalRowIdAttrMap)
 
     val metadataProjection = if (metadataAttrs.nonEmpty) {
       val outputsWithMetadata = filterOutputs(outputs, OPERATIONS_WITH_METADATA)
-      Some(newLazyProjection(plan, outputsWithMetadata, metadataAttrs))
+      Some(newLazyProjection(plan, outputsWithMetadata, metadataAttrs, projectedAttrMap))
     } else {
       None
     }
@@ -278,8 +287,9 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   private def newLazyProjection(
       plan: LogicalPlan,
       outputs: Seq[Seq[Expression]],
-      attrs: Seq[Attribute]): ProjectingInternalRow = {
-    val colOrdinals = attrs.map(attr => findColOrdinal(plan, attr.name))
+      attrs: Seq[Attribute],
+      projectedAttrMap: AttributeMap[Attribute]): ProjectingInternalRow = {
+    val colOrdinals = attrs.map(attr => findColOrdinal(plan, projectedAttrMap(attr)))
     createProjectingInternalRow(outputs, colOrdinals, attrs)
   }
 
@@ -288,10 +298,12 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   private def newLazyRowIdProjection(
       plan: LogicalPlan,
       outputs: Seq[Seq[Expression]],
-      rowIdAttrs: Seq[Attribute]): ProjectingInternalRow = {
+      rowIdAttrs: Seq[Attribute],
+      projectedAttrMap: AttributeMap[Attribute],
+      originalRowIdAttrMap: AttributeMap[Attribute]): ProjectingInternalRow = {
     val colOrdinals = rowIdAttrs.map { attr =>
-      val originalValueIndex = findColOrdinal(plan, ORIGINAL_ROW_ID_VALUE_PREFIX + attr.name)
-      if (originalValueIndex != -1) originalValueIndex else findColOrdinal(plan, attr.name)
+      val projectedAttr = originalRowIdAttrMap.getOrElse(attr, projectedAttrMap(attr))
+      findColOrdinal(plan, projectedAttr)
     }
     createProjectingInternalRow(outputs, colOrdinals, rowIdAttrs)
   }
@@ -302,20 +314,45 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       attrs: Seq[Attribute]): ProjectingInternalRow = {
     val schema = StructType(attrs.zipWithIndex.map { case (attr, index) =>
       val nullable = outputs.exists(output => output(colOrdinals(index)).nullable)
-      StructField(attr.name, attr.dataType, nullable, attr.metadata)
+      val name = attr match {
+        case MetadataAttributeWithLogicalName(_, logicalName) => logicalName
+        case _ => attr.name
+      }
+      StructField(name, attr.dataType, nullable, attr.metadata)
     })
     ProjectingInternalRow(schema, colOrdinals)
   }
 
-  private def findColOrdinal(plan: LogicalPlan, name: String): Int = {
-    plan.output.indexWhere(attr => conf.resolver(attr.name, name))
+  private def buildProjectedAttrMap(
+      plan: LogicalPlan,
+      sourceAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
+    val projectedAttrs = plan.output.slice(1, sourceAttrs.length + 1)
+    assert(projectedAttrs.length == sourceAttrs.length)
+    AttributeMap(sourceAttrs.zip(projectedAttrs))
+  }
+
+  private def buildOriginalRowIdAttrMap(
+      plan: LogicalPlan,
+      sourceAttrs: Seq[Attribute],
+      originalRowIdAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
+    val start = sourceAttrs.length + 1
+    val projectedAttrs = plan.output.slice(start, start + originalRowIdAttrs.length)
+    assert(projectedAttrs.length == originalRowIdAttrs.length)
+    AttributeMap(originalRowIdAttrs.zip(projectedAttrs))
+  }
+
+  private def findColOrdinal(plan: LogicalPlan, projectedAttr: Attribute): Int = {
+    val ordinal = plan.output.indexWhere(_.exprId == projectedAttr.exprId)
+    assert(ordinal != -1, s"Cannot find projected attr $projectedAttr")
+    ordinal
   }
 
   protected def buildOriginalRowIdValues(
       rowIdAttrs: Seq[Attribute],
-      assignments: Seq[Assignment]): Seq[Alias] = {
+      assignments: Seq[Assignment],
+      metadataAttrs: Seq[Attribute] = Nil): Seq[Alias] = {
     val rowIdAttrSet = AttributeSet(rowIdAttrs)
-    assignments.flatMap { assignment =>
+    val assignedOriginalValues = assignments.flatMap { assignment =>
       val key = assignment.key.asInstanceOf[Attribute]
       val value = assignment.value
       if (rowIdAttrSet.contains(key) && !key.semanticEquals(value)) {
@@ -324,6 +361,13 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
         None
       }
     }
+    val copiedRowIdAttrSet = AttributeSet(assignedOriginalValues.map(_.child))
+    val metadataAttrSet = AttributeSet(metadataAttrs)
+    val overlappingOriginalValues = rowIdAttrs.collect {
+      case attr if metadataAttrSet.contains(attr) && !copiedRowIdAttrSet.contains(attr) =>
+        Alias(attr, ORIGINAL_ROW_ID_VALUE_PREFIX + attr.name)()
+    }
+    assignedOriginalValues ++ overlappingOriginalValues
   }
 
   // generates output attributes with fresh expr IDs and correct nullability for nodes like Expand

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -78,7 +78,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val projections = buildReplaceDataProjections(
+      query, relation.output, metadataAttrs, readRelation.output)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
@@ -113,7 +114,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val projections = buildReplaceDataProjections(
+      query, relation.output, metadataAttrs, readRelation.output)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
@@ -167,15 +169,26 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
+    val rowIdAssignments = if (operation.representUpdateAsDeleteAndInsert) Nil else assignments
+    val originalRowIdValues =
+      buildOriginalRowIdValues(rowIdAttrs, rowIdAssignments, metadataAttrs)
     val rowDeltaPlan = if (operation.representUpdateAsDeleteAndInsert) {
-      buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
+      buildDeletesAndInserts(
+        matchedRowsPlan, assignments, rowIdAttrs, originalRowIdValues)
     } else {
-      buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
+      buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, originalRowIdValues)
     }
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(rowDeltaPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+    val originalRowIdAttrs = originalRowIdValues.map(_.child.asInstanceOf[Attribute])
+    val projections = buildWriteDeltaProjections(
+      rowDeltaPlan,
+      rowAttrs,
+      rowIdAttrs,
+      metadataAttrs,
+      readRelation.output,
+      originalRowIdAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     WriteDelta(writeRelation, cond, rowDeltaPlan, relation, projections, groupFilterCond)
   }
@@ -184,7 +197,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   private def buildWriteDeltaUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
-      rowIdAttrs: Seq[Attribute]): LogicalPlan = {
+      originalRowIdValues: Seq[Alias]): LogicalPlan = {
 
     // the plan output may include immutable metadata columns at the end
     // that's why the number of assignments may not match the number of plan output columns
@@ -203,10 +216,6 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       }
     }
 
-    // original row ID values must be preserved and passed back to the table to encode updates
-    // if there are any assignments to row ID attributes, add extra columns for the original values
-    val originalRowIdValues = buildOriginalRowIdValues(rowIdAttrs, assignments)
-
     val operationType = Alias(Literal(UPDATE_OPERATION), OPERATION_COLUMN)()
 
     Project(Seq(operationType) ++ updatedValues ++ originalRowIdValues, plan)
@@ -215,16 +224,19 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   private def buildDeletesAndInserts(
       matchedRowsPlan: LogicalPlan,
       assignments: Seq[Assignment],
-      rowIdAttrs: Seq[Attribute]): Expand = {
+      rowIdAttrs: Seq[Attribute],
+      originalRowIdValues: Seq[Alias]): Expand = {
 
     val (metadataAttrs, rowAttrs) = matchedRowsPlan.output.partition { attr =>
       MetadataAttribute.isValid(attr.metadata)
     }
-    val deleteOutput = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs)
-    val insertOutput = deltaReinsertOutput(assignments, metadataAttrs)
+    val deleteOutput = deltaDeleteOutput(
+      rowAttrs, rowIdAttrs, metadataAttrs, originalRowIdValues)
+    val insertOutput = deltaReinsertOutput(assignments, metadataAttrs, originalRowIdValues)
     val outputs = Seq(deleteOutput, insertOutput)
     val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
-    val attrs = operationTypeAttr +: matchedRowsPlan.output
+    val originalRowIdAttrs = originalRowIdValues.map(_.toAttribute)
+    val attrs = Seq(operationTypeAttr) ++ matchedRowsPlan.output ++ originalRowIdAttrs
     val expandOutput = generateExpandOutput(attrs, outputs)
     Expand(outputs, expandOutput, matchedRowsPlan)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
@@ -60,6 +60,21 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
     refs.map(ref => resolveRef[T](ref, plan))
   }
 
+  def resolveMetadataRef(ref: NamedReference, plan: LogicalPlan): AttributeReference = {
+    val fieldNames = ref.fieldNames.toImmutableArraySeq
+    if (fieldNames.length != 1) {
+      val name = fieldNames.quoted
+      throw QueryCompilationErrors.cannotResolveAttributeError(name, plan.output.mkString(","))
+    }
+    plan.getMetadataAttributeByName(fieldNames.head)
+  }
+
+  def resolveMetadataRefs(
+      refs: Seq[NamedReference],
+      plan: LogicalPlan): Seq[AttributeReference] = {
+    refs.map(ref => resolveMetadataRef(ref, plan))
+  }
+
   /**
    * Resolves [[NamedReference]]s against the given output and returns them as an [[AttributeSet]].
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, Unevaluable}
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, ROW_ID}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.Instruction
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.types.{DataType, NullType}
@@ -29,7 +29,7 @@ case class MergeRows(
     matchedInstructions: Seq[Instruction],
     notMatchedInstructions: Seq[Instruction],
     notMatchedBySourceInstructions: Seq[Instruction],
-    checkCardinality: Boolean,
+    cardinalityRowId: Option[Attribute],
     output: Seq[Attribute],
     child: LogicalPlan) extends UnaryNode {
 
@@ -39,13 +39,7 @@ case class MergeRows(
 
   @transient
   override lazy val references: AttributeSet = {
-    val usedExprs = if (checkCardinality) {
-      val rowIdAttr = child.output.find(attr => conf.resolver(attr.name, ROW_ID))
-      assert(rowIdAttr.isDefined, "Cannot find row ID attr")
-      rowIdAttr.get +: expressions
-    } else {
-      expressions
-    }
+    val usedExprs = cardinalityRowId.toSeq ++ expressions
     AttributeSet.fromAttributeSets(usedExprs.map(_.references)) -- producedAttributes
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -362,9 +362,14 @@ trait RowLevelWrite extends V2WriteCommand with SupportsSubquery {
   }
 
   protected def projectedMetadataAttrs: Seq[Attribute] = {
-    V2ExpressionUtils.resolveRefs[AttributeReference](
+    V2ExpressionUtils.resolveMetadataRefs(
       operation.requiredMetadataAttributes.toImmutableArraySeq,
-      originalTable)
+      originalTable).map(withLogicalMetadataName)
+  }
+
+  protected def withLogicalMetadataName(attr: Attribute): Attribute = attr match {
+    case MetadataAttributeWithLogicalName(_, logicalName) => attr.withName(logicalName)
+    case _ => attr
   }
 }
 
@@ -518,9 +523,16 @@ case class WriteDelta(
 
   // validates row ID projection output is compatible with row ID attributes
   private def rowIdAttrsResolved: Boolean = {
-    val outRowIdAttrs = V2ExpressionUtils.resolveRefs[AttributeReference](
-      operation.rowId.toImmutableArraySeq,
-      originalTable)
+    val outRowIdAttrs = operation.rowId.toImmutableArraySeq.map { ref =>
+      val fieldNames = ref.fieldNames.toImmutableArraySeq
+      val attr = if (fieldNames.length == 1) {
+        originalTable.getMetadataAttributeByNameOpt(fieldNames.head)
+          .getOrElse(V2ExpressionUtils.resolveRef[AttributeReference](ref, originalTable))
+      } else {
+        V2ExpressionUtils.resolveRef[AttributeReference](ref, originalTable)
+      }
+      withLogicalMetadataName(attr)
+    }
     val inRowIdAttrs = DataTypeUtils.toAttributes(projections.rowIdProjection.schema)
     areCompatible(inRowIdAttrs, outRowIdAttrs)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -77,6 +77,7 @@ class InMemoryRowLevelOperationTable private (
   private final val INDEX_COLUMN_REF = FieldReference(IndexColumn.name)
   private final val SUPPORTS_DELTAS = "supports-deltas"
   private final val SPLIT_UPDATES = "split-updates"
+  private final val ROW_ID = "row-id"
   private final val NO_METADATA = "no-metadata"
   private final val USE_CATALYST_RUNTIME_FILTERING = "use-catalyst-runtime-filtering"
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
@@ -202,7 +203,7 @@ class InMemoryRowLevelOperationTable private (
 
   case class DeltaBasedOperation(command: Command, options: CaseInsensitiveStringMap)
     extends RowLevelOperation with SupportsDelta with RowLevelOperationWithOptions {
-    private final val PK_COLUMN_REF = FieldReference("pk")
+    private final val rowIdRef = FieldReference(properties.getOrDefault(ROW_ID, "pk"))
 
     override def requiredMetadataAttributes(): Array[NamedReference] = {
       if (noMetadata) {
@@ -212,7 +213,7 @@ class InMemoryRowLevelOperationTable private (
       }
     }
 
-    override def rowId(): Array[NamedReference] = Array(PK_COLUMN_REF)
+    override def rowId(): Array[NamedReference] = Array(rowIdRef)
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       newRowLevelScanBuilder(options)(_ => ())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -602,9 +602,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         r.name) :: Nil
 
     case MergeRows(isSourceRowPresent, isTargetRowPresent, matchedInstructions,
-        notMatchedInstructions, notMatchedBySourceInstructions, checkCardinality, output, child) =>
+        notMatchedInstructions, notMatchedBySourceInstructions, cardinalityRowId, output, child) =>
       MergeRowsExec(isSourceRowPresent, isTargetRowPresent, matchedInstructions,
-        notMatchedInstructions, notMatchedBySourceInstructions, checkCardinality,
+        notMatchedInstructions, notMatchedBySourceInstructions, cardinalityRowId,
         output, planLater(child)) :: Nil
 
     case WriteToContinuousDataSource(writer, query, customMetrics) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, ResolveTimeZone, TypeCoercion}
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, SortOrder, TransformExpression, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal, SortOrder, TransformExpression, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils._
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, RebalancePartitions, RepartitionByExpression, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, RebalancePartitions, RepartitionByExpression, Sort}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.connector.catalog.FunctionCatalog
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
@@ -34,17 +34,26 @@ object DistributionAndOrderingUtils {
   def prepareQuery(
       write: Write,
       query: LogicalPlan,
-      funCatalogOpt: Option[FunctionCatalog]): LogicalPlan = write match {
+      funCatalogOpt: Option[FunctionCatalog]): LogicalPlan = {
+    prepareQuery(write, query, funCatalogOpt, Nil)
+  }
+
+  def prepareQuery(
+      write: Write,
+      query: LogicalPlan,
+      funCatalogOpt: Option[FunctionCatalog],
+      writeAttrs: Seq[Attribute]): LogicalPlan = write match {
     case write: RequiresDistributionAndOrdering =>
       val numPartitions = write.requiredNumPartitions()
       val partitionSize = write.advisoryPartitionSizeInBytes()
+      val resolutionQuery = buildResolutionQuery(query, writeAttrs)
 
       val distribution = write.requiredDistribution match {
         case d: OrderedDistribution =>
-          toCatalystOrdering(d.ordering(), query, funCatalogOpt)
+          toCatalystOrdering(d.ordering(), resolutionQuery, funCatalogOpt)
             .map(e => resolveTransformExpression(e).asInstanceOf[SortOrder])
         case d: ClusteredDistribution =>
-          d.clustering.map(e => toCatalyst(e, query, funCatalogOpt))
+          d.clustering.map(e => toCatalyst(e, resolutionQuery, funCatalogOpt))
             .map(e => resolveTransformExpression(e)).toImmutableArraySeq
         case _: UnspecifiedDistribution => Seq.empty[Expression]
       }
@@ -74,7 +83,7 @@ object DistributionAndOrderingUtils {
         query
       }
 
-      val ordering = toCatalystOrdering(write.requiredOrdering, query, funCatalogOpt)
+      val ordering = toCatalystOrdering(write.requiredOrdering, resolutionQuery, funCatalogOpt)
       val queryWithDistributionAndOrdering = if (ordering.nonEmpty) {
         Sort(
           ordering.map(e => resolveTransformExpression(e).asInstanceOf[SortOrder]),
@@ -87,6 +96,31 @@ object DistributionAndOrderingUtils {
       TypeCoercionExecutor.execute(queryWithDistributionAndOrdering)
     case _ =>
       query
+  }
+
+  private def buildResolutionQuery(
+      query: LogicalPlan,
+      writeAttrs: Seq[Attribute]): LogicalPlan = {
+    if (writeAttrs.isEmpty) {
+      query
+    } else {
+      val preferredAttrs = writeAttrs.foldLeft(Seq.empty[Attribute]) { (attrs, attr) =>
+        if (attrs.exists(existing => conf.resolver(existing.name, attr.name))) {
+          attrs
+        } else {
+          attrs :+ attr
+        }
+      }
+      val resolutionOutput = query.output.map { attr =>
+        writeAttrs.find(_.exprId == attr.exprId) match {
+          case Some(writeAttr) if preferredAttrs.exists(_.exprId == writeAttr.exprId) =>
+            attr.withName(writeAttr.name)
+          case _ =>
+            attr.withName(s"__row_level_internal_${attr.exprId.id}")
+        }
+      }
+      LocalRelation(resolutionOutput)
+    }
   }
 
   private object TypeCoercionExecutor extends RuleExecutor[LogicalPlan] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.Projection
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, FalseLiteral, GeneratePredicate, JavaCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Context, Copy, Delete, Discard, Insert, Instruction, Keep, ROW_ID, Split, Update}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Context, Copy, Delete, Discard, Insert, Instruction, Keep, Split, Update}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{CodegenSupport, SparkPlan, UnaryExecNode}
@@ -45,7 +45,7 @@ case class MergeRowsExec(
     matchedInstructions: Seq[Instruction],
     notMatchedInstructions: Seq[Instruction],
     notMatchedBySourceInstructions: Seq[Instruction],
-    checkCardinality: Boolean,
+    cardinalityRowId: Option[Attribute],
     output: Seq[Attribute],
     child: SparkPlan) extends UnaryExecNode with CodegenSupport {
 
@@ -73,13 +73,7 @@ case class MergeRowsExec(
 
   @transient
   override lazy val references: AttributeSet = {
-    val usedExprs = if (checkCardinality) {
-      val rowIdAttr = child.output.find(attr => conf.resolver(attr.name, ROW_ID))
-      assert(rowIdAttr.isDefined, "Cannot find row ID attr")
-      rowIdAttr.get +: expressions
-    } else {
-      expressions
-    }
+    val usedExprs = cardinalityRowId.toSeq ++ expressions
     AttributeSet.fromAttributeSets(usedExprs.map(_.references)) -- producedAttributes
   }
 
@@ -178,13 +172,11 @@ case class MergeRowsExec(
     val notMatchedBySourceInstructionsCode = generateInstructionsCode(
       ctx, notMatchedBySourceInstructions, inputExprs, sourcePresent = false)
 
-    val cardinalityValidationCode = if (checkCardinality) {
-      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+    val cardinalityValidationCode = cardinalityRowId.map { rowIdAttr =>
+      val rowIdOrdinal = child.output.indexWhere(_.exprId == rowIdAttr.exprId)
       assert(rowIdOrdinal != -1, "Cannot find row ID attr")
       generateCardinalityValidationCode(ctx, rowIdOrdinal, inputExprs).code
-    } else {
-      ""
-    }
+    }.getOrElse("")
 
     s"""
        |${ctx.registerComment("evaluate source/target row presence")}
@@ -411,13 +403,11 @@ case class MergeRowsExec(
     val notMatchedInstructionExecs = planInstructions(notMatchedInstructions)
     val notMatchedBySourceInstructionExecs = planInstructions(notMatchedBySourceInstructions)
 
-    val cardinalityValidator = if (checkCardinality) {
-      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+    val cardinalityValidator = cardinalityRowId.map { rowIdAttr =>
+      val rowIdOrdinal = child.output.indexWhere(_.exprId == rowIdAttr.exprId)
       assert(rowIdOrdinal != -1, "Cannot find row ID attr")
       BitmapCardinalityValidator(rowIdOrdinal)
-    } else {
-      NoopCardinalityValidator
-    }
+    }.getOrElse(NoopCardinalityValidator)
 
     val mergeIterator = new MergeRowIterator(
       rowIterator, cardinalityValidator, isTargetRowPresentPred, isSourceRowPresentPred,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -21,7 +21,8 @@ import java.util.UUID
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.sql.catalyst.ProjectingInternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, PredicateHelper}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, InsertOnlyMerge, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, ReplaceData, WriteDelta}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
@@ -114,14 +115,21 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
       val writeOptions = mergeOptions(Map.empty, r.options.asCaseSensitiveMap.asScala.toMap)
       val writeBuilder = newWriteBuilder(r.table, writeOptions, rowSchema, metadataSchema)
       val write = writeBuilder.build()
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, r.funCatalog)
+      val writeAttrs = projections.metadataProjection.toSeq.flatMap(projectedAttrs(query, _)) ++
+        projectedAttrs(query, projections.rowProjection)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(
+        write, query, r.funCatalog, writeAttrs)
       rd.copy(write = Some(write), query = newQuery)
 
     case wd @ WriteDelta(r: DataSourceV2Relation, _, query, _, projections, _, None) =>
       val writeOptions = mergeOptions(Map.empty, r.options.asCaseSensitiveMap.asScala.toMap)
       val deltaWriteBuilder = newDeltaWriteBuilder(r.table, writeOptions, projections)
       val deltaWrite = deltaWriteBuilder.build()
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(deltaWrite, query, r.funCatalog)
+      val writeAttrs = projectedAttrs(query, projections.rowIdProjection) ++
+        projections.metadataProjection.toSeq.flatMap(projectedAttrs(query, _)) ++
+        projections.rowProjection.toSeq.flatMap(projectedAttrs(query, _))
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(
+        deltaWrite, query, r.funCatalog, writeAttrs)
       wd.copy(write = Some(deltaWrite), query = newQuery)
   }
 
@@ -133,6 +141,14 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
     // for SQL cases, options are only carried by DataSourceV2Relation
     assert(commandOptions == dsOptions || commandOptions.isEmpty || dsOptions.isEmpty)
     commandOptions ++ dsOptions
+  }
+
+  private def projectedAttrs(
+      query: LogicalPlan,
+      projection: ProjectingInternalRow): Seq[Attribute] = {
+    projection.schema.fields.zip(projection.colOrdinals).map { case (field, ordinal) =>
+      query.output(ordinal).withName(field.name)
+    }.toImmutableArraySeq
   }
 
   private def buildWriteForMicroBatch(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -155,19 +155,13 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
   private def buildTableToScanAttrMap(
       tableAttrs: Seq[Attribute],
       scanAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
-
-    val attrMapping = tableAttrs.map { tableAttr =>
-      scanAttrs
-        .find(scanAttr => conf.resolver(scanAttr.name, tableAttr.name))
-        .map(scanAttr => tableAttr -> scanAttr)
-        .getOrElse {
-          throw new AnalysisException(
-            errorClass = "_LEGACY_ERROR_TEMP_3075",
-            messageParameters = Map(
-              "tableAttr" -> tableAttr.toString,
-              "scanAttrs" -> scanAttrs.mkString(",")))
-        }
+    if (tableAttrs.length > scanAttrs.length) {
+      throw new AnalysisException(
+        errorClass = "_LEGACY_ERROR_TEMP_3075",
+        messageParameters = Map(
+          "tableAttr" -> tableAttrs.mkString(","),
+          "scanAttrs" -> scanAttrs.mkString(",")))
     }
-    AttributeMap(attrMapping)
+    AttributeMap(tableAttrs.zip(scanAttrs))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedDeleteFromTableSuite.scala
@@ -170,3 +170,35 @@ class DeltaBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
     checkDeleteMetrics(numDeletedRows = 1, numCopiedRows = 0)
   }
 }
+
+class DeltaBasedMetadataRowIdDeleteFromTableSuite extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props.put("row-id", "index")
+    props
+  }
+
+  test("SPARK-58815: preserve a metadata row ID when deleting a row") {
+    withTempView("deleted_pks") {
+      createAndInitTable("pk INT NOT NULL, index INT, dep STRING",
+        """{ "pk": 0, "index": 100, "dep": "hr" }
+          |""".stripMargin)
+
+      Seq(0).toDF("pk").createOrReplaceTempView("deleted_pks")
+
+      sql(s"DELETE FROM $tableNameAsString WHERE pk IN (SELECT pk FROM deleted_pks)")
+
+      checkAnswer(sql(s"SELECT * FROM $tableNameAsString"), Nil)
+
+      checkLastWriteInfo(
+        expectedRowIdSchema = Some(StructType(Array(INDEX_FIELD))),
+        expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+
+      checkLastWriteLog(deleteWriteLogEntry(id = 0, metadata = Row("hr", null)))
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
@@ -171,3 +171,48 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
       Row(1, 1, -1, "hr") :: Row(2, 2, 150, "software") :: Row(3, 3, 120, "hr") :: Nil)
   }
 }
+
+abstract class DeltaBasedMetadataRowIdUpdateTableSuiteBase(
+    splitUpdates: Boolean) extends RowLevelOperationSuiteBase {
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props.put("row-id", "index")
+    props.put("split-updates", splitUpdates.toString)
+    props
+  }
+
+  test("SPARK-58815: resolve a metadata row ID despite a conflicting data column") {
+    createAndInitTable("pk INT NOT NULL, index INT, dep STRING",
+      """{ "pk": 0, "index": 100, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET dep = 'software' WHERE pk = 0")
+
+    checkAnswer(sql(s"SELECT * FROM $tableNameAsString"), Row(0, 100, "software"))
+
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(table.schema.map {
+        case field if field.name == "dep" => field.copy(nullable = false) // input is a constant
+        case field => field
+      }),
+      expectedRowIdSchema = Some(StructType(Array(INDEX_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+
+    if (splitUpdates) {
+      checkLastWriteLog(
+        deleteWriteLogEntry(id = 0, metadata = Row("hr", null)),
+        reinsertWriteLogEntry(metadata = Row("hr", null), data = Row(0, 100, "software")))
+    } else {
+      checkLastWriteLog(
+        updateWriteLogEntry(id = 0, metadata = Row("hr", null), data = Row(0, 100, "software")))
+    }
+  }
+}
+
+class DeltaBasedMetadataRowIdUpdateTableSuite
+  extends DeltaBasedMetadataRowIdUpdateTableSuiteBase(splitUpdates = false)
+
+class DeltaBasedMetadataRowIdUpdateAsDeleteAndInsertTableSuite
+  extends DeltaBasedMetadataRowIdUpdateTableSuiteBase(splitUpdates = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedUpdateTableSuite.scala
@@ -50,6 +50,27 @@ class GroupBasedUpdateTableSuite extends UpdateTableSuiteBase {
       writeWithMetadataLogEntry(metadata = Row("hr", 1), data = Row(3, 3, "hr")))
   }
 
+  test("SPARK-58815: preserve metadata identity when metadata and data names conflict") {
+    createAndInitTable("pk INT NOT NULL, index INT, dep STRING",
+      """{ "pk": 1, "index": 100, "dep": "hr" }
+        |{ "pk": 2, "index": 200, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET index = index + 1 WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(1, 101, "hr") :: Row(2, 200, "hr") :: Nil)
+
+    checkLastWriteInfo(
+      expectedRowSchema = table.schema,
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+
+    checkLastWriteLog(
+      writeWithMetadataLogEntry(metadata = Row("hr", null), data = Row(1, 101, "hr")),
+      writeWithMetadataLogEntry(metadata = Row("hr", 1), data = Row(2, 200, "hr")))
+  }
+
   test("update with subquery handles metadata columns correctly") {
     withTempView("updated_dep") {
       createAndInitTable("pk INT NOT NULL, id INT, dep STRING",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -1290,6 +1290,29 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
     }
   }
 
+  test("SPARK-58815: MERGE cardinality check uses the generated row ID") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, __row_id INT, dep STRING",
+        """{ "pk": 1, "__row_id": 10, "dep": "hr" }
+          |{ "pk": 2, "__row_id": 10, "dep": "hr" }
+          |""".stripMargin)
+
+      Seq(1, 2).toDF("pk").createOrReplaceTempView("source")
+
+      sql(
+        s"""MERGE INTO $tableNameAsString AS t
+           |USING source AS s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET t.dep = 'software'
+           |""".stripMargin)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(Row(1, 10, "software"), Row(2, 10, "software")))
+    }
+  }
+
   test("merge cardinality check with unconditional MATCHED clause (delete)") {
     withTempView("source") {
       createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/MergeRowsExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/MergeRowsExecBenchmark.scala
@@ -107,7 +107,7 @@ object MergeRowsExecBenchmark extends SqlBasedBenchmark with ClassicConversions 
       matchedInstructions = matchedInstr,
       notMatchedInstructions = notMatchedInstr,
       notMatchedBySourceInstructions = notMatchedBySourceInstr,
-      checkCardinality = false,
+      cardinalityRowId = None,
       output = outputAttrs,
       child = inputPlan
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Resolve row-level operation attributes by identity instead of name. This covers metadata columns, row IDs, MERGE internal attributes, projections, and write requirements.

### Why are the changes needed?

Data columns may have the same names as metadata or internally generated columns. Name-based lookup can select the wrong attribute, causing analysis failures or incorrect DELETE, UPDATE, and MERGE behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Row-level operations now work correctly when data, metadata, or internal columns have conflicting names. There is no public API change.

### How was this patch tested?

Added regression tests for metadata conflicts, metadata row IDs, split updates, deletes, and MERGE cardinality checks.

Ran the affected DELETE, UPDATE, and MERGE suites. All 948 full regression tests, 429 follow-up tests, Scalastyle, and Scalafmt checks passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex