### PR TITLE
[SPARK-58856][ML][FOLLOWUP] Assign tree leaf indices in place

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala
@@ -136,23 +136,19 @@ private[ml] object Node {
     new LeafNode(0.0, 0.0, ImpurityCalculator.getCalculator("gini", Array.empty, 0))
   }
 
-  /** Return a copy of the tree with left-to-right DFS indices assigned to leaves. */
+  /** Assign left-to-right DFS indices to leaves and return the same tree. */
   private[ml] def withLeafIndices(rootNode: Node): Node = {
-    withLeafIndices(rootNode, 0)._1
-  }
-
-  private def withLeafIndices(node: Node, nextLeafIndex: Int): (Node, Int) = {
-    node match {
+    var nextLeafIndex = 0
+    def assignLeafIndices(node: Node): Unit = node match {
       case n: LeafNode =>
-        (new LeafNode(n.prediction, n.impurity, n.impurityStats, nextLeafIndex),
-          nextLeafIndex + 1)
+        n.leafIndex = nextLeafIndex
+        nextLeafIndex += 1
       case n: InternalNode =>
-        val (leftChild, nextIndex) = withLeafIndices(n.leftChild, nextLeafIndex)
-        val (rightChild, endIndex) = withLeafIndices(n.rightChild, nextIndex)
-        val newNode = new InternalNode(n.prediction, n.impurity, n.gain, leftChild, rightChild,
-          n.split, n.impurityStats)
-        (newNode, endIndex)
+        assignLeafIndices(n.leftChild)
+        assignLeafIndices(n.rightChild)
     }
+    assignLeafIndices(rootNode)
+    rootNode
   }
 }
 
@@ -165,7 +161,7 @@ class LeafNode private[ml] (
     override val prediction: Double,
     override val impurity: Double,
     override private[ml] val impurityStats: ImpurityCalculator,
-    private[tree] val leafIndex: Int = -1) extends Node {
+    private[tree] var leafIndex: Int = -1) extends Node {
 
   override def toString: String =
     s"LeafNode(prediction = $prediction, impurity = $impurity)"

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -490,7 +490,8 @@ private[ml] object DecisionTreeClassifierSuite extends SparkFunSuite {
       dt: DecisionTreeClassifier,
       categoricalFeatures: Map[Int, Int],
       numClasses: Int): Unit = {
-    val numFeatures = data.first().features.size
+    val features = data.first().features
+    val numFeatures = features.size
     val oldStrategy = dt.getOldStrategy(categoricalFeatures, numClasses)
     val oldTree = OldDecisionTree.train(data.map(OldLabeledPoint.fromML), oldStrategy)
     val newData: DataFrame = TreeTests.setMetadata(data, categoricalFeatures, numClasses)
@@ -499,6 +500,7 @@ private[ml] object DecisionTreeClassifierSuite extends SparkFunSuite {
     val oldTreeAsNew = DecisionTreeClassificationModel.fromOld(
       oldTree, newTree.parent.asInstanceOf[DecisionTreeClassifier], categoricalFeatures)
     TreeTests.checkEqual(oldTreeAsNew, newTree)
+    assert(oldTreeAsNew.predictLeaf(features) === newTree.predictLeaf(features))
     assert(newTree.numFeatures === numFeatures)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -272,7 +272,8 @@ private[ml] object DecisionTreeRegressorSuite extends SparkFunSuite {
       data: RDD[LabeledPoint],
       dt: DecisionTreeRegressor,
       categoricalFeatures: Map[Int, Int]): Unit = {
-    val numFeatures = data.first().features.size
+    val features = data.first().features
+    val numFeatures = features.size
     val oldStrategy = dt.getOldStrategy(categoricalFeatures)
     val oldTree = OldDecisionTree.train(data.map(OldLabeledPoint.fromML), oldStrategy)
     val newData: DataFrame = TreeTests.setMetadata(data, categoricalFeatures, numClasses = 0)
@@ -281,6 +282,7 @@ private[ml] object DecisionTreeRegressorSuite extends SparkFunSuite {
     val oldTreeAsNew = DecisionTreeRegressionModel.fromOld(
       oldTree, newTree.parent.asInstanceOf[DecisionTreeRegressor], categoricalFeatures)
     TreeTests.checkEqual(oldTreeAsNew, newTree)
+    assert(oldTreeAsNew.predictLeaf(features) === newTree.predictLeaf(features))
     assert(newTree.numFeatures === numFeatures)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -40,6 +40,17 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   import RandomForestSuite.mapToVec
 
+  test("withLeafIndices assigns leaf indices in place") {
+    val left = new LeafNode(0.0, Double.NaN, null)
+    val right = new LeafNode(1.0, Double.NaN, null)
+    val root = new InternalNode(0.0, Double.NaN, Double.NaN, left, right,
+      new ContinuousSplit(0, 0.0), null)
+
+    assert(Node.withLeafIndices(root) eq root)
+    assert(left.leafIndex === 0)
+    assert(right.leafIndex === 1)
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Tests for split calculation
   /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #57389.

This PR changes `Node.withLeafIndices` to assign leaf indices directly on the existing leaf nodes
and return the original root. It no longer rebuilds the complete `Node` graph. The leaf index is
therefore a package-private mutable field that is initialized once before the model is published.

The tests verify that leaf indexing preserves root identity and assigns the expected left-to-right
indices. The old-API conversion tests now also call `predictLeaf` on converted classification and
regression trees.

### Why are the changes needed?

The implementation in #57389 constructed a second complete node graph while the original graph was
still reachable. During training and model loading, that added O(number of nodes) temporary driver
memory and could cause an out-of-memory failure for a large tree.

Assigning the integer fields in place avoids replacement node allocations while preserving the same
DFS ordering. Calling `predictLeaf` in the legacy conversion tests ensures those paths cannot omit
leaf-index initialization unnoticed.

### Does this PR introduce _any_ user-facing change?

No. This changes the internal initialization of an optimization on the unreleased `master` branch.
Leaf IDs and prediction behavior remain unchanged.

### How was this patch tested?

Ran:

`JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./build/sbt 'mllib/testOnly org.apache.spark.ml.tree.impl.RandomForestSuite org.apache.spark.ml.classification.DecisionTreeClassifierSuite org.apache.spark.ml.regression.DecisionTreeRegressorSuite'`

All 60 tests passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
