### PR TITLE
[SPARK-58951][SQL] Support non-binary collations in collect_set

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -79,9 +79,9 @@ abstract class Collect[T <: Growable[Any] with Iterable[Any]] extends TypedImper
 
   protected val bufferElementType: DataType
 
-  private lazy val projection = UnsafeProjection.create(
+  protected lazy val projection = UnsafeProjection.create(
     Array[DataType](ArrayType(elementType = bufferElementType, containsNull = bufferContainsNull)))
-  private lazy val row = new UnsafeRow(1)
+  protected lazy val row = new UnsafeRow(1)
 
   override def serialize(obj: T): Array[Byte] = {
     val array = new GenericArrayData(obj.toArray)
@@ -200,7 +200,6 @@ case class CollectList(
   """,
   group = "agg_funcs",
   since = "2.0.0")
-// TODO: Make CollectSet collation aware
 case class CollectSet(
     child: Expression,
     mutableAggBufferOffset: Int = 0,
@@ -235,13 +234,35 @@ case class CollectSet(
     buffer
   }
 
+  // Non-binary collated inputs (a collated string, or one nested in a struct/array) cannot dedup
+  // on the raw value's binary form: e.g. 'foo' and 'FOO' are equal under UTF8_LCASE but binary
+  // distinct. For those we store a wrapper in the HashSet keyed on a collation-aware key while
+  // keeping the original first-seen value for output. Binary-stable inputs stay on the fast path.
+  @transient private lazy val needsCollationKey: Boolean =
+    !UnsafeRowUtils.isBinaryStable(child.dataType)
+
+  // Projects a value to its collation- and float-normalized dedup key bytes. injectCollationKey
+  // handles collated strings nested at any depth; NormalizeFloatingNumbers folds them in too.
+  @transient private lazy val collationKeyBytes: Any => Array[Byte] = {
+    val ref = BoundReference(0, child.dataType, nullable = true)
+    val proj = UnsafeProjection.create(
+      Seq(CollationKey.injectCollationKey(NormalizeFloatingNumbers.normalize(ref))))
+    (value: Any) => proj(InternalRow(value)).getBytes
+  }
+
   @transient private lazy val complexNormalizer: Any => Any = {
     val ref = BoundReference(0, child.dataType, nullable = true)
     val proj = UnsafeProjection.create(NormalizeFloatingNumbers.normalize(ref))
     (value: Any) => InternalRow.copyValue(proj(InternalRow(value)).get(0, child.dataType))
   }
 
-  override def convertToBufferElement(value: Any): Any = child.dataType match {
+  override def convertToBufferElement(value: Any): Any = if (needsCollationKey) {
+    // Store the float-normalized value (not the raw one) so the emitted representative is
+    // canonical, matching the complex path below (e.g. -0.0 surfaces as 0.0). normalize is a
+    // no-op for pure collated strings, so this only affects nested floats. The dedup key already
+    // folds in the same normalization.
+    new CollationKeyedElement(collationKeyBytes(value), complexNormalizer(value))
+  } else child.dataType match {
     /*
      * collect_set() of BinaryType should not return duplicate elements,
      * Java byte arrays use referential equality and identity hash codes
@@ -279,21 +300,49 @@ case class CollectSet(
           case null => null
           case v => java.lang.Float.intBitsToFloat(v.asInstanceOf[Int])
         }.toArray[Any]
+      case _ if needsCollationKey =>
+        buffer.iterator.map {
+          case null => null
+          case v => v.asInstanceOf[CollationKeyedElement].value
+        }.toArray[Any]
       case _ => buffer.toArray
     }
     new GenericArrayData(array)
   }
 
+  // For the collation-key case the buffer holds wrappers, so serialize the original values (typed
+  // as bufferElementType) and re-wrap on deserialize. Recomputing the key on deserialize keeps
+  // post-merge dedup collation-aware. Binary-stable inputs use the base implementations unchanged.
+  override def serialize(obj: mutable.HashSet[Any]): Array[Byte] = if (!needsCollationKey) {
+    super.serialize(obj)
+  } else {
+    val values = obj.iterator.map {
+      case null => null
+      case v => v.asInstanceOf[CollationKeyedElement].value
+    }
+    val array = new GenericArrayData(values.toArray)
+    projection.apply(InternalRow.apply(array)).getBytes()
+  }
+
+  override def deserialize(bytes: Array[Byte]): mutable.HashSet[Any] = if (!needsCollationKey) {
+    super.deserialize(bytes)
+  } else {
+    val buffer = createAggregationBuffer()
+    row.pointTo(bytes, bytes.length)
+    row.getArray(0).foreach(bufferElementType, (_, x: Any) =>
+      buffer += (if (x == null) null else convertToBufferElement(x)))
+    buffer
+  }
+
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (!child.dataType.existsRecursively(_.isInstanceOf[MapType]) &&
-        UnsafeRowUtils.isBinaryStable(child.dataType)) {
+    if (!child.dataType.existsRecursively(_.isInstanceOf[MapType])) {
       TypeCheckResult.TypeCheckSuccess
     } else {
       DataTypeMismatch(
         errorSubClass = "UNSUPPORTED_INPUT_TYPE",
         messageParameters = Map(
           "functionName" -> toSQLId(prettyName),
-          "dataType" -> (s"${toSQLType(MapType)} " + "or \"COLLATED STRING\"")
+          "dataType" -> toSQLType(MapType)
         )
       )
     }
@@ -322,6 +371,20 @@ case class CollectSet(
 
   override protected def withNewChildInternal(newChild: Expression): CollectSet =
     copy(child = newChild)
+}
+
+/**
+ * A collect_set buffer element for non-binary collated inputs. Equality and hashing use the
+ * collation-aware key bytes, so collation-equal values (e.g. 'foo' and 'FOO' under UTF8_LCASE)
+ * dedup to a single entry, while [[value]] retains the original first-seen value for output.
+ */
+private[aggregate] class CollationKeyedElement(val key: Array[Byte], val value: Any) {
+  override def hashCode(): Int = java.util.Arrays.hashCode(key)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: CollationKeyedElement => java.util.Arrays.equals(key, that.key)
+    case _ => false
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -989,7 +989,7 @@ class DataFrameAggregateSuite extends SharedSparkSession
       condition = "DATATYPE_MISMATCH.UNSUPPORTED_INPUT_TYPE",
       parameters = Map(
         "functionName" -> "`collect_set`",
-        "dataType" -> "\"MAP\" or \"COLLATED STRING\"",
+        "dataType" -> "\"MAP\"",
         "sqlExpr" -> "\"collect_set(b)\""
       ),
       context = ExpectedContext(

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -390,6 +390,40 @@ class CollationAggregationSuite
     }
   }
 
+  test("collect_set is collation-aware for collated strings nested at depth >= 2") {
+    val tblName = "collect_set_nested_deep"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo'), ('FOO'), ('bar')")
+
+      // array(named_struct('s', c1)) nests the collated string two levels deep (array of struct),
+      // exercising the injectCollationKey recursion below the top-level struct/array cases above.
+      checkAnswer(
+        sql(s"SELECT size(collect_set(array(named_struct('s', c1)))) FROM $tblName"),
+        Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(array(named_struct('s', c1))), " +
+          s"x -> lower(x[0].s))) FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+    }
+  }
+
+  test("collect_set dedups on a space-trimming collation (UTF8_LCASE_RTRIM)") {
+    val tblName = "collect_set_lcase_rtrim"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE_RTRIM) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo '), ('foo'), ('FOO'), ('bar'), ('BAR  ')")
+
+      // UTF8_LCASE_RTRIM ignores both case and trailing spaces, so 'foo '/'foo'/'FOO' collapse to
+      // one group and 'bar'/'BAR  ' to another. The retained representative may keep trailing
+      // spaces, so collapse with trim(lower(...)) before comparing.
+      checkAnswer(sql(s"SELECT size(collect_set(c1)) FROM $tblName"), Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(c1), x -> trim(lower(x)))) FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+    }
+  }
+
   test("collect_set collation and float normalization compose for nested structs") {
     val tblName = "collect_set_nested_float"
     withTable(tblName) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -333,6 +334,173 @@ class CollationAggregationSuite
           |""".stripMargin)
       assertUsesSortAggregate(result)
       checkAnswer(result, Seq(Row("hello", 3L), Row("world", 9L)))
+    }
+  }
+
+  // collect_set is non-deterministic in which representative of a collation-equal group it keeps,
+  // so tests assert on a collation-collapsed form (lower(...)) rather than a fixed case.
+
+  test("collect_set dedups collation-equal strings (UTF8_LCASE)") {
+    val tblName = "collect_set_lcase"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo'), ('FOO'), ('FoO'), ('bar'), ('BAR')")
+
+      // 'foo'/'FOO'/'FoO' collapse to one group and 'bar'/'BAR' to another under UTF8_LCASE.
+      checkAnswer(sql(s"SELECT size(collect_set(c1)) FROM $tblName"), Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(c1), x -> lower(x))) FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+    }
+  }
+
+  test("collect_set dedups collation-equal strings (UNICODE_CI)") {
+    val tblName = "collect_set_unicode_ci"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UNICODE_CI) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('cafe'), ('CAFE'), ('Cafe'), ('bar')")
+
+      checkAnswer(sql(s"SELECT size(collect_set(c1)) FROM $tblName"), Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(c1), x -> lower(x))) FROM $tblName"),
+        Seq(Row(Seq("bar", "cafe"))))
+    }
+  }
+
+  test("collect_set is collation-aware for collated strings nested in struct/array") {
+    val tblName = "collect_set_nested"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE, c2 INT) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo', 1), ('FOO', 1), ('bar', 1)")
+
+      // Nested in a struct: named_struct('s', c1) dedups on c1's collation key.
+      checkAnswer(
+        sql(s"SELECT size(collect_set(named_struct('s', c1))) FROM $tblName"), Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(named_struct('s', c1)), " +
+          s"x -> lower(x.s))) FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+
+      // Nested in an array: array(c1) dedups on the element's collation key.
+      checkAnswer(sql(s"SELECT size(collect_set(array(c1))) FROM $tblName"), Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(array(c1)), x -> lower(x[0]))) " +
+          s"FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+    }
+  }
+
+  test("collect_set collation and float normalization compose for nested structs") {
+    val tblName = "collect_set_nested_float"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE, d DOUBLE) USING PARQUET")
+      // ('foo', 0.0) and ('FOO', -0.0) dedup only if BOTH the collation key and float
+      // normalization fire on the same nested key (size 2, not 3).
+      sql(s"INSERT INTO $tblName VALUES ('foo', 0.0), ('FOO', -0.0), ('bar', 1.0)")
+
+      checkAnswer(
+        sql(s"SELECT size(collect_set(named_struct('s', c1, 'd', d))) FROM $tblName"),
+        Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(named_struct('s', c1, 'd', d)), " +
+          s"x -> lower(x.s))) FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+    }
+  }
+
+  test("collect_set IGNORE NULLS (default) drops nulls while deduping collated values") {
+    val tblName = "collect_set_ignore_nulls"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo'), ('FOO'), (NULL), ('bar'), (NULL)")
+
+      // Default IGNORE NULLS: nulls are dropped, and 'foo'/'FOO' still collapse under UTF8_LCASE,
+      // so the set is {<foo group>, <bar group>} -> size 2 with no null element.
+      checkAnswer(sql(s"SELECT size(collect_set(c1)) FROM $tblName"), Seq(Row(2)))
+      checkAnswer(
+        sql(s"SELECT array_sort(transform(collect_set(c1), x -> lower(x))) FROM $tblName"),
+        Seq(Row(Seq("bar", "foo"))))
+    }
+  }
+
+  test("collect_set still rejects maps even when they carry collated strings") {
+    // The collation relaxation must not open the map gate: a HashSet cannot dedup maps, so a map
+    // with a collated-string key (which would otherwise take the collation-key path) must still
+    // fail checkInputDataTypes with UNSUPPORTED_INPUT_TYPE.
+    val collatedMap = spark.sql(
+      "SELECT map(CAST(k AS STRING COLLATE UTF8_LCASE), v) AS m " +
+        "FROM VALUES ('a', 1), ('A', 2) AS t(k, v)")
+    checkError(
+      exception = intercept[AnalysisException](collatedMap.select(collect_set(col("m")))),
+      condition = "DATATYPE_MISMATCH.UNSUPPORTED_INPUT_TYPE",
+      parameters = Map(
+        "functionName" -> "`collect_set`",
+        "dataType" -> "\"MAP\"",
+        "sqlExpr" -> "\"collect_set(m)\""),
+      context = ExpectedContext(
+        fragment = "collect_set", callSitePattern = getCurrentClassCallSitePattern))
+
+    // A map nested alongside a collated string in a struct is still rejected: existsRecursively
+    // finds the MapType before the collation-key path is ever considered.
+    val nestedMap = spark.sql(
+      "SELECT named_struct('s', CAST(k AS STRING COLLATE UTF8_LCASE), 'm', map(k, v)) AS a " +
+        "FROM VALUES ('a', 1), ('A', 2) AS t(k, v)")
+    checkError(
+      exception = intercept[AnalysisException](nestedMap.select(collect_set(col("a")))),
+      condition = "DATATYPE_MISMATCH.UNSUPPORTED_INPUT_TYPE",
+      parameters = Map(
+        "functionName" -> "`collect_set`",
+        "dataType" -> "\"MAP\"",
+        "sqlExpr" -> "\"collect_set(a)\""),
+      context = ExpectedContext(
+        fragment = "collect_set", callSitePattern = getCurrentClassCallSitePattern))
+  }
+
+  test("collect_set RESPECT NULLS keeps one null alongside collation-deduped values") {
+    val tblName = "collect_set_respect_nulls"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING COLLATE UTF8_LCASE) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo'), ('FOO'), (NULL), ('bar'), (NULL)")
+
+      // RESPECT NULLS keeps a single null; 'foo'/'FOO' still collapse under UTF8_LCASE, so the
+      // set is {null, <foo group>, <bar group>} -> size 3. sort_array orders null first.
+      checkAnswer(
+        sql(s"SELECT size(collect_set(c1) RESPECT NULLS) FROM $tblName"), Seq(Row(3)))
+      checkAnswer(
+        sql(s"SELECT sort_array(transform(collect_set(c1) RESPECT NULLS, x -> lower(x))) " +
+          s"FROM $tblName"),
+        Seq(Row(Seq(null, "bar", "foo"))))
+    }
+  }
+
+  test("collect_set collation-aware dedup survives the merge path across partitions") {
+    Seq("UTF8_LCASE", "UNICODE_CI").foreach { collation =>
+      withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "8") {
+        val values = (0 until 200).map(i => if (i % 2 == 0) "foo" else "FOO")
+        val df = values.toDF("c")
+          .select(col("c").cast(s"string collate $collation").as("c"))
+          .repartition(8)
+
+        // All 200 values are collation-equal, so after partial aggregation on 8 partitions and
+        // the final merge (serialize/deserialize + union), the set has a single element.
+        val result = df.agg(collect_set(col("c")).as("s"))
+        checkAnswer(result.select(size(col("s"))), Seq(Row(1)))
+        checkAnswer(result.select(transform(col("s"), x => lower(x))), Seq(Row(Seq("foo"))))
+      }
+    }
+  }
+
+  test("collect_set on UTF8_BINARY strings is unchanged (case-sensitive)") {
+    val tblName = "collect_set_binary"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName (c1 STRING) USING PARQUET")
+      sql(s"INSERT INTO $tblName VALUES ('foo'), ('FOO'), ('foo'), ('bar')")
+
+      // Default UTF8_BINARY collation is case-sensitive: 'foo' and 'FOO' stay distinct.
+      checkAnswer(sql(s"SELECT size(collect_set(c1)) FROM $tblName"), Seq(Row(3)))
+      checkAnswer(
+        sql(s"SELECT array_sort(collect_set(c1)) FROM $tblName"),
+        Seq(Row(Seq("FOO", "bar", "foo"))))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR makes `collect_set` support non-binary collated string inputs . Previously such inputs were rejected with an `UNSUPPORTED_INPUT_TYPE` error; now `collect_set` deduplicates them collation-aware, returning one representative per collation-equal group. Binary-stable inputs are unchanged, and MapType is still rejected.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
collect_set on a non-binary collated column throws instead of working:

```sql
CREATE OR REPLACE TEMP VIEW v AS
SELECT CAST(s AS STRING COLLATE UTF8_LCASE) AS s
FROM VALUES ('foo'), ('FOO'), ('bar') AS raw(s);

SELECT collect_set(s) FROM v;
-- [DATATYPE_MISMATCH.UNSUPPORTED_INPUT_TYPE] ... collect_set ...
```

Under `UTF8_LCASE`, 'foo' and 'FOO' are equal, so `collect_set` should treat them as one group rather than error out. This closes a gap in collation support for aggregate functions.

Actual result after this PR:

```sql
SELECT collect_set(s) FROM v;
+----------------+
|collect_set(s)  |
+----------------+
|[foo, bar]      |
+----------------+
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. `collect_set` over a non-binary collated string (top-level or nested in a struct/array) now succeeds instead of raising `UNSUPPORTED_INPUT_TYPE`, returning one representative per collation-equal group. For the view above, the result has 2 elements ({foo-group, bar}). As with any set aggregate, which representative of a group appears is unspecified. 
No change for default (`UTF8_BINARY`) or non-string inputs; MapType is still rejected.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new tests in `CollationAggregationSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. Generated-by: Claude Code