### PR TITLE
[SPARK-58582][PS][FOLLOWUP] Keep integral operands in integer space for NumPy fmod

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -152,7 +152,11 @@ def _copysign_func(c1: Column, c2: Column) -> Column:
 def _fmod_func(c1: Column, c2: Column) -> Column:
     c1_double = c1.cast("double")
     c2_double = c2.cast("double")
+    integral_types = ["tinyint", "smallint", "int", "bigint"]
 
+    # Dispatched on type twice: floating operands need a NaN for a zero divisor, and among the
+    # rest, at the end of the branch below, only integral operands can take the remainder in
+    # integer space.
     return F.when(
         F.typeof(c1).isin("float", "double") | F.typeof(c2).isin("float", "double"),
         F.when(c1.isNull() | F.isnan(c1), c1_double)
@@ -160,9 +164,17 @@ def _fmod_func(c1: Column, c2: Column) -> Column:
         .when(c2_double == 0, F.lit(float("nan")))
         .otherwise(F.try_mod(c1_double, c2_double)),
     ).otherwise(
+        # Non-floating operands, where NumPy normalizes a zero divisor to 0 instead of a NaN.
         F.when(c1.isNull() | F.isnan(c1), c1_double)
         .when(c2.isNull() | F.isnan(c2), c2_double)
         .when(c2_double == 0, F.lit(0.0))
+        # Casting an operand above 2**53 to double drops its low bits, turning 9007199254740993
+        # into 9007199254740992, so integral operands take the remainder as longs. A decimal
+        # column cannot be named in a typeof test, so it falls through to the double casts.
+        .when(
+            F.typeof(c1).isin(integral_types) & F.typeof(c2).isin(integral_types),
+            F.try_mod(c1.cast("long"), c2.cast("long")).cast("double"),
+        )
         .otherwise(F.try_mod(c1_double, c2_double))
     )
 

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -154,28 +154,26 @@ def _fmod_func(c1: Column, c2: Column) -> Column:
     c2_double = c2.cast("double")
     integral_types = ["tinyint", "smallint", "int", "bigint"]
 
-    # Dispatched on type twice: floating operands need a NaN for a zero divisor, and among the
-    # rest, at the end of the branch below, only integral operands can take the remainder in
-    # integer space.
-    return F.when(
-        F.typeof(c1).isin("float", "double") | F.typeof(c2).isin("float", "double"),
+    return (
+        # A null or a nan propagates for every operand type.
         F.when(c1.isNull() | F.isnan(c1), c1_double)
         .when(c2.isNull() | F.isnan(c2), c2_double)
-        .when(c2_double == 0, F.lit(float("nan")))
-        .otherwise(F.try_mod(c1_double, c2_double)),
-    ).otherwise(
-        # Non-floating operands, where NumPy normalizes a zero divisor to 0 instead of a NaN.
-        F.when(c1.isNull() | F.isnan(c1), c1_double)
-        .when(c2.isNull() | F.isnan(c2), c2_double)
-        .when(c2_double == 0, F.lit(0.0))
-        # Casting an operand above 2**53 to double drops its low bits, turning 9007199254740993
-        # into 9007199254740992, so integral operands take the remainder as longs. A decimal
-        # column cannot be named in a typeof test, so it falls through to the double casts.
+        # Integral operands take the remainder as longs: a double cannot hold 9007199254740993.
         .when(
             F.typeof(c1).isin(integral_types) & F.typeof(c2).isin(integral_types),
-            F.try_mod(c1.cast("long"), c2.cast("long")).cast("double"),
+            F.when(c2_double == 0, F.lit(0.0)).otherwise(
+                F.try_mod(c1.cast("long"), c2.cast("long")).cast("double")
+            ),
         )
-        .otherwise(F.try_mod(c1_double, c2_double))
+        # Floating operands, where a zero divisor is nan rather than the 0 above.
+        .when(
+            F.typeof(c1).isin("float", "double") | F.typeof(c2).isin("float", "double"),
+            F.when(c2_double == 0, F.lit(float("nan"))).otherwise(F.try_mod(c1_double, c2_double)),
+        )
+        # A decimal falls through here, since typeof carries its precision, as in decimal(10,2).
+        # np.fmod raises on Decimal objects, so there is no NumPy behavior to match: a zero
+        # divisor returns 0 and any other divisor takes the remainder in double.
+        .otherwise(F.when(c2_double == 0, F.lit(0.0)).otherwise(F.try_mod(c1_double, c2_double)))
     )
 
 

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -313,6 +313,27 @@ class NumPyCompatTestsMixin:
 
             self.assert_eq(np.fmod(psdf.x1, psdf.x2), np.fmod(pdf.x1, pdf.x2), almost=True)
 
+        # Integral operands above 2**53, where casting an operand to double would drop its low
+        # bits: fmod(9007199254740993, 2) is 1, not 0. Compared exactly, since almost=True would
+        # accept an off-by-one at these magnitudes.
+        pdf = pd.DataFrame(
+            {
+                "x1": [9007199254740993, 9007199254740995, -9007199254740993, 4611686018427387905],
+                "x2": [2, 4, 2, 1000000000],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.fmod(psdf.x1, psdf.x2), np.fmod(pdf.x1, pdf.x2).astype("float64"))
+
+        # almost=True treats -0.0 and 0.0 as equal, so check the sign of zero explicitly:
+        # an integral remainder is never negative zero, unlike a double one.
+        pdf = pd.DataFrame({"x1": [-64, -2, 0, 64], "x2": [2, 2, 3, 2]})
+        psdf = ps.from_pandas(pdf)
+
+        result = np.fmod(psdf.x1, psdf.x2)
+        expected = np.fmod(pdf.x1, pdf.x2)
+        self.assert_eq(np.signbit(result.to_pandas()), np.signbit(expected))
+
     def test_np_modf(self):
         # np.modf(x) returns a tuple (fractional part, integral part).
         for pdf in (


### PR DESCRIPTION
### What changes were proposed in this pull request?

`_fmod_func` cast both operands to double before taking the remainder, including on the branch reached only when neither operand is floating. Integral operands now take the remainder as longs, and only the result is cast back to double.

### Why are the changes needed?

A double carries 53 bits of mantissa, so an integral operand above 2**53 was rounded before the remainder was taken: `np.fmod(9007199254740993, 2)` gave `0.0` where pandas gives `1`. The same cast also returned `-0.0` for `-64 % 2`, a sign of zero an integral remainder cannot have. The `pandas_udf` this mapping replaced called NumPy directly and was exact.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New rows in `test_np_fmod` for integral operands above 2**53, compared exactly since a relative tolerance accepts an off-by-one at those magnitudes, plus an `np.signbit` assertion for the sign of zero. Both fail without the change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
