### PR TITLE
[SPARK-58955][BUILD] Upgrade `commons-collections4` to 4.6.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -50,7 +50,7 @@ chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.11.0//commons-cli-1.11.0.jar
 commons-codec/1.22.0//commons-codec-1.22.0.jar
-commons-collections4/4.5.0//commons-collections4-4.5.0.jar
+commons-collections4/4.6.0//commons-collections4-4.6.0.jar
 commons-compiler/3.1.12//commons-compiler-3.1.12.jar
 commons-compress/1.28.0//commons-compress-1.28.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <commons.httpclient.version>4.5.14</commons.httpclient.version>
     <commons.httpcore.version>4.4.16</commons.httpcore.version>
     <commons.math3.version>3.6.1</commons.math3.version>
-    <commons.collections4.version>4.5.0</commons.collections4.version>
+    <commons.collections4.version>4.6.0</commons.collections4.version>
     <scala.version>2.13.18</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-collections4` to 4.6.0.

### Why are the changes needed?

To bring the latest bug fixes and improvements. Apache Commons Collections 4.6.0 was released on 2026-08-10 and is a feature and maintenance release on the existing 4.x line.

- https://github.com/apache/commons-collections/releases/tag/rel%2Fcommons-collections-4.6.0 (2026-08-10)

Since 4.5.0 (2025-04-22), it contains many bug fixes including the following.

- [COLLECTIONS-838](https://issues.apache.org/jira/browse/COLLECTIONS-838): Calling `SetUtils.union` on multiple instances of `SetView` causes JVM to hang
- [COLLECTIONS-888](https://issues.apache.org/jira/browse/COLLECTIONS-888): `PatriciaTrie` incompatible with Java 21 (JEP 431 Sequenced Collections)
- [COLLECTIONS-885](https://issues.apache.org/jira/browse/COLLECTIONS-885): `PatriciaTrie` submap and range view operations silently mutate trie structure resulting in `ConcurrentModificationException` for any iterating threads
- [COLLECTIONS-776](https://issues.apache.org/jira/browse/COLLECTIONS-776): Wrapping `PassiveExpiringMap` in `Collections.synchronizedMap` breaks expiration
- [COLLECTIONS-722](https://issues.apache.org/jira/browse/COLLECTIONS-722): Improve `IteratorUtils.chainedIterator()` performance

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5