### PR TITLE
[SPARK-52589][K8S] Prune `schedulerKnownNewlyCreatedExecs` entries unknown to the scheduler backend

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -221,9 +221,7 @@ class ExecutorPodsAllocator(
     // transfer the scheduler backend known executor requests from the newlyCreatedExecutors
     // to the schedulerKnownNewlyCreatedExecs
     val schedulerKnownExecs = schedulerBackend.getExecutorIds().map(_.toLong).toSet
-    schedulerKnownNewlyCreatedExecs.filterInPlace { case (k, _) =>
-      schedulerKnownExecs.contains(k)
-    }
+    schedulerKnownNewlyCreatedExecs.filterInPlace((k, _) => schedulerKnownExecs.contains(k))
     schedulerKnownNewlyCreatedExecs ++=
       newlyCreatedExecutors.filter { case (k, _) => schedulerKnownExecs.contains(k) }
         .map { case (k, v) => (k, v._1) }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -221,6 +221,9 @@ class ExecutorPodsAllocator(
     // transfer the scheduler backend known executor requests from the newlyCreatedExecutors
     // to the schedulerKnownNewlyCreatedExecs
     val schedulerKnownExecs = schedulerBackend.getExecutorIds().map(_.toLong).toSet
+    schedulerKnownNewlyCreatedExecs.filterInPlace { case (k, _) =>
+      schedulerKnownExecs.contains(k)
+    }
     schedulerKnownNewlyCreatedExecs ++=
       newlyCreatedExecutors.filter { case (k, _) => schedulerKnownExecs.contains(k) }
         .map { case (k, v) => (k, v._1) }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -366,6 +366,26 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     assert(m.contains("Exceed the pod creation limit: 1"))
   }
 
+  test("SPARK-52589: Prune scheduler-known newly created executors if " +
+    "removed from scheduler backend") {
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(1))
+
+    // Executor 1 is registered with schedulerBackend
+    when(schedulerBackend.getExecutorIds()).thenReturn(Seq("1"))
+    snapshotsStore.notifySubscribers()
+
+    // Executor 1 is decommissioned/removed from schedulerBackend without appearing in pod snapshot
+    when(schedulerBackend.getExecutorIds()).thenReturn(Seq.empty)
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 0))
+    snapshotsStore.notifySubscribers()
+
+    // Upscale to 1 executor; verify new executor 2 is requested
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
+    snapshotsStore.notifySubscribers()
+    verify(podsWithNamespace).resource(podWithAttachedContainerForId(2))
+  }
+
   test("Request executors in batches. Allow another batch to be requested if" +
     " all pending executors start running.") {
     val counter = PrivateMethod[AtomicInteger](Symbol("EXECUTOR_ID_COUNTER"))()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Prune `schedulerKnownNewlyCreatedExecs` in `ExecutorPodsAllocator` during `onNewSnapshots` if the executor is no longer registered with `schedulerBackend`.

### Why are the changes needed?
If an executor registers with the driver and is removed before appearing in a K8s pod snapshot, it remains trapped in `schedulerKnownNewlyCreatedExecs` as a ghost executor. When `minExecutors=0` and new work arrives, `podCountForRpId` includes this ghost executor and prevents Spark from requesting new executor pods, hanging the job.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added `ExecutorPodsAllocatorSuite` unit test `SPARK-52589: Prune scheduler-known newly created executors if removed from scheduler backend`.

### Was this patch authored or co-authored using generative AI tooling?
No.
