### PR TITLE
[SPARK-58006][SQL][FOLLOWUP] Reject escaping outer refs in forceSkipInline defs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -95,6 +95,16 @@ case class InlineCTE(
     // escape, so the definition is self-contained and safe to materialize. Walk the whole
     // definition (main tree plus nested subquery plans) once, collect every attribute bound
     // anywhere in the definition, and reject only references that resolve to none of them.
+    //
+    // Matching by exprId is exact for plans produced by a single analysis pass: every
+    // `OuterReference` wraps the very attribute it binds to, exprIds are allocated fresh
+    // per resolution, and `DeduplicateRelations` rewrites duplicated relation instances
+    // (self-join, union, etc.) with fresh exprIds before the optimizer runs. The known
+    // residual gap is a plan stitched together from already-analyzed plans (e.g. a producer
+    // embedding the same analyzed dataset twice): such a tree can carry the same exprId in
+    // multiple places, so an escaping reference could match a duplicated exprId and slip
+    // through. Such a query is ill-formed and fails later during planning or execution
+    // anyway; this check is defense-in-depth that fails fast with a clear error otherwise.
     val allNodes = cteDef.child.collectWithSubqueries { case n: LogicalPlan => n }
     val boundExprIds = allNodes.iterator
       .flatMap(_.output.filter(_.resolved).map(_.exprId))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -90,19 +90,16 @@ case class InlineCTE(
 
   private def validateNoOuterReferencesAcrossCTEBoundary(cteDef: CTERelationDef): Unit = {
     // Only an outer reference that actually escapes the CTE definition is invalid. An outer
-    // reference that resolves to an operator inside the definition body (e.g. a correlated
-    // subquery whose correlated column lives in the body) is self-contained and safe to
-    // materialize. So collect every attribute bound anywhere in the definition (including in
-    // nested subquery plans) and reject only references that resolve to none of them.
-    val boundExprIds = cteDef.child
-      .collectWithSubqueries { case n: LogicalPlan => n }
-      .flatMap(_.output.filter(_.resolved).map(_.exprId))
-      .toSet
-
-    // Walk the whole definition (main tree plus nested subquery plans). Locate either a direct
-    // `OuterReference` or a correlated subquery whose outer-scope attributes escape the def --
-    // i.e. resolve to none of `boundExprIds`.
+    // reference that points to an attribute produced by an operator inside the definition
+    // body (e.g. a correlated subquery whose correlated column lives in the body) is
+    // self-contained and safe to materialize. So walk the whole definition (main tree plus
+    // nested subquery plans) once, collect every attribute bound anywhere in the definition,
+    // and reject only references that resolve to none of them.
     val allNodes = cteDef.child.collectWithSubqueries { case n: LogicalPlan => n }
+    val boundExprIds = allNodes.flatMap(_.output.filter(_.resolved).map(_.exprId)).toSet
+
+    // Locate either a direct `OuterReference` or a correlated subquery whose outer-scope
+    // attributes escape the def -- i.e. resolve to none of `boundExprIds`.
     val escapingOuterRef = allNodes.iterator
       .flatMap(_.expressions.iterator.flatMap(_.collect {
         case o: OuterReference if !boundExprIds.contains(o.exprId) => o

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -89,30 +89,48 @@ case class InlineCTE(
   }
 
   private def validateNoOuterReferencesAcrossCTEBoundary(cteDef: CTERelationDef): Unit = {
-    val outerRefs = cteDef.child.flatMap(
-      _.expressions.flatMap(_.collect { case o: OuterReference => o }))
-    if (outerRefs.nonEmpty) {
-      throw SparkException.internalError(
-        "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
-          s"found outer reference '${outerRefs.head.name}' in the CTE definition " +
-          s"(cteId=${cteDef.id}).")
-    }
+    // Only an outer reference that actually escapes the CTE definition is invalid. An outer
+    // reference that resolves to an operator inside the definition body (e.g. a correlated
+    // subquery whose correlated column lives in the body) is self-contained and safe to
+    // materialize. So collect every attribute bound anywhere in the definition (including in
+    // nested subquery plans) and reject only references that resolve to none of them.
+    val boundExprIds = cteDef.child
+      .collectWithSubqueries { case n: LogicalPlan => n }
+      .flatMap(_.output.filter(_.resolved).map(_.exprId))
+      .toSet
 
-    val outerScopeSubqueries = cteDef.child.flatMap(
-      _.expressions.flatMap(_.collect {
-        case s: SubqueryExpression if s.outerScopeAttrs.nonEmpty => s
+    // Walk the whole definition (main tree plus nested subquery plans). Locate either a direct
+    // `OuterReference` or a correlated subquery whose outer-scope attributes escape the def --
+    // i.e. resolve to none of `boundExprIds`.
+    val allNodes = cteDef.child.collectWithSubqueries { case n: LogicalPlan => n }
+    val escapingOuterRef = allNodes.iterator
+      .flatMap(_.expressions.iterator.flatMap(_.collect {
+        case o: OuterReference if !boundExprIds.contains(o.exprId) => o
       }))
-    if (outerScopeSubqueries.nonEmpty) {
-      // `outerScopeAttrs` are expressions that contain an `OuterScopeReference` and may be
-      // compound (e.g. `Add(OuterScopeReference(a), Literal(1))`), so collect the reference node
-      // rather than assuming the attribute itself is one.
-      val outerScopeRef = outerScopeSubqueries.head.outerScopeAttrs
-        .flatMap(_.collect { case r: OuterScopeReference => r }).head
-      throw SparkException.internalError(
-        "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
-          "found a subquery with outer-scope reference " +
-          s"'${outerScopeRef.name}' in the CTE definition " +
-          s"(cteId=${cteDef.id}).")
+      .toSeq
+      .headOption
+    val escapingOuterScopeRef = allNodes.iterator
+      .flatMap(_.expressions.iterator.flatMap(
+        _.collect { case s: SubqueryExpression => s.outerScopeAttrs }
+          .flatMap(_.collect {
+            case r: OuterScopeReference if !boundExprIds.contains(r.exprId) => r
+          })))
+      .toSeq
+      .headOption
+
+    (escapingOuterRef, escapingOuterScopeRef) match {
+      case (Some(o), _) =>
+        throw SparkException.internalError(
+          "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
+            s"found outer reference '${o.name}' in the CTE definition " +
+            s"(cteId=${cteDef.id}).")
+      case (None, Some(r)) =>
+        throw SparkException.internalError(
+          "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
+            "found a subquery with outer-scope reference " +
+            s"'${r.name}' in the CTE definition " +
+            s"(cteId=${cteDef.id}).")
+      case (None, None) =>
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -100,13 +100,22 @@ case class InlineCTE(
       .flatMap(_.output.filter(_.resolved).map(_.exprId))
       .toSet
 
-    // Locate either a direct `OuterReference` or a correlated subquery whose outer-scope
-    // attributes escape the def -- i.e. resolve to none of `boundExprIds`.
+    // Check the direct `OuterReference` first: if one escapes the def boundary, report it
+    // and stop; the outer-scope scan below only runs when no direct reference escapes.
     val escapingOuterRef = allNodes.iterator
       .flatMap(_.expressions.iterator.flatMap(_.collect {
         case o: OuterReference if !boundExprIds.contains(o.exprId) => o
       }))
       .nextOption()
+    escapingOuterRef.foreach { o =>
+      throw SparkException.internalError(
+        "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
+          s"found outer reference '${o.name}' in the CTE definition " +
+          s"(cteId=${cteDef.id}).")
+    }
+
+    // Then check for a correlated subquery whose outer-scope attributes escape the def,
+    // i.e. resolve to none of `boundExprIds`.
     val escapingOuterScopeRef = allNodes.iterator
       .flatMap(_.expressions.iterator.flatMap(
         _.collect { case s: SubqueryExpression => s.outerScopeAttrs }
@@ -114,20 +123,12 @@ case class InlineCTE(
             case r: OuterScopeReference if !boundExprIds.contains(r.exprId) => r
           })))
       .nextOption()
-
-    (escapingOuterRef, escapingOuterScopeRef) match {
-      case (Some(o), _) =>
-        throw SparkException.internalError(
-          "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
-            s"found outer reference '${o.name}' in the CTE definition " +
-            s"(cteId=${cteDef.id}).")
-      case (None, Some(r)) =>
-        throw SparkException.internalError(
-          "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
-            "found a subquery with outer-scope reference " +
-            s"'${r.name}' in the CTE definition " +
-            s"(cteId=${cteDef.id}).")
-      case (None, None) =>
+    escapingOuterScopeRef.foreach { r =>
+      throw SparkException.internalError(
+        "A force-materialized CTE cannot carry an outer reference across its boundary, but " +
+          "found a subquery with outer-scope reference " +
+          s"'${r.name}' in the CTE definition " +
+          s"(cteId=${cteDef.id}).")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -96,7 +96,9 @@ case class InlineCTE(
     // nested subquery plans) once, collect every attribute bound anywhere in the definition,
     // and reject only references that resolve to none of them.
     val allNodes = cteDef.child.collectWithSubqueries { case n: LogicalPlan => n }
-    val boundExprIds = allNodes.flatMap(_.output.filter(_.resolved).map(_.exprId)).toSet
+    val boundExprIds = allNodes.iterator
+      .flatMap(_.output.filter(_.resolved).map(_.exprId))
+      .toSet
 
     // Locate either a direct `OuterReference` or a correlated subquery whose outer-scope
     // attributes escape the def -- i.e. resolve to none of `boundExprIds`.
@@ -104,16 +106,14 @@ case class InlineCTE(
       .flatMap(_.expressions.iterator.flatMap(_.collect {
         case o: OuterReference if !boundExprIds.contains(o.exprId) => o
       }))
-      .toSeq
-      .headOption
+      .nextOption()
     val escapingOuterScopeRef = allNodes.iterator
       .flatMap(_.expressions.iterator.flatMap(
         _.collect { case s: SubqueryExpression => s.outerScopeAttrs }
           .flatMap(_.collect {
             case r: OuterScopeReference if !boundExprIds.contains(r.exprId) => r
           })))
-      .toSeq
-      .headOption
+      .nextOption()
 
     (escapingOuterRef, escapingOuterScopeRef) match {
       case (Some(o), _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTE.scala
@@ -91,10 +91,10 @@ case class InlineCTE(
   private def validateNoOuterReferencesAcrossCTEBoundary(cteDef: CTERelationDef): Unit = {
     // Only an outer reference that actually escapes the CTE definition is invalid. An outer
     // reference that points to an attribute produced by an operator inside the definition
-    // body (e.g. a correlated subquery whose correlated column lives in the body) is
-    // self-contained and safe to materialize. So walk the whole definition (main tree plus
-    // nested subquery plans) once, collect every attribute bound anywhere in the definition,
-    // and reject only references that resolve to none of them.
+    // body (e.g. a correlated subquery whose correlated column lives in the body) does not
+    // escape, so the definition is self-contained and safe to materialize. Walk the whole
+    // definition (main tree plus nested subquery plans) once, collect every attribute bound
+    // anywhere in the definition, and reject only references that resolve to none of them.
     val allNodes = cteDef.child.collectWithSubqueries { case n: LogicalPlan => n }
     val boundExprIds = allNodes.iterator
       .flatMap(_.output.filter(_.resolved).map(_.exprId))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
@@ -116,6 +116,12 @@ case class UnionLoopRef(
  *                        regardless of determinism or reference count. This lets a producer
  *                        force the CTE to be materialized instead of duplicated, e.g. when the
  *                        CTE wraps a non-deterministic source that must be evaluated exactly once.
+ *                        A materialized definition must be self-contained: it cannot carry an
+ *                        outer reference across its boundary, because after materialization
+ *                        there is no surrounding operator to resolve the reference against.
+ *                        [[InlineCTE]] validates this and rejects escaping references with an
+ *                        internal error, while tolerating correlations that resolve inside the
+ *                        definition body.
  */
 case class CTERelationDef(
     child: LogicalPlan,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTESuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTESuite.scala
@@ -21,8 +21,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.TestRelation
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{OuterReference, OuterScopeReference, ScalarSubquery}
-import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.expressions.{Exists, OuterReference, OuterScopeReference, ScalarSubquery}
+import org.apache.spark.sql.catalyst.plans.{Cross, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CTERelationDef, CTERelationRef, LogicalPlan, OneRowRelation, WithCTE}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
@@ -107,6 +107,74 @@ class InlineCTESuite extends PlanTest {
     assert(e.getCondition == "INTERNAL_ERROR")
     assert(e.getMessage.contains(
       "found a subquery with outer-scope reference"))
+  }
+
+  test("SPARK-58006: forceSkipInline CTE with an internal outer reference is materialized") {
+    // Corresponds to: WITH t AS (SELECT a FROM r WHERE EXISTS (SELECT 1 FROM s WHERE s.k = t.a))
+    //                 SELECT a FROM t
+    // The outer reference to `a` resolves inside the CTE def body, so it must be tolerated.
+    val relation = TestRelation(Seq($"a".int))
+    val subRel = TestRelation(Seq($"k".int))
+    val exists = Exists(
+      subRel.where(subRel.output.head === OuterReference(relation.output.head)),
+      outerAttrs = Seq(relation.output.head))
+    val cteChild = relation.where(exists)
+    val cteDef = CTERelationDef(cteChild, forceSkipInline = true)
+    val cteRef = CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+    val plan = WithCTE(cteRef.select(relation.output.head), Seq(cteDef))
+    assert(plan.resolved)
+    val optimized = Optimize.execute(plan)
+    // The internal correlation is safe: the def stays materialized and validation passes.
+    assert(optimized.collectFirst { case _: WithCTE => true }.isDefined,
+      "CTE with an internal outer reference should be materialized, not rejected")
+  }
+
+  test("SPARK-58006: forceSkipInline CTE with an internal outer-scope subquery is materialized") {
+    // Corresponds to: WITH t AS (
+    //   SELECT (SELECT v FROM s2 WHERE s2.v < (SELECT c FROM s1 WHERE s1.k = t.a)) AS s
+    //   FROM r) SELECT s FROM t
+    // The innermost reference to `t.a` is two scopes out but resolves inside the def.
+    val relation = TestRelation(Seq($"a".int))
+    val s1 = TestRelation(Seq($"k".int, $"c".int))
+    val s2 = TestRelation(Seq($"v".int))
+    val deep = ScalarSubquery(
+      s1.where(s1.output.head === OuterReference(relation.output.head)).select(s1.output(1)),
+      outerAttrs = Seq(OuterScopeReference(relation.output.head)))
+    val shallow = ScalarSubquery(
+      s2.where(s2.output.head < deep),
+      outerAttrs = Seq(relation.output.head))
+    val cteChild = relation.select(shallow.as("s"))
+    val cteDef = CTERelationDef(cteChild, forceSkipInline = true)
+    val cteRef = CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+    val plan = WithCTE(cteRef.select(cteDef.output.head), Seq(cteDef))
+    assert(plan.resolved)
+    val optimized = Optimize.execute(plan)
+    assert(optimized.collectFirst { case _: WithCTE => true }.isDefined,
+      "CTE with an internal outer-scope subquery should be materialized, not rejected")
+  }
+
+  test("SPARK-58006: forceSkipInline CTE with an outer reference inside a subquery plan fails") {
+    // Corresponds to: WITH t AS (SELECT (SELECT c FROM s WHERE s.k = m.a) AS x FROM r)
+    //                 SELECT x FROM t, m
+    // `m.a` is produced outside the CTE, so the reference escapes the boundary and must fail.
+    val relation = TestRelation(Seq($"c".int))
+    val outerA = $"m.a".int
+    val subquery = ScalarSubquery(
+      relation.where(relation.output.head === OuterReference(outerA)),
+      outerAttrs = Seq(outerA))
+    val cteChild = TestRelation(Seq($"b".int)).select(subquery.as("s"))
+    val cteDef = CTERelationDef(cteChild, forceSkipInline = true)
+    val cteRef = CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+    val m = TestRelation(Seq(outerA))
+    val main = cteRef.select(cteDef.output.head).join(m, Cross)
+    val plan = WithCTE(main, Seq(cteDef))
+    assert(plan.resolved)
+    val e = intercept[SparkException] {
+      Optimize.execute(plan)
+    }
+    assert(e.getCondition == "INTERNAL_ERROR")
+    assert(e.getMessage.contains(
+      "A force-materialized CTE cannot carry an outer reference across its boundary"))
   }
 
   test("SPARK-58779: optimizer InlineCTE (isAnalysis = false) fails on a ref with no definition") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTESuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InlineCTESuite.scala
@@ -110,7 +110,7 @@ class InlineCTESuite extends PlanTest {
   }
 
   test("SPARK-58006: forceSkipInline CTE with an internal outer reference is materialized") {
-    // Corresponds to: WITH t AS (SELECT a FROM r WHERE EXISTS (SELECT 1 FROM s WHERE s.k = t.a))
+    // Corresponds to: WITH t AS (SELECT a FROM r WHERE EXISTS (SELECT 1 FROM s WHERE s.k = r.a))
     //                 SELECT a FROM t
     // The outer reference to `a` resolves inside the CTE def body, so it must be tolerated.
     val relation = TestRelation(Seq($"a".int))
@@ -131,9 +131,9 @@ class InlineCTESuite extends PlanTest {
 
   test("SPARK-58006: forceSkipInline CTE with an internal outer-scope subquery is materialized") {
     // Corresponds to: WITH t AS (
-    //   SELECT (SELECT v FROM s2 WHERE s2.v < (SELECT c FROM s1 WHERE s1.k = t.a)) AS s
+    //   SELECT (SELECT v FROM s2 WHERE s2.v < (SELECT c FROM s1 WHERE s1.k = r.a)) AS s
     //   FROM r) SELECT s FROM t
-    // The innermost reference to `t.a` is two scopes out but resolves inside the def.
+    // The innermost reference to `r.a` is two scopes out but resolves inside the def.
     val relation = TestRelation(Seq($"a".int))
     val s1 = TestRelation(Seq($"k".int, $"c".int))
     val s2 = TestRelation(Seq($"v".int))

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.{CurrentNamespace, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, GreaterThan, LessThan, Literal, Or, Rand}
 import org.apache.spark.sql.catalyst.optimizer.InlineCTE
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
@@ -938,6 +940,62 @@ abstract class CTEInlineSuiteBase
           |LEFT JOIN agg1 a1 ON b.c1 = a1.c1
           |LEFT JOIN agg2 a2 ON b.c2 = a2.c2
           |""".stripMargin).show()
+    }
+  }
+
+  test("SPARK-58006: forceSkipInline CTE with self-contained correlation is materialized") {
+    // End-to-end with a real analyzer: the CTE definition is a fully analyzed plan containing a
+    // correlated subquery whose outer reference binds inside the definition body. Validation
+    // must tolerate it, and the query must run with the CTE kept materialized (replaced by
+    // repartitioned subplans instead of being inlined).
+    withTempView("t1", "t2") {
+      Seq(1, 2).toDF("id").createOrReplaceTempView("t1")
+      Seq(2, 3).toDF("id").createOrReplaceTempView("t2")
+      val analyzed =
+        sql("SELECT id FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.id = t1.id)")
+          .queryExecution.analyzed
+      val cteDef = CTERelationDef(analyzed, forceSkipInline = true)
+      val cteRef1 = CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+      val cteRef2 = CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+      // Reference the CTE twice so that inlining would duplicate the definition; with
+      // forceSkipInline the refs must be materialized as repartitioned subplans instead.
+      val main = Union(
+        Project(cteDef.output, cteRef1),
+        Project(cteDef.output, cteRef2))
+      val df = Dataset.ofRows(spark, WithCTE(main, Seq(cteDef)))
+      checkAnswer(df, Row(2) :: Row(2) :: Nil)
+      val reparts = df.queryExecution.optimizedPlan.collect {
+        case r: RepartitionOperation => r
+      }
+      assert(reparts.nonEmpty,
+        "forceSkipInline CTE with a self-contained correlation should be materialized.")
+    }
+  }
+
+  test("SPARK-58006: forceSkipInline CTE with an escaping reference from stitched plans fails") {
+    // Simulates a producer stitching already-analyzed plans: the correlated condition is
+    // re-anchored on a plan that no longer produces the correlated column, so the outer
+    // reference escapes the definition boundary. Unlike the hand-built plans in
+    // InlineCTESuite, this exercises the validation against exprIds allocated by the real
+    // analyzer.
+    withTempView("t1", "t2") {
+      Seq(1, 2).toDF("id").createOrReplaceTempView("t1")
+      Seq(2, 3).toDF("id").createOrReplaceTempView("t2")
+      val analyzed =
+        sql("SELECT id FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.id = t1.id)")
+          .queryExecution.analyzed
+      val correlatedCond = analyzed.collectFirst { case f: Filter => f.condition }.get
+      // Re-anchor the condition on t2, which does not produce the correlated column t1.id.
+      val stitched =
+        Filter(correlatedCond, sql("SELECT id FROM t2").queryExecution.analyzed)
+      val cteDef = CTERelationDef(stitched, forceSkipInline = true)
+      val cteRef = CTERelationRef(cteDef.id, cteDef.resolved, cteDef.output, cteDef.isStreaming)
+      val e = intercept[SparkException] {
+        InlineCTE().apply(WithCTE(Project(Seq(cteDef.output.head), cteRef), Seq(cteDef)))
+      }
+      assert(e.getCondition == "INTERNAL_ERROR")
+      assert(e.getMessage.contains(
+        "A force-materialized CTE cannot carry an outer reference across its boundary"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`InlineCTE.validateNoOuterReferencesAcrossCTEBoundary` currently throws `INTERNAL_ERROR` whenever a `forceSkipInline` CTE definition's body contains any `OuterReference` or correlated subquery (with non-empty `outerScopeAttrs`), even when that reference resolves to an operator *inside* the definition body. Such an internal correlation is self-contained and safe to materialize, because after materialization the def body itself still provides the operator the reference resolves against.

This PR makes the validator reject a reference only when it genuinely escapes the CTE boundary: it collects every attribute bound anywhere in the definition (including inside nested subquery plans, skipping unresolved outputs), and throws only when an `OuterReference` / `OuterScopeReference`'s exprId resolves to none of those bound exprIds.

### Why are the changes needed?

SPARK-58006 added `forceSkipInline` to guarantee a CTE is materialized rather than duplicated. The follow-up validation was too strict: it flagged *any* outer reference in the def, including self-contained ones. Concretely, a view whose correlated subquery references a column produced within its own body could not be materialized as a `forceSkipInline` CTE — analysis failed or the conversion was silently skipped — even though such a correlation has a valid resolution home inside the materialized def.

### Does this PR introduce _any_ user-facing change?

No. It affects only internal optimizer behavior for the newly added `forceSkipInline` path: instead of raising `INTERNAL_ERROR` for self-contained correlations, the CTE is now materialized correctly. Truly escaping references still raise the same `INTERNAL_ERROR`.

### How was this patch tested?

Updated `InlineCTESuite` under `sql/catalyst`:
- regression: an internal `OuterReference` (correlated `EXISTS`) inside a `forceSkipInline` def is materialized (no throw);
- regression: an internal `OuterScopeReference` (nested correlated scalar subquery, two scopes out) is materialized (no throw);
- negative: an outer reference inside a nested subquery plan that escapes the def still fails with `INTERNAL_ERROR`.

Ran:

```
build/sbt "catalyst/Test/compile"
build/sbt "catalyst/Test/scalastyle"
build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.InlineCTESuite"
```

All 10 tests in the suite pass; scalastyle reports 0 errors.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Pi