### PR TITLE
[SPARK-58982][PYTHON] Remove unused _is_namedtuple_ attribute in serializers

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -357,7 +357,6 @@ if os.environ.get("PYSPARK_ENABLE_NAMEDTUPLE_PATCH") == "1":
             return (_restore, (name, fields, tuple(self)))
 
         cls.__reduce__ = __reduce__
-        cls._is_namedtuple_ = True
         return cls
 
     def _hijack_namedtuple():


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the write-only `_is_namedtuple_` attribute set on hijacked namedtuple classes in `_hack_namedtuple` (`python/pyspark/serializers.py`). It is assigned but never read anywhere in the codebase. The `PYSPARK_ENABLE_NAMEDTUPLE_PATCH` monkey-patch itself is intentionally left in place.

### Why are the changes needed?

The attribute was introduced in SPARK-10542 as a marker read by the then-vendored cloudpickle (`_load_namedtuple`) to special-case PySpark-hijacked namedtuples. That reader was dropped when cloudpickle was later upgraded, leaving the assignment write-only dead code.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No
