### PR TITLE
[SPARK-58906][ML][PYTHON] Make vector and matrix UDTs singletons

### DIFF
--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -45,6 +45,7 @@ from typing import (
 import numpy as np
 
 from pyspark.sql.types import (
+    DataTypeSingleton,
     UserDefinedType,
     StructField,
     StructType,
@@ -157,7 +158,7 @@ def _double_to_long_bits(value: float) -> int:
     return struct.unpack("Q", struct.pack("d", value))[0]
 
 
-class VectorUDT(UserDefinedType):
+class VectorUDT(UserDefinedType, metaclass=DataTypeSingleton):
     """
     SQL user-defined type (UDT) for Vector.
     """
@@ -212,7 +213,7 @@ class VectorUDT(UserDefinedType):
         return "vector"
 
 
-class MatrixUDT(UserDefinedType):
+class MatrixUDT(UserDefinedType, metaclass=DataTypeSingleton):
     """
     SQL user-defined type (UDT) for Matrix.
     """

--- a/python/pyspark/ml/tests/test_linalg.py
+++ b/python/pyspark/ml/tests/test_linalg.py
@@ -328,6 +328,10 @@ class VectorUDTTests(MLlibTestCase):
     def test_json_schema(self):
         self.assertEqual(VectorUDT.fromJson(self.udt.jsonValue()), self.udt)
 
+    def test_singleton(self):
+        self.assertIs(VectorUDT(), VectorUDT())
+        self.assertIs(VectorUDT.fromJson(self.udt.jsonValue()), self.udt)
+
     def test_serialization(self):
         for v in [self.dv0, self.dv1, self.sv0, self.sv1]:
             self.assertEqual(v, self.udt.deserialize(self.udt.serialize(v)))
@@ -376,6 +380,10 @@ class MatrixUDTTests(MLlibTestCase):
 
     def test_json_schema(self):
         self.assertEqual(MatrixUDT.fromJson(self.udt.jsonValue()), self.udt)
+
+    def test_singleton(self):
+        self.assertIs(MatrixUDT(), MatrixUDT())
+        self.assertIs(MatrixUDT.fromJson(self.udt.jsonValue()), self.udt)
 
     def test_serialization(self):
         for m in [self.dm1, self.dm2, self.sm1, self.sm2]:

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -49,6 +49,7 @@ import numpy as np
 from pyspark import since
 from pyspark.ml import linalg as newlinalg
 from pyspark.sql.types import (
+    DataTypeSingleton,
     UserDefinedType,
     StructField,
     StructType,
@@ -167,7 +168,7 @@ def _double_to_long_bits(value: float) -> int:
     return struct.unpack("Q", struct.pack("d", value))[0]
 
 
-class VectorUDT(UserDefinedType):
+class VectorUDT(UserDefinedType, metaclass=DataTypeSingleton):
     """
     SQL user-defined type (UDT) for Vector.
     """
@@ -222,7 +223,7 @@ class VectorUDT(UserDefinedType):
         return "vector"
 
 
-class MatrixUDT(UserDefinedType):
+class MatrixUDT(UserDefinedType, metaclass=DataTypeSingleton):
     """
     SQL user-defined type (UDT) for Matrix.
     """

--- a/python/pyspark/mllib/tests/test_linalg.py
+++ b/python/pyspark/mllib/tests/test_linalg.py
@@ -418,6 +418,10 @@ class VectorUDTTests(MLlibTestCase):
     def test_json_schema(self):
         self.assertEqual(VectorUDT.fromJson(self.udt.jsonValue()), self.udt)
 
+    def test_singleton(self):
+        self.assertIs(VectorUDT(), VectorUDT())
+        self.assertIs(VectorUDT.fromJson(self.udt.jsonValue()), self.udt)
+
     def test_serialization(self):
         for v in [self.dv0, self.dv1, self.sv0, self.sv1]:
             self.assertEqual(v, self.udt.deserialize(self.udt.serialize(v)))
@@ -478,6 +482,10 @@ class MatrixUDTTests(MLlibTestCase):
 
     def test_json_schema(self):
         self.assertEqual(MatrixUDT.fromJson(self.udt.jsonValue()), self.udt)
+
+    def test_singleton(self):
+        self.assertIs(MatrixUDT(), MatrixUDT())
+        self.assertIs(MatrixUDT.fromJson(self.udt.jsonValue()), self.udt)
 
     def test_serialization(self):
         for m in [self.dm1, self.dm2, self.sm1, self.sm2]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the Python ML vector and matrix UDT implementations singletons by using
the existing `DataTypeSingleton` metaclass:

- `pyspark.ml.linalg.VectorUDT`
- `pyspark.ml.linalg.MatrixUDT`
- `pyspark.mllib.linalg.VectorUDT`
- `pyspark.mllib.linalg.MatrixUDT`

It also adds tests that repeated constructor calls and schema JSON round-trips return the
same UDT instance.

This follows the same singleton reuse direction as
https://github.com/apache/spark/pull/57757, which reused the canonical ML vector data
type to avoid repeated equivalent UDT allocations.

### Why are the changes needed?

These UDT classes are stateless. Reusing one Python instance avoids repeated equivalent
allocations and keeps schema round-trips consistent with the singleton behavior already
used by stateless SQL data types.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added focused tests for both `pyspark.ml.linalg` and `pyspark.mllib.linalg` UDTs.

Also ran:

```
git diff --check
grep -rn -P "[^\x00-\x7F]" python/pyspark/ml/linalg/__init__.py python/pyspark/mllib/linalg/__init__.py python/pyspark/ml/tests/test_linalg.py python/pyspark/mllib/tests/test_linalg.py
awk 'length>100 && $0 !~ /^[[:space:]]*(import|package) / && $0 !~ /https?:\/\// {print FILENAME":"FNR": "length" chars"}' python/pyspark/ml/linalg/__init__.py python/pyspark/mllib/linalg/__init__.py python/pyspark/ml/tests/test_linalg.py python/pyspark/mllib/tests/test_linalg.py
```

The full PySpark test suites were not run locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
