### PR TITLE
[SPARK-58959][SQL] Duplicate PIVOT values corrupt the aggregation buffer on the PivotFirst fast path

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import scala.collection.immutable.{HashMap, TreeMap}
+import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -88,11 +89,27 @@ case class PivotFirst(
 
   private val usesTreeMap: Boolean = !TypeUtils.typeWithProperEquals(pivotColumn.dataType)
 
-  val pivotIndex: Map[Any, Int] = if (usesTreeMap) {
-    TreeMap(pivotColumnValues.zipWithIndex: _*)(
-      TypeUtils.getInterpretedOrdering(pivotColumn.dataType))
-  } else {
-    HashMap(pivotColumnValues.zipWithIndex: _*)
+  // Every pivot value gets a buffer slot, shared between the values that compare as equal, so a
+  // repeated value does not shrink the buffer below the number of output columns.
+  private val (pivotIndex, slotOfValue, slotValues) = {
+    val slots = new Array[Int](pivotColumnValues.length)
+    val values = mutable.ArrayBuffer.empty[Any]
+    var index: Map[Any, Int] = if (usesTreeMap) {
+      TreeMap.empty[Any, Int](TypeUtils.getInterpretedOrdering(pivotColumn.dataType))
+    } else {
+      HashMap.empty[Any, Int]
+    }
+    pivotColumnValues.zipWithIndex.foreach { case (value, i) =>
+      val existingSlot = index.getOrElse(value, -1)
+      if (existingSlot >= 0) {
+        slots(i) = existingSlot
+      } else {
+        slots(i) = values.length
+        index = index.updated(value, values.length)
+        values += value
+      }
+    }
+    (index, slots, values.toSeq)
   }
 
   // Null-safe lookup into pivotIndex. When pivotIndex is a TreeMap, its comparison-based lookup
@@ -104,7 +121,7 @@ case class PivotFirst(
     case _ => pivotIndex.getOrElse(key, -1)
   }
 
-  val indexSize = pivotIndex.size
+  val indexSize = slotValues.length
 
   private val updateRow: (InternalRow, Int, Any) => Unit = PivotFirst.updateFunction(valueDataType)
 
@@ -142,9 +159,9 @@ case class PivotFirst(
   }
 
   override def eval(input: InternalRow): Any = {
-    val result = new Array[Any](indexSize)
-    for (i <- 0 until indexSize) {
-      result(i) = input.get(mutableAggBufferOffset + i, valueDataType)
+    val result = new Array[Any](slotOfValue.length)
+    for (i <- slotOfValue.indices) {
+      result(i) = input.get(mutableAggBufferOffset + slotOfValue(i), valueDataType)
     }
     new GenericArrayData(result)
   }
@@ -157,8 +174,8 @@ case class PivotFirst(
 
 
   override val aggBufferAttributes: Seq[AttributeReference] =
-    pivotIndex.toList.sortBy(_._2).map { kv =>
-      AttributeReference(Option(kv._1).getOrElse("null").toString, valueDataType)()
+    slotValues.map { value =>
+      AttributeReference(Option(value).getOrElse("null").toString, valueDataType)()
     }
 
   override val aggBufferSchema: StructType = DataTypeUtils.fromAttributes(aggBufferAttributes)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -89,8 +89,6 @@ case class PivotFirst(
 
   private val usesTreeMap: Boolean = !TypeUtils.typeWithProperEquals(pivotColumn.dataType)
 
-  // Every pivot value gets a buffer slot, shared between the values that compare as equal, so a
-  // repeated value does not shrink the buffer below the number of output columns.
   private val (pivotIndex, slotOfValue, slotValues) = {
     val slots = new Array[Int](pivotColumnValues.length)
     val values = mutable.ArrayBuffer.empty[Any]
@@ -100,13 +98,13 @@ case class PivotFirst(
       HashMap.empty[Any, Int]
     }
     pivotColumnValues.zipWithIndex.foreach { case (value, i) =>
-      val existingSlot = index.getOrElse(value, -1)
-      if (existingSlot >= 0) {
-        slots(i) = existingSlot
-      } else {
-        slots(i) = values.length
-        index = index.updated(value, values.length)
-        values += value
+      index.get(value) match {
+        case Some(existingSlot) =>
+          slots(i) = existingSlot
+        case None =>
+          slots(i) = values.length
+          index = index.updated(value, values.length)
+          values += value
       }
     }
     (index, slots, values.toSeq)
@@ -121,6 +119,8 @@ case class PivotFirst(
     case _ => pivotIndex.getOrElse(key, -1)
   }
 
+  // Values that compare as equal share a slot, so this counts distinct slots; the output has one
+  // element per entry in slotOfValue.
   val indexSize = slotValues.length
 
   private val updateRow: (InternalRow, Int, Any) => Unit = PivotFirst.updateFunction(valueDataType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -532,15 +532,12 @@ class DataFramePivotSuite extends SharedSparkSession {
           |  (2, 1, 30)
           |AS t(id, k, v)""".stripMargin)
 
-      // The optimized PivotFirst path deduplicates the pivot values into a map, so a repeated
-      // value must not shrink the aggregation buffer below the number of output columns.
       val df = sql(
         """SELECT * FROM dup_pivot
           |PIVOT (SUM(v) FOR k IN (1 AS x, 1 AS y, 2 AS z))""".stripMargin)
       assert(usesPivotFirst(df))
       checkAnswer(df, Row(1, 10L, 10L, 20L) :: Row(2, 30L, 30L, null) :: Nil)
 
-      // The path that does not use PivotFirst answers the same query the same way.
       val arrayDf = sql(
         """SELECT * FROM (SELECT id, k, ARRAY(v) AS v FROM dup_pivot)
           |PIVOT (MIN(v) FOR k IN (1 AS x, 1 AS y, 2 AS z))""".stripMargin)
@@ -562,9 +559,6 @@ class DataFramePivotSuite extends SharedSparkSession {
           |  (2, 1, 30)
           |AS t(id, k, v)""".stripMargin)
 
-      // With more than one aggregate the PivotFirst buffers sit back to back in a single row, so
-      // an out-of-range index reaches into the next aggregate's slots: SUM writes over MAX's
-      // buffer, and MAX runs off the end of the row entirely.
       val df = sql(
         """SELECT * FROM dup_multi_agg
           |PIVOT (SUM(v) AS s, MAX(v) AS m FOR k IN (1 AS x, 1 AS y, 2 AS z))""".stripMargin)
@@ -587,18 +581,16 @@ class DataFramePivotSuite extends SharedSparkSession {
       Seq("s" -> "'a'", "b" -> "1Y", "sh" -> "1S", "i" -> "1", "l" -> "1L",
         "f" -> "1.0F", "d" -> "1.0D", "dec" -> "1.0BD", "bool" -> "TRUE").foreach {
         case (column, value) =>
-          checkAnswer(
-            sql(
-              s"""SELECT * FROM (SELECT $column AS k, v FROM dup_types)
-                 |PIVOT (SUM(v) FOR k IN ($value AS x, $value AS y))""".stripMargin),
-            Row(10L, 10L))
+          val df = sql(
+            s"""SELECT * FROM (SELECT $column AS k, v FROM dup_types)
+               |PIVOT (SUM(v) FOR k IN ($value AS x, $value AS y))""".stripMargin)
+          assert(usesPivotFirst(df))
+          checkAnswer(df, Row(10L, 10L))
       }
     }
   }
 
   test("SPARK-58959: pivot values that compare as equal share an output value") {
-    // The pivot column is collated, so PivotFirst indexes the values with a comparison-based
-    // TreeMap: 'a' and 'A' are distinct strings that compare as equal under UTF8_LCASE.
     withTable("dup_lcase_pivot") {
       sql(
         """CREATE TABLE dup_lcase_pivot (
@@ -610,11 +602,56 @@ class DataFramePivotSuite extends SharedSparkSession {
           |  ('a', 10),
           |  ('b', 20)""".stripMargin)
 
-      checkAnswer(
-        sql(
-          """SELECT * FROM dup_lcase_pivot
-            |PIVOT (SUM(amount) FOR key IN ('a' AS x, 'A' AS y, 'b' AS z))""".stripMargin),
-        Row(10L, 10L, 20L))
+      val df = sql(
+        """SELECT * FROM dup_lcase_pivot
+          |PIVOT (SUM(amount) FOR key IN ('a' AS x, 'A' AS y, 'b' AS z))""".stripMargin)
+      assert(usesPivotFirst(df))
+      checkAnswer(df, Row(10L, 10L, 20L))
+    }
+
+    val structDf = sql(
+      """SELECT * FROM (SELECT named_struct('f', k) AS k, v FROM VALUES (1, 10), (2, 20) AS t(k, v))
+        |PIVOT (SUM(v) FOR k IN (
+        |  named_struct('f', 1) AS x, named_struct('f', 1) AS y, named_struct('f', 2) AS z))
+        |""".stripMargin)
+    assert(usesPivotFirst(structDf))
+    checkAnswer(structDf, Row(10L, 10L, 20L))
+  }
+
+  test("SPARK-58959: duplicate pivot values given through the DataFrame pivot API") {
+    val df = Seq((1, 1, 10), (1, 2, 20), (2, 1, 30)).toDF("id", "k", "v")
+      .groupBy("id").pivot("k", Seq(1, 1, 2)).sum("v")
+    assert(usesPivotFirst(df))
+    checkAnswer(df, Row(1, 10L, 10L, 20L) :: Row(2, 30L, 30L, null) :: Nil)
+  }
+
+  test("SPARK-58959: signed zeros and repeated NaN as pivot values") {
+    withTempView("dup_zero_pivot") {
+      sql(
+        """CREATE OR REPLACE TEMP VIEW dup_zero_pivot AS
+          |SELECT * FROM VALUES
+          |  (0.0D, 0.0F, 10),
+          |  (2.0D, 2.0F, 20)
+          |AS t(d, f, v)""".stripMargin)
+
+      val doubleDf = sql(
+        """SELECT * FROM (SELECT d AS k, v FROM dup_zero_pivot)
+          |PIVOT (SUM(v) FOR k IN (0.0D AS x, -0.0D AS y, 2.0D AS z))""".stripMargin)
+      assert(usesPivotFirst(doubleDf))
+      checkAnswer(doubleDf, Row(10L, 10L, 20L))
+
+      val floatDf = sql(
+        """SELECT * FROM (SELECT f AS k, v FROM dup_zero_pivot)
+          |PIVOT (SUM(v) FOR k IN (0.0F AS x, -0.0F AS y, 2.0F AS z))""".stripMargin)
+      assert(usesPivotFirst(floatDf))
+      checkAnswer(floatDf, Row(10L, 10L, 20L))
+
+      val nanDf = sql(
+        """SELECT * FROM (SELECT d AS k, v FROM dup_zero_pivot)
+          |PIVOT (SUM(v) FOR k IN (
+          |  DOUBLE('NaN') AS x, DOUBLE('NaN') AS y, 2.0D AS z))""".stripMargin)
+      assert(usesPivotFirst(nanDf))
+      checkAnswer(nanDf, Row(null, null, 20L))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -29,6 +29,10 @@ import org.apache.spark.sql.types._
 class DataFramePivotSuite extends SharedSparkSession {
   import testImplicits._
 
+  private def usesPivotFirst(df: DataFrame): Boolean = {
+    df.queryExecution.analyzed.exists(_.expressions.exists(_.exists(_.isInstanceOf[PivotFirst])))
+  }
+
   test("pivot courses") {
     val expected = Row(2012, 15000.0, 20000.0) :: Row(2013, 48000.0, 30000.0) :: Nil
     checkAnswer(
@@ -515,6 +519,102 @@ class DataFramePivotSuite extends SharedSparkSession {
           "input" -> "\"id\", \"1\", \"2\"",
           "operator" -> "!Sort \\[v#\\d+ ASC NULLS FIRST\\], true"),
         matchPVals = true)
+    }
+  }
+
+  test("SPARK-58959: duplicate pivot values each get their own output column") {
+    withTempView("dup_pivot") {
+      sql(
+        """CREATE OR REPLACE TEMP VIEW dup_pivot AS
+          |SELECT * FROM VALUES
+          |  (1, 1, 10),
+          |  (1, 2, 20),
+          |  (2, 1, 30)
+          |AS t(id, k, v)""".stripMargin)
+
+      // The optimized PivotFirst path deduplicates the pivot values into a map, so a repeated
+      // value must not shrink the aggregation buffer below the number of output columns.
+      val df = sql(
+        """SELECT * FROM dup_pivot
+          |PIVOT (SUM(v) FOR k IN (1 AS x, 1 AS y, 2 AS z))""".stripMargin)
+      assert(usesPivotFirst(df))
+      checkAnswer(df, Row(1, 10L, 10L, 20L) :: Row(2, 30L, 30L, null) :: Nil)
+
+      // The path that does not use PivotFirst answers the same query the same way.
+      val arrayDf = sql(
+        """SELECT * FROM (SELECT id, k, ARRAY(v) AS v FROM dup_pivot)
+          |PIVOT (MIN(v) FOR k IN (1 AS x, 1 AS y, 2 AS z))""".stripMargin)
+      assert(!usesPivotFirst(arrayDf))
+      checkAnswer(
+        arrayDf,
+        Row(1, Seq(10), Seq(10), Seq(20)) :: Row(2, Seq(30), Seq(30), null) :: Nil)
+    }
+  }
+
+  test("SPARK-58959: duplicate pivot values do not corrupt a neighbouring aggregate buffer") {
+    withTempView("dup_multi_agg") {
+      sql(
+        """CREATE OR REPLACE TEMP VIEW dup_multi_agg AS
+          |SELECT * FROM VALUES
+          |  (1, 1, 10),
+          |  (1, 1, 40),
+          |  (1, 2, 20),
+          |  (2, 1, 30)
+          |AS t(id, k, v)""".stripMargin)
+
+      // With more than one aggregate the PivotFirst buffers sit back to back in a single row, so
+      // an out-of-range index reaches into the next aggregate's slots: SUM writes over MAX's
+      // buffer, and MAX runs off the end of the row entirely.
+      val df = sql(
+        """SELECT * FROM dup_multi_agg
+          |PIVOT (SUM(v) AS s, MAX(v) AS m FOR k IN (1 AS x, 1 AS y, 2 AS z))""".stripMargin)
+      assert(usesPivotFirst(df))
+      checkAnswer(
+        df,
+        Row(1, 50L, 40, 50L, 40, 20L, 20) :: Row(2, 30L, 30, 30L, 30, null, null) :: Nil)
+    }
+  }
+
+  test("SPARK-58959: duplicate pivot values of every PivotFirst datatype") {
+    withTempView("dup_types") {
+      sql(
+        """CREATE OR REPLACE TEMP VIEW dup_types AS
+          |SELECT * FROM VALUES
+          |  ('a', 1Y, 1S, 1, 1L, 1.0F, 1.0D, 1.0BD, TRUE, 10),
+          |  ('b', 2Y, 2S, 2, 2L, 2.0F, 2.0D, 2.0BD, FALSE, 20)
+          |AS t(s, b, sh, i, l, f, d, dec, bool, v)""".stripMargin)
+
+      Seq("s" -> "'a'", "b" -> "1Y", "sh" -> "1S", "i" -> "1", "l" -> "1L",
+        "f" -> "1.0F", "d" -> "1.0D", "dec" -> "1.0BD", "bool" -> "TRUE").foreach {
+        case (column, value) =>
+          checkAnswer(
+            sql(
+              s"""SELECT * FROM (SELECT $column AS k, v FROM dup_types)
+                 |PIVOT (SUM(v) FOR k IN ($value AS x, $value AS y))""".stripMargin),
+            Row(10L, 10L))
+      }
+    }
+  }
+
+  test("SPARK-58959: pivot values that compare as equal share an output value") {
+    // The pivot column is collated, so PivotFirst indexes the values with a comparison-based
+    // TreeMap: 'a' and 'A' are distinct strings that compare as equal under UTF8_LCASE.
+    withTable("dup_lcase_pivot") {
+      sql(
+        """CREATE TABLE dup_lcase_pivot (
+          |  key STRING COLLATE UTF8_LCASE,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql(
+        """INSERT INTO dup_lcase_pivot VALUES
+          |  ('a', 10),
+          |  ('b', 20)""".stripMargin)
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM dup_lcase_pivot
+            |PIVOT (SUM(amount) FOR key IN ('a' AS x, 'A' AS y, 'b' AS z))""".stripMargin),
+        Row(10L, 10L, 20L))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`PivotFirst` indexed the pivot values with `Map(pivotColumnValues.zipWithIndex)`, so values that compare as equal collapsed onto one entry holding the *last* of their indices while `indexSize` shrank to the distinct count, leaving the stored index pointing past the end of the buffer. With this PR, every entry now gets its own slot, shared between entries that compare as equal, and `eval` expands back to one array element per entry.

### Why are the changes needed?
A PIVOT whose `IN` list repeats a value writes outside its allocated slots in the aggregation buffer:

```sql
SELECT * FROM VALUES (1, 1, 10), (1, 2, 20) AS t(id, k, v)
PIVOT (sum(v) FOR k IN (1 AS x, 1 AS y));

java.lang.AssertionError: index (1) should < 1
```

The bounds check is a Java assert which lives only under -ea. A normal build writes outside the slots unchecked, then fails with [INVALID_ARRAY_INDEX]. The index 1 is out of bounds under ANSI, or returns [1, null, null] instead of [1, 10, 10] without it. **Duplicates are identical literals, and values that compare equal on the current index (UTF8_LCASE 'a'/'A', equal structs/binaries, etc)** The non-optimized path already answers these queries correctly.

Note: a NULL in the IN list is out of scope here. It still fails on the TreeMap path exactly as it does on master. Making null a usable pivot value is handled separately in #58234. 

### Does this PR introduce _any_ user-facing change?
Yes. The optimized path now returns one column per listed value, matching the non-optimized path, instead of failing with AssertionError or silently corrupting the buffer.

### How was this patch tested?
Added UT cases.


### Was this patch authored or co-authored using generative AI tooling?
Yes.
