### PR TITLE
[SPARK-59031][CONNECT][PYTHON] Support best-effort commands that no-op on servers missing the API

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -33,6 +33,7 @@ import time
 import traceback
 import urllib.parse
 import uuid
+import warnings
 import weakref
 from dataclasses import dataclass, fields
 from typing import (
@@ -128,6 +129,34 @@ if TYPE_CHECKING:
 
 PYSPARK_ROOT = os.path.dirname(pyspark.__file__)
 _OPERATION_ID_METADATA_KEY = "spark-connect-operation-id"
+
+
+# Error conditions a Spark Connect server raises when it does not implement an API that the
+# client requested. Spark Connect is only guaranteed to be backward compatible (an older client
+# talking to a newer server); a newer client may send a request that an older server does not
+# understand. When that happens the server rejects the request with one of these conditions
+# without performing any work. A request issued with ``optional=True`` downgrades such a failure
+# to a warning and behaves as a no-op instead of raising, giving graceful newer-client /
+# older-server handling. Keep this restricted to conditions that unambiguously mean "the server
+# does not implement this API"; do not add conditions that can also signal a genuine user error.
+_UNSUPPORTED_API_ERROR_CONDITIONS = frozenset({"CONNECT_INVALID_PLAN.NO_HANDLER_FOR_EXTENSION"})
+
+
+def _is_unsupported_api_error(error: BaseException) -> bool:
+    """Return True if ``error`` is a Spark Connect server rejection of an unsupported API."""
+    return (
+        isinstance(error, SparkConnectException)
+        and error.getCondition() in _UNSUPPORTED_API_ERROR_CONDITIONS
+    )
+
+
+def _warn_unsupported_api(error: SparkConnectException) -> None:
+    warnings.warn(
+        f"The Spark Connect server does not support this API and the request was skipped "
+        f"(error condition: {error.getCondition()}). This can happen when a newer client "
+        f"connects to an older server.",
+        RuntimeWarning,
+    )
 
 
 @dataclass(frozen=True)
@@ -1424,10 +1453,22 @@ class SparkConnectClient(object):
         return result
 
     def execute_command(
-        self, command: pb2.Command, observations: Optional[Dict[str, Observation]] = None
+        self,
+        command: pb2.Command,
+        observations: Optional[Dict[str, Observation]] = None,
+        optional: bool = False,
     ) -> Tuple[Optional[pd.DataFrame], Dict[str, Any], ExecutionInfo]:
         """
         Execute given command.
+
+        If ``optional`` is True, the command is sent on a best-effort basis: when the server
+        does not implement the API (for example, a newer client issued the request to an older
+        server), the failure is downgraded to a warning and this returns an empty no-op result
+        instead of raising. Only set ``optional`` for commands whose effect is safe to skip on
+        servers that do not support them; any other failure is always re-raised.
+
+        .. versionchanged:: 4.4.0
+            Added the ``optional`` parameter.
         """
         if logger.isEnabledFor(logging.DEBUG):
             # inside an if statement to not incur a performance cost converting proto to string
@@ -1435,9 +1476,15 @@ class SparkConnectClient(object):
             logger.debug(f"Execute command for command {self._proto_to_string(command, True)}")
         req = self._execute_plan_request_with_metadata()
         self._set_command_in_plan(req.plan, command)
-        data, _, metrics, observed_metrics, properties = self._execute_and_fetch(
-            req, observations or {}
-        )
+        try:
+            data, _, metrics, observed_metrics, properties = self._execute_and_fetch(
+                req, observations or {}
+            )
+        except SparkConnectException as e:
+            if optional and _is_unsupported_api_error(e):
+                _warn_unsupported_api(e)
+                return (None, {}, ExecutionInfo(None, None, req.operation_id))
+            raise
         # Create a query execution object.
         ei = ExecutionInfo(metrics, observed_metrics, req.operation_id)
         if data is not None:
@@ -1446,10 +1493,20 @@ class SparkConnectClient(object):
             return (None, properties, ei)
 
     def execute_command_as_iterator(
-        self, command: pb2.Command, observations: Optional[Dict[str, Observation]] = None
+        self,
+        command: pb2.Command,
+        observations: Optional[Dict[str, Observation]] = None,
+        optional: bool = False,
     ) -> Iterator[Dict[str, Any]]:
         """
         Execute given command. Similar to execute_command, but the value is returned using yield.
+
+        If ``optional`` is True, the command is sent on a best-effort basis: when the server does
+        not implement the API and rejects the request before producing any response, the failure
+        is downgraded to a warning and iteration ends without yielding. See ``execute_command``.
+
+        .. versionchanged:: 4.4.0
+            Added the ``optional`` parameter.
         """
         if logger.isEnabledFor(logging.DEBUG):
             # inside an if statement to not incur a performance cost converting proto to string
@@ -1459,16 +1516,26 @@ class SparkConnectClient(object):
             )
         req = self._execute_plan_request_with_metadata()
         self._set_command_in_plan(req.plan, command)
-        for response in self._execute_and_fetch_as_iterator(req, observations or {}):
-            if isinstance(response, dict):
-                yield response
-            else:
-                raise PySparkValueError(
-                    errorClass="UNKNOWN_RESPONSE",
-                    messageParameters={
-                        "response": str(response),
-                    },
-                )
+        yielded = False
+        try:
+            for response in self._execute_and_fetch_as_iterator(req, observations or {}):
+                if isinstance(response, dict):
+                    yielded = True
+                    yield response
+                else:
+                    raise PySparkValueError(
+                        errorClass="UNKNOWN_RESPONSE",
+                        messageParameters={
+                            "response": str(response),
+                        },
+                    )
+        except SparkConnectException as e:
+            # Only downgrade to a no-op when the server rejected the API before streaming any
+            # response; if partial results were already delivered, degrading would be unsafe.
+            if optional and not yielded and _is_unsupported_api_error(e):
+                _warn_unsupported_api(e)
+                return
+            raise
 
     def same_semantics(self, plan: pb2.Plan, other: pb2.Plan) -> bool:
         """

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -135,14 +135,14 @@ _OPERATION_ID_METADATA_KEY = "spark-connect-operation-id"
 # client requested. Spark Connect is only guaranteed to be backward compatible (an older client
 # talking to a newer server); a newer client may send a request that an older server does not
 # understand. When that happens the server rejects the request with one of these conditions
-# without performing any work. A request issued with ``optional=True`` downgrades such a failure
-# to a warning and behaves as a no-op instead of raising, giving graceful newer-client /
-# older-server handling. Keep this restricted to conditions that unambiguously mean "the server
+# without performing any work. A request issued with ``skip_if_unsupported=True`` downgrades such
+# a failure to a warning and behaves as a no-op instead of raising, giving graceful newer-client
+# / older-server handling. Keep this restricted to conditions that unambiguously mean "the server
 # does not implement this API"; do not add conditions that can also signal a genuine user error.
 _UNSUPPORTED_API_ERROR_CONDITIONS = frozenset({"CONNECT_INVALID_PLAN.NO_HANDLER_FOR_EXTENSION"})
 
 
-def _is_unsupported_api_error(error: BaseException) -> bool:
+def _is_unsupported_api_error(error: Exception) -> bool:
     """Return True if ``error`` is a Spark Connect server rejection of an unsupported API."""
     return (
         isinstance(error, SparkConnectException)
@@ -1456,19 +1456,19 @@ class SparkConnectClient(object):
         self,
         command: pb2.Command,
         observations: Optional[Dict[str, Observation]] = None,
-        optional: bool = False,
+        skip_if_unsupported: bool = False,
     ) -> Tuple[Optional[pd.DataFrame], Dict[str, Any], ExecutionInfo]:
         """
         Execute given command.
 
-        If ``optional`` is True, the command is sent on a best-effort basis: when the server
-        does not implement the API (for example, a newer client issued the request to an older
-        server), the failure is downgraded to a warning and this returns an empty no-op result
-        instead of raising. Only set ``optional`` for commands whose effect is safe to skip on
-        servers that do not support them; any other failure is always re-raised.
+        If ``skip_if_unsupported`` is True, the command is sent on a best-effort basis: when the
+        server does not implement the API (for example, a newer client issued the request to an
+        older server), the failure is downgraded to a warning and this returns an empty no-op
+        result instead of raising. Only set ``skip_if_unsupported`` for commands whose effect is
+        safe to skip on servers that do not support them; any other failure is always re-raised.
 
         .. versionchanged:: 4.4.0
-            Added the ``optional`` parameter.
+            Added the ``skip_if_unsupported`` parameter.
         """
         if logger.isEnabledFor(logging.DEBUG):
             # inside an if statement to not incur a performance cost converting proto to string
@@ -1481,7 +1481,7 @@ class SparkConnectClient(object):
                 req, observations or {}
             )
         except SparkConnectException as e:
-            if optional and _is_unsupported_api_error(e):
+            if skip_if_unsupported and _is_unsupported_api_error(e):
                 _warn_unsupported_api(e)
                 return (None, {}, ExecutionInfo(None, None, req.operation_id))
             raise
@@ -1496,17 +1496,18 @@ class SparkConnectClient(object):
         self,
         command: pb2.Command,
         observations: Optional[Dict[str, Observation]] = None,
-        optional: bool = False,
+        skip_if_unsupported: bool = False,
     ) -> Iterator[Dict[str, Any]]:
         """
         Execute given command. Similar to execute_command, but the value is returned using yield.
 
-        If ``optional`` is True, the command is sent on a best-effort basis: when the server does
-        not implement the API and rejects the request before producing any response, the failure
-        is downgraded to a warning and iteration ends without yielding. See ``execute_command``.
+        If ``skip_if_unsupported`` is True, the command is sent on a best-effort basis: when the
+        server does not implement the API and rejects the request before producing any response,
+        the failure is downgraded to a warning and iteration ends without yielding. See
+        ``execute_command``.
 
         .. versionchanged:: 4.4.0
-            Added the ``optional`` parameter.
+            Added the ``skip_if_unsupported`` parameter.
         """
         if logger.isEnabledFor(logging.DEBUG):
             # inside an if statement to not incur a performance cost converting proto to string
@@ -1532,7 +1533,7 @@ class SparkConnectClient(object):
         except SparkConnectException as e:
             # Only downgrade to a no-op when the server rejected the API before streaming any
             # response; if partial results were already delivered, degrading would be unsafe.
-            if optional and not yielded and _is_unsupported_api_error(e):
+            if skip_if_unsupported and not yielded and _is_unsupported_api_error(e):
                 _warn_unsupported_api(e)
                 return
             raise

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -19,6 +19,7 @@ import unittest
 import uuid
 from collections.abc import Generator
 from typing import Any, Optional, Union
+from unittest import mock
 
 from pyspark.testing.connectutils import connect_requirement_message, should_test_connect
 from pyspark.testing.utils import eventually
@@ -34,7 +35,10 @@ if should_test_connect:
 
     import pyspark.sql.connect.proto as proto
     from pyspark.errors import PySparkRuntimeError
-    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
+    from pyspark.errors.exceptions.connect import (
+        SparkConnectException,
+        SparkConnectGrpcException,
+    )
     from pyspark.sql.connect.client import DefaultChannelBuilder, SparkConnectClient
     from pyspark.sql.connect.client.core import RpcDeadlines
     from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
@@ -1010,6 +1014,71 @@ class SparkConnectClientTestCase(unittest.TestCase):
         rel, captured = make_relation(RpcDeadlines.disabled())
         rel.__del__()
         self.assertIsNone(captured["timeout"])
+
+    def _unsupported_api_error(self):
+        # Mirrors what an older server raises for an extension API it does not implement,
+        # i.e. InvalidInputErrors.noHandlerFoundForExtension on the server side.
+        return SparkConnectGrpcException(
+            message="No handler found for extension type: foo.Bar",
+            errorClass="CONNECT_INVALID_PLAN.NO_HANDLER_FOR_EXTENSION",
+        )
+
+    def test_execute_command_optional_skips_unsupported_api(self):
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        self.addCleanup(client.close)
+        command = proto.Command()
+
+        def _raise(*args, **kwargs):
+            raise self._unsupported_api_error()
+
+        # _set_command_in_plan is stubbed out because it issues a config RPC that would block
+        # against the fake endpoint; the request payload is irrelevant to the tested behavior.
+        with (
+            mock.patch.object(client, "_set_command_in_plan"),
+            mock.patch.object(client, "_execute_and_fetch", side_effect=_raise),
+        ):
+            # optional=True downgrades the unsupported-API failure to a warning + no-op result.
+            with self.assertWarns(RuntimeWarning):
+                data, properties, _ = client.execute_command(command, optional=True)
+            self.assertIsNone(data)
+            self.assertEqual(properties, {})
+            # The default (optional=False) still surfaces the failure.
+            with self.assertRaises(SparkConnectException):
+                client.execute_command(command)
+
+    def test_execute_command_optional_reraises_other_errors(self):
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        self.addCleanup(client.close)
+        command = proto.Command()
+
+        def _raise(*args, **kwargs):
+            raise SparkConnectGrpcException(message="boom", errorClass="DIVIDE_BY_ZERO")
+
+        with (
+            mock.patch.object(client, "_set_command_in_plan"),
+            mock.patch.object(client, "_execute_and_fetch", side_effect=_raise),
+        ):
+            # optional=True must not swallow failures that are not unsupported-API rejections.
+            with self.assertRaises(SparkConnectException):
+                client.execute_command(command, optional=True)
+
+    def test_execute_command_as_iterator_optional_skips_unsupported_api(self):
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        self.addCleanup(client.close)
+        command = proto.Command()
+
+        def _raise(*args, **kwargs):
+            raise self._unsupported_api_error()
+
+        with (
+            mock.patch.object(client, "_set_command_in_plan"),
+            mock.patch.object(client, "_execute_and_fetch_as_iterator", side_effect=_raise),
+        ):
+            with self.assertWarns(RuntimeWarning):
+                results = list(client.execute_command_as_iterator(command, optional=True))
+            self.assertEqual(results, [])
+            with self.assertRaises(SparkConnectException):
+                list(client.execute_command_as_iterator(command))
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -1023,7 +1023,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
             errorClass="CONNECT_INVALID_PLAN.NO_HANDLER_FOR_EXTENSION",
         )
 
-    def test_execute_command_optional_skips_unsupported_api(self):
+    def test_execute_command_skip_if_unsupported_skips_unsupported_api(self):
         client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         self.addCleanup(client.close)
         command = proto.Command()
@@ -1037,16 +1037,16 @@ class SparkConnectClientTestCase(unittest.TestCase):
             mock.patch.object(client, "_set_command_in_plan"),
             mock.patch.object(client, "_execute_and_fetch", side_effect=_raise),
         ):
-            # optional=True downgrades the unsupported-API failure to a warning + no-op result.
+            # skip_if_unsupported=True downgrades the unsupported-API failure to a warning + no-op.
             with self.assertWarns(RuntimeWarning):
-                data, properties, _ = client.execute_command(command, optional=True)
+                data, properties, _ = client.execute_command(command, skip_if_unsupported=True)
             self.assertIsNone(data)
             self.assertEqual(properties, {})
-            # The default (optional=False) still surfaces the failure.
+            # The default (skip_if_unsupported=False) still surfaces the failure.
             with self.assertRaises(SparkConnectException):
                 client.execute_command(command)
 
-    def test_execute_command_optional_reraises_other_errors(self):
+    def test_execute_command_skip_if_unsupported_reraises_other_errors(self):
         client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         self.addCleanup(client.close)
         command = proto.Command()
@@ -1058,11 +1058,11 @@ class SparkConnectClientTestCase(unittest.TestCase):
             mock.patch.object(client, "_set_command_in_plan"),
             mock.patch.object(client, "_execute_and_fetch", side_effect=_raise),
         ):
-            # optional=True must not swallow failures that are not unsupported-API rejections.
+            # skip_if_unsupported must not swallow failures that are not unsupported-API rejections.
             with self.assertRaises(SparkConnectException):
-                client.execute_command(command, optional=True)
+                client.execute_command(command, skip_if_unsupported=True)
 
-    def test_execute_command_as_iterator_optional_skips_unsupported_api(self):
+    def test_execute_command_as_iterator_skip_if_unsupported_skips_unsupported_api(self):
         client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         self.addCleanup(client.close)
         command = proto.Command()
@@ -1075,7 +1075,9 @@ class SparkConnectClientTestCase(unittest.TestCase):
             mock.patch.object(client, "_execute_and_fetch_as_iterator", side_effect=_raise),
         ):
             with self.assertWarns(RuntimeWarning):
-                results = list(client.execute_command_as_iterator(command, optional=True))
+                results = list(
+                    client.execute_command_as_iterator(command, skip_if_unsupported=True)
+                )
             self.assertEqual(results, [])
             with self.assertRaises(SparkConnectException):
                 list(client.execute_command_as_iterator(command))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a `skip_if_unsupported` flag (default `False`) to the Spark Connect Python client's `execute_command` and `execute_command_as_iterator`. When set, and the server rejects the command with `CONNECT_INVALID_PLAN.NO_HANDLER_FOR_EXTENSION` (raised when the server has no handler for an extension API), the client emits a `RuntimeWarning` and returns a no-op instead of raising. Any other failure is always re-raised; the iterator path only downgrades when no response was streamed yet. No proto change.

### Why are the changes needed?

Spark Connect is only backward compatible (older client -> newer server). A newer client reaching an older server (e.g. during a rollback) fails hard even for advisory commands that are safe to skip. This gives callers an explicit, per-request way to no-op such commands instead.

### Does this PR introduce _any_ user-facing change?

No. The parameter defaults to `False`, so behavior is unchanged unless a caller opts in.

### How was this patch tested?

New unit tests in `test_client.py`: `skip_if_unsupported=True` warns and no-ops on the unsupported-API rejection (default still raises); it does not swallow unrelated errors; and the iterator variant warns and yields nothing.

### Was this patch authored or co-authored using generative AI tooling?

No.
