### PR TITLE
[MINOR][PYTHON][TESTS] Retry PySpark logger UDF log assertion

### DIFF
--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -54,7 +54,7 @@ from pyspark.testing.sqlutils import (
     test_compiled,
     test_not_compiled_message,
 )
-from pyspark.testing.utils import assertDataFrameEqual, timeout
+from pyspark.testing.utils import assertDataFrameEqual, eventually, timeout
 from pyspark.util import is_remote_only
 
 
@@ -1706,20 +1706,23 @@ class BaseUDFTestsMixin:
                 [Row(result=str(i)) for i in range(2)],
             )
 
-            logs = self.spark.tvf.python_worker_logs()
+            @eventually(timeout=10, catch_assertions=True)
+            def check_logs():
+                logs = self.spark.tvf.python_worker_logs()
+                assertDataFrameEqual(
+                    logs.select("level", "msg", "context", "logger"),
+                    [
+                        Row(
+                            level="WARNING",
+                            msg="PySparkLogger test",
+                            context={"func_name": my_udf.__name__, "x": str(i)},
+                            logger="PySparkLogger",
+                        )
+                        for i in range(2)
+                    ],
+                )
 
-            assertDataFrameEqual(
-                logs.select("level", "msg", "context", "logger"),
-                [
-                    Row(
-                        level="WARNING",
-                        msg="PySparkLogger test",
-                        context={"func_name": my_udf.__name__, "x": str(i)},
-                        logger="PySparkLogger",
-                    )
-                    for i in range(2)
-                ],
-            )
+            check_logs()
 
 
 class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR retries the `python_worker_logs()` assertion in
`test_udf_with_pyspark_logger`.

The UDF result assertion still runs once. Only the follow-up read from the Python
worker log TVF is retried, using the existing `eventually` helper.

### Why are the changes needed?

The log assertion can be flaky when a Python worker log row is not visible at
the moment the test reads `python_worker_logs()`. Retrying the log-table
assertion keeps the expected rows unchanged while tolerating delayed log
visibility.

This was observed in https://github.com/apache/spark/pull/58124 at
https://github.com/zhengruifeng/spark/actions/runs/32337222716/job/96337527156.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not run.

Checked locally:

```
git diff --check
awk 'length>100 && $0 !~ /^[[:space:]]*(import|package) / && $0 !~ /https?:\/\// {print FILENAME":"FNR": "length" chars"}' python/pyspark/sql/tests/test_udf.py
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
