### PR TITLE
[SPARK-58601][PYTHON][TESTS][4.1] Guard mapInPandas/mapInArrow list-return tests with the legacy acceptAnyIterable flag

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -55,6 +55,19 @@ class MapInArrowTestsMixin(object):
         expected = df.collect()
         self.assertEqual(actual, expected)
 
+    def test_map_in_arrow_legacy_accept_any_iterable(self):
+        # With the legacy flag enabled, returning a non-Iterator iterable (e.g. list) is accepted.
+        def list_not_iter(iterator):
+            return [batch for batch in iterator]
+
+        with self.sql_conf(
+            {"spark.sql.execution.pythonUDF.mapInBatch.legacy.acceptAnyIterable.enabled": True}
+        ):
+            df = self.spark.range(10)
+            actual = df.mapInArrow(list_not_iter, "id long").collect()
+            expected = df.collect()
+            self.assertEqual(actual, expected)
+
     def test_map_in_arrow_with_limit(self):
         def get_size(iterator):
             for batch in iterator:

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -85,11 +85,15 @@ class MapInPandasTestsMixin:
         expected = df.collect()
         self.assertEqual(actual, expected)
 
-        # test returning list of DataFrames
-        df = self.spark.range(10, numPartitions=3)
-        actual = df.mapInPandas(lambda it: [pdf for pdf in it], "id long").collect()
-        expected = df.collect()
-        self.assertEqual(actual, expected)
+    def test_map_in_pandas_legacy_accept_any_iterable(self):
+        # With the legacy flag enabled, returning a non-Iterator iterable (e.g. list) is accepted.
+        with self.sql_conf(
+            {"spark.sql.execution.pythonUDF.mapInBatch.legacy.acceptAnyIterable.enabled": True}
+        ):
+            df = self.spark.range(10, numPartitions=3)
+            actual = df.mapInPandas(lambda it: [pdf for pdf in it], "id long").collect()
+            expected = df.collect()
+            self.assertEqual(actual, expected)
 
     def test_multiple_columns(self):
         data = [(1, "foo"), (2, None), (3, "bar"), (4, "bar")]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This mirrors #58286 (branch-4.0) onto branch-4.1: it moves the `mapInPandas` and `mapInArrow` list-return (non-`Iterator` iterable) test cases under the `spark.sql.execution.pythonUDF.mapInBatch.legacy.acceptAnyIterable.enabled=true` flag, and leaves the default `test_map_in_pandas` / `test_map_in_arrow` cases returning a strict iterator. This matches the return-value contract introduced on master by SPARK-58601 (strict `Iterator` by default; any iterable accepted only under the legacy flag).

### Why are the changes needed?

The connect old-client compatibility job runs a release branch's Python tests against a `master` Spark Connect server. On master, SPARK-58601 tightened `mapInPandas` / `mapInArrow` to require a strict `Iterator` return by default, so a release branch's `test_map_in_pandas`, which returned a bare `list`, fails against that server with `UDF_RETURN_TYPE`. #58286 fixed this for branch-4.0; this PR keeps branch-4.1 consistent so the same tests stay green if the compatibility job's target advances to this branch. The change is also safe on branch-4.1's own server: the flag is unknown there and ignored, and branch-4.1 accepts lists regardless, so the tests pass both on branch-4.1 and against a strict-Iterator server.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Existing tests, restructured. `test_map_in_pandas` / `test_map_in_arrow` assert the default iterator path; the new `test_map_in_pandas_legacy_accept_any_iterable` / `test_map_in_arrow_legacy_accept_any_iterable` assert the list path under the legacy flag.

### Was this patch authored or co-authored using generative AI tooling?

No.
