### PR TITLE
[SPARK-58948][SQL] Deduplicate nulls-buffer creation in columnar decompressors

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
@@ -45,6 +45,13 @@ private[columnar] trait Decoder[T <: PhysicalDataType] {
   def hasNext: Boolean
 
   def decompress(columnVector: WritableColumnVector, capacity: Int): Unit
+
+  /** Duplicates `buffer` in native byte order and rewinds it, for reading null state. */
+  protected def createNullsBuffer(buffer: ByteBuffer): ByteBuffer = {
+    val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
+    nullsBuffer.rewind()
+    nullsBuffer
+  }
 }
 
 private[columnar] trait CompressionScheme {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
@@ -45,13 +45,6 @@ private[columnar] trait Decoder[T <: PhysicalDataType] {
   def hasNext: Boolean
 
   def decompress(columnVector: WritableColumnVector, capacity: Int): Unit
-
-  /** Duplicates `buffer` in native byte order and rewinds it, for reading null state. */
-  protected def createNullsBuffer(buffer: ByteBuffer): ByteBuffer = {
-    val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-    nullsBuffer.rewind()
-    nullsBuffer
-  }
 }
 
 private[columnar] trait CompressionScheme {
@@ -90,5 +83,11 @@ private[columnar] object CompressionScheme {
     val nullCount = header.getInt()
     // null count + null positions
     4 + 4 * nullCount
+  }
+
+  def createNullsBuffer(buffer: ByteBuffer): ByteBuffer = {
+    val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
+    nullsBuffer.rewind()
+    nullsBuffer
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
@@ -107,7 +107,7 @@ private[columnar] case object PassThrough extends CompressionScheme {
         capacity: Int,
         unitSize: Int,
         putFunction: (WritableColumnVector, Int, Int, Int) => Unit): Unit = {
-      val nullsBuffer = createNullsBuffer(buffer)
+      val nullsBuffer = CompressionScheme.createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else capacity
       var pos = 0
@@ -305,7 +305,7 @@ private[columnar] case object RunLengthEncoding extends CompressionScheme {
         capacity: Int,
         getFunction: (ByteBuffer) => Long,
         putFunction: (WritableColumnVector, Int, Long) => Unit): Unit = {
-      val nullsBuffer = createNullsBuffer(buffer)
+      val nullsBuffer = CompressionScheme.createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -483,7 +483,7 @@ private[columnar] case object DictionaryEncoding extends CompressionScheme {
     override def hasNext: Boolean = buffer.hasRemaining
 
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
-      val nullsBuffer = createNullsBuffer(buffer)
+      val nullsBuffer = CompressionScheme.createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -615,7 +615,7 @@ private[columnar] case object BooleanBitSet extends CompressionScheme {
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
       var currentWordLocal: Long = 0
       var visitedLocal: Int = 0
-      val nullsBuffer = createNullsBuffer(buffer)
+      val nullsBuffer = CompressionScheme.createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -725,7 +725,7 @@ private[columnar] case object IntDelta extends CompressionScheme {
 
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
       var prevLocal: Int = 0
-      val nullsBuffer = createNullsBuffer(buffer)
+      val nullsBuffer = CompressionScheme.createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -831,7 +831,7 @@ private[columnar] case object LongDelta extends CompressionScheme {
 
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
       var prevLocal: Long = 0
-      val nullsBuffer = createNullsBuffer(buffer)
+      val nullsBuffer = CompressionScheme.createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
@@ -108,8 +108,7 @@ private[columnar] case object PassThrough extends CompressionScheme {
         capacity: Int,
         unitSize: Int,
         putFunction: (WritableColumnVector, Int, Int, Int) => Unit): Unit = {
-      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-      nullsBuffer.rewind()
+      val nullsBuffer = createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else capacity
       var pos = 0
@@ -307,8 +306,7 @@ private[columnar] case object RunLengthEncoding extends CompressionScheme {
         capacity: Int,
         getFunction: (ByteBuffer) => Long,
         putFunction: (WritableColumnVector, Int, Long) => Unit): Unit = {
-      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-      nullsBuffer.rewind()
+      val nullsBuffer = createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -486,8 +484,7 @@ private[columnar] case object DictionaryEncoding extends CompressionScheme {
     override def hasNext: Boolean = buffer.hasRemaining
 
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
-      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-      nullsBuffer.rewind()
+      val nullsBuffer = createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -619,8 +616,7 @@ private[columnar] case object BooleanBitSet extends CompressionScheme {
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
       var currentWordLocal: Long = 0
       var visitedLocal: Int = 0
-      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-      nullsBuffer.rewind()
+      val nullsBuffer = createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -730,8 +726,7 @@ private[columnar] case object IntDelta extends CompressionScheme {
 
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
       var prevLocal: Int = 0
-      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-      nullsBuffer.rewind()
+      val nullsBuffer = createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0
@@ -837,8 +832,7 @@ private[columnar] case object LongDelta extends CompressionScheme {
 
     override def decompress(columnVector: WritableColumnVector, capacity: Int): Unit = {
       var prevLocal: Long = 0
-      val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
-      nullsBuffer.rewind
+      val nullsBuffer = createNullsBuffer(buffer)
       val nullCount = ByteBufferHelper.getInt(nullsBuffer)
       var nextNullIndex = if (nullCount > 0) ByteBufferHelper.getInt(nullsBuffer) else -1
       var pos = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.columnar.compression
 
 import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
 import scala.collection.mutable
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Each columnar decompressor repeats the same two-line idiom to build the "nulls buffer" it reads null-tracking state from:

```scala
val nullsBuffer = buffer.duplicate().order(ByteOrder.nativeOrder())
nullsBuffer.rewind()
```

This adds a `createNullsBuffer(buffer: ByteBuffer)` helper to the `CompressionScheme` companion object (alongside the existing `columnHeaderSize` helper) and routes the six call sites through it (`PassThrough`, `RunLengthEncoding`, `DictionaryEncoding`, `BooleanBitSet`, `IntDelta`, `LongDelta`). The subsequent `nullCount` / `nextNullIndex` reads stay inline, since the `nextNullIndex` sentinel legitimately differs (`-1`, and `capacity` for `PassThrough`).

### Why are the changes needed?

The idiom was duplicated across all six decoders. Naming it once removes the duplication and gives a single home for the "duplicate, set native order, rewind" convention. It also normalizes the `LongDelta` site, which called `rewind` without parentheses.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing columnar compression tests. `createNullsBuffer` returns exactly the previously-inlined expression, so decompression behavior is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

