### PR TITLE
[SPARK-58212][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1052

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1,4 +1,10 @@
 {
+  "ADD_COLUMN_NOT_NULL_UNSUPPORTED" : {
+    "message" : [
+      "ADD COLUMN with v1 tables cannot specify NOT NULL."
+    ],
+    "sqlState" : "0A000"
+  },
   "ADD_DEFAULT_UNSUPPORTED" : {
     "message" : [
       "Failed to execute <statementType> command because DEFAULT values are not supported when adding new columns to previously existing target data source with table provider: \"<dataSource>\"."
@@ -10110,11 +10116,6 @@
   "_LEGACY_ERROR_TEMP_1050" : {
     "message" : [
       "Can only star expand struct data types. Attribute: `<attributes>`."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1052" : {
-    "message" : [
-      "ADD COLUMN with v1 tables cannot specify NOT NULL."
     ]
   },
   "_LEGACY_ERROR_TEMP_1059" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1197,7 +1197,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def addColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1052",
+      errorClass = "ADD_COLUMN_NOT_NULL_UNSUPPORTED",
       messageParameters = Map.empty)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1151,6 +1151,19 @@ class QueryCompilationErrorsSuite
       parameters = Map("identifier" -> identifier.toString)
     )
   }
+
+  test("ADD_COLUMN_NOT_NULL_UNSUPPORTED: v1 table ADD COLUMN with NOT NULL") {
+    withTable("t") {
+      sql("CREATE TABLE t(i INT) USING parquet")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("ALTER TABLE t ADD COLUMN c INT NOT NULL")
+        },
+        condition = "ADD_COLUMN_NOT_NULL_UNSUPPORTED",
+        sqlState = "0A000",
+        parameters = Map())
+    }
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Assign a stable name to `_LEGACY_ERROR_TEMP_1052` (ADD COLUMN ... NOT NULL on v1 tables).

- Catalog: delete `_LEGACY_ERROR_TEMP_1052`, add `ADD_COLUMN_NOT_NULL_UNSUPPORTED` with SQLSTATE `0A000` and the same message: `ADD COLUMN with v1 tables cannot specify NOT NULL.`
- `QueryCompilationErrors.addColumnWithV1TableCannotSpecifyNotNullError` now uses that condition. The helper name and `ResolveSessionCatalog` call site are unchanged.
- Add one `checkError` in `QueryCompilationErrorsSuite` for `ALTER TABLE t ADD COLUMN c INT NOT NULL` on a `USING parquet` table.

This does not reuse `UNSUPPORTED_FEATURE.TABLE_OPERATION`. Closed apache/spark#57364 did that and changed the user text. This PR is a catalog rename only.

### Why are the changes needed?

https://issues.apache.org/jira/browse/SPARK-58212

Sub-task of SPARK-37935. TEMP ids are not a stable public condition. The id is still in current `master`. The earlier close of apache/spark#57364 ("another pr has completed this work") was incorrect.

### Does this PR introduce _any_ user-facing change?

Yes. Clients that match `_LEGACY_ERROR_TEMP_1052` by condition name will need the new name. The message text is unchanged. Named conditions now report SQLSTATE `0A000` (TEMP entries omit it).

### How was this patch tested?

- `build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryCompilationErrorsSuite -- -z ADD_COLUMN_NOT_NULL_UNSUPPORTED"`
- `build/sbt "core/testOnly org.apache.spark.SparkThrowableSuite -- -z \"Error conditions are correctly formatted\""`

No SQL golden files. No Hive suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6

cc @uros-b @MaxGekk
