### PR TITLE
[SPARK-58966][SQL] Resolve SQL variables in UPDATE and MERGE INTO conditions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1850,7 +1850,7 @@ class Analyzer(
                 // The insert action is used when not matched, so its condition and value can only
                 // access columns from the source table.
                 val resolvedInsertCondition = insertCondition.map(
-                  resolveExpressionByPlanOutput(_, m.sourceTable))
+                  resolveExpressionByPlanOutput(_, m.sourceTable, includeLastResort = true))
                 InsertAction(
                   resolvedInsertCondition,
                   resolveAssignments(assignments, m, MergeResolvePolicy.SOURCE, throws))
@@ -1858,7 +1858,7 @@ class Analyzer(
                 // The insert action is used when not matched, so its condition and value can only
                 // access columns from the source table.
                 val resolvedInsertCondition = insertCondition.map(
-                  resolveExpressionByPlanOutput(_, m.sourceTable))
+                  resolveExpressionByPlanOutput(_, m.sourceTable, includeLastResort = true))
                 // Expand star to top level source columns.  If source has less columns than target,
                 // assignments will be added by ResolveRowLevelCommandAssignments later.
                 val assignments = if (m.schemaEvolutionEnabled) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1811,11 +1811,11 @@ class Analyzer(
             val newMatchedActions = m.matchedActions.map {
               case DeleteAction(deleteCondition) =>
                 val resolvedDeleteCondition = deleteCondition.map(
-                  resolveExpressionByPlanChildren(_, m))
+                  resolveExpressionByPlanChildren(_, m, includeLastResort = true))
                 DeleteAction(resolvedDeleteCondition)
               case UpdateAction(updateCondition, assignments, fromStar) =>
                 val resolvedUpdateCondition = updateCondition.map(
-                  resolveExpressionByPlanChildren(_, m))
+                  resolveExpressionByPlanChildren(_, m, includeLastResort = true))
                 UpdateAction(
                   resolvedUpdateCondition,
                   // The update value can access columns from both target and source tables.
@@ -1838,7 +1838,8 @@ class Analyzer(
                   }
                 }
                 UpdateAction(
-                  updateCondition.map(resolveExpressionByPlanChildren(_, m)),
+                  updateCondition.map(
+                    resolveExpressionByPlanChildren(_, m, includeLastResort = true)),
                   // For UPDATE *, the value must be from source table.
                   resolveAssignments(assignments, m, MergeResolvePolicy.SOURCE, throws),
                   fromStar = true)
@@ -1881,11 +1882,11 @@ class Analyzer(
             val newNotMatchedBySourceActions = m.notMatchedBySourceActions.map {
               case DeleteAction(deleteCondition) =>
                 val resolvedDeleteCondition = deleteCondition.map(
-                  resolveExpressionByPlanOutput(_, targetTable))
+                  resolveExpressionByPlanOutput(_, targetTable, includeLastResort = true))
                 DeleteAction(resolvedDeleteCondition)
               case UpdateAction(updateCondition, assignments, fromStar) =>
                 val resolvedUpdateCondition = updateCondition.map(
-                  resolveExpressionByPlanOutput(_, targetTable))
+                  resolveExpressionByPlanOutput(_, targetTable, includeLastResort = true))
                 UpdateAction(
                   resolvedUpdateCondition,
                   // The update value can access columns from the target table only.
@@ -1894,7 +1895,8 @@ class Analyzer(
               case o => o
             }
 
-            val resolvedMergeCondition = resolveExpressionByPlanChildren(m.mergeCondition, m)
+            val resolvedMergeCondition =
+              resolveExpressionByPlanChildren(m.mergeCondition, m, includeLastResort = true)
             m.copy(mergeCondition = resolvedMergeCondition,
               matchedActions = newMatchedActions,
               notMatchedActions = newNotMatchedActions,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInUpdate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInUpdate.scala
@@ -25,13 +25,16 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
 
 /**
  * A virtual rule to resolve [[UnresolvedAttribute]] in [[UpdateTable]]. It's only used by the real
- * rule `ResolveReferences`. The column resolution order for [[UpdateTable]] is:
+ * rule `ResolveReferences`. Assignments and the condition share the first two steps below, then
+ * diverge: step 3 applies to assignments only, and steps 4 and 5 to the condition only.
  * 1. Resolves the column to `AttributeReference` with the output of the child plan. This
  *    includes metadata columns as well.
  * 2. Resolves the column to a literal function which is allowed to be invoked without braces, e.g.
  *    `SELECT col, current_date FROM t`.
  * 3. Resolves the column to the default value expression, if the column is the assignment value
  *    and the corresponding assignment key is a top-level column.
+ * 4. Resolves the column to an outer reference.
+ * 5. Resolves the column to a SQL variable, which is always tried after outer references.
  */
 class ResolveReferencesInUpdate(val catalogManager: CatalogManager)
   extends SQLConfHelper with ColumnResolutionHelper {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInUpdate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInUpdate.scala
@@ -67,7 +67,8 @@ class ResolveReferencesInUpdate(val catalogManager: CatalogManager)
 
     val newUpdate = u.copy(
       assignments = newAssignments,
-      condition = u.condition.map(resolveExpressionByPlanChildren(_, u)))
+      condition = u.condition.map(
+        resolveExpressionByPlanChildren(_, u, includeLastResort = true)))
     newUpdate.copyTagsFrom(u)
     newUpdate
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -3061,7 +3061,8 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
           |""".stripMargin)
       Seq(1, 2).toDF("pk").createOrReplaceTempView("source")
 
-      withSessionVariable("target_dep", "STRING", "'hr'") {
+      withSessionVariable("target_dep") {
+        sql("DECLARE VARIABLE target_dep STRING DEFAULT 'hr'")
         sql(
           s"""MERGE INTO $tableNameAsString t
              |USING source s
@@ -3084,7 +3085,8 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
           |""".stripMargin)
       Seq(1).toDF("pk").createOrReplaceTempView("source")
 
-      withSessionVariable("salary_threshold", "INT", "150") {
+      withSessionVariable("salary_threshold") {
+        sql("DECLARE VARIABLE salary_threshold INT DEFAULT 150")
         sql(
           s"""MERGE INTO $tableNameAsString t
              |USING source s
@@ -3108,7 +3110,8 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
       Seq((2, 200, "software"), (3, 300, "hr"))
         .toDF("pk", "salary", "dep").createOrReplaceTempView("source")
 
-      withSessionVariable("pk_threshold", "INT", "3") {
+      withSessionVariable("pk_threshold") {
+        sql("DECLARE VARIABLE pk_threshold INT DEFAULT 3")
         sql(
           s"""MERGE INTO $tableNameAsString t
              |USING source s
@@ -3132,7 +3135,8 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
       Seq((2, 200, "software"), (3, 300, "hr"))
         .toDF("pk", "salary", "dep").createOrReplaceTempView("source")
 
-      withSessionVariable("pk_threshold", "INT", "3") {
+      withSessionVariable("pk_threshold") {
+        sql("DECLARE VARIABLE pk_threshold INT DEFAULT 3")
         sql(
           s"""MERGE INTO $tableNameAsString t
              |USING source s

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -3100,4 +3100,51 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
     }
   }
 
+  test("merge with a SQL variable in the not-matched insert condition") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |""".stripMargin)
+      Seq((2, 200, "software"), (3, 300, "hr"))
+        .toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSessionVariable("pk_threshold", "INT", "3") {
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk < pk_threshold THEN
+             |  INSERT (pk, salary, dep) VALUES (s.pk, s.salary, s.dep)
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Row(1, 100, "hr") :: Row(2, 200, "software") :: Nil)
+      }
+    }
+  }
+
+  test("merge with a SQL variable in the not-matched insert-star condition") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |""".stripMargin)
+      Seq((2, 200, "software"), (3, 300, "hr"))
+        .toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSessionVariable("pk_threshold", "INT", "3") {
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk < pk_threshold THEN INSERT *
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Row(1, 100, "hr") :: Row(2, 200, "software") :: Nil)
+      }
+    }
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -3052,4 +3052,52 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
       case None => fail(s"$metricName metric not found")
     }
   }
+
+  test("merge with a SQL variable in the merge condition") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+      Seq(1, 2).toDF("pk").createOrReplaceTempView("source")
+
+      withSessionVariable("target_dep", "STRING", "'hr'") {
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk AND t.dep = target_dep
+             |WHEN MATCHED THEN UPDATE SET t.salary = 999
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Row(1, 999, "hr") :: Row(2, 200, "software") :: Nil)
+      }
+    }
+  }
+
+  test("merge with a SQL variable in matched and not-matched-by-source conditions") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+      Seq(1).toDF("pk").createOrReplaceTempView("source")
+
+      withSessionVariable("salary_threshold", "INT", "150") {
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.salary < salary_threshold THEN UPDATE SET t.salary = 999
+             |WHEN NOT MATCHED BY SOURCE AND t.salary > salary_threshold THEN DELETE
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Row(1, 999, "hr") :: Nil)
+      }
+    }
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -127,15 +127,6 @@ abstract class RowLevelOperationSuiteBase
     catalog.createTable(ident, tableInfo)
   }
 
-  /** Declares a session variable for the duration of `f`, dropping it afterwards. */
-  protected def withSessionVariable(
-      name: String,
-      dataType: String,
-      default: String)(f: => Unit): Unit = {
-    sql(s"DECLARE OR REPLACE VARIABLE $name $dataType DEFAULT $default")
-    try f finally sql(s"DROP TEMPORARY VARIABLE IF EXISTS $name")
-  }
-
   protected def createAndInitTable(schemaString: String, jsonData: String): Unit = {
     createTable(schemaString)
     append(schemaString, jsonData)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -127,6 +127,15 @@ abstract class RowLevelOperationSuiteBase
     catalog.createTable(ident, tableInfo)
   }
 
+  /** Declares a session variable for the duration of `f`, dropping it afterwards. */
+  protected def withSessionVariable(
+      name: String,
+      dataType: String,
+      default: String)(f: => Unit): Unit = {
+    sql(s"DECLARE OR REPLACE VARIABLE $name $dataType DEFAULT $default")
+    try f finally sql(s"DROP TEMPORARY VARIABLE IF EXISTS $name")
+  }
+
   protected def createAndInitTable(schemaString: String, jsonData: String): Unit = {
     createTable(schemaString)
     append(schemaString, jsonData)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -1377,7 +1377,8 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
         |{ "pk": 2, "salary": 200, "dep": "software" }
         |""".stripMargin)
 
-    withSessionVariable("target_dep", "STRING", "'hr'") {
+    withSessionVariable("target_dep") {
+      sql("DECLARE VARIABLE target_dep STRING DEFAULT 'hr'")
       sql(s"UPDATE $tableNameAsString SET salary = 999 WHERE dep = target_dep")
 
       checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -1370,4 +1370,38 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
       sql(s"SELECT * FROM $tableNameAsString"),
       Row(1, -1, "hr") :: Row(2, 200, "software") :: Row(3, -1, "hr") :: Nil)
   }
+
+  test("update with a SQL variable in the condition") {
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    withSessionVariable("target_dep", "STRING", "'hr'") {
+      sql(s"UPDATE $tableNameAsString SET salary = 999 WHERE dep = target_dep")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Row(1, 999, "hr") :: Row(2, 200, "software") :: Nil)
+    }
+  }
+
+  test("update with a SQL scripting local variable in the condition") {
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    sql(
+      s"""BEGIN
+         |  DECLARE local_dep STRING DEFAULT 'hr';
+         |  UPDATE $tableNameAsString SET salary = 999 WHERE dep = local_dep;
+         |END
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(1, 999, "hr") :: Row(2, 200, "software") :: Nil)
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

SQL variables declared with `DECLARE` cannot be referenced in the conditions of an
`UPDATE` or `MERGE INTO` statement. This passes `includeLastResort = true` at the nine
condition-resolution sites that make up those clauses, matching what SPARK-57260 did for
`OverwriteByExpression.deleteExpr`.

Variable resolution only runs from `resolveColsLastResort`, which is reached when
`resolveExpressionByPlanOutput` / `resolveExpressionByPlanChildren` are called with
`includeLastResort = true`. Both default the flag to `false`. Plans with no dedicated
resolution rule fall through to the generic operator case in `ResolveReferences`, which
does pass the flag -- which is why `DELETE ... WHERE` already works. `UPDATE` and
`MERGE INTO` each have a dedicated rule that omitted it:

- `UPDATE` condition (`ResolveReferencesInUpdate`)
- `MERGE` `ON` condition
- `MERGE` `WHEN MATCHED` `DELETE` / `UPDATE` conditions
- `MERGE` `UPDATE *` condition
- `MERGE` `WHEN NOT MATCHED` `INSERT` / `INSERT *` conditions
- `MERGE` `WHEN NOT MATCHED BY SOURCE` `DELETE` / `UPDATE` conditions

This covers every `MergeAction` condition form, so all `MERGE` conditions now resolve
variables consistently.

Assignment values (`SET col = var`, `INSERT VALUES (var)`) are affected by the same root
cause, but they resolve through `resolveExprInAssignment`, which sets
`includeLastResort = false` explicitly rather than by default. That is left unchanged
here pending a decision on whether the explicit `false` was deliberate, so this PR is
scoped to conditions only.

### Why are the changes needed?

Variables resolve in `SELECT`, `INSERT` (including `REPLACE WHERE`) and `DELETE`, but in
no condition of `UPDATE` or `MERGE INTO`, which fails analysis with:

```
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with
name `target_dep` cannot be resolved. SQLSTATE: 42703
```

The message itself offers "A column, variable, or function parameter", so the analyzer
reports that variable resolution was attempted. Nothing in `error-conditions.json`, the
tests, or the docs records a restriction here. Where Spark does intentionally block
variables (SPARK-57360, generated columns) it uses an explicit validation and a dedicated
error class, so the inconsistency looks like an oversight rather than a deliberate
limitation.

This affects both session variables and SQL scripting local variables.

### Does this PR introduce _any_ user-facing change?

Yes, a bug fix.

Before, against a table using the built-in DSv2 row-level operation framework:

```sql
DECLARE OR REPLACE VARIABLE target_dep STRING DEFAULT 'hr';
UPDATE cat.ns1.test_table SET salary = 0 WHERE dep = target_dep;
-- [UNRESOLVED_COLUMN.WITH_SUGGESTION] ... `target_dep` cannot be resolved. SQLSTATE: 42703
```

After, the statement analyzes and executes, resolving `target_dep` to the declared
variable. Statements that previously succeeded are unaffected: the flag only enables a
last-resort resolution step that runs after normal column resolution fails, so column
references continue to take precedence over same-named variables.

### How was this patch tested?

Six new tests, plus a shared `withSessionVariable` helper in
`RowLevelOperationSuiteBase`:

- `UpdateTableSuiteBase` -- a session variable and a SQL scripting local variable in an
  `UPDATE` condition.
- `MergeIntoTableSuiteBase` -- a variable in the `MERGE` `ON` condition, in the
  `WHEN MATCHED` / `WHEN NOT MATCHED BY SOURCE` conditions, and in the
  `WHEN NOT MATCHED` `INSERT` and `INSERT *` conditions.

Each test was verified to fail without the fix (raising `UNRESOLVED_COLUMN`) and to pass
with it. The not-matched tests keep a source row that the variable predicate excludes, so
they fail if the variable is resolved but evaluated incorrectly, not just if resolution
fails.

Suites run: `GroupBasedUpdateTableSuite`, `GroupBasedMergeIntoTableSuite`,
`DeltaBasedUpdateTableSuite` and `DeltaBasedMergeIntoTableSuite` -- 289 tests, all
passing. Reverting only the `Analyzer` change makes the two not-matched tests fail with
`UNRESOLVED_COLUMN` on the variable in the `insertaction` condition.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
