### PR TITLE
[SPARK-58891][SQL] Reorder Window stacks to minimize exchanges

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
@@ -73,7 +73,7 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
    * All window expressions should use the same expanding window and do not contains
    * `SizeBasedWindowFunction`, so that we can safely do the early stop.
    */
-  private def isExpandingWindow(
+  private[optimizer] def isExpandingWindow(
       windowExpression: NamedExpression): Boolean = windowExpression match {
     case Alias(WindowExpression(windowFunction, WindowSpecDefinition(_, _,
     SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))), _)
@@ -81,7 +81,7 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
     case _ => false
   }
 
-  private def support(windowFunction: Expression): Boolean = windowFunction match {
+  private[optimizer] def support(windowFunction: Expression): Boolean = windowFunction match {
     case _: Rank | _: DenseRank | _: RowNumber => true
     case _ => false
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1834,12 +1834,339 @@ object CollapseWindow extends Rule[LogicalPlan] {
 }
 
 /**
- * Transpose Adjacent Window Expressions.
- * - If the partition spec of the parent Window expression is compatible with the partition spec
- *   of the child window expression, transpose them.
+ * Reorder a stack of `Window` operators so that the fewest possible exchanges are inserted
+ * for it. Window operators only append their output columns and each of them
+ * (re-)partitions/(re-)sorts its input independently of its position in the stack, so two
+ * windows can be swapped freely as long as neither references the other's output. Physically,
+ * a window rides the exchange created for the nearest window below it iff that exchange's key
+ * set is a subset of the window's partition spec (`HashPartitioning` satisfying
+ * `ClusteredDistribution`), and `EnsureRequirements` only creates exchanges keyed on exactly
+ * some window's partition spec. The minimum exchange count for a stack therefore equals the
+ * number of its minimal partition specs (under semantic subset), and it is achieved by
+ * grouping the windows by the minimal partition spec their own partition spec contains,
+ * smaller specs first within a group. This subsumes the previous adjacent-pair transposition.
+ * Under `requireAllClusterKeysForDistribution`, a partitioning only satisfies a window's
+ * `ClusteredDistribution` with the exact same keys in the same order, so the subset relation
+ * degenerates to exact spec equality: the minimum equals the number of distinct exact
+ * partition specs, achieved by grouping identical specs adjacently.
+ *
+ * The matched stack is a maximal run of `Window` operators connected by transparent links,
+ * where a transparent link is a deterministic `Project` made only of plain attributes and
+ * aliases. Besides pass-through, rename or drop, an alias may also compute a derived,
+ * deterministic expression (e.g. `Alias(a + b, "s")`). Hoisting such a link above the
+ * windows only changes where its expression is computed, not the values it computes on
+ * (windows never rewrite their input), so the one unsafe case is a window above the link
+ * referencing its aliased output, which `reorderable` excludes. The links are stripped and
+ * re-applied above the reordered windows, and a chain-top `Project` restores the original
+ * output attribute order when needed.
+ *
+ * If the stack is directly topped by a rank filter (e.g. `rn <= 1`, the pattern that
+ * `InferWindowGroupLimit` rewrites later, in a `Once` batch), the top window is pinned in
+ * place and only the windows below it are reordered, with the order-restoring `Project`
+ * placed below the pinned window, so that the strict `Filter`-over-`Window` match survives.
+ *
+ * The stack reordering is gated by `spark.sql.optimizer.windowReorder.enabled` (default
+ * false); when disabled, the rule falls back to transposing only adjacent window pairs whose
+ * upper partition spec is a proper subset of the lower one (see `transposeAdjacentPairs`).
  */
 object TransposeWindow extends Rule[LogicalPlan] {
-  private def compatiblePartitions(ps1 : Seq[Expression], ps2: Seq[Expression]): Boolean = {
+
+  /**
+   * A `Project` is a transparent link of a window chain if it only passes through, renames
+   * or drops attributes, or adds deterministic aliases (which may compute derived
+   * expressions), and is itself deterministic.
+   */
+  private def isTransparentLink(plan: LogicalPlan): Boolean = plan match {
+    case p: Project =>
+      p.projectList.forall(e => e.isInstanceOf[Attribute] || e.isInstanceOf[Alias]) &&
+        p.expressions.forall(_.deterministic)
+    case _ => false
+  }
+
+  /**
+   * A maximal run of adjacent `Window` operators connected by transparent links.
+   *
+   * @param windows the windows of the chain, bottom-to-top
+   * @param betweenLinks `betweenLinks(i)` holds the transparent links between `windows(i)`
+   *                     and `windows(i + 1)`, bottom-to-top; it has one element less than
+   *                     `windows`
+   * @param topLinks the transparent links above the top window, bottom-to-top
+   * @param bottomChild the child of the bottom window
+   * @param topWindowChildOutput the output of the child of the top window, in the original
+   *                             plan
+   * @param originalOutput the output of the whole chain, in the original plan
+   */
+  private case class WindowChain(
+      windows: Seq[Window],
+      betweenLinks: Seq[Seq[Project]],
+      topLinks: Seq[Project],
+      bottomChild: LogicalPlan,
+      topWindowChildOutput: Seq[Attribute],
+      originalOutput: Seq[Attribute])
+
+  /** Collect the maximal window chain topped by `plan`, if `plan` tops at least 2 windows. */
+  private def collectChain(plan: LogicalPlan): Option[WindowChain] = {
+    // Collect the chain top-down: `windows` is filled from the top window down,
+    // `betweenLinks(i)` holds the transparent links accumulated right above `windows(i)`,
+    // and `pending` the links found since the last window. The buffers are reversed into
+    // the bottom-to-top order of `WindowChain` at the end.
+    val windows = mutable.ArrayBuffer.empty[Window]
+    val betweenLinks = mutable.ArrayBuffer.empty[Seq[Project]]
+    var pending = Vector.empty[Project]
+    var cur = plan
+    var collecting = true
+    while (collecting) {
+      cur match {
+        case p: Project if isTransparentLink(p) =>
+          pending = pending :+ p
+          cur = p.child
+        case w: Window =>
+          betweenLinks += pending
+          windows += w
+          pending = Vector.empty
+          cur = w.child
+        case _ =>
+          collecting = false
+      }
+    }
+
+    if (windows.length < 2) {
+      None
+    } else {
+      val n = windows.length
+      Some(WindowChain(
+        windows = windows.reverse.toSeq,
+        betweenLinks = (0 until n - 1).map(i => betweenLinks(n - 1 - i).reverse),
+        topLinks = betweenLinks.head.reverse,
+        bottomChild = windows.last.child,
+        topWindowChildOutput = windows.head.child.output,
+        originalOutput = plan.output))
+    }
+  }
+
+  /**
+   * Whether an exchange keyed on `spec2` can satisfy the `ClusteredDistribution` of a window
+   * with partition spec `spec1`. By default (subset semantics) a partitioning satisfies the
+   * distribution if every partitioning key appears in the required clustering keys, so
+   * `spec1` being a subset of `spec2` suffices; under
+   * `requireAllClusterKeysForDistribution` the partitioning must match the required keys
+   * exactly and in order, so only identical specs ride each other's exchange.
+   */
+  private def subsetOf(spec1: Seq[Expression], spec2: Seq[Expression]): Boolean =
+    if (conf.getConf(SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_DISTRIBUTION)) {
+      spec1.length == spec2.length &&
+        spec1.zip(spec2).forall { case (e1, e2) => e1.semanticEquals(e2) }
+    } else {
+      spec1.forall(e1 => spec2.exists(e1.semanticEquals))
+    }
+
+  /** Semantic equivalence of two partition specs, i.e. mutual subset. */
+  private def equivalent(spec1: Seq[Expression], spec2: Seq[Expression]): Boolean =
+    subsetOf(spec1, spec2) && subsetOf(spec2, spec1)
+
+  /**
+   * The chain is reorderable if all windows are deterministic and have a non-empty partition
+   * spec (an empty one requires `AllTuples` and must not move), no window references another
+   * window's output, and no window references the aliased output of a link below it (such a
+   * link could not be re-applied above that window). The aliased output may be any
+   * deterministic expression; hoisting it above the windows only changes where it is
+   * computed, never the values it sees, so this check is the real safety property regardless
+   * of whether a link's alias is a bare rename or a derived expression.
+   */
+  private def reorderable(chain: WindowChain): Boolean = {
+    val windows = chain.windows
+    windows.forall(_.expressions.forall(_.deterministic)) &&
+    windows.forall(_.partitionSpec.nonEmpty) &&
+    windows.indices.forall { i =>
+      windows.indices.forall { j =>
+        i == j || windows(i).references.intersect(windows(j).windowOutputSet).isEmpty
+      }
+    } &&
+    chain.betweenLinks.zipWithIndex.forall { case (links, i) =>
+      val aliasedOutputs = AttributeSet(links.flatMap(_.projectList).collect {
+        case a: Alias => a.toAttribute
+      })
+      // The windows above these links are `windows(i + 1)` and up.
+      aliasedOutputs.isEmpty ||
+        (i + 1 until windows.length).forall { k =>
+          windows(k).references.intersect(aliasedOutputs).isEmpty
+        }
+    }
+  }
+
+  /**
+   * The exchange-minimal window order, as indices into `windows` (bottom-to-top): group the
+   * windows by the minimal partition spec their own partition spec contains, groups ordered
+   * by first appearance, smaller specs first within a group; the sort is stable, so windows
+   * with equal keys keep their original relative order. Each group leader pays for its
+   * exchange and every other member rides it, because a riding window never changes the
+   * partitioning seen by the windows above it, so the result needs one exchange per minimal
+   * partition spec.
+   */
+  private def optimalOrder(windows: Seq[Window]): Seq[Int] = {
+    val specs = windows.map(_.partitionSpec)
+    val minimal = specs.indices.map { i =>
+      !specs.indices.exists { j =>
+        j != i && subsetOf(specs(j), specs(i)) && !equivalent(specs(j), specs(i))
+      }
+    }
+    // The distinct minimal specs, ranked by first appearance, bottom-to-top.
+    val minimalSpecs = mutable.ArrayBuffer.empty[Seq[Expression]]
+    specs.indices.filter(minimal).foreach { i =>
+      if (!minimalSpecs.exists(equivalent(_, specs(i)))) {
+        minimalSpecs += specs(i)
+      }
+    }
+    val classOf = specs.indices.map { i =>
+      minimalSpecs.indices.filter(j => subsetOf(minimalSpecs(j), specs(i))).min
+    }
+    specs.indices.sortBy(i => (classOf(i), specs(i).length))
+  }
+
+  /**
+   * Whether `filter` above the chain top is a rank filter on the chain's top window that
+   * `InferWindowGroupLimit` would rewrite later (e.g. `rn <= 1` under
+   * `windowGroupLimitThreshold`). The condition is looked through the chain's top links, as
+   * the predicate pushdown rules may not have moved the filter below them yet.
+   */
+  private def isRankFilterOnTopWindow(filter: Filter, chain: WindowChain): Boolean = {
+    if (conf.windowGroupLimitThreshold == -1) return false
+    val topWindow = chain.windows.last
+    if (topWindow.orderSpec.isEmpty ||
+      !topWindow.windowExpressions.forall(InferWindowGroupLimit.isExpandingWindow)) {
+      return false
+    }
+
+    // There might be Project(s) between Filter and Window now. Here we peel off the
+    // aliases added by these Projects, so we can check whether Filter contains conditions
+    // that is checking rank function result produced by the windows.
+    val condition = chain.topLinks.reverse.foldLeft(filter.condition) { (cond, link) =>
+      val aliasMap = link.projectList.collect { case a: Alias => a.toAttribute -> a.child }.toMap
+      if (aliasMap.isEmpty) {
+        cond
+      } else {
+        cond.transform { case a: Attribute if aliasMap.contains(a) => aliasMap(a) }
+      }
+    }
+
+    topWindow.windowExpressions.exists {
+      case alias @ Alias(WindowExpression(rankLikeFunction, _), _)
+          if InferWindowGroupLimit.support(rankLikeFunction) =>
+        InferWindowGroupLimit.extractLimits(condition, alias.toAttribute)
+          .exists(_ <= conf.windowGroupLimitThreshold)
+      case _ => false
+    }
+  }
+
+  /**
+   * Reorder `chain` into the exchange-minimal order and rebuild it, keeping the top window in
+   * place if `pinTopWindow` (see `isRankFilterOnTopWindow`): only the windows below it are
+   * reordered then and the order-restoring `Project` is placed below the pinned window, so
+   * that the strict `Filter`-over-`Window` match of `InferWindowGroupLimit` survives. The
+   * stripped links are re-applied above the reordered windows (below the pinned window if
+   * pinned), each additionally passing through the attributes that anything above it still
+   * references. Returns `None` if the chain is already in an optimal order.
+   */
+  private def reorderChain(chain: WindowChain, pinTopWindow: Boolean): Option[LogicalPlan] = {
+    val windows = chain.windows
+    val toPermute = if (pinTopWindow) windows.dropRight(1) else windows
+    val order = optimalOrder(toPermute)
+    if (order == toPermute.indices) {
+      return None
+    }
+
+    val baseAttrs = chain.bottomChild.output ++
+      windows.flatMap(_.windowExpressions.map(_.toAttribute))
+    val hoistedLinks =
+      if (pinTopWindow) chain.betweenLinks.flatten
+      else chain.betweenLinks.flatten ++ chain.topLinks
+    val boundaryOutput =
+      if (pinTopWindow) chain.topWindowChildOutput else chain.originalOutput
+    val boundaryIds = boundaryOutput.map(_.exprId).toSet
+
+    // refsAbove(i): the attribute ids referenced by the links above hoistedLinks(i).
+    val refsAbove = new Array[Set[ExprId]](hoistedLinks.length)
+    var acc = Set.empty[ExprId]
+    hoistedLinks.indices.reverse.foreach { i =>
+      refsAbove(i) = acc
+      acc = acc ++ hoistedLinks(i).references.map(_.exprId)
+    }
+
+    var cur: LogicalPlan = chain.bottomChild
+    order.foreach(i => cur = toPermute(i).withNewChildren(Seq(cur)))
+
+    var available = baseAttrs.map(_.exprId).toSet
+    hoistedLinks.indices.foreach { i =>
+      val link = hoistedLinks(i)
+      val required = boundaryIds ++ refsAbove(i)
+      val missing = baseAttrs.filter(a =>
+        required.contains(a.exprId) && available.contains(a.exprId) &&
+          !link.output.exists(_.exprId == a.exprId))
+      cur = if (missing.isEmpty) {
+        link.withNewChildren(Seq(cur))
+      } else {
+        link.copy(projectList = link.projectList ++ missing, child = cur)
+      }
+      available = cur.output.map(_.exprId).toSet
+    }
+
+    if (pinTopWindow) {
+      if (cur.output.map(_.exprId) != chain.topWindowChildOutput.map(_.exprId)) {
+        cur = Project(chain.topWindowChildOutput, cur)
+      }
+      cur = windows.last.withNewChildren(Seq(cur))
+      chain.topLinks.foreach(link => cur = link.withNewChildren(Seq(cur)))
+    } else if (cur.output.map(_.exprId) != chain.originalOutput.map(_.exprId)) {
+      cur = Project(chain.originalOutput, cur)
+    }
+    Some(cur)
+  }
+
+  /** Reorder the window chain topped by `plan`, if any, given the plan's parent. */
+  private def reorderIfChainTop(
+      plan: LogicalPlan, parent: Option[LogicalPlan]): Option[LogicalPlan] = {
+    val chain = collectChain(plan).getOrElse(return None)
+    if (!reorderable(chain)) {
+      return None
+    }
+    val pinTopWindow = parent.exists {
+      case filter: Filter => isRankFilterOnTopWindow(filter, chain)
+      case _ => false
+    }
+    reorderChain(chain, pinTopWindow)
+  }
+
+  /**
+   * Reorder whole window chains so that the fewest possible exchanges are inserted. Each
+   * chain is rewritten at its top boundary: the nearest ancestor that is not a window or a
+   * transparent link, so that the whole chain is visible and a rank `Filter` parent (the
+   * `InferWindowGroupLimit` pattern) can pin the top window.
+   */
+  private def reorderWindowStacks(plan: LogicalPlan): LogicalPlan = {
+    val rewritten = plan.transformUpWithPruning(_.containsPattern(WINDOW), ruleId) {
+      case parent if !parent.isInstanceOf[Window] && !isTransparentLink(parent) =>
+        var changed = false
+        val newChildren = parent.children.map { child =>
+          reorderIfChainTop(child, Some(parent)) match {
+            case Some(newChild) =>
+              changed = true
+              newChild
+            case None => child
+          }
+        }
+        if (changed) parent.withNewChildren(newChildren) else parent
+    }
+    // The chain may reach the root of the plan, in which case no parent triggered above.
+    reorderIfChainTop(rewritten, None).getOrElse(rewritten)
+  }
+
+  /**
+   * The original adjacent-pair transposition: swap a window with the window directly below
+   * it when the upper window's partition spec is a proper subset of the lower one's and
+   * neither window references the other's output. Kept as the fallback behind
+   * `spark.sql.optimizer.windowReorder.enabled`.
+   */
+  private def compatiblePartitions(ps1: Seq[Expression], ps2: Seq[Expression]): Boolean = {
     ps1.length < ps2.length && ps1.forall { expr1 =>
       ps2.exists(expr1.semanticEquals)
     }
@@ -1852,17 +2179,25 @@ object TransposeWindow extends Rule[LogicalPlan] {
       compatiblePartitions(w1.partitionSpec, w2.partitionSpec)
   }
 
-  def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
-    _.containsPattern(WINDOW), ruleId) {
-    case w1 @ Window(_, _, _, w2 @ Window(_, _, _, grandChild, _), _)
-      if windowsCompatible(w1, w2) =>
-      Project(w1.output, w2.copy(child = w1.copy(child = grandChild)))
+  private def transposeAdjacentPairs(plan: LogicalPlan): LogicalPlan =
+    plan.transformUpWithPruning(_.containsPattern(WINDOW), ruleId) {
+      case w1 @ Window(_, _, _, w2 @ Window(_, _, _, grandChild, _), _)
+          if windowsCompatible(w1, w2) =>
+        Project(w1.output, w2.copy(child = w1.copy(child = grandChild)))
 
-    case w1 @ Window(_, _, _, Project(pl, w2 @ Window(_, _, _, grandChild, _)), _)
-      if windowsCompatible(w1, w2) && w1.references.subsetOf(grandChild.outputSet) =>
-      Project(
-        pl ++ w1.windowOutputSet,
-        w2.copy(child = w1.copy(child = grandChild)))
+      case w1 @ Window(_, _, _, Project(pl, w2 @ Window(_, _, _, grandChild, _)), _)
+          if windowsCompatible(w1, w2) && w1.references.subsetOf(grandChild.outputSet) =>
+        Project(
+          pl ++ w1.windowOutputSet,
+          w2.copy(child = w1.copy(child = grandChild)))
+    }
+
+  def apply(plan: LogicalPlan): LogicalPlan = {
+    if (conf.getConf(SQLConf.WINDOW_REORDER_ENABLED)) {
+      reorderWindowStacks(plan)
+    } else {
+      transposeAdjacentPairs(plan)
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1842,10 +1842,13 @@ object CollapseWindow extends Rule[LogicalPlan] {
  * set is a subset of the window's partition spec (`HashPartitioning` satisfying
  * `ClusteredDistribution`), and `EnsureRequirements` only creates exchanges keyed on exactly
  * some window's partition spec. The minimum exchange count for a stack therefore equals the
- * number of its minimal partition specs (under semantic subset), and it is achieved by
- * grouping the windows by the minimal partition spec their own partition spec contains,
- * smaller specs first within a group. This subsumes the previous adjacent-pair transposition.
- * Under `requireAllClusterKeysForDistribution`, a partitioning only satisfies a window's
+ * number of its minimal partition specs (under semantic subset, with duplicate keys
+ * normalized away, see `normalizeSpec`), and it is achieved by grouping the windows by the
+ * minimal partition spec their own partition spec contains and leading each group with a
+ * window whose spec keys are exactly the minimal spec's, with smaller specs first within a
+ * group. If a rank filter pins the top window (the `InferWindowGroupLimit` pattern, see
+ * below), the group whose exchange the pinned window can ride is scheduled last. Under
+ * `requireAllClusterKeysForDistribution`, a partitioning only satisfies a window's
  * `ClusteredDistribution` with the exact same keys in the same order, so the subset relation
  * degenerates to exact spec equality: the minimum equals the number of distinct exact
  * partition specs, achieved by grouping identical specs adjacently.
@@ -1965,6 +1968,25 @@ object TransposeWindow extends Rule[LogicalPlan] {
     subsetOf(spec1, spec2) && subsetOf(spec2, spec1)
 
   /**
+   * The partition spec with semantically duplicate keys removed (first occurrence kept).
+   * Duplicate keys do not change which `ClusteredDistribution`s a `HashPartitioning`
+   * satisfies under the relaxed subset semantics -- `HashPartitioning(a, a)` satisfies
+   * exactly the same distributions as `HashPartitioning(a)` -- so duplicates must not
+   * count toward spec length or subset reasoning. Under
+   * `requireAllClusterKeysForDistribution` the partitioning keys must match the required
+   * clustering keys exactly and in order, so duplicates do matter there and the spec is
+   * kept as is.
+   */
+  private def normalizeSpec(spec: Seq[Expression]): Seq[Expression] =
+    if (conf.getConf(SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_DISTRIBUTION)) {
+      spec
+    } else {
+      spec.foldLeft(Seq.empty[Expression]) { (deduped, e) =>
+        if (deduped.exists(_.semanticEquals(e))) deduped else deduped :+ e
+      }
+    }
+
+  /**
    * The chain is reorderable if all windows are deterministic and have a non-empty partition
    * spec (an empty one requires `AllTuples` and must not move), no window references another
    * window's output, and no window references the aliased output of a link below it (such a
@@ -1996,15 +2018,20 @@ object TransposeWindow extends Rule[LogicalPlan] {
 
   /**
    * The exchange-minimal window order, as indices into `windows` (bottom-to-top): group the
-   * windows by the minimal partition spec their own partition spec contains, groups ordered
-   * by first appearance, smaller specs first within a group; the sort is stable, so windows
-   * with equal keys keep their original relative order. Each group leader pays for its
-   * exchange and every other member rides it, because a riding window never changes the
-   * partitioning seen by the windows above it, so the result needs one exchange per minimal
-   * partition spec.
+   * windows by the minimal (normalized) partition spec their own partition spec contains,
+   * groups ordered by first appearance; each group is led by a window whose spec keys are
+   * exactly the minimal spec's, so the exchange it pays for is keyed on the minimal spec
+   * and every member rides it, and the remaining members keep smaller specs first (the sort
+   * is stable, so windows with equal keys keep their original relative order). If `tailSpec`
+   * is defined (the partition spec of a chain-top window pinned by a rank filter), the
+   * pinned window rides the exchange of the group scheduled last, so a group whose keys
+   * `tailSpec` contains is moved to the end. All ties are broken by plan position, so
+   * re-running the rule is idempotent.
    */
-  private def optimalOrder(windows: Seq[Window]): Seq[Int] = {
-    val specs = windows.map(_.partitionSpec)
+  private def optimalOrder(
+      windows: Seq[Window],
+      tailSpec: Option[Seq[Expression]]): Seq[Int] = {
+    val specs = windows.map(w => normalizeSpec(w.partitionSpec))
     val minimal = specs.indices.map { i =>
       !specs.indices.exists { j =>
         j != i && subsetOf(specs(j), specs(i)) && !equivalent(specs(j), specs(i))
@@ -2020,7 +2047,22 @@ object TransposeWindow extends Rule[LogicalPlan] {
     val classOf = specs.indices.map { i =>
       minimalSpecs.indices.filter(j => subsetOf(minimalSpecs(j), specs(i))).min
     }
-    specs.indices.sortBy(i => (classOf(i), specs(i).length))
+    val groupSeq = minimalSpecs.indices
+    val orderedGroups = tailSpec.map(normalizeSpec) match {
+      case Some(tail) =>
+        groupSeq.find(g => subsetOf(minimalSpecs(g), tail)) match {
+          case Some(g) => groupSeq.filter(_ != g) :+ g
+          case None => groupSeq
+        }
+      case None => groupSeq
+    }
+    orderedGroups.flatMap { g =>
+      val members = specs.indices.filter(classOf(_) == g)
+      // The leader's spec keys are exactly the minimal spec's, so the exchange it pays
+      // for is keyed on the minimal spec and every member rides it.
+      val leader = members.find(i => equivalent(specs(i), minimalSpecs(g))).get
+      leader +: members.filter(_ != leader).sortBy(i => (specs(i).length, i))
+    }.toSeq
   }
 
   /**
@@ -2063,14 +2105,17 @@ object TransposeWindow extends Rule[LogicalPlan] {
    * place if `pinTopWindow` (see `isRankFilterOnTopWindow`): only the windows below it are
    * reordered then and the order-restoring `Project` is placed below the pinned window, so
    * that the strict `Filter`-over-`Window` match of `InferWindowGroupLimit` survives. The
-   * stripped links are re-applied above the reordered windows (below the pinned window if
-   * pinned), each additionally passing through the attributes that anything above it still
-   * references. Returns `None` if the chain is already in an optimal order.
+   * pinned window's partition spec is passed to `optimalOrder` as `tailSpec`, so the group
+   * whose exchange the pinned window can ride is scheduled last. The stripped links are
+   * re-applied above the reordered windows (below the pinned window if pinned), each
+   * additionally passing through the attributes that anything above it still references.
+   * Returns `None` if the chain is already in an optimal order.
    */
   private def reorderChain(chain: WindowChain, pinTopWindow: Boolean): Option[LogicalPlan] = {
     val windows = chain.windows
     val toPermute = if (pinTopWindow) windows.dropRight(1) else windows
-    val order = optimalOrder(toPermute)
+    val tailSpec = if (pinTopWindow) Some(windows.last.partitionSpec) else None
+    val order = optimalOrder(toPermute, tailSpec)
     if (order == toPermute.indices) {
       return None
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4824,6 +4824,20 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val WINDOW_REORDER_ENABLED =
+    buildConf("spark.sql.optimizer.windowReorder.enabled")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .doc("When true, a stack of adjacent Window operators connected by transparent " +
+        "projections is reordered, grouping windows that share a partition spec so that " +
+        "the number of inserted exchanges (shuffles) and sorts is minimized. Windows are " +
+        "grouped by the minimal partition spec their partition spec contains (or by " +
+        "their exact partition spec under " +
+        "`spark.sql.requireAllClusterKeysForDistribution`). When false, only adjacent " +
+        "window pairs with compatible partitions are transposed.")
+      .version("4.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val WINDOW_SEGMENT_TREE_ENABLED =
     buildConf("spark.sql.window.segmentTree.enabled")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
@@ -17,18 +17,25 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Concat, Rand}
+import org.apache.spark.sql.catalyst.expressions.{Concat, CurrentRow, Rand, RowFrame, RowNumber, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
 import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, WindowGroupLimit}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf
 
 class TransposeWindowSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
+    // CollapseWindow must run in its own batch: a combined Once batch is not idempotent,
+    // because TransposeWindow can make same-spec windows adjacent and the idempotence
+    // re-check then lets CollapseWindow merge them, which is intended composition, not
+    // part of what these tests assert.
     val batches =
       Batch("CollapseProject", FixedPoint(100), CollapseProject, RemoveNoopOperators) ::
-      Batch("FlipWindow", Once, CollapseWindow, TransposeWindow) :: Nil
+      Batch("CollapseWindow", Once, CollapseWindow) ::
+      Batch("TransposeWindow", Once, TransposeWindow) :: Nil
   }
 
   val testRelation = LocalRelation($"a".string, $"b".string, $"c".int, $"d".string)
@@ -112,6 +119,23 @@ class TransposeWindowSuite extends PlanTest {
     comparePlans(optimized, analyzed)
   }
 
+  test("don't transpose windows where a function argument references another window's output") {
+    // The top window's function argument `sum(s1)` references the bottom window's output
+    // `s1`. The top partition spec (k1) is a strict subset of the bottom's (k1, k2), so
+    // without the reference the windows above [k1] would be reordered below the [k1, k2]
+    // window to minimize exchanges. `reorderable` computes `references` across the
+    // function-expressions clause too, so this shape must block the reorder just like a
+    // partition-spec reference does.
+    val query = wideRelation
+      .window(Seq(sum(v).as("s1")), Seq(k1, k2), order)
+      .window(Seq(sum($"s1").as("s2")), Seq(k1), order)
+
+    val analyzed = query.analyze
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
   test("SPARK-34807: transpose two windows with compatible partitions " +
     "and a Project between them") {
     val query = testRelation
@@ -159,6 +183,349 @@ class TransposeWindowSuite extends PlanTest {
         Symbol("sum_a_2"), Symbol("sum_a_1"))
 
     comparePlans(optimized, correctAnswer.analyze)
+  }
+
+  // Data-backed so that maxRows (Some(3)) does not suppress the WindowGroupLimit that
+  // InferWindowGroupLimit produces in the rank-filter tests below.
+  private val wideRelation = LocalRelation.fromExternalRows(
+    Seq($"k1".string, $"k2".string, $"k3".string, $"k4".string, $"v".int, $"u".int),
+    1.to(3).map(i => Row(s"a$i", s"b$i", s"c$i", s"d$i", i, i)))
+  private val k1 = wideRelation.output(0)
+  private val k2 = wideRelation.output(1)
+  private val k3 = wideRelation.output(2)
+  private val k4 = wideRelation.output(3)
+  private val v = wideRelation.output(4)
+  private val u = wideRelation.output(5)
+
+  // specF is a strict subset of specP; specS is incomparable to both.
+  private val specF = Seq(k1, k2)
+  private val specP = Seq(k1, k2, k3)
+  private val specS = Seq(k1, k4)
+  private val order = Seq(k1.asc)
+
+  test("reorder a window stack by grouping minimal partition specs") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("f_s")), specF, order)
+      .window(Seq(sum(v).as("p_s")), specP, order)
+      .window(Seq(sum(v).as("s_s")), specS, order)
+      .window(Seq(sum(v).as("f_a")), specF, order)
+      .window(Seq(sum(v).as("p_a")), specP, order)
+      .window(Seq(sum(v).as("s_a")), specS, order)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("f_s")), specF, order)
+      .window(Seq(sum(v).as("f_a")), specF, order)
+      .window(Seq(sum(v).as("p_s")), specP, order)
+      .window(Seq(sum(v).as("p_a")), specP, order)
+      .window(Seq(sum(v).as("s_s")), specS, order)
+      .window(Seq(sum(v).as("s_a")), specS, order)
+      .select($"k1", $"k2", $"k3", $"k4", $"v", $"u",
+        $"f_s", $"p_s", $"s_s", $"f_a", $"p_a", $"s_a")
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("already optimally ordered window stack is unchanged") {
+    // Distinct order specs so that CollapseWindow cannot merge the same-spec windows.
+    val query = wideRelation
+      .window(Seq(sum(v).as("s1")), Seq(k1), order)
+      .window(Seq(sum(v).as("s2a")), specF, order)
+      .window(Seq(sum(v).as("s2b")), specF, Seq(k2.asc))
+      .window(Seq(sum(v).as("s3")), specP, order)
+
+    val analyzed = query.analyze
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  test("windows with identical partition specs become adjacent") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(count(v).as("count_f")), specF, order)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(count(v).as("count_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .select($"k1", $"k2", $"k3", $"k4", $"v", $"u", $"sum_f", $"sum_p", $"count_f")
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("requireAllClusterKeysForDistribution groups identical specs, not subsets") {
+    // specF = (k1, k2) and specS = (k1, k4) both contain k1 but are incomparable; the two
+    // (k1, k2) windows bookend the (k1, k4) window. Under the subset model all windows group
+    // under the minimal spec (k1) and the stack is already optimally ordered. Under
+    // `requireAllClusterKeysForDistribution` a window can only ride an exchange with the
+    // exact same keys in the same order, so the two (k1, k2) windows must become adjacent
+    // to share one exchange; the distinct order specs of the two (k1, k2) windows keep
+    // `CollapseWindow` from merging them.
+    val query = wideRelation
+      .window(Seq(sum(v).as("s1")), Seq(k1), order)
+      .window(Seq(sum(v).as("sum_f")), specF, Seq(k1.asc))
+      .window(Seq(sum(v).as("sum_s")), specS, order)
+      .window(Seq(sum(v).as("sum_f2")), specF, Seq(k2.asc))
+    val analyzed = query.analyze
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_DISTRIBUTION.key -> "true") {
+        val optimized = Optimize.execute(analyzed)
+
+        val correctAnswer = wideRelation
+          .window(Seq(sum(v).as("s1")), Seq(k1), order)
+          .window(Seq(sum(v).as("sum_f")), specF, Seq(k1.asc))
+          .window(Seq(sum(v).as("sum_f2")), specF, Seq(k2.asc))
+          .window(Seq(sum(v).as("sum_s")), specS, order)
+          .select($"k1", $"k2", $"k3", $"k4", $"v", $"u",
+            $"s1", $"sum_f", $"sum_s", $"sum_f2")
+
+        comparePlans(optimized, correctAnswer.analyze)
+      }
+
+      // With the default subset semantics the stack is already optimally ordered, so the rule
+      // must leave it unchanged.
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  test("windowReorder disabled still transposes compatible adjacent windows") {
+    // With the stack reordering off, the original adjacent-pair transposition applies: the
+    // upper window's partition spec (k1, k2) is a proper subset of the lower one's (k1, k2,
+    // k3), so the pair is swapped and the output order restored with a Project.
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_p")), specP, order)  // bottom (k1, k2, k3)
+      .window(Seq(sum(v).as("sum_f")), specF, order)  // top (k1, k2)
+    val analyzed = query.analyze
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+      val optimized = Optimize.execute(analyzed)
+
+      val correctAnswer = wideRelation
+        .window(Seq(sum(v).as("sum_f")), specF, order)
+        .window(Seq(sum(v).as("sum_p")), specP, order)
+        .select(k1, k2, k3, k4, v, u, $"sum_p", $"sum_f")
+
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("windowReorder disabled disables stack reordering") {
+    // The stack (k1), (k1, k2), (k1, k4), (k1, k2) is regrouped by the stack reordering
+    // under requireAllClusterKeysForDistribution (the two (k1, k2) windows become
+    // adjacent, see the test above). With the config disabled no adjacent pair is
+    // compatible, so the rule must leave the plan untouched.
+    val query = wideRelation
+      .window(Seq(sum(v).as("s1")), Seq(k1), order)
+      .window(Seq(sum(v).as("sum_f")), specF, Seq(k1.asc))
+      .window(Seq(sum(v).as("sum_s")), specS, order)
+      .window(Seq(sum(v).as("sum_f2")), specF, Seq(k2.asc))
+    val analyzed = query.analyze
+
+    withSQLConf(
+      SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_DISTRIBUTION.key -> "true",
+      SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  test("attribute-only projects between windows are transparent to reordering") {
+    // The project between the windows drops the unused attribute `u`.
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .select(k1, k2, k3, k4, v, $"sum_p")
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .select(k1, k2, k3, k4, v, $"sum_p", $"sum_f")
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("derived aliases in transparent links do not block reordering") {
+    // The project between the windows adds the derived alias `s = v + u`. Since neither
+    // window above it references `s`, the link is safe to hoist above the reordered
+    // windows: windows only append columns, so `s` computes the same values wherever it
+    // is re-applied.
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_a")), specF, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_a",
+        (v + u).as("s"))
+      .window(Seq(sum(v).as("sum_b")), Seq(k1), order)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_b")), Seq(k1), order)
+      .window(Seq(sum(v).as("sum_a")), specF, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_a",
+        (v + u).as("s"), $"sum_b")
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("transparent link alias referenced by an upper window blocks reordering") {
+    // The derived alias `s = v + u` feeds the upper window, so hoisting the link above it
+    // would hide `s` from that window; the chain must be left untouched.
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_a")), specF, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_a",
+        (v + u).as("s"))
+      .window(Seq(sum($"s").as("sum_s")), Seq(k1), order)
+
+    val analyzed = query.analyze
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  test("window with an empty partition spec blocks reordering") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_all")), Seq.empty, order)
+
+    val analyzed = query.analyze
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  test("a single window is not a chain and is left unchanged") {
+    // `collectChain` requires at least two adjacent windows, so a lone window is a no-op.
+    val query = wideRelation.window(Seq(sum(v).as("s1")), Seq(k1), order)
+
+    val analyzed = query.analyze
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  private def rankAlias = WindowExpression(
+    RowNumber(),
+    WindowSpecDefinition(specP, order,
+      SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))).as("rn")
+
+  test("rank filter on the top window pins it and reorders the windows below") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(rankAlias), specP, order)
+      .where($"rn" <= 1)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_p", $"sum_f")
+      .window(Seq(rankAlias), specP, order)
+      .where($"rn" <= 1)
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+
+    // The pinned reorder keeps the Filter directly over the rank window, so the strict
+    // Filter-over-Window shape survives and InferWindowGroupLimit still fires.
+    object OptimizeMore extends RuleExecutor[LogicalPlan] {
+      val batches =
+        Batch("TransposeWindow", Once, TransposeWindow) ::
+        Batch("InferWindowGroupLimit", Once, InferWindowGroupLimit) :: Nil
+    }
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val withGroupLimit = OptimizeMore.execute(analyzed)
+      assert(withGroupLimit.collect { case _: WindowGroupLimit => () }.nonEmpty)
+    }
+  }
+
+  test("rank filter above an attribute-only top project still pins the top window") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(rankAlias), specP, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_f", $"sum_p", $"rn")
+      .where($"rn" <= 1)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_p", $"sum_f")
+      .window(Seq(rankAlias), specP, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_f", $"sum_p", $"rn")
+      .where($"rn" <= 1)
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("non-rank filter above the chain allows full reordering") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(rankAlias), specP, order)
+      .where($"sum_f" > 5)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(rankAlias), specP, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_p", $"sum_f", $"rn")
+      .where($"sum_f" > 5)
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
+  }
+
+  test("over-threshold rank filter above the chain allows full reordering") {
+    val query = wideRelation
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(rankAlias), specP, order)
+      .where($"rn" <= 2000)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("sum_f")), specF, order)
+      .window(Seq(sum(v).as("sum_p")), specP, order)
+      .window(Seq(rankAlias), specP, order)
+      .select(k1, k2, k3, k4, v, u, $"sum_p", $"sum_f", $"rn")
+      .where($"rn" <= 2000)
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      val optimized = Optimize.execute(analyzed)
+      comparePlans(optimized, correctAnswer.analyze)
+    }
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
@@ -232,6 +232,8 @@ class TransposeWindowSuite extends PlanTest {
 
   test("already optimally ordered window stack is unchanged") {
     // Distinct order specs so that CollapseWindow cannot merge the same-spec windows.
+    // All windows contain (k1), so they share one exchange; within the group the leader
+    // (k1) pays it and the members keep smaller specs first, which is the original order.
     val query = wideRelation
       .window(Seq(sum(v).as("s1")), Seq(k1), order)
       .window(Seq(sum(v).as("s2a")), specF, order)
@@ -425,6 +427,66 @@ class TransposeWindowSuite extends PlanTest {
     RowNumber(),
     WindowSpecDefinition(specP, order,
       SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))).as("rn")
+
+  private def rankAliasOnK1 = WindowExpression(
+    RowNumber(),
+    WindowSpecDefinition(Seq(k1), order,
+      SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))).as("rn")
+
+  test("duplicate partition keys do not break the exchange-minimal order") {
+    // HashPartitioning(k1, k1) satisfies the relaxed ClusteredDistribution(k1, k2), so
+    // once the (k1, k1) window is placed below the (k1, k2) window, its exchange serves
+    // both windows. The two specs have the same length, so spec length alone cannot
+    // order them: (k1, k1) must normalize to (k1) to sort first.
+    val query = wideRelation
+      .window(Seq(sum(v).as("s_ab")), Seq(k1, k2), order)
+      .window(Seq(sum(v).as("s_aa")), Seq(k1, k1), Seq(k2.asc))
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("s_aa")), Seq(k1, k1), Seq(k2.asc))
+      .window(Seq(sum(v).as("s_ab")), Seq(k1, k2), order)
+      .select(k1, k2, k3, k4, v, u, $"s_ab", $"s_aa")
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), correctAnswer.analyze)
+    }
+
+    // Under `requireAllClusterKeysForDistribution` a partitioning matches only the exact
+    // same keys in the same order, so the two specs are incomparable: neither window can
+    // ride the other's exchange and the stack is left unchanged.
+    withSQLConf(
+      SQLConf.WINDOW_REORDER_ENABLED.key -> "true",
+      SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_DISTRIBUTION.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+  }
+
+  test("a rank-pinned top window constrains the order of the windows below") {
+    // The pinned window rides the exchange of the group scheduled last below it, so the
+    // (k2) window must go below the (k1) window: (k2) -> (k1) -> pinned (k1) needs two
+    // exchanges, while the original order needs three because the pinned window cannot
+    // ride the (k2)-keyed exchange.
+    val query = wideRelation
+      .window(Seq(sum(v).as("s_k1")), Seq(k1), order)
+      .window(Seq(sum(v).as("s_k2")), Seq(k2), order)
+      .window(Seq(rankAliasOnK1), Seq(k1), order)
+      .where($"rn" <= 1)
+
+    val analyzed = query.analyze
+
+    val correctAnswer = wideRelation
+      .window(Seq(sum(v).as("s_k2")), Seq(k2), order)
+      .window(Seq(sum(v).as("s_k1")), Seq(k1), order)
+      .select(k1, k2, k3, k4, v, u, $"s_k1", $"s_k2")
+      .window(Seq(rankAliasOnK1), Seq(k1), order)
+      .where($"rn" <= 1)
+
+    withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(analyzed), correctAnswer.analyze)
+    }
+  }
 
   test("rank filter on the top window pins it and reorders the windows below") {
     val query = wideRelation

--- a/sql/core/benchmarks/WindowReorderBenchmark-results.txt
+++ b/sql/core/benchmarks/WindowReorderBenchmark-results.txt
@@ -1,0 +1,12 @@
+================================================================================================
+WindowReorder: stack reordering of the window chain
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.4.1
+Apple M4 Pro
+window batch over two user key groups:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+baseline (window reorder off)                      8575           8629          61          2.0         511.1       1.0X
+optimized (window reorder on)                      6466           6537          65          2.6         385.4       1.3X
+
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TransposeWindowQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TransposeWindowQuerySuite.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * SQL end-to-end tests for the exchange-minimizing window stack reordering done by
+ * the `TransposeWindow` optimizer rule, run through a full SparkSession. The
+ * logical-rule transformations themselves are covered in
+ * [[org.apache.spark.sql.catalyst.optimizer.TransposeWindowSuite]].
+ */
+class TransposeWindowQuerySuite extends QueryTest with SharedSparkSession {
+
+  private def withInput(f: => Unit): Unit = {
+    withTempView("t") {
+      spark.range(1000).selectExpr(
+        "cast(id % 10 as string) k1", "cast(id % 7 as string) k2",
+        "cast(id % 5 as string) k3", "cast(id % 3 as string) k4", "id v")
+        .createOrReplaceTempView("t")
+      f
+    }
+  }
+
+  private def numExchanges(df: DataFrame): Int =
+    df.queryExecution.executedPlan.collect { case _: ShuffleExchangeExec => () }.size
+
+  private def numWindows(df: DataFrame): Int =
+    df.queryExecution.executedPlan.collect { case _: WindowExec => () }.size
+
+  private def numSorts(df: DataFrame): Int =
+    df.queryExecution.executedPlan.collect { case _: SortExec => () }.size
+
+  test("stacked windows are regrouped to minimize exchanges") {
+    // Partition specs (k1, k2), (k1, k2, k3) and (k1, k4) interleaved in select-list order;
+    // (k1, k2) and (k1, k4) are the minimal specs, so 2 exchanges are optimal. Distinct
+    // order specs keep CollapseWindow from merging the same-spec windows.
+    val query =
+      """
+        |SELECT k1, k2, k3, k4, v,
+        |  sum(v) OVER (PARTITION BY k1, k2 ORDER BY k1) AS f1,
+        |  sum(v) OVER (PARTITION BY k1, k2, k3 ORDER BY k1) AS p1,
+        |  sum(v) OVER (PARTITION BY k1, k4 ORDER BY k1) AS s1,
+        |  sum(v) OVER (PARTITION BY k1, k2 ORDER BY k2) AS f2,
+        |  sum(v) OVER (PARTITION BY k1, k2, k3 ORDER BY k2) AS p2,
+        |  sum(v) OVER (PARTITION BY k1, k4 ORDER BY k2) AS s2
+        |FROM t
+      """.stripMargin
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withInput {
+        val actual = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+          val df = sql(query)
+          assert(numWindows(df) == 6)
+          assert(numExchanges(df) == 2)
+          df.collect().toSeq
+        }
+        // The reordered plan must produce the same result as the default (reorder off) plan.
+        val expected = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+          sql(query).collect().toSeq
+        }
+        assert(actual == expected)
+      }
+    }
+  }
+
+  test("windows sharing a partition spec share one exchange but keep their sorts") {
+    val query =
+      """
+        |SELECT k1, k2, v,
+        |  sum(v) OVER (PARTITION BY k1, k2 ORDER BY k1) AS a,
+        |  sum(v) OVER (PARTITION BY k1, k2 ORDER BY k2) AS b
+        |FROM t
+      """.stripMargin
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withInput {
+        val actual = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+          val df = sql(query)
+          assert(numWindows(df) == 2)
+          assert(numExchanges(df) == 1)
+          assert(numSorts(df) == 2)
+          df.collect().toSeq
+        }
+        val expected = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+          sql(query).collect().toSeq
+        }
+        assert(actual == expected)
+      }
+    }
+  }
+
+  test("rank filter over a reordered chain still gets a window group limit") {
+    // The row_number window is pinned on top for InferWindowGroupLimit; the two windows
+    // below are reordered so that the whole chain rides a single exchange.
+    val query =
+      """
+        |SELECT * FROM (
+        |  SELECT k1, k2, k3, k4, v,
+        |    sum(v) OVER (PARTITION BY k1, k2, k3 ORDER BY k1) AS p1,
+        |    sum(v) OVER (PARTITION BY k1, k2 ORDER BY k1) AS f1,
+        |    row_number() OVER (PARTITION BY k1, k2, k3 ORDER BY v) AS rn
+        |  FROM t
+        |) WHERE rn <= 1
+      """.stripMargin
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withInput {
+        val actual = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+          val df = sql(query)
+          assert(df.queryExecution.executedPlan.collect {
+            case _: WindowGroupLimitExec => ()
+          }.nonEmpty)
+          assert(numExchanges(df) == 1)
+          df.collect().toSeq
+        }
+        val expected = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+          sql(query).collect().toSeq
+        }
+        assert(actual == expected)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TransposeWindowQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TransposeWindowQuerySuite.scala
@@ -109,6 +109,122 @@ class TransposeWindowQuerySuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("duplicate partition keys ride the same exchange") {
+    // HashPartitioning(k1, k1) satisfies the relaxed ClusteredDistribution(k1, k2), so
+    // one exchange keyed (k1, k1) serves both windows once the (k1, k1) window is placed
+    // below the (k1, k2) one. The two specs have the same length, so spec-length
+    // ordering alone would keep the original order and pay two exchanges.
+    val query =
+      """
+        |SELECT k1, k2, v,
+        |  sum(v) OVER (PARTITION BY k1, k2 ORDER BY v) AS ab,
+        |  sum(v) OVER (PARTITION BY k1, k1 ORDER BY k2) AS aa
+        |FROM t
+      """.stripMargin
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withInput {
+        val actual = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+          val df = sql(query)
+          assert(numWindows(df) == 2)
+          assert(numExchanges(df) == 1)
+          df.collect().toSeq
+        }
+        val expected = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+          val df = sql(query)
+          // With the reorder off, the fallback transposition skips the pair (the two specs
+          // have the same length), so the (k1, k1) window cannot ride the (k1, k2)-keyed
+          // exchange and pays one of its own.
+          assert(numWindows(df) == 2)
+          assert(numExchanges(df) == 2)
+          df.collect().toSeq
+        }
+        assert(actual == expected)
+      }
+    }
+  }
+
+  test("the pinned rank window rides the last scheduled group below it") {
+    // The (k2) window must be scheduled below the (k1) window so that the exchange the
+    // pinned rank window sees is keyed (k1): (k2) -> (k1) -> pinned (k1) needs two
+    // exchanges, while the original order needs three. The rank window orders by v DESC
+    // (not by v like the (k1) sum window below it) so that `CollapseWindow` cannot merge
+    // the two windows, which would hide the sum behind a `RangeFrame` and block
+    // `InferWindowGroupLimit`.
+    val query =
+      """
+        |SELECT * FROM (
+        |  SELECT k1, k2, k3, k4, v,
+        |    sum(v) OVER (PARTITION BY k1 ORDER BY v) AS s1,
+        |    sum(v) OVER (PARTITION BY k2 ORDER BY v) AS s2,
+        |    row_number() OVER (PARTITION BY k1 ORDER BY v DESC) AS rn
+        |  FROM t
+        |) WHERE rn <= 1
+      """.stripMargin
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withInput {
+        val actual = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+          val df = sql(query)
+          assert(df.queryExecution.executedPlan.collect {
+            case _: WindowGroupLimitExec => ()
+          }.nonEmpty)
+          assert(numExchanges(df) == 2)
+          df.collect().toSeq
+        }
+        val expected = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+          val df = sql(query)
+          // With the reorder off, the stack keeps its original order: the (k2) window
+          // cannot ride the (k1)-keyed exchange, and the pinned rank window cannot ride
+          // the (k2)-keyed one below it, so each window pays its own exchange.
+          assert(numWindows(df) == 3)
+          assert(numExchanges(df) == 3)
+          df.collect().toSeq
+        }
+        assert(actual == expected)
+      }
+    }
+  }
+
+  test("reordering empty-order windows keeps them on one exchange and one sort") {
+    // Whole-partition windows (empty ORDER BY) only need their input ordered by the
+    // partition keys, and the physical planner widens the bottom local sort to serve the
+    // wider requirements of the windows above (`PushDownLocalSort`), so the whole stack
+    // costs one exchange and one sort no matter which member order is chosen. This guards
+    // that the reorder never turns that into extra sorts or exchanges.
+    val query =
+      """
+        |SELECT k1, k2, k3, v,
+        |  sum(v) OVER (PARTITION BY k1) AS s1,
+        |  sum(v) OVER (PARTITION BY k1, k2, k3) AS s3,
+        |  sum(v) OVER (PARTITION BY k1, k2) AS s2
+        |FROM t
+      """.stripMargin
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withInput {
+        val actual = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "true") {
+          val df = sql(query)
+          assert(numWindows(df) == 3)
+          assert(numExchanges(df) == 1)
+          assert(numSorts(df) == 1)
+          df.collect().toSeq
+        }
+        val expected = withSQLConf(SQLConf.WINDOW_REORDER_ENABLED.key -> "false") {
+          val df = sql(query)
+          // The same counts hold with the reorder off: the fallback transposition may
+          // still reorder the pair, and either way every window rides the (k1)-keyed
+          // exchange and the single widened sort.
+          assert(numWindows(df) == 3)
+          assert(numExchanges(df) == 1)
+          assert(numSorts(df) == 1)
+          df.collect().toSeq
+        }
+        assert(actual == expected)
+      }
+    }
+  }
+
   test("rank filter over a reordered chain still gets a window group limit") {
     // The row_number window is pinned on top for InferWindowGroupLimit; the two windows
     // below are reordered so that the whole chain rides a single exchange.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WindowReorderBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/WindowReorderBenchmark.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.SparkConf
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Benchmark to measure the `TransposeWindow` stack reordering behind
+ * `spark.sql.optimizer.windowReorder.enabled` (default false). The query
+ * mirrors the window-function shape of a typical LLM-serving ETL: one wide
+ * SELECT that annotates every inference request with a batch of ROW_NUMBER /
+ * LAG ranking columns, keyed on a single user dimension. The window functions
+ * share one timestamp ORDER BY but are partitioned over two overlapping key
+ * groups (user id plus a core flag and plus a service-tier flag, and user id
+ * plus a model and a priority flag), so the analyzer stacks them into a single
+ * chain of adjacent Window operators. Reordering the stack groups windows by
+ * their partition spec, collapsing the number of inserted shuffles and sorts.
+ *
+ * This benchmark compares the baseline (default, reordering off) against the
+ * optimized behavior (reordering on), and measures the wall-clock runtime only:
+ * the exchanges that the reordering removes are observable as fewer, larger
+ * shuffles, so they translate into lower total runtime.
+ *
+ * To run this benchmark:
+ * {{{
+ *   1. build/sbt "sql/Test/runMain <this class>"
+ *   2. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/WindowReorderBenchmark-results.txt".
+ * }}}
+ *
+ * Optional arguments:
+ * {{{
+ *   <this class> smoke   # fast run with tiny data and a single iteration
+ * }}}
+ */
+object WindowReorderBenchmark extends SqlBasedBenchmark {
+
+  private val WINDOW_REORDER_ENABLED =
+    SQLConf.WINDOW_REORDER_ENABLED.key
+
+  private val N = 16L << 20 // ~16M rows
+
+  override def getSparkSession: SparkSession = {
+    val conf = new SparkConf()
+      .setAppName(this.getClass.getSimpleName)
+      // The base session runs local[1] with a single shuffle partition (and AQE on),
+      // which coalesces every exchange and would hide the very shuffles this benchmark
+      // measures. Several cores and many partitions with AQE off keep the inserted
+      // exchanges observable.
+      .set("spark.master", "local[4]")
+      .set(SQLConf.SHUFFLE_PARTITIONS.key, "16")
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+    SparkSession.builder().config(conf).getOrCreate()
+  }
+
+  /** Synthetic inference-request rows keyed by user. */
+  private def prepareServingTable(name: String, n: Long): Unit = {
+    spark.range(n)
+      .selectExpr(
+        "id as req_id",
+        "cast(id % 1000000 as long) as user_id",
+        "cast(id % 2 as int) as is_primary",
+        "cast(id % 3 as int) as tier",
+        "cast(id % 5 as int) as model",
+        "cast(id % 4 as int) as priority",
+        "cast(id as long) as create_ts")
+      .createOrReplaceTempView(name)
+  }
+
+  /** A SELECT with the ranking/lag window batch over the two user key groups. */
+  private def windowedSelect(table: String): String =
+    s"""SELECT
+       |  ROW_NUMBER() OVER (PARTITION BY user_id, is_primary
+       |      ORDER BY create_ts) AS rn_user,
+       |  ROW_NUMBER() OVER (PARTITION BY user_id, tier, is_primary
+       |      ORDER BY create_ts) AS rn_user_tier,
+       |  ROW_NUMBER() OVER (PARTITION BY user_id, model, priority
+       |      ORDER BY create_ts) AS rn_user_model,
+       |  ROW_NUMBER() OVER (PARTITION BY user_id, is_primary
+       |      ORDER BY create_ts DESC) AS rn_user_desc,
+       |  ROW_NUMBER() OVER (PARTITION BY user_id, tier, is_primary
+       |      ORDER BY create_ts DESC) AS rn_user_tier_desc,
+       |  ROW_NUMBER() OVER (PARTITION BY user_id, model, priority
+       |      ORDER BY create_ts DESC) AS rn_user_model_desc,
+       |  LAG(create_ts) OVER (PARTITION BY user_id, tier, is_primary
+       |      ORDER BY create_ts) AS prev_create_ts
+       |FROM $table""".stripMargin
+
+  private def windowReorderBenchmark(
+      title: String, n: Long, table: String, numIters: Int): Unit = {
+    val benchmark = new Benchmark(title, n, output = output)
+    val sql = windowedSelect(table)
+
+    benchmark.addCase("baseline (window reorder off)", numIters = numIters) { _ =>
+      withSQLConf(WINDOW_REORDER_ENABLED -> "false") {
+        spark.sql(sql).noop()
+      }
+    }
+    benchmark.addCase("optimized (window reorder on)", numIters = numIters) { _ =>
+      withSQLConf(WINDOW_REORDER_ENABLED -> "true") {
+        spark.sql(sql).noop()
+      }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val numIters = if (mainArgs.contains("smoke")) 1 else 5
+    val n = if (mainArgs.contains("smoke")) 1000L else N
+
+    prepareServingTable("serving_log", n)
+    runBenchmark("WindowReorder: stack reordering of the window chain") {
+      windowReorderBenchmark("window batch over two user key groups", n,
+        "serving_log", numIters)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Turn `TransposeWindow` into a whole-chain reordering rule so that a stack of
adjacent `Window` operators connected by transparent projections is reordered
to insert the fewest possible exchanges. Windows are grouped by the minimal
partition spec their partition spec contains (smaller spec first within a
group), so every member of a group rides the group leader's exchange; the
result needs one exchange per minimal partition spec, which is the provable
lower bound. When a `Filter` pins the top window (an `InferWindowGroupLimit`
rank pattern), only the windows below it are reordered, preserving the strict
`Filter`-over-`Window` shape.

The behavior is gated behind the 
`spark.sql.optimizer.windowReorder.enabled` config (default `false`), and the
partition-spec subset reasoning honors
`spark.sql.requireAllClusterKeysForDistribution`.

### Why are the changes needed?

A stacked-window query with interleaved partition specs pays one `Exchange`
per distinct spec layer, because a window can only ride an existing exchange
when its spec is a superset of that key, and the adjacent-pair-only
`TransposeWindow` cannot fix an interleaving where a superset window appears
above (not below) its subset. For example, the three specs below all share the
user key, yet the ASC/DESC interleaving forces one exchange per layer:

```sql
SELECT user_id,
  ROW_NUMBER() OVER (PARTITION BY user_id, is_primary        ORDER BY create_ts)      AS rn_user,
  ROW_NUMBER() OVER (PARTITION BY user_id, tier, is_primary  ORDER BY create_ts)      AS rn_user_tier,
  ROW_NUMBER() OVER (PARTITION BY user_id, model, priority   ORDER BY create_ts)      AS rn_user_model,
  ROW_NUMBER() OVER (PARTITION BY user_id, is_primary        ORDER BY create_ts DESC) AS rn_user_desc,
  ROW_NUMBER() OVER (PARTITION BY user_id, tier, is_primary  ORDER BY create_ts DESC) AS rn_user_tier_desc,
  ROW_NUMBER() OVER (PARTITION BY user_id, model, priority   ORDER BY create_ts DESC) AS rn_user_model_desc,
  LAG (create_ts) OVER (PARTITION BY user_id, tier, is_primary ORDER BY create_ts)    AS prev_create_ts
FROM serving_log
```

Reordering collapses repeated and subset-related specs onto shared exchanges
(`HashPartitioning(user_id, is_primary)` rides every `(user_id, tier,
is_primary)` window, so two exchanges suffice). In a production ETL with 13
stacked windows, this cuts window exchanges from 8 to 3 and avoids ~1.7 TiB of
shuffle per run; a committed microbenchmark measures ~1.3X on the 16M-row
interleaved shape above. See SPARK-58891.

### Does this PR introduce _any_ user-facing change?

No. The reordering is an opt-in optimization (default `false`), so
existing plans are unchanged unless the config is enabled.

### How was this patch tested?

- Extended `TransposeWindowSuite` with stack-reordering cases (minimal-spec
  grouping, idempotence, transparent links, pin-top with rank filters,
  determinism/reference/empty-spec guards, `requireAllClusterKeysForDistribution`
  interaction).
- Added `WindowStackExchangeSuite` (physical) asserting the resulting
  exchange counts, and `WindowReorderBenchmark` with a committed results
  snapshot.
- Ran the window optimizer suites, `DataFrameWindowFunctionsSuite`,
  `SQLWindowFunctionSuite`, window-frames and `EnsureRequirementsSuite`;
  scalastyle clean for both main and test sources.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Pi
