### PR TITLE
[SPARK-58362][CORE] Fix resource profile ID collision with default profile ID

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -371,7 +371,7 @@ object ResourceProfile extends Logging {
   val UNKNOWN_RESOURCE_PROFILE_ID = -1
   val DEFAULT_RESOURCE_PROFILE_ID = 0
 
-  private lazy val nextProfileId = new AtomicInteger(0)
+  private lazy val nextProfileId = new AtomicInteger(1)
   private val DEFAULT_PROFILE_LOCK = new Object()
 
   // The default resource profile uses the application level configs.

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -501,7 +501,7 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
   test("SPARK-58362: Custom RP ID does not collide with DEFAULT_RESOURCE_PROFILE_ID") {
     val rp = new ResourceProfileBuilder().build()
     assert(rp.id != ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
-    assert(rp.id === 1)
+    assert(rp.id > ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
   }
 
   private def withMockSparkEnv(conf: SparkConf)(f: => Unit): Unit = {

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -498,6 +498,12 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
     new ResourceProfileBuilder().require(treqs).build()
   }
 
+  test("SPARK-58362: Custom RP ID does not collide with DEFAULT_RESOURCE_PROFILE_ID") {
+    val rp = new ResourceProfileBuilder().build()
+    assert(rp.id != ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
+    assert(rp.id === 1)
+  }
+
   private def withMockSparkEnv(conf: SparkConf)(f: => Unit): Unit = {
     val previousEnv = SparkEnv.get
     val mockEnv = mock[SparkEnv]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a resource profile ID collision where custom stage-level `ResourceProfile` instances were assigned `id = 0`, colliding with `ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID` (`0`).

Specifically, `nextProfileId` in `ResourceProfile.scala` is now initialized to `1` so that custom profiles start allocation at ID `1`.

### Why are the changes needed?

Spark uses `DEFAULT_RESOURCE_PROFILE_ID = 0` for the default profile. Previously, `nextProfileId` was initialized to `0`, causing the first user-created `ResourceProfile` to also receive `id = 0`. This caused schedulers and cluster manager allocators (Yarn, K8s, Standalone) to misidentify custom stage-level resource profiles as the default profile.

### Does this PR introduce _any_ user-facing change?

No API changes. Fixes incorrect profile ID assignment for custom resource profiles.

### How was this patch tested?

Added unit test in `ResourceProfileSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No.
