### PR TITLE
[SPARK-58814][SQL] Cover CHAR/VARCHAR round-trips and stop ORC truncating scans

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.TestingUDT.IntervalData
 import org.apache.spark.sql.avro.AvroCompressionCodec._
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.Filter
-import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeTestUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, LA, UTC}
 import org.apache.spark.sql.execution.{FormattedMode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, DataSource, FilePartition}
@@ -3721,6 +3721,82 @@ abstract class AvroSuite
       val readDf = spark.read.format("avro").load(dir.toString)
       assert(readDf.schema("t").dataType == TimeType(TimeType.MICROS_PRECISION))
       checkAnswer(readDf, Row(java.time.LocalTime.of(12, 34, 56, 123456000)))
+    }
+  }
+
+  test("SPARK-58814: Avro infers nested CHAR/VARCHAR schema and values") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        val input = spark.range(1).selectExpr(
+          "cast('ab' AS CHAR(4)) AS c",
+          "cast('xy' AS VARCHAR(3)) AS v",
+          "named_struct('c', cast('z' AS CHAR(2))) AS s",
+          "array(cast('q' AS VARCHAR(2))) AS a",
+          "map(cast('k' AS CHAR(2)), cast('v' AS VARCHAR(2))) AS m")
+        input.write.mode("overwrite").format("avro").save(path)
+
+        val readBack = spark.read.format("avro").load(path)
+        assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema))
+        checkAnswer(
+          readBack.selectExpr("concat('<', c, '>')", "v", "concat('<', s.c, '>')"),
+          Row("<ab  >", "xy", "<z >"))
+
+        withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
+          assert(DataType.equalsIgnoreNullability(
+            spark.read.format("avro").load(path).schema,
+            CharVarcharUtils.replaceCharVarcharWithString(input.schema)))
+        }
+        withSQLConf(
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+          assert(DataType.equalsIgnoreNullability(
+            spark.read.format("avro").load(path).schema,
+            input.schema))
+        }
+      }
+
+      withTempPath { dir =>
+        Seq("ab").toDF("c").write.format("avro").save(dir.getCanonicalPath)
+        val charDf = spark.read.schema("c CHAR(4)").format("avro").load(dir.getCanonicalPath)
+        checkAnswer(
+          charDf.selectExpr("concat('<', c, '>')"),
+          Row("<ab  >"))
+      }
+      withTempPath { dir =>
+        Seq("abcdef").toDF("c").write.format("avro").save(dir.getCanonicalPath)
+        Seq("CHAR", "VARCHAR").foreach { typ =>
+          checkError(
+            exception = intercept[SparkRuntimeException] {
+              spark.read.schema(s"c $typ(4)").format("avro")
+                .load(dir.getCanonicalPath).collect()
+            },
+            condition = "EXCEED_LIMIT_LENGTH",
+            parameters = Map("limit" -> "4"))
+        }
+      }
+
+      withTable("avro_char_varchar_assignment") {
+        sql(
+          """CREATE TABLE avro_char_varchar_assignment
+            |(c CHAR(4), v VARCHAR(4)) USING avro""".stripMargin)
+        sql("INSERT INTO avro_char_varchar_assignment VALUES ('ab', 'xy')")
+        assert(spark.table("avro_char_varchar_assignment").schema.map(_.dataType) ===
+          Seq(CharType(4), VarcharType(4)))
+        checkAnswer(
+          sql(
+            """SELECT concat('<', c, '>'), v
+              |FROM avro_char_varchar_assignment""".stripMargin),
+          Row("<ab  >", "xy"))
+        checkError(
+          exception = intercept[SparkRuntimeException] {
+            sql(
+              """INSERT INTO avro_char_varchar_assignment
+                |VALUES ('abcde', 'xy')""".stripMargin).collect()
+          },
+          condition = "EXCEED_LIMIT_LENGTH",
+          parameters = Map("limit" -> "4"))
+      }
     }
   }
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.TestingUDT.IntervalData
 import org.apache.spark.sql.avro.AvroCompressionCodec._
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.Filter
-import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeTestUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, LA, UTC}
 import org.apache.spark.sql.connector.catalog.TableCapability
 import org.apache.spark.sql.execution.{FileSourceScanExec, FormattedMode, SparkPlan}
@@ -3859,6 +3859,82 @@ abstract class AvroSuite
       val readDf = spark.read.format("avro").load(dir.toString)
       assert(readDf.schema("t").dataType == TimeType(TimeType.MICROS_PRECISION))
       checkAnswer(readDf, Row(java.time.LocalTime.of(12, 34, 56, 123456000)))
+    }
+  }
+
+  test("SPARK-58814: Avro infers nested CHAR/VARCHAR schema and values") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        val input = spark.range(1).selectExpr(
+          "cast('ab' AS CHAR(4)) AS c",
+          "cast('xy' AS VARCHAR(3)) AS v",
+          "named_struct('c', cast('z' AS CHAR(2))) AS s",
+          "array(cast('q' AS VARCHAR(2))) AS a",
+          "map(cast('k' AS CHAR(2)), cast('v' AS VARCHAR(2))) AS m")
+        input.write.mode("overwrite").format("avro").save(path)
+
+        val readBack = spark.read.format("avro").load(path)
+        assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema))
+        checkAnswer(
+          readBack.selectExpr("concat('<', c, '>')", "v", "concat('<', s.c, '>')"),
+          Row("<ab  >", "xy", "<z >"))
+
+        withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
+          assert(DataType.equalsIgnoreNullability(
+            spark.read.format("avro").load(path).schema,
+            CharVarcharUtils.replaceCharVarcharWithString(input.schema)))
+        }
+        withSQLConf(
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+          assert(DataType.equalsIgnoreNullability(
+            spark.read.format("avro").load(path).schema,
+            input.schema))
+        }
+      }
+
+      withTempPath { dir =>
+        Seq("ab").toDF("c").write.format("avro").save(dir.getCanonicalPath)
+        val charDf = spark.read.schema("c CHAR(4)").format("avro").load(dir.getCanonicalPath)
+        checkAnswer(
+          charDf.selectExpr("concat('<', c, '>')"),
+          Row("<ab  >"))
+      }
+      withTempPath { dir =>
+        Seq("abcdef").toDF("c").write.format("avro").save(dir.getCanonicalPath)
+        Seq("CHAR", "VARCHAR").foreach { typ =>
+          checkError(
+            exception = intercept[SparkRuntimeException] {
+              spark.read.schema(s"c $typ(4)").format("avro")
+                .load(dir.getCanonicalPath).collect()
+            },
+            condition = "EXCEED_LIMIT_LENGTH",
+            parameters = Map("limit" -> "4"))
+        }
+      }
+
+      withTable("avro_char_varchar_assignment") {
+        sql(
+          """CREATE TABLE avro_char_varchar_assignment
+            |(c CHAR(4), v VARCHAR(4)) USING avro""".stripMargin)
+        sql("INSERT INTO avro_char_varchar_assignment VALUES ('ab', 'xy')")
+        assert(spark.table("avro_char_varchar_assignment").schema.map(_.dataType) ===
+          Seq(CharType(4), VarcharType(4)))
+        checkAnswer(
+          sql(
+            """SELECT concat('<', c, '>'), v
+              |FROM avro_char_varchar_assignment""".stripMargin),
+          Row("<ab  >", "xy"))
+        checkError(
+          exception = intercept[SparkRuntimeException] {
+            sql(
+              """INSERT INTO avro_char_varchar_assignment
+                |VALUES ('abcde', 'xy')""".stripMargin).collect()
+          },
+          condition = "EXCEED_LIMIT_LENGTH",
+          parameters = Map("limit" -> "4"))
+      }
     }
   }
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -3877,8 +3877,13 @@ abstract class AvroSuite
         val readBack = spark.read.format("avro").load(path)
         assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema))
         checkAnswer(
-          readBack.selectExpr("concat('<', c, '>')", "v", "concat('<', s.c, '>')"),
-          Row("<ab  >", "xy", "<z >"))
+          readBack.selectExpr(
+            "concat('<', c, '>')",
+            "v",
+            "concat('<', s.c, '>')",
+            "a",
+            "m"),
+          Row("<ab  >", "xy", "<z >", Seq("q"), Map("k " -> "v")))
 
         withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
           assert(DataType.equalsIgnoreNullability(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -344,7 +344,10 @@ class RelationResolution(
                 writePrivileges == null && !u.isStreaming
               cached <- lookupSharedRelationCache(catalog, ident, t, tableKey.stateOptions)
             } yield {
-              val updatedRelation = cached.copy(options = finalOptions)
+              // A shared cache entry may have been analyzed under another session's CHAR/VARCHAR
+              // policy. Rebind it in this analysis instead of inheriting that session's scan mode.
+              val updatedRelation =
+                cached.copy(options = finalOptions, charVarcharScanMode = None)
               updatedRelation.copyTagsFrom(cached)
               val nameParts = ident.toQualifiedNameParts(catalog)
               val aliasedRelation = SubqueryAlias(nameParts, updatedRelation)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -121,7 +121,7 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUp {
-    case rel @ DataSourceV2Relation(table: ChangelogTable, _, _, _, _, _) if !table.resolved =>
+    case rel @ DataSourceV2Relation(table: ChangelogTable, _, _, _, _, _, _) if !table.resolved =>
       val changelog = table.changelog
       val req = evaluateRequirements(changelog, table.changelogContext)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -1185,7 +1185,7 @@ case class HiveTableRelation(
     partitionCols: Seq[AttributeReference],
     tableStats: Option[Statistics] = None,
     @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None,
-    charVarcharStandardSemantics: Option[Boolean] = None)
+    charVarcharScanMode: Option[CharVarcharScanMode] = None)
   extends LeafNode with MultiInstanceRelation with NormalizeableRelation {
   assert(tableMeta.identifier.database.isDefined,
     "Table identifier " + tableMeta.identifier.quotedString + " is missing database name. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -1184,7 +1184,8 @@ case class HiveTableRelation(
     dataCols: Seq[AttributeReference],
     partitionCols: Seq[AttributeReference],
     tableStats: Option[Statistics] = None,
-    @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None)
+    @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None,
+    charVarcharStandardSemantics: Option[Boolean] = None)
   extends LeafNode with MultiInstanceRelation with NormalizeableRelation {
   assert(tableMeta.identifier.database.isDefined,
     "Table identifier " + tableMeta.identifier.quotedString + " is missing database name. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharScanMode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharScanMode.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+/**
+ * The CHAR/VARCHAR scan mode bound to a relation (and its scan) during analysis.
+ *
+ * A relation carries `Option[CharVarcharScanMode]`: `None` means the relation was not analyzed
+ * under first-class CHAR/VARCHAR types (native reader behavior), while a `Some` value pins the
+ * mode so that `sameResult` / cache reuse keep the two variants distinct.
+ */
+sealed trait CharVarcharScanMode
+
+object CharVarcharScanMode {
+  /**
+   * Preserve the native, constrained CHAR/VARCHAR types of the source (e.g. native ORC
+   * padding/truncation). Corresponds to preserve-only semantics.
+   */
+  case object PreserveNative extends CharVarcharScanMode
+
+  /**
+   * Request physical STRING from the source so Spark observes the original value and applies
+   * standard CHAR/VARCHAR length checks. Corresponds to standard semantics.
+   */
+  case object SparkStandard extends CharVarcharScanMode
+
+  /** Maps the boolean `spark.sql.charVarcharStandardSemantics` value to the typed mode. */
+  def apply(standardSemantics: Boolean): CharVarcharScanMode =
+    if (standardSemantics) SparkStandard else PreserveNative
+
+  /** Parses a mode from its `toString` name; the inverse of [[CharVarcharScanMode.toString]]. */
+  def fromName(name: String): CharVarcharScanMode = name match {
+    case "PreserveNative" => PreserveNative
+    case "SparkStandard" => SparkStandard
+    case other => throw new IllegalArgumentException(s"Unknown CharVarcharScanMode: $other")
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharScanMode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharScanMode.scala
@@ -24,9 +24,9 @@ package org.apache.spark.sql.catalyst.util
  * under first-class CHAR/VARCHAR types (native reader behavior), while a `Some` value pins the
  * mode so that `sameResult` / cache reuse keep the two variants distinct.
  */
-sealed trait CharVarcharScanMode
+private[sql] sealed trait CharVarcharScanMode
 
-object CharVarcharScanMode {
+private[sql] object CharVarcharScanMode {
   /**
    * Preserve the native, constrained CHAR/VARCHAR types of the source (e.g. native ORC
    * padding/truncation). Corresponds to preserve-only semantics.
@@ -39,7 +39,9 @@ object CharVarcharScanMode {
    */
   case object SparkStandard extends CharVarcharScanMode
 
-  /** Maps the boolean `spark.sql.charVarcharStandardSemantics` value to the typed mode. */
+  /**
+   * Maps the boolean `spark.sql.charVarchar.standardSemantics.enabled` value to the typed mode.
+   */
   def apply(standardSemantics: Boolean): CharVarcharScanMode =
     if (standardSemantics) SparkStandard else PreserveNative
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -32,10 +32,6 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
 
   // visible for testing
   private[sql] val CHAR_VARCHAR_TYPE_STRING_METADATA_KEY = "__CHAR_VARCHAR_TYPE_STRING"
-  private[sql] val CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY =
-    "__CHAR_VARCHAR_STANDARD_SEMANTICS"
-  private[sql] val CHAR_VARCHAR_STANDARD_SEMANTICS_SCAN_OPTION =
-    "__charVarcharStandardSemantics"
 
   /**
    * Creates a StringRPad expression with the pad literal inheriting the collation from the
@@ -109,45 +105,6 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
   }
 
   /**
-   * Cleans the raw CHAR/VARCHAR metadata while retaining the semantics already bound during
-   * analysis. Data source readers use this marker instead of the caller's active SQLConf.
-   */
-  def cleanAttrMetadataForScan(
-      attr: AttributeReference,
-      standardSemantics: Boolean): AttributeReference = {
-    val metadataBuilder = new MetadataBuilder().withMetadata(cleanMetadata(attr.metadata))
-    if (standardSemantics && getRawType(attr.metadata).isDefined) {
-      metadataBuilder.putBoolean(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY, true)
-    }
-    attr.withMetadata(metadataBuilder.build())
-  }
-
-  def markStandardSemanticsForScan(
-      schema: StructType,
-      standardSemantics: Boolean): StructType = {
-    if (standardSemantics) {
-      StructType(schema.map { field =>
-        if (hasCharVarchar(field.dataType)) {
-          val metadata = new MetadataBuilder()
-            .withMetadata(field.metadata)
-            .putBoolean(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY, true)
-            .build()
-          field.copy(metadata = metadata)
-        } else {
-          field
-        }
-      })
-    } else {
-      schema
-    }
-  }
-
-  def hasStandardSemantics(metadata: Metadata): Boolean = {
-    metadata.contains(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY) &&
-      metadata.getBoolean(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY)
-  }
-
-  /**
    * Removes the metadata entry that contains the original type string of CharType/VarcharType from
    * the given metadata.
    */
@@ -155,7 +112,6 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
     new MetadataBuilder()
       .withMetadata(metadata)
       .remove(CHAR_VARCHAR_TYPE_STRING_METADATA_KEY)
-      .remove(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY)
       .build()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -32,6 +32,10 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
 
   // visible for testing
   private[sql] val CHAR_VARCHAR_TYPE_STRING_METADATA_KEY = "__CHAR_VARCHAR_TYPE_STRING"
+  private[sql] val CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY =
+    "__CHAR_VARCHAR_STANDARD_SEMANTICS"
+  private[sql] val CHAR_VARCHAR_STANDARD_SEMANTICS_SCAN_OPTION =
+    "__charVarcharStandardSemantics"
 
   /**
    * Creates a StringRPad expression with the pad literal inheriting the collation from the
@@ -105,6 +109,45 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
   }
 
   /**
+   * Cleans the raw CHAR/VARCHAR metadata while retaining the semantics already bound during
+   * analysis. Data source readers use this marker instead of the caller's active SQLConf.
+   */
+  def cleanAttrMetadataForScan(
+      attr: AttributeReference,
+      standardSemantics: Boolean): AttributeReference = {
+    val metadataBuilder = new MetadataBuilder().withMetadata(cleanMetadata(attr.metadata))
+    if (standardSemantics && getRawType(attr.metadata).isDefined) {
+      metadataBuilder.putBoolean(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY, true)
+    }
+    attr.withMetadata(metadataBuilder.build())
+  }
+
+  def markStandardSemanticsForScan(
+      schema: StructType,
+      standardSemantics: Boolean): StructType = {
+    if (standardSemantics) {
+      StructType(schema.map { field =>
+        if (hasCharVarchar(field.dataType)) {
+          val metadata = new MetadataBuilder()
+            .withMetadata(field.metadata)
+            .putBoolean(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY, true)
+            .build()
+          field.copy(metadata = metadata)
+        } else {
+          field
+        }
+      })
+    } else {
+      schema
+    }
+  }
+
+  def hasStandardSemantics(metadata: Metadata): Boolean = {
+    metadata.contains(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY) &&
+      metadata.getBoolean(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY)
+  }
+
+  /**
    * Removes the metadata entry that contains the original type string of CharType/VarcharType from
    * the given metadata.
    */
@@ -112,6 +155,7 @@ object CharVarcharUtils extends Logging with SparkCharVarcharUtils {
     new MetadataBuilder()
       .withMetadata(metadata)
       .remove(CHAR_VARCHAR_TYPE_STRING_METADATA_KEY)
+      .remove(CHAR_VARCHAR_STANDARD_SEMANTICS_METADATA_KEY)
       .build()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUti
 import org.apache.spark.sql.catalyst.streaming.{StreamingSourceIdentifyingName, Unassigned}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{DATA_SOURCE_V2_RELATION, DATA_SOURCE_V2_SCAN_RELATION, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.{fromAttributes, toAttributes}
-import org.apache.spark.sql.catalyst.util.{removeInternalMetadata, truncatedString, CharVarcharUtils}
+import org.apache.spark.sql.catalyst.util.{removeInternalMetadata, truncatedString, CharVarcharScanMode, CharVarcharUtils}
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, Table, TableCapability, TableCatalog, V2TableUtil}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
 import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
@@ -118,7 +118,7 @@ case class DataSourceV2Relation(
     timeTravelSpec: Option[TimeTravelSpec] = None,
     // Bound at analysis so sameResult / cache reuse distinguish preserve-only vs standard
     // CHAR/VARCHAR scans. None means the relation was not analyzed under first-class types.
-    charVarcharStandardSemantics: Option[Boolean] = None)
+    charVarcharScanMode: Option[CharVarcharScanMode] = None)
   extends DataSourceV2RelationBase(table, output, catalog, identifier, options, timeTravelSpec)
   with ExposesMetadataColumns {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -115,7 +115,10 @@ case class DataSourceV2Relation(
     catalog: Option[CatalogPlugin],
     identifier: Option[Identifier],
     options: CaseInsensitiveStringMap,
-    timeTravelSpec: Option[TimeTravelSpec] = None)
+    timeTravelSpec: Option[TimeTravelSpec] = None,
+    // Bound at analysis so sameResult / cache reuse distinguish preserve-only vs standard
+    // CHAR/VARCHAR scans. None means the relation was not analyzed under first-class types.
+    charVarcharStandardSemantics: Option[Boolean] = None)
   extends DataSourceV2RelationBase(table, output, catalog, identifier, options, timeTravelSpec)
   with ExposesMetadataColumns {
 
@@ -441,7 +444,7 @@ object ExtractV2Table {
 object ExtractV2CatalogAndIdentifier {
   def unapply(relation: DataSourceV2Relation): Option[(TableCatalog, Identifier)] = {
     relation match {
-      case DataSourceV2Relation(_, _, Some(catalog), Some(identifier), _, _) =>
+      case DataSourceV2Relation(_, _, Some(catalog), Some(identifier), _, _, _) =>
         Some((catalog.asTableCatalog, identifier))
       case _ =>
         None

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -258,14 +258,14 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
       case LogicalRelationWithTable(_, Some(catalogTable)) =>
         isSameName(name, catalogTable.identifier.nameParts, resolver)
 
-      case DataSourceV2Relation(_, _, Some(catalog), Some(v2Ident), _, timeTravelSpec) =>
+      case DataSourceV2Relation(_, _, Some(catalog), Some(v2Ident), _, timeTravelSpec, _) =>
         val nameInCache = v2Ident.toQualifiedNameParts(catalog)
         isSameName(name, nameInCache, resolver) && (includeTimeTravel || timeTravelSpec.isEmpty)
 
       case v: View =>
         isSameName(name, v.desc.identifier.nameParts, resolver)
 
-      case HiveTableRelation(catalogTable, _, _, _, _) =>
+      case HiveTableRelation(catalogTable, _, _, _, _, _) =>
         isSameName(name, catalogTable.identifier.nameParts, resolver)
 
       case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.execution.datasources.{FileIndex, HadoopFsRelation, LogicalRelation, LogicalRelationWithTable}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2Relation, ExtractV2CatalogAndIdentifier, ExtractV2Table, FileTable, V2TableRefreshUtil}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK
@@ -346,6 +347,18 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   def recacheByPlan(spark: SparkSession, plan: LogicalPlan): Unit = {
     val normalized = QueryExecution.normalize(spark, plan)
     recacheByCondition(spark, _.plan.exists(_.sameResult(normalized)))
+  }
+
+  /**
+   * Re-caches every entry whose plan contains a [[LogicalRelation]] for `relation`.
+   * Unlike [[recacheByPlan]], this ignores CHAR/VARCHAR scan-mode identity so a V1 write
+   * invalidates preserve-only, standard, and unbound cache entries for that BaseRelation.
+   */
+  def recacheByV1Relation(spark: SparkSession, relation: BaseRelation): Unit = {
+    recacheByCondition(spark, cd => cd.plan.exists {
+      case logical: LogicalRelation => logical.relation == relation
+      case _ => false
+    })
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -376,16 +376,18 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   }
 
   /**
-   * Looks up a cache entry for a V2 table mutation while ignoring only its analyzed CHAR/VARCHAR
-   * scan mode. Normal cache substitution remains mode-sensitive.
+   * Looks up direct cache entries for a V2 table mutation while ignoring only their analyzed
+   * CHAR/VARCHAR scan mode. Normal cache substitution remains mode-sensitive.
    */
-  def lookupCachedDataByV2Relation(relation: DataSourceV2Relation): Option[CachedData] = {
+  def lookupCachedDataByV2Relation(relation: DataSourceV2Relation): Seq[CachedData] = {
     val unboundRelation = relation.copy(charVarcharScanMode = None)
-    cachedData.find(_.plan.exists {
-      case cached: DataSourceV2Relation =>
-        cached.copy(charVarcharScanMode = None).sameResult(unboundRelation)
-      case _ => false
-    })
+    cachedData.filter { cd =>
+      EliminateSubqueryAliases(cd.plan) match {
+        case cached: DataSourceV2Relation =>
+          cached.copy(charVarcharScanMode = None).sameResult(unboundRelation)
+        case _ => false
+      }
+    }
   }
 
   /**
@@ -462,7 +464,9 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
         case r @ ExtractV2CatalogAndIdentifier(catalog, ident) if r.timeTravelSpec.isEmpty =>
           val table = CatalogV2Util.getTable(catalog, ident, options = r.options)
           if (r.table.id == table.id) {
-            Some(DataSourceV2Relation.create(table, Some(catalog), Some(ident), r.options))
+            Some(DataSourceV2Relation
+              .create(table, Some(catalog), Some(ident), r.options)
+              .copy(charVarcharScanMode = r.charVarcharScanMode))
           } else {
             None
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -362,6 +362,20 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   }
 
   /**
+   * Re-caches every entry whose plan contains the given catalog-less [[DataSourceV2Relation]].
+   * The scan mode is ignored only for this mutation-specific match so an unbound write target
+   * invalidates preserve-native and standard cache entries without weakening normal cache identity.
+   */
+  def recacheByV2Relation(spark: SparkSession, relation: DataSourceV2Relation): Unit = {
+    val unboundRelation = relation.copy(charVarcharScanMode = None)
+    recacheByCondition(spark, cd => cd.plan.exists {
+      case cached: DataSourceV2Relation =>
+        cached.copy(charVarcharScanMode = None).sameResult(unboundRelation)
+      case _ => false
+    })
+  }
+
+  /**
    * Re-caches all cache entries that reference the given table name.
    */
   def recacheTableOrView(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -376,6 +376,19 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   }
 
   /**
+   * Looks up a cache entry for a V2 table mutation while ignoring only its analyzed CHAR/VARCHAR
+   * scan mode. Normal cache substitution remains mode-sensitive.
+   */
+  def lookupCachedDataByV2Relation(relation: DataSourceV2Relation): Option[CachedData] = {
+    val unboundRelation = relation.copy(charVarcharScanMode = None)
+    cachedData.find(_.plan.exists {
+      case cached: DataSourceV2Relation =>
+        cached.copy(charVarcharScanMode = None).sameResult(unboundRelation)
+      case _ => false
+    })
+  }
+
+  /**
    * Re-caches all cache entries that reference the given table name.
    */
   def recacheTableOrView(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -29,12 +29,11 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, SinglePartition, UnknownPartitioning}
-import org.apache.spark.sql.catalyst.util.{truncatedString, CaseInsensitiveMap}
+import org.apache.spark.sql.catalyst.util.{truncatedString, CaseInsensitiveMap, CharVarcharScanMode}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
 import org.apache.spark.sql.execution.datasources.v2.{PushedDownOperators, TableSampleInfo}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -716,9 +715,9 @@ trait FileSourceScanLike extends DataSourceScanExec with SessionStateHelper {
  * @param tableIdentifier Identifier for the table in the metastore.
  * @param disableBucketedScan Disable bucketed scan based on physical query plan, see rule
  *                            [[DisableUnnecessaryBucketedScan]] for details.
- * @param charVarcharStandardSemantics Analyzed CHAR/VARCHAR scan mode. Compared by
- *                                    sameResult so preserve-only and standard scans are
- *                                    not reused. None means unbound (native ORC types).
+ * @param charVarcharScanMode Analyzed CHAR/VARCHAR scan mode. Compared by
+ *                            sameResult so preserve-only and standard scans are
+ *                            not reused. None means unbound (native ORC types).
  */
 case class FileSourceScanExec(
     @transient override val relation: HadoopFsRelation,
@@ -732,7 +731,7 @@ case class FileSourceScanExec(
     override val tableIdentifier: Option[TableIdentifier],
     override val disableBucketedScan: Boolean = false,
     override val markedForSingleTaskExecution: Boolean = false,
-    charVarcharStandardSemantics: Option[Boolean] = None)
+    charVarcharScanMode: Option[CharVarcharScanMode] = None)
   extends FileSourceScanLike {
 
   // Note that some vals referring the file-based relation are lazy intentionally
@@ -758,11 +757,13 @@ case class FileSourceScanExec(
     val options = relation.options +
       (FileFormat.OPTION_RETURNING_BATCH -> supportsColumnar.toString)
     val hadoopConf = getHadoopConf(relation.sparkSession, relation.options)
-    val readFile: (PartitionedFile) => Iterator[InternalRow] = relation.fileFormat match {
-      case format: OrcFileFormat
-          if format.getClass == classOf[OrcFileFormat] &&
-            charVarcharStandardSemantics.isDefined =>
-        format.buildReaderWithPartitionValues(
+    val readFile: (PartitionedFile) => Iterator[InternalRow] = charVarcharScanMode match {
+      // A bound mode routes through the mode-aware overload regardless of the concrete file
+      // format. Its default implementation bridges the mode across the legacy signature via an
+      // engine-private Hadoop entry and dispatches virtually, so a format subclass (and its
+      // `super` call) observes the analyzed mode instead of defaulting to preserve-native.
+      case Some(mode) =>
+        relation.fileFormat.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,
           partitionSchema = relation.partitionSchema,
@@ -770,9 +771,9 @@ case class FileSourceScanExec(
           filters = pushedDownFilters,
           options = options,
           hadoopConf = hadoopConf,
-          charVarcharStandardSemantics = charVarcharStandardSemantics.get)
-      case format =>
-        format.buildReaderWithPartitionValues(
+          charVarcharScanMode = mode)
+      case None =>
+        relation.fileFormat.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,
           partitionSchema = relation.partitionSchema,
@@ -992,7 +993,7 @@ case class FileSourceScanExec(
       None,
       disableBucketedScan,
       markedForSingleTaskExecution,
-      charVarcharStandardSemantics)
+      charVarcharScanMode)
   }
 
   override def getStream: Option[SparkDataStream] = stream

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
 import org.apache.spark.sql.execution.datasources.v2.{PushedDownOperators, TableSampleInfo}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -752,15 +753,30 @@ case class FileSourceScanExec(
   lazy val inputRDD: RDD[InternalRow] = {
     val options = relation.options +
       (FileFormat.OPTION_RETURNING_BATCH -> supportsColumnar.toString)
-    val readFile: (PartitionedFile) => Iterator[InternalRow] =
-      relation.fileFormat.buildReaderWithPartitionValues(
-        sparkSession = relation.sparkSession,
-        dataSchema = relation.dataSchema,
-        partitionSchema = relation.partitionSchema,
-        requiredSchema = requiredSchema,
-        filters = pushedDownFilters,
-        options = options,
-        hadoopConf = getHadoopConf(relation.sparkSession, relation.options))
+    val hadoopConf = getHadoopConf(relation.sparkSession, relation.options)
+    val readFile: (PartitionedFile) => Iterator[InternalRow] = relation.fileFormat match {
+      case format: OrcFileFormat
+          if getTagValue(ApplyCharTypePadding.standardSemanticsTag).isDefined =>
+        format.buildReaderWithPartitionValues(
+          sparkSession = relation.sparkSession,
+          dataSchema = relation.dataSchema,
+          partitionSchema = relation.partitionSchema,
+          requiredSchema = requiredSchema,
+          filters = pushedDownFilters,
+          options = options,
+          hadoopConf = hadoopConf,
+          charVarcharStandardSemantics =
+            getTagValue(ApplyCharTypePadding.standardSemanticsTag).get)
+      case format =>
+        format.buildReaderWithPartitionValues(
+          sparkSession = relation.sparkSession,
+          dataSchema = relation.dataSchema,
+          partitionSchema = relation.partitionSchema,
+          requiredSchema = requiredSchema,
+          filters = pushedDownFilters,
+          options = options,
+          hadoopConf = hadoopConf)
+    }
 
     val readRDD = if (bucketedScan) {
       createBucketedReadRDD(relation.bucketSpec.get, readFile, dynamicallySelectedPartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -759,7 +759,9 @@ case class FileSourceScanExec(
       (FileFormat.OPTION_RETURNING_BATCH -> supportsColumnar.toString)
     val hadoopConf = getHadoopConf(relation.sparkSession, relation.options)
     val readFile: (PartitionedFile) => Iterator[InternalRow] = relation.fileFormat match {
-      case format: OrcFileFormat if charVarcharStandardSemantics.isDefined =>
+      case format: OrcFileFormat
+          if format.getClass == classOf[OrcFileFormat] &&
+            charVarcharStandardSemantics.isDefined =>
         format.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -716,6 +716,9 @@ trait FileSourceScanLike extends DataSourceScanExec with SessionStateHelper {
  * @param tableIdentifier Identifier for the table in the metastore.
  * @param disableBucketedScan Disable bucketed scan based on physical query plan, see rule
  *                            [[DisableUnnecessaryBucketedScan]] for details.
+ * @param charVarcharStandardSemantics Analyzed CHAR/VARCHAR scan mode. Compared by
+ *                                    sameResult so preserve-only and standard scans are
+ *                                    not reused. None means unbound (native ORC types).
  */
 case class FileSourceScanExec(
     @transient override val relation: HadoopFsRelation,
@@ -728,7 +731,8 @@ case class FileSourceScanExec(
     override val dataFilters: Seq[Expression],
     override val tableIdentifier: Option[TableIdentifier],
     override val disableBucketedScan: Boolean = false,
-    override val markedForSingleTaskExecution: Boolean = false)
+    override val markedForSingleTaskExecution: Boolean = false,
+    charVarcharStandardSemantics: Option[Boolean] = None)
   extends FileSourceScanLike {
 
   // Note that some vals referring the file-based relation are lazy intentionally
@@ -755,8 +759,7 @@ case class FileSourceScanExec(
       (FileFormat.OPTION_RETURNING_BATCH -> supportsColumnar.toString)
     val hadoopConf = getHadoopConf(relation.sparkSession, relation.options)
     val readFile: (PartitionedFile) => Iterator[InternalRow] = relation.fileFormat match {
-      case format: OrcFileFormat
-          if getTagValue(ApplyCharTypePadding.standardSemanticsTag).isDefined =>
+      case format: OrcFileFormat if charVarcharStandardSemantics.isDefined =>
         format.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,
@@ -765,8 +768,7 @@ case class FileSourceScanExec(
           filters = pushedDownFilters,
           options = options,
           hadoopConf = hadoopConf,
-          charVarcharStandardSemantics =
-            getTagValue(ApplyCharTypePadding.standardSemanticsTag).get)
+          charVarcharStandardSemantics = charVarcharStandardSemantics.get)
       case format =>
         format.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
@@ -987,7 +989,8 @@ case class FileSourceScanExec(
       QueryPlan.normalizePredicates(dataFilters, output),
       None,
       disableBucketedScan,
-      markedForSingleTaskExecution)
+      markedForSingleTaskExecution,
+      charVarcharStandardSemantics)
   }
 
   override def getStream: Option[SparkDataStream] = stream

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -757,6 +757,7 @@ case class FileSourceScanExec(
     val options = relation.options +
       (FileFormat.OPTION_RETURNING_BATCH -> supportsColumnar.toString)
     val hadoopConf = getHadoopConf(relation.sparkSession, relation.options)
+    hadoopConf.unset(FileFormat.CHAR_VARCHAR_SCAN_MODE)
     val readFile: (PartitionedFile) => Iterator[InternalRow] = charVarcharScanMode match {
       // A bound mode routes through the mode-aware overload regardless of the concrete file
       // format. Its default implementation bridges the mode across the legacy signature via an

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -1293,9 +1293,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     val unwrapped = EliminateSubqueryAliases(table)
     unwrapped match {
       // Check specific types before NamedRelation since they extend it
-      case DataSourceV2Relation(_, _, catalog, Some(ident), _, _) =>
+      case DataSourceV2Relation(_, _, catalog, Some(ident), _, _, _) =>
         (catalog.map(_.name()).toSeq ++ ident.asMultipartIdentifier).mkString(".")
-      case LogicalRelation(_, _, Some(catalogTable), _, _) =>
+      case LogicalRelation(_, _, Some(catalogTable), _, _, _) =>
         catalogTable.identifier.unquotedString
       case r: NamedRelation =>
         r.name

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.analysis.ApplyCharTypePaddingHelper
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
@@ -40,9 +39,6 @@ import org.apache.spark.sql.internal.SQLConf
  */
 object ApplyCharTypePadding extends Rule[LogicalPlan] {
 
-  private[sql] val standardSemanticsTag =
-    TreeNodeTag[Boolean]("__char_varchar_standard_semantics")
-
   private val readSidePaddingOverrideWarned = new AtomicBoolean(false)
 
   private def warnReadSidePaddingOverride(): Unit = {
@@ -57,11 +53,23 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     val standardSemantics = conf.charVarcharStandardSemantics
 
-    def bindStandardSemantics[T <: LogicalPlan](relation: T): T = {
-      if (relation.getTagValue(standardSemanticsTag).isEmpty) {
-        relation.setTagValue(standardSemanticsTag, standardSemantics)
-      }
-      relation
+    // Bind into case-class state, not a TreeNodeTag: tags are dropped by canonicalization
+    // so cache lookup and scan reuse would treat preserve-only and standard scans as the
+    // same plan. Keep an already-bound value (views, catalog-cached relations) unchanged.
+    def bindStandardSemantics(p: LogicalPlan): LogicalPlan = p match {
+      case relation: LogicalRelation if relation.charVarcharStandardSemantics.isEmpty =>
+        val bound = relation.copy(charVarcharStandardSemantics = Some(standardSemantics))
+        bound.copyTagsFrom(relation)
+        bound
+      case relation: DataSourceV2Relation if relation.charVarcharStandardSemantics.isEmpty =>
+        val bound = relation.copy(charVarcharStandardSemantics = Some(standardSemantics))
+        bound.copyTagsFrom(relation)
+        bound
+      case relation: HiveTableRelation if relation.charVarcharStandardSemantics.isEmpty =>
+        val bound = relation.copy(charVarcharStandardSemantics = Some(standardSemantics))
+        bound.copyTagsFrom(relation)
+        bound
+      case _ => p
     }
 
     val boundPlan = if (conf.charVarcharFirstClassTypes) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -17,16 +17,19 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.util.HashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.internal.LogKeys
 import org.apache.spark.sql.catalyst.analysis.ApplyCharTypePaddingHelper
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * This rule performs string padding for char type.
@@ -51,27 +54,55 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
+    val standardSemantics = conf.charVarcharStandardSemantics
+
     // standardSemantics takes precedence over legacy charVarcharAsString.
-    if (conf.charVarcharAsString && !conf.charVarcharStandardSemantics) {
+    if (conf.charVarcharAsString && !standardSemantics) {
       return plan
     }
 
-    if (conf.charVarcharStandardSemantics && !conf.readSideCharPadding) {
+    if (standardSemantics && !conf.readSideCharPadding) {
       warnReadSidePaddingOverride()
     }
 
-    if (conf.readSideCharPadding || conf.charVarcharStandardSemantics) {
+    if (conf.readSideCharPadding || standardSemantics) {
+      def cleanAttrMetadata(attr: AttributeReference): AttributeReference = {
+        CharVarcharUtils.cleanAttrMetadataForScan(attr, standardSemantics)
+      }
+
       val newPlan = plan.resolveOperatorsUpWithNewOutput {
         case r: LogicalRelation =>
-          ApplyCharTypePaddingHelper.readSidePadding(r, () =>
-            r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata)))
+          ApplyCharTypePaddingHelper.readSidePadding(r, () => {
+            val cleanedRelation = r.relation match {
+              case relation: HadoopFsRelation =>
+                relation.copy(
+                  dataSchema = CharVarcharUtils.markStandardSemanticsForScan(
+                    relation.dataSchema,
+                    standardSemantics),
+                  partitionSchema = CharVarcharUtils.markStandardSemanticsForScan(
+                    relation.partitionSchema,
+                    standardSemantics))(relation.sparkSession)
+              case other => other
+            }
+            r.copy(relation = cleanedRelation, output = r.output.map(cleanAttrMetadata))
+          })
         case r: DataSourceV2Relation =>
-          ApplyCharTypePaddingHelper.readSidePadding(r, () =>
-            r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata)))
+          ApplyCharTypePaddingHelper.readSidePadding(r, () => {
+            val options = if (standardSemantics) {
+              val boundOptions = new HashMap[String, String](r.options.asCaseSensitiveMap)
+              boundOptions.put(
+                CharVarcharUtils.CHAR_VARCHAR_STANDARD_SEMANTICS_SCAN_OPTION,
+                true.toString)
+              new CaseInsensitiveStringMap(boundOptions)
+            } else {
+              r.options
+            }
+            r.copy(output = r.output.map(cleanAttrMetadata), options = options)
+          })
         case r: HiveTableRelation =>
           ApplyCharTypePaddingHelper.readSidePadding(r, () => {
-            val cleanedDataCols = r.dataCols.map(CharVarcharUtils.cleanAttrMetadata)
-            val cleanedPartCols = r.partitionCols.map(CharVarcharUtils.cleanAttrMetadata)
+            val cleanedDataCols = r.dataCols.map(cleanAttrMetadata)
+            val cleanedPartCols = r.partitionCols.map(cleanAttrMetadata)
             r.copy(dataCols = cleanedDataCols, partitionCols = cleanedPartCols)
           })
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -17,19 +17,17 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.util.HashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.internal.LogKeys
 import org.apache.spark.sql.catalyst.analysis.ApplyCharTypePaddingHelper
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * This rule performs string padding for char type.
@@ -41,6 +39,9 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * right-pad the shorter one to the longer length.
  */
 object ApplyCharTypePadding extends Rule[LogicalPlan] {
+
+  private[sql] val standardSemanticsTag =
+    TreeNodeTag[Boolean]("__char_varchar_standard_semantics")
 
   private val readSidePaddingOverrideWarned = new AtomicBoolean(false)
 
@@ -66,44 +67,31 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
     }
 
     if (conf.readSideCharPadding || standardSemantics) {
-      def cleanAttrMetadata(attr: AttributeReference): AttributeReference = {
-        CharVarcharUtils.cleanAttrMetadataForScan(attr, standardSemantics)
+      def bindStandardSemantics[T <: LogicalPlan](relation: T): T = {
+        if (relation.getTagValue(standardSemanticsTag).isEmpty) {
+          relation.setTagValue(standardSemanticsTag, standardSemantics)
+        }
+        relation
       }
 
       val newPlan = plan.resolveOperatorsUpWithNewOutput {
         case r: LogicalRelation =>
-          ApplyCharTypePaddingHelper.readSidePadding(r, () => {
-            val cleanedRelation = r.relation match {
-              case relation: HadoopFsRelation =>
-                relation.copy(
-                  dataSchema = CharVarcharUtils.markStandardSemanticsForScan(
-                    relation.dataSchema,
-                    standardSemantics),
-                  partitionSchema = CharVarcharUtils.markStandardSemanticsForScan(
-                    relation.partitionSchema,
-                    standardSemantics))(relation.sparkSession)
-              case other => other
-            }
-            r.copy(relation = cleanedRelation, output = r.output.map(cleanAttrMetadata))
-          })
+          bindStandardSemantics(r)
+          ApplyCharTypePaddingHelper.readSidePadding(r, () =>
+            bindStandardSemantics(
+              r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata))))
         case r: DataSourceV2Relation =>
-          ApplyCharTypePaddingHelper.readSidePadding(r, () => {
-            val options = if (standardSemantics) {
-              val boundOptions = new HashMap[String, String](r.options.asCaseSensitiveMap)
-              boundOptions.put(
-                CharVarcharUtils.CHAR_VARCHAR_STANDARD_SEMANTICS_SCAN_OPTION,
-                true.toString)
-              new CaseInsensitiveStringMap(boundOptions)
-            } else {
-              r.options
-            }
-            r.copy(output = r.output.map(cleanAttrMetadata), options = options)
-          })
+          bindStandardSemantics(r)
+          ApplyCharTypePaddingHelper.readSidePadding(r, () =>
+            bindStandardSemantics(
+              r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata))))
         case r: HiveTableRelation =>
+          bindStandardSemantics(r)
           ApplyCharTypePaddingHelper.readSidePadding(r, () => {
-            val cleanedDataCols = r.dataCols.map(cleanAttrMetadata)
-            val cleanedPartCols = r.partitionCols.map(cleanAttrMetadata)
-            r.copy(dataCols = cleanedDataCols, partitionCols = cleanedPartCols)
+            val cleanedDataCols = r.dataCols.map(CharVarcharUtils.cleanAttrMetadata)
+            val cleanedPartCols = r.partitionCols.map(CharVarcharUtils.cleanAttrMetadata)
+            bindStandardSemantics(
+              r.copy(dataCols = cleanedDataCols, partitionCols = cleanedPartCols))
           })
       }
       ApplyCharTypePaddingHelper.paddingForStringComparison(newPlan, padCharCol = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -57,9 +57,26 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     val standardSemantics = conf.charVarcharStandardSemantics
 
+    def bindStandardSemantics[T <: LogicalPlan](relation: T): T = {
+      if (relation.getTagValue(standardSemanticsTag).isEmpty) {
+        relation.setTagValue(standardSemanticsTag, standardSemantics)
+      }
+      relation
+    }
+
+    val boundPlan = if (conf.charVarcharFirstClassTypes) {
+      plan.resolveOperatorsUp {
+        case relation: LogicalRelation => bindStandardSemantics(relation)
+        case relation: DataSourceV2Relation => bindStandardSemantics(relation)
+        case relation: HiveTableRelation => bindStandardSemantics(relation)
+      }
+    } else {
+      plan
+    }
+
     // standardSemantics takes precedence over legacy charVarcharAsString.
     if (conf.charVarcharAsString && !standardSemantics) {
-      return plan
+      return boundPlan
     }
 
     if (standardSemantics && !conf.readSideCharPadding) {
@@ -67,14 +84,7 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
     }
 
     if (conf.readSideCharPadding || standardSemantics) {
-      def bindStandardSemantics[T <: LogicalPlan](relation: T): T = {
-        if (relation.getTagValue(standardSemanticsTag).isEmpty) {
-          relation.setTagValue(standardSemanticsTag, standardSemantics)
-        }
-        relation
-      }
-
-      val newPlan = plan.resolveOperatorsUpWithNewOutput {
+      val newPlan = boundPlan.resolveOperatorsUpWithNewOutput {
         case r: LogicalRelation =>
           bindStandardSemantics(r)
           ApplyCharTypePaddingHelper.readSidePadding(r, () =>
@@ -97,7 +107,7 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
       ApplyCharTypePaddingHelper.paddingForStringComparison(newPlan, padCharCol = false)
     } else {
       ApplyCharTypePaddingHelper.paddingForStringComparison(
-        plan, padCharCol = !conf.getConf(SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE))
+        boundPlan, padCharCol = !conf.getConf(SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE))
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.ApplyCharTypePaddingHelper
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.catalyst.util.{CharVarcharScanMode, CharVarcharUtils}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
 
@@ -52,21 +52,24 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     val standardSemantics = conf.charVarcharStandardSemantics
+    val scanMode = CharVarcharScanMode(standardSemantics)
 
-    // Bind into case-class state, not a TreeNodeTag: tags are dropped by canonicalization
-    // so cache lookup and scan reuse would treat preserve-only and standard scans as the
-    // same plan. Keep an already-bound value (views, catalog-cached relations) unchanged.
+    // Bind into case-class state, not a TreeNodeTag: `TreeNode.makeCopy` calls `copyTagsFrom`,
+    // so a tag survives canonicalization, but it does not participate in structural plan
+    // equality / sameResult, so cache lookup and scan reuse would treat preserve-only and
+    // standard scans as the same plan. A case-class field does participate. Keep an
+    // already-bound value (views, catalog-cached relations) unchanged.
     def bindStandardSemantics(p: LogicalPlan): LogicalPlan = p match {
-      case relation: LogicalRelation if relation.charVarcharStandardSemantics.isEmpty =>
-        val bound = relation.copy(charVarcharStandardSemantics = Some(standardSemantics))
+      case relation: LogicalRelation if relation.charVarcharScanMode.isEmpty =>
+        val bound = relation.copy(charVarcharScanMode = Some(scanMode))
         bound.copyTagsFrom(relation)
         bound
-      case relation: DataSourceV2Relation if relation.charVarcharStandardSemantics.isEmpty =>
-        val bound = relation.copy(charVarcharStandardSemantics = Some(standardSemantics))
+      case relation: DataSourceV2Relation if relation.charVarcharScanMode.isEmpty =>
+        val bound = relation.copy(charVarcharScanMode = Some(scanMode))
         bound.copyTagsFrom(relation)
         bound
-      case relation: HiveTableRelation if relation.charVarcharStandardSemantics.isEmpty =>
-        val bound = relation.copy(charVarcharStandardSemantics = Some(standardSemantics))
+      case relation: HiveTableRelation if relation.charVarcharScanMode.isEmpty =>
+        val bound = relation.copy(charVarcharScanMode = Some(scanMode))
         bound.copyTagsFrom(relation)
         bound
       case _ => p

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -96,17 +96,14 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
     if (conf.readSideCharPadding || standardSemantics) {
       val newPlan = boundPlan.resolveOperatorsUpWithNewOutput {
         case r: LogicalRelation =>
-          bindStandardSemantics(r)
           ApplyCharTypePaddingHelper.readSidePadding(r, () =>
             bindStandardSemantics(
               r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata))))
         case r: DataSourceV2Relation =>
-          bindStandardSemantics(r)
           ApplyCharTypePaddingHelper.readSidePadding(r, () =>
             bindStandardSemantics(
               r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata))))
         case r: HiveTableRelation =>
-          bindStandardSemantics(r)
           ApplyCharTypePaddingHelper.readSidePadding(r, () => {
             val cleanedDataCols = r.dataCols.map(CharVarcharUtils.cleanAttrMetadata)
             val cleanedPartCols = r.partitionCols.map(CharVarcharUtils.cleanAttrMetadata)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -54,11 +54,10 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
     val standardSemantics = conf.charVarcharStandardSemantics
     val scanMode = CharVarcharScanMode(standardSemantics)
 
-    // Bind into case-class state, not a TreeNodeTag: `TreeNode.makeCopy` calls `copyTagsFrom`,
-    // so a tag survives canonicalization, but it does not participate in structural plan
-    // equality / sameResult, so cache lookup and scan reuse would treat preserve-only and
-    // standard scans as the same plan. A case-class field does participate. Keep an
-    // already-bound value (views, catalog-cached relations) unchanged.
+    // Bind into case-class state, not a TreeNodeTag: tags do not participate in structural plan
+    // equality / sameResult, so cache lookup and scan reuse would treat preserve-only and standard
+    // scans as the same plan. A case-class field does participate. Keep an already-bound value
+    // (views, catalog-cached relations) unchanged.
     def bindStandardSemantics(p: LogicalPlan): LogicalPlan = p match {
       case relation: LogicalRelation if relation.charVarcharScanMode.isEmpty =>
         val bound = relation.copy(charVarcharScanMode = Some(scanMode))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -282,7 +282,7 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
       // 2. Return a new LogicalRelation with the updated HadoopFsRelation
       // This ensures the relation reflects any changes in data source options.
       // Otherwise, leave the cached table relation as is
-      case r @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _, _)
+      case r @ LogicalRelation(fsRelation: HadoopFsRelation, _, _, _, _, _)
         if !readFileSourceTableCacheIgnoreOptions &&
           (new CaseInsensitiveStringMap(fsRelation.options.asJava) !=
           new CaseInsensitiveStringMap(dsOptions.asJava)) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.catalyst.util.CharVarcharScanMode
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.{SessionStateHelper, SQLConf}
 import org.apache.spark.sql.sources.Filter
@@ -166,6 +167,34 @@ trait FileFormat {
   }
 
   /**
+   * Same as [[buildReaderWithPartitionValues]] but also carries the analyzed CHAR/VARCHAR scan
+   * mode. [[FileSourceScanExec]] calls this overload whenever the relation has a bound mode,
+   * regardless of the concrete file format.
+   *
+   * The default implementation bridges the mode across the legacy seven-argument signature: it
+   * clones the per-call Hadoop configuration, writes an engine-private entry with the explicit
+   * mode, then invokes the seven-argument method virtually. A format that honors first-class
+   * CHAR/VARCHAR types (e.g. [[org.apache.spark.sql.execution.datasources.orc.OrcFileFormat]])
+   * reads that entry in its seven-argument override, so existing subclasses keep their override
+   * and a call to `super` retains the bound mode. The Hadoop entry is only a transport across the
+   * legacy signature; the authoritative state remains the typed plan field and this parameter.
+   */
+  def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration,
+      charVarcharScanMode: CharVarcharScanMode): PartitionedFile => Iterator[InternalRow] = {
+    val taggedConf = new Configuration(hadoopConf)
+    FileFormat.setCharVarcharScanMode(taggedConf, charVarcharScanMode)
+    buildReaderWithPartitionValues(
+      sparkSession, dataSchema, partitionSchema, requiredSchema, filters, options, taggedConf)
+  }
+
+  /**
    * Create a file metadata struct column containing fields supported by the given file format.
    */
   def createFileMetadataCol(): AttributeReference = {
@@ -265,6 +294,25 @@ object FileFormat {
    * by calling supportBatch.
    */
   val OPTION_RETURNING_BATCH = "returning_batch"
+
+  /**
+   * Engine-private Hadoop configuration entry that transports the analyzed CHAR/VARCHAR scan mode
+   * across the legacy [[FileFormat.buildReaderWithPartitionValues]] signature. It is written by the
+   * mode-aware overload and read by formats that honor first-class CHAR/VARCHAR types. This is not
+   * a public option; the authoritative state is the typed plan field and overload parameter.
+   */
+  val CHAR_VARCHAR_SCAN_MODE = "__spark_sql_char_varchar_scan_mode"
+
+  /** Writes the CHAR/VARCHAR scan mode into `conf` under [[CHAR_VARCHAR_SCAN_MODE]]. */
+  private[sql] def setCharVarcharScanMode(
+      conf: Configuration, mode: CharVarcharScanMode): Unit = {
+    conf.set(CHAR_VARCHAR_SCAN_MODE, mode.toString)
+  }
+
+  /** Reads the CHAR/VARCHAR scan mode from `conf`, or `None` if no mode was bridged in. */
+  private[sql] def charVarcharScanMode(conf: Configuration): Option[CharVarcharScanMode] = {
+    Option(conf.get(CHAR_VARCHAR_SCAN_MODE)).map(CharVarcharScanMode.fromName)
+  }
 
   /**
    * Schema of metadata struct that can be produced by every file format,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -179,7 +179,7 @@ trait FileFormat {
    * and a call to `super` retains the bound mode. The Hadoop entry is only a transport across the
    * legacy signature; the authoritative state remains the typed plan field and this parameter.
    */
-  def buildReaderWithPartitionValues(
+  private[sql] def buildReaderWithPartitionValues(
       sparkSession: SparkSession,
       dataSchema: StructType,
       partitionSchema: StructType,
@@ -301,7 +301,7 @@ object FileFormat {
    * mode-aware overload and read by formats that honor first-class CHAR/VARCHAR types. This is not
    * a public option; the authoritative state is the typed plan field and overload parameter.
    */
-  val CHAR_VARCHAR_SCAN_MODE = "__spark_sql_char_varchar_scan_mode"
+  private[sql] val CHAR_VARCHAR_SCAN_MODE = "__spark_sql_char_varchar_scan_mode"
 
   /** Writes the CHAR/VARCHAR scan mode into `conf` under [[CHAR_VARCHAR_SCAN_MODE]]. */
   private[sql] def setCharVarcharScanMode(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -340,6 +340,9 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           table.map(_.identifier),
           markedForSingleTaskExecution =
             l.getTagValue(MarkSingleTaskExecution.markTag).getOrElse(false))
+      l.getTagValue(ApplyCharTypePadding.standardSemanticsTag).foreach {
+        enabled => scan.setTagValue(ApplyCharTypePadding.standardSemanticsTag, enabled)
+      }
 
       // extra Project node: wrap flat metadata columns to a metadata struct
       val withMetadataProjections = metadataStructOpt.map { metadataStruct =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -339,10 +339,8 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           rebindFileSourceMetadataAttributesInFilters(expandedDataFilters),
           table.map(_.identifier),
           markedForSingleTaskExecution =
-            l.getTagValue(MarkSingleTaskExecution.markTag).getOrElse(false))
-      l.getTagValue(ApplyCharTypePadding.standardSemanticsTag).foreach {
-        enabled => scan.setTagValue(ApplyCharTypePadding.standardSemanticsTag, enabled)
-      }
+            l.getTagValue(MarkSingleTaskExecution.markTag).getOrElse(false),
+          charVarcharStandardSemantics = l.charVarcharStandardSemantics)
 
       // extra Project node: wrap flat metadata columns to a metadata struct
       val withMetadataProjections = metadataStructOpt.map { metadataStruct =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -340,7 +340,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           table.map(_.identifier),
           markedForSingleTaskExecution =
             l.getTagValue(MarkSingleTaskExecution.markTag).getOrElse(false),
-          charVarcharStandardSemantics = l.charVarcharStandardSemantics)
+          charVarcharScanMode = l.charVarcharScanMode)
 
       // extra Project node: wrap flat metadata columns to a metadata struct
       val withMetadataProjections = metadataStructOpt.map { metadataStruct =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommand.scala
@@ -45,7 +45,8 @@ case class InsertIntoDataSourceCommand(
 
     // Re-cache all cached plans(including this relation itself, if it's cached) that refer to this
     // data source relation.
-    sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, logicalRelation)
+    sparkSession.sharedState.cacheManager.recacheByV1Relation(
+      sparkSession, logicalRelation.relation)
 
     Seq.empty[Row]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReferen
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{ExposesMetadataColumns, LeafNode, LogicalPlan, Statistics, StreamSourceAwareLogicalPlan}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils}
+import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharScanMode, CharVarcharUtils}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.sources.BaseRelation
 
@@ -44,7 +44,7 @@ case class LogicalRelation(
     @transient stream: Option[SparkDataStream],
     // Bound at analysis so sameResult / cache reuse distinguish preserve-only vs standard
     // CHAR/VARCHAR scans. None means the relation was not analyzed under first-class types.
-    charVarcharStandardSemantics: Option[Boolean])
+    charVarcharScanMode: Option[CharVarcharScanMode])
   extends LeafNode
   with StreamSourceAwareLogicalPlan
   with MultiInstanceRelation

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -41,7 +41,10 @@ case class LogicalRelation(
     output: Seq[AttributeReference],
     catalogTable: Option[CatalogTable],
     override val isStreaming: Boolean,
-    @transient stream: Option[SparkDataStream])
+    @transient stream: Option[SparkDataStream],
+    // Bound at analysis so sameResult / cache reuse distinguish preserve-only vs standard
+    // CHAR/VARCHAR scans. None means the relation was not analyzed under first-class types.
+    charVarcharStandardSemantics: Option[Boolean])
   extends LeafNode
   with StreamSourceAwareLogicalPlan
   with MultiInstanceRelation
@@ -116,14 +119,14 @@ object LogicalRelation {
     // The v1 source may return schema containing char/varchar type. We replace char/varchar
     // with "annotated" string type here as the query engine doesn't support char/varchar yet.
     val schema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(relation.schema)
-    LogicalRelation(relation, toAttributes(schema), None, isStreaming, None)
+    LogicalRelation(relation, toAttributes(schema), None, isStreaming, None, None)
   }
 
   def apply(relation: BaseRelation, table: CatalogTable): LogicalRelation = {
     // The v1 source may return schema containing char/varchar type. We replace char/varchar
     // with "annotated" string type here as the query engine doesn't support char/varchar yet.
     val schema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(relation.schema)
-    LogicalRelation(relation, toAttributes(schema), Some(table), false, None)
+    LogicalRelation(relation, toAttributes(schema), Some(table), false, None, None)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -23,7 +23,6 @@ import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{CTEInChildren, CTERelationDef, LogicalPlan, WithCTE}
-import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -70,9 +69,7 @@ case class SaveIntoDataSourceCommand(
     }
 
     try {
-      val logicalRelation = LogicalRelation(relation, toAttributes(relation.schema), None,
-        false, None, None)
-      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, logicalRelation)
+      sparkSession.sharedState.cacheManager.recacheByV1Relation(sparkSession, relation)
     } catch {
       case NonFatal(_) =>
         // some data source can not support return a valid relation, e.g. `KafkaSourceProvider`

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -71,7 +71,7 @@ case class SaveIntoDataSourceCommand(
 
     try {
       val logicalRelation = LogicalRelation(relation, toAttributes(relation.schema), None,
-        false, None)
+        false, None, None)
       sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, logicalRelation)
     } catch {
       case NonFatal(_) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -136,7 +136,7 @@ class OrcDeserializer(
       case DoubleType => (ordinal, value) =>
         updater.setDouble(ordinal, value.asInstanceOf[DoubleWritable].get)
 
-      case StringType => (ordinal, value) =>
+      case _: StringType => (ordinal, value) =>
         updater.set(ordinal, UTF8String.fromBytes(value.asInstanceOf[Text].copyBytes))
 
       case BinaryType => (ordinal, value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.{FileSourceOptions, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.catalyst.util.CharVarcharScanMode
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SessionStateHelper
 import org.apache.spark.sql.internal.SQLConf
@@ -146,6 +147,12 @@ class OrcFileFormat
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+    // The analyzed CHAR/VARCHAR scan mode, if any, is bridged in via an engine-private Hadoop
+    // entry by FileFormat's mode-aware overload. Reading it here (rather than taking it as a
+    // parameter) keeps this public override's signature stable, so a subclass that delegates to
+    // `super` retains the bound mode. Absent an entry, keep native constrained ORC types.
+    val charVarcharStandardSemantics =
+      FileFormat.charVarcharScanMode(hadoopConf).contains(CharVarcharScanMode.SparkStandard)
     buildReaderWithPartitionValues(
       sparkSession,
       dataSchema,
@@ -154,7 +161,7 @@ class OrcFileFormat
       filters,
       options,
       hadoopConf,
-      charVarcharStandardSemantics = false)
+      charVarcharStandardSemantics = charVarcharStandardSemantics)
   }
 
   private[sql] def buildReaderWithPartitionValues(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -154,7 +154,7 @@ class OrcFileFormat
       filters,
       options,
       hadoopConf,
-      getSqlConf(sparkSession).charVarcharStandardSemantics)
+      charVarcharStandardSemantics = false)
   }
 
   private[sql] def buildReaderWithPartitionValues(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -146,7 +146,26 @@ class OrcFileFormat
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+    buildReaderWithPartitionValues(
+      sparkSession,
+      dataSchema,
+      partitionSchema,
+      requiredSchema,
+      filters,
+      options,
+      hadoopConf,
+      getSqlConf(sparkSession).charVarcharStandardSemantics)
+  }
 
+  private[sql] def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration,
+      charVarcharStandardSemantics: Boolean): (PartitionedFile) => Iterator[InternalRow] = {
     val resultSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
     val sqlConf = getSqlConf(sparkSession)
     val capacity = sqlConf.orcVectorizedReaderBatchSize
@@ -205,7 +224,7 @@ class OrcFileFormat
 
         val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
         val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
-          dataSchema, resultSchema, partitionSchema, conf)
+          dataSchema, resultSchema, partitionSchema, conf, charVarcharStandardSemantics)
         assert(requestedColIds.length == requiredSchema.length,
           "[BUG] requested column IDs do not match required schema")
         val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -541,6 +541,9 @@ object OrcUtils extends Logging {
    * @param resultSchema Result data schema created after pruning cols.
    * @param partitionSchema Schema of partitions.
    * @param conf Hadoop Configuration.
+   * @param charVarcharStandardSemantics When true, request physical ORC STRING so Spark can
+   *                                 apply CHAR/VARCHAR length checks. When false, keep native
+   *                                 constrained ORC CHAR/VARCHAR types.
    * @return Returns the result schema as string.
    */
   def orcResultSchemaString(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -437,9 +437,11 @@ object OrcUtils extends Logging {
       s"array<${getOrcSchemaString(a.elementType)}>"
     case m: MapType =>
       s"map<${getOrcSchemaString(m.keyType)},${getOrcSchemaString(m.valueType)}>"
-    // Keep Spark responsible for CHAR/VARCHAR assignment and scan checks. Native ORC
-    // CHAR/VARCHAR would truncate or pad before Spark can validate the original value.
-    case _: CharType | _: VarcharType => StringType.catalogString
+    // Under standard semantics, keep Spark responsible for CHAR/VARCHAR assignment and scan
+    // checks. Native ORC would truncate or pad before Spark can validate the original value.
+    // Preserve-only mode retains the native constrained schema and its legacy enforcement.
+    case _: CharType | _: VarcharType if SQLConf.get.charVarcharStandardSemantics =>
+      StringType.catalogString
     case _: DayTimeIntervalType | _: TimestampNTZType => LongType.catalogString
     case _: YearMonthIntervalType => IntegerType.catalogString
     // Framework types (TimeType, nanosecond timestamps) supply their own ORC schema string.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -548,10 +548,8 @@ object OrcUtils extends Logging {
       dataSchema: StructType,
       resultSchema: StructType,
       partitionSchema: StructType,
-      conf: Configuration): String = {
-    val charVarcharStandardSemantics =
-      (dataSchema ++ resultSchema ++ partitionSchema)
-        .exists(field => CharVarcharUtils.hasStandardSemantics(field.metadata))
+      conf: Configuration,
+      charVarcharStandardSemantics: Boolean): String = {
     val resultSchemaString = if (canPruneCols) {
       OrcUtils.getOrcSchemaString(resultSchema, charVarcharStandardSemantics)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -437,6 +437,9 @@ object OrcUtils extends Logging {
       s"array<${getOrcSchemaString(a.elementType)}>"
     case m: MapType =>
       s"map<${getOrcSchemaString(m.keyType)},${getOrcSchemaString(m.valueType)}>"
+    // Keep Spark responsible for CHAR/VARCHAR assignment and scan checks. Native ORC
+    // CHAR/VARCHAR would truncate or pad before Spark can validate the original value.
+    case _: CharType | _: VarcharType => StringType.catalogString
     case _: DayTimeIntervalType | _: TimestampNTZType => LongType.catalogString
     case _: YearMonthIntervalType => IntegerType.catalogString
     // Framework types (TimeType, nanosecond timestamps) supply their own ORC schema string.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -427,20 +427,28 @@ object OrcUtils extends Logging {
    * Given a `StructType` object, this methods converts it to corresponding string representation
    * in ORC.
    */
-  def getOrcSchemaString(dt: DataType): String = dt match {
+  def getOrcSchemaString(dt: DataType): String = {
+    getOrcSchemaString(dt, SQLConf.get.charVarcharStandardSemantics)
+  }
+
+  private def getOrcSchemaString(
+      dt: DataType,
+      charVarcharStandardSemantics: Boolean): String = dt match {
     case s: StructType =>
       val fieldTypes = s.fields.map { f =>
-        s"${quoteIdentifier(f.name)}:${getOrcSchemaString(f.dataType)}"
+        s"${quoteIdentifier(f.name)}:" +
+          s"${getOrcSchemaString(f.dataType, charVarcharStandardSemantics)}"
       }
       s"struct<${fieldTypes.mkString(",")}>"
     case a: ArrayType =>
-      s"array<${getOrcSchemaString(a.elementType)}>"
+      s"array<${getOrcSchemaString(a.elementType, charVarcharStandardSemantics)}>"
     case m: MapType =>
-      s"map<${getOrcSchemaString(m.keyType)},${getOrcSchemaString(m.valueType)}>"
+      s"map<${getOrcSchemaString(m.keyType, charVarcharStandardSemantics)}," +
+        s"${getOrcSchemaString(m.valueType, charVarcharStandardSemantics)}>"
     // Under standard semantics, keep Spark responsible for CHAR/VARCHAR assignment and scan
     // checks. Native ORC would truncate or pad before Spark can validate the original value.
     // Preserve-only mode retains the native constrained schema and its legacy enforcement.
-    case _: CharType | _: VarcharType if SQLConf.get.charVarcharStandardSemantics =>
+    case _: CharType | _: VarcharType if charVarcharStandardSemantics =>
       StringType.catalogString
     case _: DayTimeIntervalType | _: TimestampNTZType => LongType.catalogString
     case _: YearMonthIntervalType => IntegerType.catalogString
@@ -541,10 +549,15 @@ object OrcUtils extends Logging {
       resultSchema: StructType,
       partitionSchema: StructType,
       conf: Configuration): String = {
+    val charVarcharStandardSemantics =
+      (dataSchema ++ resultSchema ++ partitionSchema)
+        .exists(field => CharVarcharUtils.hasStandardSemantics(field.metadata))
     val resultSchemaString = if (canPruneCols) {
-      OrcUtils.getOrcSchemaString(resultSchema)
+      OrcUtils.getOrcSchemaString(resultSchema, charVarcharStandardSemantics)
     } else {
-      OrcUtils.getOrcSchemaString(StructType(dataSchema.fields ++ partitionSchema.fields))
+      OrcUtils.getOrcSchemaString(
+        StructType(dataSchema.fields ++ partitionSchema.fields),
+        charVarcharStandardSemantics)
     }
     OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
     resultSchemaString

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -73,7 +73,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       val nameParts = ident.toQualifiedNameParts(catalog)
       cacheManager.recacheTableOrView(session, nameParts, includeTimeTravel = false)
     case _ =>
-      cacheManager.recacheByPlan(session, r)
+      cacheManager.recacheByV2Relation(session, r)
   }
 
   private def recacheTable(r: ResolvedTable, includeTimeTravel: Boolean)(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -82,13 +82,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
   }
 
   // Invalidates the cache associated with the given table. If the invalidated cache matches the
-  // given table, the cache's storage level is returned.
+  // given table, each cache's storage level and scan mode are returned.
   private def invalidateTableCache(
-      r: ResolvedTable)(): Option[(StorageLevel, Option[CharVarcharScanMode])] = {
+      r: ResolvedTable)(): Seq[(StorageLevel, Option[CharVarcharScanMode])] = {
     val v2Relation = DataSourceV2Relation.create(r.table, Some(r.catalog), Some(r.identifier))
-    val cache = cacheManager.lookupCachedDataByV2Relation(v2Relation)
+    val caches = cacheManager.lookupCachedDataByV2Relation(v2Relation)
     invalidateCache(r.catalog, r.identifier)
-    cache.map { entry =>
+    caches.map { entry =>
       val scanMode = entry.plan.collectFirst {
         case relation: DataSourceV2Relation => relation.charVarcharScanMode
       }.flatten

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.optimizer.UnwrapCastInBinaryComparison
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.TreePattern.SCALAR_SUBQUERY
-import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, toPrettySQL, GeneratedColumn, IdentityColumn, ResolveDefaultColumns, ResolveTableConstraints, V2ExpressionBuilder}
+import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, toPrettySQL, CharVarcharScanMode, GeneratedColumn, IdentityColumn, ResolveDefaultColumns, ResolveTableConstraints, V2ExpressionBuilder}
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, DependencyList, Identifier, StagingTableCatalog, SupportsDeleteV2, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, TableCapability, TableCatalog, TableSummary, TruncatableTable, V1Table, V1View, ViewCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange
@@ -83,15 +83,16 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
 
   // Invalidates the cache associated with the given table. If the invalidated cache matches the
   // given table, the cache's storage level is returned.
-  private def invalidateTableCache(r: ResolvedTable)(): Option[StorageLevel] = {
+  private def invalidateTableCache(
+      r: ResolvedTable)(): Option[(StorageLevel, Option[CharVarcharScanMode])] = {
     val v2Relation = DataSourceV2Relation.create(r.table, Some(r.catalog), Some(r.identifier))
-    val cache = cacheManager.lookupCachedData(session, v2Relation)
+    val cache = cacheManager.lookupCachedDataByV2Relation(v2Relation)
     invalidateCache(r.catalog, r.identifier)
-    if (cache.isDefined) {
-      val cacheLevel = cache.get.cachedRepresentation.cacheBuilder.storageLevel
-      Some(cacheLevel)
-    } else {
-      None
+    cache.map { entry =>
+      val scanMode = entry.plan.collectFirst {
+        case relation: DataSourceV2Relation => relation.charVarcharScanMode
+      }.flatten
+      (entry.cachedRepresentation.cacheBuilder.storageLevel, scanMode)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
@@ -27,6 +27,10 @@ import org.apache.spark.sql.internal.connector.SupportsPushDownCatalystFilters
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
+private[sql] trait SupportsCharVarcharStandardSemantics {
+  def bindCharVarcharStandardSemantics(enabled: Boolean): Unit
+}
+
 abstract class FileScanBuilder(
     sparkSession: SparkSession,
     fileIndex: PartitioningAwareFileIndex,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.CharVarcharScanMode
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.IdentifierHelper
@@ -32,7 +33,7 @@ case class RenameTableExec(
     catalog: TableCatalog,
     oldIdent: Identifier,
     newIdent: Identifier,
-    invalidateCache: () => Option[StorageLevel],
+    invalidateCache: () => Option[(StorageLevel, Option[CharVarcharScanMode])],
     cacheTable: (SparkSession, LogicalPlan, Option[String], StorageLevel) => Unit)
   extends LeafV2CommandExec {
 
@@ -49,9 +50,11 @@ case class RenameTableExec(
     } else newIdent
     catalog.renameTable(oldIdent, qualifiedNewIdent)
 
-    optOldStorageLevel.foreach { oldStorageLevel =>
+    optOldStorageLevel.foreach { case (oldStorageLevel, scanMode) =>
       val tbl = catalog.loadTable(qualifiedNewIdent)
-      val newRelation = DataSourceV2Relation.create(tbl, Some(catalog), Some(qualifiedNewIdent))
+      val newRelation = DataSourceV2Relation
+        .create(tbl, Some(catalog), Some(qualifiedNewIdent))
+        .copy(charVarcharScanMode = scanMode)
       cacheTable(
         session,
         newRelation,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala
@@ -33,14 +33,14 @@ case class RenameTableExec(
     catalog: TableCatalog,
     oldIdent: Identifier,
     newIdent: Identifier,
-    invalidateCache: () => Option[(StorageLevel, Option[CharVarcharScanMode])],
+    invalidateCache: () => Seq[(StorageLevel, Option[CharVarcharScanMode])],
     cacheTable: (SparkSession, LogicalPlan, Option[String], StorageLevel) => Unit)
   extends LeafV2CommandExec {
 
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
-    val optOldStorageLevel = invalidateCache()
+    val oldCaches = invalidateCache()
     catalog.invalidateTable(oldIdent)
 
     // If new identifier consists of a table name only, the table should be renamed in place.
@@ -50,7 +50,7 @@ case class RenameTableExec(
     } else newIdent
     catalog.renameTable(oldIdent, qualifiedNewIdent)
 
-    optOldStorageLevel.foreach { case (oldStorageLevel, scanMode) =>
+    oldCaches.foreach { case (oldStorageLevel, scanMode) =>
       val tbl = catalog.loadTable(qualifiedNewIdent)
       val newRelation = DataSourceV2Relation
         .create(tbl, Some(catalog), Some(qualifiedNewIdent))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.planning.{PhysicalOperation, ScanOperation}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LeafNode, Limit, LimitAndOffset, LocalLimit, LogicalPlan, Offset, OffsetAndLimit, Project, Sample, SampleMethod, Sort}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.catalyst.util.CharVarcharScanMode
 import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
@@ -99,9 +100,9 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
   private def createScanBuilder(plan: LogicalPlan) = plan.transform {
     case r: DataSourceV2Relation =>
       val builder = r.table.asReadable.newScanBuilder(r.options)
-      (r.charVarcharStandardSemantics, builder) match {
-        case (Some(enabled), supports: SupportsCharVarcharStandardSemantics) =>
-          supports.bindCharVarcharStandardSemantics(enabled)
+      (r.charVarcharScanMode, builder) match {
+        case (Some(mode), supports: SupportsCharVarcharStandardSemantics) =>
+          supports.bindCharVarcharStandardSemantics(mode == CharVarcharScanMode.SparkStandard)
         case _ =>
       }
       ScanBuilderHolder(r.output, r, builder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, Statistics => V2Statistics, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, SupportsReportStatistics, V1Scan, VariantExtraction}
-import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, VariantInRelation, VariantMetadata}
+import org.apache.spark.sql.execution.datasources.{ApplyCharTypePadding, DataSourceStrategy, VariantInRelation, VariantMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.VariantExtractionImpl
 import org.apache.spark.sql.sources
@@ -98,7 +98,13 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
 
   private def createScanBuilder(plan: LogicalPlan) = plan.transform {
     case r: DataSourceV2Relation =>
-      ScanBuilderHolder(r.output, r, r.table.asReadable.newScanBuilder(r.options))
+      val builder = r.table.asReadable.newScanBuilder(r.options)
+      (r.getTagValue(ApplyCharTypePadding.standardSemanticsTag), builder) match {
+        case (Some(enabled), supports: SupportsCharVarcharStandardSemantics) =>
+          supports.bindCharVarcharStandardSemantics(enabled)
+        case _ =>
+      }
+      ScanBuilderHolder(r.output, r, builder)
   }
 
   private def pushDownFilters(plan: LogicalPlan) = plan.transform {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, Statistics => V2Statistics, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, SupportsReportStatistics, V1Scan, VariantExtraction}
-import org.apache.spark.sql.execution.datasources.{ApplyCharTypePadding, DataSourceStrategy, VariantInRelation, VariantMetadata}
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, VariantInRelation, VariantMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.VariantExtractionImpl
 import org.apache.spark.sql.sources
@@ -99,7 +99,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
   private def createScanBuilder(plan: LogicalPlan) = plan.transform {
     case r: DataSourceV2Relation =>
       val builder = r.table.asReadable.newScanBuilder(r.options)
-      (r.getTagValue(ApplyCharTypePadding.standardSemanticsTag), builder) match {
+      (r.charVarcharStandardSemantics, builder) match {
         case (Some(enabled), supports: SupportsCharVarcharStandardSemantics) =>
           supports.bindCharVarcharStandardSemantics(enabled)
         case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -49,6 +49,7 @@ import org.apache.spark.util.ArrayImplicits._
  * @param readDataSchema Required data schema in the batch scan.
  * @param partitionSchema Schema of partitions.
  * @param options Options for parsing ORC files.
+ * @param charVarcharStandardSemantics CHAR/VARCHAR semantics bound during analysis.
  */
 case class OrcPartitionReaderFactory(
     sqlConf: SQLConf,
@@ -59,7 +60,8 @@ case class OrcPartitionReaderFactory(
     filters: Array[Filter],
     aggregation: Option[Aggregation],
     options: OrcOptions,
-    memoryMode: MemoryMode) extends FilePartitionReaderFactory {
+    memoryMode: MemoryMode,
+    charVarcharStandardSemantics: Boolean = false) extends FilePartitionReaderFactory {
   private val resultSchema = StructType(readDataSchema.fields ++ partitionSchema.fields)
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val capacity = sqlConf.orcVectorizedReaderBatchSize
@@ -97,7 +99,13 @@ case class OrcPartitionReaderFactory(
       new EmptyPartitionReader[InternalRow]
     } else {
       val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      OrcUtils.orcResultSchemaString(canPruneCols, dataSchema, resultSchema, partitionSchema, conf)
+      OrcUtils.orcResultSchemaString(
+        canPruneCols,
+        dataSchema,
+        resultSchema,
+        partitionSchema,
+        conf,
+        charVarcharStandardSemantics)
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -138,7 +146,7 @@ case class OrcPartitionReaderFactory(
     } else {
       val (requestedDataColIds, canPruneCols) = resultedColPruneInfo.get
       val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
-        dataSchema, resultSchema, partitionSchema, conf)
+        dataSchema, resultSchema, partitionSchema, conf, charVarcharStandardSemantics)
       val requestedColIds = requestedDataColIds ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
@@ -46,7 +46,8 @@ case class OrcScan(
     pushedAggregate: Option[Aggregation] = None,
     pushedFilters: Array[Filter],
     partitionFilters: Seq[Expression] = Seq.empty,
-    dataFilters: Seq[Expression] = Seq.empty) extends FileScan {
+    dataFilters: Seq[Expression] = Seq.empty,
+    charVarcharStandardSemantics: Boolean = false) extends FileScan {
   override def isSplitable(path: Path): Boolean = {
     // If aggregate is pushed down, only the file footer will be read once,
     // so file should not be split across multiple tasks.
@@ -75,7 +76,7 @@ case class OrcScan(
     // We should use `readPartitionSchema` as the partition schema here.
     OrcPartitionReaderFactory(conf, broadcastedConf,
       dataSchema, readDataSchema, readPartitionSchema, pushedFilters, pushedAggregate,
-      new OrcOptions(options.asScala.toMap, conf), memoryMode)
+      new OrcOptions(options.asScala.toMap, conf), memoryMode, charVarcharStandardSemantics)
   }
 
   override def equals(obj: Any): Boolean = obj match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
@@ -87,7 +87,8 @@ case class OrcScan(
         pushedAggregate.isEmpty && o.pushedAggregate.isEmpty
       }
       super.equals(o) && dataSchema == o.dataSchema && options == o.options &&
-        equivalentFilters(pushedFilters, o.pushedFilters) && pushedDownAggEqual
+        equivalentFilters(pushedFilters, o.pushedFilters) && pushedDownAggEqual &&
+        charVarcharStandardSemantics == o.charVarcharStandardSemantics
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.read.SupportsPushDownAggregates
 import org.apache.spark.sql.execution.datasources.{AggregatePushDownUtils, PartitioningAwareFileIndex}
 import org.apache.spark.sql.execution.datasources.orc.OrcFilters
-import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
+import org.apache.spark.sql.execution.datasources.v2.{FileScanBuilder, SupportsCharVarcharStandardSemantics}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -38,7 +38,8 @@ case class OrcScanBuilder(
     dataSchema: StructType,
     options: CaseInsensitiveStringMap)
   extends FileScanBuilder(sparkSession, fileIndex, dataSchema)
-  with SupportsPushDownAggregates {
+  with SupportsPushDownAggregates
+  with SupportsCharVarcharStandardSemantics {
 
   lazy val hadoopConf = {
     val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
@@ -49,6 +50,12 @@ case class OrcScanBuilder(
   private var finalSchema = new StructType()
 
   private var pushedAggregations = Option.empty[Aggregation]
+  private var charVarcharStandardSemantics =
+    sparkSession.sessionState.conf.charVarcharStandardSemantics
+
+  override def bindCharVarcharStandardSemantics(enabled: Boolean): Unit = {
+    charVarcharStandardSemantics = enabled
+  }
 
   override protected val supportsNestedSchemaPruning: Boolean = true
 
@@ -61,7 +68,7 @@ case class OrcScanBuilder(
     }
     OrcScan(sparkSession, hadoopConf, fileIndex, dataSchema, finalSchema,
       readPartitionSchema(), options, pushedAggregations, pushedDataFilters, partitionFilters,
-      dataFilters)
+      dataFilters, charVarcharStandardSemantics)
   }
 
   override def pushDataFilters(dataFilters: Array[Filter]): Array[Filter] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -50,8 +50,7 @@ case class OrcScanBuilder(
   private var finalSchema = new StructType()
 
   private var pushedAggregations = Option.empty[Aggregation]
-  private var charVarcharStandardSemantics =
-    sparkSession.sessionState.conf.charVarcharStandardSemantics
+  private var charVarcharStandardSemantics = false
 
   override def bindCharVarcharStandardSemantics(enabled: Boolean): Unit = {
     charVarcharStandardSemantics = enabled

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcTable.scala
@@ -21,7 +21,6 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, Write, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.orc.OrcUtils
@@ -38,14 +37,8 @@ case class OrcTable(
     fallbackFileFormat: Class[_ <: FileFormat])
   extends FileTable(sparkSession, options, paths, userSpecifiedSchema) {
 
-  override def newScanBuilder(options: CaseInsensitiveStringMap): OrcScanBuilder = {
-    val scanOptions = mergedOptions(options)
-    val standardSemantics =
-      scanOptions.get(CharVarcharUtils.CHAR_VARCHAR_STANDARD_SEMANTICS_SCAN_OPTION) == true.toString
-    val scanDataSchema =
-      CharVarcharUtils.markStandardSemanticsForScan(dataSchema, standardSemantics)
-    OrcScanBuilder(sparkSession, fileIndex, schema, scanDataSchema, scanOptions)
-  }
+  override def newScanBuilder(options: CaseInsensitiveStringMap): OrcScanBuilder =
+    OrcScanBuilder(sparkSession, fileIndex, schema, dataSchema, mergedOptions(options))
 
   override def inferSchema(files: Seq[FileStatus]): Option[StructType] =
     OrcUtils.inferSchema(sparkSession, files, options.asScala.toMap)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcTable.scala
@@ -21,6 +21,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, Write, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.orc.OrcUtils
@@ -37,8 +38,14 @@ case class OrcTable(
     fallbackFileFormat: Class[_ <: FileFormat])
   extends FileTable(sparkSession, options, paths, userSpecifiedSchema) {
 
-  override def newScanBuilder(options: CaseInsensitiveStringMap): OrcScanBuilder =
-    OrcScanBuilder(sparkSession, fileIndex, schema, dataSchema, mergedOptions(options))
+  override def newScanBuilder(options: CaseInsensitiveStringMap): OrcScanBuilder = {
+    val scanOptions = mergedOptions(options)
+    val standardSemantics =
+      scanOptions.get(CharVarcharUtils.CHAR_VARCHAR_STANDARD_SEMANTICS_SCAN_OPTION) == true.toString
+    val scanDataSchema =
+      CharVarcharUtils.markStandardSemanticsForScan(dataSchema, standardSemantics)
+    OrcScanBuilder(sparkSession, fileIndex, schema, scanDataSchema, scanOptions)
+  }
 
   override def inferSchema(files: Seq[FileStatus]): Option[StructType] =
     OrcUtils.inferSchema(sparkSession, files, options.asScala.toMap)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
@@ -77,7 +77,7 @@ object CleanupDynamicPruningFilters extends Rule[LogicalPlan] with PredicateHelp
         removeUnnecessaryDynamicPruningSubquery(p)
       // pass through anything that is pushed down into PhysicalOperation
       case p @ NodeWithOnlyDeterministicProjectAndFilter(
-          HiveTableRelation(_, _, _, _, _)) =>
+          HiveTableRelation(_, _, _, _, _, _)) =>
         removeUnnecessaryDynamicPruningSubquery(p)
       case p @ NodeWithOnlyDeterministicProjectAndFilter(
           _: DataSourceV2ScanRelation) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.analysis.AsOfVersion
 import org.apache.spark.sql.catalyst.analysis.TempTableAlreadyExistsException
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, Join, JoinStrategyHint, SHUFFLE_HASH}
-import org.apache.spark.sql.catalyst.util.DateTimeConstants
+import org.apache.spark.sql.catalyst.util.{CharVarcharScanMode, DateTimeConstants}
 import org.apache.spark.sql.connector.catalog.BasicInMemoryTableCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
@@ -57,7 +57,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.util.PartitionKeyedAccumulator
 import org.apache.spark.storage.{RDDBlockId, StorageLevel}
-import org.apache.spark.storage.StorageLevel.{MEMORY_AND_DISK_2, MEMORY_ONLY}
+import org.apache.spark.storage.StorageLevel.{DISK_ONLY, MEMORY_AND_DISK_2, MEMORY_ONLY}
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.{AccumulatorContext, Utils}
@@ -2348,53 +2348,123 @@ class CachedTableSuite extends SharedSparkSession
   }
 
   test("RENAME TABLE manages cache with time travel plans correctly") {
+    val t = "testcat.tbl"
+    val tRenamed = "testcat.tbl_renamed"
+    val ident = Identifier.of(Array(), "tbl")
+    val version1 = "v1"
+    val version2 = "v2"
     val boundModes = Seq(
-      Seq(
+      (Seq(
         SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
-        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false"),
-      Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"))
-    boundModes.foreach { modeConf =>
-      withSQLConf(modeConf: _*) {
-        val t = "testcat.tbl"
-        val tRenamed = "testcat.tbl_renamed"
-        val ident = Identifier.of(Array(), "tbl")
-        val version1 = "v1"
-        val version2 = "v2"
-        withTable(t, tRenamed, "cached_tt1", "cached_tt2") {
-          sql(s"CREATE TABLE $t (id int, data string) USING foo")
-          sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')")
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false"), MEMORY_ONLY, "MEMORY_ONLY"),
+      (Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"), DISK_ONLY, "DISK_ONLY"))
+    withTable(t, tRenamed, "cached_tt1", "cached_tt2") {
+      sql(s"CREATE TABLE $t (id int, data string) USING foo")
+      sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')")
 
-          // pin v1
-          pinTable("testcat", ident, version1)
+      // pin v1
+      pinTable("testcat", ident, version1)
 
-          sql(s"INSERT INTO $t VALUES (3, 'c'), (4, 'd')")
+      sql(s"INSERT INTO $t VALUES (3, 'c'), (4, 'd')")
 
-          // pin v2
-          pinTable("testcat", ident, version2)
+      // pin v2
+      pinTable("testcat", ident, version2)
 
-          sql(s"INSERT INTO $t VALUES (4, 'e'), (5, 'f')")
+      sql(s"INSERT INTO $t VALUES (4, 'e'), (5, 'f')")
 
-          // cache base and both versions
-          sql(s"CACHE TABLE $t")
+      // Cache both mode-specific variants of the base table at once.
+      boundModes.foreach { case (modeConf, storageLevel, storageLevelName) =>
+        withSQLConf(modeConf: _*) {
+          sql(s"CACHE TABLE $t OPTIONS('storageLevel' '$storageLevelName')")
           assertCached(sql(s"SELECT * FROM $t"))
-          val storageLevel = spark.table(t).storageLevel
-          sql(s"CACHE TABLE cached_tt1 AS SELECT * FROM $t VERSION AS OF '$version1'")
-          assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version1'"))
-          sql(s"CACHE TABLE cached_tt2 AS SELECT * FROM $t VERSION AS OF '$version2'")
-          assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version2'"))
+          assert(spark.table(t).storageLevel === storageLevel)
+        }
+      }
+      sql(s"CACHE TABLE cached_tt1 AS SELECT * FROM $t VERSION AS OF '$version1'")
+      assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version1'"))
+      sql(s"CACHE TABLE cached_tt2 AS SELECT * FROM $t VERSION AS OF '$version2'")
+      assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version2'"))
 
-          // must have 3 cache entries
-          assert(cacheManager.numCachedEntries == 3)
+      assert(cacheManager.numCachedEntries == 4)
 
-          // rename base table
-          sql(s"ALTER TABLE $t RENAME TO tbl_renamed")
+      sql(s"ALTER TABLE $t RENAME TO tbl_renamed")
 
-          // assert cache was cleared and renamed table (current version) was cached again
-          assert(cacheManager.numCachedEntries == 1)
+      // Time-travel and dependent caches are invalidated; both direct mode variants are restored.
+      assert(cacheManager.numCachedEntries == 2)
+      boundModes.foreach { case (modeConf, storageLevel, _) =>
+        withSQLConf(modeConf: _*) {
           assertCached(sql(s"SELECT * FROM $tRenamed"))
           assert(spark.table(tRenamed).storageLevel === storageLevel)
         }
       }
+    }
+  }
+
+  test("RENAME TABLE does not promote a dependent query cache to a table cache") {
+    val t = "testcat.tbl"
+    val tRenamed = "testcat.tbl_renamed"
+    withTable(t, tRenamed, "cached_query") {
+      sql(s"CREATE TABLE $t (id int, data string) USING foo")
+      sql(s"INSERT INTO $t VALUES (1, 'a')")
+      sql(s"CACHE TABLE cached_query AS SELECT * FROM $t")
+      assertCached(sql("SELECT * FROM cached_query"))
+
+      sql(s"ALTER TABLE $t RENAME TO tbl_renamed")
+
+      assert(!spark.catalog.isCached(tRenamed))
+      assert(cacheManager.numCachedEntries == 0)
+    }
+  }
+
+  test("catalog V2 recache preserves all bound CHAR/VARCHAR scan modes") {
+    val t = "testcat.tbl"
+    val preserveConf = Seq(
+      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+      SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false")
+    val standardConf = Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true")
+
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id int, data string) USING foo")
+      sql(s"INSERT INTO $t VALUES (1, 'a')")
+
+      def cachedData(modeConf: Seq[(String, String)]) = {
+        withSQLConf(modeConf: _*) {
+          cacheManager.lookupCachedData(sql(s"SELECT * FROM $t")).getOrElse {
+            fail(s"Expected $t to be cached for $modeConf")
+          }
+        }
+      }
+
+      def scanMode(modeConf: Seq[(String, String)]): Option[CharVarcharScanMode] = {
+        cachedData(modeConf).plan.collectFirst {
+          case relation: DataSourceV2Relation => relation.charVarcharScanMode
+        }.flatten
+      }
+
+      withSQLConf(preserveConf: _*) {
+        sql(s"CACHE TABLE $t OPTIONS('storageLevel' 'MEMORY_ONLY')")
+        checkAnswer(sql(s"SELECT * FROM $t"), Row(1, "a"))
+      }
+      withSQLConf(standardConf: _*) {
+        sql(s"CACHE TABLE $t OPTIONS('storageLevel' 'DISK_ONLY')")
+        checkAnswer(sql(s"SELECT * FROM $t"), Row(1, "a"))
+      }
+
+      withSQLConf(preserveConf: _*) {
+        sql(s"INSERT INTO $t VALUES (2, 'b')")
+      }
+
+      withSQLConf(preserveConf: _*) {
+        checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(1, "a"), Row(2, "b")))
+      }
+      withSQLConf(standardConf: _*) {
+        checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(1, "a"), Row(2, "b")))
+      }
+      assert(scanMode(preserveConf).contains(CharVarcharScanMode.PreserveNative))
+      assert(scanMode(standardConf).contains(CharVarcharScanMode.SparkStandard))
+      assert(
+        cachedData(preserveConf).cachedRepresentation.cacheBuilder.storageLevel === MEMORY_ONLY)
+      assert(cachedData(standardConf).cachedRepresentation.cacheBuilder.storageLevel === DISK_ONLY)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -2348,42 +2348,53 @@ class CachedTableSuite extends SharedSparkSession
   }
 
   test("RENAME TABLE manages cache with time travel plans correctly") {
-    val t = "testcat.tbl"
-    val tRenamed = "testcat.tbl_renamed"
-    val ident = Identifier.of(Array(), "tbl")
-    val version1 = "v1"
-    val version2 = "v2"
-    withTable(t, tRenamed, "cached_tt1", "cached_tt2") {
-      sql(s"CREATE TABLE $t (id int, data string) USING foo")
-      sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')")
+    val boundModes = Seq(
+      Seq(
+        SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false"),
+      Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"))
+    boundModes.foreach { modeConf =>
+      withSQLConf(modeConf: _*) {
+        val t = "testcat.tbl"
+        val tRenamed = "testcat.tbl_renamed"
+        val ident = Identifier.of(Array(), "tbl")
+        val version1 = "v1"
+        val version2 = "v2"
+        withTable(t, tRenamed, "cached_tt1", "cached_tt2") {
+          sql(s"CREATE TABLE $t (id int, data string) USING foo")
+          sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')")
 
-      // pin v1
-      pinTable("testcat", ident, version1)
+          // pin v1
+          pinTable("testcat", ident, version1)
 
-      sql(s"INSERT INTO $t VALUES (3, 'c'), (4, 'd')")
+          sql(s"INSERT INTO $t VALUES (3, 'c'), (4, 'd')")
 
-      // pin v2
-      pinTable("testcat", ident, version2)
+          // pin v2
+          pinTable("testcat", ident, version2)
 
-      sql(s"INSERT INTO $t VALUES (4, 'e'), (5, 'f')")
+          sql(s"INSERT INTO $t VALUES (4, 'e'), (5, 'f')")
 
-      // cache base and both versions
-      sql(s"CACHE TABLE $t")
-      assertCached(sql(s"SELECT * FROM $t"))
-      sql(s"CACHE TABLE cached_tt1 AS SELECT * FROM $t VERSION AS OF '$version1'")
-      assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version1'"))
-      sql(s"CACHE TABLE cached_tt2 AS SELECT * FROM $t VERSION AS OF '$version2'")
-      assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version2'"))
+          // cache base and both versions
+          sql(s"CACHE TABLE $t")
+          assertCached(sql(s"SELECT * FROM $t"))
+          val storageLevel = spark.table(t).storageLevel
+          sql(s"CACHE TABLE cached_tt1 AS SELECT * FROM $t VERSION AS OF '$version1'")
+          assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version1'"))
+          sql(s"CACHE TABLE cached_tt2 AS SELECT * FROM $t VERSION AS OF '$version2'")
+          assertCached(sql(s"SELECT * FROM $t VERSION AS OF '$version2'"))
 
-      // must have 3 cache entries
-      assert(cacheManager.numCachedEntries == 3)
+          // must have 3 cache entries
+          assert(cacheManager.numCachedEntries == 3)
 
-      // rename base table
-      sql(s"ALTER TABLE $t RENAME TO tbl_renamed")
+          // rename base table
+          sql(s"ALTER TABLE $t RENAME TO tbl_renamed")
 
-      // assert cache was cleared and renamed table (current version) was cached again
-      assert(cacheManager.numCachedEntries == 1)
-      assertCached(sql(s"SELECT * FROM $tRenamed"))
+          // assert cache was cleared and renamed table (current version) was cached again
+          assert(cacheManager.numCachedEntries == 1)
+          assertCached(sql(s"SELECT * FROM $tRenamed"))
+          assert(spark.table(tRenamed).storageLevel === storageLevel)
+        }
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1697,33 +1697,94 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         sql("DROP TEMPORARY FUNCTION IF EXISTS std_char_param")
         sql("DROP TEMPORARY FUNCTION IF EXISTS std_varchar_param")
       }
+    }
+  }
 
-      // ORC catalog tables stamp the catalyst type so typeof survives write/read.
-      withTable("std_orc") {
-        sql("CREATE TABLE std_orc (c CHAR(5), v VARCHAR(5)) USING orc")
-        sql("INSERT INTO std_orc VALUES ('ab', 'cd')")
-        assert(spark.table("std_orc").schema.map(_.dataType) ===
-          Seq(CharType(5), VarcharType(5)))
-        checkAnswer(
-          sql("SELECT concat('<', c, '>'), concat('<', v, '>') FROM std_orc"),
-          Row("<ab   >", "<cd>"))
-      }
+  test("SPARK-58814: major formats preserve CHAR/VARCHAR schemas and values") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      Seq("parquet", "orc").foreach { format =>
+        Seq("v1" -> format, "v2" -> "").foreach { case (sourceVersion, useV1List) =>
+          withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> useV1List) {
+            withTempPath { dir =>
+              val path = dir.getCanonicalPath
+              val input = spark.range(1).selectExpr(
+                "cast('ab' AS CHAR(4)) AS c",
+                "cast('xy' AS VARCHAR(3)) AS v",
+                "named_struct('c', cast('z' AS CHAR(2))) AS s",
+                "array(cast('q' AS VARCHAR(2))) AS a",
+                "map(cast('k' AS CHAR(2)), cast('v' AS VARCHAR(2))) AS m")
+              input.write.mode("overwrite").format(format).save(path)
 
-      // File-only ORC inference recovers the catalyst type stamped on write.
-      withTempPath { dir =>
-        val path = dir.getCanonicalPath
-        spark.range(1).selectExpr("cast('ab' AS CHAR(4)) AS c")
-          .write.mode("overwrite").orc(path)
-        val orcDf = spark.read.orc(path)
-        assert(orcDf.schema.head.dataType === CharType(4))
-        checkAnswer(orcDf.selectExpr("concat('<', c, '>')"), Row("<ab  >"))
-        // Reading with first-class types off replaces CHAR with STRING even if the
-        // file was stamped under standardSemantics.
-        withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
-          val readOff = spark.read.orc(path)
-          assert(readOff.schema.head.dataType === StringType)
+              val readBack = spark.read.format(format).load(path)
+              assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema),
+                s"$format $sourceVersion lost CHAR/VARCHAR schema")
+              checkAnswer(
+                readBack.selectExpr("concat('<', c, '>')", "v", "concat('<', s.c, '>')"),
+                Row("<ab  >", "xy", "<z >"))
+
+              withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
+                val readOff = spark.read.format(format).load(path)
+                assert(DataType.equalsIgnoreNullability(
+                  readOff.schema,
+                  CharVarcharUtils.replaceCharVarcharWithString(input.schema)))
+              }
+              withSQLConf(
+                  SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                  SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                assert(DataType.equalsIgnoreNullability(
+                  spark.read.format(format).load(path).schema,
+                  input.schema))
+              }
+            }
+          }
         }
       }
+
+      Seq("parquet", "orc", "csv").foreach { format =>
+        Seq("v1" -> format, "v2" -> "").foreach { case (sourceVersion, useV1List) =>
+          withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> useV1List) {
+            withTempPath { dir =>
+              Seq("ab").toDF("c").write.format(format).save(dir.getCanonicalPath)
+              val charDf = spark.read.schema("c CHAR(4)").format(format)
+                .load(dir.getCanonicalPath)
+              checkAnswer(charDf.selectExpr("concat('<', c, '>')"), Row("<ab  >"))
+            }
+            withTempPath { dir =>
+              Seq("abcdef").toDF("c").write.format(format).save(dir.getCanonicalPath)
+              Seq("CHAR", "VARCHAR").foreach { typ =>
+                withClue(s"$format $sourceVersion $typ: ") {
+                  val readDf = spark.read.schema(s"c $typ(4)").format(format)
+                    .load(dir.getCanonicalPath)
+                  checkError(
+                    exception = intercept[SparkRuntimeException] {
+                      readDf.collect()
+                    },
+                    condition = "EXCEED_LIMIT_LENGTH",
+                    parameters = Map("limit" -> "4"))
+                }
+              }
+            }
+
+            val table = s"std_${format}_${sourceVersion}_assignment"
+            withTable(table) {
+              sql(s"CREATE TABLE $table (c CHAR(4), v VARCHAR(4)) USING $format")
+              sql(s"INSERT INTO $table VALUES ('ab', 'xy')")
+              assert(spark.table(table).schema.map(_.dataType) ===
+                Seq(CharType(4), VarcharType(4)))
+              checkAnswer(
+                sql(s"SELECT concat('<', c, '>'), v FROM $table"),
+                Row("<ab  >", "xy"))
+              checkError(
+                exception = intercept[SparkRuntimeException] {
+                  sql(s"INSERT INTO $table VALUES ('abcde', 'xy')").collect()
+                },
+                condition = "EXCEED_LIMIT_LENGTH",
+                parameters = Map("limit" -> "4"))
+            }
+          }
+        }
+      }
+
       // First-class types off: CAST CHAR is STRING before the writer, so ORC does not stamp CHAR.
       withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
         withTempPath { dir =>
@@ -1731,17 +1792,6 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
           spark.range(1).selectExpr("cast('ab' AS CHAR(4)) AS c")
             .write.mode("overwrite").orc(path)
           assert(spark.read.orc(path).schema.head.dataType === StringType)
-        }
-      }
-      // preserveCharVarcharTypeInfo also keeps first-class types, so write still stamps CHAR.
-      withSQLConf(
-          SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
-          SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
-        withTempPath { dir =>
-          val path = dir.getCanonicalPath
-          spark.range(1).selectExpr("cast('ab' AS CHAR(4)) AS c")
-            .write.mode("overwrite").orc(path)
-          assert(spark.read.orc(path).schema.head.dataType === CharType(4))
         }
       }
       // ORC stamps collated unbounded STRING as plain "string"; the inferred type is the
@@ -1825,7 +1875,7 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         }
       }
 
-      // JSON / CSV keep a user-specified CHAR/VARCHAR schema under the flag.
+      // JSON has no embedded schema, so a user-specified schema supplies the logical type.
       withTempPath { dir =>
         val path = dir.getCanonicalPath
         spark.range(1).selectExpr("cast(id AS STRING) AS c").write.mode("overwrite")
@@ -1833,13 +1883,6 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         val jsonDf = spark.read.schema("c CHAR(5)").json(s"$path/json")
         assert(jsonDf.schema.head.dataType === CharType(5))
         checkAnswer(jsonDf.selectExpr("concat('<', c, '>')"), Row("<0    >"))
-
-        spark.range(1).selectExpr("cast(id AS STRING) AS c").write.mode("overwrite")
-          .option("header", "true").csv(s"$path/csv")
-        val csvDf = spark.read.schema("c VARCHAR(5)").option("header", "true")
-          .csv(s"$path/csv")
-        assert(csvDf.schema.head.dataType === VarcharType(5))
-        checkAnswer(csvDf, Row("0"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -2702,6 +2702,36 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-58814: shared V2 relation cache rebinds the CHAR/VARCHAR scan mode") {
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+        withTable("shared_orc_relation_cache") {
+          sql(
+            s"""CREATE TABLE shared_orc_relation_cache (v VARCHAR(4))
+               |USING orc LOCATION '$path'""".stripMargin)
+          withSQLConf(
+              SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+              SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+            sql("CACHE TABLE shared_orc_relation_cache")
+            checkAnswer(sql("SELECT * FROM shared_orc_relation_cache"), Row("abcd"))
+          }
+
+          val standardSession = spark.newSession()
+          standardSession.conf.set(SQLConf.USE_V1_SOURCE_LIST.key, "")
+          standardSession.conf.set(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key, "true")
+          checkError(
+            exception = intercept[SparkRuntimeException] {
+              standardSession.table("shared_orc_relation_cache").collect()
+            },
+            condition = "EXCEED_LIMIT_LENGTH",
+            parameters = Map("limit" -> "4"))
+        }
+      }
+    }
+  }
+
   test("SPARK-59001: text datasource accepts CHAR/VARCHAR as a string family type") {
     Seq("text", "").foreach { useV1SourceList =>
       withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -23,13 +23,16 @@ import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException, Spark
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.analysis.resolver.ResolverGuard
 import org.apache.spark.sql.catalyst.expressions.{
-  ArrayJoin, Attribute, Concat, EqualTo, Expression, GreaterThan, InSet, Literal, ScalarSubquery,
-  StringRPad, StringToMap, Upper
+  Alias, ArrayJoin, Attribute, Concat, EqualTo, Expression, GreaterThan, InSet, Literal,
+  ScalarSubquery, StringRPad, StringToMap, Upper
 }
 import org.apache.spark.sql.catalyst.expressions.Cast.toSQLId
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{
+  Aggregate, Filter, LogicalPlan, OneRowRelation, Project
+}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.connector.SchemaRequiredDataSource
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, InMemoryPartitionTableCatalog}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -39,6 +42,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.SimpleInsertSource
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 // The base trait for char/varchar tests that need to be run with different table implementations.
 trait CharVarcharTestSuite extends QueryTest {
@@ -1968,7 +1972,15 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
               Seq("abcdef").toDF("c").write.format(format).save(dir.getCanonicalPath)
               Seq("CHAR", "VARCHAR").foreach { typ =>
                 withClue(s"$format $sourceVersion $typ: ") {
-                  val readDf = spark.read.schema(s"c $typ(4)").format(format)
+                  val forgedMetadata = new MetadataBuilder()
+                    .putBoolean("__CHAR_VARCHAR_STANDARD_SEMANTICS", false)
+                    .build()
+                  val readSchema = StructType(Seq(
+                    StructField("c", CatalystSqlParser.parseDataType(s"$typ(4)"),
+                      metadata = forgedMetadata)))
+                  val readDf = spark.read.schema(readSchema)
+                    .option("__charVarcharStandardSemantics", "false")
+                    .format(format)
                     .load(dir.getCanonicalPath)
                   checkError(
                     exception = intercept[SparkRuntimeException] {
@@ -2036,9 +2048,28 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
               withTempPath { dir =>
                 val path = dir.getCanonicalPath
                 Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
-                val readBack = spark.read.schema("v VARCHAR(4)").orc(path)
+                val forgedMetadata = new MetadataBuilder()
+                  .putBoolean("__CHAR_VARCHAR_STANDARD_SEMANTICS", true)
+                  .build()
+                val readSchema = StructType(Seq(
+                  StructField("v", VarcharType(4), metadata = forgedMetadata)))
+                val readBack = spark.read.schema(readSchema)
+                  .option("__charVarcharStandardSemantics", "true")
+                  .orc(path)
                 assert(readBack.schema.head.dataType === VarcharType(4))
                 checkAnswer(readBack, Row("abcd"))
+              }
+              withTempPath { dir =>
+                val path = dir.getCanonicalPath
+                // Bypass CAST conversion so native ORC owns preserve-only padding/truncation.
+                val input = Dataset.ofRows(spark, Project(Seq(
+                  Alias(Literal(UTF8String.fromString("ab"), CharType(4)), "c")(),
+                  Alias(Literal(UTF8String.fromString("abcdef"), VarcharType(4)), "v")()),
+                  OneRowRelation()))
+                input.write.mode("overwrite").orc(path)
+                val readBack = spark.read.orc(path)
+                assert(readBack.schema.map(_.dataType) === Seq(CharType(4), VarcharType(4)))
+                checkAnswer(readBack, Row("ab  ", "abcd"))
               }
             }
 
@@ -2065,6 +2096,27 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                         condition = "EXCEED_LIMIT_LENGTH",
                         parameters = Map("limit" -> "4"))
                     }
+                  }
+                }
+              }
+            }
+
+            withTempPath { dir =>
+              val path = dir.getCanonicalPath
+              Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+              val table = "preserve_orc_view_source"
+              val view = "preserve_orc_view"
+              withTable(table) {
+                withView(view) {
+                  withSQLConf(
+                      SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                    sql(s"CREATE TABLE $table (v VARCHAR(4)) USING orc LOCATION '$path'")
+                    sql(s"CREATE VIEW $view AS SELECT v FROM $table")
+                  }
+                  withClue(
+                      s"ORC view $sourceVersion vectorized=$vectorizedReaderEnabled: ") {
+                    checkAnswer(sql(s"SELECT * FROM $view"), Row("abcd"))
                   }
                 }
               }
@@ -2419,6 +2471,22 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         .format(classOf[SchemaRequiredDataSource].getName).load())
       checkSchema(spark.read.schema("id char(5)")
         .format(classOf[SchemaRequiredDataSource].getName).load())
+    }
+  }
+
+  test("standard semantics does not add options to non-ORC V2 relations") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val relation = spark.read
+        .schema("id CHAR(5)")
+        .option("expected", "value")
+        .format(classOf[SchemaRequiredDataSource].getName)
+        .load()
+        .queryExecution
+        .analyzed
+        .collectFirst { case relation: DataSourceV2Relation => relation }
+        .get
+      assert(relation.options.size() === 1)
+      assert(relation.options.get("expected") === "value")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1947,7 +1947,8 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                   }
                   withSQLConf(
                       SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
-                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+                      SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
                     assert(DataType.equalsIgnoreNullability(
                       spark.read.format(format).load(path).schema,
                       input.schema))
@@ -2110,7 +2111,8 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                 withView(view) {
                   withSQLConf(
                       SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
-                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+                      SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
                     sql(s"CREATE TABLE $table (v VARCHAR(4)) USING orc LOCATION '$path'")
                     sql(s"CREATE VIEW $view AS SELECT v FROM $table")
                   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.connector.SchemaRequiredDataSource
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, InMemoryPartitionTableCatalog}
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions
@@ -2120,6 +2121,48 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                       s"ORC view $sourceVersion vectorized=$vectorizedReaderEnabled: ") {
                     checkAnswer(sql(s"SELECT * FROM $view"), Row("abcd"))
                   }
+                }
+              }
+            }
+
+            withTempPath { dir =>
+              val path = dir.getCanonicalPath
+              Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+              val table = "orc_scan_cache_reuse"
+              withTable(table) {
+                sql(s"CREATE TABLE $table (v VARCHAR(4)) USING orc LOCATION '$path'")
+                val preservePlan = withSQLConf(
+                    SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                    SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+                    SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
+                  spark.table(table).queryExecution.sparkPlan
+                }
+                val standardPlan = spark.table(table).queryExecution.sparkPlan
+                withClue(
+                    s"ORC sameResult $sourceVersion " +
+                      s"vectorized=$vectorizedReaderEnabled: ") {
+                  assert(!preservePlan.sameResult(standardPlan))
+                }
+                withSQLConf(
+                    SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                    SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+                    SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
+                  sql(s"CACHE TABLE $table")
+                  checkAnswer(sql(s"SELECT * FROM $table"), Row("abcd"))
+                }
+                withClue(
+                    s"ORC cache $sourceVersion vectorized=$vectorizedReaderEnabled: ") {
+                  val df = sql(s"SELECT * FROM $table")
+                  assert(
+                    !df.queryExecution.sparkPlan.exists(
+                      _.isInstanceOf[InMemoryTableScanExec]),
+                    "preserve-only cache must not satisfy a standard-semantics scan")
+                  checkError(
+                    exception = intercept[SparkRuntimeException] {
+                      df.collect()
+                    },
+                    condition = "EXCEED_LIMIT_LENGTH",
+                    parameters = Map("limit" -> "4"))
                 }
               }
             }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -19,7 +19,10 @@ package org.apache.spark.sql
 
 import scala.util.Try
 
+import org.apache.hadoop.conf.Configuration
+
 import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException, SparkThrowable}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.analysis.resolver.ResolverGuard
 import org.apache.spark.sql.catalyst.expressions.{
@@ -36,7 +39,8 @@ import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.connector.SchemaRequiredDataSource
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, InMemoryPartitionTableCatalog}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
-import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.{LogicalRelation, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.internal.SQLConf
@@ -2620,6 +2624,29 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-58814: OrcFileFormat subclasses keep public reader dispatch") {
+    import testImplicits._
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      Seq("ab").toDF("v").write.mode("overwrite").orc(path)
+      val formatName = classOf[TrackingOrcFileFormat].getName
+      val boundModes = Seq(
+        Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"),
+        Seq(
+          SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+          SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+          SQLConf.READ_SIDE_CHAR_PADDING.key -> "false"))
+      boundModes.foreach { extraConf =>
+        TrackingOrcFileFormat.publicReaderCalls = 0
+        withSQLConf(extraConf: _*) {
+          spark.read.format(formatName).schema("v VARCHAR(4)").load(path).collect()
+          assert(TrackingOrcFileFormat.publicReaderCalls > 0,
+            s"subclass reader override was skipped for $extraConf")
+        }
+      }
+    }
+  }
+
   test("SPARK-59001: text datasource accepts CHAR/VARCHAR as a string family type") {
     Seq("text", "").foreach { useV1SourceList =>
       withSQLConf(
@@ -2642,6 +2669,27 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
       }
     }
   }
+}
+
+class TrackingOrcFileFormat extends OrcFileFormat {
+  override def shortName(): String = "tracking-orc"
+
+  override def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[org.apache.spark.sql.sources.Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+    TrackingOrcFileFormat.publicReaderCalls += 1
+    super.buildReaderWithPartitionValues(
+      sparkSession, dataSchema, partitionSchema, requiredSchema, filters, options, hadoopConf)
+  }
+}
+
+object TrackingOrcFileFormat {
+  @volatile var publicReaderCalls: Int = 0
 }
 
 class FileSourceCharVarcharTestSuite extends CharVarcharTestSuite with SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -2626,22 +2626,59 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
 
   test("SPARK-58814: OrcFileFormat subclasses keep public reader dispatch") {
     import testImplicits._
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
-      Seq("ab").toDF("v").write.mode("overwrite").orc(path)
-      val formatName = classOf[TrackingOrcFileFormat].getName
-      val boundModes = Seq(
-        Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"),
-        Seq(
-          SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
-          SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
-          SQLConf.READ_SIDE_CHAR_PADDING.key -> "false"))
-      boundModes.foreach { extraConf =>
-        TrackingOrcFileFormat.publicReaderCalls = 0
-        withSQLConf(extraConf: _*) {
-          spark.read.format(formatName).schema("v VARCHAR(4)").load(path).collect()
-          assert(TrackingOrcFileFormat.publicReaderCalls > 0,
-            s"subclass reader override was skipped for $extraConf")
+    val formatName = classOf[TrackingOrcFileFormat].getName
+    // A delegating subclass overrides the public seven-argument reader and calls `super`. That
+    // `super` call must retain the analyzed scan mode bridged across the legacy signature, so a
+    // standard-semantics scan cannot be silently downgraded to native preserve behavior. Cover
+    // both the row and vectorized ORC readers.
+    Seq(true, false).foreach { vectorizedReaderEnabled =>
+      withSQLConf(
+          SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorizedReaderEnabled.toString) {
+        // In-length value: assert the subclass override actually runs under both bound modes.
+        withTempPath { dir =>
+          val path = dir.getCanonicalPath
+          Seq("ab").toDF("v").write.mode("overwrite").orc(path)
+          val boundModes = Seq(
+            Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"),
+            Seq(
+              SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+              SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+              SQLConf.READ_SIDE_CHAR_PADDING.key -> "false"))
+          boundModes.foreach { extraConf =>
+            TrackingOrcFileFormat.publicReaderCalls = 0
+            withSQLConf(extraConf: _*) {
+              spark.read.format(formatName).schema("v VARCHAR(4)").load(path).collect()
+              assert(TrackingOrcFileFormat.publicReaderCalls > 0,
+                s"subclass reader override was skipped for $extraConf " +
+                  s"(vectorized=$vectorizedReaderEnabled)")
+            }
+          }
+        }
+        // Over-length value: SparkStandard must observe the original value and raise
+        // EXCEED_LIMIT_LENGTH; PreserveNative keeps native ORC truncation.
+        withTempPath { dir =>
+          val path = dir.getCanonicalPath
+          Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+          withClue(s"SparkStandard vectorized=$vectorizedReaderEnabled: ") {
+            withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+              checkError(
+                exception = intercept[SparkRuntimeException] {
+                  spark.read.format(formatName).schema("v VARCHAR(4)").load(path).collect()
+                },
+                condition = "EXCEED_LIMIT_LENGTH",
+                parameters = Map("limit" -> "4"))
+            }
+          }
+          withClue(s"PreserveNative vectorized=$vectorizedReaderEnabled: ") {
+            withSQLConf(
+                SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+                SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
+              checkAnswer(
+                spark.read.format(formatName).schema("v VARCHAR(4)").load(path),
+                Row("abcd"))
+            }
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.connector.SchemaRequiredDataSource
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, InMemoryPartitionTableCatalog}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
-import org.apache.spark.sql.execution.datasources.{LogicalRelation, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{FileFormat, LogicalRelation, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions
@@ -2679,6 +2679,24 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                 Row("abcd"))
             }
           }
+        }
+      }
+    }
+  }
+
+  test("SPARK-58814: caller options cannot set the private ORC scan mode") {
+    import testImplicits._
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "orc") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+
+        Seq("not-a-mode", "SparkStandard", "PreserveNative").foreach { optionValue =>
+          checkAnswer(
+            spark.read
+              .option(FileFormat.CHAR_VARCHAR_SCAN_MODE, optionValue)
+              .orc(path),
+            Row("abcdef"))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -2041,6 +2041,34 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                 checkAnswer(readBack, Row("abcd"))
               }
             }
+
+            withTempPath { dir =>
+              val path = dir.getCanonicalPath
+              Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+              val table = "std_orc_view_source"
+              val view = "std_orc_view"
+              withTable(table) {
+                withView(view) {
+                  sql(s"CREATE TABLE $table (v VARCHAR(4)) USING orc LOCATION '$path'")
+                  sql(s"CREATE VIEW $view AS SELECT v FROM $table")
+                  // Keep first-class output enabled in the caller so this isolates whether ORC
+                  // honors the standard semantics captured while resolving the view body.
+                  withSQLConf(
+                      SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                    withClue(
+                        s"ORC view $sourceVersion vectorized=$vectorizedReaderEnabled: ") {
+                      checkError(
+                        exception = intercept[SparkRuntimeException] {
+                          sql(s"SELECT * FROM $view").collect()
+                        },
+                        condition = "EXCEED_LIMIT_LENGTH",
+                        parameters = Map("limit" -> "4"))
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1900,33 +1900,94 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         sql("DROP TEMPORARY FUNCTION IF EXISTS std_char_param")
         sql("DROP TEMPORARY FUNCTION IF EXISTS std_varchar_param")
       }
+    }
+  }
 
-      // ORC catalog tables stamp the catalyst type so typeof survives write/read.
-      withTable("std_orc") {
-        sql("CREATE TABLE std_orc (c CHAR(5), v VARCHAR(5)) USING orc")
-        sql("INSERT INTO std_orc VALUES ('ab', 'cd')")
-        assert(spark.table("std_orc").schema.map(_.dataType) ===
-          Seq(CharType(5), VarcharType(5)))
-        checkAnswer(
-          sql("SELECT concat('<', c, '>'), concat('<', v, '>') FROM std_orc"),
-          Row("<ab   >", "<cd>"))
-      }
+  test("SPARK-58814: major formats preserve CHAR/VARCHAR schemas and values") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      Seq("parquet", "orc").foreach { format =>
+        Seq("v1" -> format, "v2" -> "").foreach { case (sourceVersion, useV1List) =>
+          withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> useV1List) {
+            withTempPath { dir =>
+              val path = dir.getCanonicalPath
+              val input = spark.range(1).selectExpr(
+                "cast('ab' AS CHAR(4)) AS c",
+                "cast('xy' AS VARCHAR(3)) AS v",
+                "named_struct('c', cast('z' AS CHAR(2))) AS s",
+                "array(cast('q' AS VARCHAR(2))) AS a",
+                "map(cast('k' AS CHAR(2)), cast('v' AS VARCHAR(2))) AS m")
+              input.write.mode("overwrite").format(format).save(path)
 
-      // File-only ORC inference recovers the catalyst type stamped on write.
-      withTempPath { dir =>
-        val path = dir.getCanonicalPath
-        spark.range(1).selectExpr("cast('ab' AS CHAR(4)) AS c")
-          .write.mode("overwrite").orc(path)
-        val orcDf = spark.read.orc(path)
-        assert(orcDf.schema.head.dataType === CharType(4))
-        checkAnswer(orcDf.selectExpr("concat('<', c, '>')"), Row("<ab  >"))
-        // Reading with first-class types off replaces CHAR with STRING even if the
-        // file was stamped under standardSemantics.
-        withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
-          val readOff = spark.read.orc(path)
-          assert(readOff.schema.head.dataType === StringType)
+              val readBack = spark.read.format(format).load(path)
+              assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema),
+                s"$format $sourceVersion lost CHAR/VARCHAR schema")
+              checkAnswer(
+                readBack.selectExpr("concat('<', c, '>')", "v", "concat('<', s.c, '>')"),
+                Row("<ab  >", "xy", "<z >"))
+
+              withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
+                val readOff = spark.read.format(format).load(path)
+                assert(DataType.equalsIgnoreNullability(
+                  readOff.schema,
+                  CharVarcharUtils.replaceCharVarcharWithString(input.schema)))
+              }
+              withSQLConf(
+                  SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                  SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                assert(DataType.equalsIgnoreNullability(
+                  spark.read.format(format).load(path).schema,
+                  input.schema))
+              }
+            }
+          }
         }
       }
+
+      Seq("parquet", "orc", "csv").foreach { format =>
+        Seq("v1" -> format, "v2" -> "").foreach { case (sourceVersion, useV1List) =>
+          withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> useV1List) {
+            withTempPath { dir =>
+              Seq("ab").toDF("c").write.format(format).save(dir.getCanonicalPath)
+              val charDf = spark.read.schema("c CHAR(4)").format(format)
+                .load(dir.getCanonicalPath)
+              checkAnswer(charDf.selectExpr("concat('<', c, '>')"), Row("<ab  >"))
+            }
+            withTempPath { dir =>
+              Seq("abcdef").toDF("c").write.format(format).save(dir.getCanonicalPath)
+              Seq("CHAR", "VARCHAR").foreach { typ =>
+                withClue(s"$format $sourceVersion $typ: ") {
+                  val readDf = spark.read.schema(s"c $typ(4)").format(format)
+                    .load(dir.getCanonicalPath)
+                  checkError(
+                    exception = intercept[SparkRuntimeException] {
+                      readDf.collect()
+                    },
+                    condition = "EXCEED_LIMIT_LENGTH",
+                    parameters = Map("limit" -> "4"))
+                }
+              }
+            }
+
+            val table = s"std_${format}_${sourceVersion}_assignment"
+            withTable(table) {
+              sql(s"CREATE TABLE $table (c CHAR(4), v VARCHAR(4)) USING $format")
+              sql(s"INSERT INTO $table VALUES ('ab', 'xy')")
+              assert(spark.table(table).schema.map(_.dataType) ===
+                Seq(CharType(4), VarcharType(4)))
+              checkAnswer(
+                sql(s"SELECT concat('<', c, '>'), v FROM $table"),
+                Row("<ab  >", "xy"))
+              checkError(
+                exception = intercept[SparkRuntimeException] {
+                  sql(s"INSERT INTO $table VALUES ('abcde', 'xy')").collect()
+                },
+                condition = "EXCEED_LIMIT_LENGTH",
+                parameters = Map("limit" -> "4"))
+            }
+          }
+        }
+      }
+
       // First-class types off: CAST CHAR is STRING before the writer, so ORC does not stamp CHAR.
       withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
         withTempPath { dir =>
@@ -1934,17 +1995,6 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
           spark.range(1).selectExpr("cast('ab' AS CHAR(4)) AS c")
             .write.mode("overwrite").orc(path)
           assert(spark.read.orc(path).schema.head.dataType === StringType)
-        }
-      }
-      // preserveCharVarcharTypeInfo also keeps first-class types, so write still stamps CHAR.
-      withSQLConf(
-          SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
-          SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
-        withTempPath { dir =>
-          val path = dir.getCanonicalPath
-          spark.range(1).selectExpr("cast('ab' AS CHAR(4)) AS c")
-            .write.mode("overwrite").orc(path)
-          assert(spark.read.orc(path).schema.head.dataType === CharType(4))
         }
       }
       // ORC stamps collated unbounded STRING as plain "string"; the inferred type is the
@@ -2028,7 +2078,7 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         }
       }
 
-      // JSON / CSV keep a user-specified CHAR/VARCHAR schema under the flag.
+      // JSON has no embedded schema, so a user-specified schema supplies the logical type.
       withTempPath { dir =>
         val path = dir.getCanonicalPath
         spark.range(1).selectExpr("cast(id AS STRING) AS c").write.mode("overwrite")
@@ -2036,13 +2086,6 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
         val jsonDf = spark.read.schema("c CHAR(5)").json(s"$path/json")
         assert(jsonDf.schema.head.dataType === CharType(5))
         checkAnswer(jsonDf.selectExpr("concat('<', c, '>')"), Row("<0    >"))
-
-        spark.range(1).selectExpr("cast(id AS STRING) AS c").write.mode("overwrite")
-          .option("header", "true").csv(s"$path/csv")
-        val csvDf = spark.read.schema("c VARCHAR(5)").option("header", "true")
-          .csv(s"$path/csv")
-        assert(csvDf.schema.head.dataType === VarcharType(5))
-        checkAnswer(csvDf, Row("0"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -1918,25 +1918,37 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                 "map(cast('k' AS CHAR(2)), cast('v' AS VARCHAR(2))) AS m")
               input.write.mode("overwrite").format(format).save(path)
 
-              val readBack = spark.read.format(format).load(path)
-              assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema),
-                s"$format $sourceVersion lost CHAR/VARCHAR schema")
-              checkAnswer(
-                readBack.selectExpr("concat('<', c, '>')", "v", "concat('<', s.c, '>')"),
-                Row("<ab  >", "xy", "<z >"))
+              val vectorizedReaderModes = if (format == "orc") Seq(true, false) else Seq(true)
+              vectorizedReaderModes.foreach { vectorizedReaderEnabled =>
+                withSQLConf(
+                    SQLConf.ORC_VECTORIZED_READER_ENABLED.key ->
+                      vectorizedReaderEnabled.toString) {
+                  val readBack = spark.read.format(format).load(path)
+                  assert(DataType.equalsIgnoreNullability(readBack.schema, input.schema),
+                    s"$format $sourceVersion lost CHAR/VARCHAR schema")
+                  checkAnswer(
+                    readBack.selectExpr(
+                      "concat('<', c, '>')",
+                      "v",
+                      "concat('<', s.c, '>')",
+                      "a",
+                      "m"),
+                    Row("<ab  >", "xy", "<z >", Seq("q"), Map("k " -> "v")))
 
-              withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
-                val readOff = spark.read.format(format).load(path)
-                assert(DataType.equalsIgnoreNullability(
-                  readOff.schema,
-                  CharVarcharUtils.replaceCharVarcharWithString(input.schema)))
-              }
-              withSQLConf(
-                  SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
-                  SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
-                assert(DataType.equalsIgnoreNullability(
-                  spark.read.format(format).load(path).schema,
-                  input.schema))
+                  withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
+                    val readOff = spark.read.format(format).load(path)
+                    assert(DataType.equalsIgnoreNullability(
+                      readOff.schema,
+                      CharVarcharUtils.replaceCharVarcharWithString(input.schema)))
+                  }
+                  withSQLConf(
+                      SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                      SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+                    assert(DataType.equalsIgnoreNullability(
+                      spark.read.format(format).load(path).schema,
+                      input.schema))
+                  }
+                }
               }
             }
           }
@@ -1983,6 +1995,51 @@ class BasicCharVarcharTestSuite extends SharedSparkSession {
                 },
                 condition = "EXCEED_LIMIT_LENGTH",
                 parameters = Map("limit" -> "4"))
+            }
+          }
+        }
+      }
+
+      Seq("v1" -> "orc", "v2" -> "").foreach { case (sourceVersion, useV1List) =>
+        Seq(true, false).foreach { vectorizedReaderEnabled =>
+          withSQLConf(
+              SQLConf.USE_V1_SOURCE_LIST.key -> useV1List,
+              SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorizedReaderEnabled.toString) {
+            withTempPath { dir =>
+              val path = dir.getCanonicalPath
+              spark.range(1).selectExpr(
+                "named_struct('c', 'abcdef') AS s",
+                "array('abcdef') AS a",
+                "map('abcdef', 'ok') AS mk",
+                "map('ok', 'abcdef') AS mv")
+                .write.mode("overwrite").orc(path)
+              val readBack = spark.read.schema(
+                """s STRUCT<c: CHAR(4)>,
+                  |a ARRAY<VARCHAR(4)>,
+                  |mk MAP<CHAR(4), VARCHAR(4)>,
+                  |mv MAP<CHAR(4), VARCHAR(4)>""".stripMargin).orc(path)
+              Seq("s.c", "a", "mk", "mv").foreach { field =>
+                withClue(
+                    s"ORC $sourceVersion vectorized=$vectorizedReaderEnabled $field: ") {
+                  checkError(
+                    exception = intercept[SparkRuntimeException] {
+                      readBack.selectExpr(field).collect()
+                    },
+                    condition = "EXCEED_LIMIT_LENGTH",
+                    parameters = Map("limit" -> "4"))
+                }
+              }
+            }
+            withSQLConf(
+                SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+                SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+              withTempPath { dir =>
+                val path = dir.getCanonicalPath
+                Seq("abcdef").toDF("v").write.mode("overwrite").orc(path)
+                val readBack = spark.read.schema("v VARCHAR(4)").orc(path)
+                assert(readBack.schema.head.dataType === VarcharType(4))
+                checkAnswer(readBack, Row("abcd"))
+              }
             }
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -447,7 +447,8 @@ class DataFrameJoinSuite extends SharedSparkSession
             }
             assert(broadcastExchanges.size == 1)
             val tables = broadcastExchanges.head.collect {
-              case FileSourceScanExec(_, _, _, _, _, _, _, _, Some(tableIdent), _, _) => tableIdent
+              case FileSourceScanExec(_, _, _, _, _, _, _, _, Some(tableIdent), _, _, _) =>
+                tableIdent
             }
             assert(tables.size == 1)
             assert(tables.head ===

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1535,7 +1535,7 @@ class SubquerySuite extends SharedSparkSession
       // need to execute the query before we can examine fs.inputRDDs()
       assert(stripAQEPlan(df.queryExecution.executedPlan) match {
         case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(
-            fs @ FileSourceScanExec(_, _, _, _, partitionFilters, _, _, _, _, _, _)))) =>
+            fs @ FileSourceScanExec(_, _, _, _, partitionFilters, _, _, _, _, _, _, _)))) =>
           partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
             fs.inputRDDs().forall(
               _.asInstanceOf[FileScanRDD].filePartitions.forall(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -505,6 +505,38 @@ class DataSourceV2Suite extends SharedSparkSession with AdaptiveSparkPlanHelper 
     }
   }
 
+  test("SPARK-58814: catalog-less V2 writes recache both CHAR/VARCHAR scan modes") {
+    val format = classOf[SimpleWritableDataSource].getName
+    val boundModes = Seq(
+      Seq(
+        SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false"),
+      Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true"))
+
+    boundModes.foreach { modeConf =>
+      withSQLConf(modeConf: _*) {
+        withTempPath { file =>
+          val path = file.getCanonicalPath
+          def readData: DataFrame = spark.read.format(format).option("path", path).load()
+          def appendData(start: Long, end: Long): Unit = {
+            spark.range(start, end).select($"id" as Symbol("i"), -$"id" as Symbol("j"))
+              .write.format(format).option("path", path).mode("append").save()
+          }
+
+          appendData(0, 1)
+          val cached = readData.cache()
+          try {
+            checkAnswer(cached, Row(0, 0))
+            appendData(1, 2)
+            checkAnswer(readData, Row(0, 0) :: Row(1, -1) :: Nil)
+          } finally {
+            cached.unpersist()
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-58352: WRITING_JOB_FAILED when batch write commit and abort both fail") {
     val cls = classOf[CommitAndAbortFailingDataSource]
     checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -101,7 +101,7 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
           queryRelations.add(alias.name)
         case LogicalRelationWithTable(_, Some(catalogTable)) =>
           queryRelations.add(catalogTable.identifier.table)
-        case HiveTableRelation(tableMeta, _, _, _, _) =>
+        case HiveTableRelation(tableMeta, _, _, _, _, _) =>
           queryRelations.add(tableMeta.identifier.table)
         case _ =>
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1399,7 +1399,8 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     def getCachedTableOptions(
         qualifiedTableName: QualifiedTableName): Map[String, String] = {
       catalog.getCachedTable(qualifiedTableName) match {
-        case LogicalRelation(fsRelation: HadoopFsRelation, _, _, _, _) => fsRelation.options
+        case LogicalRelation(fsRelation: HadoopFsRelation, _, _, _, _, _) =>
+          fsRelation.options
       }
     }
 
@@ -1501,7 +1502,8 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
         case cmd: InsertIntoHadoopFsRelationCommand => cmd.options
       }.getOrElse(fail("target InsertIntoHadoopFsRelationCommand not found"))
       val sourceOptions = qe.analyzed.collect {
-        case LogicalRelation(fsRelation: HadoopFsRelation, _, _, _, _) => fsRelation.options
+        case LogicalRelation(fsRelation: HadoopFsRelation, _, _, _, _, _) =>
+          fsRelation.options
       }.find(_.get("sep").contains(";")).getOrElse(fail("source relation with sep=; not found"))
       assert(targetOptions.get("sep").contains("|"), "target write option")
       assert(sourceOptions("sep") === ";", "source read option")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{AlterColumns, AlterColumnSpec, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DefaultValueExpression, DeleteAction, DeleteFromTable, DescribeRelation, DescribeTablePartition, DropTable, InsertAction, InsertIntoStatement, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, OverwriteByExpression, OverwritePartitionsDynamic, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.CharVarcharScanMode
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
 import org.apache.spark.sql.connector.FakeV2Provider
 import org.apache.spark.sql.connector.catalog.{CatalogManager, Column, ColumnDefaultValue, Identifier, SupportsDelete, Table, TableCapability, TableCatalog, TableChange, TableContext, TableWritePrivilege, V1Table}
@@ -3512,6 +3513,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
     def cachedRelationWith(opts: java.util.Map[String, String]): DataSourceV2Relation = {
       val r = DataSourceV2Relation.create(
         cachedTable, Some(testCat), Some(ident), new CaseInsensitiveStringMap(opts))
+        .copy(charVarcharScanMode = Some(CharVarcharScanMode.PreserveNative))
       r.setTagValue(LogicalPlan.PLAN_ID_TAG, 4242L)
       r
     }
@@ -3537,6 +3539,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
     val reused = resolveWith(
       java.util.Map.of("split-size", "5"), java.util.Map.of("split-size", "5"))
     assert(reused.options.get("split-size") === "5")
+    assert(reused.charVarcharScanMode.isEmpty)
     assert(reused.getTagValue(LogicalPlan.PLAN_ID_TAG).contains(4242L),
       "matching options should reuse the cached relation")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, TableScan}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
@@ -69,7 +70,29 @@ class SaveIntoDataSourceCommandSuite extends SharedSparkSession {
     saveIntoDataSource(2)
     checkAnswer(loadData, Row(0) :: Row(1) :: Nil)
 
+    spark.catalog.clearCache()
     FakeV1DataSource.data = null
+
+    // Bound modes store Some(false)/Some(true) on LogicalRelation, so recache must match
+    // the written BaseRelation rather than sameResult against an unbound probe.
+    Seq(
+      Seq(
+        SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false"),
+      Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true")).foreach { extraConf =>
+      extraConf.foreach { case (k, v) => spark.conf.set(k, v) }
+      try {
+        saveIntoDataSource(1)
+        val boundCached = loadData.cache()
+        checkAnswer(boundCached, Row(0))
+        saveIntoDataSource(2)
+        checkAnswer(loadData, Row(0) :: Row(1) :: Nil)
+      } finally {
+        spark.catalog.clearCache()
+        extraConf.foreach { case (k, _) => spark.conf.unset(k) }
+        FakeV1DataSource.data = null
+      }
+    }
   }
 
   test("Data type support") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -73,8 +73,8 @@ class SaveIntoDataSourceCommandSuite extends SharedSparkSession {
     spark.catalog.clearCache()
     FakeV1DataSource.data = null
 
-    // Bound modes store Some(false)/Some(true) on LogicalRelation, so recache must match
-    // the written BaseRelation rather than sameResult against an unbound probe.
+    // The two bound scan modes are part of LogicalRelation identity, so recache must match the
+    // written BaseRelation rather than sameResult against an unbound probe.
     Seq(
       Seq(
         SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -27,14 +27,14 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector
 import org.apache.logging.log4j.Level
-import org.apache.orc.OrcConf.COMPRESS
+import org.apache.orc.OrcConf.{COMPRESS, FORCE_POSITIONAL_EVOLUTION}
 import org.apache.orc.OrcFile
 import org.apache.orc.OrcProto.ColumnEncoding.Kind.{DICTIONARY_V2, DIRECT, DIRECT_V2}
 import org.apache.orc.OrcProto.Stream.Kind
 import org.apache.orc.TypeDescription
 import org.apache.orc.impl.RecordReaderImpl
 
-import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException}
+import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException, SparkRuntimeException}
 import org.apache.spark.sql.{QueryTestBase, Row, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, SchemaMergeUtils}
 import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec._
@@ -635,6 +635,7 @@ abstract class OrcSuite
 }
 
 abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
+  import testImplicits._
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
@@ -668,6 +669,33 @@ abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
          |  PATH '${new File(orcTableAsDir.getAbsolutePath).toURI}'
          |)
        """.stripMargin)
+  }
+
+  test("SPARK-58814: positional ORC evolution preserves standard CHAR semantics") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      withTempPath { dir =>
+        Seq("ab").toDF("c").write.orc(dir.getCanonicalPath)
+        val result = spark.read
+          .schema("c CHAR(4)")
+          .option(FORCE_POSITIONAL_EVOLUTION.getAttribute, "true")
+          .orc(dir.getCanonicalPath)
+        checkAnswer(result.selectExpr("concat('<', c, '>')"), Row("<ab  >"))
+      }
+
+      withTempPath { dir =>
+        Seq("abcdef").toDF("c").write.orc(dir.getCanonicalPath)
+        val result = spark.read
+          .schema("c CHAR(4)")
+          .option(FORCE_POSITIONAL_EVOLUTION.getAttribute, "true")
+          .orc(dir.getCanonicalPath)
+        checkError(
+          exception = intercept[SparkRuntimeException] {
+            result.collect()
+          },
+          condition = "EXCEED_LIMIT_LENGTH",
+          parameters = Map("limit" -> "4"))
+      }
+    }
   }
 
   test("Check BloomFilter creation") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -399,6 +399,29 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     assertCached(sql("SELECT * FROM jsonTable"), 0)
   }
 
+  test("SPARK-58814: insert recaches both bound CHAR/VARCHAR scan modes") {
+    Seq(
+      Seq(
+        SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false"),
+      Seq(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true")).foreach { modeConf =>
+      withSQLConf(modeConf: _*) {
+        sql("INSERT OVERWRITE TABLE jsonTable SELECT a, b FROM jt")
+        spark.catalog.cacheTable("jsonTable")
+        try {
+          checkAnswer(sql("SELECT * FROM jsonTable"), (1 to 10).map(i => Row(i, s"str$i")))
+          sql("INSERT OVERWRITE TABLE jsonTable SELECT a * 2, b FROM jt")
+          assertCached(sql("SELECT * FROM jsonTable"))
+          checkAnswer(
+            sql("SELECT * FROM jsonTable"),
+            (1 to 10).map(i => Row(i * 2, s"str$i")))
+        } finally {
+          spark.catalog.uncacheTable("jsonTable")
+        }
+      }
+    }
+  }
+
   test("it's not allowed to insert into a relation that is not an InsertableRelation") {
     sql(
       """

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -187,7 +187,7 @@ object HiveAnalysis extends Rule[LogicalPlan] {
 
       InsertIntoHiveDirCommand(isLocal, storage, child, overwrite, child.output.map(_.name))
 
-    case DeleteFromTable(SubqueryAlias(_, HiveTableRelation(table, _, _, _, _)), _) =>
+    case DeleteFromTable(SubqueryAlias(_, HiveTableRelation(table, _, _, _, _, _)), _) =>
       throw QueryCompilationErrors.unsupportedTableOperationError(
         table.identifier,
         "DELETE")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive
 
 import java.io.File
 
+import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.classic.Dataset
@@ -26,6 +27,7 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.datasources.{CatalogFileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.RDDBlockId
 import org.apache.spark.storage.StorageLevel.{DISK_ONLY, MEMORY_ONLY}
@@ -34,6 +36,7 @@ import org.apache.spark.util.Utils
 
 class CachedTableSuite extends QueryTest with TestHiveSingleton {
   import hiveContext._
+  import testImplicits._
 
   def rddIdOf(tableName: String): Int = {
     val plan = table(tableName).queryExecution.sparkPlan
@@ -86,6 +89,60 @@ class CachedTableSuite extends QueryTest with TestHiveSingleton {
       table("src").collect().toSeq ++ table("src").collect().toSeq)
 
     sql("DROP TABLE cachedTable")
+  }
+
+  test("SPARK-58814: Hive ORC caches do not cross CHAR/VARCHAR scan modes") {
+    val tableName = "hive_char_cache"
+    withTempPath { path =>
+      Seq("abcdef").toDF("v").write.orc(path.getCanonicalPath)
+      withTable(tableName) {
+        sql(
+          s"""CREATE EXTERNAL TABLE $tableName (v CHAR(4))
+             |STORED AS ORC LOCATION '${path.toURI}'""".stripMargin)
+
+        withSQLConf(
+            HiveUtils.CONVERT_METASTORE_ORC.key -> "true",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+            SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
+          val preserveRead = table(tableName).cache()
+          checkAnswer(preserveRead, Row("abcd"))
+          assertCached(preserveRead)
+        }
+        withSQLConf(
+            HiveUtils.CONVERT_METASTORE_ORC.key -> "true",
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+          val standardRead = table(tableName)
+          assertCached(standardRead, 0)
+          checkError(
+            exception = intercept[SparkRuntimeException] {
+              standardRead.collect()
+            },
+            condition = "EXCEED_LIMIT_LENGTH",
+            parameters = Map("limit" -> "4"))
+        }
+
+        spark.catalog.clearCache()
+        Seq("ab").toDF("v").write.mode("overwrite").orc(path.getCanonicalPath)
+        sql(s"REFRESH TABLE $tableName")
+        withSQLConf(
+            HiveUtils.CONVERT_METASTORE_ORC.key -> "true",
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+          val standardRead = table(tableName).cache()
+          checkAnswer(standardRead, Row("ab  "))
+          assertCached(standardRead)
+        }
+        withSQLConf(
+            HiveUtils.CONVERT_METASTORE_ORC.key -> "true",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+            SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
+          val preserveRead = table(tableName)
+          assertCached(preserveRead, 0)
+          checkAnswer(preserveRead, Row("ab  "))
+        }
+      }
+    }
   }
 
   test("Drop cached table") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Parent: [SPARK-58794](https://issues.apache.org/jira/browse/SPARK-58794) (first-class CHAR/VARCHAR under `spark.sql.charVarchar.standardSemantics.enabled`).

- Under `standardSemantics`, keep Spark responsible for CHAR/VARCHAR assignment and scan checks on ORC by requesting physical ORC STRING. The row decoder accepts all `StringType` subtypes recursively. Preserve-only mode retains native ORC CHAR/VARCHAR enforcement.
- Bind a typed CHAR/VARCHAR scan mode to first-class relations so preserve-only and standard scans have distinct cache identities. Writes, refresh, rename, and micro-batch updates recache every bound mode while non-CHAR relations remain unbound.
- Add SPARK-58814 coverage for major formats under `standardSemantics`:
  - Parquet/ORC nested CHAR/VARCHAR (struct/array/map keys) on file-only inference, V1 and V2
  - Avro nested inference plus explicit-schema pad/overflow (V1 and V2)
  - CSV/JSON user-schema scans, length checks, and catalog INSERT assignment/overflow
  - Cross-flag: `standardSemantics=false` collapses to STRING; `preserveCharVarcharTypeInfo` keeps types

Parquet already embeds Spark schema JSON in footer metadata, so nested CHAR/VARCHAR inference needed tests rather than a writer change.

### Why are the changes needed?

Without this, Spark-written files and user-specified schemas do not keep first-class CHAR/VARCHAR through round-trips in the remaining format gaps. For ORC specifically, an explicit `schema("c CHAR(4)")` read sent native ORC `char(n)` via `MAPRED_INPUT_SCHEMA`, so ORC truncated `"abcdef"` to `"abcd"` before `charTypeReadSideCheck` and `EXCEED_LIMIT_LENGTH` never fired.

### Does this PR introduce _any_ user-facing change?

Yes, when `spark.sql.charVarchar.standardSemantics.enabled` is true (unreleased / master):

- ORC no longer silently truncates oversized CHAR/VARCHAR values on schema-specified reads; Spark rejects them with `EXCEED_LIMIT_LENGTH`.
- Parquet/ORC/Avro file-only inference and CSV/JSON user schemas preserve CHAR/VARCHAR types and apply pad/length and INSERT assignment as covered by the new tests.

### How was this patch tested?

New tests in `BasicCharVarcharTestSuite` (`SPARK-58814: major formats preserve CHAR/VARCHAR schemas and values`) and `AvroSuite` (V1 and V2). Also ran existing ORC query suites and scalastyle:

```
build/sbt "sql/testOnly org.apache.spark.sql.BasicCharVarcharTestSuite -- -z SPARK-58814"
build/sbt "avro/testOnly org.apache.spark.sql.avro.AvroV1Suite -- -z SPARK-58814"
build/sbt "avro/testOnly org.apache.spark.sql.avro.AvroV2Suite -- -z SPARK-58814"
build/sbt "sql/testOnly org.apache.spark.sql.execution.datasources.orc.OrcV1QuerySuite"
build/sbt "sql/testOnly org.apache.spark.sql.execution.datasources.orc.OrcV2QuerySuite"
build/sbt "sql/scalastyle" "sql/Test/scalastyle" "avro/scalastyle" "avro/Test/scalastyle"
```

Follow-up cache and scan-mode verification:

```
build/sbt -Dsbt.override.build.repos=true   'sql/testOnly org.apache.spark.sql.CachedTableSuite -- -z "RENAME TABLE" -z "CHAR/VARCHAR"'
build/sbt -Dsbt.override.build.repos=true   'sql/testOnly org.apache.spark.sql.streaming.test.DataStreamTableAPISuite -- -z "micro-batch V2 write"'
build/sbt -Dsbt.override.build.repos=true   'sql/testOnly org.apache.spark.sql.connector.DataSourceV2Suite -- -z SPARK-58814'
build/sbt -Dsbt.override.build.repos=true   ';sql/compile;sql/Test/compile;sql/scalastyle;sql/Test/scalastyle'
```

The focused rename/cache tests passed 5/5, micro-batch cache tests passed 2/2, and SQL compile and scalastyle passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6
