### PR TITLE
[SPARK-58898][ML] Use Identifiable for temporary ML column names

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -199,13 +199,12 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
   (ClassificationModel[FeaturesType, M], String, String) = {
     val model = if ($(rawPredictionCol).isEmpty && $(predictionCol).isEmpty) {
       copy(ParamMap.empty)
-        .setRawPredictionCol("rawPrediction_" + java.util.UUID.randomUUID.toString)
-        .setPredictionCol("prediction_" + java.util.UUID.randomUUID.toString)
+        .setRawPredictionCol(Identifiable.randomUID("rawPrediction"))
+        .setPredictionCol(Identifiable.randomUID("prediction"))
     } else if ($(rawPredictionCol).isEmpty) {
-      copy(ParamMap.empty).setRawPredictionCol("rawPrediction_" +
-        java.util.UUID.randomUUID.toString)
+      copy(ParamMap.empty).setRawPredictionCol(Identifiable.randomUID("rawPrediction"))
     } else if ($(predictionCol).isEmpty) {
-      copy(ParamMap.empty).setPredictionCol("prediction_" + java.util.UUID.randomUUID.toString)
+      copy(ParamMap.empty).setPredictionCol(Identifiable.randomUID("prediction"))
     } else {
       this
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import java.util.UUID
-
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.existentials
@@ -201,10 +199,10 @@ final class OneVsRestModel private[ml] (
     val isProbModel = models.head.isInstanceOf[ProbabilisticClassificationModel[_, _]]
 
     // use a temporary raw prediction column to avoid column conflict
-    val tmpRawPredName = "mbc$raw" + UUID.randomUUID().toString
+    val tmpRawPredName = Identifiable.randomUID("mbc$raw")
 
     // add an accumulator column to store predictions of all the models
-    val accColName = "mbc$acc" + UUID.randomUUID().toString
+    val accColName = Identifiable.randomUID("mbc$acc")
     val newDataset = dataset.withColumn(accColName, lit(Array.emptyDoubleArray))
     val columns = newDataset.schema.fieldNames.map(col)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -22,7 +22,7 @@ import org.apache.spark.internal.{LogKeys}
 import org.apache.spark.ml.linalg.{DenseVector, SQLDataTypes, Vector}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.param.shared._
-import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -241,12 +241,12 @@ abstract class ProbabilisticClassificationModel[
   (ProbabilisticClassificationModel[FeaturesType, M], String, String) = {
     val model = if ($(probabilityCol).isEmpty && $(predictionCol).isEmpty) {
       copy(ParamMap.empty)
-        .setProbabilityCol("probability_" + java.util.UUID.randomUUID.toString)
-        .setPredictionCol("prediction_" + java.util.UUID.randomUUID.toString)
+        .setProbabilityCol(Identifiable.randomUID("probability"))
+        .setPredictionCol(Identifiable.randomUID("prediction"))
     } else if ($(probabilityCol).isEmpty) {
-      copy(ParamMap.empty).setProbabilityCol("probability_" + java.util.UUID.randomUUID.toString)
+      copy(ParamMap.empty).setProbabilityCol(Identifiable.randomUID("probability"))
     } else if ($(predictionCol).isEmpty) {
-      copy(ParamMap.empty).setPredictionCol("prediction_" + java.util.UUID.randomUUID.toString)
+      copy(ParamMap.empty).setPredictionCol(Identifiable.randomUID("prediction"))
     } else {
       this
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1282,7 +1282,7 @@ class GeneralizedLinearRegressionSummary private[regression] (
     if (origModel.isDefined(origModel.predictionCol) && origModel.getPredictionCol.nonEmpty) {
       origModel.getPredictionCol
     } else {
-      "prediction_" + java.util.UUID.randomUUID.toString
+      Identifiable.randomUID("prediction")
     }
   }
 
@@ -1456,7 +1456,7 @@ class GeneralizedLinearRegressionSummary private[regression] (
         link.link(glrSummary.getDouble(4))
       } else {
         // Create empty feature column and fit intercept only model using param setting from model
-        val featureNull = "feature_" + java.util.UUID.randomUUID.toString
+        val featureNull = Identifiable.randomUID("feature")
         val paramMap = model.extractParamMap()
         paramMap.put(model.featuresCol, featureNull)
         if (family.name != "tweedie") {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -742,7 +742,7 @@ class LinearRegressionModel private[ml] (
   private[regression] def findSummaryModelAndPredictionCol(): (LinearRegressionModel, String) = {
     $(predictionCol) match {
       case "" =>
-        val predictionColName = "prediction_" + java.util.UUID.randomUUID.toString
+        val predictionColName = Identifiable.randomUID("prediction")
         (copy(ParamMap.empty).setPredictionCol(predictionColName), predictionColName)
       case p => (this, p)
     }
@@ -1160,4 +1160,3 @@ class LinearRegressionSummary private[regression] (
     }
   }
 }
-


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces ad hoc UUID concatenation for Scala ML temporary and fallback column names
with `Identifiable.randomUID(prefix)`.

The updated paths cover classification/regression summary fallback output columns and
`OneVsRestModel` intermediate columns.

### Why are the changes needed?

Scala ML code already uses `Identifiable.randomUID` for collision-resistant generated names.
Using it in these remaining column-name paths keeps the Scala side consistent and avoids direct
`java.util.UUID` usage for temporary ML columns.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually checked with:

```
git diff --check
grep -rn -P "[^\x00-\x7F]" mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
```

Unit tests were not run because this is a small internal refactor of generated column names.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
