### PR TITLE
[SPARK-58916][SQL] Handle infinite relativeError in approxQuantile

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -81,7 +81,8 @@ object StatFunctions extends Logging {
     val accuracy = if (relativeError == 0.0) {
       Int.MaxValue
     } else {
-      math.min(Int.MaxValue, (1.0 / relativeError).ceil.toLong).toInt
+      val raw = (1.0 / relativeError).ceil.toLong
+      math.max(1, math.min(Int.MaxValue, raw)).toInt
     }
 
     val results = Array.fill(cols.size)(Seq.empty[Double])

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -264,7 +264,7 @@ class DataFrameStatSuite extends SharedSparkSession {
 
     val q1 = 0.5
     val q2 = 0.8
-    val epsilons = List(2.0, 5.0, 100.0)
+    val epsilons = List(2.0, 5.0, 100.0, Double.PositiveInfinity)
 
     val Array(single1_1) = df.stat.approxQuantile("singles", Array(q1), 1.0)
     val Array(s1_1, s2_1) = df.stat.approxQuantile("singles", Array(q1, q2), 1.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clamp the integer accuracy derived by `DataFrameStatFunctions.approxQuantile` to at least 1 when delegating to `approx_percentile`.

### Why are the changes needed?
After SPARK-51816, `approxQuantile` computes `approx_percentile` accuracy from `relativeError` as `ceil(1.0 / relativeError)`. `Double.PositiveInfinity` is accepted by the existing non-negative relative-error check, but that formula produces accuracy 0, which is invalid for `approx_percentile`. Clamping to 1 keeps the coarsest valid approximation for this edge case.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added `Double.PositiveInfinity` to the existing `DataFrameStatSuite` coverage for `relativeError > 1`.

Not run locally.