### PR TITLE
[SPARK-58866][SQL] Add expression-level entry points to optimizer rules

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeTravelSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeTravelSpec.scala
@@ -18,9 +18,8 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Expression, Literal, SubqueryExpression, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal, SubqueryExpression, Unevaluable}
 import org.apache.spark.sql.catalyst.optimizer.{ComputeCurrentTime, ReplaceExpressions}
-import org.apache.spark.sql.catalyst.plans.logical.{OneRowRelation, Project}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -47,11 +46,7 @@ object TimeTravelSpec {
       throw QueryCompilationErrors.invalidTimestampExprForTimeTravel(
         "INVALID_TIME_TRAVEL_TIMESTAMP_EXPR.INPUT", ts)
     }
-    val tsToEval = {
-      val fakeProject = Project(Seq(Alias(ts, "ts")()), OneRowRelation())
-      ComputeCurrentTime(ReplaceExpressions(fakeProject)).asInstanceOf[Project]
-        .expressions.head.asInstanceOf[Alias].child
-    }
+    val tsToEval = ComputeCurrentTime.applyForExpression(ReplaceExpressions.replace(ts))
     tsToEval.foreach {
       case _: Unevaluable =>
         throw QueryCompilationErrors.invalidTimestampExprForTimeTravel(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -164,9 +164,10 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
       case ref: CommonExpressionRef => safeIds.contains(ref.id)
       // Any other leaf varies per row (attribute) or reads a clock.
       case _: LeafExpression => false
-      // A TIME -> TIMESTAMP cast stabilized by ComputeCurrentTime is a pure builder StaticInvoke;
-      // accept it here before the blanket NonSQLExpression rejection below.
-      case _ if ComputeCurrentTime.isStabilizedTimeToTimestamp(e) =>
+      // ComputeCurrentTime stabilizes a TIME -> TIMESTAMP cast into a DateTimeUtils.makeTimestamp*
+      // builder, which depends only on its arguments (none read a clock). Accept it here, ahead
+      // of the blanket NonSQLExpression rejection below, when every argument is a literal tree.
+      case _ if ComputeCurrentTime.isMakeTimestampBuilder(e) =>
         e.children.forall(isLiteralTree)
       // Arbitrary Java methods and UDFs can be foldable without being pure.
       case _: NonSQLExpression | _: UserDefinedExpression => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -68,14 +68,25 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
 
   /**
    * Rewrites the `With` expressions in a single expression tree by inlining their common
-   * expressions. Uses `transformUp` to handle nested `With`.
+   * expressions. Uses `transformUp` to handle nested `With`. Inlining duplicates a definition at
+   * every reference, so this rejects non-foldable definitions: inlining one referenced more than
+   * once would evaluate it more than once, breaking `With`'s evaluate-once contract.
    *
    * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
    * may contain a subquery must rewrite those plans separately.
    */
-  def applyForExpression(expression: Expression): Expression = {
+  def applyForExpression(expression: Expression): Expression =
+    inlineWith(expression, rejectNonFoldableDefs = true)
+
+  // The plan-level rewrite shares this to inline `With` in conditional branches, which may not be
+  // evaluated and so can't be pulled into a Project; it passes false to allow non-foldable defs.
+  private def inlineWith(expression: Expression, rejectNonFoldableDefs: Boolean): Expression = {
     expression.transformUpWithPruning(_.containsPattern(WITH_EXPRESSION)) {
       case With(child, defs) =>
+        if (rejectNonFoldableDefs && !defs.forall(_.child.foldable)) {
+          throw SparkException.internalError(
+            "Cannot inline a With expression with a non-foldable common expression definition.")
+        }
         val refToExpr = defs.map(commonExprDef => commonExprDef.id -> commonExprDef.child).toMap
         child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
           case ref: CommonExpressionRef if refToExpr.contains(ref.id) => refToExpr(ref.id)
@@ -199,9 +210,9 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
             _, inputPlans, commonExprsPerChild, commonExprIdSet, isNestedWith))
         val newExpr = c.withNewAlwaysEvaluatedInputs(newAlwaysEvaluatedInputs)
         // For With in the conditional branches, they may not be evaluated at all and we can't
-        // pull the common expressions into a project which will always be evaluated. Inline it.
-        // Use transformUp to handle nested With.
-        applyForExpression(newExpr)
+        // pull the common expressions into a project which will always be evaluated. Inline it,
+        // even when the definition is not foldable. Use transformUp to handle nested With.
+        inlineWith(newExpr, rejectNonFoldableDefs = false)
 
       case other => other.mapChildren(
         rewriteWithExprAndInputPlans(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, PlanHelper, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern.{COMMON_EXPR_REF, WITH_EXPRESSION}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{CAST_TO_TIMESTAMP, COMMON_EXPR_REF, CURRENT_LIKE, WITH_EXPRESSION}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -68,30 +68,101 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
 
   /**
    * Rewrites the `With` expressions in a single expression tree by inlining their common
-   * expressions. Uses `transformUp` to handle nested `With`. Inlining duplicates a definition at
-   * every reference, so this rejects non-foldable definitions: inlining one referenced more than
-   * once would evaluate it more than once, breaking `With`'s evaluate-once contract.
+   * expressions. Uses `transformUp` to handle nested `With`.
+   *
+   * Inlining duplicates a definition at every reference, so a definition referenced more than once
+   * must be safe to duplicate (see `isSafeToDuplicate`); anything else throws, as there is no plan
+   * here to pre-evaluate it into. Run [[ComputeCurrentTime]], [[ReplaceCurrentLike]] and
+   * [[SpecialDatetimeValues]] first to fold the current date/time and catalog expressions to
+   * literals.
    *
    * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
    * may contain a subquery must rewrite those plans separately.
    */
-  def applyForExpression(expression: Expression): Expression =
-    inlineWith(expression, rejectNonFoldableDefs = true)
+  private[sql] def applyForExpression(expression: Expression): Expression =
+    inlineWith(expression, checkDuplication = true)
 
   // The plan-level rewrite shares this to inline `With` in conditional branches, which may not be
-  // evaluated and so can't be pulled into a Project; it passes false to allow non-foldable defs.
-  private def inlineWith(expression: Expression, rejectNonFoldableDefs: Boolean): Expression = {
+  // evaluated and so can't be pulled into a Project; it passes false to inline unconditionally.
+  private def inlineWith(expression: Expression, checkDuplication: Boolean): Expression = {
+    // Which definitions are safe to duplicate can only be decided outer-first, so it is collected
+    // in a separate pass before inlining bottom-up.
+    val safeIds = if (checkDuplication) {
+      safeToDuplicateIds(expression)
+    } else {
+      Set.empty[CommonExpressionId]
+    }
     expression.transformUpWithPruning(_.containsPattern(WITH_EXPRESSION)) {
       case With(child, defs) =>
-        if (rejectNonFoldableDefs && !defs.forall(_.child.foldable)) {
-          throw SparkException.internalError(
-            "Cannot inline a With expression with a non-foldable common expression definition.")
+        if (checkDuplication) {
+          // Nested `With` is already rewritten, so a ref left in `child` belongs to `defs` or to
+          // an enclosing `With`. Only the ids defined here are checked.
+          val refCounts = child.collect { case ref: CommonExpressionRef => ref.id }
+            .groupBy(identity)
+            .transform((_, refs) => refs.size)
+          defs.foreach { commonExprDef =>
+            if (refCounts.getOrElse(commonExprDef.id, 0) > 1 &&
+              !safeIds.contains(commonExprDef.id)) {
+              throw SparkException.internalError(
+                "Cannot inline a common expression definition that is referenced more than " +
+                  s"once and is not safe to duplicate: ${commonExprDef.child.sql}")
+            }
+          }
         }
         val refToExpr = defs.map(commonExprDef => commonExprDef.id -> commonExprDef.child).toMap
         child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
           case ref: CommonExpressionRef if refToExpr.contains(ref.id) => refToExpr(ref.id)
         }
     }
+  }
+
+  /**
+   * Ids of the definitions that are safe to duplicate. Walks outer-first, so a definition that
+   * references an enclosing one is decided after it, and visits a definition's own nested `With`
+   * before the definition itself. Ids are globally unique, so one flat set is enough.
+   */
+  private def safeToDuplicateIds(expression: Expression): Set[CommonExpressionId] = {
+    val safeIds = mutable.Set.empty[CommonExpressionId]
+    def visit(e: Expression): Unit = if (e.containsPattern(WITH_EXPRESSION)) {
+      e match {
+        case With(child, defs) =>
+          defs.foreach { commonExprDef =>
+            visit(commonExprDef.child)
+            if (isSafeToDuplicate(commonExprDef.child, safeIds)) {
+              safeIds += commonExprDef.id
+            }
+          }
+          visit(child)
+        case other => other.children.foreach(visit)
+      }
+    }
+    visit(expression)
+    safeIds.toSet
+  }
+
+  /**
+   * Whether a copy of `e` at every reference always evaluates to the same value. `foldable` is not
+   * enough: `current_timestamp()` re-reads the clock, a TIME -> TIMESTAMP cast derives the current
+   * date, `aes_encrypt` is a foldable `StaticInvoke` with a random IV, and a Hive UDF is foldable
+   * on a user-declared determinism flag.
+   */
+  private def isSafeToDuplicate(
+      e: Expression,
+      safeIds: collection.Set[CommonExpressionId]): Boolean = {
+    // A whitelist: an unrecognized expression is rejected rather than assumed safe.
+    def isLiteralTree(e: Expression): Boolean = e match {
+      case _: Literal => true
+      // A ref is safe exactly when the definition it points to is.
+      case ref: CommonExpressionRef => safeIds.contains(ref.id)
+      // Any other leaf varies per row (attribute) or reads a clock.
+      case _: LeafExpression => false
+      // Arbitrary Java methods and UDFs can be foldable without being pure.
+      case _: NonSQLExpression | _: UserDefinedExpression => false
+      case _ => e.deterministic && e.children.forall(isLiteralTree)
+    }
+    // `current_time()` and a TIME -> TIMESTAMP cast are not leaves and their only leaf is a
+    // literal, so the tree walk accepts them and only these patterns reject them.
+    !e.containsAnyPattern(CURRENT_LIKE, CAST_TO_TIMESTAMP) && isLiteralTree(e)
   }
 
   private def applyInternal(p: LogicalPlan): LogicalPlan = {
@@ -210,9 +281,9 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
             _, inputPlans, commonExprsPerChild, commonExprIdSet, isNestedWith))
         val newExpr = c.withNewAlwaysEvaluatedInputs(newAlwaysEvaluatedInputs)
         // For With in the conditional branches, they may not be evaluated at all and we can't
-        // pull the common expressions into a project which will always be evaluated. Inline it,
-        // even when the definition is not foldable. Use transformUp to handle nested With.
-        inlineWith(newExpr, rejectNonFoldableDefs = false)
+        // pull the common expressions into a project which will always be evaluated. Inline it
+        // unconditionally. Use transformUp to handle nested With.
+        inlineWith(newExpr, checkDuplication = false)
 
       case other => other.mapChildren(
         rewriteWithExprAndInputPlans(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, PlanHelper, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern.{CAST_TO_TIMESTAMP, COMMON_EXPR_REF, CURRENT_LIKE, WITH_EXPRESSION}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{COMMON_EXPR_REF, CURRENT_LIKE, WITH_EXPRESSION}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -72,9 +72,7 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
    *
    * Inlining duplicates a definition at every reference, so a definition referenced more than once
    * must be safe to duplicate (see `isSafeToDuplicate`); anything else throws, as there is no plan
-   * here to pre-evaluate it into. Run [[ComputeCurrentTime]], [[ReplaceCurrentLike]] and
-   * [[SpecialDatetimeValues]] first to fold the current date/time and catalog expressions to
-   * literals.
+   * here to pre-evaluate it into.
    *
    * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
    * may contain a subquery must rewrite those plans separately.
@@ -101,6 +99,13 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
             .groupBy(identity)
             .transform((_, refs) => refs.size)
           defs.foreach { commonExprDef =>
+            // Canonicalization re-numbers ids per `With`, so sibling `With`s reuse ids and break
+            // the global uniqueness `safeIds` relies on. Reject them, as the plan-level rewrite
+            // does.
+            if (commonExprDef.id.canonicalized) {
+              throw SparkException.internalError(
+                "Cannot inline canonicalized common expression definitions")
+            }
             if (refCounts.getOrElse(commonExprDef.id, 0) > 1 &&
               !safeIds.contains(commonExprDef.id)) {
               throw SparkException.internalError(
@@ -110,6 +115,9 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
           }
         }
         val refToExpr = defs.map(commonExprDef => commonExprDef.id -> commonExprDef.child).toMap
+        // The guard skips refs to an enclosing `With`, which are inlined when `transformUp` reaches
+        // it. Without it those refs hit `Map.apply` on a missing key and throw
+        // NoSuchElementException.
         child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
           case ref: CommonExpressionRef if refToExpr.contains(ref.id) => refToExpr(ref.id)
         }
@@ -158,11 +166,18 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
       case _: LeafExpression => false
       // Arbitrary Java methods and UDFs can be foldable without being pure.
       case _: NonSQLExpression | _: UserDefinedExpression => false
+      // A TIME -> TIMESTAMP cast has no date of its own; it derives one from the current date at
+      // eval time, so duplicated copies could resolve different dates. Reject it. Scope to exactly
+      // this source/target pair -- other timestamp-target casts (e.g. CAST('1970-01-01' AS
+      // TIMESTAMP)) are ordinary deterministic casts and fall through to the generic check below.
+      case c: Cast
+          if Cast.isTimeToTimestampNTZ(c.child.dataType, c.dataType) ||
+            Cast.isTimeToTimestampLTZ(c.child.dataType, c.dataType) => false
       case _ => e.deterministic && e.children.forall(isLiteralTree)
     }
-    // `current_time()` and a TIME -> TIMESTAMP cast are not leaves and their only leaf is a
-    // literal, so the tree walk accepts them and only these patterns reject them.
-    !e.containsAnyPattern(CURRENT_LIKE, CAST_TO_TIMESTAMP) && isLiteralTree(e)
+    // `current_time()` is a non-leaf whose only leaf is a literal, so the tree walk accepts it;
+    // the CURRENT_LIKE pattern is what rejects it.
+    !e.containsPattern(CURRENT_LIKE) && isLiteralTree(e)
   }
 
   private def applyInternal(p: LogicalPlan): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -164,6 +164,10 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
       case ref: CommonExpressionRef => safeIds.contains(ref.id)
       // Any other leaf varies per row (attribute) or reads a clock.
       case _: LeafExpression => false
+      // A TIME -> TIMESTAMP cast stabilized by ComputeCurrentTime is a pure builder StaticInvoke;
+      // accept it here before the blanket NonSQLExpression rejection below.
+      case _ if ComputeCurrentTime.isStabilizedTimeToTimestamp(e) =>
+        e.children.forall(isLiteralTree)
       // Arbitrary Java methods and UDFs can be foldable without being pure.
       case _: NonSQLExpression | _: UserDefinedExpression => false
       // A TIME -> TIMESTAMP cast has no date of its own; it derives one from the current date at

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -66,6 +66,20 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
     }
   }
 
+  /**
+   * Rewrites the `With` expressions in a single expression tree by inlining their common
+   * expressions. Uses `transformUp` to handle nested `With`.
+   */
+  def applyForExpression(expression: Expression): Expression = {
+    expression.transformUpWithPruning(_.containsPattern(WITH_EXPRESSION)) {
+      case With(child, defs) =>
+        val refToExpr = defs.map(commonExprDef => commonExprDef.id -> commonExprDef.child).toMap
+        child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
+          case ref: CommonExpressionRef => refToExpr(ref.id)
+        }
+    }
+  }
+
   private def applyInternal(p: LogicalPlan): LogicalPlan = {
     val inputPlans = p.children
     val commonExprIdSet = p.expressions
@@ -181,16 +195,10 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
           rewriteWithExprAndInputPlans(
             _, inputPlans, commonExprsPerChild, commonExprIdSet, isNestedWith))
         val newExpr = c.withNewAlwaysEvaluatedInputs(newAlwaysEvaluatedInputs)
+        // For With in the conditional branches, they may not be evaluated at all and we can't
+        // pull the common expressions into a project which will always be evaluated. Inline it.
         // Use transformUp to handle nested With.
-        newExpr.transformUpWithPruning(_.containsPattern(WITH_EXPRESSION)) {
-          case With(child, defs) =>
-            // For With in the conditional branches, they may not be evaluated at all and we can't
-            // pull the common expressions into a project which will always be evaluated. Inline it.
-            val refToExpr = defs.map(d => d.id -> d.child).toMap
-            child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
-              case ref: CommonExpressionRef => refToExpr(ref.id)
-            }
-        }
+        applyForExpression(newExpr)
 
       case other => other.mapChildren(
         rewriteWithExprAndInputPlans(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -69,13 +69,16 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
   /**
    * Rewrites the `With` expressions in a single expression tree by inlining their common
    * expressions. Uses `transformUp` to handle nested `With`.
+   *
+   * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
+   * may contain a subquery must rewrite those plans separately.
    */
   def applyForExpression(expression: Expression): Expression = {
     expression.transformUpWithPruning(_.containsPattern(WITH_EXPRESSION)) {
       case With(child, defs) =>
         val refToExpr = defs.map(commonExprDef => commonExprDef.id -> commonExprDef.child).toMap
         child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
-          case ref: CommonExpressionRef => refToExpr(ref.id)
+          case ref: CommonExpressionRef if refToExpr.contains(ref.id) => refToExpr(ref.id)
         }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.{CurrentUserContext, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.{CastSupport, ResolvedInlineTable}
 import org.apache.spark.sql.catalyst.analysis.ResolveInlineTables.prepareForEval
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.TreePattern._
@@ -237,6 +238,13 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
           localDateTimeToTimestampNanos(asDateTime, lt.precision),
           TimestampNTZNanosType(lt.precision))
       })
+  }
+
+  /** Whether `e` is a `DateTimeUtils.makeTimestamp*` builder that `expressionTransform` emits. */
+  private[optimizer] def isStabilizedTimeToTimestamp(e: Expression): Boolean = e match {
+    case si: StaticInvoke if si.staticObject == classOf[DateTimeUtils.type] =>
+      si.functionName.startsWith("makeTimestamp")
+    case _ => false
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -240,8 +240,11 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
       })
   }
 
-  /** Whether `e` is a `DateTimeUtils.makeTimestamp*` builder that `expressionTransform` emits. */
-  private[optimizer] def isStabilizedTimeToTimestamp(e: Expression): Boolean = e match {
+  /**
+   * Whether `e` is a `DateTimeUtils.makeTimestamp*` builder `StaticInvoke`, the shape
+   * `expressionTransform` emits when stabilizing a TIME -> TIMESTAMP cast.
+   */
+  private[optimizer] def isMakeTimestampBuilder(e: Expression): Boolean = e match {
     case si: StaticInvoke if si.staticObject == classOf[DateTimeUtils.type] =>
       si.functionName.startsWith("makeTimestamp")
     case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -53,7 +53,7 @@ object ReplaceExpressions extends Rule[LogicalPlan] {
     case p => p.mapExpressions(replace)
   }
 
-  def replace(e: Expression): Expression = e match {
+  private[sql] def replace(e: Expression): Expression = e match {
     case r: RuntimeReplaceable => replace(r.replacement)
     case _ => e.mapChildren(replace)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -121,7 +121,7 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
   }
 
   /** Rewrites the current date/time functions in a single expression tree. */
-  def applyForExpression(expression: Expression): Expression =
+  private[sql] def applyForExpression(expression: Expression): Expression =
     applyForExpression(expression, Instant.now())
 
   /**
@@ -131,7 +131,7 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
    * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
    * may contain a subquery must rewrite those plans separately, reusing the same `instant`.
    */
-  def applyForExpression(expression: Expression, instant: Instant): Expression = {
+  private[sql] def applyForExpression(expression: Expression, instant: Instant): Expression = {
     val snapshot = new TimeSnapshot(instant)
     expression.transformWithPruning(transformCondition)(expressionTransform(snapshot))
   }
@@ -255,7 +255,7 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
    * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
    * may contain a subquery must rewrite those plans separately.
    */
-  def applyForExpression(expression: Expression): Expression = {
+  private[sql] def applyForExpression(expression: Expression): Expression = {
     expression.transformWithPruning(_.containsPattern(CURRENT_LIKE))(currentLikeRewrite)
   }
 
@@ -298,7 +298,7 @@ object SpecialDatetimeValues extends Rule[LogicalPlan] {
    * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
    * may contain a subquery must rewrite those plans separately.
    */
-  def applyForExpression(expression: Expression): Expression = {
+  private[sql] def applyForExpression(expression: Expression): Expression = {
     expression.transformWithPruning(_.containsPattern(CAST))(specialDatetimeRewrite)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -53,7 +53,7 @@ object ReplaceExpressions extends Rule[LogicalPlan] {
     case p => p.mapExpressions(replace)
   }
 
-  private[sql] def replace(e: Expression): Expression = e match {
+  def replace(e: Expression): Expression = e match {
     case r: RuntimeReplaceable => replace(r.replacement)
     case _ => e.mapChildren(replace)
   }
@@ -127,6 +127,9 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
   /**
    * Rewrites the current date/time functions in a single expression tree using `instant`. Callers
    * reducing several expressions that must observe the same wall clock pass one shared instant.
+   *
+   * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
+   * may contain a subquery must rewrite those plans separately, reusing the same `instant`.
    */
   def applyForExpression(expression: Expression, instant: Instant): Expression = {
     val snapshot = new TimeSnapshot(instant)
@@ -246,7 +249,12 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
     plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE))(currentLikeRewrite)
   }
 
-  /** Replaces the current catalog/database/path/user expressions in a single expression tree. */
+  /**
+   * Replaces the current catalog/database/path/user expressions in a single expression tree.
+   *
+   * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
+   * may contain a subquery must rewrite those plans separately.
+   */
   def applyForExpression(expression: Expression): Expression = {
     expression.transformWithPruning(_.containsPattern(CURRENT_LIKE))(currentLikeRewrite)
   }
@@ -284,7 +292,12 @@ object SpecialDatetimeValues extends Rule[LogicalPlan] {
     plan.transformAllExpressionsWithPruning(_.containsPattern(CAST))(specialDatetimeRewrite)
   }
 
-  /** Replaces casts of foldable special datetime strings in a single expression tree. */
+  /**
+   * Replaces casts of foldable special datetime strings in a single expression tree.
+   *
+   * Does not descend into subquery plans (e.g. `ScalarSubquery`). A caller whose expression
+   * may contain a subquery must rewrite those plans separately.
+   */
   def applyForExpression(expression: Expression): Expression = {
     expression.transformWithPruning(_.containsPattern(CAST))(specialDatetimeRewrite)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -53,7 +53,7 @@ object ReplaceExpressions extends Rule[LogicalPlan] {
     case p => p.mapExpressions(replace)
   }
 
-  private def replace(e: Expression): Expression = e match {
+  private[sql] def replace(e: Expression): Expression = e match {
     case r: RuntimeReplaceable => replace(r.replacement)
     case _ => e.mapChildren(replace)
   }
@@ -112,11 +112,49 @@ object EvalInlineTables extends Rule[LogicalPlan] with CastSupport {
  */
 object ComputeCurrentTime extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
-    val instant = Instant.now()
-    val currentTimestampMicros = instantToMicros(instant)
-    val currentTime = Literal.create(currentTimestampMicros, TimestampType)
-    val currentTimeOfDayNanos = instantToNanosOfDay(instant, conf.sessionLocalTimeZone)
-    val timezone = Literal.create(conf.sessionLocalTimeZone, StringType)
+    val snapshot = new TimeSnapshot(Instant.now())
+    plan.transformDownWithSubqueriesAndPruning(transformCondition) {
+      case subQuery =>
+        subQuery.transformAllExpressionsWithPruning(transformCondition)(
+          expressionTransform(snapshot))
+    }
+  }
+
+  /** Rewrites the current date/time functions in a single expression tree. */
+  def applyForExpression(expression: Expression): Expression =
+    applyForExpression(expression, Instant.now())
+
+  /**
+   * Rewrites the current date/time functions in a single expression tree using `instant`. Callers
+   * reducing several expressions that must observe the same wall clock pass one shared instant.
+   */
+  def applyForExpression(expression: Expression, instant: Instant): Expression = {
+    val snapshot = new TimeSnapshot(instant)
+    expression.transformWithPruning(transformCondition)(expressionTransform(snapshot))
+  }
+
+  // CAST_TO_TIMESTAMP is a dedicated tree-pattern bit set on Cast nodes whose target type is
+  // any timestamp type (NTZ or LTZ family). This lets the rule reach both TIME -> TIMESTAMP_NTZ
+  // and TIME -> TIMESTAMP_LTZ rewrites (which derive date fields from CURRENT_DATE) without the
+  // broad CAST pattern that previously widened traversal to nearly every plan. Node-level
+  // isTimeToTimestamp{NTZ,LTZ} guards keep rewrite semantics unchanged.
+  // We intentionally do NOT tag these casts with CURRENT_LIKE: inline-table validation treats
+  // CURRENT_LIKE as safe to defer, so tagging would let unrelated non-foldable timestamp-target
+  // casts (e.g. CAST(rand() AS TIMESTAMP_NTZ)) bypass validation (see SPARK-57618).
+  private def transformCondition(treePatternbits: TreePatternBits): Boolean = {
+    treePatternbits.containsPattern(CURRENT_LIKE) ||
+      treePatternbits.containsPattern(CAST_TO_TIMESTAMP)
+  }
+
+  /**
+   * Holds the wall-clock instant and the per-invocation literal caches shared by every rewrite, so
+   * all current date/time references within one invocation observe the same instant.
+   */
+  private class TimeSnapshot(val instant: Instant) {
+    val currentTimestampMicros: Long = instantToMicros(instant)
+    val currentTime: Literal = Literal.create(currentTimestampMicros, TimestampType)
+    val currentTimeOfDayNanos: Long = instantToNanosOfDay(instant, conf.sessionLocalTimeZone)
+    val timezone: Literal = Literal.create(conf.sessionLocalTimeZone, StringType)
     val currentDates = collection.mutable.HashMap.empty[ZoneId, Literal]
     val localTimestamps = collection.mutable.HashMap.empty[ZoneId, Literal]
     // Nanosecond current-timestamp literals depend on the requested precision (sub-precision
@@ -124,94 +162,78 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
     // by precision only; NTZ (localtimestamp) is keyed by (zone, precision) like its micro sibling.
     val currentTimestampNanos = collection.mutable.HashMap.empty[Int, Literal]
     val localTimestampNanos = collection.mutable.HashMap.empty[(ZoneId, Int), Literal]
+  }
 
-    // CAST_TO_TIMESTAMP is a dedicated tree-pattern bit set on Cast nodes whose target type is
-    // any timestamp type (NTZ or LTZ family). This lets the rule reach both TIME -> TIMESTAMP_NTZ
-    // and TIME -> TIMESTAMP_LTZ rewrites (which derive date fields from CURRENT_DATE) without the
-    // broad CAST pattern that previously widened traversal to nearly every plan. Node-level
-    // isTimeToTimestamp{NTZ,LTZ} guards keep rewrite semantics unchanged.
-    // We intentionally do NOT tag these casts with CURRENT_LIKE: inline-table validation treats
-    // CURRENT_LIKE as safe to defer, so tagging would let unrelated non-foldable timestamp-target
-    // casts (e.g. CAST(rand() AS TIMESTAMP_NTZ)) bypass validation (see SPARK-57618).
-    def transformCondition(treePatternbits: TreePatternBits): Boolean = {
-      treePatternbits.containsPattern(CURRENT_LIKE) ||
-        treePatternbits.containsPattern(CAST_TO_TIMESTAMP)
-    }
-
-    plan.transformDownWithSubqueriesAndPruning(transformCondition) {
-      case subQuery =>
-        subQuery.transformAllExpressionsWithPruning(transformCondition) {
-          case cd: CurrentDate =>
-            currentDates.getOrElseUpdate(cd.zoneId, {
-              Literal.create(
-                DateTimeUtils.microsToDays(currentTimestampMicros, cd.zoneId), DateType)
-            })
-          // CAST(time AS TIMESTAMP_NTZ(q)) fills the date fields from CURRENT_DATE. Rewrite it to
-          // a date+time builder anchored on the same query-stable current date literal that
-          // current_date() resolves to, so all references agree within the query. The builder's
-          // `replacement` (a StaticInvoke) is emitted directly because ReplaceExpressions has
-          // already run earlier in this batch and will not expand a fresh RuntimeReplaceable.
-          case c: Cast if Cast.isTimeToTimestampNTZ(c.child.dataType, c.dataType) =>
-            val dateLit = currentDates.getOrElseUpdate(c.zoneId, {
-              Literal.create(
-                DateTimeUtils.microsToDays(currentTimestampMicros, c.zoneId), DateType)
-            })
-            c.dataType match {
-              case n: TimestampNTZNanosType =>
-                MakeTimestampNTZNanos(dateLit, c.child, n.precision).replacement
-              case _: TimestampNTZType =>
-                MakeTimestampNTZ(dateLit, c.child).replacement
-              case other =>
-                // Unreachable: the outer guard `Cast.isTimeToTimestampNTZ` only matches the micro
-                // TimestampNTZType and the nanosecond TimestampNTZNanosType targets.
-                throw SparkException.internalError(
-                  s"Unexpected target type in TIME -> TIMESTAMP_NTZ rewrite: $other")
-            }
-          // CAST(time AS TIMESTAMP_LTZ(q)) likewise fills the date fields from CURRENT_DATE.
-          // Rewrite it to a zone-aware date+time builder anchored on the same query-stable current
-          // date literal, so all references agree within the query.
-          case c: Cast if Cast.isTimeToTimestampLTZ(c.child.dataType, c.dataType) =>
-            val dateLit = currentDates.getOrElseUpdate(c.zoneId, {
-              Literal.create(
-                DateTimeUtils.microsToDays(currentTimestampMicros, c.zoneId), DateType)
-            })
-            c.dataType match {
-              case l: TimestampLTZNanosType =>
-                MakeTimestampLTZNanos(dateLit, c.child, l.precision, c.timeZoneId).replacement
-              case _: TimestampType =>
-                MakeTimestampLTZ(dateLit, c.child, c.timeZoneId).replacement
-              case other =>
-                // Unreachable: the outer guard `Cast.isTimeToTimestampLTZ` only matches the micro
-                // TimestampType and the nanosecond TimestampLTZNanosType targets.
-                throw SparkException.internalError(
-                  s"Unexpected target type in TIME -> TIMESTAMP_LTZ rewrite: $other")
-            }
-          case currentTimeType : CurrentTime =>
-            val truncatedTime = truncateTimeToPrecision(currentTimeOfDayNanos,
-              currentTimeType.precision)
-            Literal.create(truncatedTime, TimeType(currentTimeType.precision))
-          case CurrentTimestamp() | Now() => currentTime
-          case ct: CurrentTimestampNanos =>
-            currentTimestampNanos.getOrElseUpdate(ct.precision, {
-              Literal.create(
-                instantToTimestampNanos(instant, ct.precision),
-                TimestampLTZNanosType(ct.precision))
-            })
-          case CurrentTimeZone() => timezone
-          case localTimestamp: LocalTimestamp =>
-            localTimestamps.getOrElseUpdate(localTimestamp.zoneId, {
-              val asDateTime = LocalDateTime.ofInstant(instant, localTimestamp.zoneId)
-              Literal.create(localDateTimeToMicros(asDateTime), TimestampNTZType)
-            })
-          case lt: LocalTimestampNanos =>
-            localTimestampNanos.getOrElseUpdate((lt.zoneId, lt.precision), {
-              val asDateTime = LocalDateTime.ofInstant(instant, lt.zoneId)
-              Literal.create(
-                localDateTimeToTimestampNanos(asDateTime, lt.precision),
-                TimestampNTZNanosType(lt.precision))
-            })
-        }
-    }
+  private def expressionTransform(ts: TimeSnapshot): PartialFunction[Expression, Expression] = {
+    case cd: CurrentDate =>
+      ts.currentDates.getOrElseUpdate(cd.zoneId, {
+        Literal.create(
+          DateTimeUtils.microsToDays(ts.currentTimestampMicros, cd.zoneId), DateType)
+      })
+    // CAST(time AS TIMESTAMP_NTZ(q)) fills the date fields from CURRENT_DATE. Rewrite it to
+    // a date+time builder anchored on the same query-stable current date literal that
+    // current_date() resolves to, so all references agree within the query. The builder's
+    // `replacement` (a StaticInvoke) is emitted directly because ReplaceExpressions has
+    // already run earlier in this batch and will not expand a fresh RuntimeReplaceable.
+    case c: Cast if Cast.isTimeToTimestampNTZ(c.child.dataType, c.dataType) =>
+      val dateLit = ts.currentDates.getOrElseUpdate(c.zoneId, {
+        Literal.create(
+          DateTimeUtils.microsToDays(ts.currentTimestampMicros, c.zoneId), DateType)
+      })
+      c.dataType match {
+        case n: TimestampNTZNanosType =>
+          MakeTimestampNTZNanos(dateLit, c.child, n.precision).replacement
+        case _: TimestampNTZType =>
+          MakeTimestampNTZ(dateLit, c.child).replacement
+        case other =>
+          // Unreachable: the outer guard `Cast.isTimeToTimestampNTZ` only matches the micro
+          // TimestampNTZType and the nanosecond TimestampNTZNanosType targets.
+          throw SparkException.internalError(
+            s"Unexpected target type in TIME -> TIMESTAMP_NTZ rewrite: $other")
+      }
+    // CAST(time AS TIMESTAMP_LTZ(q)) likewise fills the date fields from CURRENT_DATE.
+    // Rewrite it to a zone-aware date+time builder anchored on the same query-stable current
+    // date literal, so all references agree within the query.
+    case c: Cast if Cast.isTimeToTimestampLTZ(c.child.dataType, c.dataType) =>
+      val dateLit = ts.currentDates.getOrElseUpdate(c.zoneId, {
+        Literal.create(
+          DateTimeUtils.microsToDays(ts.currentTimestampMicros, c.zoneId), DateType)
+      })
+      c.dataType match {
+        case l: TimestampLTZNanosType =>
+          MakeTimestampLTZNanos(dateLit, c.child, l.precision, c.timeZoneId).replacement
+        case _: TimestampType =>
+          MakeTimestampLTZ(dateLit, c.child, c.timeZoneId).replacement
+        case other =>
+          // Unreachable: the outer guard `Cast.isTimeToTimestampLTZ` only matches the micro
+          // TimestampType and the nanosecond TimestampLTZNanosType targets.
+          throw SparkException.internalError(
+            s"Unexpected target type in TIME -> TIMESTAMP_LTZ rewrite: $other")
+      }
+    case currentTimeType : CurrentTime =>
+      val truncatedTime = truncateTimeToPrecision(ts.currentTimeOfDayNanos,
+        currentTimeType.precision)
+      Literal.create(truncatedTime, TimeType(currentTimeType.precision))
+    case CurrentTimestamp() | Now() => ts.currentTime
+    case ct: CurrentTimestampNanos =>
+      ts.currentTimestampNanos.getOrElseUpdate(ct.precision, {
+        Literal.create(
+          instantToTimestampNanos(ts.instant, ct.precision),
+          TimestampLTZNanosType(ct.precision))
+      })
+    case CurrentTimeZone() => ts.timezone
+    case localTimestamp: LocalTimestamp =>
+      ts.localTimestamps.getOrElseUpdate(localTimestamp.zoneId, {
+        val asDateTime = LocalDateTime.ofInstant(ts.instant, localTimestamp.zoneId)
+        Literal.create(localDateTimeToMicros(asDateTime), TimestampNTZType)
+      })
+    case lt: LocalTimestampNanos =>
+      ts.localTimestampNanos.getOrElseUpdate((lt.zoneId, lt.precision), {
+        val asDateTime = LocalDateTime.ofInstant(ts.instant, lt.zoneId)
+        Literal.create(
+          localDateTimeToTimestampNanos(asDateTime, lt.precision),
+          TimestampNTZNanosType(lt.precision))
+      })
   }
 }
 
@@ -221,13 +243,22 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
  */
 case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE))(currentLikeRewrite)
+  }
+
+  /** Replaces the current catalog/database/path/user expressions in a single expression tree. */
+  def applyForExpression(expression: Expression): Expression = {
+    expression.transformWithPruning(_.containsPattern(CURRENT_LIKE))(currentLikeRewrite)
+  }
+
+  private def currentLikeRewrite: PartialFunction[Expression, Expression] = {
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
     lazy val currentNamespace = catalogManager.currentNamespace.quoted
     lazy val currentCatalog = catalogManager.currentCatalog.name()
     lazy val currentUser = CurrentUserContext.getCurrentUser
     lazy val currentPathStr = catalogManager.currentPathString
 
-    plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
+    {
       case CurrentDatabase() =>
         Literal.create(currentNamespace, StringType)
       case CurrentCatalog() =>
@@ -250,14 +281,21 @@ object SpecialDatetimeValues extends Rule[LogicalPlan] {
     TimestampType -> convertSpecialTimestamp,
     TimestampNTZType -> convertSpecialTimestampNTZ)
   def apply(plan: LogicalPlan): LogicalPlan = {
-    plan.transformAllExpressionsWithPruning(_.containsPattern(CAST)) {
-      case cast @ Cast(e, dt @ (DateType | TimestampType | TimestampNTZType), _, _)
-        if e.foldable && e.dataType == StringType =>
-        Option(e.eval())
-          .flatMap(s => conv(dt)(s.toString, cast.zoneId))
-          .map(Literal(_, dt))
-          .getOrElse(cast)
-    }
+    plan.transformAllExpressionsWithPruning(_.containsPattern(CAST))(specialDatetimeRewrite)
+  }
+
+  /** Replaces casts of foldable special datetime strings in a single expression tree. */
+  def applyForExpression(expression: Expression): Expression = {
+    expression.transformWithPruning(_.containsPattern(CAST))(specialDatetimeRewrite)
+  }
+
+  private val specialDatetimeRewrite: PartialFunction[Expression, Expression] = {
+    case cast @ Cast(e, dt @ (DateType | TimestampType | TimestampNTZType), _, _)
+      if e.foldable && e.dataType == StringType =>
+      Option(e.eval())
+        .flatMap(s => conv(dt)(s.toString, cast.zoneId))
+        .map(Literal(_, dt))
+        .getOrElse(cast)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Cast, CurrentDate, CurrentTime, CurrentTimestamp, CurrentTimestampNanos, CurrentTimeZone, Expression, InSubquery, ListQuery, Literal, LocalTimestamp, LocalTimestampNanos, Now}
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Cast, CurrentDate, CurrentTime, CurrentTimestamp, CurrentTimestampNanos, CurrentTimeZone, Expression, InSubquery, ListQuery, Literal, LocalTimestamp, LocalTimestampNanos, Now, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
@@ -336,6 +336,32 @@ class ComputeCurrentTimeSuite extends PlanTest {
     checkLiterals({ zoneId: String => LocalTimestamp(Some(zoneId)) }, numUniqueZoneIds)
     checkLiterals({ _: String => Now() }, 1)
     checkLiterals({ zoneId: String => CurrentDate(Some(zoneId)) }, numUniqueZoneIds)
+  }
+
+  test("applyForExpression rewrites current date/time leaves to literals") {
+    val date = ComputeCurrentTime.applyForExpression(CurrentDate(Some("UTC")))
+    assert(date.isInstanceOf[Literal] && date.dataType == DateType)
+    val timestamp = ComputeCurrentTime.applyForExpression(CurrentTimestamp())
+    assert(timestamp.isInstanceOf[Literal] && timestamp.dataType == TimestampType)
+  }
+
+  test("applyForExpression shares the provided instant across expressions") {
+    val instant = Instant.now()
+    val timestamp = ComputeCurrentTime.applyForExpression(CurrentTimestamp(), instant)
+    val now = ComputeCurrentTime.applyForExpression(Now(), instant)
+    assert(timestamp.isInstanceOf[Literal] && now.isInstanceOf[Literal])
+    val micros = DateTimeUtils.instantToMicros(instant)
+    assert(timestamp.asInstanceOf[Literal].value == micros)
+    assert(now.asInstanceOf[Literal].value == micros)
+  }
+
+  test("applyForExpression does not descend into subquery plans") {
+    // current_timestamp() inside the subquery plan is left for a separate pass.
+    val subquery = ScalarSubquery(
+      Project(Seq(Alias(CurrentTimestamp(), "ts")()), LocalRelation()))
+    val rewritten = ComputeCurrentTime.applyForExpression(subquery)
+    val innerPlan = rewritten.asInstanceOf[ScalarSubquery].plan
+    assert(innerPlan.expressions.exists(_.exists(_.isInstanceOf[CurrentTimestamp])))
   }
 
   test("CAST(time AS TIMESTAMP_NTZ) is stabilized with the query current date") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
@@ -45,6 +45,23 @@ class ConstantFoldingSuite extends PlanTest {
 
   val testRelation = LocalRelation($"a".int, $"b".int, $"c".int)
 
+  test("constantFolding folds a foldable expression tree to a literal") {
+    assert(ConstantFolding.constantFolding(Literal(1) + Literal(2)) == Literal(3))
+  }
+
+  test("constantFolding folds nested foldable subtrees") {
+    assert(ConstantFolding.constantFolding((Literal(1) + Literal(2)) * Literal(3)) == Literal(9))
+  }
+
+  test("constantFolding folds only the foldable parts of a partially-foldable tree") {
+    val a = testRelation.output.head
+    assert(ConstantFolding.constantFolding(a + (Literal(1) + Literal(2))) == a + Literal(3))
+  }
+
+  test("constantFolding returns a literal unchanged") {
+    assert(ConstantFolding.constantFolding(Literal(5)) == Literal(5))
+  }
+
   test("eliminate subqueries") {
     val originalQuery =
       testRelation

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceCurrentLikeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceCurrentLikeSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.analysis.{EmptyFunctionRegistry, EmptyTableFunctionRegistry, FakeV2SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.expressions.{Coalesce, CurrentCatalog, CurrentDatabase, Literal}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+import org.apache.spark.sql.connector.catalog.DefaultCatalogManager
+import org.apache.spark.sql.types.StringType
+
+class ReplaceCurrentLikeSuite extends PlanTest {
+  private val catalogManager = new DefaultCatalogManager(
+    FakeV2SessionCatalog,
+    new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, EmptyTableFunctionRegistry))
+  private val rule = ReplaceCurrentLike(catalogManager)
+
+  test("applyForExpression replaces current catalog/database with literals") {
+    assert(rule.applyForExpression(CurrentCatalog()) ==
+      Literal.create(catalogManager.currentCatalog.name(), StringType))
+    assert(rule.applyForExpression(CurrentDatabase()) ==
+      Literal.create(catalogManager.currentNamespace.quoted, StringType))
+  }
+
+  test("applyForExpression rewrites current-like nested in a larger expression") {
+    val expr = Coalesce(Seq(CurrentCatalog(), Literal("x")))
+    val expected = Coalesce(Seq(
+      Literal.create(catalogManager.currentCatalog.name(), StringType), Literal("x")))
+    assert(rule.applyForExpression(expr) == expected)
+  }
+
+  test("applyForExpression leaves expressions without current-like unchanged") {
+    assert(rule.applyForExpression(Literal("x")) == Literal("x"))
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceCurrentLikeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceCurrentLikeSuite.scala
@@ -17,15 +17,15 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis.{EmptyFunctionRegistry, EmptyTableFunctionRegistry, FakeV2SessionCatalog}
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{Coalesce, CurrentCatalog, CurrentDatabase, Literal}
-import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.DefaultCatalogManager
 import org.apache.spark.sql.types.StringType
 
-class ReplaceCurrentLikeSuite extends PlanTest {
+class ReplaceCurrentLikeSuite extends SparkFunSuite {
   private val catalogManager = new DefaultCatalogManager(
     FakeV2SessionCatalog,
     new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, EmptyTableFunctionRegistry))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExpressionsSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.{Add, Coalesce, Literal, Nvl, RuntimeReplaceable}
-import org.apache.spark.sql.catalyst.plans.PlanTest
 
-class ReplaceExpressionsSuite extends PlanTest {
+class ReplaceExpressionsSuite extends SparkFunSuite {
 
   test("replace expands RuntimeReplaceable expressions") {
     val replaced = ReplaceExpressions.replace(new Nvl(Literal(1), Literal(2)))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceExpressionsSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Add, Coalesce, Literal, Nvl, RuntimeReplaceable}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+
+class ReplaceExpressionsSuite extends PlanTest {
+
+  test("replace expands RuntimeReplaceable expressions") {
+    val replaced = ReplaceExpressions.replace(new Nvl(Literal(1), Literal(2)))
+    assert(!replaced.exists(_.isInstanceOf[RuntimeReplaceable]))
+    assert(replaced == Coalesce(Seq(Literal(1), Literal(2))))
+  }
+
+  test("replace expands nested RuntimeReplaceable expressions") {
+    val nested = new Nvl(new Nvl(Literal(1), Literal(2)), Literal(3))
+    val replaced = ReplaceExpressions.replace(nested)
+    assert(!replaced.exists(_.isInstanceOf[RuntimeReplaceable]))
+    assert(replaced == Coalesce(Seq(Coalesce(Seq(Literal(1), Literal(2))), Literal(3))))
+  }
+
+  test("replace recurses into children of non-RuntimeReplaceable expressions") {
+    val e = Add(Literal(1), new Nvl(Literal(2), Literal(3)))
+    assert(ReplaceExpressions.replace(e) == Add(Literal(1), Coalesce(Seq(Literal(2), Literal(3)))))
+  }
+
+  test("replace leaves expressions without RuntimeReplaceable unchanged") {
+    assert(ReplaceExpressions.replace(Literal(1)) == Literal(1))
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -290,6 +290,20 @@ class RewriteWithExpressionSuite extends PlanTest {
     assert(finishAnalysisAndInline(expr, Instant.now()) == EqualTo(expected, expected))
   }
 
+  test("applyForExpression inlines a TIME -> TIMESTAMP cast stabilized by ComputeCurrentTime") {
+    // ComputeCurrentTime rewrites the cast to a pure makeTimestamp* builder StaticInvoke anchored
+    // on a query-stable current-date literal. Even though ConstantFolding (not part of this
+    // pipeline) has not folded it to a single literal, inlining it at both references is safe.
+    val expr = With(Cast(Literal(0L, TimeType(6)), TimestampNTZType, Some("UTC"))) {
+      case Seq(ref) => EqualTo(ref, ref)
+    }
+    val rewritten = finishAnalysisAndInline(expr, Instant.now())
+    assert(!rewritten.exists(_.isInstanceOf[With]))
+    val EqualTo(left, right) = rewritten: @unchecked
+    assert(ComputeCurrentTime.isStabilizedTimeToTimestamp(left))
+    assert(left == right)
+  }
+
   test("non-cheap common expression") {
     val a = testRelation.output.head
     val expr = With(a + a) { case Seq(ref) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -300,7 +300,19 @@ class RewriteWithExpressionSuite extends PlanTest {
     val rewritten = finishAnalysisAndInline(expr, Instant.now())
     assert(!rewritten.exists(_.isInstanceOf[With]))
     val EqualTo(left, right) = rewritten: @unchecked
-    assert(ComputeCurrentTime.isStabilizedTimeToTimestamp(left))
+    assert(ComputeCurrentTime.isMakeTimestampBuilder(left))
+    assert(left == right)
+  }
+
+  test("applyForExpression inlines a stabilized TIME -> TIMESTAMP_LTZ cast") {
+    // The LTZ target reaches isMakeTimestampBuilder through the same gate as the NTZ case above.
+    val expr = With(Cast(Literal(0L, TimeType(6)), TimestampType, Some("UTC"))) {
+      case Seq(ref) => EqualTo(ref, ref)
+    }
+    val rewritten = finishAnalysisAndInline(expr, Instant.now())
+    assert(!rewritten.exists(_.isInstanceOf[With]))
+    val EqualTo(left, right) = rewritten: @unchecked
+    assert(ComputeCurrentTime.isMakeTimestampBuilder(left))
     assert(left == right)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -17,14 +17,21 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import java.time.Instant
+
 import org.apache.spark.SparkException
-import org.apache.spark.sql.catalyst.analysis.TempResolvedColumn
+import org.apache.spark.sql.catalyst.analysis.{EmptyFunctionRegistry, EmptyTableFunctionRegistry, FakeV2SessionCatalog, TempResolvedColumn}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+import org.apache.spark.sql.connector.catalog.DefaultCatalogManager
+import org.apache.spark.sql.types.{DateType, StringType, TimestampNTZType, TimestampType, TimeType}
 
 class RewriteWithExpressionSuite extends PlanTest {
 
@@ -36,6 +43,21 @@ class RewriteWithExpressionSuite extends PlanTest {
 
   private val testRelation = LocalRelation($"a".int, $"b".int)
   private val testRelation2 = LocalRelation($"x".int, $"y".int)
+
+  private val catalogManager = new DefaultCatalogManager(
+    FakeV2SessionCatalog,
+    new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, EmptyTableFunctionRegistry))
+
+  /**
+   * Runs the expression-level rewrites that `applyForExpression` requires to have run first, in
+   * the same order as the optimizer's `FinishAnalysis` batch, then inlines the `With`.
+   */
+  private def finishAnalysisAndInline(expr: Expression, instant: Instant): Expression = {
+    val afterCurrentTime = ComputeCurrentTime.applyForExpression(expr, instant)
+    val afterCurrentLike = ReplaceCurrentLike(catalogManager).applyForExpression(afterCurrentTime)
+    RewriteWithExpression.applyForExpression(
+      SpecialDatetimeValues.applyForExpression(afterCurrentLike))
+  }
 
   private def normalizeCommonExpressionIds(plan: LogicalPlan): LogicalPlan = {
     plan.transformAllExpressions {
@@ -60,7 +82,7 @@ class RewriteWithExpressionSuite extends PlanTest {
     comparePlans(Optimizer.execute(plan), testRelation.select((a + a).as("col")))
   }
 
-  test("applyForExpression inlines foldable common expressions") {
+  test("applyForExpression inlines a literal referenced more than once") {
     val expr = With(Literal(1)) { case Seq(ref) =>
       ref + ref
     }
@@ -69,15 +91,98 @@ class RewriteWithExpressionSuite extends PlanTest {
     assert(rewritten == Literal(1) + Literal(1))
   }
 
-  test("applyForExpression rejects non-foldable common expressions") {
-    // Inlining would duplicate `a + a` at every reference, violating the evaluate-once contract,
-    // so a non-foldable definition is rejected rather than inlined.
+  test("applyForExpression inlines a non-literal referenced at most once") {
+    // Inlining does not duplicate the definition here, so it is safe whatever the definition is.
+    val a = testRelation.output.head
+    val referencedOnce = With(a + a) { case Seq(ref) =>
+      ref * Literal(2)
+    }
+    assert(RewriteWithExpression.applyForExpression(referencedOnce) == (a + a) * Literal(2))
+    val neverReferenced = With(a + a) { case Seq(_) =>
+      Literal(3)
+    }
+    assert(RewriteWithExpression.applyForExpression(neverReferenced) == Literal(3))
+  }
+
+  test("applyForExpression rejects a non-literal referenced more than once") {
+    // Inlining would duplicate `a + a` at every reference, violating the evaluate-once contract.
     val a = testRelation.output.head
     val expr = With(a + a) { case Seq(ref) =>
       ref * ref
     }
     intercept[SparkException] {
       RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
+  test("applyForExpression inlines a tree of literals referenced more than once") {
+    val expr = With(Literal(1) + Literal(1)) { case Seq(ref) =>
+      ref * ref
+    }
+    val rewritten = RewriteWithExpression.applyForExpression(expr)
+    assert(rewritten == (Literal(1) + Literal(1)) * (Literal(1) + Literal(1)))
+  }
+
+  test("applyForExpression rejects an impure foldable definition referenced more than once") {
+    // aes_encrypt becomes a foldable StaticInvoke that draws a fresh random IV on every eval, so
+    // two inlined copies would encrypt to different values.
+    val aes = ReplaceExpressions.replace(
+      new AesEncrypt(Literal("abc".getBytes), Literal("1234567890123456".getBytes)))
+    assert(aes.foldable, "the AES rewrite is only interesting while it stays foldable")
+    val expr = With(aes) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
+  test("applyForExpression rejects current_time referenced more than once") {
+    // CurrentTime is not a leaf and its only leaf is a literal precision, so the structural check
+    // alone would accept it.
+    val expr = With(CurrentTime()) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
+  test("applyForExpression rejects a TIME -> TIMESTAMP cast referenced more than once") {
+    // The cast fills its date fields from the current date, so it is not safe to duplicate even
+    // though its only leaf is a literal.
+    val expr = With(Cast(Literal(0L, TimeType(6)), TimestampNTZType, Some("UTC"))) {
+      case Seq(ref) => EqualTo(ref, ref)
+    }
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
+  test("applyForExpression inlines an inner def referencing a foldable outer def") {
+    val outer = With(Literal(1)) { case Seq(outerRef) =>
+      With(outerRef + Literal(1)) { case Seq(innerRef) =>
+        innerRef + innerRef
+      }
+    }
+    val rewritten = RewriteWithExpression.applyForExpression(outer)
+    assert(!rewritten.exists(_.isInstanceOf[With]))
+    assert(!rewritten.exists(_.isInstanceOf[CommonExpressionRef]))
+    val inlinedInner = Literal(1) + Literal(1)
+    assert(rewritten == inlinedInner + inlinedInner)
+  }
+
+  test("applyForExpression rejects an inner def referencing a per-row outer def") {
+    // A ref is only safe to duplicate when its definition is: here the outer definition is an
+    // attribute, so duplicating `a + 1` would evaluate it once per reference.
+    val a = testRelation.output.head
+    val outer = With(a) { case Seq(outerRef) =>
+      With(outerRef + Literal(1)) { case Seq(innerRef) =>
+        innerRef + innerRef
+      }
+    }
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(outer)
     }
   }
 
@@ -91,6 +196,8 @@ class RewriteWithExpressionSuite extends PlanTest {
     val rewritten = RewriteWithExpression.applyForExpression(outer)
     assert(!rewritten.exists(_.isInstanceOf[With]))
     assert(!rewritten.exists(_.isInstanceOf[CommonExpressionRef]))
+    val inlinedInner = Literal(1) * Literal(1) + Literal(2)
+    assert(rewritten == inlinedInner + inlinedInner)
   }
 
   test("applyForExpression leaves expressions without With unchanged") {
@@ -110,6 +217,42 @@ class RewriteWithExpressionSuite extends PlanTest {
     assert(!rewritten.exists(_.isInstanceOf[With]))
     assert(!rewritten.exists(_.isInstanceOf[CommonExpressionRef]))
     assert(rewritten == Literal(1) + Literal(2))
+  }
+
+  test("applyForExpression rejects current_timestamp that ComputeCurrentTime has not folded") {
+    // current_timestamp() is foldable, but each eval re-reads the clock, so inlining it at two
+    // references could produce two different values.
+    val expr = With(CurrentTimestamp()) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
+  test("applyForExpression inlines current_timestamp folded to one shared literal") {
+    val instant = Instant.now()
+    val expr = With(CurrentTimestamp()) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    val expected = Literal.create(DateTimeUtils.instantToMicros(instant), TimestampType)
+    assert(finishAnalysisAndInline(expr, instant) == EqualTo(expected, expected))
+  }
+
+  test("applyForExpression inlines current_database folded by ReplaceCurrentLike") {
+    val expr = With(CurrentDatabase()) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    val expected = Literal.create(catalogManager.currentNamespace.quoted, StringType)
+    assert(finishAnalysisAndInline(expr, Instant.now()) == EqualTo(expected, expected))
+  }
+
+  test("applyForExpression inlines a special datetime value folded by SpecialDatetimeValues") {
+    val expr = With(Cast(Literal("epoch"), DateType, Some("UTC"))) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    val expected = Literal(0, DateType)
+    assert(finishAnalysisAndInline(expr, Instant.now()) == EqualTo(expected, expected))
   }
 
   test("non-cheap common expression") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -49,11 +49,12 @@ class RewriteWithExpressionSuite extends PlanTest {
     new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, EmptyTableFunctionRegistry))
 
   /**
-   * Runs the expression-level rewrites that `applyForExpression` requires to have run first, in
-   * the same order as the optimizer's `FinishAnalysis` batch, then inlines the `With`.
+   * Runs the expression-level rewrites in the same order as the optimizer's `FinishAnalysis`
+   * batch, then inlines the `With`.
    */
   private def finishAnalysisAndInline(expr: Expression, instant: Instant): Expression = {
-    val afterCurrentTime = ComputeCurrentTime.applyForExpression(expr, instant)
+    val afterReplace = ReplaceExpressions.replace(expr)
+    val afterCurrentTime = ComputeCurrentTime.applyForExpression(afterReplace, instant)
     val afterCurrentLike = ReplaceCurrentLike(catalogManager).applyForExpression(afterCurrentTime)
     RewriteWithExpression.applyForExpression(
       SpecialDatetimeValues.applyForExpression(afterCurrentLike))
@@ -137,6 +138,19 @@ class RewriteWithExpressionSuite extends PlanTest {
     }
   }
 
+  test("applyForExpression rejects canonicalized common expression ids") {
+    // Canonicalization re-numbers ids per `With`, starting from 1, so these two siblings both get
+    // id 1: the safe (literal) definition would otherwise mark id 1 safe in the flat `safeIds` set
+    // and authorize duplicating the unsafe (per-row attribute) definition with the same id.
+    val a = testRelation.output.head
+    val safe = With(Literal(1)) { case Seq(ref) => ref + ref }
+    val unsafe = With(a) { case Seq(ref) => ref + ref }
+    val expr = (safe + unsafe).canonicalized
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
   test("applyForExpression rejects current_time referenced more than once") {
     // CurrentTime is not a leaf and its only leaf is a literal precision, so the structural check
     // alone would accept it.
@@ -157,6 +171,27 @@ class RewriteWithExpressionSuite extends PlanTest {
     intercept[SparkException] {
       RewriteWithExpression.applyForExpression(expr)
     }
+  }
+
+  test("applyForExpression rejects a TIME -> TIMESTAMP_LTZ cast referenced more than once") {
+    // Same TimestampType target as the inlined string cast below; only the TIME source makes it
+    // unsafe, so the node-level check must key on the source type, not the target.
+    val expr = With(Cast(Literal(0L, TimeType(6)), TimestampType, Some("UTC"))) {
+      case Seq(ref) => EqualTo(ref, ref)
+    }
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
+  }
+
+  test("applyForExpression inlines a non-TIME timestamp-target cast referenced more than once") {
+    // A string -> TIMESTAMP cast carries the CAST_TO_TIMESTAMP tree pattern (keyed on target type
+    // alone) but is an ordinary deterministic cast, so it must inline rather than be rejected.
+    val cast = Cast(Literal("1970-01-01"), TimestampType, Some("UTC"))
+    val expr = With(cast) { case Seq(ref) =>
+      EqualTo(ref, ref)
+    }
+    assert(RewriteWithExpression.applyForExpression(expr) == EqualTo(cast, cast))
   }
 
   test("applyForExpression inlines an inner def referencing a foldable outer def") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.TempResolvedColumn
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
@@ -59,33 +60,32 @@ class RewriteWithExpressionSuite extends PlanTest {
     comparePlans(Optimizer.execute(plan), testRelation.select((a + a).as("col")))
   }
 
-  test("applyForExpression inlines With common expressions") {
-    val a = testRelation.output.head
-    val expr = With(a) { case Seq(ref) =>
+  test("applyForExpression inlines foldable common expressions") {
+    val expr = With(Literal(1)) { case Seq(ref) =>
       ref + ref
     }
     val rewritten = RewriteWithExpression.applyForExpression(expr)
     assert(!rewritten.isInstanceOf[With])
-    assert(rewritten == a + a)
+    assert(rewritten == Literal(1) + Literal(1))
   }
 
-  test("applyForExpression always inlines non-cheap common expressions") {
+  test("applyForExpression rejects non-foldable common expressions") {
+    // Inlining would duplicate `a + a` at every reference, violating the evaluate-once contract,
+    // so a non-foldable definition is rejected rather than inlined.
     val a = testRelation.output.head
     val expr = With(a + a) { case Seq(ref) =>
       ref * ref
     }
-    val rewritten = RewriteWithExpression.applyForExpression(expr)
-    assert(!rewritten.exists(_.isInstanceOf[With]))
-    assert(rewritten == (a + a) * (a + a))
+    intercept[SparkException] {
+      RewriteWithExpression.applyForExpression(expr)
+    }
   }
 
   test("applyForExpression handles nested With") {
-    val a = testRelation.output.head
-    val b = testRelation.output.last
-    val inner = With(a + a) { case Seq(ref) =>
+    val inner = With(Literal(1)) { case Seq(ref) =>
       ref * ref
     }
-    val outer = With(inner + b) { case Seq(ref) =>
+    val outer = With(inner + Literal(2)) { case Seq(ref) =>
       ref + ref
     }
     val rewritten = RewriteWithExpression.applyForExpression(outer)
@@ -101,16 +101,15 @@ class RewriteWithExpressionSuite extends PlanTest {
   test("applyForExpression defers a ref to an outer common expression to the enclosing With") {
     // The inner `With` is rewritten first, so the outer ref it references is not yet in scope
     // and must be left for the enclosing `With` to inline.
-    val a = testRelation.output.head
-    val outer = With(a + a) { case Seq(outerRef) =>
-      With(a * a) { case Seq(innerRef) =>
+    val outer = With(Literal(1)) { case Seq(outerRef) =>
+      With(Literal(2)) { case Seq(innerRef) =>
         outerRef + innerRef
       }
     }
     val rewritten = RewriteWithExpression.applyForExpression(outer)
     assert(!rewritten.exists(_.isInstanceOf[With]))
     assert(!rewritten.exists(_.isInstanceOf[CommonExpressionRef]))
-    assert(rewritten == (a + a) + (a * a))
+    assert(rewritten == Literal(1) + Literal(2))
   }
 
   test("non-cheap common expression") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -59,6 +59,60 @@ class RewriteWithExpressionSuite extends PlanTest {
     comparePlans(Optimizer.execute(plan), testRelation.select((a + a).as("col")))
   }
 
+  test("applyForExpression inlines With common expressions") {
+    val a = testRelation.output.head
+    val expr = With(a) { case Seq(ref) =>
+      ref + ref
+    }
+    val rewritten = RewriteWithExpression.applyForExpression(expr)
+    assert(!rewritten.isInstanceOf[With])
+    assert(rewritten == a + a)
+  }
+
+  test("applyForExpression always inlines non-cheap common expressions") {
+    val a = testRelation.output.head
+    val expr = With(a + a) { case Seq(ref) =>
+      ref * ref
+    }
+    val rewritten = RewriteWithExpression.applyForExpression(expr)
+    assert(!rewritten.exists(_.isInstanceOf[With]))
+    assert(rewritten == (a + a) * (a + a))
+  }
+
+  test("applyForExpression handles nested With") {
+    val a = testRelation.output.head
+    val b = testRelation.output.last
+    val inner = With(a + a) { case Seq(ref) =>
+      ref * ref
+    }
+    val outer = With(inner + b) { case Seq(ref) =>
+      ref + ref
+    }
+    val rewritten = RewriteWithExpression.applyForExpression(outer)
+    assert(!rewritten.exists(_.isInstanceOf[With]))
+    assert(!rewritten.exists(_.isInstanceOf[CommonExpressionRef]))
+  }
+
+  test("applyForExpression leaves expressions without With unchanged") {
+    val a = testRelation.output.head
+    assert(RewriteWithExpression.applyForExpression(a + a) == a + a)
+  }
+
+  test("applyForExpression defers a ref to an outer common expression to the enclosing With") {
+    // The inner `With` is rewritten first, so the outer ref it references is not yet in scope
+    // and must be left for the enclosing `With` to inline.
+    val a = testRelation.output.head
+    val outer = With(a + a) { case Seq(outerRef) =>
+      With(a * a) { case Seq(innerRef) =>
+        outerRef + innerRef
+      }
+    }
+    val rewritten = RewriteWithExpression.applyForExpression(outer)
+    assert(!rewritten.exists(_.isInstanceOf[With]))
+    assert(!rewritten.exists(_.isInstanceOf[CommonExpressionRef]))
+    assert(rewritten == (a + a) + (a * a))
+  }
+
   test("non-cheap common expression") {
     val a = testRelation.output.head
     val expr = With(a + a) { case Seq(ref) =>
@@ -248,6 +302,20 @@ class RewriteWithExpressionSuite extends PlanTest {
         .select(Coalesce(Seq(($"_common_expr_0" * $"_common_expr_0"), a)).as("col"))
         .analyze
     )
+  }
+
+  test("WITH in a conditional branch referencing an outer common expression") {
+    val a = testRelation.output.head
+    // The conditional branch holds a nested `With` referencing the outer common expression.
+    // Both are inlined; the outer ref must survive the inner rewrite.
+    val expr = With(a + a) { case Seq(outerRef) =>
+      Coalesce(Seq(a, With(a * a) { case Seq(innerRef) =>
+        outerRef + innerRef
+      }))
+    }
+    val plan = testRelation.select(expr.as("col"))
+    val inlinedExpr = Coalesce(Seq(a, (a + a) + (a * a)))
+    comparePlans(Optimizer.execute(plan), testRelation.select(inlinedExpr.as("col")))
   }
 
   test("WITH expression in grouping exprs") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
@@ -58,6 +58,23 @@ class SpecialDatetimeValuesSuite extends PlanTest {
     }
   }
 
+  test("applyForExpression rewrites a foldable special datetime cast to a literal") {
+    val zoneId = ZoneId.systemDefault()
+    val cast = Cast(Literal("epoch"), DateType, Some(zoneId.getId))
+    assert(SpecialDatetimeValues.applyForExpression(cast) == Literal(0, DateType))
+  }
+
+  test("applyForExpression folds special timestamp values") {
+    val cast = Cast(Literal("epoch"), TimestampType, Some("UTC"))
+    assert(SpecialDatetimeValues.applyForExpression(cast) == Literal(0L, TimestampType))
+  }
+
+  test("applyForExpression leaves non-special casts and other expressions unchanged") {
+    val cast = Cast(Literal("2021-01-01"), DateType, Some("UTC"))
+    assert(SpecialDatetimeValues.applyForExpression(cast) == cast)
+    assert(SpecialDatetimeValues.applyForExpression(Literal(1)) == Literal(1))
+  }
+
   private def testSpecialTs(tsType: AtomicType, expected: Set[Long], zoneId: ZoneId): Unit = {
     val in = Project(Seq(
       Alias(Cast(Literal("epoch"), tsType, Some(zoneId.getId)), "epoch")(),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This refactor exposes expression-level entry points on several `FinishAnalysis` rules and on the `RewriteWithExpression` rule so they can rewrite a single `Expression` tree, not just a whole `LogicalPlan`. Each rule's rewrite logic is factored into a reusable partial function, the existing plan-level `apply` delegates to it, and a new `applyForExpression` (or widened visibility) is added.

`TimeTravelSpec.resolveTimestampExpression` is converted to the new entry points, which lets it drop the fake `Project(Alias(ts), OneRowRelation())` wrapper and the two `asInstanceOf` casts it needed to unwrap the result. In this PR only `ComputeCurrentTime.applyForExpression` and `ReplaceExpressions.replace` have a production caller (`TimeTravelSpec`); the `ReplaceCurrentLike`, `SpecialDatetimeValues` and `RewriteWithExpression` expression entry points are added here, covered by unit tests, and will be wired into the single-pass analyzer separately.

For `ComputeCurrentTime`, `ReplaceExpressions`, `ReplaceCurrentLike` and `SpecialDatetimeValues`, the extracted partial functions are identical to the original inline bodies, so the plan-level rules produce the same output as before.

One plan-level behavior does change. `RewriteWithExpression`'s conditional-branch inlining previously did an unguarded `refToExpr(ref.id)` lookup that threw `NoSuchElementException` for a nested `With` inside a non-always-evaluated conditional branch that references an outer common expression. The refactor adds a `refToExpr.contains(ref.id)` guard so the outer reference is deferred to the enclosing `With` and inlined correctly instead. This is a latent-crash fix: the crashing shape is not produced by any current `RuntimeReplaceable` expansion (e.g. `Between`, `NullIf`), so no real query changes its result. The new plan-level test "WITH in a conditional branch referencing an outer common expression" locks this behavior.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The single-pass analyzer needs to apply these `FinishAnalysis` rewrites to individual, already-resolved expression trees rather than by running a full plan-wide rule pass. Today the logic is reachable only through each rule's plan-level apply, so it can't be invoked on a single `Expression`. Extracting shared entry points makes the rewrites reusable.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This is an internal refactor. All plan-level rules produce the same output as before. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New unit tests, 39 cases across 6 suites in sql/catalyst: `ReplaceExpressionsSuite, ReplaceCurrentLikeSuite, ComputeCurrentTimeSuite, SpecialDatetimeValuesSuite, ConstantFoldingSuite, RewriteWithExpressionSuite`

Existing coverage for the refactored rules (ComputeCurrentTimeSuite, SpecialDatetimeValuesSuite,
RewriteWithExpressionSuite, ConstantFoldingSuite, and the sql module suites) passes unchanged,
which is what guards the behavior-preserving part of the refactor.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.8
