### PR TITLE
[SPARK-59006][CORE] Generalize `checkAndGetSparkContext` to take a feature name

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/OneApplicationResource.scala
@@ -57,7 +57,7 @@ private[v1] class AbstractApplicationResource extends BaseAppResource {
   @Path("executors/{executorId}/threads")
   def threadDump(@PathParam("executorId") execId: String): Array[ThreadStackTrace] = withUI { ui =>
     checkExecutorId(execId)
-    val safeSparkContext = checkAndGetSparkContext()
+    val safeSparkContext = checkAndGetSparkContext("Thread dumps")
     ui.store.asOption(ui.store.executorSummary(execId)) match {
       case Some(executorSummary) if executorSummary.isActive =>
           val safeThreadDump = safeSparkContext.getExecutorThreadDump(execId).getOrElse {
@@ -75,7 +75,7 @@ private[v1] class AbstractApplicationResource extends BaseAppResource {
       @QueryParam("taskId") taskId: Long,
       @QueryParam("executorId") execId: String): ThreadStackTrace = {
     checkExecutorId(execId)
-    val safeSparkContext = checkAndGetSparkContext()
+    val safeSparkContext = checkAndGetSparkContext("Thread dumps")
     safeSparkContext
       .getTaskThreadDump(taskId, execId)
       .getOrElse {
@@ -188,9 +188,13 @@ private[v1] class AbstractApplicationResource extends BaseAppResource {
     }
   }
 
-  private def checkAndGetSparkContext(): SparkContext = withUI { ui =>
+  /**
+   * Returns the live `SparkContext` for live-only endpoints. `feature` is the subject of the
+   * error message, e.g. "Thread dumps" -> "Thread dumps not available through the history server."
+   */
+  private def checkAndGetSparkContext(feature: String): SparkContext = withUI { ui =>
     ui.sc.getOrElse {
-      throw new ServiceUnavailable("Thread dumps not available through the history server.")
+      throw new ServiceUnavailable(s"$feature not available through the history server.")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the private helper `checkAndGetSparkContext()` in `AbstractApplicationResource`
take the name of the feature requesting the live `SparkContext`:

```scala
private def checkAndGetSparkContext(feature: String): SparkContext = withUI { ui =>
  ui.sc.getOrElse {
    throw new ServiceUnavailable(s"$feature not available through the history server.")
  }
}
```

Both call sites, `threadDump` and `getTaskThreadDump`, pass `"Thread dumps"`.

### Why are the changes needed?

The helper hardcoded `"Thread dumps"` in its message, so only the two thread-dump endpoints
could use it. Any other live-only endpoint needing the live `SparkContext` had to inline its own
`ui.sc.getOrElse { throw new ServiceUnavailable(...) }` just to get a correct message. Passing the
feature name keeps the shared `"... not available through the history server."` wording in one place.

### Does this PR introduce _any_ user-facing change?

No. The existing error messages are unchanged.

### How was this patch tested?

Pass the CIs with the existing tests, including `UISeleniumSuite`, which exercises the
thread-dump REST endpoint.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5