### PR TITLE
[MINOR][INFRA] Instruct agents to use `--no-track` when creating worktrees or branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Before the first code edit or running test in a session, ensure a clean working 
 3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
    - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
-   - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
+   - **New edits**: ask the user to choose: create a new git worktree from `<origin>/master` and work from there (recommended), or create and switch to a new branch from `<origin>/master`.
    - **Running tests**: use `<upstream>/master`.
 
 ## Development Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,20 +16,17 @@ Before the first code edit or test in a session, complete these checks:
     git fetch origin master
     ```
 4. Choose the work path:
-     - **Review or continue work on an existing PR**: resolve its head repository, ref, and SHA:
+   - **Review or continue work on an existing PR**: resolve its head repository, ref, and SHA:
 
-         ```sh
-         gh api repos/apache/spark/pulls/<number> \
-             --jq '{repo: .head.repo.full_name, ref: .head.ref, sha: .head.sha}'
-         ```
+     ```sh
+     gh api repos/apache/spark/pulls/<number> \
+       --jq '{repo: .head.repo.full_name, ref: .head.ref, sha: .head.sha}'
+     ```
 
-         For a review, use a local branch at the returned SHA. To continue edits, switch to a
-         matching local branch if one exists and inform the user. If the needed branch is not local,
-         ask whether to fetch the returned head repository and ref or use a differently named local
-         branch.
-     - **New PR**: ask the user to choose:
-         - **Linked worktree (recommended)**: follow Creating a Worktree below.
-         - **New branch**: create and switch to a new branch from `origin/master`.
+     For a review, use a local branch at the returned SHA.
+   - **New PR**: ask the user to choose:
+     - **Linked worktree (recommended)**: follow "Creating a Worktree" below.
+     - **New branch**: create and switch to a new branch from `origin/master`.
 
 ### Creating a Worktree
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,22 +5,13 @@
 Before the first code edit or running test in a session, ensure a clean working
 environment. DO NOT skip these checks:
 
-1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear,
-     ask the user to configure their remotes following the standard convention (`origin` for the
-     fork, `upstream` for `apache/spark`).
-2. If the latest commit on `<upstream>/master` is more than a day old (check with
-     `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
-3. If there are uncommitted changes (check with `git status`), ask the user to stash them before
-     proceeding.
+1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
+2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
+3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
-     - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq
-         '.head.ref'`, then look for a local branch matching that name. If found, switch to it and
-         inform the user. If not found, ask whether to fetch it or if there is a local branch under a
-         different name.
-     - **New edits**: ask the user to choose: create a new git worktree from
-         `<upstream>/master` with `--no-track` and work from there (recommended), or
-         create and switch to a new branch from `<upstream>/master` with `--no-track`.
-     - **Running tests**: use `<upstream>/master`.
+   - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
+   - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` with `--no-track` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
+   - **Running tests**: use `<upstream>/master`.
 
 ## Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,54 +2,25 @@
 
 ## Pre-flight Checks
 
-Before the first code edit or test in a session, complete these checks:
+Before the first code edit or running test in a session, ensure a clean working
+environment. DO NOT skip these checks:
 
-1. Run `git remote -v`: both `origin` fetch and push URLs must be the user's personal fork,
-    and `upstream` must be `apache/spark`. Otherwise, ask the user to configure the remotes.
-2. Run `git status`; if there are uncommitted changes, ask the user to stash them.
-3. Before creating a branch or worktree from `origin/master`, check the age of the commit at
-    local `upstream/master` with `git log -1 --format="%ci" upstream/master`. If it is more than
-    a day old, refresh both refs:
-
-    ```sh
-    git fetch upstream master
-    git fetch origin master
-    ```
-4. Choose the work path:
-   - **Review or continue work on an existing PR**: resolve its head repository, ref, and SHA:
-
-     ```sh
-     gh api repos/apache/spark/pulls/<number> \
-       --jq '{repo: .head.repo.full_name, ref: .head.ref, sha: .head.sha}'
-     ```
-
-     For a review, use a local branch at the returned SHA.
-   - **New PR**: ask the user to choose:
-     - **Linked worktree (recommended)**: follow "Creating a Worktree" below.
-     - **New branch**: create and switch to a new branch from `origin/master`.
-
-### Creating a Worktree
-
-For a new PR or test-only worktree, verify that `origin` is the user's personal fork. Create it
-only with:
-
-```sh
-git worktree add -b <branch> --track <path> origin/master
-```
-
-Do not substitute `upstream/master`, omit `--track`, or use `--force`. A branch worktree must
-never track or push through `upstream` or `apache` (`apache/spark`). Read or fetch `upstream` only
-in the main checkout.
-
-After creating a linked worktree, before editing files or running tests, run:
-
-```sh
-git -C <path> status -sb
-```
-
-Proceed only when the status reports `...origin/...`.
-
-Otherwise, stop and ask the user how to proceed.
+1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear,
+     ask the user to configure their remotes following the standard convention (`origin` for the
+     fork, `upstream` for `apache/spark`).
+2. If the latest commit on `<upstream>/master` is more than a day old (check with
+     `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
+3. If there are uncommitted changes (check with `git status`), ask the user to stash them before
+     proceeding.
+4. Switch to the appropriate branch:
+     - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq
+         '.head.ref'`, then look for a local branch matching that name. If found, switch to it and
+         inform the user. If not found, ask whether to fetch it or if there is a local branch under a
+         different name.
+     - **New edits**: ask the user to choose: create a new git worktree from
+         `<upstream>/master` with `--no-track` and work from there (recommended), or
+         create and switch to a new branch from `<upstream>/master` with `--no-track`.
+     - **Running tests**: use `<upstream>/master`.
 
 ## Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,14 @@
 
 ## Pre-flight Checks
 
-Before the first code edit or running test in a session, ensure a clean working
-environment. DO NOT skip these checks:
+Before the first code edit or running test in a session, ensure a clean working environment. DO NOT skip these checks:
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
 3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
    - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
-   - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` with `--no-track` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
+   - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` with `--no-track` and work from there (recommended), or create and switch to a new branch from `<upstream>/master` with `--no-track`.
    - **Running tests**: use `<upstream>/master`.
 
 ## Development Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,57 @@
 
 ## Pre-flight Checks
 
-Before the first code edit or running test in a session, ensure a clean working environment. DO NOT skip these checks:
+Before the first code edit or test in a session, complete these checks:
 
-1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
-2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
-3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
-4. Switch to the appropriate branch:
-   - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
-   - **New edits**: ask the user to choose: create a new git worktree from `<origin>/master` and work from there (recommended), or create and switch to a new branch from `<origin>/master`.
-   - **Running tests**: use `<upstream>/master`.
+1. Run `git remote -v`: both `origin` fetch and push URLs must be the user's personal fork,
+    and `upstream` must be `apache/spark`. Otherwise, ask the user to configure the remotes.
+2. Run `git status`; if there are uncommitted changes, ask the user to stash them.
+3. Before creating a branch or worktree from `origin/master`, check the age of the commit at
+    local `upstream/master` with `git log -1 --format="%ci" upstream/master`. If it is more than
+    a day old, refresh both refs:
+
+    ```sh
+    git fetch upstream master
+    git fetch origin master
+    ```
+4. Choose the work path:
+     - **Review or continue work on an existing PR**: resolve its head repository, ref, and SHA:
+
+         ```sh
+         gh api repos/apache/spark/pulls/<number> \
+             --jq '{repo: .head.repo.full_name, ref: .head.ref, sha: .head.sha}'
+         ```
+
+         For a review, use a local branch at the returned SHA. To continue edits, switch to a
+         matching local branch if one exists and inform the user. If the needed branch is not local,
+         ask whether to fetch the returned head repository and ref or use a differently named local
+         branch.
+     - **New PR**: ask the user to choose:
+         - **Linked worktree (recommended)**: follow Creating a Worktree below.
+         - **New branch**: create and switch to a new branch from `origin/master`.
+
+### Creating a Worktree
+
+For a new PR or test-only worktree, verify that `origin` is the user's personal fork. Create it
+only with:
+
+```sh
+git worktree add -b <branch> --track <path> origin/master
+```
+
+Do not substitute `upstream/master`, omit `--track`, or use `--force`. A branch worktree must
+never track or push through `upstream` or `apache` (`apache/spark`). Read or fetch `upstream` only
+in the main checkout.
+
+After creating a linked worktree, before editing files or running tests, run:
+
+```sh
+git -C <path> status -sb
+```
+
+Proceed only when the status reports `...origin/...`.
+
+Otherwise, stop and ask the user how to proceed.
 
 ## Development Notes
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Specify that when creating a new worktree or branch, agents should use `--no-track` so they don't accidentally target `upstream/master`.

### Why are the changes needed?

I just pushed https://github.com/apache/spark/commit/3731453175d31125a8765f61d5df2e5936ffb28d directly to `master` from a new worktree. It was a mistake and I was surprised by it. The worktree was configured to push directly to `upstream/master`. I believe this happened because I let an agent (for the first time) create the worktree for me and it followed the instructions in our AGENTS file:

> create a new git worktree from `<upstream>/master` and work from there

More background here: https://github.com/apache/spark/pull/58136#issuecomment-5371893133

To be clear, I made the commit and push myself, not the agent. What the agent did is create the worktree.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

In a fresh session I had Grok 4.5 create a new worktree using the updated instructions and it ran the following (edited for clarity):

```
git fetch upstream master
git worktree add --no-track -b test-changes ../test-changes upstream/master
git worktree list
git -C ../test-changes status
git -C ../test-changes log -1 --oneline
```

I then switched to the new worktree and confirmed it does not track any upstream:

```
$ git status -sb
## test-changes
```

### Was this patch authored or co-authored using generative AI tooling?

No.
