### PR TITLE
[SPARK-54694][K8S] Fail app on ConfigMap size over limit

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model._
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils
 import org.apache.spark.util.ArrayImplicits._
 
 /**
@@ -116,14 +117,15 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
     if (confDir.isDefined) {
       val fileMap = confFiles.map { file =>
         (file.getName(), Files.readString(file.toPath))
-      }.toMap.asJava
+      }.toMap
+      KubernetesClientUtils.validateConfigMapSize(fileMap, conf.sparkConf)
 
       Seq(new ConfigMapBuilder()
         .withNewMetadata()
           .withName(newConfigMapName)
           .endMetadata()
         .withImmutable(true)
-        .addToData(fileMap)
+        .addToData(fileMap.asJava)
         .build())
     } else {
       Nil

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
@@ -30,6 +30,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.k8s.{KubernetesDriverConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
@@ -230,13 +231,14 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
     Seq[HasMetadata]() ++ {
       krb5File.map { path =>
         val file = new File(path)
+        val fileMap = Map(file.getName() -> Files.readString(file.toPath))
+        KubernetesClientUtils.validateConfigMapSize(fileMap, kubernetesConf.sparkConf)
         new ConfigMapBuilder()
           .withNewMetadata()
             .withName(newConfigMapName)
             .endMetadata()
           .withImmutable(true)
-          .addToData(
-            Map(file.getName() -> Files.readString(file.toPath)).asJava)
+          .addToData(fileMap.asJava)
           .build()
       }
     } ++ {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
@@ -25,6 +25,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils
 import org.apache.spark.util.DependencyUtils.downloadFile
 import org.apache.spark.util.Utils
 
@@ -81,6 +82,8 @@ private[spark] class PodTemplateConfigMapStep(conf: KubernetesConf)
       val uri = downloadFile(podTemplateFile, Utils.createTempDir(), conf.sparkConf, hadoopConf)
       val file = new java.net.URI(uri).getPath
       val podTemplateString = Files.readString(new File(file).toPath)
+      KubernetesClientUtils.validateConfigMapSize(
+        Map(POD_TEMPLATE_KEY -> podTemplateString), conf.sparkConf)
       Seq(new ConfigMapBuilder()
           .withNewMetadata()
             .withName(configmapName)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -106,8 +106,9 @@ private[spark] class Client(
     val configMapName = KubernetesClientUtils.configMapNameDriver
     val confFilesMap = KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName,
       conf.sparkConf, resolvedDriverSpec.systemProperties)
-    val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap +
-        (KUBERNETES_NAMESPACE.key -> conf.namespace))
+    val configMapDataMap = confFilesMap + (KUBERNETES_NAMESPACE.key -> conf.namespace)
+    KubernetesClientUtils.validateConfigMapSize(configMapDataMap, conf.sparkConf)
+    val configMap = KubernetesClientUtils.buildConfigMap(configMapName, configMapDataMap)
 
     // The include of the ENV_VAR for "SPARK_CONF_DIR" is to allow for the
     // Spark command builder to pickup on the Java Options present in the ConfigMap

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -34,7 +34,7 @@ import org.apache.spark.deploy.k8s.{Config, Constants, KubernetesUtils}
 import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH, KUBERNETES_NAMESPACE}
 import org.apache.spark.deploy.k8s.Constants.ENV_SPARK_CONF_DIR
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{CONFIG, PATH, PATHS}
+import org.apache.spark.internal.LogKeys.{PATH, PATHS}
 import org.apache.spark.util.ArrayImplicits._
 
 /**
@@ -147,34 +147,42 @@ object KubernetesClientUtils extends Logging {
       .build()
   }
 
-  private def orderFilesBySize(confFiles: Seq[File]): Seq[File] = {
-    val fileToFileSizePairs = confFiles.map(f => (f, f.getName.length + f.length()))
-    // sort first by name and then by length, so that during tests we have consistent results.
-    fileToFileSizePairs.sortBy(f => f._1).sortBy(f => f._2).map(_._1)
+  /**
+   * Validate the total size of a config map's data against
+   * `spark.kubernetes.configMap.maxSize`.
+   *
+   * Kubernetes rejects ConfigMaps whose serialized size exceeds a server-side limit
+   * (by default ~1MiB, see https://etcd.io/docs/v3.4.0/dev-guide/limit/). Rather than
+   * silently dropping configuration files to stay under that limit -- which can leave
+   * an application running with missing or unexpected configuration -- callers should
+   * invoke this method before building the config map so that Spark fails fast with a
+   * clear error instead.
+   */
+  @Since("5.0.0")
+  def validateConfigMapSize(confFileMap: Map[String, String], sparkConf: SparkConf): Unit = {
+    val maxSize = sparkConf.get(Config.CONFIG_MAP_MAXSIZE)
+    val mapSize = confFileMap.map { case (k, v) => k.length + v.length }.sum
+    if (mapSize > maxSize) {
+      throw new IllegalArgumentException(
+        s"Data for config map with size $mapSize bytes exceeds the maximum config map " +
+          s"size of $maxSize bytes. Please see config: `${Config.CONFIG_MAP_MAXSIZE.key}` " +
+          "for more details.")
+    }
   }
 
   // exposed for testing
   private[submit] def loadSparkConfDirFiles(conf: SparkConf): Map[String, String] = {
     val confDir = Option(conf.getenv(ENV_SPARK_CONF_DIR)).orElse(
       conf.getOption("spark.home").map(dir => s"$dir/conf"))
-    val maxSize = conf.get(Config.CONFIG_MAP_MAXSIZE)
     if (confDir.isDefined) {
-      val confFiles: Seq[File] = listConfFiles(confDir.get, maxSize)
-      val orderedConfFiles = orderFilesBySize(confFiles)
-      var truncatedMapSize: Long = 0
-      val truncatedMap = mutable.HashMap[String, String]()
-      val skippedFiles = mutable.HashSet[String]()
+      val confFiles: Seq[File] = listConfFiles(confDir.get)
+      val confFileMap = mutable.HashMap[String, String]()
       var source: Source = Source.fromString("") // init with empty source.
-      for (file <- orderedConfFiles) {
+      for (file <- confFiles) {
         try {
           source = Source.fromFile(file)(Codec.UTF8)
           val (fileName, fileContent) = file.getName -> source.mkString
-          if ((truncatedMapSize + fileName.length + fileContent.length) < maxSize) {
-            truncatedMap.put(fileName, fileContent)
-            truncatedMapSize = truncatedMapSize + (fileName.length + fileContent.length)
-          } else {
-            skippedFiles.add(fileName)
-          }
+          confFileMap.put(fileName, fileContent)
         } catch {
           case e: MalformedInputException =>
             logWarning(log"Unable to read a non UTF-8 encoded file " +
@@ -183,27 +191,20 @@ object KubernetesClientUtils extends Logging {
           source.close()
         }
       }
-      if (truncatedMap.nonEmpty) {
+      if (confFileMap.nonEmpty) {
         logInfo(log"Spark configuration files loaded from ${MDC(PATH, confDir)} : " +
-          log"${MDC(PATHS, truncatedMap.keys.mkString(","))}")
+          log"${MDC(PATHS, confFileMap.keys.mkString(","))}")
       }
-      if (skippedFiles.nonEmpty) {
-        logWarning(log"Skipped conf file(s) ${MDC(PATHS, skippedFiles.mkString(","))}, due to " +
-          log"size constraint. Please see, config: " +
-          log"`${MDC(CONFIG, Config.CONFIG_MAP_MAXSIZE.key)}` for more details.")
-      }
-      truncatedMap.toMap
+      confFileMap.toMap
     } else {
       Map.empty[String, String]
     }
   }
 
-  private def listConfFiles(confDir: String, maxSize: Long): Seq[File] = {
-    // At the moment configmaps do not support storing binary content (i.e. skip jar,tar,gzip,zip),
-    // and configMaps do not allow for size greater than 1.5 MiB(configurable).
-    // https://etcd.io/docs/v3.4.0/dev-guide/limit/
-    def testIfTooLargeOrBinary(f: File): Boolean = (f.length() + f.getName.length > maxSize) ||
-      f.getName.matches(".*\\.(gz|zip|jar|tar)")
+  private def listConfFiles(confDir: String): Seq[File] = {
+    // At the moment configmaps do not support storing binary content
+    // (i.e. skip jar,tar,gzip,zip).
+    def testIfBinary(f: File): Boolean = f.getName.matches(".*\\.(gz|zip|jar|tar)")
 
     // We exclude all the template files and user provided spark conf or properties,
     // Spark properties are resolved in a different step.
@@ -211,7 +212,7 @@ object KubernetesClientUtils extends Logging {
       f.getName.matches("spark.*(conf|properties)")
 
     val fileFilter = (f: File) => {
-      f.isFile && !testIfTooLargeOrBinary(f) && !testIfSparkConfOrTemplates(f)
+      f.isFile && !testIfBinary(f) && !testIfSparkConfOrTemplates(f)
     }
     val confFiles: Seq[File] = {
       val dir = new File(confDir)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -91,6 +91,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     val confFilesMap = KubernetesClientUtils
       .buildSparkConfDirFilesMap(configMapName, conf, resolvedExecutorProperties) ++
       resolvedExecutorProperties
+    KubernetesClientUtils.validateConfigMapSize(confFilesMap, conf)
     val labels =
       Map(SPARK_APP_ID_LABEL -> applicationId(), SPARK_ROLE_LABEL -> SPARK_POD_EXECUTOR_ROLE)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap, labels)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -29,7 +29,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.deploy.k8s.Config
+import org.apache.spark.deploy.k8s.{Config, Constants}
 import org.apache.spark.util.Utils
 
 class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
@@ -60,26 +60,54 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     assert(output === expectedOutput)
   }
 
-  test("verify load files, truncates the content to maxSize, when keys are very large in number.") {
+  test("SPARK-54694: loadSparkConfDirFiles no longer silently truncates/skips files " +
+      "when their combined size would exceed the config map max size") {
+    // Before SPARK-54694, files were silently dropped here to stay under maxSize,
+    // which could leave an application running with missing configuration. Now, all
+    // conf dir files are loaded as-is; enforcing the size limit is the responsibility
+    // of `validateConfigMapSize`, called right before the config map is actually built.
     val input = (for (i <- 10000 to 1 by -1) yield (s"testConf.${i}" -> "test123456")).toMap
     val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
       .set(Config.CONFIG_MAP_MAXSIZE.key, "60")
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456")
-    assert(output === expectedOutput)
-    val output1 = KubernetesClientUtils.loadSparkConfDirFiles(
-      sparkConf.set(Config.CONFIG_MAP_MAXSIZE.key, "250000"))
-    assert(output1 === input)
+    assert(output === input)
   }
 
-  test("verify load files, truncates the content to maxSize, when keys are equal in length.") {
-    val input = (for (i <- 9 to 1 by -1) yield (s"testConf.${i}" -> "test123456")).toMap
-    val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
-      .set(Config.CONFIG_MAP_MAXSIZE.key, "80")
-    val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456",
-      "testConf.3" -> "test123456")
-    assert(output === expectedOutput)
+  test("SPARK-54694: validateConfigMapSize fails fast when config map data exceeds maxSize") {
+    val confFileMap = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456")
+    val sparkConf = new SparkConf(loadDefaults = false)
+      .set(Config.CONFIG_MAP_MAXSIZE.key, "10")
+    val ex = intercept[IllegalArgumentException] {
+      KubernetesClientUtils.validateConfigMapSize(confFileMap, sparkConf)
+    }
+    assert(ex.getMessage.contains("exceeds the maximum config map size"))
+  }
+
+  test("SPARK-54694: validateConfigMapSize allows config map data within maxSize") {
+    val confFileMap = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456")
+    val exactSize = confFileMap.map { case (k, v) => k.length + v.length }.sum
+    val sparkConf = new SparkConf(loadDefaults = false)
+      .set(Config.CONFIG_MAP_MAXSIZE.key, exactSize.toString)
+    // Should not throw: data size exactly at the limit is allowed.
+    KubernetesClientUtils.validateConfigMapSize(confFileMap, sparkConf)
+  }
+
+  test("SPARK-54694: validateConfigMapSize accounts for the resolved spark.properties size") {
+    // Reproduces the second defect described in SPARK-54694: the size of the
+    // resolved spark.properties file was not previously included when checking
+    // the config map size limit, since that check only ran over the raw conf
+    // dir files before spark.properties was merged in.
+    val configMapName = s"configmap-name-${UUID.randomUUID.toString}"
+    val sparkConf = testSetup(Map.empty)
+    val resolvedProperties = Map("spark.testConf" -> ("v" * 1000))
+    val confFileMap = KubernetesClientUtils.buildSparkConfDirFilesMap(
+      configMapName, sparkConf, resolvedProperties)
+    assert(confFileMap.contains(Constants.SPARK_CONF_FILE_NAME))
+    val ex = intercept[IllegalArgumentException] {
+      KubernetesClientUtils.validateConfigMapSize(
+        confFileMap, sparkConf.set(Config.CONFIG_MAP_MAXSIZE.key, "10"))
+    }
+    assert(ex.getMessage.contains("exceeds the maximum config map size"))
   }
 
   test("verify that configmap built as expected") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `KubernetesClientUtils.validateConfigMapSize`, a single validation point invoked right before every Spark-managed Kubernetes ConfigMap is built (driver base conf map, Hadoop conf map, Kerberos conf map, pod template conf map, and executor conf map). It fails fast with an `IllegalArgumentException` when the combined size of a ConfigMap's data would exceed `spark.kubernetes.configMap.maxSize`.

`KubernetesClientUtils.loadSparkConfDirFiles` no longer silently truncates/skips conf dir files to stay under the size limit; all files are loaded as-is, and enforcing the limit is now the responsibility of `validateConfigMapSize`.

### Why are the changes needed?

Currently, when the combined size of configuration files exceeds the Kubernetes ConfigMap size limit, Spark silently skips loading some files. This can leave an application running with missing or unexpected configuration.

The existing validation is also incomplete and inconsistent:
1. Only the driver's base conf map is validated against the limit; the Hadoop conf, Kerberos conf, pod template, and executor conf maps are never checked, so Kubernetes itself ends up rejecting an oversized ConfigMap with a raw API error instead of Spark failing with a clear message.
2. The resolved `spark.properties` file is added to the driver conf map *after* the old size check ran, so its size was never counted toward the limit.

`validateConfigMapSize` is invoked once the full data map (including resolved `spark.properties`, where applicable) has been assembled for each of the five ConfigMap call sites, so both gaps are addressed by a single, uniformly-applied check.

The existing public `buildConfigMap`/`buildConfigMapJava` APIs are left unchanged so that external callers (e.g. the Spark Kubernetes Operator) relying on their current signature and behavior are not affected.

There was a previous attempt at this issue in #53455, which went stale without any review and was closed by stale-bot (`Closed with unmerged commits`). This PR independently reproduces the underlying bug and takes a smaller, source- and binary-compatible approach: rather than changing the signature of the existing `@Stable` `buildConfigMap`/`buildConfigMapJava` APIs, this PR adds a separate `validateConfigMapSize` check invoked at each call site.

### Does this PR introduce _any_ user-facing change?

Yes. An application will now fail fast with a clear error when the combined size of Spark's generated Kubernetes ConfigMap(s) exceeds `spark.kubernetes.configMap.maxSize`, instead of silently continuing with missing configuration.

### How was this patch tested?

* Reverted the fix locally and reran the updated `KubernetesClientUtilsSuite` against the unmodified code to confirm the new tests fail against the original behavior (conf files were silently truncated from 10,000 down to 2), then confirmed they pass with the fix applied.
* Added `KubernetesClientUtilsSuite` cases covering: no more silent truncation, `validateConfigMapSize` throwing when the limit is exceeded, allowing data exactly at the limit (safety/no regression for normal-sized configs), and accounting for the resolved `spark.properties` size.
* Ran the full `kubernetes/core` module test suite: 386/386 passed.
* `scalastyle` and `checkstyle`: no violations.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 5