### PR TITLE
[SPARK-58878][BUILD] Upgrade Apache Ivy from 2.5.3 to 2.6.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -104,7 +104,7 @@ httpcore/4.4.16//httpcore-4.4.16.jar
 icu4j/78.3//icu4j-78.3.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/4.1.2//istack-commons-runtime-4.1.2.jar
-ivy/2.5.3//ivy-2.5.3.jar
+ivy/2.6.0//ivy-2.6.0.jar
 jackson-annotations/2.22//jackson-annotations-2.22.jar
 jackson-core/2.22.0//jackson-core-2.22.0.jar
 jackson-databind/2.22.0//jackson-databind-2.22.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <javaxservlet.version>4.0.1</javaxservlet.version>
     <chill.version>0.10.0</chill.version>
     <kryo.version>4.0.3</kryo.version>
-    <ivy.version>2.5.3</ivy.version>
+    <ivy.version>2.6.0</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
     If you change codahale.metrics.version, you also need to change


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade Apache Ivy from 2.5.3 to 2.6.0.

### Why are the changes needed?

Fixes CVE-2026-26032 (MEDIUM 5.4): Security vulnerability in Ivy dependency resolution.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Build passes with `./dev/make-distribution.sh --name hadoop3 --tgz -Phadoop-3 -DskipTests`.

### Was this patch authored or co-authored using generative AI tooling?

Yes

