### PR TITLE
[SPARK-58904][SS] Enforce correct watermark placement for stream-stream left semi and left outer joins

### DIFF
--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -1293,6 +1293,20 @@ joined <- join(
 </div>
 
 
+For a **left outer** join, the surviving unmatched left rows are emitted when the left-side state is
+evicted, and an already-emitted `NULL`-extended row can be invalidated by a right row that arrives
+later. Correct results therefore require the watermark to be placed so that (1) the left state is
+actually evicted and (2) both sides are late-filtered on the dimension that bounds matching.
+Concretely: for an equality join on a watermarked event-time key, that key must be watermarked on
+**both** sides; for a time range condition, the range bound must relate watermarked event-time
+columns from both sides. The recommended, always-correct configuration -- watermarking both sides on
+the event-time column used by the join, as in the example above -- satisfies both. Configurations
+that leave the left state un-evicted (a watermark on only the right side of a range condition) or
+leave either side unfiltered on the eviction key (a watermark on only one equality join key) are
+rejected at analysis time. To restore the previous, looser behavior, set
+`spark.sql.streaming.join.stricterWatermarkRequirements.enabled` to `false`; note that the looser
+behavior can silently produce incorrect (missing) outer results.
+
 ###### Semantic Guarantees of Stream-stream Outer Joins with Watermarking
 Outer joins have the same guarantees as [inner joins](#semantic-guarantees-of-stream-stream-inner-joins-with-watermarking)
 regarding watermark delays and whether data will be dropped or not.
@@ -1317,6 +1331,15 @@ It is also referred to as a left semi join. Similar to outer joins, watermark + 
 constraints must be specified for semi join. This is to evict unmatched input rows on left side,
 the engine must know when an input row on left side is not going to match with anything on right
 side in future.
+
+As with a left outer join, the left state must be evicted so that never-matched left rows do not
+accumulate: for an equality join the watermarked join key evicts the left key state; for a time
+range condition the range bound must relate watermarked event-time columns from both sides. Unlike
+outer joins, a semi join has no additional late-filtering requirement, because it emits a row on
+match rather than at eviction, so there is no already-emitted row for a late right row to
+invalidate. A range condition watermarked only on one side is rejected at analysis time; to restore
+the previous, looser behavior (which leaves the left state unbounded), set
+`spark.sql.streaming.join.stricterWatermarkRequirements.enabled` to `false`.
 
 ###### Semantic Guarantees of Stream-stream Semi Joins with Watermarking
 Semi joins have the same guarantees as [inner joins](#semantic-guarantees-of-stream-stream-inner-joins-with-watermarking)
@@ -1398,8 +1421,9 @@ regarding watermark delays and whether data will be dropped or not.
   <tr>
     <td style="vertical-align: middle;">Left Outer</td>
     <td style="vertical-align: middle;">
-      Conditionally supported, must specify watermark on right + time constraints for correct
-      results, optionally specify watermark on left for all state cleanup
+      Conditionally supported. For equality-key joins, watermark both sides of the join key used for
+      eviction. For range-condition joins, the range bound must use watermarked columns from both
+      sides.
     </td>
   </tr>
   <tr>
@@ -1419,8 +1443,8 @@ regarding watermark delays and whether data will be dropped or not.
   <tr>
     <td style="vertical-align: middle;">Left Semi</td>
     <td style="vertical-align: middle;">
-      Conditionally supported, must specify watermark on right + time constraints for correct
-      results, optionally specify watermark on left for all state cleanup
+      Conditionally supported. Equality-key joins require a watermark on a join key for state
+      cleanup. Range-condition joins require watermarked range-bound columns from both sides.
     </td>
   </tr>
   <tr>

--- a/docs/streaming/ss-migration-guide.md
+++ b/docs/streaming/ss-migration-guide.md
@@ -23,6 +23,10 @@ Note that this migration guide describes the items specific to Structured Stream
 Many items of SQL migration can be applied when migrating Structured Streaming to higher versions.
 Please refer [Migration Guide: SQL, Datasets and DataFrame](../sql-migration-guide.html).
 
+## Upgrading from Structured Streaming 4.3 to 4.4
+
+- Since Spark 4.4, stream-stream left semi and left outer joins enforce stricter watermark-placement requirements at analysis time, so that the left-side state their output (or bounded state size) depends on is actually evicted, and, for left outer, so that late rows cannot invalidate an already-emitted unmatched row. Configurations that previously ran but could silently produce incorrect results or unbounded state -- for example a range-condition join whose range bound is not between watermarked attributes on both sides, or a left outer equality join whose eviction key is not watermarked on both sides -- now fail with an `AnalysisException`. To restore the previous behavior, set `spark.sql.streaming.join.stricterWatermarkRequirements.enabled` to `false`. (See [SPARK-58904](https://issues.apache.org/jira/browse/SPARK-58904) for more details.)
+
 ## Upgrading from Structured Streaming 4.1 to 4.2
 
 - Since Spark 4.2, restarting a streaming query from a checkpoint whose metadata file is missing while the offset or commit logs contain data fails with `STREAMING_CHECKPOINT_MISSING_METADATA_FILE`, instead of silently generating a new query ID (which can duplicate data in exactly-once sinks). Restore the metadata file or use a new checkpoint location. To restore the previous behavior, set `spark.sql.streaming.checkpoint.verifyMetadataExists.enabled` to `false`. (See [SPARK-55058](https://issues.apache.org/jira/browse/SPARK-55058) for more details.)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelper.scala
@@ -23,9 +23,10 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
-import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, Join, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_DAY
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -33,6 +34,34 @@ import org.apache.spark.unsafe.types.CalendarInterval
  * Helper object for stream joins. See [[StreamingSymmetricHashJoinExec]] in SQL for more details.
  */
 object StreamingJoinHelper extends PredicateHelper with Logging {
+
+  private def isWatermarked(expression: Expression): Boolean = expression match {
+    case ne: NamedExpression => ne.metadata.contains(delayKey)
+    case _ => false
+  }
+
+  private def runtimeWatermarkedAttribute(attributes: Seq[Attribute]): Option[Attribute] = {
+    runtimeWatermarkedAttribute(
+      attributes,
+      allowMultipleEventTimeColumns =
+        !SQLConf.get.getConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE))
+  }
+
+  private def runtimeWatermarkedAttribute(
+      attributes: Seq[Attribute],
+      allowMultipleEventTimeColumns: Boolean): Option[Attribute] = {
+    // Mirror WatermarkSupport.findEventTimeColumn without depending on sql/core from catalyst.
+    val watermarked = attributes.filter(_.metadata.contains(delayKey))
+    if (watermarked.isEmpty) {
+      None
+    } else if (!allowMultipleEventTimeColumns &&
+        watermarked.map(_.exprId).toSet.size > 1) {
+      // Runtime rejects multiple distinct event-time columns in this mode.
+      None
+    } else {
+      Some(watermarked.head)
+    }
+  }
 
   /**
    * Check the provided logical plan to see if its join keys contain a watermark attribute.
@@ -48,6 +77,153 @@ object StreamingJoinHelper extends PredicateHelper with Logging {
           case _ => false
         }
       case _ => false
+    }
+  }
+
+  /**
+   * Whether both equality join keys at the state-key eviction ordinal are watermarked.
+   *
+   * This is required by outer-like equality joins (left outer). Eviction of left state must be
+   * aligned with late-event filtering on both sides: a right watermark drops late right rows after
+   * unmatched rows have been emitted, and a left watermark drops late left rows after the right
+   * state that could have matched them has been evicted.
+   *
+   * The eviction ordinal is chosen in the same way as
+   * StreamingSymmetricHashJoinHelper.findJoinKeyOrdinalForWatermark.
+   */
+  def isWatermarkOnBothEvictionJoinKeys(join: Join): Boolean = {
+    join match {
+      case ExtractEquiJoinKeys(_, leftKeys, rightKeys, _, _, _, _, _) =>
+        joinKeyOrdinalForWatermark(leftKeys, rightKeys).exists { ordinal =>
+          val leftRuntimeWatermark = runtimeWatermarkedAttribute(join.left.output)
+          val rightRuntimeWatermark = runtimeWatermarkedAttribute(join.right.output)
+          ordinal < leftKeys.length && ordinal < rightKeys.length &&
+            isWatermarked(leftKeys(ordinal)) && isWatermarked(rightKeys(ordinal)) &&
+            leftRuntimeWatermark.exists(leftKeys(ordinal).references.contains) &&
+            rightRuntimeWatermark.exists(rightKeys(ordinal).references.contains)
+        }
+      case _ => false
+    }
+  }
+
+  private def joinKeyOrdinalForWatermark(
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression]): Option[Int] = {
+    leftKeys.indexWhere(isWatermarked) match {
+      case i if i >= 0 => Some(i)
+      case _ =>
+        rightKeys.indexWhere(isWatermarked) match {
+          case i if i >= 0 => Some(i)
+          case _ => None
+        }
+    }
+  }
+
+  /**
+   * Like [[getStateValueWatermark]], but only succeeds when the state watermark is derived from
+   * watermarked attributes on both sides, and is actually a function of the other side's event
+   * watermark. This is useful for analysis-time validation of range conditions: the runtime
+   * value-watermark predicate is applied to the watermarked attribute on the side being evicted,
+   * so accepting a range bound over some other attribute would make the predicate either
+   * ineffective or incorrect.
+   *
+   * Restricting the eligible attributes to watermarked ones is not sufficient on its own:
+   * [[getStateValueWatermark]] requires the evicted side's watermarked attribute to appear in the
+   * condition (it is the attribute the state watermark is solved for), but it treats the
+   * watermark-providing side as satisfied whenever that side merely *has* a watermark, even one
+   * absent from the range bound. A predicate with a constant bound (e.g. `leftTime > <literal>`)
+   * would then still yield a state watermark -- but a constant one, not tied to the other stream's
+   * progress -- so the runtime eviction predicate degenerates to a static constant and the left
+   * state is not really evicted. We therefore additionally require the derived state watermark to
+   * move with the event watermark: a bound that is independent of it does not relate the two sides.
+   */
+  def getStateValueWatermarkOnWatermarkedAttributes(
+      attributesToFindStateWatermarkFor: Seq[Attribute],
+      attributesWithEventWatermark: Seq[Attribute],
+      joinCondition: Option[Expression],
+      eventWatermark: Option[Long],
+      allowMultipleEventTimeColumns: Boolean =
+        !SQLConf.get.getConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE)): Option[Long] = {
+    val evictedSide = runtimeWatermarkedAttribute(
+      attributesToFindStateWatermarkFor, allowMultipleEventTimeColumns)
+      .map(attr => AttributeSet(Seq(attr)))
+    val watermarkProvidingSide = runtimeWatermarkedAttribute(
+      attributesWithEventWatermark, allowMultipleEventTimeColumns)
+      .map(attr => AttributeSet(Seq(attr)))
+    val runtimeEvictedSide = AttributeSet(attributesToFindStateWatermarkFor)
+    val runtimeWatermarkProvidingSide = AttributeSet(attributesWithEventWatermark)
+    eventWatermark match {
+      case Some(wm) if evictedSide.isDefined && watermarkProvidingSide.isDefined =>
+        // Probe with two well-separated event watermark values; a genuine cross-stream range bound
+        // shifts the state watermark forward, whereas a constant or anti-monotonic bound does not.
+        val altWm = wm + 1000000L
+        if (hasNonAdvancingGenericOnlyStateWatermarkPredicate(
+            runtimeEvictedSide, runtimeWatermarkProvidingSide, evictedSide.get,
+            watermarkProvidingSide.get, joinCondition, wm, altWm)) {
+          return None
+        }
+        if (hasNonAdvancingStrictStateWatermarkPredicate(
+            evictedSide.get, watermarkProvidingSide.get, joinCondition, wm, altWm)) {
+          return None
+        }
+        val watermarkAt = getStateValueWatermark(
+          evictedSide.get, watermarkProvidingSide.get, joinCondition, Some(wm),
+          requireWatermarkSideInCondition = true)
+        val watermarkAtAlt = getStateValueWatermark(
+          evictedSide.get, watermarkProvidingSide.get, joinCondition, Some(altWm),
+          requireWatermarkSideInCondition = true)
+        (watermarkAt, watermarkAtAlt) match {
+          case (result @ Some(a), Some(b)) if b > a => result
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  private def hasNonAdvancingGenericOnlyStateWatermarkPredicate(
+      runtimeAttributesToFindStateWatermarkFor: AttributeSet,
+      runtimeAttributesWithEventWatermark: AttributeSet,
+      strictAttributesToFindStateWatermarkFor: AttributeSet,
+      strictAttributesWithEventWatermark: AttributeSet,
+      joinCondition: Option[Expression],
+      eventWatermark: Long,
+      altEventWatermark: Long): Boolean = {
+    joinCondition.exists { condition =>
+      splitConjunctivePredicates(condition).exists { predicate =>
+        val genericWatermark = getStateValueWatermark(
+          runtimeAttributesToFindStateWatermarkFor, runtimeAttributesWithEventWatermark,
+          Some(predicate), Some(eventWatermark))
+        val genericWatermarkAtAlt = getStateValueWatermark(
+          runtimeAttributesToFindStateWatermarkFor, runtimeAttributesWithEventWatermark,
+          Some(predicate), Some(altEventWatermark))
+        val strictWatermark = getStateValueWatermark(
+          strictAttributesToFindStateWatermarkFor, strictAttributesWithEventWatermark,
+          Some(predicate), Some(eventWatermark), requireWatermarkSideInCondition = true)
+        genericWatermark.exists { watermark =>
+          strictWatermark.isEmpty && genericWatermarkAtAlt.forall(_ <= watermark)
+        }
+      }
+    }
+  }
+
+  private def hasNonAdvancingStrictStateWatermarkPredicate(
+      strictAttributesToFindStateWatermarkFor: AttributeSet,
+      strictAttributesWithEventWatermark: AttributeSet,
+      joinCondition: Option[Expression],
+      eventWatermark: Long,
+      altEventWatermark: Long): Boolean = {
+    joinCondition.exists { condition =>
+      splitConjunctivePredicates(condition).exists { predicate =>
+        val watermark = getStateValueWatermark(
+          strictAttributesToFindStateWatermarkFor, strictAttributesWithEventWatermark,
+          Some(predicate), Some(eventWatermark), requireWatermarkSideInCondition = true)
+        val watermarkAtAlt = getStateValueWatermark(
+          strictAttributesToFindStateWatermarkFor, strictAttributesWithEventWatermark,
+          Some(predicate), Some(altEventWatermark), requireWatermarkSideInCondition = true)
+        watermark.exists { value =>
+          watermarkAtAlt.forall(_ <= value)
+        }
+      }
     }
   }
 
@@ -73,6 +249,20 @@ object StreamingJoinHelper extends PredicateHelper with Logging {
       attributesWithEventWatermark: AttributeSet,
       joinCondition: Option[Expression],
       eventWatermark: Option[Long]): Option[Long] = {
+    getStateValueWatermark(
+      attributesToFindStateWatermarkFor,
+      attributesWithEventWatermark,
+      joinCondition,
+      eventWatermark,
+      requireWatermarkSideInCondition = false)
+  }
+
+  private def getStateValueWatermark(
+      attributesToFindStateWatermarkFor: AttributeSet,
+      attributesWithEventWatermark: AttributeSet,
+      joinCondition: Option[Expression],
+      eventWatermark: Option[Long],
+      requireWatermarkSideInCondition: Boolean): Option[Long] = {
 
     // If condition or event time watermark is not provided, then cannot calculate state watermark
     if (joinCondition.isEmpty || eventWatermark.isEmpty) return None
@@ -83,7 +273,8 @@ object StreamingJoinHelper extends PredicateHelper with Logging {
     def getStateWatermarkSafely(l: Expression, r: Expression): Option[Long] = {
       try {
         getStateWatermarkFromLessThenPredicate(
-          l, r, attributesToFindStateWatermarkFor, attributesWithEventWatermark, eventWatermark)
+          l, r, attributesToFindStateWatermarkFor, attributesWithEventWatermark, eventWatermark,
+          requireWatermarkSideInCondition)
       } catch {
         case NonFatal(e) =>
           logWarning(log"Error trying to extract state constraint from condition " +
@@ -132,15 +323,32 @@ object StreamingJoinHelper extends PredicateHelper with Logging {
       rightExpr: Expression,
       attributesToFindStateWatermarkFor: AttributeSet,
       attributesWithEventWatermark: AttributeSet,
-      eventWatermark: Option[Long]): Option[Long] = {
+      eventWatermark: Option[Long],
+      requireWatermarkSideInCondition: Boolean): Option[Long] = {
 
-    val attributesInCondition = AttributeSet(
+    val attributesInConditionSeq =
       leftExpr.collect { case a: AttributeReference => a } ++
-      rightExpr.collect { case a: AttributeReference => a }
-    )
-    if (attributesInCondition.count(attributesToFindStateWatermarkFor.contains) > 1 ||
-        attributesInCondition.count(attributesWithEventWatermark.contains) > 1) {
+        rightExpr.collect { case a: AttributeReference => a }
+    val attributesInCondition = AttributeSet(attributesInConditionSeq)
+    val stateSideAttributeCount =
+      if (requireWatermarkSideInCondition) {
+        attributesInConditionSeq.count(attributesToFindStateWatermarkFor.contains)
+      } else {
+        attributesInCondition.count(attributesToFindStateWatermarkFor.contains)
+      }
+    val watermarkSideAttributeCount =
+      if (requireWatermarkSideInCondition) {
+        attributesInConditionSeq.count(attributesWithEventWatermark.contains)
+      } else {
+        attributesInCondition.count(attributesWithEventWatermark.contains)
+      }
+    if (stateSideAttributeCount > 1 || watermarkSideAttributeCount > 1) {
       // If more than attributes present in condition from one side, then it cannot be solved
+      return None
+    }
+    if (requireWatermarkSideInCondition && watermarkSideAttributeCount == 0) {
+      // A state watermark must move with the other side's event watermark. A bound that does not
+      // reference the watermark-providing side may produce a constant, but not a valid watermark.
       return None
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -722,5 +722,112 @@ object UnsupportedOperationChecker extends Logging {
           "is not supported without a watermark in the join keys, or a watermark on " +
           "the nullable side and an appropriate range condition")(join)
     }
+
+    // The generic check above is side- and ordinal-insensitive: it accepts any watermark in the
+    // join keys, or any watermark that yields a state value watermark on the nullable side. That is
+    // not enough for the join types whose output (or bounded state size) depends on the left state
+    // being evicted: left semi and left outer. The stricter, per-join-type requirements are applied
+    // below; for the join types that previously ran under the loose behavior they can be
+    // temporarily disabled with SQLConf.STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED.
+    checkStreamStreamJoinWatermarkPlacement(join, watermarkInJoinKeys)
+  }
+
+  /**
+   * Enforce stricter watermark-placement requirements for the stream-stream join types whose
+   * correctness or bounded state depends on the left-side state being evicted: left semi and left
+   * outer. These requirements are stricter than the generic check in
+   * [[checkForStreamStreamJoinWatermark]]. For the join types that previously ran under the loose
+   * behavior (left semi and left outer) they are gated by
+   * [[SQLConf.STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED]] so the behavioral change can
+   * be reverted; a newly supported join type (e.g. left anti) would enforce them unconditionally.
+   *
+   * Two independent requirements apply:
+   *
+   *  1. Left-state eviction. Left semi/outer both rely on the left state being evicted: left outer
+   *     emits its surviving unmatched left rows from that eviction (so without it the outer output
+   *     is never produced), and left semi cleans up its never-matched left rows there (so without
+   *     it the left state grows without bound). In the equi-join path the left key state is evicted
+   *     through the shared watermarked join key. In the range-condition path the left *value* state
+   *     is evicted only when the range condition derives the left state watermark from watermarked
+   *     attributes on both sides.
+   *
+   *  2. No invalidation by late rows. This applies only to left outer, whose already-emitted
+   *     unmatched (null-extended) row can be invalidated by a later match. Both sides must be
+   *     late-filtered on the same dimension the left state is evicted by; otherwise a row that is
+   *     old on the eviction key can still match an already-emitted unmatched row. In the equi-join
+   *     path this requires both join keys at the eviction ordinal to be watermarked. Left semi does
+   *     not need this: it emits on match while joining, never at eviction, so there is nothing to
+   *     invalidate.
+   */
+  private def checkStreamStreamJoinWatermarkPlacement(
+      join: Join,
+      watermarkInJoinKeys: Boolean): Unit = {
+    // (requiresLeftStateEviction, isOuterLike, canRestorePreviousBehavior) per join type. Only the
+    // left-side-eviction join types are constrained here; inner, right outer, and full outer keep
+    // their existing behavior.
+    //
+    // canRestorePreviousBehavior marks join types whose stricter requirement is a revertible
+    // behavioral change: left semi and left outer previously ran under the loose generic check, so
+    // their check is gated by the kill switch below and their error offers a restore hint. A newly
+    // supported join type (e.g. left anti), which never ran under the loose behavior, would set
+    // this to false so the requirement is always enforced and no restore hint is offered.
+    val (requiresLeftStateEviction, isOuterLike, canRestorePreviousBehavior) = join.joinType match {
+      case LeftOuter => (true, true, true)
+      case LeftSemi => (true, false, true)
+      case _ => (false, false, false)
+    }
+
+    // Kill switch: when this join type's stricter requirement is a revertible behavioral change and
+    // the user has opted out, skip it and fall back to the previous, looser behavior.
+    if (canRestorePreviousBehavior && !SQLConf.get.streamingJoinStricterWatermarkRequirements) {
+      return
+    }
+
+    if (requiresLeftStateEviction) {
+      val restore =
+        if (canRestorePreviousBehavior) {
+          " To restore the previous behavior, set " +
+            s"${SQLConf.STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED.key}=false."
+        } else {
+          ""
+        }
+      if (watermarkInJoinKeys) {
+        // Equi-join path: the left key state is evicted via the join-key watermark, so the
+        // eviction requirement is met. For the outer-like types we additionally need both sides
+        // late-filtered on the same key ordinal used for eviction. A watermark on only one side, on
+        // an unrelated column, or on a different key position (composite keys) would let a late row
+        // match an already-emitted unmatched row.
+        if (isOuterLike && !StreamingJoinHelper.isWatermarkOnBothEvictionJoinKeys(join)) {
+          throwError(
+            s"Stream-stream ${join.joinType} join between two streaming DataFrame/Datasets with " +
+              "a watermarked join key requires watermarks on both join keys used for state " +
+              "eviction (for a composite key, the left and right keys at the same position), so " +
+              "that late rows on either side are dropped and cannot invalidate already-emitted " +
+              s"unmatched rows. A watermark on only one side is not supported.$restore")(join)
+        }
+      } else {
+        // Range-condition path (hasValidWatermarkRange holds here): the left state is evicted only
+        // when the range condition derives its state watermark from watermarked attributes on both
+        // sides. A right-only watermark, or a watermark on an unrelated left/right attribute,
+        // leaves the runtime eviction predicate ineffective or incorrect.
+        val hasWatermarkRangeOnBothSides =
+          StreamingJoinHelper.getStateValueWatermarkOnWatermarkedAttributes(
+            join.left.output, join.right.output, join.condition, Some(1000000)).isDefined
+        if (!hasWatermarkRangeOnBothSides) {
+          val reason =
+            if (isOuterLike) {
+              "so that the left state whose surviving unmatched rows form the " +
+                s"${join.joinType} output is evicted"
+            } else {
+              "so that the left state is evicted and does not grow without bound"
+            }
+          throwError(
+            s"Stream-stream ${join.joinType} join between two streaming DataFrame/Datasets with " +
+              "a range condition requires a range bound between watermarked attributes on both " +
+              s"sides, $reason. A watermark on only one side, or on an unrelated attribute, is " +
+              s"not supported.$restore")(join)
+        }
+      }
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3857,6 +3857,22 @@ object SQLConf {
       .checkValue(v => Set(1, 2, 3, 4).contains(v), "Valid versions are 1, 2, 3, and 4")
       .createWithDefault(2)
 
+  val STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED =
+    buildConf("spark.sql.streaming.join.stricterWatermarkRequirements.enabled")
+      .doc("When true, the analyzer enforces stricter watermark-placement requirements for " +
+        "stream-stream left semi and left outer joins, so that the left-side state which their " +
+        "output (or bounded state size) depends on is actually evicted, and, for left outer, so " +
+        "that late rows cannot invalidate an already-emitted unmatched row. Configurations that " +
+        "would otherwise silently produce incorrect results or unbounded state (e.g. a " +
+        "range-condition join whose range bound is not between watermarked attributes on both " +
+        "sides, or a left outer equality join whose eviction key is not watermarked on both " +
+        "sides) are rejected. Set this to false to restore the previous, looser behavior for " +
+        "left semi and left outer joins.")
+      .version("4.4.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(true)
+
   val STREAMING_SESSION_WINDOW_MERGE_SESSIONS_IN_LOCAL_PARTITION =
     buildConf("spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition")
       .doc("When true, streaming session window sorts and merge sessions in local partition " +
@@ -8693,6 +8709,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def stateStoreSkipNullsForStreamStreamJoins: Boolean =
     getConf(STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS)
+
+  def streamingJoinStricterWatermarkRequirements: Boolean =
+    getConf(STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED)
 
   def stateStoreCoordinatorMultiplierForMinVersionDiffToLog: Long =
     getConf(STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_VERSION_DIFF_TO_LOG)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -477,8 +477,11 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
       Seq("is not supported in Complete output mode", allowedModesMsg))
   }
 
-  // Left outer, right outer, full outer, left semi joins
-  Seq(LeftOuter, RightOuter, FullOuter, LeftSemi).foreach { joinType =>
+  // Right outer and full outer joins keep the side-insensitive watermark behavior. Left outer and
+  // left semi are handled in a dedicated block below: they have stricter watermark-placement
+  // requirements (see checkStreamStreamJoinWatermarkPlacement), so the side-insensitive cases here
+  // do not all apply to them.
+  Seq(RightOuter, FullOuter).foreach { joinType =>
     // Stream-stream allowed with join on watermark attribute
     // Note that the attribute need not be watermarked on both sides.
     assertSupportedInStreamingPlan(
@@ -523,6 +526,331 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
       OutputMode.Append(),
       Seq("is not supported without a watermark in the join keys, or a watermark on " +
         "the nullable side and an appropriate range condition"))
+  }
+
+  // Left outer and left semi joins: stricter watermark-placement requirements (see
+  // checkStreamStreamJoinWatermarkPlacement) gated by
+  // STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED. Their left-side state must be
+  // evicted -- left outer emits its unmatched rows from that eviction, left semi cleans up its
+  // never-matched rows there -- and left outer, being outer-like, additionally needs both sides
+  // late-filtered on the eviction key so late rows cannot invalidate already-emitted unmatched
+  // rows. Distinct attributes per side avoid exprId collisions in these synthetic plans.
+  {
+    val leftWm = AttributeReference("olw", IntegerType)().withMetadata(watermarkMetadata)
+    val rightWm = AttributeReference("orw", IntegerType)().withMetadata(watermarkMetadata)
+    val leftPlain = AttributeReference("olp", IntegerType)()
+    val rightPlain = AttributeReference("orp", IntegerType)()
+    val leftOtherWm = AttributeReference("olo", IntegerType)().withMetadata(watermarkMetadata)
+    val rightOtherWm = AttributeReference("oro", IntegerType)().withMetadata(watermarkMetadata)
+    val strictKey = SQLConf.STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED.key
+
+    Seq(LeftOuter, LeftSemi).foreach { joinType =>
+      // Supported: range condition with a watermark on both sides (the left value state is evicted
+      // on its own watermark, derived from the right watermark).
+      assertSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, watermark on both sides",
+        new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10)),
+        OutputMode.Append())
+
+      // Not supported: range condition with a watermark on the right only -- the left state is
+      // never evicted (so left outer never emits its unmatched rows, and left semi's left state
+      // grows without bound).
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, right watermark only",
+        new TestStreamingRelation(leftPlain).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftPlain > rightWm + 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: the left watermark is unrelated to the range-bound left attribute, so the
+      // runtime eviction predicate would be applied to the wrong column.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, unrelated left " +
+          "watermark",
+        new TestStreamingRelation(Seq(leftPlain, leftOtherWm)).join(
+          new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftPlain > rightWm + 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: the right watermark is unrelated to the range-bound right attribute, so the
+      // state watermark cannot be derived from the runtime late-filtering column.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, unrelated right " +
+          "watermark",
+        new TestStreamingRelation(leftWm).join(
+          new TestStreamingRelation(Seq(rightPlain, rightOtherWm)),
+          joinType = joinType, condition = Some(leftWm > rightPlain + 10)),
+        OutputMode.Append(),
+        Seq("without a watermark in the join keys"))
+
+      // Not supported: the range bound is a constant rather than the other stream's event time.
+      // The right side has a watermark, but it does not appear in the bound, so the derived left
+      // state watermark is a fixed constant not tied to the right stream's progress -- the left
+      // state would not really be evicted. (Rejected even though the generic check, which only
+      // requires the right side to have some watermark, accepts it.)
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, constant bound",
+        new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm > 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: the dynamic range bound is otherwise valid, but runtime uses the minimum
+      // generic state watermark across conjuncts. A static conjunct could pin that watermark and
+      // prevent the left state from being evicted as the right watermark advances.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, static conjunct",
+        new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10 && leftWm > 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: runtime derives state watermarks from the full left output before applying
+      // them to the left event-time column. A static conjunct on another left column could
+      // therefore pin the left event-time state watermark even when the event-time range is valid.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, static conjunct " +
+          "on non-watermarked left attribute",
+        new TestStreamingRelation(Seq(leftWm, leftPlain)).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10 && leftPlain > 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Supported: a non-watermarked left conjunct that also derives an advancing state watermark
+      // from the right event-time watermark does not pin runtime eviction. The valid event-time
+      // range bound above still proves old left event-time rows cannot match future right rows.
+      assertSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and range condition, dynamic conjunct " +
+          "on non-watermarked left attribute",
+        new TestStreamingRelation(Seq(leftWm, leftPlain)).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10 &&
+            leftPlain > rightWm + 10)),
+        OutputMode.Append())
+
+      // Not supported: this predicate changes as the right watermark changes, but in the wrong
+      // direction. It does not prove old left rows can no longer match future right rows.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and anti-monotonic range condition",
+        new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm + rightWm > 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: a valid advancing bound must not hide a second strict bound whose derived
+      // state watermark moves backward as the right watermark advances. That second bound can
+      // become the runtime minimum later and stop left-state eviction from advancing.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and masked anti-monotonic range condition",
+        new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10 &&
+            leftWm + rightWm > 10000000)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: repeating the event-time attribute makes the derived state watermark unsafe
+      // because the range condition is no longer a unit-coefficient bound between the two sides.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and repeated event-time range attribute",
+        new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftWm + leftWm > rightWm)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // Not supported: an "insufficient" range condition (wrong inequality direction) yields no
+      // left state watermark and is rejected by the generic check. This change is specifically
+      // about tightening the range-condition boundary, so keep explicit coverage that it still
+      // rejects here.
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and insufficient range condition",
+        new TestStreamingRelation(leftPlain).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftPlain < rightWm + 10)),
+        OutputMode.Append(),
+        Seq("an appropriate range condition"))
+
+      // The generic rejection is independent of the kill switch: disabling the stricter
+      // requirements does not relax it, so the insufficient range condition is still rejected.
+      test(s"streaming plan - $joinType join, insufficient range condition, still rejected " +
+        "when stricter reqs off: not supported") {
+        withSQLConf(strictKey -> "false") {
+          val e = intercept[AnalysisException] {
+            UnsupportedOperationChecker.checkForStreaming(
+              wrapInStreaming(new TestStreamingRelation(leftPlain).join(
+                new TestStreamingRelation(rightWm),
+                joinType = joinType, condition = Some(leftPlain < rightWm + 10))),
+              OutputMode.Append())
+          }
+          assert(e.getMessage.contains("an appropriate range condition"))
+        }
+      }
+
+      // Kill switch: with the stricter requirements disabled, the right-only range config falls
+      // back to the previous (looser) behavior and is accepted again.
+      assertSupportedInStreamingPlan(
+        s"$joinType join, right watermark only, accepted when stricter requirements disabled",
+        new TestStreamingRelation(leftPlain).join(new TestStreamingRelation(rightWm),
+          joinType = joinType, condition = Some(leftPlain > rightWm + 10)),
+        OutputMode.Append(),
+        strictKey -> "false")
+    }
+
+    Seq(LeftOuter, LeftSemi).foreach { joinType =>
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with multiple event-time columns and first-column range watermark in " +
+          "default mode",
+        new TestStreamingRelation(Seq(leftWm, leftOtherWm)).join(
+          new TestStreamingRelation(Seq(rightWm, rightOtherWm)),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      // In legacy stateful-operator mode, runtime uses the first event-time column for value-state
+      // eviction. Accept the range only when that first column is the range column.
+      assertSupportedInStreamingPlan(
+        s"$joinType join with multiple event-time columns and first-column range watermark",
+        new TestStreamingRelation(Seq(leftWm, leftOtherWm)).join(
+          new TestStreamingRelation(Seq(rightWm, rightOtherWm)),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10)),
+        OutputMode.Append(),
+        SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key -> "false")
+
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with multiple event-time columns and later-column range watermark",
+        new TestStreamingRelation(Seq(leftOtherWm, leftWm)).join(
+          new TestStreamingRelation(Seq(rightOtherWm, rightWm)),
+          joinType = joinType, condition = Some(leftWm > rightWm + 10)),
+        OutputMode.Append(),
+        Seq("requires a range bound between watermarked attributes on both sides"))
+
+      test(s"streaming plan - $joinType join with multiple event-time columns and " +
+        "later-column range watermark in legacy mode: not supported") {
+        withSQLConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key -> "false") {
+          val e = intercept[AnalysisException] {
+            UnsupportedOperationChecker.checkForStreaming(
+              wrapInStreaming(new TestStreamingRelation(Seq(leftOtherWm, leftWm)).join(
+                new TestStreamingRelation(Seq(rightOtherWm, rightWm)),
+                joinType = joinType, condition = Some(leftWm > rightWm + 10))),
+              OutputMode.Append())
+          }
+          assert(e.getMessage.contains(
+            "requires a range bound between watermarked attributes on both sides"))
+        }
+      }
+    }
+
+    // Left semi is not outer-like: it emits on match, never at eviction, so the equi-join path has
+    // no no-invalidation requirement. A one-sided key watermark is enough to evict the left key
+    // state through the shared equality key.
+    assertSupportedInStreamingPlan(
+      "left semi join with stream-stream relations and join key watermarked on the right side only",
+      new TestStreamingRelation(leftPlain).join(new TestStreamingRelation(rightWm),
+        joinType = LeftSemi, condition = Some(leftPlain === rightWm)),
+      OutputMode.Append())
+    assertSupportedInStreamingPlan(
+      "left semi join with stream-stream relations and join key watermarked on the left side only",
+      new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightPlain),
+        joinType = LeftSemi, condition = Some(leftWm === rightPlain)),
+      OutputMode.Append())
+
+    // Left outer is outer-like, so equality joins require both keys at the eviction ordinal to be
+    // watermarked. Otherwise one side is not late-filtered on the dimension used to evict state.
+    assertSupportedInStreamingPlan(
+      "left outer join with stream-stream relations and both join keys watermarked",
+      new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightWm),
+        joinType = LeftOuter, condition = Some(leftWm === rightWm)),
+      OutputMode.Append())
+    assertNotSupportedInStreamingPlan(
+      "left outer join with multiple event-time columns and first-column key watermark in " +
+        "default mode",
+      new TestStreamingRelation(Seq(leftWm, leftOtherWm)).join(
+        new TestStreamingRelation(Seq(rightWm, rightOtherWm)),
+        joinType = LeftOuter, condition = Some(leftWm === rightWm)),
+      OutputMode.Append(),
+      Seq("requires watermarks on both join keys used for state eviction"))
+    assertSupportedInStreamingPlan(
+      "left outer join with multiple event-time columns and first-column key watermark",
+      new TestStreamingRelation(Seq(leftWm, leftOtherWm)).join(
+        new TestStreamingRelation(Seq(rightWm, rightOtherWm)),
+        joinType = LeftOuter, condition = Some(leftWm === rightWm)),
+      OutputMode.Append(),
+      SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key -> "false")
+    Seq(
+      ("right side only", leftPlain, rightWm),
+      ("left side only", leftWm, rightPlain)
+    ).foreach { case (side, leftKey, rightKey) =>
+      assertNotSupportedInStreamingPlan(
+        s"left outer join with stream-stream relations and join key watermarked on $side",
+        new TestStreamingRelation(leftKey).join(new TestStreamingRelation(rightKey),
+          joinType = LeftOuter, condition = Some(leftKey === rightKey)),
+        OutputMode.Append(),
+        Seq("requires watermarks on both join keys used for state eviction"))
+    }
+
+    assertNotSupportedInStreamingPlan(
+      "left outer join with stream-stream relations and watermark on an unrelated right column",
+      new TestStreamingRelation(leftWm).join(
+        new TestStreamingRelation(Seq(rightPlain, rightWm)),
+        joinType = LeftOuter, condition = Some(leftWm === rightPlain)),
+      OutputMode.Append(),
+      Seq("requires watermarks on both join keys used for state eviction"))
+
+    test("streaming plan - left outer join with multiple event-time columns and later-column " +
+      "key watermark in legacy mode: not supported") {
+      withSQLConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key -> "false") {
+        val e = intercept[AnalysisException] {
+          UnsupportedOperationChecker.checkForStreaming(
+            wrapInStreaming(new TestStreamingRelation(Seq(leftOtherWm, leftWm)).join(
+              new TestStreamingRelation(Seq(rightOtherWm, rightWm)),
+              joinType = LeftOuter, condition = Some(leftWm === rightWm))),
+            OutputMode.Append())
+        }
+        assert(e.getMessage.contains("requires watermarks on both join keys used for state"))
+      }
+    }
+
+    // Composite equality keys. State-key eviction uses a single ordinal (the first watermarked
+    // left key), so both keys at that ordinal must be watermarked.
+    val outerLeftWm1 = AttributeReference("olw1", IntegerType)().withMetadata(watermarkMetadata)
+    val outerLeftPlain2 = AttributeReference("olp2", IntegerType)()
+    val outerRightWm1 = AttributeReference("orw1", IntegerType)().withMetadata(watermarkMetadata)
+    val outerRightPlain1 = AttributeReference("orp1", IntegerType)()
+    val outerRightPlain2 = AttributeReference("orp2", IntegerType)()
+    val outerRightWm2 = AttributeReference("orw2", IntegerType)().withMetadata(watermarkMetadata)
+
+    assertSupportedInStreamingPlan(
+      "left outer join with stream-stream relations and composite key watermarked at same ordinal",
+      new TestStreamingRelation(Seq(outerLeftWm1, outerLeftPlain2)).join(
+        new TestStreamingRelation(Seq(outerRightWm1, outerRightPlain2)),
+        joinType = LeftOuter,
+        condition = Some(outerLeftWm1 === outerRightWm1 &&
+          outerLeftPlain2 === outerRightPlain2)),
+      OutputMode.Append())
+
+    assertNotSupportedInStreamingPlan(
+      "left outer join with stream-stream relations and composite key watermarked on mismatched " +
+        "ordinals",
+      new TestStreamingRelation(Seq(outerLeftWm1, outerLeftPlain2)).join(
+        new TestStreamingRelation(Seq(outerRightPlain1, outerRightWm2)),
+        joinType = LeftOuter,
+        condition = Some(outerLeftWm1 === outerRightPlain1 &&
+          outerLeftPlain2 === outerRightWm2)),
+      OutputMode.Append(),
+      Seq("requires watermarks on both join keys used for state eviction"))
+
+    // Kill switch: accepted again when the stricter requirements are disabled.
+    assertSupportedInStreamingPlan(
+      "left outer join, right-only key watermark, accepted when stricter requirements disabled",
+      new TestStreamingRelation(leftPlain).join(new TestStreamingRelation(rightWm),
+        joinType = LeftOuter, condition = Some(leftPlain === rightWm)),
+      OutputMode.Append(),
+      strictKey -> "false")
+    assertSupportedInStreamingPlan(
+      "left outer join, left-only key watermark, accepted when stricter requirements disabled",
+      new TestStreamingRelation(leftWm).join(new TestStreamingRelation(rightPlain),
+        joinType = LeftOuter, condition = Some(leftWm === rightPlain)),
+      OutputMode.Append(),
+      strictKey -> "false")
   }
 
   // multi-aggregations only supported in Append mode

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -239,16 +239,19 @@ abstract class StreamingJoinSuite
       joinType: String,
       watermark: String = "10 seconds",
       lowerBound: String = "interval 5 seconds",
-      upperBound: String = "interval 5 seconds")
+      upperBound: String = "interval 5 seconds",
+      leftWatermark: Boolean = true)
     : (MemoryStream[(Int, Int)], MemoryStream[(Int, Int)], DataFrame) = {
 
     val leftInput = MemoryStream[(Int, Int)]
     val rightInput = MemoryStream[(Int, Int)]
 
-    val df1 = leftInput.toDF().toDF("leftKey", "time")
+    val df1Base = leftInput.toDF().toDF("leftKey", "time")
       .select($"leftKey", timestamp_seconds($"time") as "leftTime",
         ($"leftKey" * 2) as "leftValue")
-      .withWatermark("leftTime", watermark)
+    // Left semi/outer require range bounds over watermarked attributes on both sides. Allow tests
+    // to omit the left watermark to exercise that analyzer path.
+    val df1 = if (leftWatermark) df1Base.withWatermark("leftTime", watermark) else df1Base
 
     val df2 = rightInput.toDF().toDF("rightKey", "time")
       .select($"rightKey", timestamp_seconds($"time") as "rightTime",
@@ -1983,6 +1986,57 @@ abstract class StreamingOuterJoinSuite extends StreamingOuterJoinBase {
       }
     }
   }
+
+  test("left outer join with a range condition requires watermarked bounds on both sides") {
+    // Only the right side is watermarked. With a range condition (no watermark in the join keys),
+    // the operator never builds a left-side eviction predicate, so the unmatched (null-extended)
+    // left rows would never be emitted. This must be rejected at analysis time rather than silently
+    // dropping the outer output.
+    val (_, _, joined) = setupJoinWithRangeCondition("left_outer", leftWatermark = false)
+
+    val e = intercept[AnalysisException] {
+      joined.writeStream.format("memory").queryName("leftOuterRightWatermarkOnly")
+        .outputMode(OutputMode.Append()).start()
+    }
+    assert(e.getMessage.contains(
+      "requires a range bound between watermarked attributes on both sides"))
+  }
+
+  test("left outer join with an equi join key watermarked on the left only is rejected") {
+    // The join key is watermarked on the left only, so the right side is not late-filtered on the
+    // eviction key: a late right row could match a left row already emitted as a null-extended
+    // outer row. Rejected at analysis time.
+    val leftInput = MemoryStream[(Int, Int)]
+    val rightInput = MemoryStream[(Int, Int)]
+    val df1 = leftInput.toDF().toDF("key", "time")
+      .select($"key", timestamp_seconds($"time") as "leftTime")
+      .withWatermark("leftTime", "10 seconds")
+    val df2 = rightInput.toDF().toDF("key", "time")
+      .select($"key", timestamp_seconds($"time") as "rightTime")
+    val joined = df1.join(df2, expr("leftTime = rightTime"), "left_outer")
+
+    val e = intercept[AnalysisException] {
+      joined.writeStream.format("memory").queryName("leftOuterLeftKeyWatermarkOnly")
+        .outputMode(OutputMode.Append()).start()
+    }
+    assert(e.getMessage.contains("requires watermarks on both join keys used for state eviction"))
+  }
+
+  test("stricter watermark requirements can be disabled for left outer join") {
+    // With the kill switch off, the right-only range config that is otherwise rejected is accepted
+    // again (falling back to the previous, looser behavior).
+    withSQLConf(
+      SQLConf.STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED.key -> "false") {
+      val (_, _, joined) = setupJoinWithRangeCondition("left_outer", leftWatermark = false)
+      val query = joined.writeStream.format("memory")
+        .queryName("leftOuterFallback").outputMode(OutputMode.Append()).start()
+      try {
+        query.processAllAvailable()
+      } finally {
+        query.stop()
+      }
+    }
+  }
 }
 
 @SlowSQLTest
@@ -2596,6 +2650,36 @@ abstract class StreamingLeftSemiJoinSuite extends StreamingLeftSemiJoinBase {
         Row(Timestamp.valueOf("2024-02-10 10:24:00"), 5, 5, 5),
       )
        */
+    }
+  }
+
+  test("left semi join with a range condition requires watermarked bounds on both sides") {
+    // With only the right side watermarked and a range condition (no watermark in the join keys),
+    // the left state is never evicted, so never-matched left rows accumulate without bound. This is
+    // rejected at analysis time.
+    val (_, _, joined) = setupJoinWithRangeCondition("left_semi", leftWatermark = false)
+
+    val e = intercept[AnalysisException] {
+      joined.writeStream.format("memory").queryName("leftSemiRightWatermarkOnly")
+        .outputMode(OutputMode.Append()).start()
+    }
+    assert(e.getMessage.contains(
+      "requires a range bound between watermarked attributes on both sides"))
+  }
+
+  test("stricter watermark requirements can be disabled for left semi join") {
+    // With the kill switch off, the right-only range config falls back to the previous behavior and
+    // is accepted again.
+    withSQLConf(
+      SQLConf.STREAMING_JOIN_STRICTER_WATERMARK_REQUIREMENTS_ENABLED.key -> "false") {
+      val (_, _, joined) = setupJoinWithRangeCondition("left_semi", leftWatermark = false)
+      val query = joined.writeStream.format("memory")
+        .queryName("leftSemiFallback").outputMode(OutputMode.Append()).start()
+      try {
+        query.processAllAvailable()
+      } finally {
+        query.stop()
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Stream-stream left semi and left outer joins rely on the left-side state being evicted by the watermark, but the analyzer did not require the watermark to be placed where that eviction can happen. This adds a shared analyzer check, `checkStreamStreamJoinWatermarkPlacement`, with two requirements: 

(1) left-state eviction for both types (the equi eviction key must be watermarked, or the range bound must sit between watermarked attributes on both sides); 
(2) for left outer only, both eviction-ordinal join keys must be watermarked so a late row cannot invalidate an already-emitted unmatched row. The new helpers mirror the runtime's own attribute selection so the analyzer rejects exactly the placements the runtime cannot honor. 

It is gated by a kill switch, `spark.sql.streaming.join.stricterWatermarkRequirements.enabled` (default true), to restore the previous behavior. This is the shared-code fix split out of #57813 (SPARK-58611, left anti).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
With only the right side watermarked, or the watermark on the wrong join-key ordinal or an unrelated attribute, the runtime builds no left-eviction predicate. Left outer then silently drops its unmatched output, and left semi state grows without bound. These placements should be rejected at analysis time rather than run incorrectly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Some stream-stream left semi and left outer queries that previously ran now fail with an `AnalysisException` explaining the required watermark placement. The behavior can be reverted with `spark.sql.streaming.join.stricterWatermarkRequirements.enabled=false`. 
Documented in the Structured Streaming migration guide (4.3 to 4.4).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added analyzer tests in `UnsupportedOperationsSuite` (range both-sides, right-only, unrelated attribute, constant and anti-monotonic bounds, multiple event-time columns, one-sided and both-sided equi keys, composite keys, kill-switch fallback) and runtime tests in `StreamingJoinSuite` for left outer and left semi. Ran locally: `UnsupportedOperationsSuite` (261) and `StreamingOuterJoinWithoutVCFSuite` + `StreamingLeftSemiJoinWithoutVCFSuite` (74), all pass.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Opus 4.8)