### PR TITLE
[SPARK-58991][PYTHON] Remove dead and broken AutoSerializer class

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -478,34 +478,6 @@ class MarshalSerializer(FramedSerializer):
         return marshal.loads(obj)
 
 
-class AutoSerializer(FramedSerializer):
-    """
-    Choose marshal or pickle as serialization protocol automatically
-    """
-
-    def __init__(self):
-        FramedSerializer.__init__(self)
-        self._type = None
-
-    def dumps(self, obj):
-        if self._type is not None:
-            return b"P" + pickle.dumps(obj, -1)
-        try:
-            return b"M" + marshal.dumps(obj)
-        except Exception:
-            self._type = b"P"
-            return b"P" + pickle.dumps(obj, -1)
-
-    def loads(self, obj):
-        _type = obj[0]
-        if _type == b"M":
-            return marshal.loads(obj[1:])
-        elif _type == b"P":
-            return pickle.loads(obj[1:])
-        else:
-            raise ValueError("invalid serialization type: %s" % _type)
-
-
 class CompressedSerializer(FramedSerializer):
     """
     Compress the serialized data

--- a/python/pyspark/tests/test_serializers.py
+++ b/python/pyspark/tests/test_serializers.py
@@ -21,7 +21,6 @@ import unittest
 from pyspark import serializers
 from pyspark.serializers import (
     AutoBatchedSerializer,
-    AutoSerializer,
     BatchedSerializer,
     CartesianDeserializer,
     CloudPickleSerializer,
@@ -151,7 +150,6 @@ class SerializationTestCase(unittest.TestCase):
         hash(UTF8Deserializer())
         hash(CPickleSerializer())
         hash(MarshalSerializer())
-        hash(AutoSerializer())
         hash(BatchedSerializer(CPickleSerializer()))
         hash(AutoBatchedSerializer(MarshalSerializer()))
         hash(PairDeserializer(NoOpSerializer(), UTF8Deserializer()))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the dead and broken `AutoSerializer` class from `python/pyspark/serializers.py`, along with its two references in `python/pyspark/tests/test_serializers.py`.

### Why are the changes needed?

`AutoSerializer` is dead and broken code:

- It is not exported in `__all__` and has no production callers.
- Its `loads()` is broken under Python 3: it reads `_type = obj[0]`, which yields an `int` rather than a `bytes` value like `b"M"`/`b"P"`, so the type check never matches and every call raises `ValueError`.
- The only reference is a smoke test in `test_serializers.py` (an import plus a `hash()` call).

### Does this PR introduce _any_ user-facing change?

No. The class is not part of the public API and is non-functional.

### How was this patch tested?

Existing `python/pyspark/tests/test_serializers.py` still passes after removing the unused import and `hash()` line.

### Was this patch authored or co-authored using generative AI tooling?

No
