### PR TITLE
[SPARK-40259][SQL][FOLLOWUP] Add cross-table DSv2 scan merge regression test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/planmerging/DSv2PlanMergingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/planmerging/DSv2PlanMergingSuite.scala
@@ -41,6 +41,7 @@ class DSv2PlanMergingSuite extends QueryTest with SharedSparkSession
 
   private val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
   private val tbl = "scanmerge.t"
+  private val tbl2 = "scanmerge.t2"
 
   before {
     spark.conf.set("spark.sql.catalog.scanmerge",
@@ -171,6 +172,29 @@ class DSv2PlanMergingSuite extends QueryTest with SharedSparkSession
           s"the merged scan should read the union of both columns; got ${scans.head.output}")
         assertNoPlaceholderRelation(df)
       }
+    }
+  }
+
+  test("SPARK-40259: do not merge DSv2 scans from different tables") {
+    withTable(tbl, tbl2) {
+      sql(s"CREATE TABLE $tbl (part_col string, c1 int) USING $v2Source " +
+        "PARTITIONED BY (part_col)")
+      sql(s"CREATE TABLE $tbl2 (part_col string, c2 int) USING $v2Source " +
+        "PARTITIONED BY (part_col)")
+      sql(s"INSERT INTO $tbl VALUES ('a', 1), ('a', 2)")
+      sql(s"INSERT INTO $tbl2 VALUES ('a', 10), ('a', 30)")
+
+      val df = sql(
+        s"""
+           |SELECT
+           |  (SELECT max(c1) FROM $tbl WHERE part_col IN ('a')) AS m1,
+           |  (SELECT max(c2) FROM $tbl2 WHERE part_col IN ('a')) AS m2
+           |""".stripMargin)
+
+      checkAnswer(df, Row(2, 30))
+      val scans = v2Scans(df)
+      assert(scans.map(_.canonicalized).distinct.length == 2,
+        s"scans from different tables must remain separate:\n${df.queryExecution.optimizedPlan}")
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Followup to https://github.com/apache/spark/pull/57360.

Add an end-to-end regression test verifying that Data Source V2 scans of two different tables are
not merged, even when both tables opt into scan merging and the query shapes are otherwise similar.

### Why are the changes needed?

Merging scans from different tables could corrupt the optimized plan and return incorrect query
results. The existing implementation compares canonical relations, and this test protects that
table-identity safety boundary.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added coverage to `DSv2PlanMergingSuite` and ran the full suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
