### PR TITLE
[SPARK-58914][CORE][WEBUI] Add a reusable `confirm-link` for Web UI links

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -139,6 +139,11 @@ a.kill-link {
   color: var(--bs-secondary-color);
 }
 
+a.confirm-link {
+  margin-left: 4px;
+  color: var(--bs-secondary-color);
+}
+
 a.name-link {
   word-wrap: break-word;
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -131,6 +131,13 @@ $(function() {
     }
   });
 
+  // generic links guarded by a confirmation prompt before navigating
+  $(document).on("click", "a.confirm-link[data-confirm-message]", function(e) {
+    if (!window.confirm($(this).data("confirm-message"))) {
+      e.preventDefault();
+    }
+  });
+
   // loadMore / loadNew buttons
   $(document).on("click", ".log-more-btn", function() { loadMore(); });
   $(document).on("click", ".log-new-btn", function() { loadNew(); });


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a reusable confirmation prompt for Web UI links:

- `webui.css`: a new `a.confirm-link` style, following the existing `a.kill-link` style.
- `webui.js`: a CSP-compliant delegated click handler for `a.confirm-link[data-confirm-message]`
  that shows `window.confirm()` with the message and cancels the navigation when declined.

### Why are the changes needed?

The only existing confirmation pattern, `kill-link`, is tied to the kill-request form submission.
`confirm-link` guards a plain link navigation instead, so any page can add a prompt without a
page-specific inline script, which the Web UI no longer allows under CSP.

### Does this PR introduce _any_ user-facing change?

No. No page renders `confirm-link` yet, so the rendered UI is unchanged.

### How was this patch tested?

Pass the CIs, including `dev/lint-js`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5