### PR TITLE
[SPARK-59040][SQL] Assign a name to the error condition `_LEGACY_ERROR_TEMP_1166,1167`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -497,13 +497,13 @@
   },
   "BUCKET_COLUMN_IN_PARTITION_COLUMNS" : {
     "message" : [
-      "Bucketing column <bucketCol> should not be part of partition columns <partitionColumns>."
+      "Bucketing column <bucketColumn> should not be part of partition columns <partitionColumns>."
     ],
     "sqlState" : "42713"
   },
   "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS" : {
     "message" : [
-      "Bucket sorting column <sortCol> should not be part of partition columns <partitionColumns>."
+      "Bucket sorting column <sortColumn> should not be part of partition columns <partitionColumns>."
     ],
     "sqlState" : "42713"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -497,15 +497,15 @@
   },
   "BUCKET_COLUMN_IN_PARTITION_COLUMNS" : {
     "message" : [
-      "Bucketing column '<bucketCol>' should not be part of partition columns '<normalizedPartCols>'."
+      "Bucketing column <bucketCol> should not be part of partition columns <partitionColumns>."
     ],
-    "sqlState" : "42601"
+    "sqlState" : "42713"
   },
   "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS" : {
     "message" : [
-      "Bucket sorting column '<sortCol>' should not be part of partition columns '<normalizedPartCols>'."
+      "Bucket sorting column <sortCol> should not be part of partition columns <partitionColumns>."
     ],
-    "sqlState" : "42601"
+    "sqlState" : "42713"
   },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -503,7 +503,7 @@
   },
   "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS" : {
     "message" : [
-      "Bucket sorting column <sortColumn> should not be part of partition columns <partitionColumns>."
+      "Bucket sort column <sortColumn> should not be part of partition columns <partitionColumns>."
     ],
     "sqlState" : "42713"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -495,6 +495,18 @@
     ],
     "sqlState" : "22001"
   },
+  "BUCKET_COLUMN_IN_PARTITION_COLUMNS" : {
+    "message" : [
+      "Bucketing column '<bucketCol>' should not be part of partition columns '<normalizedPartCols>'."
+    ],
+    "sqlState" : "42601"
+  },
+  "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS" : {
+    "message" : [
+      "Bucket sorting column '<sortCol>' should not be part of partition columns '<normalizedPartCols>'."
+    ],
+    "sqlState" : "42601"
+  },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [
       "The method <methodName> can not be called on streaming Dataset/DataFrame."
@@ -10362,16 +10374,6 @@
   "_LEGACY_ERROR_TEMP_1165" : {
     "message" : [
       "It is not allowed to specify partitioning when the table schema is not defined."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1166" : {
-    "message" : [
-      "Bucketing column '<bucketCol>' should not be part of partition columns '<normalizedPartCols>'."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1167" : {
-    "message" : [
-      "Bucket sorting column '<sortCol>' should not be part of partition columns '<normalizedPartCols>'."
     ]
   },
   "_LEGACY_ERROR_TEMP_1169" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2232,8 +2232,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
-        "bucketCol" -> toSQLId(bucketCol),
-        "partitionColumns" -> normalizedPartCols.map(toSQLId).mkString(", ")))
+        "bucketCol" -> toSQLId(Seq(bucketCol)),
+        "partitionColumns" -> normalizedPartCols.map(c => toSQLId(Seq(c))).mkString(", ")))
   }
 
   def bucketSortingColumnCannotBePartOfPartitionColumnsError(
@@ -2241,8 +2241,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
-        "sortCol" -> toSQLId(sortCol),
-        "partitionColumns" -> normalizedPartCols.map(toSQLId).mkString(", ")))
+        "sortCol" -> toSQLId(Seq(sortCol)),
+        "partitionColumns" -> normalizedPartCols.map(c => toSQLId(Seq(c))).mkString(", ")))
   }
 
   def invalidBucketColumnDataTypeError(dataType: DataType): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2229,6 +2229,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def bucketingColumnCannotBePartOfPartitionColumnsError(
       bucketCol: String, normalizedPartCols: Seq[String]): Throwable = {
+    // These names are already resolved against the table schema, so each is quoted as a single
+    // part. The `String` overload of `toSQLId` would parse them instead.
     new AnalysisException(
       errorClass = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
@@ -2237,7 +2239,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   }
 
   def bucketSortingColumnCannotBePartOfPartitionColumnsError(
-    sortCol: String, normalizedPartCols: Seq[String]): Throwable = {
+      sortCol: String, normalizedPartCols: Seq[String]): Throwable = {
+    // Quoted as single parts, as in bucketingColumnCannotBePartOfPartitionColumnsError above.
     new AnalysisException(
       errorClass = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2232,8 +2232,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
-        "bucketCol" -> bucketCol,
-        "normalizedPartCols" -> normalizedPartCols.mkString(", ")))
+        "bucketCol" -> toSQLId(bucketCol),
+        "partitionColumns" -> normalizedPartCols.map(toSQLId).mkString(", ")))
   }
 
   def bucketSortingColumnCannotBePartOfPartitionColumnsError(
@@ -2241,8 +2241,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
-        "sortCol" -> sortCol,
-        "normalizedPartCols" -> normalizedPartCols.mkString(", ")))
+        "sortCol" -> toSQLId(sortCol),
+        "partitionColumns" -> normalizedPartCols.map(toSQLId).mkString(", ")))
   }
 
   def invalidBucketColumnDataTypeError(dataType: DataType): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2232,7 +2232,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
-        "bucketCol" -> toSQLId(Seq(bucketCol)),
+        "bucketColumn" -> toSQLId(Seq(bucketCol)),
         "partitionColumns" -> normalizedPartCols.map(c => toSQLId(Seq(c))).mkString(", ")))
   }
 
@@ -2241,7 +2241,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
-        "sortCol" -> toSQLId(Seq(sortCol)),
+        "sortColumn" -> toSQLId(Seq(sortCol)),
         "partitionColumns" -> normalizedPartCols.map(c => toSQLId(Seq(c))).mkString(", ")))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2230,7 +2230,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def bucketingColumnCannotBePartOfPartitionColumnsError(
       bucketCol: String, normalizedPartCols: Seq[String]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1166",
+      errorClass = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
         "bucketCol" -> bucketCol,
         "normalizedPartCols" -> normalizedPartCols.mkString(", ")))
@@ -2239,7 +2239,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def bucketSortingColumnCannotBePartOfPartitionColumnsError(
     sortCol: String, normalizedPartCols: Seq[String]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1167",
+      errorClass = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
       messageParameters = Map(
         "sortCol" -> sortCol,
         "normalizedPartCols" -> normalizedPartCols.mkString(", ")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -253,8 +253,8 @@ abstract class BucketedWriteSuite extends QueryTest {
         .sortBy("k")
         .saveAsTable("bucketed_table")),
       condition = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
-      sqlState = "42601",
-      parameters = Map("bucketCol" -> "j", "normalizedPartCols" -> "i, j"))
+      sqlState = "42713",
+      parameters = Map("bucketCol" -> "`j`", "partitionColumns" -> "`i`, `j`"))
 
     checkError(
       exception = intercept[AnalysisException](df.write
@@ -263,8 +263,8 @@ abstract class BucketedWriteSuite extends QueryTest {
         .sortBy("i")
         .saveAsTable("bucketed_table")),
       condition = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
-      sqlState = "42601",
-      parameters = Map("sortCol" -> "i", "normalizedPartCols" -> "i, j"))
+      sqlState = "42713",
+      parameters = Map("sortCol" -> "`i`", "partitionColumns" -> "`i`, `j`"))
   }
 
   test("write bucketed data without partitionBy") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -267,6 +267,20 @@ abstract class BucketedWriteSuite extends QueryTest {
       parameters = Map("sortCol" -> "`i`", "partitionColumns" -> "`i`, `j`"))
   }
 
+  test("SPARK-59040: overlapping column names are quoted as single identifiers") {
+    // A name is already resolved here, so it must not be parsed: "x.y" is one column rather than
+    // a qualified reference, and a name holding a backtick has it escaped rather than rejected.
+    val df = Seq((1, "a", 2)).toDF("x.y", "z`w", "k")
+    checkError(
+      exception = intercept[AnalysisException](df.write
+        .partitionBy("x.y", "z`w")
+        .bucketBy(8, "x.y")
+        .saveAsTable("bucketed_table")),
+      condition = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
+      sqlState = "42713",
+      parameters = Map("bucketCol" -> "`x.y`", "partitionColumns" -> "`x.y`, `z``w`"))
+  }
+
   test("write bucketed data without partitionBy") {
     for (source <- fileFormatsToTest) {
       withTable("bucketed_table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -252,7 +252,8 @@ abstract class BucketedWriteSuite extends QueryTest {
         .bucketBy(8, "j", "k")
         .sortBy("k")
         .saveAsTable("bucketed_table")),
-      condition = "_LEGACY_ERROR_TEMP_1166",
+      condition = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
+      sqlState = "42601",
       parameters = Map("bucketCol" -> "j", "normalizedPartCols" -> "i, j"))
 
     checkError(
@@ -261,7 +262,8 @@ abstract class BucketedWriteSuite extends QueryTest {
         .bucketBy(8, "k")
         .sortBy("i")
         .saveAsTable("bucketed_table")),
-      condition = "_LEGACY_ERROR_TEMP_1167",
+      condition = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
+      sqlState = "42601",
       parameters = Map("sortCol" -> "i", "normalizedPartCols" -> "i, j"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -254,7 +254,7 @@ abstract class BucketedWriteSuite extends QueryTest {
         .saveAsTable("bucketed_table")),
       condition = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       sqlState = "42713",
-      parameters = Map("bucketCol" -> "`j`", "partitionColumns" -> "`i`, `j`"))
+      parameters = Map("bucketColumn" -> "`j`", "partitionColumns" -> "`i`, `j`"))
 
     checkError(
       exception = intercept[AnalysisException](df.write
@@ -264,7 +264,7 @@ abstract class BucketedWriteSuite extends QueryTest {
         .saveAsTable("bucketed_table")),
       condition = "BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS",
       sqlState = "42713",
-      parameters = Map("sortCol" -> "`i`", "partitionColumns" -> "`i`, `j`"))
+      parameters = Map("sortColumn" -> "`i`", "partitionColumns" -> "`i`, `j`"))
   }
 
   test("SPARK-59040: overlapping column names are quoted as single identifiers") {
@@ -278,7 +278,7 @@ abstract class BucketedWriteSuite extends QueryTest {
         .saveAsTable("bucketed_table")),
       condition = "BUCKET_COLUMN_IN_PARTITION_COLUMNS",
       sqlState = "42713",
-      parameters = Map("bucketCol" -> "`x.y`", "partitionColumns" -> "`x.y`, `z``w`"))
+      parameters = Map("bucketColumn" -> "`x.y`", "partitionColumns" -> "`x.y`, `z``w`"))
   }
 
   test("write bucketed data without partitionBy") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR assigns proper names to two placeholder error conditions, both with SQLSTATE `42713`:

| legacy condition | new condition |
|---|---|
| `_LEGACY_ERROR_TEMP_1166` | `BUCKET_COLUMN_IN_PARTITION_COLUMNS` |
| `_LEGACY_ERROR_TEMP_1167` | `BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS` |

The first message is unchanged. The second now says "Bucket sort column" where it said "Bucket sorting column", so that the sentence, the condition name and the parameter key all use the same term. Two things about how both render also change: the column names go through `toSQLId(Seq(...))` instead of the legacy single quotes, and the three message parameters are renamed from `bucketCol`, `sortCol` and `normalizedPartCols` to `bucketColumn`, `sortColumn` and `partitionColumns`. Both builders keep their Scala method names, so the throw sites in `PreprocessTableCreation.normalizeCatalogTable` stay out of the diff. The one existing test that covers both conditions, `BucketedWriteSuite`'s "write bucketed data with the overlapping bucketBy/sortBy and partitionBy columns", moves to the new names, parameters and SQLSTATE, and a second test covers column names that contain a dot or a backtick.

### Why are the changes needed?

This continues the work of replacing `_LEGACY_ERROR_TEMP_*` placeholders with real condition names. Both of these are reachable from user code: `normalizeCatalogTable` runs for `CREATE TABLE`, CTAS and `df.write.partitionBy(...).bucketBy(...).saveAsTable(...)`, and either error fires when a column is named in both the partition spec and the bucket spec. A proper name is the right outcome here, not an internal error.

The names follow how this file already splits the vocabulary: `BUCKET_*` when it means the object, `BUCKETING` when it means the feature or the clause. Hence `BUCKET_COLUMN` and `BUCKET_SORT_COLUMN`, alongside `INVALID_BUCKET_COLUMN_DATA_TYPE` and `CANNOT_ALTER_COLLATION_BUCKET_COLUMN` on one side and `SORT_BY_WITHOUT_BUCKETING` and `SPECIFY_BUCKETING_IS_NOT_ALLOWED` on the other. `BucketSpec` calls the fields `bucketColumnNames` and `sortColumnNames`. Both stay top-level rather than becoming an umbrella with two subclasses, matching the pair just above them in the same file, `SPECIFY_PARTITION_IS_NOT_ALLOWED` and `SPECIFY_BUCKETING_IS_NOT_ALLOWED`: one rule, one SQLSTATE, two names, differing only in which clause tripped it.

`42713` reads "A duplicate object was detected in a list or is the same as an existing object", and the second half of that is what happens here: a column named in `CLUSTERED BY` is the same as one already named in `PARTITIONED BY`. The closest match in the repo is `STATIC_PARTITION_COLUMN_IN_INSERT_COLUMN_LIST`, "Static partition column `<staticName>` is also specified in the column list", which is both the same shape and the precedent for the `X_IN_Y` name. It also leaves a readable split across the three states this area uses: `42711` (`COLUMN_ALREADY_EXISTS`) for a name repeated inside one list, which `SchemaUtils.checkColumnNameDuplication` already checks on the normalized partition columns before the bucket check runs, `42713` for one column claimed by two clauses, and `42601` for plain clause errors such as `SORT_BY_WITHOUT_BUCKETING`.

On the quoting, `QueryErrorsBase`'s scaladoc asks for identifiers to be wrapped in backticks via `toSQLId()`, which `QueryCompilationErrors` already does throughout. The `Seq` overload is the right one here: these names arrive already resolved against the table schema, so each is a single part, whereas `toSQLId(String)` runs them through `AttributeNameParser.parseAttributeName` first and would render a column literally named `x.y` as `` `x`.`y` ``, or fail with `INVALID_ATTRIBUTE_NAME_SYNTAX` while building the message for a name that contains a backtick. `TableOutputResolver` and `ResolveDefaultColumnsUtil` use `toSQLId(Seq(name))` for the same reason. Quoting at all also fixes something the legacy template got wrong: `'<normalizedPartCols>'` put a single pair of quotes around a comma-joined list, so two partition columns rendered as `'i, j'` and read like one identifier with a comma in its name. Per-column quoting gives `` `i`, `j` ``.

The parameter names are worth settling now for a similar reason of timing: they appear in the generated documentation and in `getMessageParameters()`, and once the conditions ship the keys cannot move without breaking anything that matches on them. `normalizedPartCols` named an internal normalization step that means nothing to a reader. The three now read as the singular and plural of one noun, which is also how this file spells them: `...Columns` is the prevailing name for a list of columns, `CANNOT_UPDATE_PARTITION_COLUMNS` with `requestedPartitionColumns` and `existingPartitionColumns` among the closest, against a single published `...ColumnNames` (`reservedColumnNames`), while a single column gets `...Column`, as in `keyColumn` and `sqlColumn`. No published condition used a `...Col` abbreviation for one column.

### Does this PR introduce _any_ user-facing change?

Yes, in the rendered message. A named condition gains the `[CONDITION] ` prefix and the ` SQLSTATE: ...` suffix that `SparkThrowableHelper.formatErrorMessage` suppresses for `_LEGACY_ERROR_`-prefixed names, and the column names are now backticked:

```
-Bucketing column 'j' should not be part of partition columns 'i, j'.
+[BUCKET_COLUMN_IN_PARTITION_COLUMNS] Bucketing column `j` should not be part of partition columns `i`, `j`. SQLSTATE: 42713

-Bucket sorting column 'i' should not be part of partition columns 'i, j'.
+[BUCKET_SORT_COLUMN_IN_PARTITION_COLUMNS] Bucket sort column `i` should not be part of partition columns `i`, `j`. SQLSTATE: 42713
```

Code that reads `getMessageParameters()` sees `bucketColumn`, `sortColumn` and `partitionColumns` where it saw `bucketCol`, `sortCol` and `normalizedPartCols`. The two conditions also start showing up in the generated error conditions documentation, which skips `_LEGACY_ERROR_*` entries.

### How was this patch tested?

`BucketedWriteSuite`'s existing assertions for both conditions now check the new names, the backticked parameter values and `sqlState = "42713"`. A new test in the same suite writes a table whose columns are named `x.y` and ``z`w``, and pins them as `` `x.y` `` and `` `z``w` ``; against the `toSQLId(String)` overload that test instead fails with `INVALID_ATTRIBUTE_NAME_SYNTAX`, which is what a user would have seen. Ran `core/testOnly org.apache.spark.SparkThrowableSuite` and `sql/testOnly *BucketedWriteWithoutHiveSupportSuite`, all passing. The `sqlState` argument was confirmed to be compared rather than ignored, by temporarily changing the JSON value and watching the test go red.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
