### PR TITLE
[SPARK-59038][ML] Avoid unused broadcasts when transform has no output columns

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -277,9 +277,9 @@ class GBTRegressionModel private[ml](
       val bcModel = dataset.sparkSession.sparkContext.broadcast(this)
 
       if ($(predictionCol).nonEmpty) {
-        val predictUDF = udf { features: Vector => bcModel.value.predict(features) }
+        val predUDF = udf { features: Vector => bcModel.value.predict(features) }
         predColNames :+= $(predictionCol)
-        predCols :+= predictUDF(col($(featuresCol)))
+        predCols :+= predUDF(col($(featuresCol)))
           .as($(predictionCol), outputSchema($(predictionCol)).metadata)
       }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -274,17 +274,17 @@ class GBTRegressionModel private[ml](
     if ($(predictionCol).nonEmpty || $(leafCol).nonEmpty) {
       var predColNames = Seq.empty[String]
       var predCols = Seq.empty[Column]
-      val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
+      val bcModel = dataset.sparkSession.sparkContext.broadcast(this)
 
       if ($(predictionCol).nonEmpty) {
-        val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
+        val predictUDF = udf { features: Vector => bcModel.value.predict(features) }
         predColNames :+= $(predictionCol)
         predCols :+= predictUDF(col($(featuresCol)))
           .as($(predictionCol), outputSchema($(predictionCol)).metadata)
       }
 
       if ($(leafCol).nonEmpty) {
-        val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
+        val leafUDF = udf { features: Vector => bcModel.value.predictLeaf(features) }
         predColNames :+= $(leafCol)
         predCols :+= leafUDF(col($(featuresCol)))
           .as($(leafCol), outputSchema($(leafCol)).metadata)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -272,25 +272,25 @@ class GBTRegressionModel private[ml](
     val outputSchema = transformSchema(dataset.schema, logging = true)
 
     if ($(predictionCol).nonEmpty || $(leafCol).nonEmpty) {
-      var predictionColNames = Seq.empty[String]
-      var predictionColumns = Seq.empty[Column]
+      var predColNames = Seq.empty[String]
+      var predCols = Seq.empty[Column]
       val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
       if ($(predictionCol).nonEmpty) {
         val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
-        predictionColNames :+= $(predictionCol)
-        predictionColumns :+= predictUDF(col($(featuresCol)))
+        predColNames :+= $(predictionCol)
+        predCols :+= predictUDF(col($(featuresCol)))
           .as($(predictionCol), outputSchema($(predictionCol)).metadata)
       }
 
       if ($(leafCol).nonEmpty) {
         val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
-        predictionColNames :+= $(leafCol)
-        predictionColumns :+= leafUDF(col($(featuresCol)))
+        predColNames :+= $(leafCol)
+        predCols :+= leafUDF(col($(featuresCol)))
           .as($(leafCol), outputSchema($(leafCol)).metadata)
       }
 
-      dataset.withColumns(predictionColNames, predictionColumns)
+      dataset.withColumns(predColNames, predCols)
     } else {
       this.logWarning(log"${MDC(LogKeys.UUID, uid)}: GBTRegressionModel.transform() " +
         log"does nothing because no output columns were set.")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -271,26 +271,25 @@ class GBTRegressionModel private[ml](
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema, logging = true)
 
-    var predictionColNames = Seq.empty[String]
-    var predictionColumns = Seq.empty[Column]
+    if ($(predictionCol).nonEmpty || $(leafCol).nonEmpty) {
+      var predictionColNames = Seq.empty[String]
+      var predictionColumns = Seq.empty[Column]
+      val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
-    val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
+      if ($(predictionCol).nonEmpty) {
+        val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
+        predictionColNames :+= $(predictionCol)
+        predictionColumns :+= predictUDF(col($(featuresCol)))
+          .as($(predictionCol), outputSchema($(predictionCol)).metadata)
+      }
 
-    if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
-      predictionColNames :+= $(predictionCol)
-      predictionColumns :+= predictUDF(col($(featuresCol)))
-        .as($(predictionCol), outputSchema($(predictionCol)).metadata)
-    }
+      if ($(leafCol).nonEmpty) {
+        val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
+        predictionColNames :+= $(leafCol)
+        predictionColumns :+= leafUDF(col($(featuresCol)))
+          .as($(leafCol), outputSchema($(leafCol)).metadata)
+      }
 
-    if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
-      predictionColNames :+= $(leafCol)
-      predictionColumns :+= leafUDF(col($(featuresCol)))
-        .as($(leafCol), outputSchema($(leafCol)).metadata)
-    }
-
-    if (predictionColNames.nonEmpty) {
       dataset.withColumns(predictionColNames, predictionColumns)
     } else {
       this.logWarning(log"${MDC(LogKeys.UUID, uid)}: GBTRegressionModel.transform() " +

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -238,26 +238,25 @@ class RandomForestRegressionModel private[ml] (
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema, logging = true)
 
-    var predictionColNames = Seq.empty[String]
-    var predictionColumns = Seq.empty[Column]
+    if ($(predictionCol).nonEmpty || $(leafCol).nonEmpty) {
+      var predictionColNames = Seq.empty[String]
+      var predictionColumns = Seq.empty[Column]
+      val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
-    val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
+      if ($(predictionCol).nonEmpty) {
+        val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
+        predictionColNames :+= $(predictionCol)
+        predictionColumns :+= predictUDF(col($(featuresCol)))
+          .as($(predictionCol), outputSchema($(predictionCol)).metadata)
+      }
 
-    if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
-      predictionColNames :+= $(predictionCol)
-      predictionColumns :+= predictUDF(col($(featuresCol)))
-        .as($(predictionCol), outputSchema($(predictionCol)).metadata)
-    }
+      if ($(leafCol).nonEmpty) {
+        val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
+        predictionColNames :+= $(leafCol)
+        predictionColumns :+= leafUDF(col($(featuresCol)))
+          .as($(leafCol), outputSchema($(leafCol)).metadata)
+      }
 
-    if ($(leafCol).nonEmpty) {
-      val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
-      predictionColNames :+= $(leafCol)
-      predictionColumns :+= leafUDF(col($(featuresCol)))
-        .as($(leafCol), outputSchema($(leafCol)).metadata)
-    }
-
-    if (predictionColNames.nonEmpty) {
       dataset.withColumns(predictionColNames, predictionColumns)
     } else {
       this.logWarning(log"${MDC(LogKeys.UUID, uid)}: RandomForestRegressionModel.transform() " +

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -244,9 +244,9 @@ class RandomForestRegressionModel private[ml] (
       val bcModel = dataset.sparkSession.sparkContext.broadcast(this)
 
       if ($(predictionCol).nonEmpty) {
-        val predictUDF = udf { features: Vector => bcModel.value.predict(features) }
+        val predUDF = udf { features: Vector => bcModel.value.predict(features) }
         predColNames :+= $(predictionCol)
-        predCols :+= predictUDF(col($(featuresCol)))
+        predCols :+= predUDF(col($(featuresCol)))
           .as($(predictionCol), outputSchema($(predictionCol)).metadata)
       }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -241,17 +241,17 @@ class RandomForestRegressionModel private[ml] (
     if ($(predictionCol).nonEmpty || $(leafCol).nonEmpty) {
       var predColNames = Seq.empty[String]
       var predCols = Seq.empty[Column]
-      val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
+      val bcModel = dataset.sparkSession.sparkContext.broadcast(this)
 
       if ($(predictionCol).nonEmpty) {
-        val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
+        val predictUDF = udf { features: Vector => bcModel.value.predict(features) }
         predColNames :+= $(predictionCol)
         predCols :+= predictUDF(col($(featuresCol)))
           .as($(predictionCol), outputSchema($(predictionCol)).metadata)
       }
 
       if ($(leafCol).nonEmpty) {
-        val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
+        val leafUDF = udf { features: Vector => bcModel.value.predictLeaf(features) }
         predColNames :+= $(leafCol)
         predCols :+= leafUDF(col($(featuresCol)))
           .as($(leafCol), outputSchema($(leafCol)).metadata)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -239,25 +239,25 @@ class RandomForestRegressionModel private[ml] (
     val outputSchema = transformSchema(dataset.schema, logging = true)
 
     if ($(predictionCol).nonEmpty || $(leafCol).nonEmpty) {
-      var predictionColNames = Seq.empty[String]
-      var predictionColumns = Seq.empty[Column]
+      var predColNames = Seq.empty[String]
+      var predCols = Seq.empty[Column]
       val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
 
       if ($(predictionCol).nonEmpty) {
         val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
-        predictionColNames :+= $(predictionCol)
-        predictionColumns :+= predictUDF(col($(featuresCol)))
+        predColNames :+= $(predictionCol)
+        predCols :+= predictUDF(col($(featuresCol)))
           .as($(predictionCol), outputSchema($(predictionCol)).metadata)
       }
 
       if ($(leafCol).nonEmpty) {
         val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
-        predictionColNames :+= $(leafCol)
-        predictionColumns :+= leafUDF(col($(featuresCol)))
+        predColNames :+= $(leafCol)
+        predCols :+= leafUDF(col($(featuresCol)))
           .as($(leafCol), outputSchema($(leafCol)).metadata)
       }
 
-      dataset.withColumns(predictionColNames, predictionColumns)
+      dataset.withColumns(predColNames, predCols)
     } else {
       this.logWarning(log"${MDC(LogKeys.UUID, uid)}: RandomForestRegressionModel.transform() " +
         log"does nothing because no output columns were set.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Create the model broadcast in `RandomForestRegressionModel.transform` and
`GBTRegressionModel.transform` only when at least one of `predictionCol` or `leafCol` is set.

### Why are the changes needed?

When both output columns are empty, these transforms return the input unchanged. Previously they
still serialized and broadcast the entire model, consuming unnecessary driver resources despite the
broadcast never being referenced.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests were added because the output and existing execution branches are unchanged. The patch was
checked with `git diff --check` and source line-length and non-ASCII scans.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
