### PR TITLE
[SPARK-58922][CORE] Extract a null/empty MDC-array check in SparkLogger

### DIFF
--- a/common/utils-java/src/main/java/org/apache/spark/internal/SparkLogger.java
+++ b/common/utils-java/src/main/java/org/apache/spark/internal/SparkLogger.java
@@ -96,7 +96,7 @@ public class SparkLogger {
   }
 
   public void error(String msg, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
+    if (isNullOrEmpty(mdcs)) {
       slf4jLogger.error(msg);
     } else if (slf4jLogger.isErrorEnabled()) {
       withLogContext(msg, mdcs, null, mt -> slf4jLogger.error(mt.message));
@@ -104,7 +104,7 @@ public class SparkLogger {
   }
 
   public void error(String msg, Throwable throwable, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
+    if (isNullOrEmpty(mdcs)) {
       slf4jLogger.error(msg, throwable);
     } else if (slf4jLogger.isErrorEnabled()) {
       withLogContext(msg, mdcs, throwable, mt -> slf4jLogger.error(mt.message, mt.throwable));
@@ -124,7 +124,7 @@ public class SparkLogger {
   }
 
   public void warn(String msg, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
+    if (isNullOrEmpty(mdcs)) {
       slf4jLogger.warn(msg);
     } else if (slf4jLogger.isWarnEnabled()) {
       withLogContext(msg, mdcs, null, mt -> slf4jLogger.warn(mt.message));
@@ -132,7 +132,7 @@ public class SparkLogger {
   }
 
   public void warn(String msg, Throwable throwable, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
+    if (isNullOrEmpty(mdcs)) {
       slf4jLogger.warn(msg, throwable);
     } else if (slf4jLogger.isWarnEnabled()) {
       withLogContext(msg, mdcs, throwable, mt -> slf4jLogger.warn(mt.message, mt.throwable));
@@ -152,7 +152,7 @@ public class SparkLogger {
   }
 
   public void info(String msg, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
+    if (isNullOrEmpty(mdcs)) {
       slf4jLogger.info(msg);
     } else if (slf4jLogger.isInfoEnabled()) {
       withLogContext(msg, mdcs, null, mt -> slf4jLogger.info(mt.message));
@@ -160,7 +160,7 @@ public class SparkLogger {
   }
 
   public void info(String msg, Throwable throwable, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
+    if (isNullOrEmpty(mdcs)) {
       slf4jLogger.info(msg, throwable);
     } else if (slf4jLogger.isInfoEnabled()) {
       withLogContext(msg, mdcs, throwable, mt -> slf4jLogger.info(mt.message, mt.throwable));
@@ -213,6 +213,10 @@ public class SparkLogger {
 
   public void trace(String msg, Throwable throwable) {
     slf4jLogger.trace(msg, throwable);
+  }
+
+  private boolean isNullOrEmpty(MDC[] mdcs) {
+    return mdcs == null || mdcs.length == 0;
   }
 
   private void withLogContext(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extracts the repeated `mdcs == null || mdcs.length == 0` guard in `SparkLogger` into a private helper `isNullOrEmpty(MDC[] mdcs)`, and routes the six call sites (the `MDC...`-varargs `error`/`warn`/`info` overloads) through it.

### Why are the changes needed?

The same null/empty check was duplicated across six logging methods. Naming it once removes the duplication and gives a single place for the guard. No behavior change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. The helper returns exactly the previous boolean expression, so behavior is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
