### PR TITLE
[WIP][PYTHON] Remove identity converter flag

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2327,7 +2327,7 @@ class DataFrame(ParentDataFrame):
         binary_as_bytes = self._get_binary_as_bytes()
         field_converters = [
             ArrowTableToRowsConversion._create_converter(
-                f.dataType, none_on_identity=False, binary_as_bytes=binary_as_bytes
+                f.dataType, binary_as_bytes=binary_as_bytes
             )
             for f in schema.fields
         ]
@@ -2340,7 +2340,11 @@ class DataFrame(ParentDataFrame):
                     ]
                     for i in range(0, table.num_rows):
                         values = [
-                            field_converters[j](columnar_data[j][i])  # type: ignore[misc]
+                            (
+                                field_converters[j](columnar_data[j][i])  # type: ignore[misc]
+                                if field_converters[j] is not None
+                                else columnar_data[j][i]
+                            )
                             for j in range(table.num_columns)
                         ]
                         yield _create_row(fields=schema.fieldNames(), values=values)

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -560,40 +560,18 @@ class LocalDataToArrowConversion:
         else:
             return False
 
-    @overload
-    @staticmethod
-    def _create_converter(
-        dataType: DataType, nullable: bool = True, *, int_to_decimal_coercion_enabled: bool = False
-    ) -> Callable:
-        pass
-
-    @overload
     @staticmethod
     def _create_converter(
         dataType: DataType,
         nullable: bool = True,
         *,
-        none_on_identity: bool = False,
-        int_to_decimal_coercion_enabled: bool = False,
-    ) -> Optional[Callable]:
-        pass
-
-    @staticmethod
-    def _create_converter(
-        dataType: DataType,
-        nullable: bool = True,
-        *,
-        none_on_identity: bool = False,
         int_to_decimal_coercion_enabled: bool = False,
     ) -> Optional[Callable]:
         assert dataType is not None and isinstance(dataType, DataType)
         assert isinstance(nullable, bool)
 
         if not LocalDataToArrowConversion._need_converter(dataType, nullable):
-            if none_on_identity:
-                return None
-            else:
-                return lambda value: value
+            return None
 
         if isinstance(dataType, NullType):
 
@@ -613,7 +591,6 @@ class LocalDataToArrowConversion:
                 LocalDataToArrowConversion._create_converter(
                     field.dataType,
                     field.nullable,
-                    none_on_identity=True,
                     int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
                 )
                 for field in dataType.fields
@@ -670,7 +647,6 @@ class LocalDataToArrowConversion:
             element_conv = LocalDataToArrowConversion._create_converter(
                 dataType.elementType,
                 dataType.containsNull,
-                none_on_identity=True,
                 int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
             )
 
@@ -707,7 +683,6 @@ class LocalDataToArrowConversion:
             value_conv = LocalDataToArrowConversion._create_converter(
                 dataType.valueType,
                 dataType.valueContainsNull,
-                none_on_identity=True,
                 int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
             )
 
@@ -820,7 +795,6 @@ class LocalDataToArrowConversion:
             conv = LocalDataToArrowConversion._create_converter(
                 udt.sqlType(),
                 nullable=nullable,
-                none_on_identity=True,
                 int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
             )
 
@@ -949,7 +923,6 @@ class LocalDataToArrowConversion:
                 LocalDataToArrowConversion._create_converter(
                     field.dataType,
                     field.nullable,
-                    none_on_identity=True,
                     # Default to False for general data conversion
                     int_to_decimal_coercion_enabled=False,
                 )
@@ -1154,29 +1127,14 @@ class ArrowTableToRowsConversion:
         else:
             return False
 
-    @overload
-    @staticmethod
-    def _create_converter(dataType: DataType, *, binary_as_bytes: bool = True) -> Callable:
-        pass
-
-    @overload
     @staticmethod
     def _create_converter(
-        dataType: DataType, *, none_on_identity: bool, binary_as_bytes: bool = True
-    ) -> Optional[Callable]:
-        pass
-
-    @staticmethod
-    def _create_converter(
-        dataType: DataType, *, none_on_identity: bool = False, binary_as_bytes: bool = True
+        dataType: DataType, *, binary_as_bytes: bool = True
     ) -> Optional[Callable]:
         assert dataType is not None and isinstance(dataType, DataType)
 
         if not ArrowTableToRowsConversion._need_converter(dataType):
-            if none_on_identity:
-                return None
-            else:
-                return lambda value: value
+            return None
 
         if isinstance(dataType, NullType):
             return lambda value: None
@@ -1187,7 +1145,7 @@ class ArrowTableToRowsConversion:
 
             field_convs = [
                 ArrowTableToRowsConversion._create_converter(
-                    f.dataType, none_on_identity=True, binary_as_bytes=binary_as_bytes
+                    f.dataType, binary_as_bytes=binary_as_bytes
                 )
                 for f in dataType.fields
             ]
@@ -1212,11 +1170,7 @@ class ArrowTableToRowsConversion:
 
         elif isinstance(dataType, ArrayType):
             element_conv = ArrowTableToRowsConversion._create_converter(
-                dataType.elementType, none_on_identity=True, binary_as_bytes=binary_as_bytes
-            )
-
-            assert element_conv is not None, (
-                f"_need_converter() returned True for ArrayType of {dataType.elementType}"
+                dataType.elementType, binary_as_bytes=binary_as_bytes
             )
 
             def convert_array(value: Any) -> Any:
@@ -1224,16 +1178,20 @@ class ArrowTableToRowsConversion:
                     return None
                 else:
                     assert isinstance(value, list)
-                    return [element_conv(v) for v in value]
+                    return (
+                        [element_conv(v) for v in value]
+                        if element_conv is not None
+                        else value
+                    )
 
             return convert_array
 
         elif isinstance(dataType, MapType):
             key_conv = ArrowTableToRowsConversion._create_converter(
-                dataType.keyType, none_on_identity=True, binary_as_bytes=binary_as_bytes
+                dataType.keyType, binary_as_bytes=binary_as_bytes
             )
             value_conv = ArrowTableToRowsConversion._create_converter(
-                dataType.valueType, none_on_identity=True, binary_as_bytes=binary_as_bytes
+                dataType.valueType, binary_as_bytes=binary_as_bytes
             )
 
             if key_conv is None:
@@ -1317,7 +1275,7 @@ class ArrowTableToRowsConversion:
             udt: UserDefinedType = dataType
 
             conv = ArrowTableToRowsConversion._create_converter(
-                udt.sqlType(), none_on_identity=True, binary_as_bytes=binary_as_bytes
+                udt.sqlType(), binary_as_bytes=binary_as_bytes
             )
 
             if conv is None:
@@ -1446,7 +1404,7 @@ class ArrowTableToRowsConversion:
         if len(fields) > 0:
             field_converters = [
                 ArrowTableToRowsConversion._create_converter(
-                    f.dataType, none_on_identity=True, binary_as_bytes=binary_as_bytes
+                    f.dataType, binary_as_bytes=binary_as_bytes
                 )
                 for f in schema.fields
             ]

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -163,10 +163,16 @@ def records_to_arrow_batches(
                 # Assign the values by name.
                 for name in column_names:
                     idx = col_mapping[name]
-                    pylist[idx].append(column_converters[idx](result[name]))
+                    converter = column_converters[idx]
+                    pylist[idx].append(
+                        converter(result[name]) if converter is not None else result[name]
+                    )
             else:
                 for col in range(num_cols):
-                    pylist[col].append(column_converters[col](result[col]))
+                    converter = column_converters[col]
+                    pylist[col].append(
+                        converter(result[col]) if converter is not None else result[col]
+                    )
         batch = pa.RecordBatch.from_arrays(pylist, schema=pa_schema)
         yield batch
 

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -192,7 +192,12 @@ def _main(infile: IO, outfile: IO) -> None:
                 ]
                 for row in range(0, batch.num_rows):
                     values = [
-                        converters[col](columns[col][row]) for col in range(batch.num_columns)
+                        (
+                            converters[col](columns[col][row])
+                            if converters[col] is not None
+                            else columns[col][row]
+                        )
+                        for col in range(batch.num_columns)
                     ]
                     yield _create_row(fields=fields, values=values)
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1643,7 +1643,6 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 converters = [
                     ArrowTableToRowsConversion._create_converter(
                         f.dataType,
-                        none_on_identity=True,
                         binary_as_bytes=runner_conf.binary_as_bytes,
                     )
                     for f in eval_conf.input_type
@@ -3321,7 +3320,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     ),
                     LocalDataToArrowConversion._create_converter(
                         udf_return_type,
-                        none_on_identity=True,
                         int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                     ),
                 )
@@ -3331,7 +3329,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
         # --- Input preparation ---
         arrow_to_py_converters = [
             ArrowTableToRowsConversion._create_converter(
-                f.dataType, none_on_identity=True, binary_as_bytes=runner_conf.binary_as_bytes
+                f.dataType, binary_as_bytes=runner_conf.binary_as_bytes
             )
             for f in eval_conf.input_type
         ]
@@ -3511,7 +3509,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             arg_converters = [
                 ArrowTableToRowsConversion._create_converter(
                     _elementwise_leaf_type(input_fields[o].dataType, depth),
-                    none_on_identity=True,
                     binary_as_bytes=runner_conf.binary_as_bytes,
                 )
                 for o in args_kwargs_offsets
@@ -3531,7 +3528,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     ),
                     LocalDataToArrowConversion._create_converter(
                         udf_return_type,
-                        none_on_identity=True,
                         int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                     ),
                 )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the `none_on_identity` flag from the PySpark Arrow conversion helper
APIs. Identity conversion now consistently returns `None`, and call sites handle
that representation explicitly.

### Why are the changes needed?

The flag made converter creation support two identity representations: a no-op
callable or `None`. Using a single representation simplifies converter behavior
and makes identity conversion explicit at call sites.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not tested yet. This is a draft PR for review of the implementation approach.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
