### PR TITLE
[SPARK-58438][CORE] Close FileSystem cache after token renewal

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
@@ -178,15 +178,9 @@ private[spark] class HadoopDelegationTokenManager(
       Option(currentUser.getRealUser()).getOrElse(currentUser).hasKerberosCredentials()
 
     if (hasKerberosCreds) {
-      val freshUGI = doLogin()
-      freshUGI.doAs(new PrivilegedExceptionAction[Unit]() {
-        override def run(): Unit = {
-          val (newTokens, _, _) = obtainDelegationTokens()
-          creds.addAll(newTokens)
-        }
-      })
-      if (!currentUser.equals(freshUGI)) {
-        FileSystem.closeAllForUGI(freshUGI)
+      doAsFreshUser {
+        val (newTokens, _, _) = obtainDelegationTokens()
+        creds.addAll(newTokens)
       }
     } else if (sparkConf.get(DIRECT_CREDENTIAL_PROVIDERS_ENABLED)) {
       val (newTokens, _, _) = obtainDelegationTokens(isolateFailures = true)
@@ -278,13 +272,9 @@ private[spark] class HadoopDelegationTokenManager(
    */
   private def obtainTokensAndScheduleRenewal(): Credentials = {
     val (creds, nextRenewal, failureCount) = if (hasKerberosCredentials) {
-      val freshUGI = doLogin()
-      freshUGI.doAs(
-        new PrivilegedExceptionAction[(Credentials, Long, Int)]() {
-          override def run(): (Credentials, Long, Int) = {
-            obtainDelegationTokens()
-          }
-        })
+      doAsFreshUser {
+        obtainDelegationTokens()
+      }
     } else if (sparkConf.get(DIRECT_CREDENTIAL_PROVIDERS_ENABLED)) {
       obtainDelegationTokens(isolateFailures = true)
     } else {
@@ -316,6 +306,20 @@ private[spark] class HadoopDelegationTokenManager(
       log" and current time ${MDC(LogKeys.CURRENT_TIME, now)}")
     scheduleRenewal(delay)
     creds
+  }
+
+  private def doAsFreshUser[T](action: => T): T = {
+    val currentUser = UserGroupInformation.getCurrentUser()
+    val freshUGI = doLogin()
+    try {
+      freshUGI.doAs(new PrivilegedExceptionAction[T]() {
+        override def run(): T = action
+      })
+    } finally {
+      if (!currentUser.equals(freshUGI)) {
+        FileSystem.closeAllForUGI(freshUGI)
+      }
+    }
   }
 
   private def doLogin(): UserGroupInformation = {

--- a/core/src/test/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManagerSuite.scala
@@ -17,15 +17,22 @@
 
 package org.apache.spark.deploy.security
 
+import java.io.File
 import java.security.PrivilegedExceptionAction
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, LocalFileSystem}
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION
 import org.apache.hadoop.minikdc.MiniKdc
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.mockito.Mockito.mock
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.config.{KEYTAB, PRINCIPAL}
+import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.security.HadoopDelegationTokenProvider
 import org.apache.spark.util.Utils
 
@@ -47,6 +54,35 @@ private class ExceptionThrowingDelegationTokenProvider extends HadoopDelegationT
 
 private object ExceptionThrowingDelegationTokenProvider {
   var constructed = false
+}
+
+private class CloseTrackingLocalFileSystem extends LocalFileSystem {
+  private val isClosed = new AtomicBoolean(false)
+  CloseTrackingLocalFileSystem.instances.add(this)
+
+  override def close(): Unit = {
+    if (isClosed.compareAndSet(false, true)) {
+      try {
+        super.close()
+      } finally {
+        CloseTrackingLocalFileSystem.closedCount.incrementAndGet()
+      }
+    }
+  }
+}
+
+private object CloseTrackingLocalFileSystem {
+  val instances = new ConcurrentLinkedQueue[CloseTrackingLocalFileSystem]()
+  val closedCount = new AtomicInteger(0)
+
+  def reset(): Unit = {
+    instances.clear()
+    closedCount.set(0)
+  }
+
+  def closeInstances(): Unit = {
+    instances.forEach(_.close())
+  }
 }
 
 class HadoopDelegationTokenManagerSuite extends SparkFunSuite {
@@ -74,6 +110,49 @@ class HadoopDelegationTokenManagerSuite extends SparkFunSuite {
     val manager = new HadoopDelegationTokenManager(sparkConf, hadoopConf, null)
     assert(!manager.isProviderLoaded("hadoopfs"))
     assert(manager.isProviderLoaded("hbase"))
+  }
+
+  test("SPARK-58438: token renewal closes filesystems cached for the fresh UGI") {
+    SparkHadoopUtil.get
+    CloseTrackingLocalFileSystem.reset()
+
+    var kdc: MiniKdc = null
+    var manager: HadoopDelegationTokenManager = null
+    try {
+      val kdcDir = Utils.createTempDir()
+      kdc = new MiniKdc(MiniKdc.createConf(), kdcDir)
+      kdc.start()
+
+      val principal = "spark"
+      val keytab = new File(kdcDir, "spark.keytab")
+      kdc.createPrincipal(keytab, principal)
+
+      val krbConf = new Configuration()
+      krbConf.set(HADOOP_SECURITY_AUTHENTICATION, "kerberos")
+      krbConf.setClass(
+        "fs.file.impl", classOf[CloseTrackingLocalFileSystem], classOf[FileSystem])
+      UserGroupInformation.setConfiguration(krbConf)
+
+      val sparkConf = new SparkConf(false)
+        .set(PRINCIPAL, s"$principal@${kdc.getRealm}")
+        .set(KEYTAB, keytab.getAbsolutePath)
+      manager = new HadoopDelegationTokenManager(
+        sparkConf, krbConf, mock(classOf[RpcEndpointRef]))
+
+      assert(manager.start() != null)
+      assert(CloseTrackingLocalFileSystem.instances.size() > 0)
+      assert(CloseTrackingLocalFileSystem.closedCount.get() ===
+        CloseTrackingLocalFileSystem.instances.size())
+    } finally {
+      if (manager != null) {
+        manager.stop()
+      }
+      CloseTrackingLocalFileSystem.closeInstances()
+      if (kdc != null) {
+        kdc.stop()
+      }
+      UserGroupInformation.reset()
+    }
   }
 
   test("SPARK-29082: do not fail if current user does not have credentials") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Close FileSystem instances cached for the fresh Hadoop UGI after obtaining delegation tokens. The cleanup is shared by both one-time token acquisition and scheduled renewal, and runs in a `finally` block.

A regression test was added to verify that FileSystem instances created during renewal are closed.

### Why are the changes needed?

Each renewal creates a fresh UGI. FileSystem instances cached for that UGI were not closed by the renewal path, causing the Hadoop FileSystem cache to grow after every renewal.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran:

    build/sbt 'core/testOnly *HadoopDelegationTokenManagerSuite -- -z "SPARK-58438"'
    build/sbt 'core/testOnly *HadoopDelegationTokenManagerSuite'
    dev/lint-scala

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex