### PR TITLE
[SPARK-58989][PYTHON][TESTS] Replace pyspark-install with pyspark-periodic

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,11 +107,11 @@ jobs:
       id: set-outputs
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
-          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-install'))"`
+          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-scheduled'))"`
           pyspark_pandas_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark-pandas')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           pandas=`./dev/is-changed.py -m $pyspark_pandas_modules`
-          pyspark_install=`./dev/is-changed.py -m pyspark-install`
+          pyspark_scheduled=`./dev/is-changed.py -m pyspark-scheduled`
           pyspark_connect_old_client="$pyspark"
           if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             yarn=`./dev/is-changed.py -m yarn`
@@ -155,7 +155,7 @@ jobs:
             docs=true
             java25=true
           else
-            pyspark_install=false
+            pyspark_scheduled=false
             pyspark_connect_old_client=false
             pandas=false
             yarn=false
@@ -177,7 +177,7 @@ jobs:
               \"build-core-utils\": \"$build_core_utils\",
               \"pyspark\": \"$pyspark\",
               \"pyspark-pandas\": \"$pandas\",
-              \"pyspark-install\": \"$pyspark_install\",
+              \"pyspark-scheduled\": \"$pyspark_scheduled\",
               \"pyspark-connect-old-client\": \"$pyspark_connect_old_client\",
               \"sparkr\": \"$sparkr\",
               \"tpcds-1g\": \"$tpcds\",
@@ -543,7 +543,7 @@ jobs:
         fromJson(needs.precondition.outputs.required).build == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
-        fromJson(needs.precondition.outputs.required).pyspark-install == 'true' ||
+        fromJson(needs.precondition.outputs.required).pyspark-scheduled == 'true' ||
         fromJson(needs.precondition.outputs.required).sparkr == 'true' ||
         fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true' ||
         fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true' ||
@@ -635,7 +635,7 @@ jobs:
           - >-
             pyspark-connect-old-client
           - >-
-            pyspark-install
+            pyspark-scheduled
           - >-
             pyspark-pandas
           - >-
@@ -650,8 +650,8 @@ jobs:
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-streaming, pyspark-structured-streaming, pyspark-structured-streaming-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-connect-old-client != 'true' &&  'pyspark-connect-old-client'}}
-          # pyspark-install is very slow so we only run it when it's changed or explicity requested
-          - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-install != 'true' && 'pyspark-install' }}
+          # pyspark-scheduled will only run when explicitly requested, it contains tests that are not sensitive to pyspark code changes.
+          - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-scheduled != 'true' && 'pyspark-scheduled' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-slow' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-connect' }}
@@ -737,7 +737,7 @@ jobs:
       run: |
         export SKIP_SCALA_BUILD=true
         echo "Reusing precompiled artifact, skipping local SBT build."
-        if [[ "$MODULES_TO_TEST" == *"pyspark-install"* ]]; then
+        if [[ "$MODULES_TO_TEST" == *"pyspark-scheduled"* ]]; then
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,11 +107,11 @@ jobs:
       id: set-outputs
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
-          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-install'))"`
+          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-scheduled'))"`
           pyspark_pandas_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark-pandas')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           pandas=`./dev/is-changed.py -m $pyspark_pandas_modules`
-          pyspark_install=`./dev/is-changed.py -m pyspark-install`
+          pyspark_scheduled=`./dev/is-changed.py -m pyspark-scheduled`
           pyspark_connect_old_client="$pyspark"
           if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             yarn=`./dev/is-changed.py -m yarn`
@@ -151,7 +151,7 @@ jobs:
             docs=true
             java25=true
           else
-            pyspark_install=false
+            pyspark_scheduled=false
             pyspark_connect_old_client=false
             pandas=false
             yarn=false
@@ -172,7 +172,7 @@ jobs:
               \"build-core-utils\": \"$build_core_utils\",
               \"pyspark\": \"$pyspark\",
               \"pyspark-pandas\": \"$pandas\",
-              \"pyspark-install\": \"$pyspark_install\",
+              \"pyspark-scheduled\": \"$pyspark_scheduled\",
               \"pyspark-connect-old-client\": \"$pyspark_connect_old_client\",
               \"sparkr\": \"$sparkr\",
               \"tpcds-1g\": \"$tpcds\",
@@ -537,7 +537,7 @@ jobs:
         fromJson(needs.precondition.outputs.required).build == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
-        fromJson(needs.precondition.outputs.required).pyspark-install == 'true' ||
+        fromJson(needs.precondition.outputs.required).pyspark-scheduled == 'true' ||
         fromJson(needs.precondition.outputs.required).sparkr == 'true' ||
         fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true' ||
         fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true' ||
@@ -628,7 +628,7 @@ jobs:
           - >-
             pyspark-connect-old-client
           - >-
-            pyspark-install
+            pyspark-scheduled
           - >-
             pyspark-pandas
           - >-
@@ -643,8 +643,8 @@ jobs:
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-streaming, pyspark-structured-streaming, pyspark-structured-streaming-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-connect-old-client != 'true' &&  'pyspark-connect-old-client'}}
-          # pyspark-install is very slow so we only run it when it's changed or explicity requested
-          - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-install != 'true' && 'pyspark-install' }}
+          # pyspark-scheduled will only run when explicitly requested, it contains tests that are not sensitive to pyspark code changes.
+          - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-scheduled != 'true' && 'pyspark-scheduled' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-slow' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-connect' }}
@@ -730,7 +730,7 @@ jobs:
       run: |
         export SKIP_SCALA_BUILD=true
         echo "Reusing precompiled artifact, skipping local SBT build."
-        if [[ "$MODULES_TO_TEST" == *"pyspark-install"* ]]; then
+        if [[ "$MODULES_TO_TEST" == *"pyspark-scheduled"* ]]; then
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -650,7 +650,7 @@ jobs:
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-streaming, pyspark-structured-streaming, pyspark-structured-streaming-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-connect-old-client != 'true' &&  'pyspark-connect-old-client'}}
-          # pyspark-periodic will only run when explicitly requested, it contains tests that are not sensitive to pyspark code changes.
+          # pyspark-periodic will only run on pre-merge and scheduled CIs, it contains tests that are not sensitive to pyspark code changes.
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-periodic != 'true' && 'pyspark-periodic' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-slow' }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,11 +107,11 @@ jobs:
       id: set-outputs
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
-          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-scheduled'))"`
+          pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark') and not m.name.startswith('pyspark-pandas') and not m.name == 'pyspark-periodic'))"`
           pyspark_pandas_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark-pandas')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           pandas=`./dev/is-changed.py -m $pyspark_pandas_modules`
-          pyspark_scheduled=`./dev/is-changed.py -m pyspark-scheduled`
+          pyspark_periodic=`./dev/is-changed.py -m pyspark-periodic`
           pyspark_connect_old_client="$pyspark"
           if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             yarn=`./dev/is-changed.py -m yarn`
@@ -155,7 +155,7 @@ jobs:
             docs=true
             java25=true
           else
-            pyspark_scheduled=false
+            pyspark_periodic=false
             pyspark_connect_old_client=false
             pandas=false
             yarn=false
@@ -177,7 +177,7 @@ jobs:
               \"build-core-utils\": \"$build_core_utils\",
               \"pyspark\": \"$pyspark\",
               \"pyspark-pandas\": \"$pandas\",
-              \"pyspark-scheduled\": \"$pyspark_scheduled\",
+              \"pyspark-periodic\": \"$pyspark_periodic\",
               \"pyspark-connect-old-client\": \"$pyspark_connect_old_client\",
               \"sparkr\": \"$sparkr\",
               \"tpcds-1g\": \"$tpcds\",
@@ -543,7 +543,7 @@ jobs:
         fromJson(needs.precondition.outputs.required).build == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
-        fromJson(needs.precondition.outputs.required).pyspark-scheduled == 'true' ||
+        fromJson(needs.precondition.outputs.required).pyspark-periodic == 'true' ||
         fromJson(needs.precondition.outputs.required).sparkr == 'true' ||
         fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true' ||
         fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true' ||
@@ -635,7 +635,7 @@ jobs:
           - >-
             pyspark-connect-old-client
           - >-
-            pyspark-scheduled
+            pyspark-periodic
           - >-
             pyspark-pandas
           - >-
@@ -650,8 +650,8 @@ jobs:
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-streaming, pyspark-structured-streaming, pyspark-structured-streaming-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark != 'true' && 'pyspark-connect' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-connect-old-client != 'true' &&  'pyspark-connect-old-client'}}
-          # pyspark-scheduled will only run when explicitly requested, it contains tests that are not sensitive to pyspark code changes.
-          - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-scheduled != 'true' && 'pyspark-scheduled' }}
+          # pyspark-periodic will only run when explicitly requested, it contains tests that are not sensitive to pyspark code changes.
+          - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-periodic != 'true' && 'pyspark-periodic' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-slow' }}
           - modules: ${{ fromJson(needs.precondition.outputs.required).pyspark-pandas != 'true' && 'pyspark-pandas-connect' }}
@@ -737,7 +737,7 @@ jobs:
       run: |
         export SKIP_SCALA_BUILD=true
         echo "Reusing precompiled artifact, skipping local SBT build."
-        if [[ "$MODULES_TO_TEST" == *"pyspark-scheduled"* ]]; then
+        if [[ "$MODULES_TO_TEST" == *"pyspark-periodic"* ]]; then
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi

--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -45,7 +45,7 @@ jobs:
         {
           "pyspark": "true",
           "pyspark-pandas": "true",
-          "pyspark-install": "true"
+          "pyspark-scheduled": "true"
         }
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -45,7 +45,7 @@ jobs:
         {
           "pyspark": "true",
           "pyspark-pandas": "true",
-          "pyspark-scheduled": "true"
+          "pyspark-periodic": "true"
         }
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build_python_3.11.yml
+++ b/.github/workflows/build_python_3.11.yml
@@ -43,5 +43,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/build_python_3.12_classic_only.yml
+++ b/.github/workflows/build_python_3.12_classic_only.yml
@@ -43,5 +43,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/build_python_3.12_pandas_3.yml
+++ b/.github/workflows/build_python_3.12_pandas_3.yml
@@ -43,5 +43,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/build_python_3.13.yml
+++ b/.github/workflows/build_python_3.13.yml
@@ -43,5 +43,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/build_python_3.14.yml
+++ b/.github/workflows/build_python_3.14.yml
@@ -43,5 +43,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/build_python_3.14_nogil.yml
+++ b/.github/workflows/build_python_3.14_nogil.yml
@@ -44,5 +44,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/build_python_minimum.yml
+++ b/.github/workflows/build_python_minimum.yml
@@ -43,5 +43,6 @@ jobs:
       jobs: >-
         {
           "pyspark": "true",
-          "pyspark-pandas": "true"
+          "pyspark-pandas": "true",
+          "pyspark-periodic": "true"
         }

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -153,6 +153,8 @@ jobs:
           - >-
             pyspark-connect
           - >-
+            pyspark-periodic
+          - >-
             pyspark-pandas
           - >-
             pyspark-pandas-slow

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -613,20 +613,6 @@ pyspark_core = Module(
         "pyspark.tests.test_worker",
         "pyspark.tests.test_stage_sched",
         "pyspark.tests.test_zero_copy_byte_stream",
-        # unittests for upstream projects
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_cast",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_non_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_type_inference",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_non_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_dataframe_from_pandas",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_ignore_timezone",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_coercion",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_inference",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_cast",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_to_pandas",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_type_coercion",
     ],
 )
 
@@ -924,20 +910,32 @@ pyspark_ml = Module(
     ],
 )
 
-pyspark_install = Module(
-    name="pyspark-install",
+pyspark_scheduled = Module(
+    name="pyspark-scheduled",
     dependencies=[],
     source_file_regexes=[
-        # Python package tests will be triggered with this module
+        # This module contains tests that are not sensitive to pyspark code changes.
+        # We run these on scheduled CIs and pre-merge CIs, not post-merge CIs.
         # Any changes in python/ should trigger this module
-        # This module won't be executed for post-commit CIs so it's cheap
         "python/",
-        "python/pyspark/install.py",
-        "python/pyspark/tests/test_install_spark.py",
     ],
     python_test_goals=[
         "pyspark.tests.test_import_spark",
         "pyspark.tests.test_install_spark",
+        # unittests for upstream projects
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_cast",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_non_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_type_inference",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_non_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_dataframe_from_pandas",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_ignore_timezone",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_coercion",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_inference",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_cast",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_to_pandas",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_type_coercion",
     ],
 )
 

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -912,8 +912,8 @@ pyspark_ml = Module(
     ],
 )
 
-pyspark_scheduled = Module(
-    name="pyspark-scheduled",
+pyspark_periodic = Module(
+    name="pyspark-periodic",
     dependencies=[],
     source_file_regexes=[
         # This module contains tests that are not sensitive to pyspark code changes.

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -614,21 +614,6 @@ pyspark_core = Module(
         "pyspark.tests.test_worker",
         "pyspark.tests.test_stage_sched",
         "pyspark.tests.test_zero_copy_byte_stream",
-        # unittests for upstream projects
-        "pyspark.tests.upstream.numpy.test_numpy_ufunc_type_coercion",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_cast",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_non_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_type_inference",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_non_default",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_dataframe_from_pandas",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_ignore_timezone",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_coercion",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_inference",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_cast",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_to_pandas",
-        "pyspark.tests.upstream.pyarrow.test_pyarrow_type_coercion",
     ],
 )
 
@@ -927,20 +912,33 @@ pyspark_ml = Module(
     ],
 )
 
-pyspark_install = Module(
-    name="pyspark-install",
+pyspark_scheduled = Module(
+    name="pyspark-scheduled",
     dependencies=[],
     source_file_regexes=[
-        # Python package tests will be triggered with this module
+        # This module contains tests that are not sensitive to pyspark code changes.
+        # We run these on scheduled CIs and pre-merge CIs, not post-merge CIs.
         # Any changes in python/ should trigger this module
-        # This module won't be executed for post-commit CIs so it's cheap
         "python/",
-        "python/pyspark/install.py",
-        "python/pyspark/tests/test_install_spark.py",
     ],
     python_test_goals=[
         "pyspark.tests.test_import_spark",
         "pyspark.tests.test_install_spark",
+        # unittests for upstream projects
+        "pyspark.tests.upstream.numpy.test_numpy_ufunc_type_coercion",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_cast",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_from_pandas_non_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_array_type_inference",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_arrow_to_pandas_non_default",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_dataframe_from_pandas",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_ignore_timezone",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_coercion",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_scalar_type_inference",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_cast",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_table_to_pandas",
+        "pyspark.tests.upstream.pyarrow.test_pyarrow_type_coercion",
     ],
 )
 

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -37,7 +37,7 @@ def determine_modules_for_files(filenames):
     file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
-    ['pyspark-core', 'pyspark-install', 'sql']
+    ['pyspark-core', 'pyspark-scheduled', 'sql']
     >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
     ['root']
     >>> [x.name for x in determine_modules_for_files(["python/README.md"])]

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -36,7 +36,7 @@ def determine_modules_for_files(filenames):
     file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
-    ['pyspark-core', 'pyspark-install', 'sql']
+    ['pyspark-core', 'pyspark-scheduled', 'sql']
     >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
     ['root']
     >>> [x.name for x in determine_modules_for_files(["python/README.md"])]

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -37,7 +37,7 @@ def determine_modules_for_files(filenames):
     file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
-    ['pyspark-core', 'pyspark-scheduled', 'sql']
+    ['pyspark-core', 'pyspark-periodic', 'sql']
     >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
     ['root']
     >>> [x.name for x in determine_modules_for_files(["python/README.md"])]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Replace `pyspark-install` with `pyspark-periodic`
* Move upstream tests to `pyspark-periodic`
* Run `pyspark-periodic` on all pre-merge CIs and scheduled CIs

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We used to run the pyspark install test separately (scheduled CI and pre-merge) because it was really slow. Then we moved packaging test into the module. Now we have upstream monitoring tests which are not sensitive to pyspark code change but put into `pyspark_core` module because there's no better place for it.

All these tests share a common feature - they are not designed for a specific feature for pyspark. We don't need to run them after every commit because they are not really testing pyspark itself. We could save some valuable time by running them on pre-merge and scheduled CI only. It also makes more sense for the categories.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.