### PR TITLE
[SPARK-59024][SQL] Use the physical plan id as the cached name for anonymous cached tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2647,6 +2647,15 @@ object SQLConf {
     .enumConf(classOf[Level])
     .createWithDefault(Level.TRACE)
 
+  val USE_SEQUENTIAL_CACHE_NAME = buildConf("spark.sql.useSequentialCacheName")
+    .internal()
+    .doc("When true and the cached table has no name, use a sequential number like " +
+      "'CachedRDD 1' as the cached name instead of the abbreviated plan tree string. " +
+      "Rendering the plan tree string can be expensive for large plans.")
+    .version("4.4.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val DROP_TABLE_VIEW_ENABLED =
     buildConf("spark.sql.dropTableOnView.enabled")
       .doc("When true, DROP TABLE command will work on VIEW as well.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2647,13 +2647,16 @@ object SQLConf {
     .enumConf(classOf[Level])
     .createWithDefault(Level.TRACE)
 
-  val USE_SEQUENTIAL_CACHE_NAME = buildConf("spark.sql.useSequentialCacheName")
-    .doc("When true and the cached table has no name, use a sequential number like " +
-      "'CachedRDD 1' as the cached name instead of the abbreviated plan tree string. " +
-      "Rendering the plan tree string can be expensive for large plans.")
-    .version("4.4.0")
-    .booleanConf
-    .createWithDefault(false)
+  val DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED =
+    buildConf("spark.sql.dataframeCache.sequentialName.enabled")
+      .internal()
+      .doc("When true and the cached table has no name, use a sequential number like " +
+        "'CachedRDD 0' as the cached name instead of the abbreviated plan tree string. " +
+        "Rendering the plan tree string can be expensive for large plans.")
+      .version("4.4.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(false)
 
   val DROP_TABLE_VIEW_ENABLED =
     buildConf("spark.sql.dropTableOnView.enabled")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2647,12 +2647,13 @@ object SQLConf {
     .enumConf(classOf[Level])
     .createWithDefault(Level.TRACE)
 
-  val DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED =
-    buildConf("spark.sql.dataframeCache.sequentialName.enabled")
+  val DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED =
+    buildConf("spark.sql.dataframeCache.planIdName.enabled")
       .internal()
-      .doc("When true and the cached table has no name, use a sequential number like " +
-        "'CachedRDD 0' as the cached name instead of the abbreviated plan tree string. " +
-        "Rendering the plan tree string can be expensive for large plans.")
+      .doc("When true and the cached table has no name, use the physical plan id, e.g. " +
+        "'CachedRDD (plan_id=42)', as the cached name instead of the abbreviated plan tree " +
+        "string. Rendering the plan tree string can be expensive for large plans. The name " +
+        "is resolved when the cache is first materialized.")
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2648,7 +2648,6 @@ object SQLConf {
     .createWithDefault(Level.TRACE)
 
   val USE_SEQUENTIAL_CACHE_NAME = buildConf("spark.sql.useSequentialCacheName")
-    .internal()
     .doc("When true and the cached table has no name, use a sequential number like " +
       "'CachedRDD 1' as the cached name instead of the abbreviated plan tree string. " +
       "Rendering the plan tree string can be expensive for large plans.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -289,8 +289,8 @@ case class CachedRDDBuilder(
   // late updates from making a rebuilt cache appear complete.
   private var partitionStats = newPartitionStats()
 
-  // Resolved on first access, which happens at cache materialization; for adaptive plans the
-  // name therefore reflects the final plan.
+  // Resolved on first access (cache materialization for anonymous caches). For adaptive plans,
+  // the name reflects the final plan.
   lazy val cachedName: String = tableName.map(n => s"In-memory table $n").getOrElse {
     if (cachedPlan.conf.getConf(SQLConf.DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED)) {
       s"CachedRDD (plan_id=${cachedPlan.id})"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.columnar
 
-import java.util.concurrent.atomic.AtomicLong
-
 import com.esotericsoftware.kryo.{DefaultSerializer, Kryo, Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
 
@@ -257,11 +255,6 @@ class DefaultCachedBatchSerializer extends SimpleMetricsCachedBatchSerializer {
   }
 }
 
-private[sql] object CachedRDDBuilder {
-  private val nextCachedRDDId = new AtomicLong(0)
-  def newCachedRDDId(): Long = nextCachedRDDId.getAndIncrement()
-}
-
 private[sql]
 case class CachedRDDBuilder(
     serializer: CachedBatchSerializer,
@@ -296,11 +289,11 @@ case class CachedRDDBuilder(
   // late updates from making a rebuilt cache appear complete.
   private var partitionStats = newPartitionStats()
 
-  // The sequential id is consumed when this lazy val is first forced; a copy of the builder
-  // would draw a new id.
+  // Resolved on first access, which happens at cache materialization; for adaptive plans the
+  // name therefore reflects the final plan.
   lazy val cachedName: String = tableName.map(n => s"In-memory table $n").getOrElse {
-    if (cachedPlan.conf.getConf(SQLConf.DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED)) {
-      s"CachedRDD ${CachedRDDBuilder.newCachedRDDId()}"
+    if (cachedPlan.conf.getConf(SQLConf.DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED)) {
+      s"CachedRDD (plan_id=${cachedPlan.id})"
     } else {
       Utils.abbreviate(cachedPlan.toString, 1024)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -258,8 +258,8 @@ class DefaultCachedBatchSerializer extends SimpleMetricsCachedBatchSerializer {
 }
 
 private[sql] object CachedRDDBuilder {
-  private val _nextCachedRDDId = new AtomicLong(0)
-  def nextCachedRDDId(): Long = _nextCachedRDDId.getAndIncrement
+  private val nextCachedRDDId = new AtomicLong(0)
+  def newCachedRDDId(): Long = nextCachedRDDId.getAndIncrement()
 }
 
 private[sql]
@@ -296,9 +296,11 @@ case class CachedRDDBuilder(
   // late updates from making a rebuilt cache appear complete.
   private var partitionStats = newPartitionStats()
 
-  val cachedName: String = tableName.map(n => s"In-memory table $n").getOrElse {
-    if (cachedPlan.session.conf.get(SQLConf.USE_SEQUENTIAL_CACHE_NAME)) {
-      s"CachedRDD ${CachedRDDBuilder.nextCachedRDDId()}"
+  // The sequential id is consumed when this lazy val is first forced; a copy of the builder
+  // would draw a new id.
+  lazy val cachedName: String = tableName.map(n => s"In-memory table $n").getOrElse {
+    if (cachedPlan.conf.getConf(SQLConf.DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED)) {
+      s"CachedRDD ${CachedRDDBuilder.newCachedRDDId()}"
     } else {
       Utils.abbreviate(cachedPlan.toString, 1024)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.columnar
 
+import java.util.concurrent.atomic.AtomicLong
+
 import com.esotericsoftware.kryo.{DefaultSerializer, Kryo, Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
 
@@ -255,6 +257,11 @@ class DefaultCachedBatchSerializer extends SimpleMetricsCachedBatchSerializer {
   }
 }
 
+private[sql] object CachedRDDBuilder {
+  private val _nextCachedRDDId = new AtomicLong(0)
+  def nextCachedRDDId(): Long = _nextCachedRDDId.getAndIncrement
+}
+
 private[sql]
 case class CachedRDDBuilder(
     serializer: CachedBatchSerializer,
@@ -289,8 +296,13 @@ case class CachedRDDBuilder(
   // late updates from making a rebuilt cache appear complete.
   private var partitionStats = newPartitionStats()
 
-  val cachedName = tableName.map(n => s"In-memory table $n")
-    .getOrElse(Utils.abbreviate(cachedPlan.toString, 1024))
+  val cachedName: String = tableName.map(n => s"In-memory table $n").getOrElse {
+    if (cachedPlan.session.conf.get(SQLConf.USE_SEQUENTIAL_CACHE_NAME)) {
+      s"CachedRDD ${CachedRDDBuilder.nextCachedRDDId()}"
+    } else {
+      Utils.abbreviate(cachedPlan.toString, 1024)
+    }
+  }
 
   val supportsColumnarInput: Boolean = {
     cachedPlan.supportsColumnar &&

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
@@ -17,9 +17,13 @@
 
 package org.apache.spark.sql.execution.columnar
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.AttributeSet
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.internal.SQLConf
@@ -53,24 +57,33 @@ class InMemoryRelationSuite extends SparkFunSuite
     assert(r1.sameResult(r2))
   }
 
-  test("SPARK-59024: sequential cached name for anonymous cached tables") {
+  test("SPARK-59024: plan id cached name for anonymous cached tables") {
     val d = spark.range(1)
-    withSQLConf(SQLConf.DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED.key -> "true") {
       val r1 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
-      val r2 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
-      assert(r1.cacheBuilder.cachedName.matches("CachedRDD \\d+"))
-      assert(r2.cacheBuilder.cachedName.matches("CachedRDD \\d+"))
+      // Caches of the same plan share the plan id.
+      val r1Again = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
+      val r2 = InMemoryRelation(StorageLevel.MEMORY_ONLY, spark.range(2).queryExecution, None)
+      assert(r1.cacheBuilder.cachedName.matches("CachedRDD \\(plan_id=\\d+\\)"))
+      assert(r1Again.cacheBuilder.cachedName == r1.cacheBuilder.cachedName)
       assert(r1.cacheBuilder.cachedName != r2.cacheBuilder.cachedName)
       // Named tables keep the usual name.
       val r3 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, Some("t1"))
       assert(r3.cacheBuilder.cachedName == "In-memory table t1")
     }
     // When disabled, the cached name keeps the abbreviated plan tree string.
-    withSQLConf(SQLConf.DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED.key -> "false") {
+    withSQLConf(SQLConf.DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED.key -> "false") {
       val r4 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
       assert(r4.cacheBuilder.cachedName ==
         Utils.abbreviate(r4.cacheBuilder.cachedPlan.toString, 1024))
     }
+  }
+
+  test("SPARK-59024: anonymous cached name is not rendered before materialization") {
+    val plan = ToStringCountingPlan()
+    InMemoryRelation(new DefaultCachedBatchSerializer, StorageLevel.MEMORY_ONLY, plan, None,
+      spark.range(1).queryExecution.optimizedPlan)
+    assert(plan.toStringCount == 0)
   }
 
   test("SPARK-47177: Cached SQL plan do not display final AQE plan in explain string") {
@@ -94,5 +107,21 @@ class InMemoryRelationSuite extends SparkFunSuite
     df.collect()
     assert(findIMRInnerChild(df.queryExecution.executedPlan).treeString
       .contains("AdaptiveSparkPlan isFinalPlan=true"))
+  }
+}
+
+case class ToStringCountingPlan() extends LeafExecNode {
+  private val _toStringCount = new AtomicInteger(0)
+
+  def toStringCount: Int = _toStringCount.get()
+
+  override def output: Seq[Attribute] = Seq.empty
+
+  override protected def doExecute(): RDD[InternalRow] =
+    throw new UnsupportedOperationException
+
+  override def toString: String = {
+    _toStringCount.incrementAndGet()
+    "ToStringCountingPlan"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.AttributeSet
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSessionBase
 import org.apache.spark.storage.StorageLevel
 
@@ -49,6 +50,23 @@ class InMemoryRelationSuite extends SparkFunSuite
     // `doCanonicalize`, which re-maps `outputOrdering` through `output`, so a stale ordering
     // throws here rather than merely producing an unequal plan.
     assert(r1.sameResult(r2))
+  }
+
+  test("sequential cached name for anonymous cached tables") {
+    val d = spark.range(1)
+    withSQLConf(SQLConf.USE_SEQUENTIAL_CACHE_NAME.key -> "true") {
+      val r1 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
+      val r2 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
+      assert(r1.cacheBuilder.cachedName.matches("CachedRDD \\d+"))
+      assert(r2.cacheBuilder.cachedName.matches("CachedRDD \\d+"))
+      assert(r1.cacheBuilder.cachedName != r2.cacheBuilder.cachedName)
+      // Named tables keep the usual name.
+      val r3 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, Some("t1"))
+      assert(r3.cacheBuilder.cachedName == "In-memory table t1")
+    }
+    // The default keeps the abbreviated plan tree string.
+    val r4 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
+    assert(!r4.cacheBuilder.cachedName.startsWith("CachedRDD "))
   }
 
   test("SPARK-47177: Cached SQL plan do not display final AQE plan in explain string") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
@@ -64,9 +64,11 @@ class InMemoryRelationSuite extends SparkFunSuite
       val r3 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, Some("t1"))
       assert(r3.cacheBuilder.cachedName == "In-memory table t1")
     }
-    // The default keeps the abbreviated plan tree string.
-    val r4 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
-    assert(!r4.cacheBuilder.cachedName.startsWith("CachedRDD "))
+    // When disabled, the cached name keeps the abbreviated plan tree string.
+    withSQLConf(SQLConf.USE_SEQUENTIAL_CACHE_NAME.key -> "false") {
+      val r4 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
+      assert(!r4.cacheBuilder.cachedName.startsWith("CachedRDD "))
+    }
   }
 
   test("SPARK-47177: Cached SQL plan do not display final AQE plan in explain string") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
@@ -61,7 +61,7 @@ class InMemoryRelationSuite extends SparkFunSuite
     val d = spark.range(1)
     withSQLConf(SQLConf.DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED.key -> "true") {
       val r1 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
-      // Caches of the same plan share the plan id.
+      // Caches of the same physical plan instance share the plan id.
       val r1Again = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
       val r2 = InMemoryRelation(StorageLevel.MEMORY_ONLY, spark.range(2).queryExecution, None)
       assert(r1.cacheBuilder.cachedName.matches("CachedRDD \\(plan_id=\\d+\\)"))
@@ -81,9 +81,12 @@ class InMemoryRelationSuite extends SparkFunSuite
 
   test("SPARK-59024: anonymous cached name is not rendered before materialization") {
     val plan = ToStringCountingPlan()
-    InMemoryRelation(new DefaultCachedBatchSerializer, StorageLevel.MEMORY_ONLY, plan, None,
-      spark.range(1).queryExecution.optimizedPlan)
+    val relation = InMemoryRelation(new DefaultCachedBatchSerializer, StorageLevel.MEMORY_ONLY,
+      plan, None, spark.range(1).queryExecution.optimizedPlan)
     assert(plan.toStringCount == 0)
+    // Forcing the name renders the tree string exactly once.
+    relation.cacheBuilder.cachedName
+    assert(plan.toStringCount == 1)
   }
 
   test("SPARK-47177: Cached SQL plan do not display final AQE plan in explain string") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryRelationSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSessionBase
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.Utils
 
 class InMemoryRelationSuite extends SparkFunSuite
   with SharedSparkSessionBase with AdaptiveSparkPlanHelper {
@@ -52,9 +53,9 @@ class InMemoryRelationSuite extends SparkFunSuite
     assert(r1.sameResult(r2))
   }
 
-  test("sequential cached name for anonymous cached tables") {
+  test("SPARK-59024: sequential cached name for anonymous cached tables") {
     val d = spark.range(1)
-    withSQLConf(SQLConf.USE_SEQUENTIAL_CACHE_NAME.key -> "true") {
+    withSQLConf(SQLConf.DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED.key -> "true") {
       val r1 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
       val r2 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
       assert(r1.cacheBuilder.cachedName.matches("CachedRDD \\d+"))
@@ -65,9 +66,10 @@ class InMemoryRelationSuite extends SparkFunSuite
       assert(r3.cacheBuilder.cachedName == "In-memory table t1")
     }
     // When disabled, the cached name keeps the abbreviated plan tree string.
-    withSQLConf(SQLConf.USE_SEQUENTIAL_CACHE_NAME.key -> "false") {
+    withSQLConf(SQLConf.DATAFRAME_CACHE_SEQUENTIAL_NAME_ENABLED.key -> "false") {
       val r4 = InMemoryRelation(StorageLevel.MEMORY_ONLY, d.queryExecution, None)
-      assert(!r4.cacheBuilder.cachedName.startsWith("CachedRDD "))
+      assert(r4.cacheBuilder.cachedName ==
+        Utils.abbreviate(r4.cacheBuilder.cachedPlan.toString, 1024))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an internal SQL config `spark.sql.dataframeCache.planIdName.enabled` (default `false`). When it is true and the cached table has no name, `CachedRDDBuilder` uses the physical plan id, e.g. `CachedRDD (plan_id=42)`, as the cached name instead of the abbreviated plan tree string. `cachedName` is also made a `lazy val`, so the name is only computed when it is actually needed:

```scala
lazy val cachedName: String = tableName.map(n => s"In-memory table $n").getOrElse {
  if (cachedPlan.conf.getConf(SQLConf.DATAFRAME_CACHE_PLAN_ID_NAME_ENABLED)) {
    s"CachedRDD (plan_id=${cachedPlan.id})"
  } else {
    Utils.abbreviate(cachedPlan.toString, 1024)
  }
}
```

### Why are the changes needed?

For anonymous cached tables, the cached name was built from the plan's tree string (`cachedPlan.toString`, abbreviated to 1024 chars) at `CachedRDDBuilder` construction time, even for caches that are never materialized. Rendering the plan tree string can be expensive for large plans, and the name is only used for display.

This is another spot, besides the SQL event plan description addressed in SPARK-59023, that hurts the same customer job: it constructs a huge plan whose `treeString` exceeds 280,000 lines, and rendering the plan tree string takes minutes per iteration and contributes to driver OOM.

### Does this PR introduce _any_ user-facing change?

The new config is internal and defaults to `false`. One nuance: because `cachedName` is now evaluated lazily, the name of anonymous caches is rendered at materialization time, so for adaptive plans the Storage tab shows a name derived from the final AQE plan instead of the pre-execution plan. No other behavior changes.

### How was this patch tested?

New unit tests in `InMemoryRelationSuite`:

- `SPARK-59024: plan id cached name for anonymous cached tables` -- verifies the `CachedRDD (plan_id=<id>)` format, that caches of the same plan share the name, that distinct plans get distinct names, that named tables keep the `In-memory table <name>` name, and that the abbreviated plan tree string is kept when the config is disabled
- `SPARK-59024: anonymous cached name is not rendered before materialization` -- verifies the plan tree string is not rendered at cache construction

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Qwen3.8 Max
