### PR TITLE
[SPARK-47672][SQL][PYTHON] Mark PythonUDF expensive to avoid double evaluation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -279,6 +279,8 @@ trait PythonFuncExpression extends NonSQLExpression with UserDefinedExpression {
 
   override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
 
+  override def expensive: Boolean = true
+
   override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
 
   override def nullable: Boolean = true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -202,7 +202,7 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("SPARK-39481: avoid evaluating scalar Python UDFs twice") {
+  test("SPARK-47672: avoid evaluating scalar Python UDFs twice") {
     val evalTypes = Seq(
       "regular" -> PythonEvalType.SQL_BATCHED_UDF,
       "Arrow-optimized" -> PythonEvalType.SQL_ARROW_BATCHED_UDF,
@@ -237,7 +237,7 @@ class FilterPushdownSuite extends PlanTest {
     }
   }
 
-  test("SPARK-39481: all Python function expressions are expensive") {
+  test("SPARK-47672: all Python function expressions are expensive") {
     val pythonExpressions = Seq(
       "mapInPandas" -> PythonUDF(
         "mapInPandas", null, StructType(Nil), Seq(attrA),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -202,6 +202,68 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
+  test("SPARK-39481: avoid evaluating scalar Python UDFs twice") {
+    val evalTypes = Seq(
+      "regular" -> PythonEvalType.SQL_BATCHED_UDF,
+      "Arrow-optimized" -> PythonEvalType.SQL_ARROW_BATCHED_UDF,
+      "Arrow element-wise" -> PythonEvalType.SQL_ARROW_ELEMENTWISE_UDF,
+      "scalar Pandas element-wise" -> PythonEvalType.SQL_SCALAR_PANDAS_ELEMENTWISE_UDF,
+      "scalar Pandas iterator element-wise" ->
+        PythonEvalType.SQL_SCALAR_PANDAS_ITER_ELEMENTWISE_UDF,
+      "scalar Arrow element-wise" -> PythonEvalType.SQL_SCALAR_ARROW_ELEMENTWISE_UDF,
+      "scalar Arrow iterator element-wise" ->
+        PythonEvalType.SQL_SCALAR_ARROW_ITER_ELEMENTWISE_UDF,
+      "scalar Pandas" -> PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+      "scalar Pandas iterator" -> PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
+      "scalar Arrow" -> PythonEvalType.SQL_SCALAR_ARROW_UDF,
+      "scalar Arrow iterator" -> PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF)
+
+    evalTypes.foreach { case (name, evalType) =>
+      withClue(s"$name Python UDF: ") {
+        val pythonUDF = PythonUDF(
+          "pythonUDF",
+          null,
+          BooleanType,
+          Seq(attrA),
+          evalType,
+          udfDeterministic = true)
+        val originalQuery = testRelation
+          .select(pythonUDF.as("result"))
+          .where($"result")
+          .analyze
+
+        comparePlans(Optimize.execute(originalQuery), originalQuery)
+      }
+    }
+  }
+
+  test("SPARK-39481: all Python function expressions are expensive") {
+    val pythonExpressions = Seq(
+      "mapInPandas" -> PythonUDF(
+        "mapInPandas", null, StructType(Nil), Seq(attrA),
+        PythonEvalType.SQL_MAP_PANDAS_ITER_UDF, udfDeterministic = true),
+      "mapInArrow" -> PythonUDF(
+        "mapInArrow", null, StructType(Nil), Seq(attrA),
+        PythonEvalType.SQL_MAP_ARROW_ITER_UDF, udfDeterministic = true),
+      "Pandas aggregate" -> PythonUDAF(
+        "pandasAggregate", null, IntegerType, Seq(attrA), udfDeterministic = true),
+      "Arrow aggregate" -> PythonUDAF(
+        "arrowAggregate", null, IntegerType, Seq(attrA), udfDeterministic = true,
+        evalType = PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF),
+      "incremental Arrow aggregate" -> PythonAggregate(
+        "incrementalArrowAggregate", null, IntegerType, Seq(attrA),
+        udfDeterministic = true, bufferSchema = StructType(Nil)),
+      "Python UDTF" -> PythonUDTF(
+        "pythonUDTF", null, StructType(Nil), None, Seq(attrA),
+        PythonEvalType.SQL_TABLE_UDF, udfDeterministic = true))
+
+    pythonExpressions.foreach { case (name, expression) =>
+      withClue(s"$name: ") {
+        assert(expression.expensive)
+      }
+    }
+  }
+
   // Case 1: Multiple filters that don't reference any projection aliases - all should be pushed
   test("SPARK-47672: Case 1 - multiple filters not referencing projection aliases") {
     val originalQuery = testStringRelation


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Mark Python UDFs `expensive` to avoid double evaluation with filter pushdown.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

https://github.com/apache/spark/pull/46143 added an `expensive` flag on expressions to avoid double evaluation with filter pushdown.  The docs mention UDFs in general:

> When true avoid pushing expensive (UDF, etc.) filters down

However, only `ScalaUDF` is currently marked expensive, and the Python UDFs can still be evaluated twice.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, `spark.sql.optimizer.avoidDoubleFilterEval` now also applies to Python UDFs


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added tests:

- Check that we avoid evaluating scalar Python UDFs twice for all of the `PythonEvalType` cases by checking the plan
- Check that all Python UDF expressions are `expensive`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes, using `codex-cli 0.147.0 (gpt-5.6-sol)`