### PR TITLE
[SPARK-59129][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_2033

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8240,7 +8240,7 @@
     ],
     "sqlState" : "42K0G"
   },
-  "UNABLE_TO_CREATE_DATABASE" : {
+  "UNABLE_TO_CREATE_DATABASE_DIRECTORY" : {
     "message" : [
       "Unable to create database <name> as failed to create its directory <locationUri>."
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8240,6 +8240,12 @@
     ],
     "sqlState" : "42K0G"
   },
+  "UNABLE_TO_CREATE_DATABASE" : {
+    "message" : [
+      "Unable to create database <name> as failed to create its directory <locationUri>."
+    ],
+    "sqlState" : "58030"
+  },
   "UNABLE_TO_FETCH_HIVE_TABLES" : {
     "message" : [
       "Unable to fetch tables of Hive database: <dbName>."
@@ -10806,11 +10812,6 @@
   "_LEGACY_ERROR_TEMP_2032" : {
     "message" : [
       "<fieldCannotBeNullMsg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2033" : {
-    "message" : [
-      "Unable to create database <name> as failed to create its directory <locationUri>."
     ]
   },
   "_LEGACY_ERROR_TEMP_2034" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -582,7 +582,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   def unableToCreateDatabaseAsFailedToCreateDirectoryError(
       dbDefinition: CatalogDatabase, e: IOException): Throwable = {
     new SparkException(
-      errorClass = "UNABLE_TO_CREATE_DATABASE",
+      errorClass = "UNABLE_TO_CREATE_DATABASE_DIRECTORY",
       messageParameters = Map(
         "name" -> dbDefinition.name,
         "locationUri" -> dbDefinition.locationUri.toString()),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -582,7 +582,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   def unableToCreateDatabaseAsFailedToCreateDirectoryError(
       dbDefinition: CatalogDatabase, e: IOException): Throwable = {
     new SparkException(
-      errorClass = "_LEGACY_ERROR_TEMP_2033",
+      errorClass = "UNABLE_TO_CREATE_DATABASE",
       messageParameters = Map(
         "name" -> dbDefinition.name,
         "locationUri" -> dbDefinition.locationUri.toString()),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalogSuite.scala
@@ -30,7 +30,7 @@ class InMemoryCatalogSuite extends ExternalCatalogSuite {
     override def newEmptyCatalog(): ExternalCatalog = new InMemoryCatalog
   }
 
-  test("createDatabase throws UNABLE_TO_CREATE_DATABASE when mkdirs fails") {
+  test("createDatabase throws UNABLE_TO_CREATE_DATABASE_DIRECTORY when mkdirs fails") {
     val parentFile = Utils.createTempDir()
     // A path nested under an existing regular file: the filesystem cannot create it as a
     // directory, so `fs.mkdirs` throws an IOException.
@@ -44,7 +44,7 @@ class InMemoryCatalogSuite extends ExternalCatalogSuite {
       exception = intercept[SparkException] {
         catalog.createDatabase(db, ignoreIfExists = false)
       },
-      condition = "UNABLE_TO_CREATE_DATABASE",
+      condition = "UNABLE_TO_CREATE_DATABASE_DIRECTORY",
       parameters = Map(
         "name" -> "unreachable_db",
         "locationUri" -> dbLocation.toString))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalogSuite.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import java.io.File
+import java.nio.file.Files
+
 import org.apache.spark.SparkException
-import org.apache.spark.util.Utils
 
 /** Test suite for the [[InMemoryCatalog]]. */
 class InMemoryCatalogSuite extends ExternalCatalogSuite {
@@ -31,23 +33,24 @@ class InMemoryCatalogSuite extends ExternalCatalogSuite {
   }
 
   test("createDatabase throws UNABLE_TO_CREATE_DATABASE_DIRECTORY when mkdirs fails") {
-    val parentFile = Utils.createTempDir()
-    // A path nested under an existing regular file: the filesystem cannot create it as a
-    // directory, so `fs.mkdirs` throws an IOException.
-    val blockingFile = new java.io.File(parentFile, "not-a-directory")
-    java.nio.file.Files.createFile(blockingFile.toPath)
-    val dbLocation = new java.io.File(blockingFile, "db_dir").toURI
+    withTempDir { parentFile =>
+      // A path nested under an existing regular file: the filesystem cannot create it as a
+      // directory, so `fs.mkdirs` throws an IOException.
+      val blockingFile = new File(parentFile, "not-a-directory")
+      Files.createFile(blockingFile.toPath)
+      val dbLocation = new File(blockingFile, "db_dir").toURI
 
-    val catalog = new InMemoryCatalog
-    val db = CatalogDatabase("unreachable_db", "db", dbLocation, Map.empty)
-    checkError(
-      exception = intercept[SparkException] {
-        catalog.createDatabase(db, ignoreIfExists = false)
-      },
-      condition = "UNABLE_TO_CREATE_DATABASE_DIRECTORY",
-      parameters = Map(
-        "name" -> "unreachable_db",
-        "locationUri" -> dbLocation.toString))
+      val catalog = new InMemoryCatalog
+      val db = CatalogDatabase("unreachable_db", "db", dbLocation, Map.empty)
+      checkError(
+        exception = intercept[SparkException] {
+          catalog.createDatabase(db, ignoreIfExists = false)
+        },
+        condition = "UNABLE_TO_CREATE_DATABASE_DIRECTORY",
+        parameters = Map(
+          "name" -> "unreachable_db",
+          "locationUri" -> dbLocation.toString))
+    }
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalogSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import org.apache.spark.SparkException
+import org.apache.spark.util.Utils
 
 /** Test suite for the [[InMemoryCatalog]]. */
 class InMemoryCatalogSuite extends ExternalCatalogSuite {
@@ -26,6 +28,26 @@ class InMemoryCatalogSuite extends ExternalCatalogSuite {
     override val tableOutputFormat: String = "org.apache.park.SequenceFileOutputFormat"
     override val defaultProvider: String = "parquet"
     override def newEmptyCatalog(): ExternalCatalog = new InMemoryCatalog
+  }
+
+  test("createDatabase throws UNABLE_TO_CREATE_DATABASE when mkdirs fails") {
+    val parentFile = Utils.createTempDir()
+    // A path nested under an existing regular file: the filesystem cannot create it as a
+    // directory, so `fs.mkdirs` throws an IOException.
+    val blockingFile = new java.io.File(parentFile, "not-a-directory")
+    java.nio.file.Files.createFile(blockingFile.toPath)
+    val dbLocation = new java.io.File(blockingFile, "db_dir").toURI
+
+    val catalog = new InMemoryCatalog
+    val db = CatalogDatabase("unreachable_db", "db", dbLocation, Map.empty)
+    checkError(
+      exception = intercept[SparkException] {
+        catalog.createDatabase(db, ignoreIfExists = false)
+      },
+      condition = "UNABLE_TO_CREATE_DATABASE",
+      parameters = Map(
+        "name" -> "unreachable_db",
+        "locationUri" -> dbLocation.toString))
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Renames `_LEGACY_ERROR_TEMP_2033` to `UNABLE_TO_CREATE_DATABASE_DIRECTORY`. It's raised by `QueryExecutionErrors.unableToCreateDatabaseAsFailedToCreateDirectoryError` when `InMemoryCatalog.createDatabase` can't create the database's backing directory. SQLSTATE `58030` follows the same convention as other filesystem I/O failures such as `FAILED_CREATE_CHECKPOINT_DIRECTORY` and `UNABLE_TO_FETCH_HIVE_TABLES`. Message text and parameters are unchanged.

### Why are the changes needed?
Part of the SPARK-37935 effort to replace `_LEGACY_ERROR_TEMP_*` placeholders with proper error conditions.

### Does this PR introduce _any_ user-facing change?
Yes. The error condition name changes from `_LEGACY_ERROR_TEMP_2033` to `UNABLE_TO_CREATE_DATABASE_DIRECTORY` and now carries SQLSTATE `58030`. The rendered message is unchanged.

### How was this patch tested?
Added a `checkError` test in `InMemoryCatalogSuite` that points `createDatabase` at a location nested under an existing regular file, so directory creation fails and the new condition fires. Ran `InMemoryCatalogSuite` and `SparkThrowableSuite` locally; both pass.

### Was this patch authored or co-authored using generative AI tooling?
No.
