### PR TITLE
fix(jdbc): make Oracle bare NUMBER scale configurable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6929,6 +6929,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val ORACLE_NUMBER_DEFAULT_SCALE =
+    buildConf("spark.sql.oracle.numberDefaultScale")
+      .doc("Default scale for Oracle bare NUMBER columns with no precision/scale " +
+        "or FLOAT columns (JDBC scale -127). Oracle reports these as precision 0 " +
+        "or scale -127 via JDBC metadata. Spark maps them to DecimalType(38, scale).")
+      .version("4.1.0")
+      .intConf
+      .checkValue(s => s >= 0 && s <= 38, "oracle numberDefaultScale must be between 0 and 38")
+      .createWithDefault(10)
+
   val LEGACY_DB2_TIMESTAMP_MAPPING_ENABLED =
     buildConf("spark.sql.legacy.db2.numericMapping.enabled")
       .internal()
@@ -9120,6 +9130,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyOracleTimestampMappingEnabled: Boolean =
     getConf(LEGACY_ORACLE_TIMESTAMP_MAPPING_ENABLED)
+
+  def oracleNumberDefaultScale: Int = getConf(ORACLE_NUMBER_DEFAULT_SCALE)
 
   def legacyDB2numericMappingEnabled: Boolean =
     getConf(LEGACY_DB2_TIMESTAMP_MAPPING_ENABLED)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -160,12 +160,20 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
           // https://github.com/apache/spark/pull/8780#issuecomment-145598968
           // and
           // https://github.com/apache/spark/pull/8780#issuecomment-144541760
-          case 0 => Option(DecimalType(DecimalType.MAX_PRECISION, 10))
+          case 0 =>
+            logWarning(s"Bare Oracle NUMBER with no precision/scale mapped to " +
+              s"DecimalType(38, ${conf.oracleNumberDefaultScale}). Set " +
+              s"spark.sql.oracle.numberDefaultScale to adjust.")
+            Option(DecimalType(DecimalType.MAX_PRECISION, conf.oracleNumberDefaultScale))
           // Handle FLOAT fields in a special way because JDBC ResultSetMetaData converts
           // this to NUMERIC with -127 scale
           // Not sure if there is a more robust way to identify the field as a float (or other
           // numeric types that do not specify a scale.
-          case _ if scale == -127L => Option(DecimalType(DecimalType.MAX_PRECISION, 10))
+          case _ if scale == -127L =>
+            logWarning(s"Oracle NUMERIC/FLOAT with scale -127 mapped to " +
+              s"DecimalType(38, ${conf.oracleNumberDefaultScale}). Set " +
+              s"spark.sql.oracle.numberDefaultScale to adjust.")
+            Option(DecimalType(DecimalType.MAX_PRECISION, conf.oracleNumberDefaultScale))
           case _ => None
         }
       case TIMESTAMP_TZ | TIMESTAMP_LTZ =>


### PR DESCRIPTION
Fixes silent precision loss for Oracle bare NUMBER.

Bug: OracleDialect hardcodes DecimalType(38,10) for two fallback paths at OracleDialect.scala:163 and 168. Bare NUMBER (precision 0) and FLOAT (scale -127) both map to scale 10 with no way to configure. This truncates or pads values that need a different scale.

Fix: Add SQLConf spark.sql.oracle.numberDefaultScale with default 10. Replace hardcoded 10 in OracleDialect.getCatalystType with conf.oracleNumberDefaultScale. Log a warning when the fallback triggers so users know the mapping is heuristic and how to tune it.

Evidence: Verified RED has hardcoded 10, GREEN uses configurable conf. git stash round-trip confirms. Diff is 2 files, 22 insertions, 2 deletions. No formatting or unrelated changes.