### PR TITLE
[SPARK-58267][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1059

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4132,6 +4132,12 @@
     ],
     "sqlState" : "42000"
   },
+  "INVALID_FILE_FORMAT_FOR_STORED_AS" : {
+    "message" : [
+      "STORED AS with file format '<serdeInfo>' is invalid."
+    ],
+    "sqlState" : "42601"
+  },
   "INVALID_FLOW_QUERY_TYPE" : {
     "message" : [
       "Flow <flowIdentifier> returns an invalid relation type."
@@ -10115,11 +10121,6 @@
   "_LEGACY_ERROR_TEMP_1052" : {
     "message" : [
       "ADD COLUMN with v1 tables cannot specify NOT NULL."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1059" : {
-    "message" : [
-      "STORED AS with file format '<serdeInfo>' is invalid."
     ]
   },
   "_LEGACY_ERROR_TEMP_1060" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1326,7 +1326,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def invalidFileFormatForStoredAsError(serdeInfo: SerdeInfo): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1059",
+      errorClass = "INVALID_FILE_FORMAT_FOR_STORED_AS",
       messageParameters = Map("serdeInfo" -> serdeInfo.storedAs.get))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1151,6 +1151,35 @@ class QueryCompilationErrorsSuite
       parameters = Map("identifier" -> identifier.toString)
     )
   }
+
+  test("SPARK-58267: INVALID_FILE_FORMAT_FOR_STORED_AS: unknown STORED AS file format") {
+    withTable("s", "t") {
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("CREATE TABLE t (c1 INT) STORED AS UNKNOWN_FORMAT")
+        },
+        condition = "INVALID_FILE_FORMAT_FOR_STORED_AS",
+        sqlState = "42601",
+        parameters = Map("serdeInfo" -> "UNKNOWN_FORMAT"))
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("CREATE TABLE t STORED AS UNKNOWN_FORMAT AS SELECT 1")
+        },
+        condition = "INVALID_FILE_FORMAT_FOR_STORED_AS",
+        sqlState = "42601",
+        parameters = Map("serdeInfo" -> "UNKNOWN_FORMAT"))
+
+      sql("CREATE TABLE s (c1 INT) USING parquet")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("CREATE TABLE t LIKE s STORED AS UNKNOWN_FORMAT")
+        },
+        condition = "INVALID_FILE_FORMAT_FOR_STORED_AS",
+        sqlState = "42601",
+        parameters = Map("serdeInfo" -> "UNKNOWN_FORMAT"))
+    }
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Assign a stable name to `_LEGACY_ERROR_TEMP_1059` (invalid `STORED AS` file format).

- Catalog: delete `_LEGACY_ERROR_TEMP_1059`, add `INVALID_FILE_FORMAT_FOR_STORED_AS` with SQLSTATE `42601` and the same message: `STORED AS with file format '<serdeInfo>' is invalid.`
- `QueryCompilationErrors.invalidFileFormatForStoredAsError` now uses that condition. The helper, the `serdeInfo` placeholder name, `ResolveSessionCatalog`, and `HiveSerDe` are unchanged.
- Add `checkError` coverage in `QueryCompilationErrorsSuite` for CREATE TABLE, CTAS, and CREATE TABLE LIKE with `STORED AS UNKNOWN_FORMAT`. The LIKE source is `USING parquet` so the suite does not need Hive.

`INSERT OVERWRITE DIRECTORY ... STORED AS` still uses `_LEGACY_ERROR_TEMP_0035` and is out of scope.

Closed apache/spark#57445 used this same name and SQLSTATE. That PR was closed after a false "already merged" claim.

### Why are the changes needed?

https://issues.apache.org/jira/browse/SPARK-58267

Sub-task of SPARK-37935. TEMP ids are not a stable public condition. The id is still in current `master`.

### Does this PR introduce _any_ user-facing change?

Yes. Clients that match `_LEGACY_ERROR_TEMP_1059` by condition name will need the new name. The message text is unchanged, including the `<serdeInfo>` placeholder. Named conditions now report SQLSTATE `42601`.

### How was this patch tested?

- `build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryCompilationErrorsSuite -- -z INVALID_FILE_FORMAT_FOR_STORED_AS"`
- `build/sbt "core/testOnly org.apache.spark.SparkThrowableSuite -- -z \"Error conditions are correctly formatted\""`

No SQL golden files. No Hive module run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6

cc @uros-b @MaxGekk
