### PR TITLE
[SPARK-58896][ML] Compute decision tree model stats in one traversal

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -203,6 +203,8 @@ class DecisionTreeClassificationModel private[ml] (
 
   override private[ml] val treeStats: NodeStats = rootNode.computeStats
 
+  private[ml] def numLeave: Int = treeStats.numLeaves
+
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -203,8 +203,6 @@ class DecisionTreeClassificationModel private[ml] (
 
   override private[ml] val treeStats: NodeStats = rootNode.computeStats
 
-  private[ml] def numLeave: Int = treeStats.numLeaves
-
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -201,6 +201,8 @@ class DecisionTreeClassificationModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Node.dummyNode, -1, -1)
 
+  override private[ml] val treeStats: Node.TreeStats = rootNode.computeStats
+
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -201,7 +201,7 @@ class DecisionTreeClassificationModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Node.dummyNode, -1, -1)
 
-  override private[ml] val treeStats: Node.TreeStats = rootNode.computeStats
+  override private[ml] val treeStats: NodeStats = rootNode.computeStats
 
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -192,6 +192,8 @@ class DecisionTreeRegressionModel private[ml] (
 
   override private[ml] val treeStats: NodeStats = rootNode.computeStats
 
+  private[ml] def numLeave: Int = treeStats.numLeaves
+
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -190,7 +190,7 @@ class DecisionTreeRegressionModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Node.dummyNode, -1)
 
-  override private[ml] val treeStats: Node.TreeStats = rootNode.computeStats
+  override private[ml] val treeStats: NodeStats = rootNode.computeStats
 
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -192,8 +192,6 @@ class DecisionTreeRegressionModel private[ml] (
 
   override private[ml] val treeStats: NodeStats = rootNode.computeStats
 
-  private[ml] def numLeave: Int = treeStats.numLeaves
-
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -190,6 +190,8 @@ class DecisionTreeRegressionModel private[ml] (
   // For ml connect only
   private[ml] def this() = this("", Node.dummyNode, -1)
 
+  override private[ml] val treeStats: Node.TreeStats = rootNode.computeStats
+
   private[spark] override def estimatedSize: Long = estimateMatadataSize + getEstimatedSize()
 
   override def predict(features: Vector): Double = {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -77,9 +77,37 @@ sealed abstract class Node extends Serializable {
    * @return  Max feature index used in a split, or -1 if there are no splits (single leaf node).
    */
   private[ml] def maxSplitFeatureIndex(): Int
+
+  private[ml] def computeStats: Node.TreeStats = {
+    var numDescendants = 0
+    var subtreeDepth = 0
+    var numLeaves = 0
+
+    def visit(node: Node, depth: Int): Unit = {
+      if (depth > 0) {
+        numDescendants += 1
+      }
+      subtreeDepth = math.max(subtreeDepth, depth)
+      node match {
+        case _: LeafNode =>
+          numLeaves += 1
+        case internal: InternalNode =>
+          visit(internal.leftChild, depth + 1)
+          visit(internal.rightChild, depth + 1)
+      }
+    }
+
+    visit(this, 0)
+    Node.TreeStats(subtreeDepth, numDescendants, numLeaves)
+  }
 }
 
 private[ml] object Node {
+
+  private[ml] case class TreeStats(
+      subtreeDepth: Int,
+      numDescendants: Int,
+      numLeaves: Int)
 
   /**
    * Create a new Node from the old Node format, recursively creating child nodes as needed.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -78,7 +78,7 @@ sealed abstract class Node extends Serializable {
    */
   private[ml] def maxSplitFeatureIndex(): Int
 
-  private[ml] def computeStats: Node.TreeStats = {
+  private[ml] def computeStats: NodeStats = {
     var numDescendants = 0
     var subtreeDepth = 0
     var numLeaves = 0
@@ -98,16 +98,16 @@ sealed abstract class Node extends Serializable {
     }
 
     visit(this, 0)
-    Node.TreeStats(subtreeDepth, numDescendants, numLeaves)
+    NodeStats(subtreeDepth, numDescendants, numLeaves)
   }
 }
 
-private[ml] object Node {
+private[ml] case class NodeStats(
+    subtreeDepth: Int,
+    numDescendants: Int,
+    numLeaves: Int)
 
-  private[ml] case class TreeStats(
-      subtreeDepth: Int,
-      numDescendants: Int,
-      numLeaves: Int)
+private[ml] object Node {
 
   /**
    * Create a new Node from the old Node format, recursively creating child nodes as needed.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -95,10 +95,7 @@ private[spark] trait DecisionTreeModel {
 
   private[ml] def numLeaves: Int = treeStats.numLeaves
 
-  private[ml] def leafAttr = {
-    NominalAttribute.defaultAttr
-      .withNumValues(numLeaves)
-  }
+  private[ml] def leafAttr = NominalAttribute.defaultAttr.withNumValues(numLeaves)
 
   private[ml] def getLeafField(leafCol: String) = {
     leafAttr.withName(leafCol).toStructField()

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -91,7 +91,7 @@ private[spark] trait DecisionTreeModel {
     }
   }
 
-  private[ml] def treeStats: Node.TreeStats
+  private[ml] def treeStats: NodeStats
 
   private[ml] def numLeaves: Int = treeStats.numLeaves
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -49,17 +49,13 @@ private[spark] trait DecisionTreeModel {
   def rootNode: Node
 
   /** Number of nodes in tree, including leaf nodes. */
-  def numNodes: Int = {
-    1 + rootNode.numDescendants
-  }
+  def numNodes: Int = treeStats.numDescendants + 1
 
   /**
    * Depth of the tree.
    * E.g.: Depth 0 means 1 leaf node.  Depth 1 means 1 internal node and 2 leaf nodes.
    */
-  lazy val depth: Int = {
-    rootNode.subtreeDepth
-  }
+  def depth: Int = treeStats.subtreeDepth
 
   /** Summary of the model */
   override def toString: String = {
@@ -95,12 +91,13 @@ private[spark] trait DecisionTreeModel {
     }
   }
 
-  private[ml] lazy val numLeave: Int =
-    leafIterator(rootNode).size
+  private[ml] def treeStats: Node.TreeStats
+
+  private[ml] def numLeaves: Int = treeStats.numLeaves
 
   private[ml] def leafAttr = {
     NominalAttribute.defaultAttr
-      .withNumValues(numLeave)
+      .withNumValues(numLeaves)
   }
 
   private[ml] def getLeafField(leafCol: String) = {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -270,7 +270,7 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
 
     val transformed = newTree.transform(newData)
     checkNominalOnDF(transformed, "prediction", newTree.numClasses)
-    checkNominalOnDF(transformed, "predictedLeafId", newTree.numLeave)
+    checkNominalOnDF(transformed, "predictedLeafId", newTree.numLeaves)
     checkVectorSizeOnDF(transformed, "rawPrediction", newTree.numClasses)
     checkVectorSizeOnDF(transformed, "probability", newTree.numClasses)
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -34,7 +34,14 @@ import com.typesafe.tools.mima.core.*
 object MimaExcludes {
 
   // Exclude rules for 5.0.x from 4.4.0 (add 5.0-specific filters below as needed).
-  lazy val v50excludes: Seq[Problem => Boolean] = v44excludes
+  lazy val v50excludes: Seq[Problem => Boolean] = v44excludes ++ Seq(
+    // [SPARK-58896] Decision tree leaf counts moved behind NodeStats. The old package-private
+    // numLeave accessors are removed from concrete models.
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "org.apache.spark.ml.classification.DecisionTreeClassificationModel.numLeave"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave")
+  )
 
   // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
   lazy val v44excludes: Seq[Problem => Boolean] = v43excludes


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR computes decision tree model stats in a single traversal of the root node.

It adds `Node.computeStats`, which returns a `NodeStats` value containing the subtree depth,
number of descendants, and number of leaves. Decision tree classification and regression models
compute these stats once and `DecisionTreeModel` reuses them for `numNodes`, `depth`, and leaf
metadata.

This also renames the package-private `numLeave` helper to `numLeaves`.

### Why are the changes needed?

Before this change, decision tree model metadata could traverse the tree separately for depth,
node count, and leaf count. Computing these values together avoids redundant tree walks.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested with:

```
git diff --check
```

Also checked changed Scala files for long lines and non-ASCII characters.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
