### PR TITLE
[SPARK-58920][DOC] Fix typos in the Quick Start and Security docs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -51,13 +51,13 @@ Or if PySpark is installed with pip in your current environment:
 
     pyspark
 
-Spark's primary abstracted is called a **Dataset**. A Dataset is a structured set of information. You can create datasets from Hadoop InputFormats (such as HDFS
+Spark's primary abstraction is called a **Dataset**. A Dataset is a structured set of information. You can create datasets from Hadoop InputFormats (such as HDFS
 files) or by transforming other Datasets. 
 
 Datasets behave differently in some languages. Because Python allows for dynamic typing, Datasets in Python are all `Dataset[Row]` on an implementation level.
 This leads to another key Spark concept: a `DataFrame`, or a Dataset with named columns. If you're familiar with DataFrames from pandas or R, you'll be familiar with how DataFrames work in Spark. In other languages, like Java, the difference between a Dataset and DataFrame is larger, but for now let's proceed with Python. 
 
-Let's make a new DataFrame using the `README.md` file in the Spark souce directory via the command line:
+Let's make a new DataFrame using the `README.md` file in the Spark source directory via the command line:
 
 {% highlight python %}
 >>> textFile = spark.read.text("README.md")
@@ -92,10 +92,10 @@ You can also chain together transformations and actions:
 
     ./bin/spark-shell
 
-Spark's primary abstracted is called a **Dataset**. A Dataset is a structured set of information. You can create datasets from Hadoop InputFormats (such as HDFS
+Spark's primary abstraction is called a **Dataset**. A Dataset is a structured set of information. You can create datasets from Hadoop InputFormats (such as HDFS
 files) or by transforming other Datasets.  
 
-Let's make a new DataFrame using the `README.md` file in the Spark souce directory via the command line:
+Let's make a new DataFrame using the `README.md` file in the Spark source directory via the command line:
 
 {% highlight scala %}
 scala> val textFile = spark.read.textFile("README.md")

--- a/docs/security.md
+++ b/docs/security.md
@@ -98,7 +98,7 @@ Kubernetes admin to ensure that Spark authentication is secure.
   <td><code>spark.authenticate.secret</code></td>
   <td>None</td>
   <td>
-    The secret key used authentication. See above for when this configuration should be set.
+    The secret key used for authentication. See above for when this configuration should be set.
   </td>
   <td>1.0.0</td>
 </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes typos in two rendered documentation pages:
- `docs/quick-start.md`: "Spark's primary abstracted is called a Dataset" -> "abstraction" (2 occurrences, in the Scala and Python sections), and "the Spark souce directory" -> "source directory" (2 occurrences).
- `docs/security.md`: "The secret key used authentication" -> "used for authentication".

### Why are the changes needed?

These are user-facing typos and a grammar error. `quick-start.md` is the first tutorial many users read.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only typo fixes.

### How was this patch tested?

No tests needed; documentation-only. The corrected words were checked to read correctly in context.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
