### PR TITLE
[SPARK-58893][UI] Fix Spark UI multi-cluster reverse proxy: propagate…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -238,6 +238,8 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _files: Seq[String] = _
   private var _archives: Seq[String] = _
   private var _shutdownHookRef: AnyRef = _
+  private var _previousProxyBase: Option[String] = None
+  private var _proxyBaseSetByContext: Boolean = false
   private var _statusStore: AppStatusStore = _
   private var _heartbeater: Heartbeater = _
   private var _resources: immutable.Map[String, ResourceInformation] = _
@@ -636,8 +638,20 @@ class SparkContext(config: SparkConf) extends Logging {
     }
 
     if (_conf.get(UI_REVERSE_PROXY)) {
-      val proxyUrl = _conf.get(UI_REVERSE_PROXY_URL).getOrElse("").stripSuffix("/")
-      System.setProperty("spark.ui.proxyBase", proxyUrl + "/proxy/" + _applicationId)
+      _previousProxyBase = sys.props.get("spark.ui.proxyBase")
+      val deploymentPrefix = _previousProxyBase.filterNot(isAppSpecificProxyBase)
+      val baseProxyUrl = _conf.get(UI_REVERSE_PROXY_URL)
+        .orElse(deploymentPrefix)
+        .getOrElse("")
+        .stripSuffix("/")
+      val newProxyBase = if (baseProxyUrl.nonEmpty) {
+        s"$baseProxyUrl/proxy/${_applicationId}"
+      } else {
+        s"/proxy/${_applicationId}"
+      }
+      _conf.set("spark.ui.proxyBase", newProxyBase)
+      System.setProperty("spark.ui.proxyBase", newProxyBase)
+      _proxyBaseSetByContext = true
     }
     _ui.foreach(_.setAppId(_applicationId))
     _env.blockManager.initialize(_applicationId)
@@ -2399,6 +2413,14 @@ class SparkContext(config: SparkConf) extends Logging {
     if (_statusStore != null) {
       _statusStore.close()
     }
+    if (_proxyBaseSetByContext) {
+      _previousProxyBase match {
+        case Some(oldBase) if !isAppSpecificProxyBase(oldBase) =>
+          System.setProperty("spark.ui.proxyBase", oldBase)
+        case _ =>
+          System.clearProperty("spark.ui.proxyBase")
+      }
+    }
     // Clear this `InheritableThreadLocal`, or it will still be inherited in child threads even this
     // `SparkContext` is stopped.
     localProperties.remove()
@@ -2406,6 +2428,13 @@ class SparkContext(config: SparkConf) extends Logging {
     // Unset YARN mode system env variable, to allow switching between cluster types.
     SparkContext.clearActiveContext()
     logInfo("Successfully stopped SparkContext")
+  }
+
+  private def isAppSpecificProxyBase(proxyBase: String): Boolean = {
+    val clean = proxyBase.stripSuffix("/")
+    clean.contains("/proxy/application_") ||
+      clean.contains("/proxy/app-") ||
+      clean.contains("/proxy/spark-")
   }
 
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -1345,11 +1345,24 @@ private[deploy] class Master(
     desc.copy(command = desc.command.copy(arguments = arguments, javaOpts = javaOpts))
   }
 
+  private def maybeAddReverseProxyConfig(desc: DriverDescription): DriverDescription = {
+    if (!reverseProxy) return desc
+    conf.get(UI_REVERSE_PROXY_URL).map(_.stripSuffix("/")).filter(_.nonEmpty) match {
+      case Some(url) =>
+        val opt = s"-Dspark.ui.reverseProxyUrl=$url"
+        val javaOpts = desc.command.javaOpts
+          .filter(!_.startsWith("-Dspark.ui.reverseProxyUrl=")) :+ opt
+        desc.copy(command = desc.command.copy(javaOpts = javaOpts))
+      case None => desc
+    }
+  }
+
   private def createDriver(desc: DriverDescription): DriverInfo = {
     val now = System.currentTimeMillis()
     val date = new Date(now)
     val id = newDriverId(date)
-    new DriverInfo(now, id, maybeUpdateAppName(desc, id), date)
+    val updatedDesc = maybeAddReverseProxyConfig(maybeUpdateAppName(desc, id))
+    new DriverInfo(now, id, updatedDesc, date)
   }
 
   private def launchDriver(worker: WorkerInfo, driver: DriverInfo): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
@@ -27,8 +27,7 @@ import org.apache.spark.deploy.master.Master
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.{HOSTS, NUM_REMOVED_WORKERS}
 import org.apache.spark.internal.config.DECOMMISSION_ENABLED
-import org.apache.spark.internal.config.UI.MASTER_UI_DECOMMISSION_ALLOW_MODE
-import org.apache.spark.internal.config.UI.UI_KILL_ENABLED
+import org.apache.spark.internal.config.UI.{MASTER_UI_DECOMMISSION_ALLOW_MODE, UI_KILL_ENABLED, UI_REVERSE_PROXY_URL}
 import org.apache.spark.ui.{SparkUI, WebUI}
 import org.apache.spark.ui.JettyUtils._
 import org.apache.spark.util.ArrayImplicits._
@@ -64,10 +63,13 @@ class MasterWebUI(
     addStaticHandler(MasterWebUI.STATIC_RESOURCE_DIR)
     addRenderLogHandler(this, master.conf)
     if (killEnabled) {
+      val killRedirectTarget = "/"
       attachHandler(createRedirectHandler(
-        "/app/kill", "/", masterPage.handleAppKillRequest, httpMethods = Set("POST")))
+        "/app/kill", killRedirectTarget, masterPage.handleAppKillRequest,
+        httpMethods = Set("POST")))
       attachHandler(createRedirectHandler(
-        "/driver/kill", "/", masterPage.handleDriverKillRequest, httpMethods = Set("POST")))
+        "/driver/kill", killRedirectTarget, masterPage.handleDriverKillRequest,
+        httpMethods = Set("POST")))
     }
     if (decommissionEnabled) {
       attachHandler(createServletHandler("/workers/kill", new HttpServlet {
@@ -97,7 +99,8 @@ class MasterWebUI(
   }
 
   def addProxy(): Unit = {
-    val handler = createProxyHandler(idToUiAddress)
+    val reverseProxyUrl = master.conf.get(UI_REVERSE_PROXY_URL).getOrElse("")
+    val handler = createProxyHandler(idToUiAddress, reverseProxyUrl)
     attachHandler(handler)
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -182,7 +182,10 @@ private[spark] object JettyUtils extends Logging {
   }
 
   /** Create a handler for proxying request to Workers and Application Drivers */
-  def createProxyHandler(idToUiAddress: String => Option[String]): ServletContextHandler = {
+  def createProxyHandler(
+      idToUiAddress: String => Option[String],
+      reverseProxyUrl: String = ""): ServletContextHandler = {
+    val normalizedReverseProxyUrl = reverseProxyUrl.stripSuffix("/")
     val servlet = new ProxyServlet {
       override def rewriteTarget(request: HttpServletRequest): String = {
         val path = request.getPathInfo
@@ -206,6 +209,25 @@ private[spark] object JettyUtils extends Logging {
           .orNull
       }
 
+      override def addProxyHeaders(
+          clientRequest: HttpServletRequest,
+          proxyRequest: org.eclipse.jetty.client.api.Request): Unit = {
+        super.addProxyHeaders(clientRequest, proxyRequest)
+        val path = clientRequest.getPathInfo
+        if (path != null) {
+          val prefixTrailingSlashIndex = path.indexOf('/', 1)
+          val prefix = if (prefixTrailingSlashIndex == -1) {
+            path
+          } else {
+            path.substring(0, prefixTrailingSlashIndex)
+          }
+          val existingContext = Option(clientRequest.getHeader("X-Forwarded-Context")).getOrElse("")
+          val contextPath = Option(clientRequest.getContextPath).getOrElse("")
+          val proxyContext = existingContext + normalizedReverseProxyUrl + contextPath + prefix
+          proxyRequest.headers(headers => headers.put("X-Forwarded-Context", proxyContext))
+        }
+      }
+
       override def newHttpClient(): HttpClient = {
         // SPARK-21176: Use the Jetty logic to calculate the number of selector threads (#CPUs/2),
         // but limit it to 8 max.
@@ -222,6 +244,15 @@ private[spark] object JettyUtils extends Logging {
           val newHeader = createProxyLocationHeader(headerValue, clientRequest,
             serverResponse.getRequest().getURI())
           if (newHeader != null) {
+            if (normalizedReverseProxyUrl.nonEmpty) {
+              val scheme = clientRequest.getScheme
+              val host = Option(clientRequest.getHeader("host")).getOrElse("")
+              val rootProxyPrefix = s"$scheme://$host/proxy/"
+              if (newHeader.startsWith(rootProxyPrefix)) {
+                val rest = newHeader.substring(rootProxyPrefix.length)
+                return s"$normalizedReverseProxyUrl/proxy/$rest"
+              }
+            }
             return newHeader
           }
         }

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -189,7 +189,7 @@ private[spark] object UIUtils extends Logging {
   // Yarn has to go through a proxy so the base uri is provided and has to be on all links
   def uiRoot(request: HttpServletRequest): String = {
     // Knox uses X-Forwarded-Context to notify the application the base path
-    val knoxBasePath = Option(request.getHeader("X-Forwarded-Context"))
+    val knoxBasePath = Option(request).flatMap(r => Option(r.getHeader("X-Forwarded-Context")))
     // SPARK-11484 - Use the proxyBase set by the AM, if not found then use env.
     sys.props.get("spark.ui.proxyBase")
       .orElse(sys.env.get("APPLICATION_WEB_PROXY_BASE"))
@@ -201,7 +201,16 @@ private[spark] object UIUtils extends Logging {
       request: HttpServletRequest,
       basePath: String = "",
       resource: String = ""): String = {
-    uiRoot(request) + basePath + resource
+    val root = uiRoot(request).stripSuffix("/")
+    val isAbsolute = basePath.startsWith("/") ||
+      basePath.startsWith("http://") || basePath.startsWith("https://")
+    val cleanBase = if (isAbsolute) basePath
+                    else if (basePath.nonEmpty) "/" + basePath
+                    else ""
+    val cleanResource = if (resource.startsWith("/")) resource
+                        else if (resource.nonEmpty) "/" + resource
+                        else ""
+    s"$root$cleanBase$cleanResource"
   }
 
   def commonHeaderNodes(request: HttpServletRequest): Seq[Node] = {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1371,6 +1371,65 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     assert(msg.contains("Cannot use the keyword 'proxy' or 'history' in reverse proxy URL"))
   }
 
+  test("SPARK-58893: propagate UI_REVERSE_PROXY_URL to spark.ui.proxyBase in SparkContext") {
+    val conf = new SparkConf().setAppName("testReverseProxyBase")
+      .setMaster("local")
+      .set(UI_REVERSE_PROXY, true)
+      .set(UI_REVERSE_PROXY_URL, "http://proxyhost:8080/myprefix")
+    sc = new SparkContext(conf)
+    assert(System.getProperty("spark.ui.proxyBase") ===
+      s"http://proxyhost:8080/myprefix/proxy/${sc.applicationId}")
+  }
+
+  test("SPARK-58893: fallback spark.ui.proxyBase when UI_REVERSE_PROXY_URL is empty") {
+    val sysProxyBase = "http://proxyhost:8080/sysprefix"
+    System.setProperty("spark.ui.proxyBase", sysProxyBase)
+    try {
+      val conf = new SparkConf().setAppName("testReverseProxyBaseSys")
+        .setMaster("local")
+        .set(UI_REVERSE_PROXY, true)
+      sc = new SparkContext(conf)
+      assert(System.getProperty("spark.ui.proxyBase") ===
+        s"$sysProxyBase/proxy/${sc.applicationId}")
+    } finally {
+      resetSparkContext()
+      System.clearProperty("spark.ui.proxyBase")
+    }
+  }
+
+  test("SPARK-58893: avoid compounding derived proxy root across multiple SparkContexts") {
+    val conf1 = new SparkConf().setAppName("testApp1")
+      .setMaster("local")
+      .set(UI_REVERSE_PROXY, true)
+    sc = new SparkContext(conf1)
+    val app1Id = sc.applicationId
+    assert(System.getProperty("spark.ui.proxyBase") === s"/proxy/$app1Id")
+    resetSparkContext()
+
+    val conf2 = new SparkConf().setAppName("testApp2")
+      .setMaster("local")
+      .set(UI_REVERSE_PROXY, true)
+    sc = new SparkContext(conf2)
+    val app2Id = sc.applicationId
+    assert(System.getProperty("spark.ui.proxyBase") === s"/proxy/$app2Id")
+  }
+
+  test("SPARK-58893: avoid inheriting previous YARN application proxy path in standalone context") {
+    val yarnAppProxyBase = "/proxy/application_1700000000000_0001"
+    System.setProperty("spark.ui.proxyBase", yarnAppProxyBase)
+    try {
+      val conf = new SparkConf().setAppName("testStandaloneAfterYarn")
+        .setMaster("local")
+        .set(UI_REVERSE_PROXY, true)
+      sc = new SparkContext(conf)
+      val appId = sc.applicationId
+      assert(System.getProperty("spark.ui.proxyBase") === s"/proxy/$appId")
+    } finally {
+      resetSparkContext()
+      System.clearProperty("spark.ui.proxyBase")
+    }
+  }
+
   test("SPARK-39957: ExitCode HEARTBEAT_FAILURE should be counted as network failure") {
     // This test is used to prove that driver will receive executorExitCode before onDisconnected
     // removes the executor. If the executor is removed by onDisconnected, the executor loss will be

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.deploy._
 import org.apache.spark.deploy.DeployMessages._
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Deploy._
+import org.apache.spark.internal.config.UI._
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.rpc.{RpcAddress, RpcEndpoint, RpcEnv}
 
@@ -258,5 +259,17 @@ class MasterSuite extends MasterSuiteBase {
     noException should be thrownBy {
       makeMaster(conf)
     }
+  }
+
+  test("SPARK-58893: Master injects reverseProxyUrl into driver javaOpts") {
+    val conf = new SparkConf()
+      .set(UI_REVERSE_PROXY, true)
+      .set(UI_REVERSE_PROXY_URL, "http://proxyhost:8080/path")
+    val master = makeMaster(conf)
+    val command = Command("mainClass", Seq.empty, Map.empty, Seq.empty, Seq.empty, Seq.empty)
+    val desc = DriverDescription("", 1, 1, false, command)
+    val result = master.invokePrivate(_maybeAddReverseProxyConfig(desc))
+    val opt = "-Dspark.ui.reverseProxyUrl=http://proxyhost:8080/path"
+    assert(result.command.javaOpts.contains(opt))
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuiteBase.scala
@@ -444,6 +444,8 @@ trait MasterSuiteBase extends SparkFunSuite
   protected val _newApplicationId = PrivateMethod[String](Symbol("newApplicationId"))
   protected val _maybeUpdateAppName =
     PrivateMethod[DriverDescription](Symbol("maybeUpdateAppName"))
+  protected val _maybeAddReverseProxyConfig =
+    PrivateMethod[DriverDescription](Symbol("maybeAddReverseProxyConfig"))
   protected val _createApplication = PrivateMethod[ApplicationInfo](Symbol("createApplication"))
 
   protected val workerInfo = makeWorkerInfo(512, 10)

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterWorkerUISuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterWorkerUISuite.scala
@@ -121,7 +121,7 @@ class MasterWorkerUISuite extends MasterSuiteBase {
           // the webuiaddress intentionally points to the local web ui.
           // explicitly construct reverse proxy url targeting the master
           val JString(workerId) = workerSummaryJson \ "id"
-          val url = s"$masterUrl/proxy/${workerId}/json"
+          val url = s"$masterUrl/proxy/${workerId}/json/"
           val workerResponse = parse(Utils
             .tryWithResource(Source.fromURL(url))(_.getLines().mkString("\n")))
           (workerResponse \ "cores").extract[Int] should be (2)

--- a/core/src/test/scala/org/apache/spark/deploy/master/ui/MasterWebUISuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/ui/MasterWebUISuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.deploy.DeployMessages.{DecommissionWorkersOnHosts, KillD
 import org.apache.spark.deploy.DeployTestUtils._
 import org.apache.spark.deploy.master._
 import org.apache.spark.internal.config.DECOMMISSION_ENABLED
-import org.apache.spark.internal.config.UI.MASTER_UI_DECOMMISSION_ALLOW_MODE
+import org.apache.spark.internal.config.UI.{MASTER_UI_DECOMMISSION_ALLOW_MODE, UI_REVERSE_PROXY, UI_REVERSE_PROXY_URL}
 import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
 import org.apache.spark.util.Utils
 
@@ -126,6 +126,80 @@ class MasterWebUISuite extends SparkFunSuite {
       assert(sendHttpRequest(url, "POST", body).getResponseCode === SC_FORBIDDEN)
     } finally {
       denyWebUI.stop()
+    }
+  }
+
+  test("SPARK-58893: kill application redirect location with reverse proxy") {
+    val reverseProxyConf = new SparkConf()
+      .set(DECOMMISSION_ENABLED, true)
+      .set(UI_REVERSE_PROXY, true)
+      .set(UI_REVERSE_PROXY_URL, "http://proxyhost:8080/myproxy")
+    val mockMaster = mock(classOf[Master])
+    when(mockMaster.securityMgr).thenReturn(securityMgr)
+    when(mockMaster.conf).thenReturn(reverseProxyConf)
+    when(mockMaster.rpcEnv).thenReturn(rpcEnv)
+    when(mockMaster.self).thenReturn(masterEndpointRef)
+
+    val activeApp = new ApplicationInfo(
+      new Date().getTime, "app-proxy-0", createAppDesc(), new Date(), null, Int.MaxValue)
+    val appMap = HashMap[String, ApplicationInfo]((activeApp.id, activeApp))
+    when(mockMaster.idToApp).thenReturn(appMap)
+
+    val webUI = new MasterWebUI(mockMaster, 0)
+    try {
+      webUI.bind()
+      val url = s"http://${Utils.localHostNameForURI()}:${webUI.boundPort}/app/kill/"
+      val body = convPostDataToString(Map(("id", activeApp.id), ("terminate", "true")))
+      val conn = new URI(url).toURL.openConnection().asInstanceOf[HttpURLConnection]
+      conn.setInstanceFollowRedirects(false)
+      conn.setRequestMethod("POST")
+      conn.setDoOutput(true)
+      conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+      val out = new DataOutputStream(conn.getOutputStream)
+      out.write(body.getBytes(StandardCharsets.UTF_8))
+      out.close()
+      val expectedLocation = s"http://${Utils.localHostNameForURI()}:${webUI.boundPort}/"
+      assert(conn.getResponseCode === 302)
+      assert(conn.getHeaderField("Location") === expectedLocation)
+    } finally {
+      webUI.stop()
+    }
+  }
+
+  test("SPARK-58893: honor reverseProxy=false when choosing kill redirect") {
+    val noProxyConf = new SparkConf()
+      .set(DECOMMISSION_ENABLED, true)
+      .set(UI_REVERSE_PROXY, false)
+      .set(UI_REVERSE_PROXY_URL, "http://proxyhost:8080/myproxy")
+    val mockMaster = mock(classOf[Master])
+    when(mockMaster.securityMgr).thenReturn(securityMgr)
+    when(mockMaster.conf).thenReturn(noProxyConf)
+    when(mockMaster.rpcEnv).thenReturn(rpcEnv)
+    when(mockMaster.self).thenReturn(masterEndpointRef)
+
+    val activeApp = new ApplicationInfo(
+      new Date().getTime, "app-proxy-1", createAppDesc(), new Date(), null, Int.MaxValue)
+    val appMap = HashMap[String, ApplicationInfo]((activeApp.id, activeApp))
+    when(mockMaster.idToApp).thenReturn(appMap)
+
+    val webUI = new MasterWebUI(mockMaster, 0)
+    try {
+      webUI.bind()
+      val url = s"http://${Utils.localHostNameForURI()}:${webUI.boundPort}/app/kill/"
+      val body = convPostDataToString(Map(("id", activeApp.id), ("terminate", "true")))
+      val conn = new URI(url).toURL.openConnection().asInstanceOf[HttpURLConnection]
+      conn.setInstanceFollowRedirects(false)
+      conn.setRequestMethod("POST")
+      conn.setDoOutput(true)
+      conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+      val out = new DataOutputStream(conn.getOutputStream)
+      out.write(body.getBytes(StandardCharsets.UTF_8))
+      out.close()
+      val expectedLocation = s"http://${Utils.localHostNameForURI()}:${webUI.boundPort}/"
+      assert(conn.getResponseCode === 302)
+      assert(conn.getHeaderField("Location") === expectedLocation)
+    } finally {
+      webUI.stop()
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/ui/UIUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UIUtilsSuite.scala
@@ -225,4 +225,20 @@ class UIUtilsSuite extends SparkFunSuite {
     assert(cell4 === <td>{"java.lang.RuntimeException"}{UIUtils.detailsUINode(isMultiline = true, e4)}</td>)
   }
   // scalastyle:on line.size.limit
+
+  test("SPARK-58893: prependBaseUri slash handling") {
+    try {
+      System.setProperty("spark.ui.proxyBase", "http://localhost:8080/foo/")
+      assert(UIUtils.prependBaseUri(null, "bar", "baz") ===
+        "http://localhost:8080/foo/bar/baz")
+      assert(UIUtils.prependBaseUri(null, "/bar", "/baz") ===
+        "http://localhost:8080/foo/bar/baz")
+      assert(UIUtils.prependBaseUri(null, "", "baz") ===
+        "http://localhost:8080/foo/baz")
+      assert(UIUtils.prependBaseUri(null, "", "") ===
+        "http://localhost:8080/foo")
+    } finally {
+      System.clearProperty("spark.ui.proxyBase")
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When `spark.ui.reverseProxy=true` is enabled in Standalone multi-cluster deployments:
1. `SparkContext` on the driver did not receive `UI_REVERSE_PROXY_URL`, causing driver UI links to drop `/proxy/<id>` prefixes. This PR propagates `UI_REVERSE_PROXY_URL` (or falls back to `spark.ui.proxyBase`) into system property `spark.ui.proxyBase`.
2. `Master` did not pass `-Dspark.ui.reverseProxyUrl=<url>` to `DriverDescription` `javaOpts`. This PR updates `Master` to inject `reverseProxyUrl` into driver `javaOpts` when reverse proxy is enabled.
3. `/app/kill` and `/driver/kill` redirect `Location` headers were redirecting to `/` instead of `reverseProxyUrl + "/"`. This PR updates `MasterWebUI` redirect handlers to preserve reverse proxy paths.
4. `UIUtils.prependBaseUri` and `uiRoot` were updated to handle `request = null` safely.

*Note: Please backport to `master`, `branch-4.1`, and `branch-3.5` if applicable.*

### Why are the changes needed?
Without these changes, multi-cluster reverse proxy deployments lose proxy prefixes when accessing driver UIs or terminating applications/drivers from Master UI, breaking navigation and reverse proxy routing.

### Does this PR introduce _any_ user-facing change?
No API changes. Fixes UI navigation links and redirect Location headers when `spark.ui.reverseProxy=true` is enabled.

### How was this patch tested?
- Added unit tests in `UIUtilsSuite`, `MasterSuite`, `MasterWebUISuite`, and `SparkContextSuite`.
- Verified local build and unit tests using `build/sbt "core/testOnly org.apache.spark.ui.UIUtilsSuite org.apache.spark.deploy.master.MasterSuite org.apache.spark.deploy.master.ui.MasterWebUISuite org.apache.spark.SparkContextSuite"`.

### Was this patch authored or co-authored using generative AI tooling?
No.