### PR TITLE
[SPARK-58925][SS][DOCS] Document maxOpenFiles troubleshooting guidance

### DIFF
--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -1851,7 +1851,7 @@ Here are the configs regarding to RocksDB instance of the state store provider:
   </tr>
   <tr>
     <td>spark.sql.streaming.stateStore.rocksdb.maxOpenFiles</td>
-    <td>The number of open files that can be used by the RocksDB instance. Value of -1 means that files opened are always kept open. If the open file limit is reached, RocksDB will evict entries from the open file cache and close those file descriptors and remove the entries from the cache.</td>
+    <td>The number of open files that can be used by the RocksDB instance. Value of -1 means that files opened are always kept open. If the open file limit is reached, RocksDB will evict entries from the open file cache and close those file descriptors and remove the entries from the cache. Set this configuration to a positive value if a query fails when opening RocksDB with <code>Too many open files</code>.</td>
     <td>-1</td>
   </tr>
   <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Document that users should set
`spark.sql.streaming.stateStore.rocksdb.maxOpenFiles` to a positive value when a
streaming query fails to open RocksDB with `Too many open files`.

JIRA: https://issues.apache.org/jira/browse/SPARK-58925

### Why are the changes needed?

The existing documentation explains the open-file cache behavior but does not
tell users how to configure RocksDB after reaching the operating system's open
file limit.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

Validated with `git diff --check`. No runtime tests are applicable to this
documentation-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
