### PR TITLE
[SPARK-58971][PS] Add pct, na_option, and axis parameters to Series.rank and DataFrame.rank

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11756,12 +11756,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # dtype: bool
         return first_series(DataFrame(internal))
 
-    # TODO(SPARK-46167): add pct, na_option parameter
     def rank(
         self,
         method: Literal["average", "min", "max", "first", "dense"] = "average",
         ascending: bool = True,
         numeric_only: bool = False,
+        na_option: str = "keep",
+        pct: bool = False,
         axis: Axis = 0,
     ) -> "DataFrame":
         """
@@ -11789,6 +11790,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             .. versionchanged:: 4.0.0
                 The default value of ``numeric_only`` is now ``False``.
 
+        na_option : {'keep', 'top', 'bottom'}, default 'keep'
+            * keep: leave NA values where they are
+            * top: smallest rank if ascending
+            * bottom: largest rank if ascending
+
+            .. versionadded:: 4.4.0
+
+        pct : bool, default False
+            Whether or not to display the returned rankings in percentile form.
+
+            .. versionadded:: 4.4.0
+
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Axis along which to rank:
 
@@ -11797,7 +11810,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             .. note:: For axis=1, pandas UDF is used which may have performance overhead
                 for very wide DataFrames (100+ columns).
-
 
         Returns
         -------
@@ -11887,14 +11899,24 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if axis == 0:
             return psdf._apply_series_op(
-                lambda psser: psser._rank(method=method, ascending=ascending), should_resolve=True
+                lambda psser: psser._rank(
+                    method=method, ascending=ascending, na_option=na_option, pct=pct
+                ),
+                should_resolve=True,
             )
         else:
             # Fast path for small dataframes
             limit = get_option("compute.shortcut_limit")
             pdf = psdf.head(limit + 1)._to_internal_pandas()
             if len(pdf) <= limit:
-                pdf_rank = pdf.rank(method=method, ascending=ascending, axis=1, numeric_only=False)
+                pdf_rank = pdf.rank(
+                    method=method,
+                    ascending=ascending,
+                    axis=1,
+                    numeric_only=False,
+                    na_option=na_option,
+                    pct=pct,
+                )
                 return DataFrame(InternalFrame.from_pandas(pdf_rank))
 
             column_label_strings = [
@@ -11911,9 +11933,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
             def rank_axis_1(*cols: pd.Series) -> pd.DataFrame:
                 pdf_row = pd.concat(cols, axis=1, keys=column_label_strings)
-                return pdf_row.rank(method=method, ascending=ascending, axis=1).rename(
-                    columns=dict(zip(pdf_row.columns, column_label_strings))
-                )
+                return pdf_row.rank(
+                    method=method,
+                    ascending=ascending,
+                    axis=1,
+                    na_option=na_option,
+                    pct=pct,
+                ).rename(columns=dict(zip(pdf_row.columns, column_label_strings)))
 
             ranked_struct_col = rank_axis_1(*psdf._internal.data_spark_columns)
             new_data_columns = [

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4190,9 +4190,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             return self._reduce_for_stat_function(quantile, name="quantile")
 
-    # TODO: add axis, pct, na_option parameter
     def rank(
-        self, method: str = "average", ascending: bool = True, numeric_only: bool = False
+        self,
+        method: str = "average",
+        ascending: bool = True,
+        numeric_only: bool = False,
+        na_option: str = "keep",
+        pct: bool = False,
+        axis: int = 0,
     ) -> "Series":
         """
         Compute numerical data ranks (1 through n) along axis. Equal values are
@@ -4219,6 +4224,20 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             .. versionchanged:: 4.0.0
                 The default value of ``numeric_only`` is now ``False``.
 
+        na_option : {'keep', 'top', 'bottom'}, default 'keep'
+            * keep: leave NA values where they are
+            * top: smallest rank if ascending
+            * bottom: largest rank if ascending
+
+            .. versionadded:: 4.4.0
+
+        pct : bool, default False
+            Whether or not to display the returned rankings in percentile form.
+
+            .. versionadded:: 4.4.0
+
+        axis : {0 or 'index'}, default 0
+            Parameter needed for compatibility with DataFrame.
 
         Returns
         -------
@@ -4286,12 +4305,42 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         y    b
         z    c
         Name: A, dtype: object
+
+        With pct=True, ranks are expressed as percentiles.
+
+        >>> s = ps.Series([1, 2, 2, 3], name='A')
+        >>> s.rank(pct=True)
+        0    0.25
+        1    0.625
+        2    0.625
+        3    1.0
+        Name: A, dtype: float64
+
+        With na_option='top', NaN values are assigned the smallest rank.
+
+        >>> s = ps.Series([1, float('nan'), 2, 3], name='A')
+        >>> s.rank(na_option='top')
+        0    2.0
+        1    1.0
+        2    3.0
+        3    4.0
+        Name: A, dtype: float64
+
+        With na_option='bottom', NaN values are assigned the largest rank.
+
+        >>> s.rank(na_option='bottom')
+        0    1.0
+        1    4.0
+        2    2.0
+        3    3.0
+        Name: A, dtype: float64
         """
+        validate_axis(axis)
         is_numeric = isinstance(self.spark.data_type, (NumericType, BooleanType))
         if numeric_only and not is_numeric:
             raise TypeError("Series.rank does not allow numeric_only=True with non-numeric dtype.")
         else:
-            return self._rank(method, ascending).spark.analyzed
+            return self._rank(method, ascending, na_option=na_option, pct=pct).spark.analyzed
 
     def _rank(
         self,
@@ -4299,32 +4348,46 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ascending: bool = True,
         *,
         part_cols: Sequence["ColumnOrName"] = (),
+        na_option: str = "keep",
+        pct: bool = False,
     ) -> "Series":
         if method not in ["average", "min", "max", "first", "dense"]:
             msg = "method must be one of 'average', 'min', 'max', 'first', 'dense'"
             raise ValueError(msg)
+        if na_option not in ["keep", "top", "bottom"]:
+            raise ValueError("na_option must be one of 'keep', 'top', 'bottom'")
 
         if self._internal.index_level > 1:
             raise NotImplementedError("rank do not support MultiIndex now")
 
+        # Determine ordering with null placement based on na_option.
+        # 'top' always assigns the smallest rank to NaN, 'bottom' the largest,
+        # regardless of ascending direction.
         if ascending:
-            asc_func = PySparkColumn.asc
+            sort_col = (
+                self.spark.column.asc_nulls_first()
+                if na_option == "top"
+                else self.spark.column.asc_nulls_last()
+            )
+            nat_order_col = F.col(NATURAL_ORDER_COLUMN_NAME).asc()
         else:
-            asc_func = PySparkColumn.desc
+            sort_col = (
+                self.spark.column.desc_nulls_first()
+                if na_option == "top"
+                else self.spark.column.desc_nulls_last()
+            )
+            nat_order_col = F.col(NATURAL_ORDER_COLUMN_NAME).desc()
 
         if method == "first":
             window = (
-                Window.orderBy(
-                    asc_func(self.spark.column),
-                    asc_func(F.col(NATURAL_ORDER_COLUMN_NAME)),
-                )
+                Window.orderBy(sort_col, nat_order_col)
                 .partitionBy(*part_cols)
                 .rowsBetween(Window.unboundedPreceding, Window.currentRow)
             )
             scol = F.row_number().over(window)
         elif method == "dense":
             window = (
-                Window.orderBy(asc_func(self.spark.column))
+                Window.orderBy(sort_col)
                 .partitionBy(*part_cols)
                 .rowsBetween(Window.unboundedPreceding, Window.currentRow)
             )
@@ -4337,7 +4400,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             elif method == "max":
                 stat_func = F.max
             window1 = (
-                Window.orderBy(asc_func(self.spark.column))
+                Window.orderBy(sort_col)
                 .partitionBy(*part_cols)
                 .rowsBetween(Window.unboundedPreceding, Window.currentRow)
             )
@@ -4346,6 +4409,26 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 cast("List[ColumnOrName]", [self.spark.column]) + list(part_cols)
             ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
             scol = stat_func(F.row_number().over(window1)).over(window2)
+
+        if pct:
+            partition_window = Window.partitionBy(*part_cols)
+            if method == "dense":
+                # For dense ranking, pct denominator is the number of distinct values.
+                if na_option == "keep":
+                    denom = F.max(F.when(self.spark.column.isNotNull(), scol)).over(
+                        partition_window
+                    )
+                else:
+                    denom = F.max(scol).over(partition_window)
+            elif na_option == "keep":
+                denom = F.count(self.spark.column).over(partition_window)
+            else:
+                denom = F.count(F.lit(1)).over(partition_window)
+            scol = scol / denom.cast(DoubleType())
+
+        if na_option == "keep":
+            scol = F.when(self.spark.column.isNotNull(), scol)
+
         return self._with_new_scol(scol.cast(DoubleType()))
 
     def filter(

--- a/python/pyspark/pandas/tests/computation/test_compute.py
+++ b/python/pyspark/pandas/tests/computation/test_compute.py
@@ -360,6 +360,60 @@ class FrameComputeMixin:
         with self.assertRaisesRegex(ValueError, "No axis named"):
             psdf.rank(axis=2)
 
+    def test_rank_pct_na_option(self):
+        pdf = pd.DataFrame(
+            {"A": [1, 2, np.nan, 3], "B": [4, np.nan, 2, 1]},
+            columns=["A", "B"],
+        )
+        psdf = ps.from_pandas(pdf)
+
+        # pct=True
+        self.assert_eq(pdf.rank(pct=True).sort_index(), psdf.rank(pct=True).sort_index())
+
+        # na_option='top'
+        self.assert_eq(
+            pdf.rank(na_option="top").sort_index(), psdf.rank(na_option="top").sort_index()
+        )
+
+        # na_option='bottom'
+        self.assert_eq(
+            pdf.rank(na_option="bottom").sort_index(), psdf.rank(na_option="bottom").sort_index()
+        )
+
+        # pct + na_option combined
+        self.assert_eq(
+            pdf.rank(pct=True, na_option="top").sort_index(),
+            psdf.rank(pct=True, na_option="top").sort_index(),
+        )
+        self.assert_eq(
+            pdf.rank(pct=True, na_option="bottom").sort_index(),
+            psdf.rank(pct=True, na_option="bottom").sort_index(),
+        )
+
+        # all methods
+        for method in ["average", "min", "max", "first", "dense"]:
+            self.assert_eq(
+                pdf.rank(method=method, pct=True).sort_index(),
+                psdf.rank(method=method, pct=True).sort_index(),
+            )
+            self.assert_eq(
+                pdf.rank(method=method, na_option="bottom").sort_index(),
+                psdf.rank(method=method, na_option="bottom").sort_index(),
+            )
+
+        # axis=1 with pct and na_option
+        self.assert_eq(
+            pdf.rank(axis=1, pct=True).sort_index(), psdf.rank(axis=1, pct=True).sort_index()
+        )
+        self.assert_eq(
+            pdf.rank(axis=1, na_option="top").sort_index(),
+            psdf.rank(axis=1, na_option="top").sort_index(),
+        )
+
+        # invalid na_option
+        with self.assertRaisesRegex(ValueError, "na_option must be one of"):
+            psdf.rank(na_option="invalid")
+
     def test_nunique(self):
         pdf = pd.DataFrame({"A": [1, 2, 3], "B": [np.nan, 3, np.nan]}, index=np.random.rand(3))
         psdf = ps.from_pandas(pdf)

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -344,6 +344,30 @@ class SeriesStatMixin:
         with self.assertRaisesRegex(ValueError, msg):
             psser.rank(method="nothing")
 
+        # pct=True
+        pser = pd.Series([1, 2, 2, 3], name="x")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.rank(pct=True), psser.rank(pct=True).sort_index())
+
+        # na_option
+        pser = pd.Series([1, float("nan"), 2, 3], name="x")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.rank(na_option="top"), psser.rank(na_option="top").sort_index())
+        self.assert_eq(pser.rank(na_option="bottom"), psser.rank(na_option="bottom").sort_index())
+        self.assert_eq(
+            pser.rank(pct=True, na_option="top"),
+            psser.rank(pct=True, na_option="top").sort_index(),
+        )
+
+        # axis=0 is accepted (no-op for Series)
+        pser = pd.Series([1, 2, 3], name="x")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.rank(axis=0), psser.rank(axis=0).sort_index())
+
+        # invalid na_option
+        with self.assertRaisesRegex(ValueError, "na_option must be one of"):
+            psser.rank(na_option="bad")
+
         msg = "method must be one of 'average', 'min', 'max', 'first', 'dense'"
         with self.assertRaisesRegex(ValueError, msg):
             psser.rank(method="nothing")

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -360,7 +360,7 @@ class SeriesStatMixin:
         )
 
         # axis=0 is accepted (no-op for Series)
-        pser = pd.Series([1, 2, 3], name="x")
+        pser = pd.Series([1, 2, 3, 1], name="x")
         psser = ps.from_pandas(pser)
         self.assert_eq(pser.rank(axis=0), psser.rank(axis=0).sort_index())
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add `na_option`, `pct`, and `axis` parameters to `Series.rank()`, and `na_option` and `pct` to
`DataFrame.rank()`, to match the pandas API.

- `na_option` (`'keep'`/`'top'`/`'bottom'`): controls how `NaN` values are ranked
- `pct`: expresses ranks as percentile fractions in `(0, 1]`
- `axis` on `Series.rank()`: accepts `0`/`'index'` only, added for API compatibility

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The pandas-on-Spark implementations were missing these parameters, making it harder to migrate
pandas code to Spark without modification. `DataFrame.rank` was tracked in SPARK-46167; this PR
also covers `Series.rank`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Two new keyword parameters on `Series.rank()` and `DataFrame.rank()`. Defaults are
unchanged so existing code is unaffected.

```python
>>> ps.Series([1, float('nan'), 2]).rank(na_option='top')
0    2.0
1    1.0
2    3.0


>>> ps.Series([1, 2, 2, 3]).rank(pct=True)
0    0.25
1    0.625
2    0.625
3    1.0
```
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New test method test_rank_pct_na_option in test_compute.py and new cases in test_stat.py
covering all methods, both axes, combined parameters, and invalid input errors.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
This patch was co-authored with AI assistance (Claude Sonnet 4.6).