### PR TITLE
[SPARK-58977][SS][PYTHON] Handle state server shutdown before Python connects

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkPythonRunner.scala
@@ -333,10 +333,10 @@ class TransformWithStateInPySparkPythonPreInitRunner(
 
   override def stop(): Unit = {
     super.stop()
-    closeServerSocketChannelSilently(stateServerSocket)
     if (daemonThread != null) {
       daemonThread.interrupt()
     }
+    closeServerSocketChannelSilently(stateServerSocket)
   }
 
   private def startStateServer(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
@@ -18,7 +18,12 @@
 package org.apache.spark.sql.execution.python.streaming
 
 import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream, EOFException, InterruptedIOException}
-import java.nio.channels.{Channels, ClosedByInterruptException, ServerSocketChannel}
+import java.nio.channels.{
+  Channels,
+  ClosedByInterruptException,
+  ClosedChannelException,
+  ServerSocketChannel
+}
 import java.time.Duration
 
 import scala.collection.mutable
@@ -138,7 +143,19 @@ class TransformWithStateInPySparkStateServer(
   } else new mutable.HashMap[String, Iterator[Long]]()
 
   def run(): Unit = {
-    val listeningSocket = stateServerSocket.accept()
+    val listeningSocket = try {
+      stateServerSocket.accept()
+    } catch {
+      case _: InterruptedException | _: InterruptedIOException | _: ClosedByInterruptException =>
+        logInfo(log"State server listener interrupted before the Python worker connected")
+        Thread.currentThread().interrupt()
+        statefulProcessorHandle.setHandleState(StatefulProcessorHandleState.CLOSED)
+        return
+      case _: ClosedChannelException =>
+        logInfo(log"State server socket closed before the Python worker connected")
+        statefulProcessorHandle.setHandleState(StatefulProcessorHandleState.CLOSED)
+        return
+    }
 
     // SPARK-51667: We have a pattern of sending messages continuously from one side
     // (Python -> JVM, and vice versa) before getting response from other side. Since most

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
@@ -34,7 +34,7 @@ import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.Eventually.{eventually, timeout}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{Encoder, Row}
@@ -48,8 +48,7 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class TransformWithStateInPySparkStateServerSuite
-  extends SparkFunSuite with BeforeAndAfterEach with Eventually {
+class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with BeforeAndAfterEach {
   val stateName = "test"
   val iteratorId = "testId"
   val serverSocket: ServerSocketChannel = mock(classOf[ServerSocketChannel])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
@@ -17,20 +17,24 @@
 package org.apache.spark.sql.execution.python.streaming
 
 import java.io.{DataOutputStream, InterruptedIOException}
+import java.net.InetSocketAddress
 import java.nio.channels.{
   AsynchronousCloseException,
   ClosedByInterruptException,
   ClosedChannelException,
   ServerSocketChannel
 }
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.mutable
+import scala.concurrent.duration._
 
 import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{Encoder, Row}
@@ -44,7 +48,8 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with BeforeAndAfterEach {
+class TransformWithStateInPySparkStateServerSuite
+  extends SparkFunSuite with BeforeAndAfterEach with Eventually {
   val stateName = "test"
   val iteratorId = "testId"
   val serverSocket: ServerSocketChannel = mock(classOf[ServerSocketChannel])
@@ -681,6 +686,49 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
       assert(!Thread.currentThread().isInterrupted)
       verify(statefulProcessorHandle).setHandleState(StatefulProcessorHandleState.CLOSED)
       verify(outputStream, times(0)).writeInt(any[Int])
+    }
+  }
+
+  Seq(
+    ("before accept", true),
+    ("while blocked in accept", false)
+  ).foreach { case (name, interruptBeforeRun) =>
+    test(s"run handles real channel shutdown $name") {
+      val socket = ServerSocketChannel.open()
+      socket.bind(new InetSocketAddress("127.0.0.1", 0))
+      val failure = new AtomicReference[Throwable]()
+      val listener = new Thread(() => {
+        if (interruptBeforeRun) {
+          Thread.currentThread().interrupt()
+        }
+        try {
+          newStateServer(socket).run()
+        } catch {
+          case t: Throwable => failure.set(t)
+        }
+      })
+
+      try {
+        listener.start()
+        if (!interruptBeforeRun) {
+          eventually(timeout(10.seconds)) {
+            assert(listener.getStackTrace.exists(_.getMethodName == "accept"))
+          }
+          listener.interrupt()
+        }
+        socket.close()
+        listener.join(10000)
+
+        assert(!listener.isAlive)
+        assert(failure.get() == null)
+        assert(!socket.isOpen)
+        verify(statefulProcessorHandle).setHandleState(StatefulProcessorHandleState.CLOSED)
+        verify(outputStream, times(0)).writeInt(any[Int])
+      } finally {
+        listener.interrupt()
+        socket.close()
+        listener.join(10000)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
@@ -31,8 +31,8 @@ import scala.concurrent.duration._
 
 import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers.{any, argThat}
-import org.mockito.invocation.InvocationOnMock
 import org.mockito.Mockito.{mock, times, verify, when}
+import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
@@ -16,13 +16,19 @@
  */
 package org.apache.spark.sql.execution.python.streaming
 
-import java.io.DataOutputStream
-import java.nio.channels.ServerSocketChannel
+import java.io.{DataOutputStream, InterruptedIOException}
+import java.nio.channels.{
+  AsynchronousCloseException,
+  ClosedByInterruptException,
+  ClosedChannelException,
+  ServerSocketChannel
+}
 
 import scala.collection.mutable
 
 import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers.{any, argThat}
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 
@@ -635,6 +641,57 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
     ).build()
     stateServer.handleUtilsRequest(message)
     verify(outputStream).writeInt(argThat((x: Int) => x > 0))
+  }
+
+  Seq(
+    ("InterruptedException", () => new InterruptedException()),
+    ("InterruptedIOException", () => new InterruptedIOException()),
+    ("ClosedByInterruptException", () => new ClosedByInterruptException())
+  ).foreach { case (name, newException) =>
+    test(s"run handles $name while waiting for the Python worker") {
+      Thread.interrupted()
+      val socket = mock(classOf[ServerSocketChannel])
+      when(socket.accept())
+        .thenAnswer((_: InvocationOnMock) => throw newException())
+
+      try {
+        newStateServer(socket).run()
+        assert(Thread.currentThread().isInterrupted)
+      } finally {
+        Thread.interrupted()
+      }
+
+      verify(statefulProcessorHandle).setHandleState(StatefulProcessorHandleState.CLOSED)
+      verify(outputStream, times(0)).writeInt(any[Int])
+    }
+  }
+
+  Seq(
+    ("AsynchronousCloseException", () => new AsynchronousCloseException()),
+    ("ClosedChannelException", () => new ClosedChannelException())
+  ).foreach { case (name, newException) =>
+    test(s"run handles $name while waiting for the Python worker") {
+      Thread.interrupted()
+      val socket = mock(classOf[ServerSocketChannel])
+      when(socket.accept())
+        .thenAnswer((_: InvocationOnMock) => throw newException())
+
+      newStateServer(socket).run()
+
+      assert(!Thread.currentThread().isInterrupted)
+      verify(statefulProcessorHandle).setHandleState(StatefulProcessorHandleState.CLOSED)
+      verify(outputStream, times(0)).writeInt(any[Int])
+    }
+  }
+
+  private def newStateServer(
+      socket: ServerSocketChannel): TransformWithStateInPySparkStateServer = {
+    new TransformWithStateInPySparkStateServer(socket,
+      statefulProcessorHandle, groupingKeySchema, 2,
+      batchTimestampMs, eventTimeWatermarkForEviction,
+      outputStream, valueStateMap, transformWithStateInPySparkDeserializer,
+      listStateMap, mutable.HashMap[String, Iterator[Row]](), mapStateMap,
+      mutable.HashMap[String, Iterator[(Row, Row)]](), expiryTimerIter, listTimerMap)
   }
 
   private def getIntegerRow(value: Int): Row = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This pull request handles state server shutdown while the listener is still waiting for the Python worker to connect.

The patch makes the following changes:

1. Reorders `TransformWithStateInPySparkPythonRunner.stop()` so that it interrupts the state server listener thread before closing the server socket channel. This matches the existing executor-side cleanup ordering.
2. Handles expected interruption and channel-closure exceptions thrown by `ServerSocketChannel.accept()` before the Python worker connects.
3. Preserves the listener thread's interrupt status for interrupt-driven shutdown and transitions the stateful processor handle to `CLOSED`.
4. Treats `ClosedChannelException`, including its `AsynchronousCloseException` subclass, as an expected shutdown path without incorrectly setting the interrupt status.
5. Adds regression coverage for the Java NIO exception hierarchy and interrupt semantics.
6. Adds real loopback `ServerSocketChannel` tests for both interruption before entering `accept()` and interruption while the listener is blocked inside `accept()`. The tests verify bounded listener termination, no escaped exception, channel closure, the `CLOSED` handle state, and no protocol output.

No public APIs or configuration options are added or changed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When a TransformWithState in PySpark runner is stopped before the Python worker connects to its JVM state server, the listener can still be blocked in `ServerSocketChannel.accept()`.

Previously, the driver-side cleanup closed the server socket channel before interrupting the listener thread. Closing the channel wakes the listener with an expected `AsynchronousCloseException`. Because the pre-connect path did not handle this exception, it escaped `TransformWithStateInPySparkStateServer.run()` and was wrapped as:

```text
TransformWithStateInPySpark state server daemon thread exited unexpectedly (crashed)
```

This reports an orderly shutdown as an unexpected daemon-thread failure. The same listener implementation is used by the executor-side lifecycle, where interruption can produce `ClosedByInterruptException`.

The patch makes both expected shutdown paths explicit. It interrupts before closing, handles the relevant Java NIO exception hierarchy, restores the interrupt flag only for interrupt-driven shutdown, and transitions the processor handle to its terminal `CLOSED` state.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes.

Previously, stopping a TransformWithState in PySpark query before its Python worker connected could report the expected state server listener shutdown as an unexpected daemon-thread crash.

After this change, the state server listener terminates cleanly during this shutdown window. Expected interruption or channel-closure exceptions no longer surface as a spurious `SparkException`.

This is a bug fix relative to released Spark versions as well as the behavior on the current `master` branch. It does not change the TransformWithState API or successful query execution behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added tests to `TransformWithStateInPySparkStateServerSuite` covering:

1. `InterruptedException`, `InterruptedIOException`, and `ClosedByInterruptException` while waiting for the Python worker, including preservation of the listener thread's interrupt status.
2. `AsynchronousCloseException` and `ClosedChannelException` while waiting for the Python worker, including verification that the listener thread is not marked interrupted.
3. A real loopback `ServerSocketChannel` with the listener thread already interrupted before entering `accept()`.
4. A real loopback `ServerSocketChannel` with the listener confirmed to be blocked inside `accept()` before applying the production-equivalent interrupt-then-close shutdown sequence.
5. Bounded listener termination, no escaped throwable, server channel closure, transition to `StatefulProcessorHandleState.CLOSED`, and no protocol output for the real-channel shutdown paths.

The following local static checks passed:

```bash
git diff --check
dev/lint-scala
```

`dev/lint-scala` completed both the Scalastyle and Scalafmt checks successfully.

The focused suite can be run with:

```bash
build/sbt -Phive -Phive-thriftserver \
  "sql/core/testOnly org.apache.spark.sql.execution.python.streaming.TransformWithStateInPySparkStateServerSuite"
```

The focused SBT suite could not be executed in the local development environment because Maven Central and the SBT repository hosts failed DNS resolution while retrieving the required SBT launcher and dependencies. The generated partial launcher file was removed from the worktree. The suite is expected to run in GitHub Actions, where the build dependencies are available.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: databricks-gpt-5-6-sol on KiroCrew 0.2.0-customapi.5