### PR TITLE
[SPARK-20711][ML] Make summarizer min/max return NaN for NaN input

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -533,12 +533,8 @@ private[spark] class SummarizerBuffer(
       val localCurrMax = currMax
       val localCurrMin = currMin
       nonZeroIterator.foreach { case (index, value) =>
-        if (localCurrMax != null && localCurrMax(index) < value) {
-          localCurrMax(index) = value
-        }
-        if (localCurrMin != null && localCurrMin(index) > value) {
-          localCurrMin(index) = value
-        }
+        if (localCurrMax != null) { localCurrMax(index) = math.max(localCurrMax(index), value) }
+        if (localCurrMin != null) { localCurrMin(index) = math.min(localCurrMin(index), value) }
 
         if (localCurrWeightSum != null) {
           if (localCurrMean != null) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -94,12 +94,8 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
     val localCurrMax = currMax
     val localCurrMin = currMin
     instance.foreachNonZero { (index, value) =>
-      if (localCurrMax(index) < value) {
-        localCurrMax(index) = value
-      }
-      if (localCurrMin(index) > value) {
-        localCurrMin(index) = value
-      }
+      localCurrMax(index) = math.max(localCurrMax(index), value)
+      localCurrMin(index) = math.min(localCurrMin(index), value)
 
       val prevMean = localCurrMean(index)
       val diff = value - prevMean

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/SummarizerSuite.scala
@@ -572,6 +572,34 @@ class SummarizerSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(summarizer3.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
   }
 
+  test("summarizer min/max with NaN samples (SPARK-20711)") {
+    val input = Seq(
+      Vectors.dense(1.0, Double.NaN, -1.0),
+      Vectors.sparse(3, Seq((0, Double.NaN), (2, 2.0))),
+      Vectors.dense(0.0, 3.0, 0.0))
+    val summarizer = input.foldLeft(new SummarizerBuffer) { (summary, vector) =>
+      summary.add(vector)
+    }
+
+    def checkResult(min: Vector, max: Vector): Unit = {
+      assert(max(0).isNaN)
+      assert(max(1).isNaN)
+      assert(max(2) === 2.0)
+      assert(min(0).isNaN)
+      assert(min(1).isNaN)
+      assert(min(2) === -1.0)
+    }
+
+    checkResult(summarizer.min, summarizer.max)
+
+    val df = input.map(Tuple1.apply).toDF("features")
+    val Row(Row(summaryMin: Vector, summaryMax: Vector), singleMin: Vector, singleMax: Vector) =
+      df.select(metrics("min", "max").summary($"features"), min($"features"), max($"features"))
+        .first()
+    checkResult(summaryMin, summaryMax)
+    checkResult(singleMin, singleMax)
+  }
+
   test("support new metrics: sum, std, numFeatures, sumL2, weightSum") {
     val summarizer1 = new SummarizerBuffer()
       .add(Vectors.dense(10.0, -10.0), 1e10)

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizerSuite.scala
@@ -271,6 +271,23 @@ class MultivariateOnlineSummarizerSuite extends SparkFunSuite {
     assert(summarizer3.min ~== Vectors.dense(0.0, -10.0) absTol 1e-14)
   }
 
+  test("test min/max with NaN samples (SPARK-20711)") {
+    val summarizer = new MultivariateOnlineSummarizer()
+      .add(Vectors.dense(1.0, Double.NaN, -1.0))
+      .add(Vectors.sparse(3, Seq((0, Double.NaN), (2, 2.0))))
+      .add(Vectors.dense(0.0, 3.0, 0.0))
+
+    val max = summarizer.max
+    val min = summarizer.min
+
+    assert(max(0).isNaN)
+    assert(max(1).isNaN)
+    assert(max(2) === 2.0)
+    assert(min(0).isNaN)
+    assert(min(1).isNaN)
+    assert(min(2) === -1.0)
+  }
+
   test ("test zero variance (SPARK-21818)") {
     val summarizer1 = (new MultivariateOnlineSummarizer)
       .add(Vectors.dense(3.0), 0.7)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `MultivariateOnlineSummarizer` and `SummarizerBuffer` to propagate `NaN`
values for `min` and `max` when a feature contains `NaN`.

The add path now uses `math.min` and `math.max`, matching the merge path behavior and
allowing `NaN` to be preserved in the running min/max arrays.

### Why are the changes needed?

Previously, `min` and `max` were updated through direct `<` and `>` comparisons. Since
comparisons with `NaN` are false, `NaN` values could be ignored and finite values could be
returned even when a column contained `NaN`.

### Does this PR introduce _any_ user-facing change?

Yes. `Statistics.colStats`, `MultivariateOnlineSummarizer`, and `Summarizer` now return
`NaN` for `min` and `max` in a feature dimension if that dimension contains `NaN`.

### How was this patch tested?

Added regression tests for both `MultivariateOnlineSummarizer` and `Summarizer`.

Ran:

```
build/sbt "mllib/testOnly org.apache.spark.mllib.stat.MultivariateOnlineSummarizerSuite org.apache.spark.ml.stat.SummarizerSuite"
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
