### PR TITLE
[MINOR][PS][DOC] Correct the null-handling comment on the numpy signbit mapping

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -89,11 +89,15 @@ unary_np_spark_mappings = {
     "rint": lambda c: F.rint(c.cast("double")),
     "sign": F.signum,
     "signbit": lambda c: F.when(
-        # A genuine <NA> from a nullable dtype (e.g. Int64) arrives as a non-double
-        # null and must propagate. A NaN from a default (numpy-backed) dtype arrives
-        # as a double null and must map to False (np.signbit(nan) is False); it falls
-        # through to otherwise(False) below. A nullable Float64 <NA> is also a double
-        # null, indistinguishable from a NaN after from_pandas, so it cannot propagate.
+        # A genuine <NA> from a nullable dtype (e.g. Int64) arrives as a non-floating null
+        # and must propagate. A NaN from a default (numpy-backed) dtype arrives as a floating
+        # null and must map to False (np.signbit(nan) is False); it falls through to
+        # otherwise(False) below. Two cases this expression cannot match, seeing only the Spark
+        # value and not the pandas dtype: a nullable float dtype's <NA> (Float32 or Float64) is
+        # also a floating null, indistinguishable from a NaN after from_pandas, so it reads False
+        # instead of propagating; and the sign of a NaN never reaches here (from_pandas nulls a
+        # NaN, and a NaN computed in Spark arrives as +NaN), so a negative NaN reads False where
+        # np.signbit reports True.
         c.isNull() & ~F.typeof(c).isin("float", "double"),
         F.lit(None).cast("boolean"),
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Comment-only: corrects and completes the null-handling comment on the `signbit` entry in `unary_np_spark_mappings`, which named fewer cases than actually reach its floating-null branch.

While fixing it I looked at whether the unmatched case could be fixed. `from_pandas` sends both a `NaN` and a genuine missing value to Spark as a null, so the expression cannot tell which of the two it has:

- **`float64` / `float32` (default):** a null is always a `NaN`, so the current answer (`False`) is right.
- **`Float64` / `Float32` (nullable):** a null may be an `<NA>`, which pandas would propagate, but it is treated as a `NaN` instead -- `np.signbit` on `pd.Series([1.0, None, -2.0], dtype="Float64")` returns `[False, False, True]` where pandas returns `[False, <NA>, True]`.

**Correction (post-merge).** This description originally claimed the pandas dtype could settle that "exactly", by choosing the answer for a null in `maybe_dispatch_ufunc_to_spark_func`. That was wrong, and I would not pursue it. `DataTypeOps.prepare` runs `col.replace({np.nan: None})` per column on `from_pandas` (`data_type_ops/base.py:549`): on a nullable column that is a no-op while no `<NA>` is present, so NaNs survive as real Spark NaNs -- but once a single `<NA>` exists the column is downcast to `object` and the unmasked NaNs are counted as missing too. So whether a NaN survives depends on whether an *unrelated* row in the same column is missing, and propagating for nullable dtypes would return different answers for the same value depending on that. Treating every floating null as a `NaN`, as the code does today, is the predictable choice. The comment added by this PR is accurate as merged; only this description was wrong.

Out of reach either way: the `NaN` *sign*. Spark cannot expose it (`NaN < 0` is false, and the string cast yields `"NaN"`), so that half of the comment stands regardless.

### Why are the changes needed?

The comment is the only place this behavior is written down, and it named fewer cases than land in that branch -- a reader trusting it would expect a nullable `Float32` `<NA>` to propagate, and a negative `NaN` to be reported as negative. Neither is true.

### Does this PR introduce _any_ user-facing change?

No. Comment-only.

### How was this patch tested?

No tests added -- the diff is comment-only, so behavior is unchanged. Ran `ruff check` / `ruff format --check` on the changed file and `test_numpy_compat.py` (`test_np_signbit` passes).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
