### PR TITLE
[SPARK-59036][SQL] Support codegen for array_sort when it is default comparator

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -580,7 +580,7 @@ case class ArraySort(
     argument: Expression,
     function: Expression,
     allowNullComparisonResult: Boolean)
-  extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback with ResultTypeFromArgument {
+  extends ArrayBasedSimpleHigherOrderFunction with ResultTypeFromArgument {
 
   def this(argument: Expression, function: Expression) = {
     this(
@@ -655,6 +655,147 @@ case class ArraySort(
       java.util.Arrays.sort(arr, comparator(inputRow))
     }
     new GenericArrayData(arr.asInstanceOf[Array[Any]])
+  }
+
+  private def isDefaultComparator: Boolean = function match {
+    case LambdaFunction(_, Seq(left: NamedLambdaVariable, right: NamedLambdaVariable), _) =>
+      val defaultFunction = LambdaFunction(ArraySort.comparator(left, right), Seq(left, right))
+      function.canonicalized == defaultFunction.canonicalized
+    case _ => false
+  }
+
+  private def sortCodegen(ctx: CodegenContext, ev: ExprCode, base: String): String = {
+    val genericArrayData = classOf[GenericArrayData].getName
+    val unsafeArrayData = classOf[UnsafeArrayData].getName
+    val array = ctx.freshName("array")
+
+    if (elementType == NullType) {
+      s"${ev.value} = $base.copy();"
+    } else {
+      val canPerformFastSort = elementType match {
+        case BooleanType | DoubleType | FloatType => false
+        case _ => CodeGenerator.isPrimitiveType(elementType) &&
+          !dataType.asInstanceOf[ArrayType].containsNull
+      }
+
+      if (canPerformFastSort) {
+        val javaType = CodeGenerator.javaType(elementType)
+        val primitiveTypeName = CodeGenerator.primitiveTypeName(elementType)
+        s"""
+           |$javaType[] $array = $base.to${primitiveTypeName}Array();
+           |java.util.Arrays.parallelSort($array);
+           |${ev.value} = $unsafeArrayData.fromPrimitiveArray($array);
+         """.stripMargin
+      } else {
+        val elementTypeTerm = ctx.addReferenceObj("elementTypeTerm", elementType)
+        val o1 = ctx.freshName("o1")
+        val o2 = ctx.freshName("o2")
+        val c = ctx.freshName("c")
+        val jt = CodeGenerator.javaType(elementType)
+        val comp = if (CodeGenerator.isPrimitiveType(elementType)) {
+          val bt = CodeGenerator.boxedType(elementType)
+          val v1 = ctx.freshName("v1")
+          val v2 = ctx.freshName("v2")
+          s"""
+             |$jt $v1 = (($bt) $o1).${jt}Value();
+             |$jt $v2 = (($bt) $o2).${jt}Value();
+             |int $c = ${ctx.genComp(elementType, v1, v2)};
+           """.stripMargin
+        } else {
+          val left = s"(($jt) $o1)"
+          val right = s"(($jt) $o2)"
+          s"int $c = ${ctx.genComp(elementType, left, right)};"
+        }
+
+        s"""
+           |Object[] $array = $base.toObjectArray($elementTypeTerm);
+           |java.util.Arrays.parallelSort($array, new java.util.Comparator() {
+           |  @Override public int compare(Object $o1, Object $o2) {
+           |    if ($o1 == null && $o2 == null) {
+           |      return 0;
+           |    } else if ($o1 == null) {
+           |      return 1;
+           |    } else if ($o2 == null) {
+           |      return -1;
+           |    }
+           |    $comp
+           |    return $c;
+           |  }
+           |});
+           |${ev.value} = new $genericArrayData($array);
+         """.stripMargin
+      }
+    }
+  }
+
+  private def fallbackCodegen(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val idx = ctx.references.length
+    ctx.references += this
+    var childIndex = idx
+    this.foreach {
+      case n: Nondeterministic =>
+        ctx.references += n
+        childIndex += 1
+        ctx.addPartitionInitializationStatement(
+          s"""
+             |((Nondeterministic) references[$childIndex])
+             |  .initialize(partitionIndex);
+          """.stripMargin)
+      case _ =>
+    }
+    val objectTerm = ctx.freshName("obj")
+    val placeHolder = ctx.registerComment(this.toString)
+    val javaType = CodeGenerator.javaType(dataType)
+    val (evalInput, evalInputCode) = if (ctx.INPUT_ROW != null) {
+      (ctx.INPUT_ROW, EmptyBlock)
+    } else {
+      val row = ctx.freshName("row")
+      val values = ctx.freshName("values")
+      val genericInternalRow = classOf[GenericInternalRow].getName
+      val inputVars = ctx.currentVars.zipWithIndex.map { case (input, ordinal) =>
+        code"""
+          ${input.code}
+          if (${input.isNull}) {
+            $values[$ordinal] = null;
+          } else {
+            $values[$ordinal] = ${input.value};
+          }
+        """
+      }
+      val inputVarsCode: Block = inputVars
+      val code = code"""
+        Object[] $values = new Object[${ctx.currentVars.length}];
+        $inputVarsCode
+        InternalRow $row = new $genericInternalRow($values);
+      """
+      (row, code)
+    }
+    if (nullable) {
+      ev.copy(code = code"""
+        $placeHolder
+        $evalInputCode
+        Object $objectTerm = ((Expression) references[$idx]).eval($evalInput);
+        boolean ${ev.isNull} = $objectTerm == null;
+        $javaType ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
+        if (!${ev.isNull}) {
+          ${ev.value} = (${CodeGenerator.boxedType(dataType)}) $objectTerm;
+        }""")
+    } else {
+      ev.copy(code = code"""
+        $placeHolder
+        $evalInputCode
+        Object $objectTerm = ((Expression) references[$idx]).eval($evalInput);
+        $javaType ${ev.value} = (${CodeGenerator.boxedType(dataType)}) $objectTerm;
+        """, isNull = FalseLiteral)
+    }
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    if (isDefaultComparator) {
+      nullSafeCodeGen(ctx, ev, arg => sortCodegen(ctx, ev, arg))
+    } else {
+      fallbackCodegen(ctx, ev)
+    }
   }
 
   override def nodeName: String = "array_sort"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.expressions.Cast._
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -238,6 +238,19 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
       Seq(null, "b", "a"))
     checkEvaluation(arraySort(a4, (left, right) => UnaryMinus(ArraySort.comparator(left, right))),
       Seq(d2, d1))
+  }
+
+  test("ArraySort codegen") {
+    def codeOf(e: Expression): String = e.genCode(new CodegenContext).code.toString
+
+    val input = Literal.create(Seq(2, 1, 3), ArrayType(IntegerType, containsNull = false))
+    val defaultComparatorCode = codeOf(arraySort(input))
+    assert(defaultComparatorCode.contains("java.util.Arrays.parallelSort"))
+    assert(!defaultComparatorCode.contains(".eval("))
+
+    val customComparatorCode =
+      codeOf(arraySort(input, (left, right) => UnaryMinus(ArraySort.comparator(left, right))))
+    assert(customComparatorCode.contains(".eval("))
   }
 
   test("MapFilter") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -26,7 +26,8 @@ import scala.util.Random
 import org.apache.spark.{QueryContextType, SPARK_DOC_ROOT, SparkException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{
+  CodegenObjectFactoryMode, Expression, Literal, UnaryExpression}
 import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
@@ -1180,6 +1181,15 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
         Row(Seq.empty[Int], Seq.empty[String]),
         Row(null, null))
     )
+    withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.CODEGEN_ONLY.toString) {
+      checkAnswer(
+        df.select(array_sort($"a"), array_sort($"b")),
+        Seq(
+          Row(Seq(1, 2, 3), Seq("a", "b", "c")),
+          Row(Seq.empty[Int], Seq.empty[String]),
+          Row(null, null))
+      )
+    }
     checkAnswer(
       df.selectExpr("array_sort(a)", "array_sort(b)"),
       Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -1181,14 +1181,32 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
         Row(Seq.empty[Int], Seq.empty[String]),
         Row(null, null))
     )
-    withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.CODEGEN_ONLY.toString) {
-      checkAnswer(
-        df.select(array_sort($"a"), array_sort($"b")),
-        Seq(
-          Row(Seq(1, 2, 3), Seq("a", "b", "c")),
-          Row(Seq.empty[Int], Seq.empty[String]),
-          Row(null, null))
-      )
+    // Verify the default array_sort comparator under whole-stage codegen. The source is
+    // materialized via a cached temp view (an InMemoryRelation) so the plan is not folded to
+    // interpreted eval by ConvertToLocalRelation, which would otherwise make CODEGEN_ONLY a no-op.
+    withTempView("array_sort_codegen") {
+      df.createOrReplaceTempView("array_sort_codegen")
+      spark.catalog.cacheTable("array_sort_codegen")
+      val query = "SELECT array_sort(a), array_sort(b) FROM array_sort_codegen"
+      val expected = Seq(
+        Row(Seq(1, 2, 3), Seq("a", "b", "c")),
+        Row(Seq.empty[Int], Seq.empty[String]),
+        Row(null, null))
+      withSQLConf(
+          SQLConf.CODEGEN_FACTORY_MODE.key ->
+            CodegenObjectFactoryMode.CODEGEN_ONLY.toString) {
+        val codegenDF = sql(query)
+        assert(
+          codegenDF.queryExecution.executedPlan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+          "expected the array_sort query to run inside whole-stage codegen")
+        checkAnswer(codegenDF, expected)
+      }
+      withSQLConf(
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+          SQLConf.CODEGEN_FACTORY_MODE.key ->
+            CodegenObjectFactoryMode.NO_CODEGEN.toString) {
+        checkAnswer(sql(query), expected)
+      }
     }
     checkAnswer(
       df.selectExpr("array_sort(a)", "array_sort(b)"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HigherOrderFunctionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HigherOrderFunctionsBenchmark.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.benchmark
 
 import org.apache.spark.benchmark.Benchmark
-import org.apache.spark.sql.Column
+import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -40,34 +40,36 @@ object HigherOrderFunctionsBenchmark extends SqlBasedBenchmark {
   private val M = 10
 
   private val df = spark.range(N).select(array(col("id"), col("id"), col("id")).alias("arr"))
+  private val arraySortDF = spark.range(N).select(sequence(lit(32), lit(1), lit(-1)).alias("arr"))
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     runBenchmark("Higher order functions") {
-      def benchFunction(name: String, col: Column) = {
+      def benchFunction(name: String, input: DataFrame, col: Column) = {
         var benchmark = new Benchmark(name, N, output = output)
         benchmark.addCase("codegen", M) { _ =>
           withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key ->
               CodegenObjectFactoryMode.CODEGEN_ONLY.toString()) {
-            df.select(col).noop()
+            input.select(col).noop()
           }
         }
 
         benchmark.addCase("interpreted", M) { _ =>
           withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key ->
               CodegenObjectFactoryMode.NO_CODEGEN.toString()) {
-            df.select(col).noop()
+            input.select(col).noop()
           }
         }
         benchmark.run()
       }
 
-      benchFunction("transform", transform(col("arr"), x => x + 1))
-      benchFunction("filter", filter(col("arr"), x => x > 1))
-      benchFunction("forall - fast", forall(col("arr"), x => x < 0))
-      benchFunction("forall - slow", forall(col("arr"), x => x >= 0))
-      benchFunction("exists - fast", exists(col("arr"), x => x >= 0))
-      benchFunction("exists - slow", exists(col("arr"), x => x < 0))
-      benchFunction("aggregate", aggregate(col("arr"), lit(0L), (acc, x) => acc + x))
+      benchFunction("transform", df, transform(col("arr"), x => x + 1))
+      benchFunction("filter", df, filter(col("arr"), x => x > 1))
+      benchFunction("forall - fast", df, forall(col("arr"), x => x < 0))
+      benchFunction("forall - slow", df, forall(col("arr"), x => x >= 0))
+      benchFunction("exists - fast", df, exists(col("arr"), x => x >= 0))
+      benchFunction("exists - slow", df, exists(col("arr"), x => x < 0))
+      benchFunction("aggregate", df, aggregate(col("arr"), lit(0L), (acc, x) => acc + x))
+      benchFunction("array_sort", arraySortDF, array_sort(col("arr")))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

  This PR adds code generation support for `array_sort` when it uses the default comparator.

  The default comparator path is recognized by rebuilding the default comparator with the analyzed
  lambda variables and comparing the canonicalized lambda expression. When the comparator is not the
  default one, `array_sort` keeps using the existing interpreted fallback path.

  This PR also adds:

  - A DataFrame API test that runs default `array_sort` under `CODEGEN_ONLY`.
  - A benchmark case for default `array_sort` in `HigherOrderFunctionsBenchmark`.

  ### Why are the changes needed?

  `array_sort(array)` currently supports whole-stage codegen around the query, but the expression
  itself still falls back to interpreted evaluation. The default comparator is a common case and has
  fixed semantics, so it can be code-generated without changing behavior or supporting arbitrary
  custom comparator codegen.

  This avoids per-row interpreted expression evaluation overhead for the default comparator path.

  Local benchmark result on Apple M3 Pro, JDK 17:
```
[info] Running benchmark: array_sort
[info]   Running case: codegen
[info]   Stopped after 10 iterations, 34935 ms
[info]   Running case: interpreted
[info]   Stopped after 10 iterations, 46261 ms
[info] OpenJDK 64-Bit Server VM 17.0.15+0 on Mac OS X 15.6.1
[info] Apple M3 Pro
[info] array_sort:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] codegen                                            3433           3494          55          2.9         343.3       1.0X
[info] interpreted                                        4572           4626          63          2.2         457.2       0.8X

```

  ### Does this PR introduce _any_ user-facing change?

  No. 

  ### How was this patch tested?

  Added unit test coverage for the default `array_sort` DataFrame API path under `CODEGEN_ONLY`.

  Was this patch authored or co-authored using generative AI tooling?

  Generated-by: TraeCode (GPT-5)




