### PR TITLE
[WIP][SQL][PYTHON] Prototype inline JVM UDF source registration

### DIFF
--- a/docs/jvm-source-udf-design.md
+++ b/docs/jvm-source-udf-design.md
@@ -1,0 +1,247 @@
+# Inline JVM UDF Source in PySpark
+
+## Status
+
+Draft proposal.
+
+## Summary
+
+Add a PySpark API that accepts Java or Scala source code, compiles it on the Spark driver or
+Spark Connect server, distributes the compiled classes to executors, and registers the class as
+a scalar SQL UDF.
+
+The new API handles source compilation only. After compilation, it reuses the existing artifact
+manager and `UDFRegistration.registerJava` path.
+
+## Motivation
+
+`spark.udf.registerJavaFunction` currently accepts a fully qualified class name. Users must compile
+their Java or Scala code into a JAR, place that JAR on Spark's class path, and then register the
+class. This is inconvenient for interactive PySpark use, especially with Spark Connect.
+
+The proposed API lets users define a small JVM UDF in the same Python application while preserving
+JVM execution. It avoids the Python worker overhead of a Python UDF, although the resulting JVM UDF
+remains opaque to Catalyst optimization.
+
+## Goals
+
+- Accept complete Java or Scala source for a scalar UDF from PySpark.
+- Support Spark Classic and Spark Connect with the same public API.
+- Compile source once per session rather than once per task or executor.
+- Reuse the existing JVM UDF validation, type inference, registration, and execution paths.
+- Make compiled classes available through Spark's session artifact class loader.
+- Return useful compiler diagnostics containing source line and column information.
+
+## Non-goals
+
+- Defining a new expression language for method bodies or lambda snippets.
+- Supporting Java or Scala aggregate UDFs in the first version.
+- Sandboxing untrusted JVM code.
+- Persisting source UDFs in an external catalog.
+- Replacing built-in SQL functions or Catalyst expressions.
+
+## Proposed API
+
+Add the following method to PySpark's `UDFRegistration`:
+
+```python
+def registerJvmFunctionFromSource(
+    self,
+    name: str,
+    className: str,
+    source: str,
+    returnType: Optional[DataTypeOrString] = None,
+    *,
+    language: str = "java",
+) -> None:
+    ...
+```
+
+`language` accepts `"java"` or `"scala"`. A separate method is preferable to overloading
+`registerJavaFunction` because the existing method has stable class-loading semantics and its
+second positional argument is already a class name.
+
+The source must declare `className`, implement exactly one of
+`org.apache.spark.sql.api.java.UDF0` through `UDF22`, and provide a public no-argument constructor.
+Scala source uses the same Java UDF interfaces, allowing the existing registration path to handle
+both languages.
+
+### Java example
+
+```python
+java_source = """
+package example;
+
+import org.apache.spark.sql.api.java.UDF1;
+
+public final class PlusOne implements UDF1<Long, Long> {
+  @Override
+  public Long call(Long value) {
+    return value == null ? null : value + 1;
+  }
+}
+"""
+
+spark.udf.registerJvmFunctionFromSource(
+    name="plus_one",
+    className="example.PlusOne",
+    source=java_source,
+    returnType="long",
+)
+```
+
+### Scala example
+
+```python
+scala_source = """
+package example
+
+import org.apache.spark.sql.api.java.UDF1
+
+final class StringLength extends UDF1[String, java.lang.Integer] {
+  override def call(value: String): java.lang.Integer = {
+    if (value == null) null else value.length
+  }
+}
+"""
+
+spark.udf.registerJvmFunctionFromSource(
+    name="string_length",
+    className="example.StringLength",
+    source=scala_source,
+    language="scala",
+)
+```
+
+When `returnType` is not specified, the existing Java reflection logic infers it from the selected
+`UDFn` interface.
+
+## Design
+
+The source is compiled on the JVM that owns the Spark session. Client-side compilation is avoided
+because a Spark Connect Python client may not have a JDK, a Scala compiler, Spark JARs, or the same
+dependencies as the server.
+
+```text
+PySpark API
+  -> Py4J call or Spark Connect command
+  -> session JVM source compiler
+  -> content-addressed JAR in the session artifact manager
+  -> existing UDFRegistration.registerJava
+  -> existing JVM UDF execution on executors
+```
+
+### Compilation
+
+Introduce an internal source compiler service in SQL core. It accepts the language, source,
+declared class name, and the session artifact class loader. It returns all generated class files.
+
+For Java, use `javax.tools.JavaCompiler` with an in-memory file manager. Disable annotation
+processing with `-proc:none`. The existing Catalyst `JdkCodeCompiler` contains useful in-memory
+compiler and class-loader-aware file-manager code, but its public shape is specific to generated
+Catalyst classes. Common compiler plumbing may be extracted rather than making the Catalyst
+code-generation API handle arbitrary user classes.
+
+For Scala, use the Scala compiler version with which Spark was built. Scala support must fail with
+a structured error when the matching compiler is unavailable. All emitted classes, including
+module, anonymous, and nested classes, must be packaged together.
+
+The compiler resolves dependencies through the session artifact class loader. Users must add
+dependency JARs before registering the source UDF.
+
+### Artifact distribution
+
+Package generated classes into a JAR named from a SHA-256 digest of the language, declared class
+name, source, Spark version, and Scala version when applicable. Add that JAR through the session
+artifact manager. This makes the class visible to the driver and distributes it to executors using
+the existing job artifact state.
+
+Compilation is idempotent within a session. Re-registering the same class and source reuses the
+artifact. Registering different source with an already compiled class name fails because JVM class
+redefinition and multiple JARs containing the same class have ambiguous behavior. Users can choose
+a new class name or create a new session.
+
+After adding the artifact, call the existing `registerJava(name, className, returnType)` method.
+That method remains responsible for loading the class, validating its `UDFn` interface, creating an
+instance, inferring the return type, and registering the temporary function.
+
+### Spark Classic
+
+PySpark calls an internal method on the classic JVM `UDFRegistration` through Py4J. The JVM method
+compiles, adds the generated artifact, and delegates to `registerJava`.
+
+### Spark Connect
+
+Add a source JVM UDF message to the `register_function` command containing:
+
+- Language.
+- Fully qualified class name.
+- Source text.
+- Optional output data type.
+
+The Connect planner invokes the same compiler service and registration logic used by Spark
+Classic. Keeping compilation on the server makes behavior independent of the Python client
+environment. An older server that does not support the new command returns the standard unsupported
+feature error.
+
+## Errors
+
+Add structured errors for:
+
+- Unsupported source language.
+- Source compilation disabled by server policy.
+- Requested compiler unavailable.
+- Compilation failure, including compiler diagnostics.
+- Declared class not generated by the source.
+- Class not implementing exactly one supported `UDFn` interface.
+- Class name already associated with different source in the session.
+
+Source text should not be included in error parameters or ordinary logs. Compiler diagnostics may
+include a bounded source excerpt, controlled by the existing code-generation logging limit or a
+similar dedicated setting.
+
+## Security and resource controls
+
+The resulting UDF is arbitrary JVM code. The API must use the same authorization policy as adding
+and executing JAR artifacts. Deployments that do not allow users to execute JVM artifacts must be
+able to disable source compilation.
+
+The implementation should also:
+
+- Limit source size and compiler diagnostic size.
+- Disable Java annotation processing.
+- Bound concurrent compilations.
+- Clean generated files when the session closes.
+- Avoid placing source text in event logs or query plans.
+
+Compilation does not provide a security sandbox. A server must not enable this API for users who
+are not already trusted to execute JVM or Python UDF code.
+
+## Compatibility
+
+The existing `registerJavaFunction` and `registerJavaUDAF` APIs are unchanged. Source UDFs are
+temporary session functions and use the same runtime semantics as an equivalent precompiled Java
+UDF.
+
+The Connect protocol change is additive. Python clients should only send the new command when the
+new API is called.
+
+## Test plan
+
+- PySpark Classic tests for Java and Scala source UDFs.
+- Spark Connect end-to-end tests for both languages.
+- Explicit and inferred return types.
+- Null inputs and primitive or boxed results.
+- Multiple generated class files from one source unit.
+- Dependency resolution from a previously added session JAR.
+- Execution on multiple executor JVMs, not only local driver execution.
+- Idempotent registration and conflicting source for the same class name.
+- Compiler unavailable, compilation disabled, invalid source, and invalid UDF class errors.
+- Source and diagnostic size limits.
+
+## Rollout
+
+Implement Java source first because the JDK compiler has a stable API and produces predictable
+class files. Add Scala source after validating compiler packaging and Spark distribution size. The
+public API includes the language argument from the start so Scala can be added without another API
+shape change.

--- a/python/docs/source/reference/pyspark.sql/udf.rst
+++ b/python/docs/source/reference/pyspark.sql/udf.rst
@@ -29,4 +29,5 @@ UDF
     udf.UserDefinedFunction.returnType
     UDFRegistration.register
     UDFRegistration.registerJavaFunction
+    UDFRegistration.registerJvmFunctionFromSource
     UDFRegistration.registerJavaUDAF

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -38,7 +38,7 @@ from pyspark.sql.udf import (
     UserDefinedFunction as PySparkUserDefinedFunction,
 )
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
-from pyspark.errors import PySparkTypeError, PySparkRuntimeError
+from pyspark.errors import PySparkNotImplementedError, PySparkTypeError, PySparkRuntimeError
 
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import (
@@ -339,6 +339,24 @@ class UDFRegistration:
         self.sparkSession._client.register_java(name, javaClassName, returnType)
 
     registerJavaFunction.__doc__ = PySparkUDFRegistration.registerJavaFunction.__doc__
+
+    def registerJvmFunctionFromSource(
+        self,
+        name: str,
+        className: str,
+        source: str,
+        returnType: Optional["DataTypeOrString"] = None,
+        *,
+        language: str = "java",
+    ) -> None:
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "registerJvmFunctionFromSource in Spark Connect"},
+        )
+
+    registerJvmFunctionFromSource.__doc__ = (
+        PySparkUDFRegistration.registerJvmFunctionFromSource.__doc__
+    )
 
     def registerJavaUDAF(self, name: str, javaClassName: str) -> None:
         self.sparkSession._client.register_java(name, javaClassName, aggregate=True)

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -46,7 +46,7 @@ from pyspark.sql.types import (
     VariantType,
     VariantVal,
 )
-from pyspark.errors import AnalysisException, PythonException, PySparkTypeError
+from pyspark.errors import AnalysisException, PythonException, PySparkTypeError, PySparkValueError
 from pyspark.logger import PySparkLogger
 from pyspark.testing.objects import ExamplePoint, ExamplePointUDT
 from pyspark.testing.sqlutils import (
@@ -1727,6 +1727,40 @@ class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):
     def setUpClass(cls):
         super(BaseUDFTestsMixin, cls).setUpClass()
         cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "false")
+
+    def test_register_jvm_function_from_source(self):
+        source = """
+            package test.pyspark.sql;
+
+            import org.apache.spark.sql.api.java.UDF1;
+
+            public final class InlinePlusOne implements UDF1<Long, Long> {
+              private static final class Helper {
+                private static Long plusOne(Long value) {
+                  return value == null ? null : value + 1;
+                }
+              }
+
+              @Override
+              public Long call(Long value) {
+                return Helper.plusOne(value);
+              }
+            }
+        """
+        with self.temp_func("inline_plus_one"):
+            self.spark.udf.registerJvmFunctionFromSource(
+                "inline_plus_one", "test.pyspark.sql.InlinePlusOne", source
+            )
+            rows = self.spark.range(3).selectExpr("inline_plus_one(id)").collect()
+            self.assertEqual([row[0] for row in rows], [1, 2, 3])
+
+        with self.assertRaises(PySparkValueError):
+            self.spark.udf.registerJvmFunctionFromSource(
+                "scala_udf",
+                "test.pyspark.sql.ScalaUDF",
+                "final class ScalaUDF",
+                language="scala",
+            )
 
     # We cannot check whether the batch size is effective or not. We just run the query with
     # various batch size and see whether the query runs successfully, and the output is

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -36,7 +36,12 @@ from pyspark.sql.types import (
 from pyspark.sql.utils import get_active_spark_context
 from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
-from pyspark.errors import PySparkTypeError, PySparkNotImplementedError, PySparkRuntimeError
+from pyspark.errors import (
+    PySparkTypeError,
+    PySparkNotImplementedError,
+    PySparkRuntimeError,
+    PySparkValueError,
+)
 
 if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject
@@ -923,6 +928,61 @@ class UDFRegistration:
                 returnType = _parse_datatype_string(returnType)
             jdt = self.sparkSession._jsparkSession.parseDataType(returnType.json())
         self.sparkSession._jsparkSession.udf().registerJava(name, javaClassName, jdt)
+
+    def registerJvmFunctionFromSource(
+        self,
+        name: str,
+        className: str,
+        source: str,
+        returnType: Optional["DataTypeOrString"] = None,
+        *,
+        language: str = "java",
+    ) -> None:
+        """Compile JVM source and register the resulting class as a SQL function.
+
+        This prototype supports Java source in Spark Classic. The source must declare
+        ``className`` and implement one of ``org.apache.spark.sql.api.java.UDF0`` through
+        ``UDF22``.
+
+        Parameters
+        ----------
+        name : str
+            name of the user-defined function
+        className : str
+            fully qualified name of the class declared by ``source``
+        source : str
+            complete Java source unit
+        returnType : :class:`pyspark.sql.types.DataType` or str, optional
+            return type of the registered function; inferred from the UDF interface when omitted
+        language : str, keyword-only
+            source language; the prototype currently accepts only ``"java"``
+
+        Examples
+        --------
+        >>> source = '''
+        ... package example;
+        ... import org.apache.spark.sql.api.java.UDF1;
+        ... public final class PlusOne implements UDF1<Long, Long> {
+        ...   public Long call(Long value) { return value == null ? null : value + 1; }
+        ... }
+        ... '''
+        >>> spark.udf.registerJvmFunctionFromSource(
+        ...     "plus_one", "example.PlusOne", source, "long")  # doctest: +SKIP
+        >>> spark.sql("SELECT plus_one(1L)").first()[0]  # doctest: +SKIP
+        2
+        """
+        if language != "java":
+            raise PySparkValueError(
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={"arg_name": "language", "allowed_values": "['java']"},
+            )
+
+        jdt = None
+        if returnType is not None:
+            if not isinstance(returnType, DataType):
+                returnType = _parse_datatype_string(returnType)
+            jdt = self.sparkSession._jsparkSession.parseDataType(returnType.json())
+        self.sparkSession._jsparkSession.udf().registerJavaSource(name, className, source, jdt)
 
     def registerJavaUDAF(self, name: str, javaClassName: str) -> None:
         """Register a Java user-defined aggregate function as a SQL function.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeCompiler.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeCompiler.scala
@@ -904,6 +904,39 @@ object JdkCodeCompiler extends CodeCompiler with Logging {
     }
   }
 
+  /**
+   * Compile a complete Java source unit and return every generated class file.
+   *
+   * This is intentionally an internal entry point. Unlike [[compile]], it does not wrap the
+   * source in Spark's generated-class contract or load the result. Callers are responsible for
+   * publishing the returned bytecode through the appropriate class loader.
+   */
+  private[sql] def compileJavaSource(
+      className: String,
+      source: String,
+      resolveLoader: ClassLoader): Map[String, Array[Byte]] = {
+    if (!isAvailable) {
+      throw new UnsupportedOperationException(
+        "javax.tools.JavaCompiler is not available on this runtime")
+    }
+
+    val future = compileExecutor.submit(new Callable[Map[String, Array[Byte]]] {
+      override def call(): Map[String, Array[Byte]] = {
+        compileToBytecode(
+          className,
+          source,
+          resolveLoader,
+          "Java source UDF",
+          () => ())
+      }
+    })
+    try {
+      Uninterruptibles.getUninterruptibly(future)
+    } catch {
+      case e: ExecutionException => throw Option(e.getCause).getOrElse(e)
+    }
+  }
+
   /** The actual compilation; always runs on [[compileExecutor]]. */
   private def doCompile(
       code: CodeAndComment,
@@ -911,7 +944,38 @@ object JdkCodeCompiler extends CodeCompiler with Logging {
       resolveLoader: ClassLoader,
       parentLoader: ClassLoader,
       failureLogMaxLines: Int): (GeneratedClass, ByteCodeStats) = {
-    val fileObject = new InMemorySourceFile(CodeCompiler.GeneratedClassName, source)
+    // On failure, dump the full compilation unit rather than the raw class body: the
+    // line numbers in javac diagnostics refer to the wrapped unit (header + adapted
+    // body), so this keeps the dump's `/* NNN */` markers aligned with `line NNN`.
+    def logSourceOnFailure(): Unit = CodeCompiler.logGeneratedCodeOnFailure(
+      new CodeAndComment(source, code.comment), failureLogMaxLines)
+
+    val classBytecodes = compileToBytecode(
+      CodeCompiler.GeneratedClassName,
+      source,
+      resolveLoader,
+      "generated Java code",
+      () => logSourceOnFailure())
+    val codeStats = CodeCompiler.computeByteCodeStats(classBytecodes)
+    val loader = new InMemoryClassLoader(classBytecodes, parentLoader)
+
+    // `getConstructor` (public-only), matching the Janino path's instantiation.
+    val generated = loader.loadClass(CodeCompiler.GeneratedClassName)
+      .getConstructor()
+      .newInstance()
+      .asInstanceOf[GeneratedClass]
+
+    (generated, codeStats)
+  }
+
+  /** Compile one Java source unit. Must run on [[compileExecutor]]. */
+  private def compileToBytecode(
+      className: String,
+      source: String,
+      resolveLoader: ClassLoader,
+      description: String,
+      logSourceOnFailure: () => Unit): Map[String, Array[Byte]] = {
+    val fileObject = new InMemorySourceFile(className, source)
     val diagnostics = new DiagnosticCollector[JavaFileObject]()
     val fileManager = new ClassLoaderFileManager(sharedFileManager, resolveLoader, source)
     // Captures anything javac writes outside the diagnostics listener (internal
@@ -927,17 +991,11 @@ object JdkCodeCompiler extends CodeCompiler with Logging {
       /* classes         = */ null,
       /* compilationUnits = */ java.util.Collections.singletonList(fileObject))
 
-    // On failure, dump the full compilation unit rather than the raw class body: the
-    // line numbers in javac diagnostics refer to the wrapped unit (header + adapted
-    // body), so this keeps the dump's `/* NNN */` markers aligned with `line NNN`.
-    def logSourceOnFailure(): Unit = CodeCompiler.logGeneratedCodeOnFailure(
-      new CodeAndComment(source, code.comment), failureLogMaxLines)
-
     val success = try {
       task.call().booleanValue()
     } catch {
       case NonFatal(e) =>
-        logError("Failed to compile the generated Java code.", e)
+        logError(s"Failed to compile $description.", e)
         logSourceOnFailure()
         throw QueryExecutionErrors.internalCompilerError(
           new InternalCompilerException(e.getMessage, e))
@@ -956,22 +1014,12 @@ object JdkCodeCompiler extends CodeCompiler with Logging {
         case parts => parts.mkString("\n")
       }
       val ex = new CompileException(message, null)
-      logError("Failed to compile the generated Java code.", ex)
+      logError(s"Failed to compile $description.", ex)
       logSourceOnFailure()
       throw QueryExecutionErrors.compilerError(ex)
     }
 
-    val classBytecodes = fileManager.snapshot()
-    val codeStats = CodeCompiler.computeByteCodeStats(classBytecodes)
-    val loader = new InMemoryClassLoader(classBytecodes.toMap, parentLoader)
-
-    // `getConstructor` (public-only), matching the Janino path's instantiation.
-    val generated = loader.loadClass(CodeCompiler.GeneratedClassName)
-      .getConstructor()
-      .newInstance()
-      .asInstanceOf[GeneratedClass]
-
-    (generated, codeStats)
+    fileManager.snapshot().toMap
   }
 
   private def formatDiagnostic(d: Diagnostic[_ <: JavaFileObject]): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeCompilerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeCompilerSuite.scala
@@ -237,6 +237,26 @@ class CodeCompilerSuite extends SparkFunSuite with SQLHelper {
     assert(stats.maxConstPoolSize > 0)
   }
 
+  test("JDK backend compiles a complete Java source unit") {
+    assume(JdkCodeCompiler.isAvailable, "javax.tools.JavaCompiler not available")
+    val className = "test.InlineSource"
+    val source =
+      """
+        |package test;
+        |
+        |public final class InlineSource {
+        |  public static final class Helper {}
+        |}
+        |""".stripMargin
+    val classBytecodes = JdkCodeCompiler.compileJavaSource(
+      className,
+      source,
+      getClass.getClassLoader)
+
+    assert(classBytecodes.keySet == Set(className, className + "$Helper"))
+    assert(classBytecodes.values.forall(_.nonEmpty))
+  }
+
   test("Both backends produce class bytecodes the ByteCodeStats parser accepts") {
     assume(JdkCodeCompiler.isAvailable, "javax.tools.JavaCompiler not available")
     val code = newCodeAndComment(sampleClassBody)

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/UDFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/UDFRegistration.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.classic
 
+import java.io.ByteArrayOutputStream
 import java.lang.reflect.ParameterizedType
+import java.util.jar.{JarEntry, JarOutputStream}
 
 import scala.collection.mutable
 
@@ -142,7 +144,7 @@ class UDFRegistration private[sql] (session: SparkSession, functionRegistry: Fun
     }
   }
 
-  /** Compile Java source, publish its class files as session artifacts, and register its UDF. */
+  /** Compile Java source, publish its classes as a session JAR, and register its UDF. */
   private[sql] def registerJavaSource(
       name: String,
       className: String,
@@ -164,10 +166,20 @@ class UDFRegistration private[sql] (session: SparkSession, functionRegistry: Fun
           throw new IllegalArgumentException(
             s"Java source did not generate the declared class '$className'")
         }
-        classBytecodes.toSeq.sortBy(_._1).foreach { case (binaryName, bytecode) =>
-          val target = binaryName.replace('.', '/') + ".class"
-          session.addArtifact(bytecode, target)
+        val jarBytes = new ByteArrayOutputStream()
+        val jar = new JarOutputStream(jarBytes)
+        try {
+          classBytecodes.toSeq.sortBy(_._1).foreach { case (binaryName, bytecode) =>
+            val entry = new JarEntry(binaryName.replace('.', '/') + ".class")
+            entry.setTime(0L)
+            jar.putNextEntry(entry)
+            jar.write(bytecode)
+            jar.closeEntry()
+          }
+        } finally {
+          jar.close()
         }
+        session.addArtifact(jarBytes.toByteArray, s"inline-jvm-udf-$sourceHash.jar")
         registerJava(name, className, returnDataType)
         javaSourceHashes.put(className, sourceHash)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/UDFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/UDFRegistration.scala
@@ -19,14 +19,18 @@ package org.apache.spark.sql.classic
 
 import java.lang.reflect.ParameterizedType
 
+import scala.collection.mutable
+
 import org.apache.spark.annotation.Stable
 import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql
 import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.catalyst.JavaTypeInference
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.codegen.JdkCodeCompiler
 import org.apache.spark.sql.classic.UserDefinedFunctionUtils.toScalaUDF
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.aggregate.{ScalaAggregator, ScalaUDAF}
@@ -47,6 +51,8 @@ import org.apache.spark.sql.types.DataType
 class UDFRegistration private[sql] (session: SparkSession, functionRegistry: FunctionRegistry)
   extends sql.UDFRegistration
   with Logging {
+  private val javaSourceHashes = mutable.HashMap.empty[String, String]
+
   protected[sql] def registerPython(name: String, udf: UserDefinedPythonFunction): Unit = {
     log.debug(
       s"""
@@ -133,6 +139,37 @@ class UDFRegistration private[sql] (session: SparkSession, functionRegistry: Fun
         throw QueryCompilationErrors.cannotLoadClassNotOnClassPathError(className)
       case _: InstantiationException | _: IllegalArgumentException =>
         throw QueryCompilationErrors.classWithoutPublicNonArgumentConstructorError(className)
+    }
+  }
+
+  /** Compile Java source, publish its class files as session artifacts, and register its UDF. */
+  private[sql] def registerJavaSource(
+      name: String,
+      className: String,
+      source: String,
+      returnDataType: DataType): Unit = javaSourceHashes.synchronized {
+    val sourceHash = JavaUtils.sha256Hex(source)
+    javaSourceHashes.get(className) match {
+      case Some(existingHash) if existingHash != sourceHash =>
+        throw new IllegalArgumentException(
+          s"Class '$className' is already registered from different Java source")
+      case Some(_) =>
+        registerJava(name, className, returnDataType)
+      case None =>
+        val classBytecodes = JdkCodeCompiler.compileJavaSource(
+          className,
+          source,
+          session.artifactManager.classloader)
+        if (!classBytecodes.contains(className)) {
+          throw new IllegalArgumentException(
+            s"Java source did not generate the declared class '$className'")
+        }
+        classBytecodes.toSeq.sortBy(_._1).foreach { case (binaryName, bytecode) =>
+          val target = binaryName.replace('.', '/') + ".class"
+          session.addArtifact(bytecode, target)
+        }
+        registerJava(name, className, returnDataType)
+        javaSourceHashes.put(className, sourceHash)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This draft PR prototypes a PySpark API for registering an inline Java source UDF:
`spark.udf.registerJvmFunctionFromSource(...)`.

The prototype:

- Adds the PySpark classic API and exposes it in the UDF API docs.
- Compiles complete Java source units with the existing JDK code compiler plumbing.
- Packages all generated classes into a deterministic session JAR and adds it through the session
  artifact manager.
- Delegates registration and return type inference to the existing Java UDF registration path.
- Adds a Spark Connect API stub that reports the feature as not implemented.
- Adds tests for compiling full Java source units and registering/executing an inline Java UDF.
- Adds a draft design document for inline JVM UDF source registration.

### Why are the changes needed?

`spark.udf.registerJavaFunction` requires users to compile JVM UDF code into a JAR and make that
JAR visible to Spark before registration. That is awkward for interactive PySpark workflows,
especially when the UDF body is small and naturally lives near the Python code using it.

This prototype explores a path where PySpark can submit Java source to the session JVM, compile it
once, distribute the generated classes through Spark's existing artifact mechanism, and execute it
through the existing JVM UDF path.

### Does this PR introduce _any_ user-facing change?

Yes. This draft adds a new PySpark classic API:
`UDFRegistration.registerJvmFunctionFromSource`.

The current prototype supports Java source only. Spark Connect exposes the method but raises a
not-implemented error.

### How was this patch tested?

Tests were added in:

- `python/pyspark/sql/tests/test_udf.py`
- `sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeCompilerSuite.scala`

Not run locally yet.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex
