### PR TITLE
[SPARK-58863][ML] Make tree leaf attribute uncached

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -98,7 +98,7 @@ private[spark] trait DecisionTreeModel {
   private[ml] lazy val numLeave: Int =
     leafIterator(rootNode).size
 
-  private[ml] lazy val leafAttr = {
+  private[ml] def leafAttr = {
     NominalAttribute.defaultAttr
       .withNumValues(numLeave)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change tree model `leafAttr` from a `lazy val` to a `def`.

`leafAttr` is a small metadata object derived from `numLeave`, and `numLeave` remains cached.


### Why are the changes needed?

`leafAttr` is only used when building leaf-column schema metadata. Since the expensive leaf count
is already cached by `numLeave`, caching the derived attribute itself is unnecessary.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Ran:

```
build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 mllib/compile
```


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)

