### PR TITLE
[SPARK-58883][CORE] Detect truncated checkpoint directory on read via persisted partition count

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1028,6 +1028,13 @@
     ],
     "sqlState" : "58030"
   },
+  "CHECKPOINT_TRUNCATED_DIRECTORY" : {
+    "message" : [
+      "The checkpoint directory <path> was written with <expected> partition(s) but only <found> partition file(s) were found. One or more trailing part files may have been lost.",
+      "Use `spark.checkpoint.verifyPartitionCount.enabled=false` to bypass this check and load the truncated directory as-is."
+    ],
+    "sqlState" : "58030"
+  },
   "CHECK_CONSTRAINT_VIOLATION" : {
     "message" : [
       "CHECK constraint <constraintName> <expression> violated by row with values:",

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -202,6 +202,19 @@ private[spark] object SparkCoreErrors {
     )
   }
 
+  def checkpointTruncatedDirectoryError(
+      checkpointDirPath: Path, expected: Int, found: Int): Throwable = {
+    new SparkException(
+      errorClass = "CHECKPOINT_TRUNCATED_DIRECTORY",
+      messageParameters = Map(
+        "path" -> s"$checkpointDirPath",
+        "expected" -> s"$expected",
+        "found" -> s"$found"
+      ),
+      cause = null
+    )
+  }
+
   def checkpointFailedToSaveError(task: Int, path: Path): Throwable = {
     new IOException("Checkpoint failed: failed to save output of task: " +
       s"$task and final output path does not exist: $path")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -3110,6 +3110,20 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val CHECKPOINT_VERIFY_PARTITION_COUNT_ENABLED =
+    ConfigBuilder("spark.checkpoint.verifyPartitionCount.enabled")
+      .internal()
+      .doc("When true, a checkpoint directory written by a Spark version that supports " +
+        "SPARK-58883 records the expected number of partitions in a _num_partitions file, and " +
+        "reading that directory back throws CHECKPOINT_TRUNCATED_DIRECTORY if the on-disk " +
+        "count disagrees with the files found. Set to false to suppress the check when " +
+        "recovering a checkpoint that was legitimately truncated. Has no effect on directories " +
+        "written before SPARK-58883 (no _num_partitions file present).")
+      .version("4.4.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val LOCAL_CHECKPOINT_VERIFY_CHECKSUM_ENABLED =
     ConfigBuilder("spark.checkpoint.local.verifyChecksum.enabled")
       .internal()

--- a/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.rdd
 
-import java.io.FileNotFoundException
+import java.io.{DataInputStream, DataOutputStream, FileNotFoundException}
 import java.util.concurrent.TimeUnit
 
 import scala.reflect.ClassTag
@@ -31,7 +31,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
-import org.apache.spark.internal.config.{BUFFER_SIZE, CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME, CHECKPOINT_COMPRESS}
+import org.apache.spark.internal.config.{BUFFER_SIZE, CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME, CHECKPOINT_COMPRESS, CHECKPOINT_VERIFY_PARTITION_COUNT_ENABLED}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
@@ -69,6 +69,8 @@ private[spark] class ReliableCheckpointRDD[T: ClassTag](
    * Since the original RDD may belong to a prior application, there is no way to know a
    * priori the number of partitions to expect. This method assumes that the original set of
    * checkpoint files are fully preserved in a reliable storage across application lifespans.
+   * When the directory was written by a Spark version that supports SPARK-58883, a
+   * `_num_partitions` file records the expected count and is compared against the files found.
    */
   protected override def getPartitions: Array[Partition] = {
     // listStatus can throw exception if path does not exist.
@@ -82,6 +84,20 @@ private[spark] class ReliableCheckpointRDD[T: ClassTag](
       if (path.getName != expectedFileName) {
         throw SparkCoreErrors.invalidCheckpointDirectoryError(path, expectedFileName)
       }
+    }
+    // If a partition-count metadata file is present and the integrity check is enabled,
+    // verify no trailing files are missing. Directories written by earlier Spark versions
+    // have no such file; a missing file is silently tolerated for backward compatibility.
+    // Set spark.checkpoint.verifyPartitionCount.enabled=false to suppress this check when
+    // recovering a legitimately truncated directory. See SPARK-58883.
+    if (context.conf.get(CHECKPOINT_VERIFY_PARTITION_COUNT_ENABLED)) {
+      ReliableCheckpointRDD.readPartitionCountFromCheckpointDir(context, checkpointPath)
+        .foreach { expected =>
+          if (inputFiles.length != expected) {
+            throw SparkCoreErrors.checkpointTruncatedDirectoryError(
+              cpath, expected, inputFiles.length)
+          }
+        }
     }
     Array.tabulate(inputFiles.length)(i => new CheckpointRDDPartition(i))
   }
@@ -143,6 +159,10 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     "_partitioner"
   }
 
+  private def checkpointPartitionCountFileName(): String = {
+    "_num_partitions"
+  }
+
   /**
    * Write RDD to checkpoint files and return a ReliableCheckpointRDD representing the RDD.
    */
@@ -170,6 +190,7 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     if (originalRDD.partitioner.nonEmpty) {
       writePartitionerToCheckpointDir(sc, originalRDD.partitioner.get, checkpointDirPath)
     }
+    writePartitionCountToCheckpointDir(sc, originalRDD.partitions.length, checkpointDirPath)
 
     val checkpointDurationMs =
       TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - checkpointStartTimeNs)
@@ -268,6 +289,81 @@ private[spark] object ReliableCheckpointRDD extends Logging {
     }
   }
 
+  /**
+   * Write the partition count of the checkpointed RDD to the checkpoint directory so that
+   * a later read via [[SparkContext.checkpointFile]] can detect a truncated directory.
+   * The file is written atomically (temp path then rename) so a torn write leaves no partial
+   * file. The payload is a 1-byte format version followed by a 4-byte big-endian Int.
+   * This is done on a best-effort basis; any exception is caught, logged and ignored so that
+   * an inability to write the file does not prevent checkpointing. See SPARK-58883.
+   */
+  private def writePartitionCountToCheckpointDir(
+      sc: SparkContext, partitionCount: Int, checkpointDirPath: Path): Unit = {
+    try {
+      val countFilePath = new Path(checkpointDirPath, checkpointPartitionCountFileName())
+      val tmpFilePath = new Path(
+        checkpointDirPath, s".${checkpointPartitionCountFileName()}-tmp")
+      val bufferSize = sc.conf.get(BUFFER_SIZE)
+      val fs = countFilePath.getFileSystem(sc.hadoopConfiguration)
+      // Write to a temp path first so readers never see a partial file.
+      val fileOutputStream = fs.create(tmpFilePath, true, bufferSize)
+      val dos = new DataOutputStream(fileOutputStream)
+      Utils.tryWithSafeFinally {
+        dos.writeByte(1) // format version
+        dos.writeInt(partitionCount)
+      } {
+        dos.close()
+      }
+      if (!fs.rename(tmpFilePath, countFilePath)) {
+        fs.delete(tmpFilePath, false)
+        logWarning(
+          log"Failed to rename ${MDC(TEMP_OUTPUT_PATH, tmpFilePath)} to " +
+          log"${MDC(PATH, countFilePath)}, " +
+          log"truncation detection will be inactive for this directory")
+      }
+      logDebug(s"Written partition count $partitionCount to $countFilePath")
+    } catch {
+      case NonFatal(e) =>
+        logWarning(log"Error writing partition count to ${MDC(PATH, checkpointDirPath)}, " +
+          log"truncation detection will be inactive for this directory", e)
+    }
+  }
+
+  /**
+   * Read the expected partition count from the checkpoint directory metadata file, if present.
+   * Returns [[None]] when the file is absent (checkpoint written by an older Spark version)
+   * or unreadable, so callers must tolerate a missing value. See SPARK-58883.
+   */
+  private def readPartitionCountFromCheckpointDir(
+      sc: SparkContext, checkpointDirPath: String): Option[Int] = {
+    try {
+      val bufferSize = sc.conf.get(BUFFER_SIZE)
+      val countFilePath = new Path(checkpointDirPath, checkpointPartitionCountFileName())
+      val fs = countFilePath.getFileSystem(sc.hadoopConfiguration)
+      val fileInputStream = fs.open(countFilePath, bufferSize)
+      val count = Utils.tryWithSafeFinally {
+        val dis = new DataInputStream(fileInputStream)
+        val version = dis.readByte()
+        if (version != 1) {
+          throw new IllegalArgumentException(
+            s"Unsupported _num_partitions format version: $version in $countFilePath")
+        }
+        dis.readInt()
+      } {
+        fileInputStream.close()
+      }
+      logDebug(s"Read partition count $count from $countFilePath")
+      Some(count)
+    } catch {
+      case _: FileNotFoundException =>
+        logDebug(s"No partition count file in $checkpointDirPath (older checkpoint)")
+        None
+      case NonFatal(e) =>
+        logWarning(log"Error reading partition count from ${MDC(PATH, checkpointDirPath)}, " +
+          log"truncation detection will be inactive for this directory", e)
+        None
+    }
+  }
 
   /**
    * Read a partitioner from the given RDD checkpoint directory, if it exists.

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -23,7 +23,7 @@ import scala.reflect.ClassTag
 
 import org.apache.hadoop.fs.{LocalFileSystem, Path}
 
-import org.apache.spark.internal.config.CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME
+import org.apache.spark.internal.config.{CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME, CHECKPOINT_VERIFY_PARTITION_COUNT_ENABLED}
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rdd._
@@ -737,6 +737,108 @@ class CheckpointStorageSuite extends SparkFunSuite with LocalSparkContext {
         condition = "FAILED_CREATE_CHECKPOINT_DIRECTORY",
         sqlState = Some("58030"),
         parameters = Map("path" -> rddPath.toString))
+    }
+  }
+
+  // SPARK-58883: truncated checkpoint directory (trailing part-* file deleted) should be
+  // detected when reading back via SparkContext.checkpointFile.
+  test("SPARK-58883: reading a truncated checkpoint directory throws an error") {
+    withTempDir { checkpointDir =>
+      val conf = new SparkConf().set(UI_ENABLED.key, "false")
+      sc = new SparkContext("local", "test", conf)
+      sc.setCheckpointDir(checkpointDir.toString)
+      val rdd = sc.makeRDD(1 to 20, numSlices = 4)
+      rdd.checkpoint()
+      rdd.collect()
+
+      val checkpointPath = new Path(rdd.getCheckpointFile.get)
+      val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+
+      // Delete the last partition file; the remaining files are still contiguous so the
+      // old contiguity check would pass silently and return a 3-partition RDD.
+      val lastPartFile = new Path(checkpointPath, "part-00003")
+      assert(fs.exists(lastPartFile), "expected part-00003 to exist before deletion")
+      fs.delete(lastPartFile, false)
+
+      // Reading back should now throw because _num_partitions records the original count.
+      val recoveredRDD = sc.checkpointFile[Int](rdd.getCheckpointFile.get)
+      checkError(
+        exception = intercept[SparkException](recoveredRDD.partitions),
+        condition = "CHECKPOINT_TRUNCATED_DIRECTORY",
+        sqlState = Some("58030"),
+        parameters = Map(
+          "path" -> rdd.getCheckpointFile.get,
+          "expected" -> "4",
+          "found" -> "3"))
+
+      // With the config disabled, the same truncated directory should load silently.
+      sc.conf.set(CHECKPOINT_VERIFY_PARTITION_COUNT_ENABLED, false)
+      try {
+        val suppressedRDD = sc.checkpointFile[Int](rdd.getCheckpointFile.get)
+        assert(suppressedRDD.partitions.length === 3)
+      } finally {
+        sc.conf.set(CHECKPOINT_VERIFY_PARTITION_COUNT_ENABLED, true)
+      }
+    }
+  }
+
+  test("SPARK-58883: checkpoint directory without _num_partitions is read without error") {
+    // Backward compatibility: a checkpoint written before SPARK-58883 has no _num_partitions
+    // file. Removing it must not prevent the RDD from being read.
+    withTempDir { checkpointDir =>
+      val conf = new SparkConf().set(UI_ENABLED.key, "false")
+      sc = new SparkContext("local", "test", conf)
+      sc.setCheckpointDir(checkpointDir.toString)
+      val rdd = sc.makeRDD(1 to 20, numSlices = 4)
+      rdd.checkpoint()
+      rdd.collect()
+
+      val checkpointPath = new Path(rdd.getCheckpointFile.get)
+      val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+
+      // Remove the metadata file to simulate a pre-SPARK-58883 checkpoint.
+      val countFile = new Path(checkpointPath, "_num_partitions")
+      assert(fs.exists(countFile), "expected _num_partitions to exist before deletion")
+      fs.delete(countFile, false)
+
+      // Must recover normally with all 4 partitions and correct data.
+      val recovered = sc.checkpointFile[Int](rdd.getCheckpointFile.get)
+      assert(recovered.partitions.length === 4)
+      assert(recovered.collect().sorted === (1 to 20).toArray)
+    }
+  }
+
+  test("SPARK-58883: corrupted _num_partitions file is tolerated") {
+    withTempDir { checkpointDir =>
+      val conf = new SparkConf().set(UI_ENABLED.key, "false")
+      sc = new SparkContext("local", "test", conf)
+      sc.setCheckpointDir(checkpointDir.toString)
+      val rdd = sc.makeRDD(1 to 20, numSlices = 4)
+      rdd.checkpoint()
+      rdd.collect()
+
+      val checkpointPath = new Path(rdd.getCheckpointFile.get)
+      val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+
+      // Overwrite _num_partitions with garbage to simulate a partial write or corruption.
+      val countFile = new Path(checkpointPath, "_num_partitions")
+      assert(fs.exists(countFile), "expected _num_partitions to exist before corruption")
+      val out = fs.create(countFile, true)
+      out.write(Array[Byte](0xff.toByte, 0xfe.toByte))
+      out.close()
+
+      // A corrupted file must not prevent recovery, and a WARN must be logged to confirm
+      // the check ran and was suppressed, not silently skipped.
+      val logAppender = new LogAppender("corrupted _num_partitions")
+      withLogAppender(logAppender,
+          loggerNames = Seq(classOf[ReliableCheckpointRDD[_]].getName),
+          level = Some(org.apache.logging.log4j.Level.WARN)) {
+        val recovered = sc.checkpointFile[Int](rdd.getCheckpointFile.get)
+        assert(recovered.partitions.length === 4)
+        assert(recovered.collect().sorted === (1 to 20).toArray)
+      }
+      assert(logAppender.loggingEvents.exists(
+        _.getMessage.getFormattedMessage.contains("truncation detection will be inactive")))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Persist the original RDD's partition count to a `_num_partitions` file in the checkpoint directory at write time, and validate it in `ReliableCheckpointRDD.getPartitions` on read. A missing file (pre-existing checkpoints) or unreadable file is tolerated for backward compatibility.

### Why are the changes needed?
`getPartitions` only checks that part-* files are contiguous from `part-00000`. Deleting a middle file breaks contiguity and is caught, but deleting the trailing file leaves the rest contiguous, so the check passes and the RDD is silently read back with fewer partitions and no error. This mainly affects `SparkContext.checkpointFile`, which Spark Streaming recovery uses to rebuild `generatedRDDs`, since that path has no original RDD to compare against.

Split out of SPARK-58770 (#58004), which deliberately left this out as needing its own on-disk format.

### Does this PR introduce any user-facing change?
Yes. Checkpoint directories now get one extra small metadata file. Reading back a directory missing its trailing partition file(s) now throws `CHECKPOINT_RDD_PARTITION_COUNT_MISMATCH` instead of silently returning fewer partitions. Directories written before this change read exactly as before.

### How was this patch tested?
Added three tests to `CheckpointStorageSuite`:
- reading a checkpoint with the trailing partition file deleted now throws
- a checkpoint missing `_num_partitions` (pre-existing checkpoint) still reads back correctly
- a corrupted `_num_partitions` file is tolerated and still reads back correctly

### Was this patch authored or co-authored using generative AI tooling?
No.