### PR TITLE
[SPARK-58442][SQL] Don't rewrite IN subquery to ExistenceJoin where NULL is observable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -432,7 +432,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
           introducedAttrs += exists
           exists
         case Not(InSubquery(values, l @ ListQuery(sub, _, _, _, conditions, subHint)))
-            if canRewriteToExistenceJoin(l, conditions, nullInsensitive) =>
+            if canRewriteToExistenceJoin(values, l, conditions, nullInsensitive) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(newPlan, sub, Some(values))
@@ -458,7 +458,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
           introducedAttrs += exists
           Not(exists)
         case InSubquery(values, l @ ListQuery(sub, _, _, _, conditions, subHint))
-            if canRewriteToExistenceJoin(l, conditions, nullInsensitive) =>
+            if canRewriteToExistenceJoin(values, l, conditions, nullInsensitive) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(newPlan, sub, Some(values))
@@ -488,14 +488,17 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
 
   /**
    * An IN/NOT IN subquery is three-valued but an [[ExistenceJoin]]'s `exists` flag is not, so the
-   * rewrite maps NULL to FALSE. Only rewrite where that is unobservable, or where the subquery is
-   * correlated and must therefore be decorrelated into a join. See SPARK-58442.
+   * rewrite maps NULL to FALSE. Rewrite only where that is unobservable, or where leaving the
+   * subquery in place is not an option: a correlated subquery must be decorrelated into a join, and
+   * a multi-column probe is compared as a whole struct by `InSubqueryExec`, which treats NULL as
+   * equal to NULL rather than comparing row-wise. See SPARK-58442.
    */
   private def canRewriteToExistenceJoin(
+      values: Seq[Expression],
       query: ListQuery,
       conditions: Seq[Expression],
       nullInsensitive: Boolean): Boolean = {
-    nullInsensitive || query.isCorrelated || conditions.nonEmpty
+    nullInsensitive || query.isCorrelated || conditions.nonEmpty || values.length > 1
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -204,7 +204,14 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
             LeftAnti, Option(finalJoinCond), JoinHint(None, subHint))
         case (p, predicate) =>
           val (newCond, inputPlan) = rewriteExistentialExpr(Seq(predicate), p)
-          Project(p.output, Filter(newCond.get, inputPlan))
+          if (inputPlan.fastEquals(p)) {
+            // No existence join was introduced, so there is no `exists` attribute to project
+            // away. Re-wrapping in a Project here would make this rule rewrite its own output
+            // indefinitely. See SPARK-58442.
+            Filter(newCond.get, p)
+          } else {
+            Project(p.output, Filter(newCond.get, inputPlan))
+          }
       }
 
     // This case takes care of predicate subqueries in join conditions that are not pushed down
@@ -403,8 +410,18 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     plan: LogicalPlan): (Option[Expression], LogicalPlan, Seq[Attribute]) = {
     var newPlan = plan
     val introducedAttrs = ArrayBuffer.empty[Attribute]
-    val newExprs = exprs.map { e =>
-      e.transformDownWithPruning(_.containsAnyPattern(EXISTS_SUBQUERY, IN_SUBQUERY)) {
+
+    // Rewriting IN/NOT IN to an ExistenceJoin represents the result as a non-nullable `exists`
+    // flag, which maps the three-valued IN result NULL to FALSE. That is only sound where NULL
+    // and FALSE are indistinguishable, so only recurse through And/Or. An uncorrelated IN left
+    // in place is executed by InSubqueryExec, which is three-valued; a correlated one must be
+    // rewritten regardless because it requires decorrelation. See SPARK-58442.
+    def rewrite(expr: Expression, nullInsensitive: Boolean): Expression = {
+      if (!expr.containsAnyPattern(EXISTS_SUBQUERY, IN_SUBQUERY)) {
+        return expr
+      }
+      expr match {
+        // EXISTS is two-valued, so a non-nullable flag is sound in any position.
         case Exists(sub, _, _, conditions, subHint) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           val existenceJoin = ExistenceJoin(exists)
@@ -414,7 +431,8 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
               existenceJoin, newCondition, subHint)
           introducedAttrs += exists
           exists
-        case Not(InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint))) =>
+        case Not(InSubquery(values, l @ ListQuery(sub, _, _, _, conditions, subHint)))
+            if canRewriteToExistenceJoin(l, conditions, nullInsensitive) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(newPlan, sub, Some(values))
@@ -439,7 +457,8 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
             ExistenceJoin(exists), Some(finalJoinCond), joinHint)
           introducedAttrs += exists
           Not(exists)
-        case InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint)) =>
+        case InSubquery(values, l @ ListQuery(sub, _, _, _, conditions, subHint))
+            if canRewriteToExistenceJoin(l, conditions, nullInsensitive) =>
           val exists = AttributeReference("exists", BooleanType, nullable = false)()
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(newPlan, sub, Some(values))
@@ -450,9 +469,33 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
             ExistenceJoin(exists), newConditions, joinHint)
           introducedAttrs += exists
           exists
+        // Leave the three-valued IN/NOT IN in place where NULL is observable. It is uncorrelated,
+        // so InSubqueryExec evaluates it directly with three-valued semantics.
+        case n @ Not(_: InSubquery) => n
+        case in: InSubquery => in
+        // NULL and FALSE stay indistinguishable below And/Or, and an Alias only names the
+        // result rather than observing it.
+        case _: And | _: Or | _: Alias =>
+          expr.mapChildren(child => rewrite(child, nullInsensitive))
+        case other => other.mapChildren(child => rewrite(child, nullInsensitive = false))
       }
     }
+
+    // Callers pass filter/join condition roots, where NULL and FALSE both reject the row.
+    val newExprs = exprs.map(rewrite(_, nullInsensitive = true))
     (newExprs.reduceOption(And), newPlan, introducedAttrs.toSeq)
+  }
+
+  /**
+   * An IN/NOT IN subquery is three-valued but an [[ExistenceJoin]]'s `exists` flag is not, so the
+   * rewrite maps NULL to FALSE. Only rewrite where that is unobservable, or where the subquery is
+   * correlated and must therefore be decorrelated into a join. See SPARK-58442.
+   */
+  private def canRewriteToExistenceJoin(
+      query: ListQuery,
+      conditions: Seq[Expression],
+      nullInsensitive: Boolean): Boolean = {
+    nullInsensitive || query.isCorrelated || conditions.nonEmpty
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Cast, EqualTo, Exists, InSubquery, IsNull, ListQuery, Literal, Not, Or}
+import org.apache.spark.sql.catalyst.expressions.{Cast, EqualNullSafe, EqualTo, Exists, InSubquery, IsNull, ListQuery, Literal, Not, Or}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, LeftSemi, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
@@ -97,6 +97,44 @@ class RewriteSubquerySuite extends PlanTest {
     assert(join.condition.get.references.intersect(join.right.outputSet).nonEmpty,
       s"join condition ${join.condition.get} must reference the right child output " +
         s"${join.right.outputSet}")
+  }
+
+  test("SPARK-58442: IN subquery under a null-observing operator is not rewritten") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int, $"d".int)
+
+    // An ExistenceJoin's `exists` flag is non-nullable, so rewriting here would turn the
+    // three-valued IN result NULL into FALSE, which IS NULL and <=> can observe.
+    Seq(
+      IsNull($"a".in(ListQuery(relation2.select($"c")))),
+      Not(IsNull($"a".in(ListQuery(relation2.select($"c"))))),
+      EqualNullSafe($"a".in(ListQuery(relation2.select($"c"))), Literal.TrueLiteral)
+    ).foreach { condition =>
+      val query = relation1.where(condition).select($"a").analyze
+      val optimized = Optimize.execute(query)
+      assert(optimized.collectFirst { case j: Join => j }.isEmpty,
+        s"IN subquery under $condition must not be rewritten to a join")
+      assert(optimized.exists(_.expressions.exists(_.exists(_.isInstanceOf[InSubquery]))),
+        s"IN subquery under $condition must be left in place for InSubqueryExec")
+    }
+  }
+
+  test("SPARK-58442: IN subquery is still rewritten where NULL and FALSE are indistinguishable") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int, $"d".int)
+    val exists = $"exists".boolean.notNull
+
+    // Under AND/OR the row is rejected for both NULL and FALSE, so the lean rewrite still applies.
+    val query = relation1
+      .where($"b" === 1 || $"a".in(ListQuery(relation2.select($"c"))))
+      .select($"a")
+    val correctAnswer = relation1
+      .join(relation2.select($"c"), ExistenceJoin(exists), Some($"a" === $"c"))
+      .where($"b" === 1 || exists)
+      .select($"a")
+      .analyze
+
+    comparePlans(Optimize.execute(query.analyze), correctAnswer)
   }
 
   test("SPARK-34598: Filters without subquery must not be modified by RewritePredicateSubquery") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -125,7 +125,9 @@ case class InSubqueryExec(
 
   @transient private lazy val inSet = InSet(child, result.toSet)
 
-  override def nullable: Boolean = child.nullable
+  // A NULL in the subquery result makes a non-matching probe evaluate to NULL, so the left side's
+  // nullability alone understates it. See SPARK-58442.
+  override def nullable: Boolean = child.nullable || plan.output.exists(_.nullable)
   override def toString: String = s"$child IN ${plan.name}"
   override def withNewPlan(plan: BaseSubqueryExec): InSubqueryExec =
     copy(plan = plan, result = null)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -904,23 +904,26 @@ class SubquerySuite extends SharedSparkSession
   }
 
   test("SPARK-58442: IN subquery under a null-observing operator keeps three-valued result") {
-    withTempView("tn", "t") {
-      Seq(Some(1), Some(2), None).toDF("c").createOrReplaceTempView("tn")
-      Seq(Some(3), None).toDF("c").createOrReplaceTempView("t")
+    withTempView("tn58442", "t58442") {
+      Seq(Some(1), Some(2), None).toDF("c").createOrReplaceTempView("tn58442")
+      Seq(Some(3), None).toDF("c").createOrReplaceTempView("t58442")
 
-      // c = NULL never matches, and t contains NULL, so `c IN (...)` is NULL for every row.
+      // c = NULL never matches, and t58442 contains NULL, so `c IN (...)` is NULL for every row.
       checkAnswer(
-        sql("SELECT c FROM tn WHERE (c IN (SELECT c FROM t)) IS NULL"),
+        sql("SELECT c FROM tn58442 WHERE (c IN (SELECT c FROM t58442)) IS NULL"),
         Row(1) :: Row(2) :: Row(null) :: Nil)
       checkAnswer(
-        sql("SELECT c FROM tn WHERE (c NOT IN (SELECT c FROM t)) IS NULL"),
+        sql("SELECT c FROM tn58442 WHERE (c NOT IN (SELECT c FROM t58442)) IS NULL"),
         Row(1) :: Row(2) :: Row(null) :: Nil)
       checkAnswer(
-        sql("SELECT c FROM tn WHERE (c IN (SELECT c FROM t)) <=> true"),
+        sql("SELECT c FROM tn58442 WHERE (c IN (SELECT c FROM t58442)) <=> true"),
+        Nil)
+      checkAnswer(
+        sql("SELECT c FROM tn58442 WHERE (c NOT IN (SELECT c FROM t58442)) <=> true"),
         Nil)
       // The rewrite is still sound below AND/OR, so those keep the ExistenceJoin plan.
       checkAnswer(
-        sql("SELECT c FROM tn WHERE c = 1 OR c IN (SELECT c FROM t)"),
+        sql("SELECT c FROM tn58442 WHERE c = 1 OR c IN (SELECT c FROM t58442)"),
         Row(1) :: Nil)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2227,9 +2227,12 @@ class SubquerySuite extends SharedSparkSession
       checkAnswer(df.where(s"(c1 NOT IN (SELECT c2 FROM $t)) != false"), Seq.empty)
       checkAnswer(df.where(s"(c1 NOT IN (SELECT c2 FROM $t WHERE c2 IS NOT NULL)) != false"),
         Row(4, null) :: Nil)
-      checkAnswer(df.where(s"NOT((c1 NOT IN (SELECT c2 FROM $t)) <=> false)"), Seq.empty)
+      // SPARK-58442: NOT IN evaluates to NULL for these rows, and NOT(NULL <=> false) is TRUE,
+      // so they are returned. Before that fix NULL was collapsed to FALSE and they were not.
+      checkAnswer(df.where(s"NOT((c1 NOT IN (SELECT c2 FROM $t)) <=> false)"),
+        Row(4, null) :: Row(null, 0) :: Nil)
       checkAnswer(df.where(s"NOT((c1 NOT IN (SELECT c2 FROM $t WHERE c2 IS NOT NULL)) <=> false)"),
-        Row(4, null) :: Nil)
+        Row(4, null) :: Row(null, 0) :: Nil)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -903,6 +903,28 @@ class SubquerySuite extends SharedSparkSession
     }
   }
 
+  test("SPARK-58442: IN subquery under a null-observing operator keeps three-valued result") {
+    withTempView("tn", "t") {
+      Seq(Some(1), Some(2), None).toDF("c").createOrReplaceTempView("tn")
+      Seq(Some(3), None).toDF("c").createOrReplaceTempView("t")
+
+      // c = NULL never matches, and t contains NULL, so `c IN (...)` is NULL for every row.
+      checkAnswer(
+        sql("SELECT c FROM tn WHERE (c IN (SELECT c FROM t)) IS NULL"),
+        Row(1) :: Row(2) :: Row(null) :: Nil)
+      checkAnswer(
+        sql("SELECT c FROM tn WHERE (c NOT IN (SELECT c FROM t)) IS NULL"),
+        Row(1) :: Row(2) :: Row(null) :: Nil)
+      checkAnswer(
+        sql("SELECT c FROM tn WHERE (c IN (SELECT c FROM t)) <=> true"),
+        Nil)
+      // The rewrite is still sound below AND/OR, so those keep the ExistenceJoin plan.
+      checkAnswer(
+        sql("SELECT c FROM tn WHERE c = 1 OR c IN (SELECT c FROM t)"),
+        Row(1) :: Nil)
+    }
+  }
+
   test("SPARK-36124: Correlated subqueries with union") {
     withTempView("t0", "t1", "t2") {
       Seq((1, 1), (2, 0)).toDF("t0a", "t0b").createOrReplaceTempView("t0")


### PR DESCRIPTION
### What changes were proposed in this pull request?

`RewritePredicateSubquery.rewriteExistentialExprWithAttrs` replaced an `IN`/`NOT IN` subquery predicate with a non-nullable `exists` attribute produced by an `ExistenceJoin`, applied via an unrestricted `transformDown` at any depth. Since `exists` is two-valued, the three-valued `IN` result NULL was mapped to FALSE.

This restricts the traversal to positions where NULL and FALSE are indistinguishable - the condition root and below `And`/`Or` (an `Alias` only names the result, so it is transparent). In an observable position an uncorrelated `IN`/`NOT IN` is left in place; `PlanSubqueries` plans it as `InSubqueryExec`, which evaluates three-valued `IN` semantics. A correlated subquery is still rewritten, since it requires decorrelation.

Two supporting changes were needed:

1. `InSubqueryExec.nullable` derived nullability from the probe alone (`child.nullable`), ignoring whether the subquery result can contain NULL. `InSet` correctly *evaluates* to NULL for a non-matching probe when the set contains NULL, but with the node declared non-nullable that NULL is read as FALSE, reintroducing the same collapse below the optimizer. This is the physical counterpart of the logical `ListQuery` nullability fix in SPARK-43413, and it only became reachable once an uncorrelated `IN` is left in place. It is now `child.nullable || plan.output.exists(_.nullable)`.

2. Leaving the subquery in place is restricted to a single-column probe. `InSubqueryExec` compares a multi-column probe as one struct, where NULL equals NULL, rather than comparing row-wise with three-valued semantics, so it would report a match for a row whose comparison is actually NULL. Multi-column probes keep going to the `ExistenceJoin`.

3. The `Project` wrapper in the nested-predicate branch is now added only when an existence join was actually introduced. It exists solely to prune the join's `exists` attribute, and re-adding it while leaving the subquery in place made the rule rewrite its own output indefinitely.

The traversal mirrors the position-restricted recursion in `ReplaceNullWithFalseInPredicate`, the same approach used to fix the sibling bug SPARK-58384 (#57791).

### Why are the changes needed?

Wrong results. With `tn(c)` containing `(1), (2), (NULL)` and `t(c)` containing a NULL:

```sql
SELECT c FROM tn WHERE (c IN (SELECT c FROM t)) IS NULL;
```

`IN` evaluates to NULL for every row, so `IS NULL` is TRUE and all rows should be returned. Before this change the rewrite collapsed NULL to FALSE, `NullPropagation` then folded `isnull(exists)` to `false`, and the query returned no rows.

The collapse is sound at a condition root and under `AND`/`OR`, since NULL and FALSE both reject the row, which is why this went unnoticed. It is observable under `IS NULL`, `IS NOT NULL` and `<=>`.

SPARK-43413 fixed the related nullability metadata on `ListQuery` and explicitly noted this rewrite as a separate remaining bug.

Two limitations are intentionally left out of scope: value positions such as `SELECT c IN (...)` (below an `Alias`) still collapse, and a correlated subquery in an observable position keeps the current behaviour because it must be decorrelated into a join.

### Does this PR introduce _any_ user-facing change?

Yes. Queries with an `IN`/`NOT IN` subquery under a null-observing operator now return correct results instead of silently wrong ones. Plans for `IN` at a condition root or under `AND`/`OR` are unchanged.

### How was this patch tested?

New tests:
- `RewriteSubquerySuite`: an `IN` subquery under `IS NULL`, `NOT(IS NULL)` and `<=>` is not rewritten to a join; and it is still rewritten to an `ExistenceJoin` under `OR`.
- `SubquerySuite`: end-to-end results for the reported repro plus the `NOT IN`, `<=>` and `OR` variants.

Two assertions in `SubquerySuite`, "SPARK-38132: Not IN subquery correctness checks", expected the collapsed result and are updated. With `c2 = {1, 2, 3, NULL, 0}` and probe `c1 = 4`: `4 IN (...)` has no match and the set contains NULL, so it is NULL; `NOT NULL` is NULL; `NULL <=> false` is FALSE; and `NOT FALSE` is TRUE, so the row is returned. The same holds for `c1 = NULL`. The other six assertions in that test are unaffected, because `= true`, `<=> true` and `!= false` all reject NULL and FALSE alike.

Existing coverage that exercises the `InSubqueryExec` nullability fix, and passes unchanged (no golden files needed regenerating):
- `subquery/in-subquery/in-nullability.sql`, in particular `(a_nonnullable not in (select b_nullable from t1)) <=> true`
- `SubquerySuite`, "SPARK-38132: Not IN subquery correctness checks"
- `DeleteFromTableSuite` / `UpdateTableSuite`, the multi-column `IN` subquery cases

### Was this patch authored or co-authored using generative AI tooling?

Generated using Kiro (Claude Opus 4.8)
