### PR TITLE
[SPARK-58889][SS] Clean up cached kafkaParams in InternalKafkaConsumerPool after invalidateKey()/reset()

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/InternalKafkaConsumerPool.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/InternalKafkaConsumerPool.scala
@@ -98,6 +98,7 @@ private[consumer] class InternalKafkaConsumerPool(
   /** Invalidates all idle consumers for the key */
   def invalidateKey(key: CacheKey): Unit = {
     pool.clear(key)
+    objectFactory.keyToKafkaParams.remove(key)
   }
 
   /**
@@ -115,6 +116,7 @@ private[consumer] class InternalKafkaConsumerPool(
     // this is the best-effort of clearing up. otherwise we should close the pool and create again
     // but we don't want to make it "var" only because of tests.
     pool.clear()
+    objectFactory.keyToKafkaParams.clear()
   }
 
   def numIdle: Int = pool.getNumIdle

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/consumer/InternalKafkaConsumerPoolSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/consumer/InternalKafkaConsumerPoolSuite.scala
@@ -194,6 +194,61 @@ class InternalKafkaConsumerPoolSuite extends SharedSparkSession {
     pool.close()
   }
 
+  test("borrowing with different kafkaParams after invalidateKey") {
+    val pool = new InternalKafkaConsumerPool(new SparkConf())
+
+    try {
+      val topicPartition = new TopicPartition("topic", 0)
+      val kafkaParams = getTestKafkaParams
+      // Differs only in a non-key field, so both map to the same CacheKey.
+      val newKafkaParams = getTestKafkaParamsWithDifferentOffsetReset
+      assert(kafkaParams != newKafkaParams)
+
+      val key = new CacheKey(topicPartition, kafkaParams)
+      assert(key === new CacheKey(topicPartition, newKafkaParams))
+
+      val pooledObject = pool.borrowObject(key, kafkaParams)
+      assertPooledObject(pooledObject, topicPartition, kafkaParams)
+      pool.returnObject(pooledObject)
+
+      pool.invalidateKey(key)
+      assertPoolStateForKey(pool, key, numIdle = 0, numActive = 0, numTotal = 0)
+
+      // Invalidation must also drop the remembered kafkaParams for the key, otherwise this borrow
+      // fails the equality check against the params of the consumer we just destroyed.
+      val newPooledObject = pool.borrowObject(key, newKafkaParams)
+      assertPooledObject(newPooledObject, topicPartition, newKafkaParams)
+      assertPoolStateForKey(pool, key, numIdle = 0, numActive = 1, numTotal = 1)
+    } finally {
+      pool.close()
+    }
+  }
+
+  test("borrowing with different kafkaParams after reset") {
+    val pool = new InternalKafkaConsumerPool(new SparkConf())
+
+    try {
+      val topicPartition = new TopicPartition("topic", 0)
+      val kafkaParams = getTestKafkaParams
+      val newKafkaParams = getTestKafkaParamsWithDifferentOffsetReset
+
+      val key = new CacheKey(topicPartition, kafkaParams)
+
+      val pooledObject = pool.borrowObject(key, kafkaParams)
+      assertPooledObject(pooledObject, topicPartition, kafkaParams)
+      pool.returnObject(pooledObject)
+
+      pool.reset()
+      assertPoolState(pool, numIdle = 0, numActive = 0, numTotal = 0)
+
+      val newPooledObject = pool.borrowObject(key, newKafkaParams)
+      assertPooledObject(newPooledObject, topicPartition, newKafkaParams)
+      assertPoolStateForKey(pool, key, numIdle = 0, numActive = 1, numTotal = 1)
+    } finally {
+      pool.close()
+    }
+  }
+
   private def createTopicPartitions(
       topicNames: Seq[String],
       countPartition: Int): List[TopicPartition] = {
@@ -247,6 +302,16 @@ class InternalKafkaConsumerPoolSuite extends SharedSparkSession {
     AUTO_OFFSET_RESET_CONFIG -> "earliest",
     ENABLE_AUTO_COMMIT_CONFIG -> "false"
   ).asJava
+
+  /**
+   * Params that differ from [[getTestKafkaParams]] but keep the same groupId, so both still map to
+   * the same [[CacheKey]] for a given topic partition.
+   */
+  private def getTestKafkaParamsWithDifferentOffsetReset: ju.Map[String, Object] = {
+    val params = new ju.HashMap[String, Object](getTestKafkaParams)
+    params.put(AUTO_OFFSET_RESET_CONFIG, "latest")
+    params
+  }
 
   private def borrowObjectsPerKey(
       pool: InternalKafkaConsumerPool,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


InternalKafkaConsumerPool remembers each CacheKey's kafkaParams in ObjectFactory.keyToKafkaParams so the factory can build consumers, but the invalidation paths never cleaned it up when the pool entry is cleaned up. A later lookup with the same cache key but different kafka Params triggers a config mismatch:
```
  java.lang.IllegalArgumentException: requirement failed: Kafka parameters for
  same cache key should be equal. old parameters: {...} new parameters: {...}
```




### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bugfix when kafka config is changed after deletion but the old/cached config is not properly cleared out.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New test cases testing both invalidateKey and reset methods

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code 2.1.236 (Anthropic Claude Opus 4.8)