### PR TITLE
[SPARK-58954][BUILD] Upgrade `commons-codec` to 1.22.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -49,7 +49,7 @@ checksums/2.35.4//checksums-2.35.4.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.11.0//commons-cli-1.11.0.jar
-commons-codec/1.22.0//commons-codec-1.22.0.jar
+commons-codec/1.22.1//commons-codec-1.22.1.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar
 commons-compiler/3.1.12//commons-compiler-3.1.12.jar
 commons-compress/1.28.0//commons-compress-1.28.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <snappy.version>1.1.10.8</snappy.version>
     <netlib.ludovic.dev.version>3.2.0</netlib.ludovic.dev.version>
-    <commons-codec.version>1.22.0</commons-codec.version>
+    <commons-codec.version>1.22.1</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.22.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-codec` to 1.22.1.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/apache/commons-codec/releases/tag/rel/commons-codec-1.22.1 (2026-07-30)

The following are the fixed bugs in this release.
- `CODEC-337`: Digest `ALL` reuses `System.in`, so only the first algorithm sees the real input.
- `CODEC-338`: `PercentCodec` loses literal `'+'` when `plusForSpace` is enabled.
- `CODEC-339`: `URLCodec.encodeUrl(BitSet, byte[])` allows custom safe sets to emit URL encoding control characters.
- `CODEC-340`: `Base58.Builder.setEncodeTable(byte...)` is ignored when encoding and decoding.
- `CODEC-341`: `Base16.Builder.setEncodeTable(byte...)` can create a codec that cannot decode its own output.
- `CODEC-342`: `Base32.Builder.setEncodeTable(byte...)` can create a codec that cannot decode its own output.
- `CODEC-343`: `Base32.Builder.setHexDecodeTable(boolean)` sets the encode table to a decode lookup table.
- `CODEC-344`: `Base64.Builder.setEncodeTable(byte...)` accepts invalid custom alphabets.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5