### PR TITLE
[SPARK-58942][DOCS] Document CHAR/VARCHAR as a character string type family

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -110,6 +110,9 @@
       url: sql-ref-ansi-compliance.html
     - text: Data Types
       url: sql-ref-datatypes.html
+      subitems:
+        - text: Character String Types
+          url: sql-ref-character-string-types.html
     - text: Datetime Pattern
       url: sql-ref-datetime-pattern.html
     - text: Number Pattern

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,6 +24,15 @@ license: |
 
 ## Upgrading from Spark SQL 4.3 to 4.4
 
+- Since Spark 4.4, `spark.sql.charVarchar.standardSemantics.enabled=true` enables first-class
+  `CHAR(n)` and `VARCHAR(n)` semantics throughout schemas and query plans. Under this opt-in mode,
+  `CHAR -> VARCHAR -> STRING` is a type-precedence family; explicit casts can return constrained
+  types; least common type resolution can return CHAR or VARCHAR; and string expressions that
+  transform their input return STRING. Assignment and reads enforce the declared character length
+  and pad CHAR values. The setting is `false` by default. It supersedes the experimental
+  `spark.sql.preserveCharVarcharTypeInfo` behavior, which can preserve constrained types through
+  transforming expressions. See
+  [Character String Types](sql-ref-character-string-types.html) for the complete semantics.
 - Since Spark 4.4, for storage-partitioned joins, `spark.sql.requireAllClusterKeysForCoPartition` requires every join key to be covered by some partition key instead of matching the partition keys positionally. As a result, a join-key column partitioned by more than one transform no longer prevents shuffle elimination, and `spark.sql.sources.v2.bucketing.allowKeysSubsetOfPartitionKeys.enabled` no longer additionally requires `spark.sql.requireAllClusterKeysForCoPartition` to be `false` when the join keys are a subset of the partition keys. As before, when the partition keys cover only part of the join keys, eliminating the shuffle still requires `spark.sql.requireAllClusterKeysForCoPartition` to be `false`.
 
 ## Upgrading from Spark SQL 4.2 to 4.3

--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -109,6 +109,9 @@ Besides, the ANSI SQL mode disallows the following type conversions which are al
 
  The valid combinations of source and target data type in a `CAST` expression are given by the following table.
 “Y” indicates that the combination is syntactically valid without restriction and “N” indicates that the combination is not valid.
+The String row represents the character string type family. For the length and padding behavior
+of casts among CHAR, VARCHAR, and STRING, see
+[Character String Types](sql-ref-character-string-types.html#casts).
 
 | Source\Target | Numeric                              | String                               | Date                                 | Time | Timestamp                            | Timestamp_NTZ                        | Interval                             | Boolean                              | Binary | Array                                | Map                                  | Struct                               |
 |---------------|--------------------------------------|--------------------------------------|--------------------------------------|------|--------------------------------------|--------------------------------------|--------------------------------------|--------------------------------------|--------|--------------------------------------|--------------------------------------|--------------------------------------|
@@ -198,6 +201,8 @@ While casting of a decimal with a fraction to an interval type with SECOND as th
 
 ### Store assignment
 As mentioned at the beginning, when `spark.sql.storeAssignmentPolicy` is set to `ANSI`(which is the default value), Spark SQL complies with the ANSI store assignment rules on table insertions. The valid combinations of source and target data type in table insertions are given by the following table.
+For CHAR and VARCHAR length checks, trailing-space handling, and CHAR padding, see
+[Character String Types](sql-ref-character-string-types.html#assignment-and-reading).
 
 | Source\Target | Numeric | String | Date | Time | Timestamp | Timestamp_NTZ | Interval | Boolean | Binary | Array | Map | Struct |
 |:-------------:|:-------:|:------:|:----:|:----:|:---------:|---------------|:--------:|:-------:|:------:|:-----:|:---:|:------:|
@@ -243,6 +248,8 @@ At the heart of this conflict resolution is the Type Precedence List which defin
 | Date      | Date -> Timestamp_NTZ -> Timestamp                                              |
 | Time      | Time                                                                            |
 | Timestamp | Timestamp                                                                       |
+| Char      | Char -> Varchar -> String****                                                   |
+| Varchar   | Varchar -> String****                                                            |
 | String    | String, Long -> Double, Date -> Timestamp_NTZ -> Timestamp , Boolean, Binary ** |
 | Binary    | Binary                                                                          |
 | Boolean   | Boolean                                                                         |
@@ -256,6 +263,10 @@ At the heart of this conflict resolution is the Type Precedence List which defin
 \*\* String can be promoted to multiple kinds of data types. Note that Byte/Short/Int/Decimal/Float is not on this precedent list. The least common type between Byte/Short/Int and String is Long, while the least common type between Decimal/Float is Double.
 
 \*\*\* For a complex type, the precedence rule applies recursively to its component elements.
+
+\*\*\*\* CHAR, VARCHAR, and STRING form the character string type family. After CHAR or VARCHAR
+reaches STRING, the STRING precedence branches also apply. See
+[Character String Types](sql-ref-character-string-types.html).
 
 The `TIME` type does not promote to any other type. Note that Spark's `TIME` type deviates from the SQL standard in two ways: the default fractional-seconds precision is `6` (the ANSI default is `0`), and `TIME WITH TIME ZONE` is not supported.
 
@@ -280,6 +291,11 @@ A least common type between decimal types should have enough digits in both inte
 More precisely, a least common type between `decimal(p1, s1)` and `decimal(p2, s2)` has the scale of `max(s1, s2)` and precision of `max(s1, s2) + max(p1 - s1, p2 - s2)`.
 However, decimal types in Spark have a maximum precision: 38. If the final decimal type need more precision, we must do truncation.
 Since the digits in the integral part are more significant, Spark truncates the digits in the fractional part first. For example, `decimal(48, 20)` will be reduced to `decimal(38, 10)`.
+
+CHAR and VARCHAR also have a type parameter: length. When
+`spark.sql.charVarchar.standardSemantics.enabled` is `true`, least common type resolution uses the
+widest input length. The least common type of two CHAR types is `CHAR(max(n, m))`; a VARCHAR input
+makes the result `VARCHAR(max(n, m))`; and a STRING input makes the result STRING.
 
 Note, arithmetic operations have special rules to calculate the least common type for decimal inputs:
 

--- a/docs/sql-ref-character-string-types.md
+++ b/docs/sql-ref-character-string-types.md
@@ -1,0 +1,253 @@
+---
+layout: global
+title: Character String Types
+displayTitle: Character String Types
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+Spark SQL has a family of three character string types:
+
+```text
+CHAR(n) -> VARCHAR(n) -> STRING
+```
+
+The arrow denotes type precedence from the most constrained type to the least constrained type.
+This is analogous to the precedence of integral numeric types such as
+`TINYINT -> SMALLINT -> INT -> BIGINT`. `CHAR`, `VARCHAR`, and `STRING` are distinct SQL types in
+the same family; `CHAR` and `VARCHAR` are not special uses of `STRING`.
+
+## Enable character string type semantics
+
+Set `spark.sql.charVarchar.standardSemantics.enabled` to `true` to use the semantics on this page:
+
+```sql
+SET spark.sql.charVarchar.standardSemantics.enabled = true;
+```
+
+The setting is `false` by default in Spark 4.4. When it is enabled, `CHAR` and `VARCHAR` remain
+first-class types in schemas and query plans, explicit casts can produce them, and type coercion
+uses the character string type family. This is an opt-in semantic change that can change expression
+types and query results. The setting is persisted with view definitions, so a view continues to
+use the semantics under which it was created.
+
+The older `spark.sql.preserveCharVarcharTypeInfo` setting is an experimental compatibility mode.
+It preserves type information, but does not apply all the type precedence and expression-result
+rules described here. Standard semantics take precedence over
+`spark.sql.legacy.charVarcharAsString` when both settings are `true`.
+
+## Type definitions
+
+| SQL type | Value constraint | Behavior |
+|----------|------------------|----------|
+| `CHAR(n)` | Exactly `n` characters | Values shorter than `n` characters are padded on the right with spaces. |
+| `VARCHAR(n)` | At most `n` characters | Values retain their length and are not padded. |
+| `STRING` | Unbounded length | Values have no declared length constraint. |
+
+The length is required for `CHAR` and `VARCHAR`. `CHARACTER(n)` is a synonym for `CHAR(n)`.
+The length `n` counts characters, not UTF-8 bytes. All three types can have a
+[collation](sql-ref-syntax-aux-show-collations.html), which controls comparison, ordering, and
+other collation-sensitive operations.
+
+For example:
+
+```sql
+SELECT typeof(CAST('ab' AS CHAR(5)));
+-- char(5)
+
+SELECT concat('<', CAST('ab' AS CHAR(5)), '>');
+-- <ab   >
+
+SELECT typeof(CAST('ab' AS VARCHAR(5)));
+-- varchar(5)
+```
+
+## Type precedence and least common type
+
+Spark finds the least common type when an operation needs one type that can represent multiple
+inputs. Within the character string family, Spark uses these rules:
+
+| Input types | Least common type |
+|-------------|-------------------|
+| `CHAR(n)`, `CHAR(m)` | `CHAR(max(n, m))` |
+| `CHAR(n)`, `VARCHAR(m)` | `VARCHAR(max(n, m))` |
+| `VARCHAR(n)`, `VARCHAR(m)` | `VARCHAR(max(n, m))` |
+| Any character string type and `STRING` | `STRING` |
+| Any character string type `T` and untyped `NULL` | `T` |
+
+These rules apply recursively to arrays, maps, and structs. They are used by expressions and
+operations such as `CASE`, `COALESCE`, `IN`, `UNION`, `INTERSECT`, `EXCEPT`, multi-row `VALUES`,
+and collection constructors.
+
+```sql
+SELECT typeof(coalesce(
+  CAST('a' AS CHAR(2)),
+  CAST('bb' AS CHAR(4))));
+-- char(4)
+
+SELECT typeof(coalesce(
+  CAST('a' AS CHAR(2)),
+  CAST('bb' AS VARCHAR(4))));
+-- varchar(4)
+
+SELECT typeof(coalesce(
+  CAST('a' AS VARCHAR(4)),
+  CAST('unbounded' AS STRING)));
+-- string
+```
+
+Collation is also part of a character string type. The least-common-type rules above apply after
+Spark resolves the input collations. When the result remains `CHAR` or `VARCHAR`, it retains the
+resolved collation.
+
+## Casts
+
+An explicit `CAST` or `TRY_CAST` can introduce a `CHAR` or `VARCHAR` value:
+
+```sql
+SELECT CAST('abc' AS CHAR(5));
+-- 'abc  '
+
+SELECT CAST('abc' AS VARCHAR(5));
+-- 'abc'
+```
+
+For an explicit cast from one character string type to another:
+
+* Casting to `CHAR(n)` truncates values longer than `n` characters and pads values shorter than
+  `n` characters.
+* Casting to `VARCHAR(n)` truncates values longer than `n` characters.
+
+For a cast from a non-character value, Spark first converts the value to characters and then
+checks the target length. `CAST` raises `EXCEED_LIMIT_LENGTH` if the value does not fit, while
+`TRY_CAST` returns `NULL`.
+
+```sql
+SELECT CAST('abcdef' AS VARCHAR(3));
+-- 'abc'
+
+SELECT TRY_CAST(12345 AS VARCHAR(4));
+-- NULL
+```
+
+## Assignment and reading
+
+Assignment to a declared `CHAR` or `VARCHAR` type is stricter than an explicit
+character-to-character cast. Assignment occurs for operations such as table writes, routine
+arguments and return values, session variables, and schema-driven Dataset or DataFrame conversion.
+
+* A value that fits is stored unchanged, except that `CHAR(n)` is padded on the right to `n`
+  characters.
+* If only trailing spaces exceed the declared length, Spark removes only the number of trailing
+  spaces needed to fit.
+* If non-space characters exceed the declared length, Spark raises `EXCEED_LIMIT_LENGTH`.
+
+Reads apply the same checks. In particular, a `CHAR(n)` value read from external or otherwise
+untrusted storage is padded if short and rejected if its non-space content is too long.
+
+```sql
+CREATE TABLE contacts (code CHAR(4), name VARCHAR(10)) USING parquet;
+
+INSERT INTO contacts VALUES ('ab', 'Ada');
+
+SELECT concat('<', code, '>'), name FROM contacts;
+-- <ab  >  Ada
+```
+
+## Expression result types
+
+A reference to a `CHAR` or `VARCHAR` column preserves its declared type. Expressions that select
+among values without changing their character content, such as `CASE` and `COALESCE`, use the
+least common type rules above.
+
+An expression that transforms character content returns `STRING`, because its result length is
+not constrained by an input declaration. This includes string functions and operators such as
+`upper`, `lower`, `substring`, `concat`, `||`, `regexp_replace`, `trim`, `split`, and `mask`.
+
+```sql
+SELECT typeof(upper(CAST('ab' AS CHAR(2))));
+-- string
+
+SELECT typeof(CAST('a' AS CHAR(1)) || CAST('b' AS VARCHAR(1)));
+-- string
+```
+
+This rule prevents a length constraint from propagating to newly computed content. To constrain
+the result, cast it explicitly to `CHAR(n)` or `VARCHAR(n)`.
+
+## Comparisons and trailing spaces
+
+Spark coerces character string operands to a least common type before comparing them. Casting to a
+wider `CHAR` pads the value, while casting to `VARCHAR` or `STRING` preserves spaces already
+present in a `CHAR` value.
+
+```sql
+SELECT CAST('a' AS CHAR(2)) = CAST('a' AS CHAR(4));
+-- true
+
+SELECT CAST('a' AS CHAR(2)) = CAST('a' AS VARCHAR(2));
+-- false
+
+SELECT CAST('a' AS CHAR(2)) = CAST('a ' AS VARCHAR(2));
+-- true
+```
+
+Ignoring trailing spaces is a collation property, not an implicit property of every `CHAR`
+comparison. Use an `RTRIM` collation when comparisons should ignore trailing spaces:
+
+```sql
+SELECT CAST('a' AS CHAR(2) COLLATE UTF8_BINARY_RTRIM) =
+       'a' COLLATE UTF8_BINARY_RTRIM;
+-- true
+```
+
+## Schema propagation
+
+With standard semantics enabled, declared character string types remain visible through Spark SQL
+and DataFrame schemas. This includes:
+
+* table, view, and common table expression columns;
+* `CREATE TABLE AS SELECT` results;
+* SQL routine parameters and return types;
+* session and scripting variables;
+* nested array, map, and struct fields; and
+* schemas supplied to Dataset and DataFrame APIs.
+
+Storage formats and catalogs differ in how they persist logical type metadata. Whenever a schema
+declares `CHAR(n)` or `VARCHAR(n)`, Spark applies the length, padding, assignment, and read checks
+described on this page.
+
+### Data source behavior
+
+Catalog tables retain `CHAR` and `VARCHAR` declarations in their catalog schema. For file-only
+schema inference, support depends on the format:
+
+| Data source | Behavior |
+|-------------|----------|
+| Parquet catalog table | Uses the catalog schema to retain the declared type. |
+| ORC | Stores logical type metadata on physical string fields so schema inference can restore `CHAR` and `VARCHAR`. |
+| Avro | Stores logical type metadata on string fields and map keys so schema inference can restore `CHAR` and `VARCHAR`. |
+| JSON and CSV | Apply `CHAR` and `VARCHAR` semantics when the reader is given an explicit schema; text inference alone does not infer a length constraint. |
+
+When standard semantics are disabled, file-only inference reads the constrained fields as
+`STRING`.
+
+### Client metadata
+
+Spark Connect and the Spark Thrift Server expose the declared character string type and length to
+clients. JDBC metadata reports `java.sql.Types.CHAR` or `java.sql.Types.VARCHAR`, the declared
+length as the precision, and four times the declared length as `CHAR_OCTET_LENGTH`, reflecting the
+maximum UTF-8 bytes per character.

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -35,10 +35,15 @@ Spark SQL and DataFrames support the following data types:
   - `FloatType`: Represents 4-byte single-precision floating point numbers.
   - `DoubleType`: Represents 8-byte double-precision floating point numbers.
   - `DecimalType`: Represents arbitrary-precision signed decimal numbers. Backed internally by `java.math.BigDecimal`. A `BigDecimal` consists of an arbitrary precision integer unscaled value and a 32-bit integer scale.
-* String type
-  - `StringType`: Represents character string values.
-  - `VarcharType(length)`: A variant of `StringType` which has a length limitation. Data writing will fail if the input string exceeds the length limitation. Note: this type can only be used in table schema, not functions/operators.
-  - `CharType(length)`: A variant of `VarcharType(length)` which is fixed length. Reading column of type `CharType(n)` always returns string values of length `n`. Char type column comparison will pad the short one to the longer length.
+* Character string types
+  - `CharType(length)`: Represents fixed-length character string values. Values shorter than
+  `length` are padded on the right with spaces.
+  - `VarcharType(length)`: Represents character string values of at most `length` characters.
+  - `StringType`: Represents character string values without a declared length limit.
+
+  `CHAR`, `VARCHAR`, and `STRING` form one character string type family, with precedence
+  `CHAR -> VARCHAR -> STRING`. See [Character String Types](sql-ref-character-string-types.html)
+  for length, cast, assignment, comparison, and least-common-type semantics.
 * Binary type
   - `BinaryType`: Represents byte sequence values.
 * Boolean type

--- a/docs/sql-ref-syntax-aux-show-collations.md
+++ b/docs/sql-ref-syntax-aux-show-collations.md
@@ -108,4 +108,4 @@ SHOW COLLATIONS LIKE 'UNICODE|UTF8_BINARY';
 
 ### Related Statements
 
-* [STRING TYPE](sql-ref-datatypes.html)
+* [CHARACTER STRING TYPES](sql-ref-character-string-types.html)

--- a/docs/sql-ref.md
+++ b/docs/sql-ref.md
@@ -24,6 +24,7 @@ Spark SQL is Apache Spark's module for working with structured data. This guide 
 
  * [ANSI Compliance](sql-ref-ansi-compliance.html)
  * [Data Types](sql-ref-datatypes.html)
+   * [Character String Types](sql-ref-character-string-types.html)
  * [Geospatial (Geometry/Geography) Types](sql-ref-geospatial-types.html)
  * [Datetime Pattern](sql-ref-datetime-pattern.html)
  * [Number Pattern](sql-ref-number-pattern.html)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7380,11 +7380,11 @@ object SQLConf {
 
   val CHAR_VARCHAR_STANDARD_SEMANTICS =
     buildConf("spark.sql.charVarchar.standardSemantics.enabled")
-      .doc("When true, enable SQL standard CHAR/VARCHAR semantics: first-class types in " +
+      .doc("When true, treat CHAR, VARCHAR, and STRING as a character string type family with " +
+        "the precedence CHAR -> VARCHAR -> STRING. CHAR and VARCHAR remain first-class types in " +
         "schemas and CAST targets; least-common-type for COALESCE/CASE/UNION may return " +
-        "CHAR/VARCHAR; transforming string functions and operators return plain STRING. " +
-        "This is a breaking change from the annotated-STRING default and from " +
-        "preserveCharVarcharTypeInfo (which keeps Char/Varchar through transforms).")
+        "CHAR/VARCHAR; transforming string functions and operators return STRING. This differs " +
+        "from preserveCharVarcharTypeInfo, which keeps Char/Varchar through transforms.")
       .version("4.4.0")
       // PERSISTED, like ANSI mode: the flag decides the types a view body resolves to, so a view
       // created under standard semantics must keep computing CHAR/VARCHAR regardless of the


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Document `CHAR` / `VARCHAR` / `STRING` as a character string type family for
[SPARK-58942](https://issues.apache.org/jira/browse/SPARK-58942), matching the
behavior behind `spark.sql.charVarchar.standardSemantics.enabled`.

- Add [Character String Types](docs/sql-ref-character-string-types.md): type
  definitions, enablement, CAST vs assignment, least common type
  (`CHAR(n) -> VARCHAR(n) -> STRING`, analogous to integral types), expression
  result typing, comparisons and RTRIM collations, schema surfaces, and
  format/client metadata.
- Rewrite the Data Types page so CHAR and VARCHAR are not described as special
  variants of STRING, and are not limited to table schemas.
- Extend ANSI type precedence / least common type, link CAST and store
  assignment to the new page, and add a Spark 4.4 migration note.
- Point SHOW COLLATIONS at the family page and update the generated
  configuration description.

Parent: [SPARK-58794](https://issues.apache.org/jira/browse/SPARK-58794).

### Why are the changes needed?

Existing docs still describe CHAR/VARCHAR as annotated STRING used only in
table schemas. That is the Spark 3.1 story and no longer matches the first-class
type family implemented under `standardSemantics`. Users need Spark-centric
SQL reference for length, padding, CAST vs assignment, LCT, and STRING-returning
transforms.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation only. Local Markdown links and SQL menu YAML were checked. The
Jekyll site was built with `SKIP_API=1 SKIP_ERRORDOC=1 bundle exec jekyll build`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6
