### PR TITLE
[SPARK-58976][UI] Remove unused generateOutputOperationStatusForUI in BatchPage

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/BatchPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/BatchPage.scala
@@ -270,19 +270,6 @@ private[ui] class BatchPage(parent: StreamingTab) extends WebUIPage("batch") {
     }
   }
 
-  private def generateOutputOperationStatusForUI(failure: String): String = {
-    if (failure.startsWith("org.apache.spark.SparkException")) {
-      "Failed due to Spark job error\n" + failure
-    } else {
-      var nextLineIndex = failure.indexOf("\n")
-      if (nextLineIndex < 0) {
-        nextLineIndex = failure.length
-      }
-      val firstLine = failure.substring(0, nextLineIndex)
-      s"Failed due to error: $firstLine\n$failure"
-    }
-  }
-
   /**
    * Generate the job table for the batch.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This removes the unused private method `generateOutputOperationStatusForUI(failure: String)` from the Spark Streaming (DStreams) Web UI page `BatchPage`.

### Why are the changes needed?

The method has no callers -- its only occurrence in the codebase is its own definition. The live code path renders output-operation failures via `UIUtils.createOutputOperationFailureForUI` instead. Removing the dead method reduces confusion and maintenance surface.

### Does this PR introduce _any_ user-facing change?

No. The method was never invoked, so removing it does not change any rendered output.

### How was this patch tested?

Existing tests. This is a pure removal of an unreferenced private method; a repo-wide search confirms `generateOutputOperationStatusForUI` had no other references.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
