### PR TITLE
[SPARK-58870][ML] Make KMeans distance measures singleton

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/DistanceMeasure.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/DistanceMeasure.scala
@@ -258,8 +258,8 @@ object DistanceMeasure {
 
   private[spark] def decodeFromString(distanceMeasure: String): DistanceMeasure =
     distanceMeasure match {
-      case EUCLIDEAN => new EuclideanDistanceMeasure
-      case COSINE => new CosineDistanceMeasure
+      case EUCLIDEAN => EuclideanDistanceMeasure
+      case COSINE => CosineDistanceMeasure
       case _ => throw new IllegalArgumentException(s"distanceMeasure must be one of: " +
         s"$EUCLIDEAN, $COSINE. $distanceMeasure provided.")
     }
@@ -278,7 +278,7 @@ object DistanceMeasure {
     k.toLong * k * numFeatures < 1000000
 }
 
-private[spark] class EuclideanDistanceMeasure extends DistanceMeasure {
+private[spark] object EuclideanDistanceMeasure extends DistanceMeasure {
 
   /**
    * Statistics used in triangle inequality to obtain useful bounds to find closest centers.
@@ -400,10 +400,7 @@ private[spark] class EuclideanDistanceMeasure extends DistanceMeasure {
       centroid: VectorWithNorm): Double = {
     EuclideanDistanceMeasure.fastSquaredDistance(point, centroid)
   }
-}
 
-
-private[spark] object EuclideanDistanceMeasure {
   /**
    * @return the squared Euclidean distance between two vectors computed by
    * [[org.apache.spark.mllib.util.MLUtils#fastSquaredDistance]].
@@ -415,7 +412,7 @@ private[spark] object EuclideanDistanceMeasure {
   }
 }
 
-private[spark] class CosineDistanceMeasure extends DistanceMeasure {
+private[spark] object CosineDistanceMeasure extends DistanceMeasure {
 
   /**
    * Statistics used in triangle inequality to obtain useful bounds to find closest centers.

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
@@ -43,7 +43,7 @@ class KMeansModel (@Since("1.0.0") val clusterCenters: Array[Vector],
   private[spark] val numIter: Int)
   extends Saveable with Serializable with PMMLExportable {
 
-  @transient private lazy val distanceMeasureInstance: DistanceMeasure =
+  private val distanceMeasureInstance: DistanceMeasure =
     DistanceMeasure.decodeFromString(distanceMeasure)
 
   @transient private lazy val clusterCentersWithNorm =

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -75,7 +75,7 @@ private[mllib] object LocalKMeans extends Logging {
 
     }
 
-    val distanceMeasureInstance = new EuclideanDistanceMeasure
+    val distanceMeasureInstance = EuclideanDistanceMeasure
 
     // Run up to maxIterations iterations of Lloyd's algorithm
     val oldClosest = Array.fill(points.length)(-1)

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -92,7 +92,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
       .setInitializationSteps(10)
       .setSeed(seed)
 
-    val distanceMeasureInstance = new EuclideanDistanceMeasure
+    val distanceMeasureInstance = EuclideanDistanceMeasure
     val initialCenters = km.initKMeansParallel(normedData, distanceMeasureInstance).map(_.vector)
     assert(initialCenters.length === initialCenters.distinct.length)
     assert(initialCenters.length <= numDistinctPoints)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates mllib KMeans distance measure implementations to use singleton objects instead of allocating a new instance when decoding the configured distance measure.

It also changes KMeansModel's decoded distanceMeasureInstance from a transient lazy val to a private val, and updates internal/test call sites to reference the Euclidean distance measure singleton directly.

### Why are the changes needed?
This is part of SPARK-58584. KMeans only has stateless distance measure implementations, so allocating per decode is unnecessary. Reusing singleton instances avoids per-model helper allocation and lets KMeansModel hold the decoded helper directly.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 mllib/compile
- build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 'mllib/testOnly org.apache.spark.mllib.clustering.KMeansSuite'

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex