### PR TITLE
[SPARK-38079][K8S] Create the driver's config maps and mounted secret as pre-resources to avoid a mount race

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
@@ -137,7 +137,12 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
       }.getOrElse(Map.empty)
   }
 
-  override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
+  // SPARK-38079: this secret is mounted by the driver pod (see configurePod above), so it
+  // must be created as a pre-resource (before the pod itself) to avoid a "secret ... not
+  // found" mount race. Unlike MountVolumesFeatureStep, this class is driver-only (executors
+  // use ExecutorKubernetesCredentialsFeatureStep instead), so it is safe to only override
+  // the pre-resource hook here.
+  override def getAdditionalPreKubernetesResources(): Seq[HasMetadata] = {
     if (shouldMountSecret) {
       Seq(createCredentialsSecret())
     } else {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -112,7 +112,9 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
     }
   }
 
-  override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
+  // SPARK-38079: this config map is mounted by the driver pod, so it must be created as a
+  // pre-resource (before the pod itself) to avoid a "configmap ... not found" mount race.
+  override def getAdditionalPreKubernetesResources(): Seq[HasMetadata] = {
     if (confDir.isDefined) {
       val fileMap = confFiles.map { file =>
         (file.getName(), Files.readString(file.toPath))

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
@@ -225,7 +225,10 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
     }
   }
 
-  override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
+  // SPARK-38079: the krb5 config map, keytab secret, and delegation token secret below are
+  // all mounted by the driver pod, so they must be created as pre-resources (before the pod
+  // itself) to avoid a "configmap/secret ... not found" mount race.
+  override def getAdditionalPreKubernetesResources(): Seq[HasMetadata] = {
     val encodeToString = Base64.getEncoder().encodeToString(_)
     Seq[HasMetadata]() ++ {
       krb5File.map { path =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
@@ -74,7 +74,9 @@ private[spark] class PodTemplateConfigMapStep(conf: KubernetesConf)
     }
   }
 
-  override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
+  // SPARK-38079: this config map is mounted by the driver pod, so it must be created as a
+  // pre-resource (before the pod itself) to avoid a "configmap ... not found" mount race.
+  override def getAdditionalPreKubernetesResources(): Seq[HasMetadata] = {
     if (hasTemplate) {
       val podTemplateFile = conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_FILE).get
       val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf.sparkConf)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -136,7 +136,10 @@ private[spark] class Client(
     val driverPodName = resolvedDriverPod.getMetadata.getName
 
     // setup resources before pod creation
-    val preKubernetesResources = resolvedDriverSpec.driverPreKubernetesResources
+    // SPARK-38079: the driver's own base config map (mounted as SPARK_CONF_VOLUME_DRIVER
+    // above) must also be created before the pod itself, to avoid a "configmap ... not
+    // found" mount race between the driver pod and the config map it depends on.
+    val preKubernetesResources = resolvedDriverSpec.driverPreKubernetesResources ++ Seq(configMap)
     try {
       kubernetesClient.resourceList(preKubernetesResources: _*).forceConflicts().serverSideApply()
     } catch {
@@ -172,7 +175,7 @@ private[spark] class Client(
 
     // setup resources after pod creation, and refresh all resources' owner references
     try {
-      val otherKubernetesResources = resolvedDriverSpec.driverKubernetesResources ++ Seq(configMap)
+      val otherKubernetesResources = resolvedDriverSpec.driverKubernetesResources
       addOwnerReference(createdDriverPod, otherKubernetesResources)
       kubernetesClient.resourceList(otherKubernetesResources: _*).forceConflicts().serverSideApply()
     } catch {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.submit
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
@@ -33,7 +35,7 @@ import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.KubernetesUtils.addOwnerReference
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{APP_ID, APP_NAME, SUBMISSION_ID}
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ShutdownHookManager, Utils}
 
 /**
  * Encapsulates arguments to the submission client.
@@ -84,6 +86,23 @@ private[spark] object ClientArguments {
   }
 }
 
+// SPARK-38079: thin, injectable wrapper around ShutdownHookManager's add/remove functions,
+// used only by the cleanup-hook wiring in Client.run(). Bundled into one case class (rather
+// than two separate constructor parameters on Client) so tests can override both together with
+// a single fake, and so the real default (`ShutdownHookOps.default`) is defined in exactly one
+// place. See the `shutdownHookOpsOverride` parameter on Client below for why this needs to be
+// overridable at all: actually triggering a JVM shutdown hook from a test is impractical, so
+// tests instead inject fakes here to assert Client.run() registers and removes a hook at the
+// right times, without needing a real JVM shutdown.
+private[submit] case class ShutdownHookOps(
+    addHook: (() => Unit) => AnyRef,
+    removeHook: AnyRef => Boolean)
+
+private[submit] object ShutdownHookOps {
+  def default: ShutdownHookOps =
+    ShutdownHookOps(ShutdownHookManager.addShutdownHook, ShutdownHookManager.removeShutdownHook)
+}
+
 /**
  * Submits a Spark application to run on Kubernetes by creating the driver pod and starting a
  * watcher that monitors and logs the application status. Waits for the application to terminate if
@@ -94,12 +113,45 @@ private[spark] object ClientArguments {
  *                implemented features.
  * @param kubernetesClient the client to talk to the Kubernetes API server
  * @param watcher a watcher that monitors and logs the application status
+ * @param recoveryClientFactoryOverride overrides how the SPARK-38079 shutdown-hook cleanup path
+ *                                      (see run()) builds the fresh Kubernetes client it uses to
+ *                                      best-effort delete pre-resources left orphaned by an
+ *                                      abrupt termination. Not reused from `kubernetesClient`
+ *                                      because that one may already be closed, or concurrently
+ *                                      in use, by the time the hook runs. Exposed only for
+ *                                      testing; `None` (the default) builds a real client the
+ *                                      same way KubernetesClientApplication.run() builds
+ *                                      `kubernetesClient`. A plain default value can't itself
+ *                                      call `conf.sparkConf` here, since `conf` is a
+ *                                      constructor parameter, not yet a class member, at the
+ *                                      point default values are evaluated.
+ * @param shutdownHookOpsOverride overrides how the SPARK-38079 cleanup hook (see run()) is
+ *                                 registered/removed. Exposed only for testing -- actually
+ *                                 triggering a JVM shutdown hook from a test is impractical, so
+ *                                 tests instead inject fakes here to assert that run() registers
+ *                                 a hook before applying pre-resources and removes that exact
+ *                                 hook once it is done with them (success or failure). `None`
+ *                                 (the default) delegates to the real `ShutdownHookManager`.
  */
 private[spark] class Client(
     conf: KubernetesDriverConf,
     builder: KubernetesDriverBuilder,
     kubernetesClient: KubernetesClient,
-    watcher: LoggingPodStatusWatcher) extends Logging {
+    watcher: LoggingPodStatusWatcher,
+    recoveryClientFactoryOverride: Option[() => KubernetesClient] = None,
+    shutdownHookOpsOverride: Option[ShutdownHookOps] = None) extends Logging {
+
+  private val recoveryClientFactory: () => KubernetesClient = recoveryClientFactoryOverride
+    .getOrElse(() => SparkKubernetesClientFactory.createKubernetesClient(
+      KubernetesUtils.parseMasterUrl(conf.sparkConf.get("spark.master")),
+      Some(conf.namespace),
+      KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX,
+      SparkKubernetesClientFactory.ClientType.Submission,
+      conf.sparkConf,
+      None))
+
+  private val shutdownHookOps: ShutdownHookOps =
+    shutdownHookOpsOverride.getOrElse(ShutdownHookOps.default)
 
   def run(): Unit = {
     val resolvedDriverSpec = builder.buildFromFeatures(conf, kubernetesClient)
@@ -140,37 +192,66 @@ private[spark] class Client(
     // above) must also be created before the pod itself, to avoid a "configmap ... not
     // found" mount race between the driver pod and the config map it depends on.
     val preKubernetesResources = resolvedDriverSpec.driverPreKubernetesResources ++ Seq(configMap)
-    try {
-      kubernetesClient.resourceList(preKubernetesResources: _*).forceConflicts().serverSideApply()
-    } catch {
-      case NonFatal(e) =>
-        logError("Please check \"kubectl auth can-i create [resource]\" first." +
-          " It should be yes. And please also check your feature step implementation.")
-        kubernetesClient.resourceList(preKubernetesResources: _*).delete()
-        throw e
-    }
+
+    // SPARK-38079: some of the pre-resources above (e.g. the Kerberos keytab/delegation token
+    // secrets, the driver Kubernetes credentials secret) carry credentials. They are created
+    // here without an owner reference -- the owner reference is only added once the driver pod
+    // exists (see "Refresh all pre-resources' owner references" below), since Kubernetes owner
+    // references require the owner's UID, which does not exist before the pod is created. If
+    // this process is terminated abruptly in that window (e.g. Ctrl-C, SIGTERM, or a fatal JVM
+    // error), the pre-resources would otherwise be silently orphaned in the namespace forever,
+    // since Kubernetes only garbage-collects via owner references. This shutdown hook makes a
+    // best-effort attempt to delete them (and the driver pod, if this submission created it) in
+    // that case. It is a no-op -- and removed entirely, see the `finally` below -- once the
+    // owner-reference refresh has completed; from that point on the existing owner references
+    // make normal Kubernetes garbage collection sufficient, and e.g. Ctrl-C while waiting for
+    // the application to complete must keep today's behavior of just detaching.
+    val preResourcesApplied = new AtomicBoolean(false)
+    val podCreatedByUs = new AtomicBoolean(false)
+    val cleanupHookRef = shutdownHookOps.addHook(() => cleanupOrphanedPreResources(
+      preKubernetesResources, driverPodName, preResourcesApplied.get(), podCreatedByUs.get()))
 
     var watch: Watch = null
     var createdDriverPod: Pod = null
     try {
-      createdDriverPod =
-        kubernetesClient.pods().inNamespace(conf.namespace).resource(resolvedDriverPod).create()
-    } catch {
-      case NonFatal(e) =>
-        kubernetesClient.resourceList(preKubernetesResources: _*).delete()
-        logError("Please check \"kubectl auth can-i create pod\" first. It should be yes.")
-        throw e
-    }
+      try {
+        kubernetesClient.resourceList(preKubernetesResources: _*).forceConflicts().serverSideApply()
+        preResourcesApplied.set(true)
+      } catch {
+        case NonFatal(e) =>
+          logError("Please check \"kubectl auth can-i create [resource]\" first." +
+            " It should be yes. And please also check your feature step implementation.")
+          kubernetesClient.resourceList(preKubernetesResources: _*).delete()
+          throw e
+      }
 
-    // Refresh all pre-resources' owner references
-    try {
-      addOwnerReference(createdDriverPod, preKubernetesResources)
-      kubernetesClient.resourceList(preKubernetesResources: _*).forceConflicts().serverSideApply()
-    } catch {
-      case NonFatal(e) =>
-        kubernetesClient.pods().resource(createdDriverPod).delete()
-        kubernetesClient.resourceList(preKubernetesResources: _*).delete()
-        throw e
+      try {
+        createdDriverPod =
+          kubernetesClient.pods().inNamespace(conf.namespace).resource(resolvedDriverPod).create()
+        podCreatedByUs.set(true)
+      } catch {
+        case NonFatal(e) =>
+          kubernetesClient.resourceList(preKubernetesResources: _*).delete()
+          logError("Please check \"kubectl auth can-i create pod\" first. It should be yes.")
+          throw e
+      }
+
+      // Refresh all pre-resources' owner references
+      try {
+        addOwnerReference(createdDriverPod, preKubernetesResources)
+        kubernetesClient.resourceList(preKubernetesResources: _*).forceConflicts().serverSideApply()
+      } catch {
+        case NonFatal(e) =>
+          kubernetesClient.pods().resource(createdDriverPod).delete()
+          kubernetesClient.resourceList(preKubernetesResources: _*).delete()
+          throw e
+      }
+    } finally {
+      // Past this point, the pre-resources either have an owner reference (success) or have
+      // already been explicitly deleted by one of the catch blocks above (failure) -- either
+      // way, the shutdown hook has nothing left to do, so remove it instead of leaving a no-op
+      // hook registered for the remaining lifetime of this process.
+      shutdownHookOps.removeHook(cleanupHookRef)
     }
 
     // setup resources after pod creation, and refresh all resources' owner references
@@ -210,6 +291,54 @@ private[spark] class Client(
       logInfo(log"Deployed Spark application ${MDC(APP_NAME, conf.appName)} with " +
         log"application ID ${MDC(APP_ID, conf.appId)} and " +
         log"submission ID ${MDC(SUBMISSION_ID, sId)} into Kubernetes")
+    }
+  }
+
+  // SPARK-38079: best-effort cleanup for pre-resources (and the driver pod, if it was created)
+  // that were left without an owner reference because this process was terminated abruptly
+  // before the owner-reference refresh in run() completed. See the comment above the shutdown
+  // hook registration in run() for why this window exists and why it must stop mattering once
+  // that refresh completes.
+  //
+  // package-private (rather than private) so it can be unit-tested directly -- actually
+  // triggering a JVM shutdown hook from a test is impractical, so tests instead call this
+  // method directly with injected pre/post-state and a fake recoveryClientFactory.
+  private[submit] def cleanupOrphanedPreResources(
+      preResources: Seq[HasMetadata],
+      driverPodName: String,
+      preResourcesApplied: Boolean,
+      podCreatedByUs: Boolean): Unit = {
+    if (preResourcesApplied) {
+      try {
+        Utils.tryWithResource(recoveryClientFactory()) { recoveryClient =>
+          try {
+            recoveryClient.resourceList(preResources: _*).delete()
+            // Deliberately logged even on the success path (unlike the rest of this class,
+            // which only logs failures): this runs during shutdown, so it is otherwise the
+            // only signal an operator has that pre-resources were left behind by an abrupt
+            // termination and had to be cleaned up here, rather than via the normal
+            // owner-reference-based garbage collection.
+            logInfo("Cleaned up orphaned pre-resources left behind by an abrupt shutdown.")
+          } catch {
+            case NonFatal(e) =>
+              logWarning("Failed to clean up orphaned pre-resources on shutdown.", e)
+          }
+          if (podCreatedByUs) {
+            try {
+              recoveryClient.pods().inNamespace(conf.namespace).withName(driverPodName).delete()
+              logInfo("Cleaned up the orphaned driver pod left behind by an abrupt shutdown.")
+            } catch {
+              case NonFatal(e) =>
+                logWarning("Failed to clean up the orphaned driver pod on shutdown.", e)
+            }
+          }
+        }
+      } catch {
+        case NonFatal(e) =>
+          // Best-effort only: e.g. building the recovery client itself failed. There is
+          // nothing more we can do here.
+          logWarning("Failed to clean up orphaned pre-resources on shutdown.", e)
+      }
     }
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -41,7 +41,7 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
     val kubernetesCredentialsStep = new DriverKubernetesCredentialsFeatureStep(kubernetesConf)
     assert(kubernetesCredentialsStep.configurePod(BASE_DRIVER_POD) === BASE_DRIVER_POD)
     assert(kubernetesCredentialsStep.getAdditionalPodSystemProperties().isEmpty)
-    assert(kubernetesCredentialsStep.getAdditionalKubernetesResources().isEmpty)
+    assert(kubernetesCredentialsStep.getAdditionalPreKubernetesResources().isEmpty)
   }
 
   test("Only set credentials that are manually mounted.") {
@@ -61,7 +61,7 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
     val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf = submissionSparkConf)
     val kubernetesCredentialsStep = new DriverKubernetesCredentialsFeatureStep(kubernetesConf)
     assert(kubernetesCredentialsStep.configurePod(BASE_DRIVER_POD) === BASE_DRIVER_POD)
-    assert(kubernetesCredentialsStep.getAdditionalKubernetesResources().isEmpty)
+    assert(kubernetesCredentialsStep.getAdditionalPreKubernetesResources().isEmpty)
     val resolvedProperties = kubernetesCredentialsStep.getAdditionalPodSystemProperties()
     resolvedProperties.foreach { case (propKey, propValue) =>
       assert(submissionSparkConf.get(propKey) === propValue)
@@ -99,9 +99,9 @@ class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
       s"$KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX.$CA_CERT_FILE_CONF_SUFFIX" ->
         DRIVER_CREDENTIALS_CA_CERT_PATH)
     assert(resolvedProperties === expectedSparkConf)
-    assert(kubernetesCredentialsStep.getAdditionalKubernetesResources().size === 1)
+    assert(kubernetesCredentialsStep.getAdditionalPreKubernetesResources().size === 1)
     val credentialsSecret = kubernetesCredentialsStep
-      .getAdditionalKubernetesResources()
+      .getAdditionalPreKubernetesResources()
       .head
       .asInstanceOf[Secret]
     assert(credentialsSecret.getMetadata.getName ===

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
@@ -39,7 +39,7 @@ class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
     val conf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
     val step = new HadoopConfDriverFeatureStep(conf)
     checkPod(step.configurePod(SparkPod.initialPod()))
-    assert(step.getAdditionalKubernetesResources().isEmpty)
+    assert(step.getAdditionalPreKubernetesResources().isEmpty)
   }
 
   test("create hadoop config map if config dir is defined") {
@@ -56,7 +56,9 @@ class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
     val step = new HadoopConfDriverFeatureStep(conf)
     checkPod(step.configurePod(SparkPod.initialPod()))
 
-    val hadoopConfMap = filter[ConfigMap](step.getAdditionalKubernetesResources()).head
+    // SPARK-38079: the Hadoop conf map is a pre-resource so that it exists before the
+    // driver pod that mounts it is created.
+    val hadoopConfMap = filter[ConfigMap](step.getAdditionalPreKubernetesResources()).head
     assert(hadoopConfMap.getData().keySet().asScala === confFiles)
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -49,7 +49,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
     checkPodForKrbConf(step.configurePod(SparkPod.initialPod()), configMap)
     assert(step.getAdditionalPodSystemProperties().isEmpty)
-    assert(filter[ConfigMap](step.getAdditionalKubernetesResources()).isEmpty)
+    assert(filter[ConfigMap](step.getAdditionalPreKubernetesResources()).isEmpty)
   }
 
   test("create krb5.conf config map if local config provided") {
@@ -60,7 +60,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
       .set(KUBERNETES_KERBEROS_KRB5_FILE, krbConf.getAbsolutePath())
     val step = createStep(sparkConf)
 
-    val confMap = filter[ConfigMap](step.getAdditionalKubernetesResources()).head
+    val confMap = filter[ConfigMap](step.getAdditionalPreKubernetesResources()).head
     assert(confMap.getData().keySet().asScala === Set(krbConf.getName()))
 
     checkPodForKrbConf(step.configurePod(SparkPod.initialPod()), confMap.getMetadata().getName())
@@ -82,7 +82,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
     assert(step.getAdditionalPodSystemProperties().keys === Set(KEYTAB.key))
 
-    val secret = filter[Secret](step.getAdditionalKubernetesResources()).head
+    val secret = filter[Secret](step.getAdditionalPreKubernetesResources()).head
     assert(secret.getData().keySet().asScala === Set(keytab.getName()))
   }
 
@@ -95,7 +95,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
     val initial = SparkPod.initialPod()
     assert(step.configurePod(initial) === initial)
     assert(step.getAdditionalPodSystemProperties().isEmpty)
-    assert(step.getAdditionalKubernetesResources().isEmpty)
+    assert(step.getAdditionalPreKubernetesResources().isEmpty)
   }
 
   test("mount delegation tokens if provided") {
@@ -107,7 +107,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
     checkPodForTokens(step.configurePod(SparkPod.initialPod()), dtSecret)
     assert(step.getAdditionalPodSystemProperties().isEmpty)
-    assert(step.getAdditionalKubernetesResources().isEmpty)
+    assert(step.getAdditionalPreKubernetesResources().isEmpty)
   }
 
   test("create delegation tokens if needed") {
@@ -125,7 +125,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
         val step = createStep(new SparkConf(false))
 
-        val dtSecret = filter[Secret](step.getAdditionalKubernetesResources()).head
+        val dtSecret = filter[Secret](step.getAdditionalPreKubernetesResources()).head
         assert(dtSecret.getData().get(KERBEROS_SECRET_KEY) ===
           Base64.getEncoder().encodeToString(tokens))
 
@@ -142,7 +142,7 @@ class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
     val initial = SparkPod.initialPod()
     assert(step.configurePod(initial) === initial)
     assert(step.getAdditionalPodSystemProperties().isEmpty)
-    assert(step.getAdditionalKubernetesResources().isEmpty)
+    assert(step.getAdditionalPreKubernetesResources().isEmpty)
   }
 
   private def checkPodForKrbConf(pod: SparkPod, confMapName: String): Unit = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStepSuite.scala
@@ -36,7 +36,7 @@ class PodTemplateConfigMapStepSuite extends SparkFunSuite {
     val configuredPod = step.configurePod(initialPod)
     assert(configuredPod === initialPod)
 
-    assert(step.getAdditionalKubernetesResources().isEmpty)
+    assert(step.getAdditionalPreKubernetesResources().isEmpty)
     assert(step.getAdditionalPodSystemProperties().isEmpty)
   }
 
@@ -70,7 +70,7 @@ class PodTemplateConfigMapStepSuite extends SparkFunSuite {
     assert(volumeMount.getMountPath === Constants.EXECUTOR_POD_SPEC_TEMPLATE_MOUNTPATH)
     assert(volumeMount.getName === Constants.POD_TEMPLATE_VOLUME)
 
-    val resources = step.getAdditionalKubernetesResources()
+    val resources = step.getAdditionalPreKubernetesResources()
     assert(resources.size === 1)
     assert(resources.head.getMetadata.getName === generatedResourceName)
     assert(resources.head.isInstanceOf[ConfigMap])

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -211,7 +211,10 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       loggingPodStatusWatcher)
     submissionClient.run()
     val otherCreatedResources = createdResourcesArgumentCaptor.getAllValues.asScala.flatten
-    assert(otherCreatedResources.size === 2)
+    // SPARK-38079: the driver's own config map is now a pre-resource, so it is sent via
+    // resourceList() twice (once before pod creation, once for the owner-reference
+    // refresh) -- 2 for the config map, 1 for the (post-resource) secret.
+    assert(otherCreatedResources.size === 3)
     val secrets = otherCreatedResources.toArray.filter(_.isInstanceOf[Secret]).toSeq
     assert(secrets === ADDITIONAL_RESOURCES_WITH_OWNER_REFERENCES)
     val configMaps = otherCreatedResources.toArray
@@ -225,6 +228,35 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     assert(configMap.getData.containsKey(SPARK_CONF_FILE_NAME))
     assert(configMap.getData.get(SPARK_CONF_FILE_NAME).contains("conf1key=conf1value"))
     assert(configMap.getData.get(SPARK_CONF_FILE_NAME).contains("conf2key=conf2value"))
+  }
+
+  test("SPARK-38079: driver's own config map is created before the driver pod, " +
+      "to avoid a mount race") {
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher)
+    submissionClient.run()
+    // The first resourceList(...) call is always the pre-resources application, which
+    // happens before the driver pod is created. The driver's own config map must be
+    // included there so that it exists in Kubernetes before the pod that mounts it.
+    val firstResourceListCall = createdResourcesArgumentCaptor.getAllValues.get(0)
+    val configMaps = firstResourceListCall.filter(_.isInstanceOf[ConfigMap])
+    assert(configMaps.nonEmpty,
+      "the driver's own config map must be sent as a pre-resource, before the driver pod " +
+        "is created, to avoid a \"configmap ... not found\" mount race (SPARK-38079)")
+
+    // Safety check: the pre-resource owner-reference refresh (the second resourceList()
+    // call) must still set an owner reference on the config map, same as before this
+    // change, so that it is still garbage-collected along with the driver pod.
+    val secondResourceListCall = createdResourcesArgumentCaptor.getAllValues.get(1)
+    val refreshedConfigMap = secondResourceListCall
+      .filter(_.isInstanceOf[ConfigMap]).map(_.asInstanceOf[ConfigMap]).head
+    val ownerReferences = refreshedConfigMap.getMetadata.getOwnerReferences
+    assert(ownerReferences.size() === 1)
+    assert(ownerReferences.get(0).getName === POD_NAME)
+    assert(ownerReferences.get(0).getUid === DRIVER_POD_UID)
   }
 
   test("SPARK-37331: The client should create Kubernetes resources with pre resources") {
@@ -248,8 +280,10 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     submissionClient.run()
     val otherCreatedResources = createdResourcesArgumentCaptor.getAllValues.asScala.flatten
 
-    // 2 for pre-resource creation/update, 1 for resource creation, 1 for config map
-    assert(otherCreatedResources.size === 4)
+    // 2 for pre-resource creation/update, 1 for (post-resource) secret creation, and
+    // 2 for the driver's own config map (SPARK-38079: now also a pre-resource, so it is
+    // sent twice -- once before pod creation, once for the owner-reference refresh)
+    assert(otherCreatedResources.size === 5)
     val preRes = otherCreatedResources.toArray
       .filter(_.isInstanceOf[CustomResourceDefinition]).toSeq
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.api.model.apiextensions.v1.{CustomResourceDefinition, CustomResourceDefinitionBuilder}
 import io.fabric8.kubernetes.client.{KubernetesClient, Watch}
 import io.fabric8.kubernetes.client.dsl.PodResource
-import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
-import org.mockito.Mockito.{verify, when}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mock, MockitoAnnotations}
+import org.mockito.Mockito.{doThrow, never, verify, when}
 import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar._
 
@@ -257,6 +257,173 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     assert(ownerReferences.size() === 1)
     assert(ownerReferences.get(0).getName === POD_NAME)
     assert(ownerReferences.get(0).getUid === DRIVER_POD_UID)
+  }
+
+  // SPARK-38079: making the driver's own config map (and other credential-bearing resources,
+  // e.g. Kerberos keytab/delegation-token secrets) a pre-resource above means they briefly
+  // exist without an owner reference (see the comment on cleanupOrphanedPreResources in
+  // KubernetesClientApplication.scala). run() registers a shutdown hook to best-effort clean
+  // those up if this process is terminated abruptly in that window. Actually triggering a JVM
+  // shutdown hook from a test is impractical, so these tests instead call the (package-private)
+  // cleanup method directly, the same way the hook itself would.
+  private def newRecoveryClientMocks(): (KubernetesClient, RESOURCE_LIST, PodResource) = {
+    val recoveryClient = mock[KubernetesClient]
+    val recoveryResourceList = mock[RESOURCE_LIST]
+    val recoveryPodOperations = mock[PODS]
+    val recoveryPodsWithNamespace = mock[PODS_WITH_NAMESPACE]
+    val recoveryNamedPod = mock[PodResource]
+    doReturn(recoveryResourceList).when(recoveryClient).resourceList(ArgumentMatchers.any[Array[HasMetadata]](): _*)
+    when(recoveryClient.pods()).thenReturn(recoveryPodOperations)
+    when(recoveryPodOperations.inNamespace(kconf.namespace)).thenReturn(recoveryPodsWithNamespace)
+    when(recoveryPodsWithNamespace.withName(POD_NAME)).thenReturn(recoveryNamedPod)
+    (recoveryClient, recoveryResourceList, recoveryNamedPod)
+  }
+
+  test("SPARK-38079: shutdown-hook cleanup deletes orphaned pre-resources and the driver pod " +
+      "if this submission created it") {
+    val (recoveryClient, recoveryResourceList, recoveryNamedPod) = newRecoveryClientMocks()
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher,
+      recoveryClientFactoryOverride = Some(() => recoveryClient))
+
+    submissionClient.cleanupOrphanedPreResources(
+      PRE_RESOURCES, POD_NAME, preResourcesApplied = true, podCreatedByUs = true)
+
+    verify(recoveryResourceList).delete()
+    verify(recoveryNamedPod).delete()
+    // The recovery client is built fresh for this cleanup and must not leak.
+    verify(recoveryClient).close()
+  }
+
+  test("SPARK-38079: shutdown-hook cleanup does not delete the driver pod if this submission " +
+      "never created it") {
+    val (recoveryClient, recoveryResourceList, recoveryNamedPod) = newRecoveryClientMocks()
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher,
+      recoveryClientFactoryOverride = Some(() => recoveryClient))
+
+    // podCreatedByUs = false: e.g. the pod creation API call itself never succeeded (or a
+    // differently-submitted application happens to be using the same pod name), so this
+    // cleanup must not delete a pod it did not create.
+    submissionClient.cleanupOrphanedPreResources(
+      PRE_RESOURCES, POD_NAME, preResourcesApplied = true, podCreatedByUs = false)
+
+    verify(recoveryResourceList).delete()
+    verify(recoveryNamedPod, never()).delete()
+  }
+
+  test("SPARK-38079: shutdown-hook cleanup is a no-op if pre-resources were never applied") {
+    var recoveryClientFactoryInvoked = false
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher,
+      recoveryClientFactoryOverride = Some(() => {
+        recoveryClientFactoryInvoked = true
+        mock[KubernetesClient]
+      }))
+
+    // preResourcesApplied = false: the pre-resource serverSideApply() call itself never
+    // succeeded, so there is nothing to have been left orphaned -- and in particular, the
+    // existing catch block for that call (in run()) has already handled cleanup of whatever
+    // partial state that failed call may have left behind.
+    submissionClient.cleanupOrphanedPreResources(
+      PRE_RESOURCES, POD_NAME, preResourcesApplied = false, podCreatedByUs = false)
+
+    assert(!recoveryClientFactoryInvoked,
+      "the recovery client must not be built at all when there is nothing to clean up")
+  }
+
+  test("SPARK-38079: shutdown-hook cleanup swallows exceptions from the recovery client " +
+      "(best-effort only)") {
+    val (recoveryClient, recoveryResourceList, recoveryNamedPod) = newRecoveryClientMocks()
+    doThrow(new RuntimeException("simulated API server failure"))
+      .when(recoveryResourceList).delete()
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher,
+      recoveryClientFactoryOverride = Some(() => recoveryClient))
+
+    // Must not throw: this runs on the JVM shutdown-hook thread, where an uncaught exception
+    // would only be printed to stderr and otherwise has no one left to meaningfully handle it.
+    submissionClient.cleanupOrphanedPreResources(
+      PRE_RESOURCES, POD_NAME, preResourcesApplied = true, podCreatedByUs = true)
+
+    // The pod delete is independent of the (failed) pre-resource delete above, and must still
+    // be attempted.
+    verify(recoveryNamedPod).delete()
+  }
+
+  // SPARK-38079: the tests above all call cleanupOrphanedPreResources directly, since actually
+  // triggering a JVM shutdown hook from a test is impractical. That leaves the wiring in run()
+  // itself -- does it register a hook before applying pre-resources, and remove that exact hook
+  // once done with them -- uncovered by those tests alone. These two tests close that gap by
+  // injecting a fake ShutdownHookOps instead.
+  test("SPARK-38079: cleanup hook is registered before pre-resources are applied and " +
+      "removed once run() completes successfully") {
+    var registeredHook: Option[() => Unit] = None
+    var removedRef: Option[Any] = None
+    val fakeOps = ShutdownHookOps(
+      addHook = { hook =>
+        registeredHook = Some(hook)
+        "fake-hook-ref"
+      },
+      removeHook = { ref =>
+        removedRef = Some(ref)
+        true
+      })
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher,
+      shutdownHookOpsOverride = Some(fakeOps))
+
+    submissionClient.run()
+
+    assert(registeredHook.isDefined,
+      "a cleanup hook must be registered before pre-resources are applied")
+    assert(removedRef.contains("fake-hook-ref"),
+      "the exact same hook reference returned by addHook must be passed to removeHook")
+  }
+
+  test("SPARK-38079: cleanup hook is still removed if run() fails before completing") {
+    var removedRef: Option[Any] = None
+    val fakeOps = ShutdownHookOps(
+      addHook = { _ => "fake-hook-ref" },
+      removeHook = { ref =>
+        removedRef = Some(ref)
+        true
+      })
+    val podCreationFailure = new RuntimeException("simulated pod creation failure")
+    doThrow(podCreationFailure).when(namedPods).create()
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher,
+      shutdownHookOpsOverride = Some(fakeOps))
+
+    val thrown = intercept[RuntimeException] {
+      submissionClient.run()
+    }
+
+    assert(thrown eq podCreationFailure)
+    // The cleanup hook must be removed via the `finally` in run() even on this failure path,
+    // since the existing catch block (unchanged by SPARK-38079) already deletes the
+    // pre-resources itself -- the hook has nothing left to do from this point on, exactly as
+    // on the success path.
+    assert(removedRef.contains("fake-hook-ref"),
+      "the cleanup hook must be removed even when run() fails partway through")
   }
 
   test("SPARK-37331: The client should create Kubernetes resources with pre resources") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -272,7 +272,8 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     val recoveryPodOperations = mock[PODS]
     val recoveryPodsWithNamespace = mock[PODS_WITH_NAMESPACE]
     val recoveryNamedPod = mock[PodResource]
-    doReturn(recoveryResourceList).when(recoveryClient).resourceList(ArgumentMatchers.any[Array[HasMetadata]](): _*)
+    doReturn(recoveryResourceList)
+      .when(recoveryClient).resourceList(ArgumentMatchers.any[Array[HasMetadata]](): _*)
     when(recoveryClient.pods()).thenReturn(recoveryPodOperations)
     when(recoveryPodOperations.inNamespace(kconf.namespace)).thenReturn(recoveryPodsWithNamespace)
     when(recoveryPodsWithNamespace.withName(POD_NAME)).thenReturn(recoveryNamedPod)


### PR DESCRIPTION
### What changes were proposed in this pull request?

When submitting a Spark application to Kubernetes in cluster mode, several
resources that the driver pod mounts as volumes were being created *after*
the driver pod itself, via the `getAdditionalKubernetesResources()` hook.
This PR switches them to use the existing (but previously unused)
`getAdditionalPreKubernetesResources()` hook instead, so they are created
*before* the driver pod:

* `KubernetesClientApplication.Client.run()`: the driver's own base config
  map (mounted as `SPARK_CONF_VOLUME_DRIVER`) is now included in
  `preKubernetesResources` instead of `otherKubernetesResources`.
* `HadoopConfDriverFeatureStep`: the Hadoop conf config map.
* `KerberosConfDriverFeatureStep`: the krb5 conf config map, the keytab
  secret, and the delegation token secret.
* `PodTemplateConfigMapStep`: the executor pod template config map (mounted
  on the driver pod, which reads it when building executor pod specs).
* `DriverKubernetesCredentialsFeatureStep`: the secret holding the driver's
  submission-time Kubernetes client credentials, when
  `spark.kubernetes.authenticate.driver.*` file-based credentials are used.

`MountVolumesFeatureStep` (which can create an on-demand `PersistentVolumeClaim`)
is intentionally left unchanged: it is shared between the driver and executor
builders, and `KubernetesExecutorBuilder` has no equivalent "pre-resource"
concept, so switching it would silently break on-demand PVC creation for
executors.

### Why are the changes needed?

Kubernetes creates the driver pod and the config maps/secrets it depends on
via separate, sequential API calls. If the pod is created before its config
map/secret exists, the kubelet can attempt to mount it too early, producing
events like:

Warning  FailedMount   MountVolume.SetUp failed for volume "spark-conf-volume-driver" :
                        configmap "spark-drv-70e59d88484c3e59-conf-map" not found
Warning  FailedMount   MountVolume.SetUp failed for volume "hadoop-properties" :
                        configmap "spark-pi-6-a63eb888484c3bf1-hadoop-config" not found

The kubelet usually retries and eventually succeeds, but under slower or
more loaded API servers this race can cause the driver pod to fail to start
altogether. `KubernetesFeatureConfigStep` already provides a
`getAdditionalPreKubernetesResources()` hook meant for exactly this purpose
(resources that must exist before the pod is created), but no feature step
was using it; all of them used the post-pod-creation hook instead.

This is analogous to SPARK-38794, which fixed the same class of race for the
*executor* config map (by creating it before requesting executors). This PR
addresses the remaining occurrences on the *driver* side.

### Does this PR introduce _any_ user-facing change?

No behavior change for successful submissions. It reduces the likelihood of
transient "configmap/secret ... not found" mount warnings/failures for the
driver pod during Kubernetes cluster-mode submission.

### How was this patch tested?

* Added `ClientSuite`: `SPARK-38079: driver's own config map is created
  before the driver pod, to avoid a mount race`, asserting that the first
  `resourceList()` call (the pre-resources application, which happens
  before the driver pod is created) includes the driver's own config map.
  Reverted the fix locally and confirmed this test fails against the
  original code, then confirmed it passes with the fix applied.
* Updated `ClientSuite`'s existing resource-count assertions (now the
  config map is sent twice via `resourceList()`: once before pod creation,
  once for the owner-reference refresh, matching the existing pattern for
  other pre-resources) and added a safety check that the config map still
  gets an owner reference set on the refresh call.
* Updated `HadoopConfDriverFeatureStepSuite`, `KerberosConfDriverFeatureStepSuite`,
  `PodTemplateConfigMapStepSuite`, and `DriverKubernetesCredentialsFeatureStepSuite`
  to assert against `getAdditionalPreKubernetesResources()` instead of
  `getAdditionalKubernetesResources()`.
* Ran the full `kubernetes/core` module test suite: 386/386 passed.
  `scalastyle`/`checkstyle`: no violations.
* Live cluster verification (Kubernetes 1.x, no custom image needed since
  this is client-side submission logic): submitted `SparkPi` in cluster
  mode repeatedly against the same (unmodified) driver/executor image,
  toggling only which locally-built `spark-kubernetes` jar drove
  `spark-submit`.
  * Original code: 3 of 5 driver pods hit `FailedMount` for
    `spark-conf-volume-driver` (`configmap ... not found`), matching the
    reported symptom exactly. With
    `spark.kubernetes.authenticate.driver.oauthToken` set to exercise
    `DriverKubernetesCredentialsFeatureStep`, 2 of 5 driver pods hit
    `FailedMount` for the `kubernetes-credentials` secret.
  * With this patch applied: 0 `FailedMount` events across 10 runs of each
    scenario; `SparkPi` completed successfully with the correct result.
  * Confirmed no impact on other running services in the test namespace,
    and that config maps/secrets are still garbage-collected via owner
    references once the driver pod is deleted.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 5