### PR TITLE
[SPARK-58921][CONNECT][PYTHON] Fix misspelled messageParameters argument in Spark Connect tag validation

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -2286,7 +2286,7 @@ class SparkConnectClient(object):
         spark_job_tags_sep = ","
         if tag is None:
             raise PySparkValueError(
-                errorClass="CANNOT_BE_NONE", message_paramters={"arg_name": "Spark Connect tag"}
+                errorClass="CANNOT_BE_NONE", messageParameters={"arg_name": "Spark Connect tag"}
             )
         if spark_job_tags_sep in tag:
             raise PySparkValueError(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes a misspelled keyword argument in a `PySparkValueError` raised by the Spark Connect Python client. In `python/pyspark/sql/connect/client/core.py`, the error for a `None` tag was constructed with `message_paramters=` instead of `messageParameters=`.

### Why are the changes needed?

`PySparkValueError.__init__` (`pyspark/errors/exceptions/base.py`) accepts `messageParameters` and does not accept `**kwargs`. As a result, when the tag validation hits the `None` case it raises `TypeError: __init__() got an unexpected keyword argument 'message_paramters'` instead of the intended `CANNOT_BE_NONE` error. This is a latent bug on the error path.

### Does this PR introduce _any_ user-facing change?

Yes. Passing `None` where a Spark Connect tag is required now raises the intended `PySparkValueError` (`CANNOT_BE_NONE`) with its message, instead of a confusing `TypeError`.

### How was this patch tested?

The keyword is corrected to match the `PySparkValueError` constructor parameter. The affected path was previously unexercised, which is why the typo went unnoticed; I can add a regression test asserting `PySparkValueError` is raised for a `None` tag if preferred.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
