### PR TITLE
[SPARK-58967][K8S] Use FQDN with configurable cluster domain for driver hostname

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -651,6 +651,18 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>2.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.clusterDomain</code></td>
+  <td><code>cluster.local</code></td>
+  <td>
+    The cluster domain name used to construct the fully-qualified driver service hostname.
+    The driver's <code>spark.driver.host</code> is set to
+    <code>&lt;service&gt;.&lt;namespace&gt;.svc.&lt;clusterDomain&gt;.</code>
+    (with a trailing dot to force absolute DNS resolution).
+    Override this when your cluster uses a non-default domain (e.g. <code>example.com</code>).
+  </td>
+  <td>4.4.0</td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.container.image</code></td>
   <td><code>(none)</code></td>
   <td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -178,6 +178,15 @@ private[spark] object Config extends Logging {
       .stringConf
       .createWithDefault("default")
 
+  val KUBERNETES_CLUSTER_DOMAIN =
+    ConfigBuilder("spark.kubernetes.clusterDomain")
+      .doc("The cluster domain name used to construct the fully-qualified driver service " +
+        "hostname. The driver's spark.driver.host is set to " +
+        "<service>.<namespace>.svc.<clusterDomain>.")
+      .version("4.4.0")
+      .stringConf
+      .createWithDefault("cluster.local")
+
   val CONTAINER_IMAGE =
     ConfigBuilder("spark.kubernetes.container.image")
       .doc("Container image to use for Spark containers. Individual container types " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 import io.fabric8.kubernetes.api.model.{HasMetadata, ServiceBuilder}
 
 import org.apache.spark.deploy.k8s.{KubernetesDriverConf, SparkPod}
-import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH, KUBERNETES_DRIVER_SERVICE_IP_FAMILIES, KUBERNETES_DRIVER_SERVICE_IP_FAMILY_POLICY, KUBERNETES_DRIVER_SERVICE_PUBLISH_NOT_READY_ADDRESSES}
+import org.apache.spark.deploy.k8s.Config.{KUBERNETES_CLUSTER_DOMAIN, KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH, KUBERNETES_DRIVER_SERVICE_IP_FAMILIES, KUBERNETES_DRIVER_SERVICE_IP_FAMILY_POLICY, KUBERNETES_DRIVER_SERVICE_PUBLISH_NOT_READY_ADDRESSES}
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.{config, Logging}
 
@@ -56,7 +56,9 @@ private[spark] class DriverServiceFeatureStep(
   override def configurePod(pod: SparkPod): SparkPod = pod
 
   override def getAdditionalPodSystemProperties(): Map[String, String] = {
-    val driverHostname = s"$resolvedServiceName.${kubernetesConf.namespace}.svc"
+    val clusterDomain = kubernetesConf.sparkConf.get(KUBERNETES_CLUSTER_DOMAIN)
+    val driverHostname =
+      s"$resolvedServiceName.${kubernetesConf.namespace}.svc.$clusterDomain."
     Map(DRIVER_HOST_KEY -> driverHostname,
       config.DRIVER_PORT.key -> driverPort.toString,
       config.DRIVER_BLOCK_MANAGER_PORT.key -> driverBlockManagerPort.toString)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
@@ -83,7 +83,23 @@ class DriverServiceFeatureStepSuite extends SparkFunSuite {
       labels = DRIVER_LABELS)
     val configurationStep = new DriverServiceFeatureStep(kconf)
     val expectedServiceName = kconf.resourceNamePrefix + DriverServiceFeatureStep.DRIVER_SVC_POSTFIX
-    val expectedHostName = s"$expectedServiceName.my-namespace.svc"
+    val expectedHostName = s"$expectedServiceName.my-namespace.svc.cluster.local."
+    val additionalProps = configurationStep.getAdditionalPodSystemProperties()
+    assert(additionalProps(DRIVER_HOST_ADDRESS.key) === expectedHostName)
+  }
+
+  test("SPARK-58967: Custom cluster domain is used in the driver hostname FQDN.") {
+    val sparkConf = new SparkConf(false)
+      .set(DRIVER_PORT, 9000)
+      .set(DRIVER_BLOCK_MANAGER_PORT, 8080)
+      .set(KUBERNETES_NAMESPACE, "my-namespace")
+      .set(KUBERNETES_CLUSTER_DOMAIN, "custom.domain")
+    val kconf = KubernetesTestConf.createDriverConf(
+      sparkConf = sparkConf,
+      labels = DRIVER_LABELS)
+    val configurationStep = new DriverServiceFeatureStep(kconf)
+    val expectedServiceName = kconf.resourceNamePrefix + DriverServiceFeatureStep.DRIVER_SVC_POSTFIX
+    val expectedHostName = s"$expectedServiceName.my-namespace.svc.custom.domain."
     val additionalProps = configurationStep.getAdditionalPodSystemProperties()
     assert(additionalProps(DRIVER_HOST_ADDRESS.key) === expectedHostName)
   }
@@ -141,7 +157,7 @@ class DriverServiceFeatureStepSuite extends SparkFunSuite {
     services.foreach { case (kconf, name, address) =>
       assert(!name.startsWith(kconf.resourceNamePrefix))
       assert(!address.startsWith(kconf.resourceNamePrefix))
-      assert(InternetDomainName.isValid(address))
+      assert(InternetDomainName.isValid(address.stripSuffix(".")))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduces a new config `spark.kubernetes.clusterDomain` (default: `cluster.local`) and changes
the driver hostname constructed in `DriverServiceFeatureStep` from a partial DNS name to a
fully-qualified domain name (FQDN) with a trailing dot:

**Before:**
```
<service>.<namespace>.svc
```

**After:**
```
<service>.<namespace>.svc.<clusterDomain>.
```

The trailing dot tells the DNS resolver to treat the name as absolute, bypassing the pod's
configured search domain list entirely.

### Why are the changes needed?

When executors resolve `spark.driver.host`, the standard Kubernetes pod DNS configuration uses
`ndots:5` with search domains:

```
search <namespace>.svc.cluster.local svc.cluster.local cluster.local
```

The existing partial hostname `<service>.<namespace>.svc` contains only 2 dots, which is below
the `ndots:5` threshold. The resolver therefore attempts to resolve it by appending each search
domain in turn, producing two NXDOMAIN responses before arriving at the correct address:

```
Attempt 1: <service>.<namespace>.svc.<namespace>.svc.cluster.local. → NXDOMAIN
Attempt 2: <service>.<namespace>.svc.svc.cluster.local.             → NXDOMAIN
Attempt 3: <service>.<namespace>.svc.cluster.local.                 → NOERROR
```

In production environments running many concurrent Spark pipelines, each executor startup
generates these spurious failed lookups. This adds unnecessary NXDOMAIN traffic to CoreDNS
(a shared cluster-wide component) and can contribute to delays during executor-to-driver
connection establishment.

Using a trailing-dot FQDN forces the resolver to issue a single absolute lookup, eliminating
all NXDOMAIN responses. The new `spark.kubernetes.clusterDomain` config accommodates clusters
that use a non-default domain (i.e., something other than `cluster.local`).

### Does this PR introduce _any_ user-facing change?

Yes. `spark.driver.host` is now set to `<service>.<namespace>.svc.cluster.local.` by default
instead of `<service>.<namespace>.svc`. This is backward compatible for standard clusters.
Users on clusters with a non-default domain can configure `spark.kubernetes.clusterDomain`.

### How was this patch tested?

The fix was validated by manually patching the jar and testing it in a local Kubernetes
development environment. The following scenarios were verified:

- Tested with the default `cluster.local` domain.
- Tested with a custom cluster DNS domain.
- Verified the resulting driver hostname is a trailing-dot FQDN.
- Confirmed that executor-to-driver connections succeed without any NXDOMAIN lookups in CoreDNS.