### PR TITLE
[SPARK-58862][INFRA] Recognize UDF as a primary component tag in the merge script

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -1050,6 +1050,8 @@ def jira_components_from_title_tags(tags):
     ['PySpark', 'Documentation']
     >>> jira_components_from_title_tags(["SQL", "TEST"])
     ['SQL', 'Tests']
+    >>> jira_components_from_title_tags(["UDF"])
+    ['UDF']
     >>> jira_components_from_title_tags(["SQL", "FOLLOWUP", "4.X", "BOGUS"])
     ['SQL']
     >>> jira_components_from_title_tags(["SQL", "SQL"])
@@ -1449,6 +1451,7 @@ COMPONENTS = (
     Component("STREAMING", ("DSTREAM", "DSTREAMS"), primary=True, jira_name="DStreams"),
     Component("SUBMIT", jira_name="Spark Submit"),
     Component("TEST", ("TESTS", "TEST-ONLY", "TESTS-ONLY"), jira_name="Tests"),
+    Component("UDF", primary=True, jira_name="UDF"),
     Component("UI", ("WEBUI", "WEB_UI"), primary=True, jira_name="Web UI"),
     Component("WINDOWS", primary=True, jira_name="Windows"),
     Component("YARN", primary=True, jira_name="YARN"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Register `UDF` (JIRA component "UDF", i.e. Frictionless UDF) as a primary component in the `dev/merge_spark_pr.py` component registry, in alphabetical order between `TEST` and `UI`.

### Why are the changes needed?

The registry mirrors the SPARK JIRA component list, and `UDF` was missing. Since the merge script requires a primary component tag, a PR titled `[SPARK-XXXXX][UDF] ...` was rejected at merge time. Marking `UDF` primary lets it stand alone, like `SQL`/`PYTHON`/`ML`. Follows [SPARK-58638] which did the same for `EXAMPLES`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`python -m doctest dev/merge_spark_pr.py`.

### Was this patch authored or co-authored using generative AI tooling?

No.
