### PR TITLE
[SPARK-58908][K8S] Do not report ExecutorKilled for heartbeat-timeout executor kills

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -278,8 +278,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
     }
     labelDecommissioningExecs(executorIds)
 
-    // Tell the executors to exit themselves.
-    executorIds.foreach { id =>
+    // Tell the executors to exit themselves. Skip the ones killed with countFailures = true
+    // (a heartbeat expiry), whose loss reason is reported by the caller right after this call.
+    executorIds.filterNot(id => executorsPendingToRemove.get(id).contains(false)).foreach { id =>
       removeExecutor(id, ExecutorKilled)
     }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -258,6 +258,27 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     verify(labeledPods).delete()
   }
 
+  test("SPARK-58908: doKillExecutors does not report ExecutorKilled when failures must count") {
+    schedulerBackendUnderTest.start()
+
+    when(podsWithNamespace.withField(any(), any())).thenReturn(labeledPods)
+    when(podsWithNamespace.withLabel(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)).thenReturn(labeledPods)
+    when(labeledPods.withLabel(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)).thenReturn(labeledPods)
+    when(labeledPods.withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)).thenReturn(labeledPods)
+    when(labeledPods.withLabelIn(SPARK_EXECUTOR_ID_LABEL, "1", "2")).thenReturn(labeledPods)
+    when(labeledPods.resources()).thenReturn(Arrays.asList[PodResource]().stream)
+
+    // killExecutors records !countFailures: a heartbeat expiry stores false, other kills true.
+    schedulerBackendUnderTest.executorsPendingToRemove.put("1", false)
+    schedulerBackendUnderTest.executorsPendingToRemove.put("2", true)
+
+    schedulerBackendUnderTest.doKillExecutors(Seq("1", "2"))
+
+    // Executor 1's loss reason is reported by the caller, so it must not be pre-empted here.
+    verify(driverEndpointRef, never()).send(RemoveExecutor("1", ExecutorKilled))
+    verify(driverEndpointRef).send(RemoveExecutor("2", ExecutorKilled))
+  }
+
   test("Annotates executor pods with deletion cost when configured") {
     sparkConf.set(KUBERNETES_EXECUTOR_POD_DELETION_COST, 7)
     schedulerBackendUnderTest.start()


### PR DESCRIPTION
### What changes were proposed in this pull request?

`KubernetesClusterSchedulerBackend.doKillExecutors` reports `ExecutorKilled` for every
executor it kills. This PR skips that report for executors killed with
`countFailures = true`, whose loss reason is reported by the caller instead.

`CoarseGrainedSchedulerBackend.killExecutors` records
`executorsPendingToRemove(id) = !countFailures`, so such a kill stores `false`.

### Why are the changes needed?

On a heartbeat timeout, `HeartbeatReceiver.expireDeadHosts` does two things in order:

1. `sc.killAndReplaceExecutor(id)`, which calls
   `killExecutors(..., countFailures = true, force = true)`
2. sends `RemoveExecutor(id, ExecutorProcessLost("Executor heartbeat timed out after N ms"))`

`doKillExecutors` runs synchronously inside step 1 (`adjustTargetNumExecutors = false`, so
the future resolves on `ThreadUtils.sameThread`), so its `RemoveExecutor(id, ExecutorKilled)`
reaches the driver endpoint first and removes the executor from `executorDataMap`. Step 2's
message then falls into the `case None` branch and has no effect. This is deterministic
rather than a race.

The recorded reason is therefore `ExecutorKilled`, which `TaskSetManager` maps to
`exitCausedByApp = false`, so the task failures do not count towards
`spark.task.maxFailures` and the job does not fast-fail. Kubernetes is the only backend
whose `doKillExecutors` reports a loss reason, which is why YARN is unaffected.

`countFailures = true` has a single caller, `SparkContext.killAndReplaceExecutor`, itself
called only from `HeartbeatReceiver.expireDeadHosts`, so only the heartbeat timeout path
changes.

### Does this PR introduce _any_ user-facing change?

Yes. On Kubernetes, tasks lost to a heartbeat timeout now count towards
`spark.task.maxFailures`. A job that repeatedly loses executors this way now fails after the
retry limit instead of retrying indefinitely, matching YARN.

### How was this patch tested?

Added a test to `KubernetesClusterSchedulerBackendSuite` covering both branches: an executor
killed with `countFailures = true` is not reported as `ExecutorKilled`, while an ordinary
kill still is. The existing "Kill executors" test, which calls `doKillExecutors` with no
pending-removal entry, is unchanged.

```
build/sbt -Pkubernetes 'kubernetes/testOnly *KubernetesClusterSchedulerBackendSuite'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
