### PR TITLE
[SPARK-58877][BUILD] Upgrade Log4j from 2.26.0 to 2.26.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -185,11 +185,11 @@ lapack/3.2.0//lapack-3.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.16.0//libthrift-0.16.0.jar
-log4j-1.2-api/2.26.0//log4j-1.2-api-2.26.0.jar
-log4j-api/2.26.0//log4j-api-2.26.0.jar
-log4j-core/2.26.0//log4j-core-2.26.0.jar
-log4j-layout-template-json/2.26.0//log4j-layout-template-json-2.26.0.jar
-log4j-slf4j2-impl/2.26.0//log4j-slf4j2-impl-2.26.0.jar
+log4j-1.2-api/2.26.1//log4j-1.2-api-2.26.1.jar
+log4j-api/2.26.1//log4j-api-2.26.1.jar
+log4j-core/2.26.1//log4j-core-2.26.1.jar
+log4j-layout-template-json/2.26.1//log4j-layout-template-json-2.26.1.jar
+log4j-slf4j2-impl/2.26.1//log4j-slf4j2-impl-2.26.1.jar
 lz4-java/1.11.2//lz4-java-1.11.2.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.10.1</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.26.0</log4j.version>
+    <log4j.version>2.26.1</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.5.0</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade Log4j from 2.26.0 to 2.26.1.

### Why are the changes needed?

Fixes CVE-2026-49844 (MEDIUM 5.9): Improper encoding of non-finite floating-point values during MapMessage JSON serialization produces invalid JSON output.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Build passes with `./dev/make-distribution.sh --name hadoop3 --tgz -Phadoop-3 -DskipTests`.

### Was this patch authored or co-authored using generative AI tooling?

Yes
