### PR TITLE
[SPARK-58928][SQL] Fix collation-aware grouping in WindowGroupLimitExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExec.scala
@@ -19,9 +19,10 @@ package org.apache.spark.sql.execution.window
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Expression, SortOrder, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Expression, InterpretedOrdering, SortOrder, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
+import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
@@ -205,6 +206,19 @@ class GroupedLimitIterator(
 
   val grouping = UnsafeProjection.create(partitionSpec, output)
 
+  private val groupEqualityCheck: (UnsafeRow, UnsafeRow) => Boolean =
+    if (partitionSpec.forall(e => UnsafeRowUtils.isBinaryStable(e.dataType))) {
+      (key1, key2) => key1.equals(key2)
+    } else {
+      // InterpretedOrdering is applied to all fields when any field is non-binary-stable
+      // (e.g. a collated STRING). As a side effect, any DOUBLE/FLOAT fields in the same
+      // spec use SQLOrderingUtil.compareDoubles, so -0.0 and +0.0 compare as equal --
+      // consistent with the sort order, but different from a pure-Double spec (binary path).
+      val types = partitionSpec.map(_.dataType)
+      val ordering = InterpretedOrdering.forSchema(types)
+      (key1, key2) => ordering.compare(key1, key2) == 0
+    }
+
   // Manage the stream and the grouping.
   var nextRow: UnsafeRow = null
   var nextGroup: UnsafeRow = null
@@ -243,7 +257,7 @@ class GroupedLimitIterator(
     // Before we start to fetch new input rows, make a copy of nextGroup.
     var currentGroup = nextGroup.copy()
 
-    def hasNext: Boolean = nextRowAvailable && nextGroup == currentGroup
+    def hasNext: Boolean = nextRowAvailable && groupEqualityCheck(nextGroup, currentGroup)
 
     def next(): InternalRow = {
       if (!hasNext) throw new NoSuchElementException

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.joins._
+import org.apache.spark.sql.execution.window.{Final, WindowGroupLimitExec}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, Metadata, MetadataBuilder, StringType, StructField, StructType}
@@ -3327,5 +3328,111 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         "SELECT :p = 'HELLO', :p = 'HELLO' COLLATE UTF8_LCASE",
         Map("p" -> "hello")),
       Row(false, true))
+  }
+
+  test("RANK/DENSE_RANK/ROW_NUMBER with collated PARTITION BY via WindowGroupLimitExec") {
+    // threshold=1 forces InferWindowGroupLimit -> WindowGroupLimitExec for WHERE r <= 1
+    withSQLConf(SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "1") {
+      withTable("t") {
+        sql("CREATE TABLE t (s STRING COLLATE UTF8_LCASE, i INT) USING PARQUET")
+        sql("INSERT INTO t VALUES ('foo', 1), ('FOO', 2), ('bar', 3), ('BAR', 4)")
+
+        // 'foo'/'FOO' and 'bar'/'BAR' collapse to one partition each under UTF8_LCASE.
+        val rankDf = sql("""SELECT s, i, r FROM (
+                           |  SELECT s, i, RANK() OVER (PARTITION BY s ORDER BY i) AS r
+                           |  FROM t) WHERE r <= 1""".stripMargin)
+        assert(collectFirst(rankDf.queryExecution.executedPlan) {
+          case _: WindowGroupLimitExec => ()
+        }.isDefined, "expected WindowGroupLimitExec in plan")
+        checkAnswer(rankDf, Row("foo", 1, 1) :: Row("bar", 3, 1) :: Nil)
+
+        val denseDf = sql("""SELECT s, i, r FROM (
+                            |  SELECT s, i, DENSE_RANK() OVER (PARTITION BY s ORDER BY i) AS r
+                            |  FROM t) WHERE r <= 1""".stripMargin)
+        assert(collectFirst(denseDf.queryExecution.executedPlan) {
+          case _: WindowGroupLimitExec => ()
+        }.isDefined, "expected WindowGroupLimitExec in plan for DENSE_RANK")
+        checkAnswer(denseDf, Row("foo", 1, 1) :: Row("bar", 3, 1) :: Nil)
+
+        val rnDf = sql("""SELECT s, i, r FROM (
+                         |  SELECT s, i, ROW_NUMBER() OVER (PARTITION BY s ORDER BY i) AS r
+                         |  FROM t) WHERE r <= 1""".stripMargin)
+        assert(collectFirst(rnDf.queryExecution.executedPlan) {
+          case _: WindowGroupLimitExec => ()
+        }.isDefined, "expected WindowGroupLimitExec in plan for ROW_NUMBER")
+        checkAnswer(rnDf, Row("foo", 1, 1) :: Row("bar", 3, 1) :: Nil)
+      }
+
+      // UTF8_BINARY: 'foo' and 'FOO' are distinct partitions, so all four rows get rank 1.
+      withTable("t2") {
+        sql("CREATE TABLE t2 (s STRING, i INT) USING PARQUET")
+        sql("INSERT INTO t2 VALUES ('foo', 1), ('FOO', 2), ('bar', 3), ('BAR', 4)")
+
+        checkAnswer(
+          sql("""SELECT s, i, r FROM (
+                |  SELECT s, i, RANK() OVER (PARTITION BY s ORDER BY i) AS r
+                |  FROM t2) WHERE r <= 1""".stripMargin),
+          Row("FOO", 2, 1) :: Row("BAR", 4, 1) :: Row("bar", 3, 1) :: Row("foo", 1, 1) :: Nil)
+      }
+    }
+  }
+
+  test("WindowGroupLimitExec collapses collated partitions (forwarded-row regression)") {
+    // The final query result is identical with or without collation-aware grouping -- the
+    // downstream WindowExec + Filter always recompute it -- so checkAnswer alone cannot
+    // catch a regression to binary grouping. The only observable that distinguishes the
+    // fix is how many rows WindowGroupLimitExec forwards: binary grouping fails to collapse
+    // 'a'/'A' and forwards every row, while collation-aware grouping collapses each
+    // UTF8_LCASE partition to its top-k.
+    //
+    // We assert on the Final node's numOutputRows only. With a single shuffle partition
+    // every window partition lands in one reduce task, so that count is deterministic
+    // across environments (2 = one survivor per collated partition). The Partial node's
+    // count depends on scan parallelism, so it is intentionally excluded. AQE is disabled
+    // to keep executedPlan stable and avoid shuffle-partition coalescing.
+    withSQLConf(
+        SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "1",
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+      withTable("t") {
+        sql("CREATE TABLE t (s STRING COLLATE UTF8_LCASE, i INT) USING PARQUET")
+        // Alternating spellings within each UTF8_LCASE partition maximize the gap: under
+        // binary grouping every adjacent row starts a new group. Distinct ORDER BY values
+        // (i) keep which row survives WHERE r <= 1 deterministic (no ties).
+        sql("""INSERT INTO t VALUES
+              |  ('a', 1), ('A', 2), ('a', 3), ('A', 4), ('a', 5), ('A', 6),
+              |  ('b', 7), ('B', 8), ('b', 9), ('B', 10)""".stripMargin)
+        val df = sql("""SELECT s, i, r FROM (
+                       |  SELECT s, i, ROW_NUMBER() OVER (PARTITION BY s ORDER BY i) AS r
+                       |  FROM t) WHERE r <= 1""".stripMargin)
+        // Collation-correct answer, unaffected by the fix.
+        checkAnswer(df, Row("a", 1, 1) :: Row("b", 7, 1) :: Nil)
+        val finalForwarded = collect(df.queryExecution.executedPlan) {
+          case w: WindowGroupLimitExec if w.mode == Final =>
+            w.metrics("numOutputRows").value
+        }.sum
+        // Post-fix collapses each collated partition to its single survivor (2 rows).
+        // Pre-fix binary grouping forwards all 10 rows.
+        assert(finalForwarded == 2,
+          s"WindowGroupLimitExec(Final) should forward 2 rows, got $finalForwarded")
+      }
+    }
+  }
+
+  test("WindowGroupLimitExec collation grouping with Double in mixed partition spec") {
+    withSQLConf(SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> "1") {
+      withTable("t_dbl") {
+        sql("CREATE TABLE t_dbl (d DOUBLE, s STRING COLLATE UTF8_LCASE, i INT) USING PARQUET")
+        sql("INSERT INTO t_dbl VALUES (-0.0, 'foo', 1), (0.0, 'foo', 2)")
+        // UTF8_LCASE on s is non-binary-stable, so InterpretedOrdering is used for all
+        // fields including d. SQLOrderingUtil.compareDoubles treats -0.0 == +0.0, so both
+        // rows land in one partition group and only the rank-1 row survives the filter.
+        val df = sql(
+          """SELECT d, s, i FROM (
+            |  SELECT d, s, i, RANK() OVER (PARTITION BY d, s ORDER BY i) AS r
+            |  FROM t_dbl) WHERE r <= 1""".stripMargin)
+        assert(df.count() == 1, "-0.0 and +0.0 should be treated as equal partition keys")
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`WindowGroupLimitExec` (injected by the `InferWindowGroupLimit` rule for rank-filter queries like WHERE rank <= N) detected partition boundaries with a raw binary `UnsafeRow` comparison (`nextGroup == currentGroup`). 

This PR makes that comparison collation-aware: it keeps the fast binary equals when all PARTITION BY keys are binary-stable, and falls back to InterpretedOrdering-based comparison when any key is not (e.g. a collated STRING), mirroring the existing pattern in `WindowEvaluatorFactory.groupEqualityCheck`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Byte-for-byte comparison is wrong for collated strings: under `UTF8_LCASE`, 'foo' and 'FOO' are equal but have different bytes, so the operator splits a single collation partition into several. The final result stays correct (the downstream WindowExec recomputes the ranking), but the limit no longer collapses collated partitions, so it forwards far more rows than needed and the optimization stops helping.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. Results are unchanged; this only restores the intended row-pruning for collated partition keys.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added tests in `CollationSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, Generated-by: Claude Code