### PR TITLE
[SPARK-58912][ML][FOLLOWUP] Avoid intermediate collections in CountVectorizer transform

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -326,9 +326,10 @@ class CountVectorizerModel(
       }
       val effectiveMinTF = if (localMinTF >= 1.0) localMinTF else tokenCount * localMinTF
       val effectiveCounts = if (localBinary) {
-        termCounts.filter(_._2 >= effectiveMinTF).map(p => (p._1, 1.0)).toSeq
+        termCounts.iterator.filter(_._2 >= effectiveMinTF).map(p => (p._1, 1.0)).toSeq
       } else {
-        termCounts.filter(_._2 >= effectiveMinTF).map(p => (p._1, p._2.toDouble)).toSeq
+        termCounts.iterator
+          .filter(_._2 >= effectiveMinTF).map(p => (p._1, p._2.toDouble)).toSeq
       }
 
       Vectors.sparse(dictSize, effectiveCounts)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up to #58170 starts the `CountVectorizerModel` count filtering and conversion
pipelines from an iterator for both binary and non-binary output.

### Why are the changes needed?

`OpenHashMap` is a strict `Iterable`, so calling `filter` and `map` on it materializes intermediate
collections for every transformed document. Using its iterator keeps those operations lazy and
materializes only the sequence required by `Vectors.sparse`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not run. This only changes collection evaluation from strict to lazy; existing
`CountVectorizerSuite` transform tests cover the output behavior. `git diff --check` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
