### PR TITLE
[SPARK-58899][BUILD] Upgrade scalapb-runtime from 0.11.17 to 0.11.20

### DIFF
--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -125,6 +125,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.thesamet.scalapb</groupId>
+      <artifactId>scalapb-runtime_${scala.binary.version}</artifactId>
+      <version>0.11.20</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
       <type>test-jar</type>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade scalapb-runtime from 0.11.17 to 0.11.20 in sql/connect/client/jvm.

### Why are the changes needed?

Fixes 4 CVEs from the transitive protobuf dependency:
- CVE-2024-7254 (HIGH 7.5): Protobuf stack overflow via recursive map fields
- CVE-2026-0994 (HIGH 7.5): Protobuf vulnerability
- CVE-2015-5237 (HIGH 8.8): Integer overflow in protobuf
- CVE-2021-22570 (MEDIUM 5.5): Protobuf null pointer dereference

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Build passes with `./dev/make-distribution.sh --name hadoop3 --tgz -Phadoop-3 -DskipTests`.

### Was this patch authored or co-authored using generative AI tooling?

Yes