### PR TITLE
[SPARK-58864][SQL] Add remediation hint to UNRECOGNIZED_SQL_TYPE error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8287,7 +8287,8 @@
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [
-      "Unrecognized SQL type - name: <typeName>, id: <jdbcType>."
+      "Unrecognized SQL type - name: <typeName>, id: <jdbcType>.",
+      "To read this column, map it explicitly with the `customSchema` option, or register a custom `JdbcDialect` that handles this type."
     ],
     "sqlState" : "42704"
   },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When the JDBC data source reads a column whose SQL type it cannot map to a Catalyst type, it fails with the `UNRECOGNIZED_SQL_TYPE` error. This PR appends a remediation hint to that error condition (in common/utils/src/main/resources/error/error-conditions.json), pointing users at the two supported ways to handle an unmapped type:

`Unrecognized SQL type - name: <typeName>, id: <jdbcType>.`

To read this column, map it explicitly with the `customSchema` option, or register a custom `JdbcDialect` that handles this type. Only the message text of the `UNRECOGNIZED_SQL_TYPE` condition changes; the error class, condition name, SQL state (42704), and message parameters are untouched.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The existing message states what failed but not what to do about it. `UNRECOGNIZED_SQL_TYPE` is thrown only from the JDBC read path (`JdbcUtils.getCatalystType`), and both remedies already exist: the `customSchema` read option and a user-registered `JdbcDialect`. Surfacing them lets users self-serve unmapped or vendor-specific types instead of reading source or filing a support request.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. The `UNRECOGNIZED_SQL_TYPE` error message now includes a second sentence with remediation guidance. There is no change to the error class, condition, SQL state, parameters, or behavior; only the human-readable text changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
No new tests are needed. Existing coverage (QueryExecutionErrorsSuite - "`UNRECOGNIZED_SQL_TYPE: unrecognized SQL type DATALINK`", and JDBCSuite) asserts on the error condition and its parameters via checkError, not on literal message text, so it continues to pass. docs/sql-error-conditions.md is generated from error-conditions.json at doc-build time, so no golden file needs regenerating. The JSON was validated as well-formed.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Opus 4.8)