### PR TITLE
[SPARK-58917][SQL] Respect inferSchema for variant ingestion in CSV parser

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -229,6 +229,12 @@ Data source options of CSV can be set via:
     <td>read</td>
   </tr>
   <tr>
+    <td><code>variantRespectInferSchema</code></td>
+    <td>false</td>
+    <td>When true and <code>inferSchema</code> is false, the CSV to Variant parser preserves scalar CSV values as strings inside the Variant instead of inferring their types. This only affects variant ingestion (<code>singleVariantColumn</code> mode or explicit <code>VariantType</code> columns). When false (the default), scalar types (long, decimal, date, timestamp, boolean) are always inferred regardless of the <code>inferSchema</code> setting, preserving existing behavior.</td>
+    <td>read</td>
+  </tr>
+  <tr>
     <td><code>multiLine</code></td>
     <td>false</td>
     <td>Allows a row to span multiple lines, by parsing line breaks within quoted values as part of the value itself. CSV built-in functions ignore this option.<br>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -340,6 +340,15 @@ class CSVOptions(
   def needHeaderForSingleVariantColumn: Boolean =
     singleVariantColumn.isDefined && headerFlag
 
+  /**
+   * When true and inferSchema is false, the CSV to Variant parser preserves scalar CSV values
+   * as strings inside the Variant instead of inferring their types. This only affects variant
+   * ingestion (singleVariantColumn mode or explicit VariantType columns).
+   *
+   * Defaults to false to preserve existing behavior where scalar types are always inferred.
+   */
+  val variantRespectInferSchema: Boolean = getBool(VARIANT_RESPECT_INFER_SCHEMA, default = false)
+
   def asWriterSettings: CsvWriterSettings = {
     val writerSettings = new CsvWriterSettings()
     val format = writerSettings.getFormat
@@ -443,6 +452,7 @@ object CSVOptions extends DataSourceOptions {
   newOption(SEP, DELIMITER)
   val COLUMN_PRUNING = newOption("columnPruning")
   val SINGLE_VARIANT_COLUMN = newOption(DataSourceOptions.SINGLE_VARIANT_COLUMN)
+  val VARIANT_RESPECT_INFER_SCHEMA = newOption("variantRespectInferSchema")
 
   // Max error content length in CSV parser/writer exception messages, and the bound on the bad
   // record embedded in MALFORMED_CSV_RECORD errors.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -460,6 +460,9 @@ class UnivocityParser(
    * input as a specific scalar type, or fails after trying all the types and defaults to the string
    * type. The state is reset for every input file.
    *
+   * When variantRespectInferSchema is true and inferSchema is false, scalar type inference is
+   * skipped and all non-null values are stored as strings.
+   *
    * Floating point types (double, float) are not considered to avoid precision loss.
    */
   private final class VariantValueConverter extends ValueConverter {
@@ -467,6 +470,8 @@ class UnivocityParser(
     // Keep consistent with `CSVInferSchema`: only produce TimestampNTZ when the default timestamp
     // type is TimestampNTZ.
     private val isDefaultNTZ = SQLConf.get.timestampType == TimestampNTZType
+    // When variantRespectInferSchema is true and inferSchema is false, skip type inference
+    private val shouldInferTypes = !options.variantRespectInferSchema || options.inferSchemaFlag
 
     override def apply(s: String): Any = {
       val builder = new VariantBuilder(false)
@@ -478,6 +483,12 @@ class UnivocityParser(
     def convertInput(builder: VariantBuilder, s: String): Unit = {
       if (s == null || s == options.nullValue) {
         builder.appendNull()
+        return
+      }
+
+      // If variantRespectInferSchema is true and inferSchema is false, store as string
+      if (!shouldInferTypes) {
+        builder.appendString(s)
         return
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -869,6 +869,59 @@ class CsvFunctionsSuite extends SharedSparkSession {
       Seq(Row(s"""{null, $largeInput}""")))
   }
 
+  test("from_csv with variant: variantRespectInferSchema option") {
+    val df = Seq("0001,100,1.1,true", "0002,200,2.2,false").toDF("value")
+    
+    // Default behavior: types are inferred (0001 becomes 1, 0002 becomes 2)
+    checkAnswer(
+      df.select(
+        from_csv(
+          $"value",
+          StructType.fromDDL("a variant, b variant, c variant, d variant"),
+          Map.empty[String, String]
+        ).cast("string")),
+      Seq(
+        Row("""{1, 100, 1.1, true}"""),
+        Row("""{2, 200, 2.2, false}""")))
+
+    // With variantRespectInferSchema=true and inferSchema=false: preserve as strings
+    checkAnswer(
+      df.select(
+        from_csv(
+          $"value",
+          StructType.fromDDL("a variant, b variant, c variant, d variant"),
+          Map("variantRespectInferSchema" -> "true", "inferSchema" -> "false")
+        ).cast("string")),
+      Seq(
+        Row("""{"0001", "100", "1.1", "true"}"""),
+        Row("""{"0002", "200", "2.2", "false"}""")))
+
+    // With variantRespectInferSchema=true and inferSchema=true: still infer types
+    checkAnswer(
+      df.select(
+        from_csv(
+          $"value",
+          StructType.fromDDL("a variant, b variant, c variant, d variant"),
+          Map("variantRespectInferSchema" -> "true", "inferSchema" -> "true")
+        ).cast("string")),
+      Seq(
+        Row("""{1, 100, 1.1, true}"""),
+        Row("""{2, 200, 2.2, false}""")))
+
+    // Test with singleVariantColumn mode
+    checkAnswer(
+      df.select(
+        from_csv(
+          $"value",
+          StructType.fromDDL("v variant"),
+          Map("singleVariantColumn" -> "v", "variantRespectInferSchema" -> "true", 
+              "inferSchema" -> "false")
+        ).cast("string")),
+      Seq(
+        Row("""{{"_c0":"0001","_c1":"100","_c2":"1.1","_c3":"true"}}"""),
+        Row("""{{"_c0":"0002","_c1":"200","_c2":"2.2","_c3":"false"}}""")))
+  }
+
   test("from_csv with variant: extreme negative scale decimal does not hang") {
     // A value like "1E99999" parses to a BigDecimal with scale=-99999.
     // Calling setScale(0) on it would hang, so it should fall through to string.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3342,10 +3342,11 @@ abstract class CSVSuite
   }
 
   test("validate CSV Options") {
-    assert(CSVOptions.getAllOptions.size == 42)
+    assert(CSVOptions.getAllOptions.size == 43)
     // Please add validation on any new CSV options here
     assert(CSVOptions.isValidOption("header"))
     assert(CSVOptions.isValidOption("inferSchema"))
+    assert(CSVOptions.isValidOption("variantRespectInferSchema"))
     assert(CSVOptions.isValidOption("ignoreLeadingWhiteSpace"))
     assert(CSVOptions.isValidOption("ignoreTrailingWhiteSpace"))
     assert(CSVOptions.isValidOption("preferDate"))
@@ -3915,6 +3916,92 @@ abstract class CSVSuite
       condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
       parameters = Map("columnName" -> "`v`", "columnType" -> "\"VARIANT\"", "format" -> "CSV")
     )
+  }
+
+  test("variantRespectInferSchema option") {
+    withTempPath { path =>
+      val data =
+        """0001,100,1.1,true
+          |0002,2000-01-01,2000-01-01 01:02:03,false
+          |0003,1e9,hello,extra
+          |""".stripMargin
+      Files.write(path.toPath, data.getBytes(StandardCharsets.UTF_8))
+
+      // Default behavior: inferSchema is always applied for variant ingestion
+      checkAnswer(
+        spark.read.option("singleVariantColumn", "v")
+          .csv(path.getCanonicalPath).selectExpr("cast(v as string)"),
+        Seq(
+          Row("""{"_c0":1,"_c1":100,"_c2":1.1,"_c3":true}"""),
+          Row("""{"_c0":2,"_c1":"2000-01-01","_c2":"2000-01-01 01:02:03-08:00","_c3":false}"""),
+          Row("""{"_c0":3,"_c1":"1e9","_c2":"hello","_c3":"extra"}""")
+        )
+      )
+
+      // With variantRespectInferSchema=true and inferSchema=false: preserve as strings
+      checkAnswer(
+        spark.read
+          .option("singleVariantColumn", "v")
+          .option("variantRespectInferSchema", "true")
+          .option("inferSchema", "false")
+          .csv(path.getCanonicalPath).selectExpr("cast(v as string)"),
+        Seq(
+          Row("""{"_c0":"0001","_c1":"100","_c2":"1.1","_c3":"true"}"""),
+          Row("""{"_c0":"0002","_c1":"2000-01-01","_c2":"2000-01-01 01:02:03","_c3":"false"}"""),
+          Row("""{"_c0":"0003","_c1":"1e9","_c2":"hello","_c3":"extra"}""")
+        )
+      )
+
+      // With variantRespectInferSchema=true and inferSchema=true: still infer types
+      checkAnswer(
+        spark.read
+          .option("singleVariantColumn", "v")
+          .option("variantRespectInferSchema", "true")
+          .option("inferSchema", "true")
+          .csv(path.getCanonicalPath).selectExpr("cast(v as string)"),
+        Seq(
+          Row("""{"_c0":1,"_c1":100,"_c2":1.1,"_c3":true}"""),
+          Row("""{"_c0":2,"_c1":"2000-01-01","_c2":"2000-01-01 01:02:03-08:00","_c3":false}"""),
+          Row("""{"_c0":3,"_c1":"1e9","_c2":"hello","_c3":"extra"}""")
+        )
+      )
+
+      // Test with explicit variant schema columns
+      checkAnswer(
+        spark.read
+          .option("variantRespectInferSchema", "true")
+          .option("inferSchema", "false")
+          .schema("c0 variant, c1 variant, c2 variant, c3 variant")
+          .csv(path.getCanonicalPath)
+          .selectExpr("cast(c0 as string)", "cast(c1 as string)", "cast(c2 as string)", "cast(c3 as string)"),
+        Seq(
+          Row("0001", "100", "1.1", "true"),
+          Row("0002", "2000-01-01", "2000-01-01 01:02:03", "false"),
+          Row("0003", "1e9", "hello", "extra")
+        )
+      )
+
+      // Test with header
+      val dataWithHeader =
+        """id,num,dec,bool
+          |0001,100,1.1,true
+          |0002,200,2.2,false
+          |""".stripMargin
+      Files.write(path.toPath, dataWithHeader.getBytes(StandardCharsets.UTF_8))
+
+      checkAnswer(
+        spark.read
+          .option("singleVariantColumn", "v")
+          .option("variantRespectInferSchema", "true")
+          .option("inferSchema", "false")
+          .option("header", "true")
+          .csv(path.getCanonicalPath).selectExpr("cast(v as string)"),
+        Seq(
+          Row("""{"bool":"true","dec":"1.1","id":"0001","num":"100"}"""),
+          Row("""{"bool":"false","dec":"2.2","id":"0002","num":"200"}""")
+        )
+      )
+    }
   }
 
   private def createTestFiles(dir: File, fileFormatWriter: Boolean,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a new CSV read option `variantRespectInferSchema` that controls type inference behavior for variant ingestion in the CSV parser. When enabled along with inferSchema=false, scalar CSV values are preserved as strings inside Variants instead of being automatically inferred to numeric or boolean types.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, the CSV to Variant parser (used by the singleVariantColumn option and explicit VariantType columns) always infers scalar types (long, decimal, date, timestamp, boolean) regardless of the inferSchema option. This means a value like "0001" is stored as the integer 1 rather than the string "0001", which may not be the desired behavior in all cases.

Users need a way to preserve the original string representation of CSV values when ingesting into Variants, particularly for:

- Leading zeros in numeric-looking strings (e.g., "0001", "00123")
- Data that should remain as strings for semantic reasons (e.g., zip codes, product codes)
- Preserving exact input format for downstream processing




### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. This PR introduces a new CSV read option, `variantRespectInferSchema` (default: false)

- When false (default): Preserves existing behavior - types are always inferred for variant values
- When true and inferSchema=false: CSV values are preserved as strings in Variants
- When true and inferSchema=true: Types are still inferred (respects the inferSchema setting)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added comprehensive tests in `CSVSuite`, and added tests in `CsvFunctionsSuite` for the `from_csv` function

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No