### PR TITLE
[SPARK-59004][CORE] Use vectorized Arrays.compare for ComparableByteArray/Int/Long.compareTo

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
@@ -81,17 +81,7 @@ class ArrayWrappers {
 
     @Override
     public int compareTo(ComparableIntArray other) {
-      int len = Math.min(array.length, other.array.length);
-      for (int i = 0; i < len; i++) {
-        // Use Integer.compare; subtraction overflows for large opposite-sign values
-        // (e.g. Integer.MIN_VALUE vs Integer.MAX_VALUE) and returns the wrong ordering.
-        int diff = Integer.compare(array[i], other.array[i]);
-        if (diff != 0) {
-          return diff;
-        }
-      }
-
-      return Integer.compare(array.length, other.array.length);
+      return Arrays.compare(array, other.array);
     }
   }
 
@@ -122,17 +112,7 @@ class ArrayWrappers {
 
     @Override
     public int compareTo(ComparableLongArray other) {
-      int len = Math.min(array.length, other.array.length);
-      for (int i = 0; i < len; i++) {
-        // Use Long.compare; subtraction overflows for large opposite-sign values
-        // (e.g. Long.MIN_VALUE vs Long.MAX_VALUE) and returns the wrong ordering.
-        int diff = Long.compare(array[i], other.array[i]);
-        if (diff != 0) {
-          return diff;
-        }
-      }
-
-      return Integer.compare(array.length, other.array.length);
+      return Arrays.compare(array, other.array);
     }
   }
 
@@ -163,15 +143,7 @@ class ArrayWrappers {
 
     @Override
     public int compareTo(ComparableByteArray other) {
-      int len = Math.min(array.length, other.array.length);
-      for (int i = 0; i < len; i++) {
-        int diff = array[i] - other.array[i];
-        if (diff != 0) {
-          return diff;
-        }
-      }
-
-      return array.length - other.array.length;
+      return Arrays.compare(array, other.array);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ArrayWrappers` (in `common/kvstore`, used to order array keys in the KVStore that backs the
Spark status/UI store) implements hand-written scalar `compareTo` loops that compare elements
one at a time for its `byte[]`, `int[]`, and `long[]` wrappers. This replaces those loops with
the corresponding `java.util.Arrays.compare(...)` overloads:

- `ComparableByteArray.compareTo` -> `Arrays.compare(byte[], byte[])`
- `ComparableIntArray.compareTo` -> `Arrays.compare(int[], int[])`
- `ComparableLongArray.compareTo` -> `Arrays.compare(long[], long[])`

`ComparableObjectArray` is left unchanged: the reference-type `Arrays.compare` overload requires
`Comparable` elements (the field is `Object[]`) and is not intrinsified, so it offers no benefit.

### Why are the changes needed?

`Arrays.compare` performs the identical comparison -- lexicographic over the common prefix,
ordering the shorter array first on a tie -- but each primitive overload is a HotSpot intrinsic
backed by a vectorized (SIMD) mismatch scan, so it is faster while preserving the exact ordering.
It is also simpler than the hand-written loops.

**Semantics are unchanged.**

- `byte[]`: the existing comparison is signed (`array[i] - other.array[i]` promotes each `byte`
  to a sign-extended `int`), which matches `Arrays.compare`'s `Byte.compare` semantics; the
  single-element byte difference cannot overflow.
- `int[]` / `long[]`: the existing loops already use `Integer.compare` / `Long.compare` per
  element, which is exactly what `Arrays.compare` uses internally, so the overflow-safe ordering
  is preserved. The prefix-tie result switches from `Integer.compare(a.length, b.length)` to
  `Arrays.compare`'s `a.length - b.length`; both lengths are non-negative, so this cannot
  overflow and yields the same sign.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by the existing `ArrayWrappersSuite` tests -- `testGenericArrayKey` (ordering for
`byte[]`, `int[]`, and `String[]` keys) and `testIntArrayCompareNoOverflow` /
`testLongArrayCompareNoOverflow` (which assert `MIN_VALUE` / `MAX_VALUE` boundary ordering, still
exercised because `Arrays.compare` delegates to `Integer.compare` / `Long.compare`). No behavior
change, so no new tests were added.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
