### PR TITLE
[SPARK-59000][SQL] Use java.util.Arrays.compareUnsigned for BinaryType comparison

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/ByteArray.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/ByteArray.java
@@ -74,6 +74,15 @@ public final class ByteArray {
     return (IS_LITTLE_ENDIAN ? java.lang.Long.reverseBytes(p) : p) & ~mask;
   }
 
+  /**
+   * Lexicographically compares two on-heap byte arrays, treating each byte as unsigned.
+   * <p>
+   * For on-heap {@code byte[]} inputs, prefer {@link java.util.Arrays#compareUnsigned(byte[],
+   * byte[])}, which is a JDK intrinsic that the JIT compiles to vectorized (SIMD) code on JDK 9+
+   * and matches this method's ordering. This overload remains only as a benchmark baseline for the
+   * hand-rolled word-at-a-time comparison; the off-heap overload below is still used for comparing
+   * memory addressed by a base object and offset.
+   */
   public static int compareBinary(byte[] leftBase, byte[] rightBase) {
     return compareBinary(leftBase, Platform.BYTE_ARRAY_OFFSET, leftBase.length,
         rightBase, Platform.BYTE_ARRAY_OFFSET, rightBase.length);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -703,7 +703,7 @@ class CodegenContext extends Logging {
     case st: StringType if st.supportsBinaryOrdering => s"$c1.binaryCompare($c2)"
     case st: StringType => s"$c1.semanticCompare($c2, ${st.collationId})"
     case dt: DataType if isPrimitiveType(dt) => s"($c1 > $c2 ? 1 : $c1 < $c2 ? -1 : 0)"
-    case BinaryType => s"org.apache.spark.unsafe.types.ByteArray.compareBinary($c1, $c2)"
+    case BinaryType => s"java.util.Arrays.compareUnsigned($c1, $c2)"
     case CalendarIntervalType => s"$c1.compareTo($c2)"
     // TimestampNanosVal exposes only `compareTo`; the AtomicType fallback below emits
     // `$c1.compare($c2)`, which would not resolve as a Java method call.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -861,7 +861,7 @@ class CodegenContext extends Logging {
     case st: StringType if st.supportsBinaryOrdering => s"$c1.binaryCompare($c2)"
     case st: StringType => s"$c1.semanticCompare($c2, ${st.collationId})"
     case dt: DataType if isPrimitiveType(dt) => s"($c1 > $c2 ? 1 : $c1 < $c2 ? -1 : 0)"
-    case BinaryType => s"org.apache.spark.unsafe.types.ByteArray.compareBinary($c1, $c2)"
+    case BinaryType => s"java.util.Arrays.compareUnsigned($c1, $c2)"
     case CalendarIntervalType => s"$c1.compareTo($c2)"
     // TimestampNanosVal exposes only `compareTo`; the AtomicType fallback below emits
     // `$c1.compare($c2)`, which would not resolve as a Java method call.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.types
 
+import java.util.Arrays
+
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 
@@ -25,7 +27,7 @@ import org.apache.spark.sql.catalyst.types.ops.TypeOps
 import org.apache.spark.sql.catalyst.util.{ArrayData, CollationFactory, MapData, SQLOrderingUtil}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteExactNumeric, ByteType, CalendarIntervalType, CharType, DataType, DateType, DayTimeIntervalType, Decimal, DecimalExactNumeric, DecimalType, DoubleExactNumeric, DoubleType, FloatExactNumeric, FloatType, FractionalType, GeographyType, GeometryType, IntegerExactNumeric, IntegerType, IntegralType, LongExactNumeric, LongType, MapType, NullType, NumericType, ShortExactNumeric, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType, VarcharType, VariantType, YearMonthIntervalType}
-import org.apache.spark.unsafe.types.{BinaryView, ByteArray, TimestampNanosVal, UTF8String, VariantVal}
+import org.apache.spark.unsafe.types.{BinaryView, TimestampNanosVal, UTF8String, VariantVal}
 import org.apache.spark.util.ArrayImplicits._
 
 sealed abstract class PhysicalDataType {
@@ -130,7 +132,7 @@ object PhysicalIntegralType {
 
 class PhysicalBinaryType() extends PhysicalDataType {
   private[sql] val ordering =
-    (x: Array[Byte], y: Array[Byte]) => ByteArray.compareBinary(x, y)
+    (x: Array[Byte], y: Array[Byte]) => Arrays.compareUnsigned(x, y)
 
   private[sql] type InternalType = Array[Byte]
   @transient private[sql] lazy val tag = classTag[InternalType]

--- a/sql/core/benchmarks/ByteArrayBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/ByteArrayBenchmark-jdk21-results.txt
@@ -2,26 +2,30 @@
 byte array comparisons
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
+AMD EPYC 9V74 80-Core Processor
 Byte Array compareTo:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2-7 byte                                            253            261           8        259.4           3.9       1.0X
-8-16 byte                                           413            439          34        158.8           6.3       0.6X
-16-32 byte                                          413            414           1        158.5           6.3       0.6X
-512-1024 byte                                       556            558           3        117.8           8.5       0.5X
-512 byte slow                                      1634           1703          63         40.1          24.9       0.2X
-2-7 byte                                            296            297           0        221.3           4.5       0.9X
+2-7 byte                                            259            262           2        253.3           3.9       1.0X
+2-7 byte (Arrays.compareUnsigned)                   332            333           1        197.4           5.1       0.8X
+8-16 byte                                           241            248          14        272.1           3.7       1.1X
+8-16 byte (Arrays.compareUnsigned)                  302            303           0        216.7           4.6       0.9X
+16-32 byte                                          240            240           0        272.8           3.7       1.1X
+16-32 byte (Arrays.compareUnsigned)                 304            305           0        215.5           4.6       0.9X
+512-1024 byte                                       371            372           0        176.6           5.7       0.7X
+512-1024 byte (Arrays.compareUnsigned)              473            474           1        138.5           7.2       0.5X
+512 byte slow                                      1642           1657          14         39.9          25.1       0.2X
+512 byte slow (Arrays.compareUnsigned)             1185           1188           4         55.3          18.1       0.2X
 
 
 ================================================================================================
 byte array equals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
+AMD EPYC 9V74 80-Core Processor
 Byte Array equals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Byte Array equals                                   802            807           5        199.6           5.0       1.0X
+Byte Array equals                                   774            776           4        206.8           4.8       1.0X
 
 

--- a/sql/core/benchmarks/ByteArrayBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/ByteArrayBenchmark-jdk25-results.txt
@@ -2,26 +2,30 @@
 byte array comparisons
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 Byte Array compareTo:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2-7 byte                                            261            291          15        251.0           4.0       1.0X
-8-16 byte                                           337            380          58        194.6           5.1       0.8X
-16-32 byte                                          341            342           2        192.4           5.2       0.8X
-512-1024 byte                                       463            465           2        141.5           7.1       0.6X
-512 byte slow                                      1542           1567          18         42.5          23.5       0.2X
-2-7 byte                                            315            316           0        207.8           4.8       0.8X
+2-7 byte                                            260            291          16        252.3           4.0       1.0X
+2-7 byte (Arrays.compareUnsigned)                   295            296           1        222.0           4.5       0.9X
+8-16 byte                                           452            464           8        145.0           6.9       0.6X
+8-16 byte (Arrays.compareUnsigned)                  292            293           0        224.3           4.5       0.9X
+16-32 byte                                          465            466           1        140.9           7.1       0.6X
+16-32 byte (Arrays.compareUnsigned)                 290            290           0        226.1           4.4       0.9X
+512-1024 byte                                       632            637           9        103.6           9.6       0.4X
+512-1024 byte (Arrays.compareUnsigned)              450            453           5        145.5           6.9       0.6X
+512 byte slow                                      1545           1564          16         42.4          23.6       0.2X
+512 byte slow (Arrays.compareUnsigned)             1109           1116           8         59.1          16.9       0.2X
 
 
 ================================================================================================
 byte array equals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 Byte Array equals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Byte Array equals                                   814            863          48        196.4           5.1       1.0X
+Byte Array equals                                   712            807          37        224.7           4.5       1.0X
 
 

--- a/sql/core/benchmarks/ByteArrayBenchmark-results.txt
+++ b/sql/core/benchmarks/ByteArrayBenchmark-results.txt
@@ -2,26 +2,30 @@
 byte array comparisons
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-INTEL(R) XEON(R) PLATINUM 8573C
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
+AMD EPYC 7763 64-Core Processor
 Byte Array compareTo:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2-7 byte                                            251            254           1        261.1           3.8       1.0X
-8-16 byte                                           603            610           5        108.7           9.2       0.4X
-16-32 byte                                          613            619           3        106.9           9.4       0.4X
-512-1024 byte                                       669            673           4         98.0          10.2       0.4X
-512 byte slow                                      2130           2211          77         30.8          32.5       0.1X
-2-7 byte                                            277            277           0        236.9           4.2       0.9X
+2-7 byte                                            259            260           1        253.3           3.9       1.0X
+2-7 byte (Arrays.compareUnsigned)                   308            308           1        213.1           4.7       0.8X
+8-16 byte                                           413            446          22        158.7           6.3       0.6X
+8-16 byte (Arrays.compareUnsigned)                  328            334           8        199.8           5.0       0.8X
+16-32 byte                                          322            379          61        203.6           4.9       0.8X
+16-32 byte (Arrays.compareUnsigned)                 326            326           0        201.3           5.0       0.8X
+512-1024 byte                                       438            561          57        149.8           6.7       0.6X
+512-1024 byte (Arrays.compareUnsigned)              473            475           2        138.7           7.2       0.5X
+512 byte slow                                      1492           1536          40         43.9          22.8       0.2X
+512 byte slow (Arrays.compareUnsigned)             1080           1096          14         60.7          16.5       0.2X
 
 
 ================================================================================================
 byte array equals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-INTEL(R) XEON(R) PLATINUM 8573C
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
+AMD EPYC 7763 64-Core Processor
 Byte Array equals:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Byte Array equals                                  1187           1190           4        134.7           7.4       1.0X
+Byte Array equals                                   817            827           9        195.8           5.1       1.0X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ByteArrayBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ByteArrayBenchmark.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.benchmark
 
+import java.util.Arrays
+
 import scala.util.Random
 
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
@@ -69,13 +71,31 @@ object ByteArrayBenchmark extends BenchmarkBase {
       }
     }
 
+    // Baseline above is the hand-rolled word-at-a-time ByteArray.compareBinary. This measures the
+    // java.util.Arrays.compareUnsigned intrinsic that the production BinaryType comparison paths
+    // now use, so the results file documents the difference side by side.
+    def compareUnsigned(data: Array[Array[Byte]]) = { _: Int =>
+      var sum = 0L
+      for (_ <- 0L until iters) {
+        var i = 0
+        while (i < count) {
+          sum += Arrays.compareUnsigned(data(i), data((i + 1) % count))
+          i += 1
+        }
+      }
+    }
+
     val benchmark = new Benchmark("Byte Array compareTo", count * iters, 25, output = output)
     benchmark.addCase("2-7 byte")(compareBinary(dataTiny))
+    benchmark.addCase("2-7 byte (Arrays.compareUnsigned)")(compareUnsigned(dataTiny))
     benchmark.addCase("8-16 byte")(compareBinary(dataSmall))
+    benchmark.addCase("8-16 byte (Arrays.compareUnsigned)")(compareUnsigned(dataSmall))
     benchmark.addCase("16-32 byte")(compareBinary(dataMedium))
+    benchmark.addCase("16-32 byte (Arrays.compareUnsigned)")(compareUnsigned(dataMedium))
     benchmark.addCase("512-1024 byte")(compareBinary(dataLarge))
+    benchmark.addCase("512-1024 byte (Arrays.compareUnsigned)")(compareUnsigned(dataLarge))
     benchmark.addCase("512 byte slow")(compareBinary(dataLargeSlow))
-    benchmark.addCase("2-7 byte")(compareBinary(dataTiny))
+    benchmark.addCase("512 byte slow (Arrays.compareUnsigned)")(compareUnsigned(dataLargeSlow))
     benchmark.run()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Migrate the production `BinaryType` comparison call sites off the hand-rolled
word-at-a-time `ByteArray.compareBinary(byte[], byte[])` onto the
`java.util.Arrays.compareUnsigned(byte[], byte[])` intrinsic, which the JIT compiles to
vectorized (SIMD) code on JDK 9+:

- **`CodegenContext.genComp`** (`case BinaryType`) — the generated row/ordering comparators
  used by `GenerateOrdering` (ORDER BY, sort-merge join keys, array/map element comparison).
- **`PhysicalBinaryType.ordering`** — the interpreted `Ordering[Array[Byte]]`.

This mirrors the sibling `genComp`/`genEqual` path, which already emits
`java.util.Arrays.equals` for `BinaryType`, so it extends an existing pattern.

The now-unused 2-arg `ByteArray.compareBinary(byte[], byte[])` overload is retained as a
benchmark baseline, with a JavaDoc pointing callers to `Arrays.compareUnsigned`. The off-heap
overload (base object + offset) is unchanged and still used by `UTF8String` / `BinaryView`.

`ByteArrayBenchmark` gains an old-vs-intrinsic A/B case per size bucket.

### Why are the changes needed?

`Arrays.compareUnsigned` is a JDK intrinsic that the JIT can vectorize, it is simpler and less
error-prone than maintaining a bespoke comparison, and it matches the intrinsic already used on the
equality path (`Arrays.equals`). It also removes a use of `sun.misc.Unsafe`-based memory access from
this hot path (see Notes). Its performance relative to the hand-rolled loop is architecture- and
size-dependent; see the measurements below.

**Semantics are unchanged.** The previous implementation compared bytes as unsigned (`& 0xFF`) and
returned the length difference on a common prefix — exactly `Arrays.compareUnsigned`'s contract.
The returned magnitude on a mismatch may differ, but the sign is identical, and all callers are
`Ordering`s that only use the sign.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests, unmodified, validate the unchanged semantics:

- `OrderingSuite` (catalyst) — including "SPARK-21344: BinaryType comparison ...", which asserts
  `compare(Array(1), Array(-1)) < 0` (unsigned). Exercises the generated comparator with the new
  intrinsic.
- `ByteArraySuite` (common/unsafe) — `testCompareBinary` unsigned assertions.

Performance was measured with the updated `ByteArrayBenchmark` (old hand-rolled
`ByteArray.compareBinary` vs the `java.util.Arrays.compareUnsigned` intrinsic) on the GitHub Actions
benchmark runners. Best Time in ms, lower is better; **Speedup = old / new** (`> 1.0` means the
intrinsic is faster). The result is clearly architecture-dependent, so both aarch64 (ARM) and
x86-64 (AMD EPYC) are shown.

aarch64 / ARM (Azure `ubuntu-24.04-arm`), JDK 17:

| Input size    | `compareBinary` (ms) | `Arrays.compareUnsigned` (ms) | Speedup |
|---------------|----------------------|-------------------------------|---------|
| 2-7 byte      | 165                  | 246                           | 0.67x   |
| 8-16 byte     | 347                  | 193                           | 1.80x   |
| 16-32 byte    | 355                  | 197                           | 1.80x   |
| 512-1024 byte | 679                  | 626                           | 1.08x   |
| 512 byte slow | 1676                 | 1689                          | 0.99x   |

x86-64 / AMD EPYC 7763, JDK 17:

| Input size    | `compareBinary` (ms) | `Arrays.compareUnsigned` (ms) | Speedup |
|---------------|----------------------|-------------------------------|---------|
| 2-7 byte      | 259                  | 308                           | 0.84x   |
| 8-16 byte     | 413                  | 328                           | 1.26x   |
| 16-32 byte    | 322                  | 326                           | 0.99x   |
| 512-1024 byte | 438                  | 473                           | 0.93x   |
| 512 byte slow | 1492                 | 1080                          | 1.38x   |

x86-64 / AMD EPYC 9V74, JDK 21:

| Input size    | `compareBinary` (ms) | `Arrays.compareUnsigned` (ms) | Speedup |
|---------------|----------------------|-------------------------------|---------|
| 2-7 byte      | 259                  | 332                           | 0.78x   |
| 8-16 byte     | 241                  | 302                           | 0.80x   |
| 16-32 byte    | 240                  | 304                           | 0.79x   |
| 512-1024 byte | 371                  | 473                           | 0.78x   |
| 512 byte slow | 1642                 | 1185                          | 1.39x   |

For an additional x86-64 Intel data point, the following was measured on a provisioned cloud
instance (Intel Xeon 6975P-C, AVX-512), JDK 17. This is not a GHA reference runner, so treat it as
indicative rather than a committed result:

| Input size    | `compareBinary` (ms) | `Arrays.compareUnsigned` (ms) | Speedup |
|---------------|----------------------|-------------------------------|---------|
| 2-7 byte      | 191                  | 231                           | 0.83x   |
| 8-16 byte     | 449                  | 209                           | 2.15x   |
| 16-32 byte    | 490                  | 219                           | 2.24x   |
| 512-1024 byte | 617                  | 444                           | 1.39x   |
| 512 byte slow | 1831                 | 1196                          | 1.53x   |

Takeaways: the benefit is strongly microarchitecture-dependent. On **Intel** (AVX-512) the intrinsic
is a large win in the common 8-32 byte `BinaryType` range (~2.2x); on **ARM** it is a clear ~1.8x
win there; on **x86-64 AMD EPYC** it is roughly neutral in that range (a modest win on JDK 17, a
slight regression on JDK 21), with the gain concentrated in the long-common-prefix "512 byte slow"
case. Sub-8-byte arrays regress on every architecture, since there is no full 8-byte word for the
intrinsic to vectorize over — exactly the regime the hand-rolled word-at-a-time loop was designed
for. (The two AMD rows landed on different EPYC models, 7763 vs 9V74, as assigned by the GHA runner
pool, so treat cross-JDK AMD differences with caution.)

### Notes

The incumbent `ByteArray.compareBinary` performs its word-at-a-time comparison by reading memory
through `sun.misc.Unsafe` (via Spark's `Platform` helpers). JEP 471 ("Deprecate the Memory-Access
Methods in `sun.misc.Unsafe` for Removal") officially deprecated the core functionality of
`sun.misc.Unsafe` in JDK 23, kicking off a multi-version effort to phase out and ultimately remove
memory access through this internal API. Replacing these on-heap `BinaryType` comparison call sites
with the `java.util.Arrays.compareUnsigned` intrinsic removes a use of that soon-to-be-removed API
from a hot path, independent of the performance results above. (The off-heap 6-arg
`ByteArray.compareBinary` overload used by `UTF8String` / `BinaryView` still relies on
`Platform`/`Unsafe` and is out of scope for this change.)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
