### PR TITLE
[SPARK-58871][INFRA] Add timeout to disk cleanup steps

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -391,6 +391,8 @@ jobs:
           coursier-${{ runner.os }}-${{ matrix.java }}-${{ matrix.hadoop }}-
           coursier-${{ runner.os }}-
     - name: Free up disk space
+      timeout-minutes: 10
+      continue-on-error: true
       run: |
         if [ -f ./dev/free_disk_space ]; then
           ./dev/free_disk_space
@@ -744,6 +746,8 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Free up disk space
+      timeout-minutes: 10
+      continue-on-error: true
       shell: 'script -q -e -c "bash {0}"'
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ matrix.java }}
@@ -924,6 +928,8 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Free up disk space
+      timeout-minutes: 10
+      continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
@@ -1071,6 +1077,8 @@ jobs:
         restore-keys: |
           docs-maven-${{ runner.os }}-
     - name: Free up disk space
+      timeout-minutes: 10
+      continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
@@ -1214,6 +1222,8 @@ jobs:
         restore-keys: |
           docs-maven-${{ runner.os }}-
     - name: Free up disk space
+      timeout-minutes: 10
+      continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
@@ -1528,6 +1538,8 @@ jobs:
           restore-keys: |
             coursier-${{ runner.os }}-
       - name: Free up disk space
+        timeout-minutes: 10
+        continue-on-error: true
         run: |
           if [ -f ./dev/free_disk_space ]; then
             ./dev/free_disk_space


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a 10-minute timeout and `continue-on-error: true` to the
`Free up disk space` steps in the GitHub Actions build workflow.

JIRA: SPARK-58871

### Why are the changes needed?

The disk cleanup step is an optimization. If it hangs, the job can spend its
entire timeout before reaching setup or tests. Continuing after the cleanup
step times out lets CI proceed with a higher disk space risk instead of
cancelling the whole job during cleanup.

For example, this CI job was cancelled while running the disk cleanup step:
https://github.com/zhengruifeng/spark/actions/runs/32230206211/job/96008694804

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not run. This is a GitHub Actions workflow-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
