### PR TITLE
[SPARK-55968][SQL] Do not treat vectorized reader capacity overflow as corrupt file exception when ignoreCorruptFiles is enabled

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -22,6 +22,7 @@ import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.RequiresPreviousReader;
 import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
@@ -71,6 +72,24 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
     return Binary.fromConstantByteArray(binaryValVector.getBinary(0));
   }
 
+  private void validateLengths(int prefixLength, int suffixLength) {
+    if (prefixLength < 0) {
+      throw new ParquetDecodingException("Invalid negative prefix length: " + prefixLength);
+    }
+    int previousLen = previous == null ? 0 : previous.remaining();
+    if (prefixLength > previousLen) {
+      throw new ParquetDecodingException("Prefix length " + prefixLength +
+          " exceeds previous value length " + previousLen);
+    }
+    if (suffixLength < 0) {
+      throw new ParquetDecodingException("Invalid negative suffix length: " + suffixLength);
+    }
+    if ((long) prefixLength + suffixLength > Integer.MAX_VALUE) {
+      throw new ParquetDecodingException("Integer overflow in value length: " +
+          prefixLength + " + " + suffixLength);
+    }
+  }
+
   private void readValues(int total, WritableColumnVector c, int rowId) {
     for (int i = 0; i < total; i++) {
       // NOTE: due to PARQUET-246, it is important that we
@@ -80,8 +99,9 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       // because of PARQUET-246.
       int prefixLength = prefixLengthVector.getInt(currentRow);
       ByteBuffer suffix = suffixReader.getBytes(currentRow);
-      byte[] suffixArray = suffix.array();
       int suffixLength = suffix.limit() - suffix.position();
+      validateLengths(prefixLength, suffixLength);
+      byte[] suffixArray = suffix.array();
       int length = prefixLength + suffixLength;
 
       // We have to do this to materialize the output
@@ -122,6 +142,7 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       int prefixLength = prefixLengthVector.getInt(currentRow);
       ByteBuffer suffix = suffixReader.getBytes(currentRow);
       int suffixLength = suffix.limit() - suffix.position();
+      validateLengths(prefixLength, suffixLength);
       int length = prefixLength + suffixLength;
 
       byte[] wkb = new byte[length];
@@ -166,8 +187,9 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
     for (int i = 0; i < total; i++) {
       int prefixLength = prefixLengthVector.getInt(currentRow);
       ByteBuffer suffix = suffixReader.getBytes(currentRow);
-      byte[] suffixArray = suffix.array();
       int suffixLength = suffix.limit() - suffix.position();
+      validateLengths(prefixLength, suffixLength);
+      byte[] suffixArray = suffix.array();
       int length = prefixLength + suffixLength;
 
       WritableColumnVector arrayData = c1.arrayData();

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedReaderCapacityOverflowException.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedReaderCapacityOverflowException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.vectorized;
+
+import org.apache.spark.annotation.DeveloperApi;
+
+/**
+ * Exception thrown when the vectorized reader capacity is exhausted or cannot be reserved.
+ */
+@DeveloperApi
+public class VectorizedReaderCapacityOverflowException extends RuntimeException {
+  public VectorizedReaderCapacityOverflowException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public VectorizedReaderCapacityOverflowException(String message) {
+    super(message);
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedReaderCapacityOverflowException.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedReaderCapacityOverflowException.java
@@ -17,12 +17,9 @@
 
 package org.apache.spark.sql.execution.vectorized;
 
-import org.apache.spark.annotation.DeveloperApi;
-
 /**
  * Exception thrown when the vectorized reader capacity is exhausted or cannot be reserved.
  */
-@DeveloperApi
 public class VectorizedReaderCapacityOverflowException extends RuntimeException {
   public VectorizedReaderCapacityOverflowException(String message, Throwable cause) {
     super(message, cause);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -156,7 +156,7 @@ public abstract class WritableColumnVector extends ColumnVector {
         "refer to " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() +
         " (default " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().defaultValueString() +
         ") and " + SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + ".";
-    throw new RuntimeException(message, cause);
+    throw new VectorizedReaderCapacityOverflowException(message, cause);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -121,6 +121,10 @@ public abstract class WritableColumnVector extends ColumnVector {
   }
 
   public void reserveAdditional(int additionalCapacity) {
+    if (additionalCapacity < 0) {
+      throw new IllegalArgumentException(
+          "Invalid negative additional capacity: " + additionalCapacity);
+    }
     reserve(elementsAppended + additionalCapacity);
   }
 
@@ -156,7 +160,7 @@ public abstract class WritableColumnVector extends ColumnVector {
         "refer to " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() +
         " (default " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().defaultValueString() +
         ") and " + SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + ".";
-    throw new RuntimeException(message, cause);
+    throw new VectorizedReaderCapacityOverflowException(message, cause);
   }
 
   @Override
@@ -455,6 +459,9 @@ public abstract class WritableColumnVector extends ColumnVector {
   }
 
   final int appendBytes(int length, ByteBuffer src, int srcPosition) {
+    if (length < 0) {
+      throw new IllegalArgumentException("Invalid negative length: " + length);
+    }
     reserve(elementsAppended + length);
     int result = elementsAppended;
     putBytes(elementsAppended, length, src, srcPosition);
@@ -627,6 +634,9 @@ public abstract class WritableColumnVector extends ColumnVector {
   }
 
   public final int appendBytes(int count, byte v) {
+    if (count < 0) {
+      throw new IllegalArgumentException("Invalid negative count: " + count);
+    }
     reserve(elementsAppended + count);
     int result = elementsAppended;
     putBytes(elementsAppended, count, v);
@@ -635,6 +645,9 @@ public abstract class WritableColumnVector extends ColumnVector {
   }
 
   public final int appendBytes(int length, byte[] src, int offset) {
+    if (length < 0) {
+      throw new IllegalArgumentException("Invalid negative length: " + length);
+    }
     reserve(elementsAppended + length);
     int result = elementsAppended;
     putBytes(elementsAppended, length, src, offset);

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
 import org.apache.spark.sql.execution.datasources.xml.XmlFileFormat
+import org.apache.spark.sql.execution.vectorized.VectorizedReaderCapacityOverflowException
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
@@ -279,6 +280,7 @@ object DataSourceUtils extends PredicateHelper {
   }
 
   def shouldIgnoreCorruptFileException(e: Throwable): Boolean = e match {
+    case _: VectorizedReaderCapacityOverflowException => false
     case _: RuntimeException | _: IOException | _: InternalError => true
     case _ => false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, RebaseDateTime, T
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
+import org.apache.spark.sql.execution.vectorized.VectorizedReaderCapacityOverflowException
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
@@ -234,6 +235,7 @@ object DataSourceUtils extends PredicateHelper {
   }
 
   def shouldIgnoreCorruptFileException(e: Throwable): Boolean = e match {
+    case _: VectorizedReaderCapacityOverflowException => false
     case _: RuntimeException | _: IOException | _: InternalError => true
     case _ => false
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
@@ -16,9 +16,12 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.parquet.bytes.DirectByteBufferAllocator
+import java.nio.ByteBuffer
+
+import org.apache.parquet.bytes.{ByteBufferInputStream, DirectByteBufferAllocator}
 import org.apache.parquet.column.values.Utils
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter
+import org.apache.parquet.io.ParquetDecodingException
 
 import org.apache.spark.sql.catalyst.util.STUtils
 import org.apache.spark.sql.execution.vectorized.{OnHeapColumnVector, WritableColumnVector}
@@ -195,5 +198,35 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
       reader.skipBinary(skipCount)
       i += skipCount + 1
     }
+  }
+
+  test("SPARK-55968: invalid negative prefix length throws ParquetDecodingException") {
+    Utils.writeData(writer, Array("a", "b"))
+    val bytes = writer.getBytes.toInputStream.readAllBytes()
+    // Byte 5 is min_delta in the prefix lengths DeltaBinaryPacked block.
+    // 3 is zig-zag encoding for -2, creating prefix lengths [0, -2].
+    bytes(5) = 3.toByte
+    val is = ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes))
+    writableColumnVector = new OnHeapColumnVector(2, StringType)
+    reader.initFromPage(2, is)
+    val ex = intercept[ParquetDecodingException] {
+      reader.readBinary(2, writableColumnVector, 0)
+    }
+    assert(ex.getMessage.contains("Invalid negative prefix length"))
+  }
+
+  test("SPARK-55968: prefix length exceeding previous length throws ParquetDecodingException") {
+    Utils.writeData(writer, Array("a", "b"))
+    val bytes = writer.getBytes.toInputStream.readAllBytes()
+    // 4 is zig-zag encoding for +2, creating prefix lengths [0, 2].
+    // Previous value has length 1 ("a"), so prefix length 2 exceeds previous value length.
+    bytes(5) = 4.toByte
+    val is = ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes))
+    writableColumnVector = new OnHeapColumnVector(2, StringType)
+    reader.initFromPage(2, is)
+    val ex = intercept[ParquetDecodingException] {
+      reader.readBinary(2, writableColumnVector, 0)
+    }
+    assert(ex.getMessage.contains("exceeds previous value length"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -32,10 +32,11 @@ import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.execution.FileSourceScanExec
-import org.apache.spark.sql.execution.datasources.{SchemaColumnConvertNotSupportedException, SQLHadoopMapReduceCommitProtocol}
+import org.apache.spark.sql.execution.datasources.{DataSourceUtils, SchemaColumnConvertNotSupportedException, SQLHadoopMapReduceCommitProtocol}
 import org.apache.spark.sql.execution.datasources.parquet.TestingUDT._
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+import org.apache.spark.sql.execution.vectorized.VectorizedReaderCapacityOverflowException
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -1285,6 +1286,54 @@ abstract class ParquetQuerySuite extends ParquetTest
         (LocalTime.parse("12:13:14.001001"), LocalTime.parse("23:59:59")),
         (null, null)).toDF()
       checkAnswer(sql("select * from tbl"), expected)
+    }
+  }
+
+  test("SPARK-55968: do not ignore vectorized reader capacity overflow " +
+    "when ignoreCorruptFiles is enabled") {
+    val capacityEx = new VectorizedReaderCapacityOverflowException("test overflow", null)
+    assert(!DataSourceUtils.shouldIgnoreCorruptFileException(capacityEx))
+
+    val corruptEx = new RuntimeException("corrupt file exception")
+    assert(DataSourceUtils.shouldIgnoreCorruptFileException(corruptEx))
+
+    val invalidLengthEx = new IllegalArgumentException("Invalid negative additional capacity: -1")
+    assert(DataSourceUtils.shouldIgnoreCorruptFileException(invalidLengthEx))
+  }
+
+  test("SPARK-55968: ignoreCorruptFiles skips corrupt DELTA_BYTE_ARRAY file " +
+    "and reads healthy file") {
+    // 211-byte corrupt DELTA_BYTE_ARRAY Parquet file with prefix lengths [0, -2].
+    // The DeltaBinaryPacked min_delta for prefix lengths is mutated to 3 (-2 in zigzag encoding),
+    // producing a malformed prefix length for the second value.
+    val corruptBytes = java.util.Base64.getDecoder.decode(
+      "UEFSMRUAFTgVOCwVBBUOFQYVBhw2ACgBYhgBYRERAAAAAgAAAAQBgAEEAgADAAAAAIABBAICAAAAA" +
+      "ABhYhUEGSw1ABgGc2NoZW1hFQIAFQwlAhgBcyUATBwAAAAWBBkcGRwmABwVDBklBg4ZGAFzFQAWB" +
+      "BZyFnImCDw2ACgBYhgBYRERABkcFQAVDhUCADwWBBkGGSYABAAAABZyFgQmCBZyACggcGFycXVld" +
+      "C1jcHAtYXJyb3cgdmVyc2lvbiAyNS4wLjEZHBwAAACOAAAAUEFSMQ==")
+
+    withTempDir { dir =>
+      val healthyDir = new File(dir, "healthy")
+      val corruptFile = new File(dir, "corrupt.parquet")
+      Seq("healthy_1", "healthy_2").toDF("s")
+        .write.parquet(healthyDir.getCanonicalPath)
+      java.nio.file.Files.write(corruptFile.toPath, corruptBytes)
+
+      // 1. With ignoreCorruptFiles = true, corrupt file is skipped and healthy rows are returned
+      withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
+        val df = spark.read.parquet(healthyDir.getCanonicalPath, corruptFile.getCanonicalPath)
+        checkAnswer(df, Seq(Row("healthy_1"), Row("healthy_2")))
+      }
+
+      // 2. With ignoreCorruptFiles = false, decoding exception is thrown, NOT capacity overflow
+      withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false") {
+        val df = spark.read.parquet(healthyDir.getCanonicalPath, corruptFile.getCanonicalPath)
+        val ex = intercept[SparkException] {
+          df.collect()
+        }
+        assert(!ex.getMessage.contains(
+          "Cannot reserve additional contiguous bytes in the vectorized reader"))
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -32,10 +32,11 @@ import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.execution.FileSourceScanExec
-import org.apache.spark.sql.execution.datasources.{SchemaColumnConvertNotSupportedException, SQLHadoopMapReduceCommitProtocol}
+import org.apache.spark.sql.execution.datasources.{DataSourceUtils, SchemaColumnConvertNotSupportedException, SQLHadoopMapReduceCommitProtocol}
 import org.apache.spark.sql.execution.datasources.parquet.TestingUDT._
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+import org.apache.spark.sql.execution.vectorized.VectorizedReaderCapacityOverflowException
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -1428,6 +1429,18 @@ class ParquetV2QuerySuite extends ParquetQuerySuite {
         }
       }
     }
+  }
+
+  test("SPARK-55968: do not ignore vectorized reader capacity overflow " +
+    "when ignoreCorruptFiles is enabled") {
+    val capacityEx = new VectorizedReaderCapacityOverflowException("test overflow", null)
+    assert(!DataSourceUtils.shouldIgnoreCorruptFileException(capacityEx))
+
+    val corruptEx = new RuntimeException("corrupt file exception")
+    assert(DataSourceUtils.shouldIgnoreCorruptFileException(corruptEx))
+
+    val invalidLengthEx = new IllegalArgumentException("Invalid negative additional capacity: -1")
+    assert(DataSourceUtils.shouldIgnoreCorruptFileException(invalidLengthEx))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR introduces `VectorizedReaderCapacityOverflowException` thrown by `WritableColumnVector` when the vectorized reader capacity is exhausted or encounters an integer overflow. `DataSourceUtils.shouldIgnoreCorruptFileException` is updated so that `VectorizedReaderCapacityOverflowException` is not ignored when `spark.sql.files.ignoreCorruptFiles=true`. Additionally, invalid negative element capacities (from corrupted file data) throw `IllegalArgumentException` so corrupt files are still safely skipped.

### Why are the changes needed?
When `ignoreCorruptFiles=true`, vectorized reader capacity overflow was previously caught as a general `RuntimeException`, silently skipping files and dropping user data without warning.

### Does this PR introduce any user-facing change?
No API changes. Fixes incorrect silent file skipping on vectorized reader capacity overflow.

### How was this patch tested?
- Added unit tests in `ParquetQuerySuite` asserting `DataSourceUtils.shouldIgnoreCorruptFileException` behavior.
- Ran scalastyle (`sql/scalastyle`) and compilation checks (`sql/Test/compile`).
