### PR TITLE
[SPARK-58872][K8S] Warn when driver credentials drop the driver service account

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
@@ -29,9 +29,10 @@ import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.KubernetesUtils.buildPodWithServiceAccount
+import org.apache.spark.internal.Logging
 
 private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: KubernetesConf)
-  extends KubernetesFeatureConfigStep {
+  extends KubernetesFeatureConfigStep with Logging {
 
   private val maybeMountedOAuthTokenFile = kubernetesConf.getOption(
     s"$KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX.$OAUTH_TOKEN_FILE_CONF_SUFFIX")
@@ -59,10 +60,18 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
     s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$CLIENT_CERT_FILE_CONF_SUFFIX",
     "Driver client cert file")
 
-  private val shouldMountSecret = oauthTokenBase64.isDefined ||
-    caCertDataBase64.isDefined ||
-    clientKeyDataBase64.isDefined ||
-    clientCertDataBase64.isDefined
+  private val activeCredentialsConfs = Seq(
+    s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$OAUTH_TOKEN_CONF_SUFFIX" ->
+      oauthTokenBase64.isDefined,
+    s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$CA_CERT_FILE_CONF_SUFFIX" ->
+      caCertDataBase64.isDefined,
+    s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$CLIENT_KEY_FILE_CONF_SUFFIX" ->
+      clientKeyDataBase64.isDefined,
+    s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$CLIENT_CERT_FILE_CONF_SUFFIX" ->
+      clientCertDataBase64.isDefined
+  ).collect { case (conf, true) => conf }
+
+  private val shouldMountSecret = activeCredentialsConfs.nonEmpty
 
   private val driverCredentialsSecretName =
     s"${kubernetesConf.resourceNamePrefix}-kubernetes-credentials"
@@ -71,6 +80,15 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
     if (!shouldMountSecret) {
       pod.copy(pod = buildPodWithServiceAccount(driverServiceAccount, pod).getOrElse(pod.pod))
     } else {
+      val accountMsg = driverServiceAccount.map(sa => s"'$sa'")
+        .getOrElse("specified service account")
+      val credsMsg = activeCredentialsConfs.mkString(", ")
+      logWarning(
+        s"Driver service account $accountMsg is dropped because client credentials " +
+        s"($credsMsg) were provided. If you want to specify both a service account " +
+        s"and credentials, use '$KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX.*' " +
+        "configurations instead.")
+
       val driverPodWithMountedKubernetesCredentials =
         new PodBuilder(pod.pod)
           .editOrNewSpec()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -127,6 +127,22 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
     assert(driverContainerVolumeMount.head.getMountPath === DRIVER_CREDENTIALS_SECRETS_BASE_DIR)
   }
 
+  test("SPARK-58872: Log warning when driver credentials drop the driver service account") {
+    val submissionSparkConf = new SparkConf(false)
+      .set(
+        s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$OAUTH_TOKEN_CONF_SUFFIX",
+        "token")
+      .set(KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME, "test-sa")
+    val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf = submissionSparkConf)
+    val kubernetesCredentialsStep = new DriverKubernetesCredentialsFeatureStep(kubernetesConf)
+    val logAppender = new LogAppender
+    withLogAppender(logAppender) {
+      kubernetesCredentialsStep.configurePod(BASE_DRIVER_POD)
+    }
+    val expectedMsg = "Driver service account 'test-sa' is dropped because client credentials"
+    assert(logAppender.loggingEvents.exists(_.getMessage.getFormattedMessage.contains(expectedMsg)))
+  }
+
   private def writeCredentials(credentialsFileName: String, credentialsContents: String): File = {
     val credentialsFile = new File(credentialsTempDirectory, credentialsFileName)
     Files.writeString(credentialsFile.toPath, credentialsContents)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a warning log in `DriverKubernetesCredentialsFeatureStep` when client credentials (such as OAuth token, client cert/key, or CA cert) are provided and cause Spark to skip configuring the driver service account on the pod.

The log message names the service account, lists which credential settings were passed, and suggests using `spark.kubernetes.authenticate.driver.mounted.*` if the user needs both.

### Why are the changes needed?

Currently, `spark.kubernetes.authenticate.driver.serviceAccountName` is silently ignored when client credentials are set. For example, setting `caCertFile` to trust a custom CA drops the service account without any warning, causing the driver pod to fall back to the default service account (which often lacks permissions to launch executors).

Adding a warning lets users know why their service account was not set without introducing breaking config changes.

### Does this PR introduce _any_ user-facing change?

Yes, a warning message is logged when client credentials drop the configured driver service account.

### How was this patch tested?

Added a unit test in `DriverKubernetesCredentialsFeatureStepSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No.
