### PR TITLE
[SPARK-58947][CORE] Handle Char in createArray and add tests for SparkCollectionUtils

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
@@ -52,6 +52,8 @@ private[spark] trait SparkCollectionUtils {
         Arrays.fill(arr.asInstanceOf[Array[Byte]], defaultValue.asInstanceOf[Byte])
       case c if c == classOf[Short] =>
         Arrays.fill(arr.asInstanceOf[Array[Short]], defaultValue.asInstanceOf[Short])
+      case c if c == classOf[Char] =>
+        Arrays.fill(arr.asInstanceOf[Array[Char]], defaultValue.asInstanceOf[Char])
       case c if c == classOf[Int] =>
         Arrays.fill(arr.asInstanceOf[Array[Int]], defaultValue.asInstanceOf[Int])
       case c if c == classOf[Long] =>

--- a/common/utils/src/test/scala/org/apache/spark/util/SparkCollectionUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/SparkCollectionUtilsSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util
+
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+
+class SparkCollectionUtilsSuite extends AnyFunSuite { // scalastyle:ignore funsuite
+
+  test("toMapWithIndex maps each key to its position, matching zipWithIndex.toMap") {
+    assert(SparkCollectionUtils.toMapWithIndex(Seq("a", "b", "c")) ===
+      Map("a" -> 0, "b" -> 1, "c" -> 2))
+    assert(SparkCollectionUtils.toMapWithIndex(Seq.empty[String]) === Map.empty[String, Int])
+    // Duplicate keys keep the last index, matching zipWithIndex.toMap.
+    assert(SparkCollectionUtils.toMapWithIndex(Seq("a", "a")) === Map("a" -> 1))
+    val keys = Seq(10, 20, 30, 40)
+    assert(SparkCollectionUtils.toMapWithIndex(keys) === keys.zipWithIndex.toMap)
+  }
+
+  test("isEmpty and isNotEmpty handle null, empty and non-empty maps") {
+    val nullMap: java.util.Map[String, Int] = null
+    assert(SparkCollectionUtils.isEmpty(nullMap))
+    assert(!SparkCollectionUtils.isNotEmpty(nullMap))
+
+    val empty = new java.util.HashMap[String, Int]()
+    assert(SparkCollectionUtils.isEmpty(empty))
+    assert(!SparkCollectionUtils.isNotEmpty(empty))
+
+    val nonEmpty = new java.util.HashMap[String, Int]()
+    nonEmpty.put("a", 1)
+    assert(!SparkCollectionUtils.isEmpty(nonEmpty))
+    assert(SparkCollectionUtils.isNotEmpty(nonEmpty))
+  }
+
+  test("createArray fills primitive-typed arrays with the default value") {
+    assert(SparkCollectionUtils.createArray(3, 7).sameElements(Array(7, 7, 7)))
+    assert(SparkCollectionUtils.createArray(2, true).sameElements(Array(true, true)))
+    assert(SparkCollectionUtils.createArray(2, 1L).sameElements(Array(1L, 1L)))
+    assert(SparkCollectionUtils.createArray(2, 2.5d).sameElements(Array(2.5d, 2.5d)))
+    assert(SparkCollectionUtils.createArray(2, 1.5f).sameElements(Array(1.5f, 1.5f)))
+    assert(SparkCollectionUtils.createArray(2, 3.toByte).sameElements(Array(3.toByte, 3.toByte)))
+    assert(
+      SparkCollectionUtils.createArray(2, 4.toShort).sameElements(Array(4.toShort, 4.toShort)))
+  }
+
+  test("createArray fills reference-typed arrays and returns empty for size 0") {
+    assert(SparkCollectionUtils.createArray(2, "x").sameElements(Array("x", "x")))
+    assert(SparkCollectionUtils.createArray(0, "x").isEmpty)
+    assert(SparkCollectionUtils.createArray(0, 7).isEmpty)
+  }
+}

--- a/common/utils/src/test/scala/org/apache/spark/util/SparkCollectionUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/SparkCollectionUtilsSuite.scala
@@ -46,20 +46,19 @@ class SparkCollectionUtilsSuite extends AnyFunSuite { // scalastyle:ignore funsu
   }
 
   test("createArray fills primitive-typed arrays with the default value") {
-    assert(SparkCollectionUtils.createArray(3, 7).sameElements(Array(7, 7, 7)))
-    assert(SparkCollectionUtils.createArray(2, true).sameElements(Array(true, true)))
-    assert(SparkCollectionUtils.createArray(2, 1L).sameElements(Array(1L, 1L)))
-    assert(SparkCollectionUtils.createArray(2, 2.5d).sameElements(Array(2.5d, 2.5d)))
-    assert(SparkCollectionUtils.createArray(2, 1.5f).sameElements(Array(1.5f, 1.5f)))
-    assert(SparkCollectionUtils.createArray(2, 3.toByte).sameElements(Array(3.toByte, 3.toByte)))
-    assert(
-      SparkCollectionUtils.createArray(2, 4.toShort).sameElements(Array(4.toShort, 4.toShort)))
-    assert(SparkCollectionUtils.createArray(2, 'a').sameElements(Array('a', 'a')))
+    assert(SparkCollectionUtils.createArray(3, 7) === Array(7, 7, 7))
+    assert(SparkCollectionUtils.createArray(2, true) === Array(true, true))
+    assert(SparkCollectionUtils.createArray(2, 1L) === Array(1L, 1L))
+    assert(SparkCollectionUtils.createArray(2, 2.5d) === Array(2.5d, 2.5d))
+    assert(SparkCollectionUtils.createArray(2, 1.5f) === Array(1.5f, 1.5f))
+    assert(SparkCollectionUtils.createArray(2, 3.toByte) === Array(3.toByte, 3.toByte))
+    assert(SparkCollectionUtils.createArray(2, 4.toShort) === Array(4.toShort, 4.toShort))
+    assert(SparkCollectionUtils.createArray(2, 'a') === Array('a', 'a'))
+    assert(SparkCollectionUtils.createArray(0, 7).isEmpty)
   }
 
   test("createArray fills reference-typed arrays and returns empty for size 0") {
-    assert(SparkCollectionUtils.createArray(2, "x").sameElements(Array("x", "x")))
+    assert(SparkCollectionUtils.createArray(2, "x") === Array("x", "x"))
     assert(SparkCollectionUtils.createArray(0, "x").isEmpty)
-    assert(SparkCollectionUtils.createArray(0, 7).isEmpty)
   }
 }

--- a/common/utils/src/test/scala/org/apache/spark/util/SparkCollectionUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/SparkCollectionUtilsSuite.scala
@@ -54,6 +54,7 @@ class SparkCollectionUtilsSuite extends AnyFunSuite { // scalastyle:ignore funsu
     assert(SparkCollectionUtils.createArray(2, 3.toByte).sameElements(Array(3.toByte, 3.toByte)))
     assert(
       SparkCollectionUtils.createArray(2, 4.toShort).sameElements(Array(4.toShort, 4.toShort)))
+    assert(SparkCollectionUtils.createArray(2, 'a').sameElements(Array('a', 'a')))
   }
 
   test("createArray fills reference-typed arrays and returns empty for size 0") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a unit test suite for `SparkCollectionUtils` (`common/utils`, `org.apache.spark.util`), which had no test coverage, and fixes a gap the tests surfaced.

Tests cover all four methods: `toMapWithIndex` (empty input, duplicate keys, equivalence to `zipWithIndex.toMap`); `isEmpty` / `isNotEmpty` (null, empty, non-empty `java.util.Map`); and `createArray` for every primitive type plus reference types and `size == 0`.

Adding the `createArray` coverage exposed a latent bug: it dispatched on 7 of the 8 primitive `classOf` types (Boolean/Byte/Short/Int/Long/Float/Double) but not `Char`, so a `Char` argument fell through to the `Array[AnyRef]` cast and threw `ClassCastException` (a `char[]` is not an `Object[]`). This adds the missing `Char` case so `createArray[Char]` fills the array like the other primitives.

### Why are the changes needed?

`SparkCollectionUtils` is used in production (e.g. `StructType` field indexing via `toMapWithIndex`) but had no tests. The `Char` gap is currently unreachable (no caller passes `Char`), but it is a latent crash for any future `Char` caller; adding the case makes the dispatch complete and symmetric with the other primitives.

### Does this PR introduce _any_ user-facing change?

No. `SparkCollectionUtils` is `private[spark]`; this adds tests and a missing internal `Char` case.

### How was this patch tested?

New `SparkCollectionUtilsSuite` (extends `AnyFunSuite`, the base used by the sibling `common/utils` suites), covering all four methods including `createArray` for all eight primitive types, reference types, and `size == 0`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
