### PR TITLE
[SPARK-58934][BUILD] Tolerate apt-get remove failures directly

### DIFF
--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -44,15 +44,26 @@ sudo rm -rf /opt/hostedtoolcache/go
 sudo rm -rf /opt/hostedtoolcache/node
 du -sh /opt/*
 
-sudo apt-get update --fix-missing
-sudo apt-get remove --purge -y '^aspnet.*'
-sudo apt-get remove --purge -y '^dotnet-.*'
-sudo apt-get remove --purge -y '^llvm-.*'
-sudo apt-get remove --purge -y '^temurin-.*'
-sudo apt-get remove --purge -y 'php.*'
-sudo apt-get remove --purge -y '^mongodb-.*'
-sudo apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable firefox
-sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell libgl1-mesa-dri
+package_patterns=(
+  '^aspnet.*'
+  '^dotnet-.*'
+  '^llvm-.*'
+  '^temurin-.*'
+  'php.*'
+  '^mongodb-.*'
+  snapd
+  google-chrome-stable
+  microsoft-edge-stable
+  firefox
+  azure-cli
+  google-cloud-sdk
+  mono-devel
+  powershell
+  libgl1-mesa-dri
+)
+for package_pattern in "${package_patterns[@]}"; do
+  sudo apt-get remove --purge -y "$package_pattern" || true
+done
 sudo apt-get autoremove --purge -y
 sudo apt-get clean
 

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -48,18 +48,18 @@ package_patterns=(
   '^aspnet.*'
   '^dotnet-.*'
   '^llvm-.*'
+  '^mongodb-.*'
   '^temurin-.*'
   'php.*'
-  '^mongodb-.*'
-  snapd
-  google-chrome-stable
-  microsoft-edge-stable
-  firefox
   azure-cli
+  firefox
+  google-chrome-stable
   google-cloud-sdk
+  libgl1-mesa-dri
+  microsoft-edge-stable
   mono-devel
   powershell
-  libgl1-mesa-dri
+  snapd
 )
 for package_pattern in "${package_patterns[@]}"; do
   sudo apt-get remove --purge -y "$package_pattern" || true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tolerate failures from `apt-get` remove directly. Refactor the list of packages to remove into an array. Remove the call to `apt-get update`.

### Why are the changes needed?

#53226 added the call to `update` specifically to fix intermittent failures when calling `remove`.

That `update`, however, had its own issues and hit up against https://github.com/actions/runner-images/issues/14594. This in turn triggered the addition of a timeout to the cleanup in https://github.com/apache/spark/pull/58121.

If we tolerate `remove` failures directly, we don't need the `update` anymore. I don't think we need the timeout either, but I've left that alone.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI on this PR.

### Was this patch authored or co-authored using generative AI tooling?

I wrote this with assistance from GitHub Copilot.
