### PR TITLE
[MINOR][INFRA] Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -130,7 +130,7 @@ jobs:
         run: cd tpcds-kit/tools && make OS=LINUX
       - name: Install Java ${{ inputs.jdk }}
         if: steps.cache-tpcds-sf-1.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.jdk }}
@@ -199,7 +199,7 @@ jobs:
         restore-keys: |
           benchmark-coursier-${{ inputs.jdk }}
     - name: Install Java ${{ inputs.jdk }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.jdk }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -381,7 +381,7 @@ jobs:
           ./dev/free_disk_space
         fi
     - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -574,7 +574,7 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -698,7 +698,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -854,7 +854,7 @@ jobs:
       continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -980,7 +980,7 @@ jobs:
       continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1053,7 +1053,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: 25
@@ -1116,7 +1116,7 @@ jobs:
       continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1200,7 +1200,7 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1323,7 +1323,7 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1401,7 +1401,7 @@ jobs:
             ./dev/free_disk_space
           fi
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}

--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             coursier-build-spark-connect-python-only-${{ runner.os }}-
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: 17

--- a/.github/workflows/build_python_connect40.yml
+++ b/.github/workflows/build_python_connect40.yml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: |
             coursier-build-spark-connect-python-only-${{ runner.os }}-
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: 17

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -47,7 +47,7 @@ jobs:
         restore-keys: |
           build-sparkr-windows-maven-${{ runner.os }}-
     - name: Install Java 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: 17

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -99,7 +99,7 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-java${{ inputs.java }}-
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}
@@ -243,7 +243,7 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-java${{ matrix.java }}-
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Free up disk space
         run: ./dev/free_disk_space_container
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: 17

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -54,13 +54,13 @@ jobs:
           snapshot-maven-${{ runner.os }}-
     - name: Install Java 8 for branch-3.x
       if: matrix.branch == 'branch-3.5'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: 8
     - name: Install Java 17
       if: matrix.branch != 'branch-3.5'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: 17

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -103,7 +103,7 @@ jobs:
           restore-keys: |
             coursier-${{ runner.os }}-
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}
@@ -206,7 +206,7 @@ jobs:
           restore-keys: |
             coursier-${{ runner.os }}-
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade all active GitHub workflow references from `actions/setup-java@v5` to `@v6`.

### Why are the changes needed?

This keeps Spark workflows on the current supported major version of setup-java.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `git diff --check`
- Verified no setup-java references older than v6 remain in active workflows

No runtime tests were run because this patch only changes the CI action version.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot
