### PR TITLE
[SPARK-59045][SQL] Fix SPJ ClassCastException when reducer changes partition key data type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
@@ -100,8 +100,12 @@ case class TransformExpression(
 
   /**
    * Re-targets this partition transform expression at `attr`. A partition transform expression
-   * has a single leaf attribute (`KeyedPartitioning.supportsExpressions`), so this replaces it
-   * and the result reports the same transform over `attr`.
+   * has a single leaf attribute (`KeyedPartitioning.supportsExpressions`), so this replaces that
+   * attribute and keeps the rest of the expression: any field path above the leaf comes from this
+   * expression, not from the re-targeted key. Re-targeting is therefore only faithful when the
+   * source and the target key expressions have the same path shape (all producers today use bare
+   * attributes; a nested-field partition key does not produce a `KeyedPartitioning`, as
+   * `supportsExpressions` does not unwrap `Alias`).
    */
   def withReference(attr: Attribute): TransformExpression =
     transform { case _: AttributeReference => attr }.asInstanceOf[TransformExpression]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
@@ -98,6 +98,14 @@ case class TransformExpression(
     }
   }
 
+  /**
+   * Re-targets this partition transform expression at `attr`. A partition transform expression
+   * has a single leaf attribute (`KeyedPartitioning.supportsExpressions`), so this replaces it
+   * and the result reports the same transform over `attr`.
+   */
+  def withReference(attr: Attribute): TransformExpression =
+    transform { case _: AttributeReference => attr }.asInstanceOf[TransformExpression]
+
   // Return a Reducer for a reducible function on another reducible function
   private def reducer(
       thisFunction: ReducibleFunction[_, _],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
@@ -103,9 +103,7 @@ case class TransformExpression(
    * has a single leaf attribute (`KeyedPartitioning.supportsExpressions`), so this replaces that
    * attribute and keeps the rest of the expression: any field path above the leaf comes from this
    * expression, not from the re-targeted key. Re-targeting is therefore only faithful when the
-   * source and the target key expressions have the same path shape (all producers today use bare
-   * attributes; a nested-field partition key does not produce a `KeyedPartitioning`, as
-   * `supportsExpressions` does not unwrap `Alias`).
+   * source and the target key expressions have the same path shape.
    */
   def withReference(attr: Attribute): TransformExpression =
     transform { case _: AttributeReference => attr }.asInstanceOf[TransformExpression]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -1455,7 +1455,9 @@ case class KeyReducer(reducer: Reducer[_, _], reducedExpression: TransformExpres
 
 /**
  * A [[Reducer]] that reduces an identity transform onto a partition transform: it applies the
- * given partition transform to the raw value of the identity transform's key.
+ * given partition transform to the raw value of the identity transform's key. For instance, an
+ * `identity(id)` side joined to a `bucket(4, id)` side reduces with
+ * `IdentityReducer(bucket(4, id))`, which maps each raw id value to its `bucket(4, id)` value.
  *
  * It is a case class so that structurally identical reducers compare by value, and plans holding
  * them stay canonicalization-equal.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -693,7 +693,9 @@ case class KeyedPartitioning(
    * Returns the reduced keys and their data types.
    */
   def reduceKeys(
-      reducers: Seq[Option[Reducer[_, _]]]): (Seq[DataType], Seq[InternalRowComparableWrapper]) =
+  def reduceKeys(
+      reducers: Seq[Option[(Reducer[_, _], TransformExpression)]]):
+      (Seq[DataType], Seq[InternalRowComparableWrapper]) =
     KeyedPartitioning.reduceKeys(partitionKeys, keyDataTypes, reducers)
 
   override def satisfies0(required: Distribution): Boolean = {
@@ -871,9 +873,10 @@ object KeyedPartitioning {
   def reduceKeys(
       keys: Seq[InternalRowComparableWrapper],
       dataTypes: Seq[DataType],
-      reducers: Seq[Option[Reducer[_, _]]]): (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
+      reducers: Seq[Option[(Reducer[_, _], TransformExpression)]]):
+      (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
     val reducedDataTypes = dataTypes.zip(reducers).map {
-      case (_, Some(reducer: Reducer[Any, Any])) => reducer.resultType()
+      case (_, Some((reducer: Reducer[Any, Any], _))) => reducer.resultType()
       case (t, _) => t
     }
     val comparableKeyWrapperFactory =
@@ -881,7 +884,7 @@ object KeyedPartitioning {
     val reducedKeys = keys.map { key =>
       val keyValues = key.row.toSeq(dataTypes)
       val reducedKey = keyValues.zip(reducers).map {
-        case (v, Some(reducer: Reducer[Any, Any])) => reducer.reduce(v)
+        case (v, Some((reducer: Reducer[Any, Any], _))) => reducer.reduce(v)
         case (v, _) => v
       }.toArray
       comparableKeyWrapperFactory(new GenericInternalRow(reducedKey))
@@ -1541,9 +1544,11 @@ case class KeyedShuffleSpec(
    *
    * @param other other key-grouped shuffle spec
    */
-  def reducers(other: KeyedShuffleSpec): Option[Seq[Option[Reducer[_, _]]]] = {
+  def reducers(
+      other: KeyedShuffleSpec): Option[Seq[Option[(Reducer[_, _], TransformExpression)]]] = {
     val results = partitioning.expressions.zip(other.partitioning.expressions).map {
-      case (e1: TransformExpression, e2: TransformExpression) => e1.reducers(e2)
+      case (e1: TransformExpression, e2: TransformExpression) =>
+        e1.reducers(e2).map(reducer => (reducer, e1))
 
       // Identity transform on this side, arbitrary transform on the other side: create a reducer
       // that applies the other's transform to the raw identity values. The symmetric case
@@ -1553,11 +1558,12 @@ case class KeyedShuffleSpec(
       case (a: AttributeReference, t: TransformExpression) =>
         val reducerExpr = t.transform { case _: AttributeReference => a }
         val boundExpr = BindReferences.bindReference(reducerExpr, AttributeSeq(Seq(a)))
-        Some(new Reducer[Any, Any] {
+        val reducer = new Reducer[Any, Any] {
           override def reduce(v: Any): Any = boundExpr.eval(new GenericInternalRow(Array[Any](v)))
           override def resultType(): DataType = reducerExpr.dataType
           override def displayName(): String = reducerExpr.toString
-        })
+        }
+        Some((reducer, reducerExpr.asInstanceOf[TransformExpression]))
 
       case (_, _) => None
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -693,7 +693,6 @@ case class KeyedPartitioning(
    * Returns the reduced keys and their data types.
    */
   def reduceKeys(
-  def reduceKeys(
       reducers: Seq[Option[KeyReducer]]): (Seq[DataType], Seq[InternalRowComparableWrapper]) =
     KeyedPartitioning.reduceKeys(partitionKeys, keyDataTypes, reducers)
 
@@ -1606,7 +1605,7 @@ case class KeyedShuffleSpec(
             // Both sides reduce: the reduced keys are r1(f1(x)) = r2(f2(x)), which no single
             // transform describes. Keep reporting the original expression; its type can differ
             // from the reduced keys, which a downstream shuffle or grouping can then fail on with
-            // a ClassCastException. Known gap, tracked in the follow-up for SPARK-59045.
+            // a ClassCastException. Known gap, tracked in SPARK-59121.
             KeyReducer(reducer, e1)
           }
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -694,8 +694,7 @@ case class KeyedPartitioning(
    */
   def reduceKeys(
   def reduceKeys(
-      reducers: Seq[Option[KeyReducer]]):
-      (Seq[DataType], Seq[InternalRowComparableWrapper]) =
+      reducers: Seq[Option[KeyReducer]]): (Seq[DataType], Seq[InternalRowComparableWrapper]) =
     KeyedPartitioning.reduceKeys(partitionKeys, keyDataTypes, reducers)
 
   override def satisfies0(required: Distribution): Boolean = {
@@ -873,8 +872,7 @@ object KeyedPartitioning {
   def reduceKeys(
       keys: Seq[InternalRowComparableWrapper],
       dataTypes: Seq[DataType],
-      reducers: Seq[Option[KeyReducer]]):
-      (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
+      reducers: Seq[Option[KeyReducer]]): (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
     val reducedDataTypes = dataTypes.zip(reducers).map {
       case (_, Some(KeyReducer(reducer: Reducer[Any, Any], _))) => reducer.resultType()
       case (t, _) => t
@@ -1447,9 +1445,11 @@ case class CoalescedHashShuffleSpec(
  * reduced keys correspond to, so the output partitioning can report a type-correct expression.
  *
  * @param reducer reducer that maps this side's partition key values onto the other side's key space
- * @param reducedExpression expression whose data type matches the reduced keys; for the
- *                          identity-vs-transform and single-side-transform reducers this is the
- *                          target transform re-targeted at this side's child attribute
+ * @param reducedExpression expression whose data type matches the reduced keys. Stored as-is from
+ *                          the expression pair that produced the reducer; the only structural
+ *                          consumer, `GroupPartitionsExec.outputPartitioning`, re-targets it at
+ *                          each reported `KeyedPartitioning`'s own key attribute, so the
+ *                          attribute it carries here is not load-bearing.
  */
 case class KeyReducer(reducer: Reducer[_, _], reducedExpression: TransformExpression)
 
@@ -1544,61 +1544,97 @@ case class KeyedShuffleSpec(
     }
 
   /**
-   * Return a set of [[Reducer]] for the partition expressions of this shuffle spec,
-   * on the partition expressions of another shuffle spec.
+   * Compute the reducers for both sides of a join between this shuffle spec and `other`, in a
+   * single pass over the two sides' partition expressions. A pair's reducer lookups
+   * (`TransformExpression.reducers`) are shared between the two directions: the reverse lookup a
+   * direction needs to detect a single-side reduce is exactly the other direction's reducer, so
+   * this materializes each catalog `Reducer` once per direction.
    * <p>
-   * A [[Reducer]] exists for a partition expression function of this shuffle spec if it is
-   * 'reducible' on the corresponding partition expression function of the other shuffle spec.
+   * A [[Reducer]] exists for a partition expression of one side if it is 'reducible' on the
+   * corresponding partition expression of the other side. If a side's value is returned, there
+   * must be one entry per partition expression of that side. A None entry indicates that the
+   * particular partition expression is not reducible on the corresponding expression.
    * <p>
-   * If a value is returned, there must be one [[Reducer]] per partition expression.
-   * A None value in the set indicates that the particular partition expression is not reducible
-   * on the corresponding expression on the other shuffle spec.
-   * <p>
-   * Returning none also indicates that none of the partition expressions can be reduced on the
-   * corresponding expression on the other shuffle spec.
+   * Returning none for a side indicates that none of its partition expressions can be reduced on
+   * the corresponding expression of the other side.
    *
    * @param other other key-grouped shuffle spec
+   * @return the reducers for this side and for `other` w.r.t. each other
    */
-  def reducers(other: KeyedShuffleSpec): Option[Seq[Option[KeyReducer]]] = {
-    val results = partitioning.expressions.zip(other.partitioning.expressions).map {
+  def reducersBothWays(other: KeyedShuffleSpec)
+      : (Option[Seq[Option[KeyReducer]]], Option[Seq[Option[KeyReducer]]]) = {
+    val results: Seq[(Option[KeyReducer], Option[KeyReducer])] =
+      partitioning.expressions.zip(other.partitioning.expressions).map {
       case (e1: TransformExpression, e2: TransformExpression) =>
-        e1.reducers(e2).map { reducer =>
-          if (e2.reducers(e1).isEmpty) {
+        val thisReducer = e1.reducers(e2)
+        val otherReducer = e2.reducers(e1)
+
+        val thisResult = thisReducer.map { reducer =>
+          if (otherReducer.isEmpty) {
             // Only this side reduces. The reducer contract is r(f1(x)) = f2(x) where "=" matches
             // both value and data type, so the reduced keys equal the target transform applied to
-            // this side's child. Report that expression (re-targeted at this side's attribute)
-            // instead of the un-reduced `e1`, whose type can differ from the reduced keys.
-            val thisSideChild = e1.references.head
-            val reducedExpr = e2.transform { case _: AttributeReference => thisSideChild }
-            KeyReducer(reducer, reducedExpr.asInstanceOf[TransformExpression])
+            // this side's child. Report the target transform (re-targeted at the reporting
+            // partitioning's key attribute by `GroupPartitionsExec`) instead of the un-reduced
+            // `e1`, whose type can differ from the reduced keys. A connector that violates the
+            // contract with a reducer of a different result type fails the reduced-types check in
+            // `EnsureRequirements`, since the other side's keys are typed by the target transform.
+            KeyReducer(reducer, e2)
           } else {
             // Both sides reduce: the reduced keys are r1(f1(x)) = r2(f2(x)), which no single
-            // transform describes. Keep reporting the original expression. Known gap, tracked in
-            // the follow-up for SPARK-59045.
+            // transform describes. Keep reporting the original expression; its type can differ
+            // from the reduced keys, which a downstream shuffle or grouping can then fail on with
+            // a ClassCastException. Known gap, tracked in the follow-up for SPARK-59045.
             KeyReducer(reducer, e1)
           }
         }
 
-      // Identity transform on this side, arbitrary transform on the other side: create a reducer
-      // that applies the other's transform to the raw identity values. The symmetric case
-      // (TransformExpression, AttributeReference) is handled when the other side calls reducers.
-      // Each partition expression is guaranteed to have exactly one leaf child (asserted in
-      // keyPositions), so `a` lives at position 0 in the row we construct.
-      case (a: AttributeReference, t: TransformExpression) =>
-        val reducerExpr = t.transform { case _: AttributeReference => a }
-        val boundExpr = BindReferences.bindReference(reducerExpr, AttributeSeq(Seq(a)))
-        val reducer = new Reducer[Any, Any] {
-          override def reduce(v: Any): Any = boundExpr.eval(new GenericInternalRow(Array[Any](v)))
-          override def resultType(): DataType = reducerExpr.dataType
-          override def displayName(): String = reducerExpr.toString
+        val otherResult = otherReducer.map { reducer =>
+          if (thisReducer.isEmpty) {
+            // Only the other side reduces; symmetric to the single-side case above.
+            KeyReducer(reducer, e1)
+          } else {
+            // Both sides reduce; symmetric to the both-sides case above.
+            KeyReducer(reducer, e2)
+          }
         }
-        Some(KeyReducer(reducer, reducerExpr.asInstanceOf[TransformExpression]))
 
-      case (_, _) => None
+        (thisResult, otherResult)
+
+      // Identity transform on this side, arbitrary transform on the other side: create a reducer
+      // that applies the other's transform to the raw identity values. Each partition expression
+      // is guaranteed to have exactly one leaf child (asserted in keyPositions), so `a` lives at
+      // position 0 in the row we construct.
+      case (a: AttributeReference, t: TransformExpression) =>
+        (Some(KeyReducer(identityReducer(t, a), t)), None)
+
+      // Symmetric: identity transform on the other side.
+      case (t: TransformExpression, a: AttributeReference) =>
+        (None, Some(KeyReducer(identityReducer(t, a), t)))
+
+      case (_, _) => (None, None)
     }
 
     // optimize to not return a value, if none of the partition expressions are reducible
-    if (results.forall(p => p.isEmpty)) None else Some(results)
+    val thisReducers = results.map(_._1)
+    val otherReducers = results.map(_._2)
+    val thisResult = if (thisReducers.forall(_.isEmpty)) None else Some(thisReducers)
+    val otherResult = if (otherReducers.forall(_.isEmpty)) None else Some(otherReducers)
+    (thisResult, otherResult)
+  }
+
+  /**
+   * Create a reducer that applies the partition transform `t` to the raw values of the identity
+   * transform's attribute `a`, i.e., the reducer that reduces the identity transform onto `t`.
+   */
+  private def identityReducer(
+      t: TransformExpression, a: AttributeReference): Reducer[Any, Any] = {
+    val reducerExpr = t.withReference(a)
+    val boundExpr = BindReferences.bindReference(reducerExpr, AttributeSeq(Seq(a)))
+    new Reducer[Any, Any] {
+      override def reduce(v: Any): Any = boundExpr.eval(new GenericInternalRow(Array[Any](v)))
+      override def resultType(): DataType = reducerExpr.dataType
+      override def displayName(): String = reducerExpr.toString
+    }
   }
 
   override def canCreatePartitioning: Boolean =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -694,7 +694,7 @@ case class KeyedPartitioning(
    */
   def reduceKeys(
   def reduceKeys(
-      reducers: Seq[Option[(Reducer[_, _], TransformExpression)]]):
+      reducers: Seq[Option[KeyReducer]]):
       (Seq[DataType], Seq[InternalRowComparableWrapper]) =
     KeyedPartitioning.reduceKeys(partitionKeys, keyDataTypes, reducers)
 
@@ -873,10 +873,10 @@ object KeyedPartitioning {
   def reduceKeys(
       keys: Seq[InternalRowComparableWrapper],
       dataTypes: Seq[DataType],
-      reducers: Seq[Option[(Reducer[_, _], TransformExpression)]]):
+      reducers: Seq[Option[KeyReducer]]):
       (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
     val reducedDataTypes = dataTypes.zip(reducers).map {
-      case (_, Some((reducer: Reducer[Any, Any], _))) => reducer.resultType()
+      case (_, Some(KeyReducer(reducer: Reducer[Any, Any], _))) => reducer.resultType()
       case (t, _) => t
     }
     val comparableKeyWrapperFactory =
@@ -884,7 +884,7 @@ object KeyedPartitioning {
     val reducedKeys = keys.map { key =>
       val keyValues = key.row.toSeq(dataTypes)
       val reducedKey = keyValues.zip(reducers).map {
-        case (v, Some((reducer: Reducer[Any, Any], _))) => reducer.reduce(v)
+        case (v, Some(KeyReducer(reducer: Reducer[Any, Any], _))) => reducer.reduce(v)
         case (v, _) => v
       }.toArray
       comparableKeyWrapperFactory(new GenericInternalRow(reducedKey))
@@ -1439,6 +1439,21 @@ case class CoalescedHashShuffleSpec(
 }
 
 /**
+ * A [[Reducer]] paired with the reduced partition expression it produces.
+ *
+ * When a key-grouped partitioning is reduced onto another partitioning's key space, the original
+ * partition expressions no longer describe the reduced keys (their data type and their value are
+ * those of the target key space). This pair carries both the reducer and the expression the
+ * reduced keys correspond to, so the output partitioning can report a type-correct expression.
+ *
+ * @param reducer reducer that maps this side's partition key values onto the other side's key space
+ * @param reducedExpression expression whose data type matches the reduced keys; for the
+ *                          identity-vs-transform and single-side-transform reducers this is the
+ *                          target transform re-targeted at this side's child attribute
+ */
+case class KeyReducer(reducer: Reducer[_, _], reducedExpression: TransformExpression)
+
+/**
  * [[ShuffleSpec]] created by [[KeyedPartitioning]].
  *
  * @param partitioning key grouped partitioning
@@ -1544,11 +1559,25 @@ case class KeyedShuffleSpec(
    *
    * @param other other key-grouped shuffle spec
    */
-  def reducers(
-      other: KeyedShuffleSpec): Option[Seq[Option[(Reducer[_, _], TransformExpression)]]] = {
+  def reducers(other: KeyedShuffleSpec): Option[Seq[Option[KeyReducer]]] = {
     val results = partitioning.expressions.zip(other.partitioning.expressions).map {
       case (e1: TransformExpression, e2: TransformExpression) =>
-        e1.reducers(e2).map(reducer => (reducer, e1))
+        e1.reducers(e2).map { reducer =>
+          if (e2.reducers(e1).isEmpty) {
+            // Only this side reduces. The reducer contract is r(f1(x)) = f2(x) where "=" matches
+            // both value and data type, so the reduced keys equal the target transform applied to
+            // this side's child. Report that expression (re-targeted at this side's attribute)
+            // instead of the un-reduced `e1`, whose type can differ from the reduced keys.
+            val thisSideChild = e1.references.head
+            val reducedExpr = e2.transform { case _: AttributeReference => thisSideChild }
+            KeyReducer(reducer, reducedExpr.asInstanceOf[TransformExpression])
+          } else {
+            // Both sides reduce: the reduced keys are r1(f1(x)) = r2(f2(x)), which no single
+            // transform describes. Keep reporting the original expression. Known gap, tracked in
+            // the follow-up for SPARK-59045.
+            KeyReducer(reducer, e1)
+          }
+        }
 
       // Identity transform on this side, arbitrary transform on the other side: create a reducer
       // that applies the other's transform to the raw identity values. The symmetric case
@@ -1563,7 +1592,7 @@ case class KeyedShuffleSpec(
           override def resultType(): DataType = reducerExpr.dataType
           override def displayName(): String = reducerExpr.toString
         }
-        Some((reducer, reducerExpr.asInstanceOf[TransformExpression]))
+        Some(KeyReducer(reducer, reducerExpr.asInstanceOf[TransformExpression]))
 
       case (_, _) => None
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -1447,11 +1447,34 @@ case class CoalescedHashShuffleSpec(
  * @param reducer reducer that maps this side's partition key values onto the other side's key space
  * @param reducedExpression expression whose data type matches the reduced keys. Stored as-is from
  *                          the expression pair that produced the reducer; the only structural
- *                          consumer, `GroupPartitionsExec.outputPartitioning`, re-targets it at
- *                          each reported `KeyedPartitioning`'s own key attribute, so the
- *                          attribute it carries here is not load-bearing.
+ *                          consumer, `GroupPartitionsExec`, re-targets it at each reported
+ *                          `KeyedPartitioning`'s own key attribute in `outputPartitioning` and
+ *                          normalizes it positionally in `doCanonicalize`, so the attribute it
+ *                          carries here is not load-bearing.
  */
 case class KeyReducer(reducer: Reducer[_, _], reducedExpression: TransformExpression)
+
+/**
+ * A [[Reducer]] that reduces an identity transform onto a partition transform: it applies the
+ * given partition transform to the raw value of the identity transform's key.
+ *
+ * It is a case class so that structurally identical reducers compare by value, and plans holding
+ * them stay canonicalization-equal.
+ *
+ * @param transform the partition transform, re-targeted at the identity side's key attribute
+ */
+case class IdentityReducer(transform: TransformExpression) extends Reducer[Any, Any] {
+  // `transform` has a single leaf attribute (`KeyedPartitioning.supportsExpressions`), which is
+  // bound to ordinal 0 of the single-value row `reduce` evaluates it against.
+  @transient private lazy val bound: Expression =
+    BindReferences.bindReference(transform, AttributeSeq(transform.references.toSeq))
+
+  override def reduce(v: Any): Any = bound.eval(new GenericInternalRow(Array[Any](v)))
+
+  override def resultType(): DataType = transform.dataType
+
+  override def displayName(): String = transform.toString
+}
 
 /**
  * [[ShuffleSpec]] created by [[KeyedPartitioning]].
@@ -1602,14 +1625,14 @@ case class KeyedShuffleSpec(
 
       // Identity transform on this side, arbitrary transform on the other side: create a reducer
       // that applies the other's transform to the raw identity values. Each partition expression
-      // is guaranteed to have exactly one leaf child (asserted in keyPositions), so `a` lives at
-      // position 0 in the row we construct.
+      // is guaranteed to have exactly one leaf child (asserted in keyPositions), which
+      // `IdentityReducer` binds to ordinal 0.
       case (a: AttributeReference, t: TransformExpression) =>
-        (Some(KeyReducer(identityReducer(t, a), t)), None)
+        (Some(KeyReducer(IdentityReducer(t.withReference(a)), t)), None)
 
       // Symmetric: identity transform on the other side.
       case (t: TransformExpression, a: AttributeReference) =>
-        (None, Some(KeyReducer(identityReducer(t, a), t)))
+        (None, Some(KeyReducer(IdentityReducer(t.withReference(a)), t)))
 
       case (_, _) => (None, None)
     }
@@ -1620,21 +1643,6 @@ case class KeyedShuffleSpec(
     val thisResult = if (thisReducers.forall(_.isEmpty)) None else Some(thisReducers)
     val otherResult = if (otherReducers.forall(_.isEmpty)) None else Some(otherReducers)
     (thisResult, otherResult)
-  }
-
-  /**
-   * Create a reducer that applies the partition transform `t` to the raw values of the identity
-   * transform's attribute `a`, i.e., the reducer that reduces the identity transform onto `t`.
-   */
-  private def identityReducer(
-      t: TransformExpression, a: AttributeReference): Reducer[Any, Any] = {
-    val reducerExpr = t.withReference(a)
-    val boundExpr = BindReferences.bindReference(reducerExpr, AttributeSeq(Seq(a)))
-    new Reducer[Any, Any] {
-      override def reduce(v: Any): Any = boundExpr.eval(new GenericInternalRow(Array[Any](v)))
-      override def resultType(): DataType = reducerExpr.dataType
-      override def displayName(): String = reducerExpr.toString
-    }
   }
 
   override def canCreatePartitioning: Boolean =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -38,16 +38,16 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, TransformExpression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
+import org.apache.spark.sql.catalyst.plans.physical.KeyReducer
 import org.apache.spark.sql.catalyst.trees.{Origin, TreeNode}
 import org.apache.spark.sql.catalyst.util.{sideBySide, CharsetProvider, DateTimeUtils, FailFastMode, IntervalUtils, MapData}
 import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-import org.apache.spark.sql.connector.catalog.functions.Reducer
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
@@ -3376,13 +3376,12 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def storagePartitionJoinIncompatibleReducedTypesError(
-      leftReducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]],
+      leftReducers: Option[Seq[Option[KeyReducer]]],
       leftReducedDataTypes: Seq[DataType],
-      rightReducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]],
+      rightReducers: Option[Seq[Option[KeyReducer]]],
       rightReducedDataTypes: Seq[DataType]): Throwable = {
-    def reducersNames(
-        reducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]]) = {
-      reducers.toSeq.flatMap(_.map(_.map(_._1.displayName()).getOrElse("identity")))
+    def reducersNames(reducers: Option[Seq[Option[KeyReducer]]]) = {
+      reducers.toSeq.flatMap(_.map(_.map(_.reducer.displayName()).getOrElse("identity")))
         .mkString("[", ", ", "]")
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, TransformExpression}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -3376,12 +3376,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def storagePartitionJoinIncompatibleReducedTypesError(
-      leftReducers: Option[Seq[Option[Reducer[_, _]]]],
+      leftReducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]],
       leftReducedDataTypes: Seq[DataType],
-      rightReducers: Option[Seq[Option[Reducer[_, _]]]],
+      rightReducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]],
       rightReducedDataTypes: Seq[DataType]): Throwable = {
-    def reducersNames(reducers: Option[Seq[Option[Reducer[_, _]]]]) = {
-      reducers.toSeq.flatMap(_.map(_.map(_.displayName()).getOrElse("identity")))
+    def reducersNames(
+        reducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]]) = {
+      reducers.toSeq.flatMap(_.map(_.map(_._1.displayName()).getOrElse("identity")))
         .mkString("[", ", ", "]")
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -25,9 +25,8 @@ import org.apache.spark.rdd.{CoalescedRDD, PartitionCoalescer, PartitionGroup, R
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
-import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, Partitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, KeyReducer, Partitioning}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
-import org.apache.spark.sql.connector.catalog.functions.Reducer
 import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
@@ -59,7 +58,7 @@ case class GroupPartitionsExec(
     child: SparkPlan,
     @transient joinKeyPositions: Option[Seq[Int]] = None,
     @transient expectedPartitionKeys: Option[Seq[(InternalRowComparableWrapper, Int)]] = None,
-    @transient reducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]] = None,
+    @transient reducers: Option[Seq[Option[KeyReducer]]] = None,
     @transient distributePartitions: Boolean = false,
     @transient enableSortedMerge: Boolean = false
   ) extends UnaryExecNode {
@@ -71,8 +70,10 @@ case class GroupPartitionsExec(
         // There can be multiple `KeyedPartitioning`s in an output partitioning of a join, but they
         // can only differ in `expressions`. Their `partitionKeys` reference and `isCollapsed` flag
         // are shared (enforced by `PartitioningCollection`), so the grouping is computed once.
-        // When reducers are applied, the reduced expressions (whose data type matches the reduced
-        // partition keys) are reported instead of the original ones.
+        // When reducers are applied, the reduced expressions are reported instead of the original
+        // ones. For the identity-vs-transform and single-side-transform reducers their data type
+        // matches the reduced partition keys by construction; for the both-sides-reduce shape no
+        // single transform describes the keys (see `KeyedShuffleSpec.reducers`).
         val partitionKeys = grouping.partitions.map(_._1)
         p.transform {
           case k: KeyedPartitioning =>
@@ -81,7 +82,12 @@ case class GroupPartitionsExec(
               case Some(exprs) =>
                 assert(projectedExpressions.length == exprs.length)
                 projectedExpressions.zip(exprs).map {
-                  case (expr, Some((_, reduced))) => reduced
+                  case (expr, Some(KeyReducer(_, reduced))) =>
+                    // `reduced` was derived from the single spec that `createKeyedShuffleSpec`
+                    // picked (`collectFirst`); re-target it at this `KeyedPartitioning`'s own key
+                    // attribute so that every `KeyedPartitioning` in a collection keeps its own.
+                    val attr = expr.references.head
+                    reduced.transform { case _: AttributeReference => attr }
                   case (expr, None) => expr
                 }
               case None => projectedExpressions
@@ -357,7 +363,7 @@ case class GroupPartitionsExec(
     }.iterator
     val expectedStr = expectedPartitionKeys.map(ks => s"ExpectedPartitionKeys: ${ks.size}")
     val reducersStr = reducers.map { seq =>
-      val names = seq.map(_.map(_._1.displayName()).getOrElse("identity"))
+      val names = seq.map(_.map(_.reducer.displayName()).getOrElse("identity"))
       s"Reducers: ${truncatedString(names, "[", ", ", "]", joinKeyMaxFields)}"
     }
     val distributeStr = Iterator(s"DistributePartitions: $distributePartitions")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -59,7 +59,7 @@ case class GroupPartitionsExec(
     child: SparkPlan,
     @transient joinKeyPositions: Option[Seq[Int]] = None,
     @transient expectedPartitionKeys: Option[Seq[(InternalRowComparableWrapper, Int)]] = None,
-    @transient reducers: Option[Seq[Option[Reducer[_, _]]]] = None,
+    @transient reducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]] = None,
     @transient distributePartitions: Boolean = false,
     @transient enableSortedMerge: Boolean = false
   ) extends UnaryExecNode {
@@ -68,14 +68,26 @@ case class GroupPartitionsExec(
     child.outputPartitioning match {
       case p: Partitioning with Expression =>
         // There can be multiple `KeyedPartitioning`s in an output partitioning of a join, but they
+        // There can be multiple `KeyedPartitioning`s in an output partitioning of a join, but they
         // can only differ in `expressions`. Their `partitionKeys` reference and `isCollapsed` flag
         // are shared (enforced by `PartitioningCollection`), so the grouping is computed once.
+        // When reducers are applied, the reduced expressions (whose data type matches the reduced
+        // partition keys) are reported instead of the original ones.
         val partitionKeys = grouping.partitions.map(_._1)
         p.transform {
           case k: KeyedPartitioning =>
             val projectedExpressions = joinKeyPositions.fold(k.expressions)(_.map(k.expressions))
+            val effectiveExpressions = reducers match {
+              case Some(exprs) =>
+                assert(projectedExpressions.length == exprs.length)
+                projectedExpressions.zip(exprs).map {
+                  case (expr, Some((_, reduced))) => reduced
+                  case (expr, None) => expr
+                }
+              case None => projectedExpressions
+            }
             KeyedPartitioning(
-              projectedExpressions, partitionKeys, grouping.isGrouped, grouping.isCollapsed)
+              effectiveExpressions, partitionKeys, grouping.isGrouped, grouping.isCollapsed)
         }.asInstanceOf[Partitioning]
       case o => o
     }
@@ -345,7 +357,7 @@ case class GroupPartitionsExec(
     }.iterator
     val expectedStr = expectedPartitionKeys.map(ks => s"ExpectedPartitionKeys: ${ks.size}")
     val reducersStr = reducers.map { seq =>
-      val names = seq.map(_.map(_.displayName()).getOrElse("identity"))
+      val names = seq.map(_.map(_._1.displayName()).getOrElse("identity"))
       s"Reducers: ${truncatedString(names, "[", ", ", "]", joinKeyMaxFields)}"
     }
     val distributeStr = Iterator(s"DistributePartitions: $distributePartitions")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -25,6 +25,7 @@ import org.apache.spark.rdd.{CoalescedRDD, PartitionCoalescer, PartitionGroup, R
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, KeyReducer, Partitioning}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, UnaryExecNode}
@@ -70,10 +71,11 @@ case class GroupPartitionsExec(
         // There can be multiple `KeyedPartitioning`s in an output partitioning of a join, but they
         // can only differ in `expressions`. Their `partitionKeys` reference and `isCollapsed` flag
         // are shared (enforced by `PartitioningCollection`), so the grouping is computed once.
-        // When reducers are applied, the reduced expressions are reported instead of the original
-        // ones. For the identity-vs-transform and single-side-transform reducers their data type
-        // matches the reduced partition keys by construction; for the both-sides-reduce shape no
-        // single transform describes the keys (see `KeyedShuffleSpec.reducers`).
+        // When reducers are applied, the stored reduced expressions are re-targeted at each
+        // `KeyedPartitioning`'s own key attribute and reported instead of the original ones. Their
+        // data types match the reduced partition keys for the identity-vs-transform and
+        // single-side-transform reducers; for the both-sides-reduce shape no single transform
+        // describes the keys (see `KeyedShuffleSpec.reducersBothWays`).
         val partitionKeys = grouping.partitions.map(_._1)
         p.transform {
           case k: KeyedPartitioning =>
@@ -83,11 +85,10 @@ case class GroupPartitionsExec(
                 assert(projectedExpressions.length == exprs.length)
                 projectedExpressions.zip(exprs).map {
                   case (expr, Some(KeyReducer(_, reduced))) =>
-                    // `reduced` was derived from the single spec that `createKeyedShuffleSpec`
+                    // `reduced` was stored from the single spec that `createKeyedShuffleSpec`
                     // picked (`collectFirst`); re-target it at this `KeyedPartitioning`'s own key
                     // attribute so that every `KeyedPartitioning` in a collection keeps its own.
-                    val attr = expr.references.head
-                    reduced.transform { case _: AttributeReference => attr }
+                    reduced.withReference(expr.references.head)
                   case (expr, None) => expr
                 }
               case None => projectedExpressions
@@ -97,6 +98,23 @@ case class GroupPartitionsExec(
         }.asInstanceOf[Partitioning]
       case o => o
     }
+  }
+
+  override def doCanonicalize(): SparkPlan = {
+    // `KeyReducer` is a plain case class, not an `Expression`, so plan canonicalization does not
+    // normalize the exprIds inside `reducedExpression`. Do it here, otherwise structurally
+    // identical SPJ subtrees with value-equal reducers stop comparing equal once reducers are
+    // applied, and exchange/subquery reuse silently stops deduplicating them.
+    val canonicalized = super.doCanonicalize().asInstanceOf[GroupPartitionsExec]
+    canonicalized.copy(reducers = canonicalized.reducers.map { reducerSeqs =>
+      reducerSeqs.map { keyReducerOpt =>
+        keyReducerOpt.map { keyReducer =>
+          keyReducer.copy(reducedExpression =
+            QueryPlan.normalizeExpressions(keyReducer.reducedExpression, child.output)
+              .asInstanceOf[TransformExpression])
+        }
+      }
+    })
   }
 
   /** Aligns partitions based on `expectedPartitionKeys` and clustering mode. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -68,7 +68,6 @@ case class GroupPartitionsExec(
     child.outputPartitioning match {
       case p: Partitioning with Expression =>
         // There can be multiple `KeyedPartitioning`s in an output partitioning of a join, but they
-        // There can be multiple `KeyedPartitioning`s in an output partitioning of a join, but they
         // can only differ in `expressions`. Their `partitionKeys` reference and `isCollapsed` flag
         // are shared (enforced by `PartitioningCollection`), so the grouping is computed once.
         // When reducers are applied, the stored reduced expressions are re-targeted at each

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, KeyReducer, Partitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{IdentityReducer, KeyedPartitioning, KeyReducer, Partitioning}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf
@@ -102,16 +102,24 @@ case class GroupPartitionsExec(
 
   override def doCanonicalize(): SparkPlan = {
     // `KeyReducer` is a plain case class, not an `Expression`, so plan canonicalization does not
-    // normalize the exprIds inside `reducedExpression`. Do it here, otherwise structurally
-    // identical SPJ subtrees with value-equal reducers stop comparing equal once reducers are
-    // applied, and exchange/subquery reuse silently stops deduplicating them.
+    // normalize the exprIds inside it. Normalize them positionally here: `reducedExpression` may
+    // reference the other join side's key, which this node's child does not output, so both it
+    // and the identity reducer's transform are normalized against their own references. Without
+    // this, structurally identical SPJ subtrees with value-equal reducers stop comparing equal
+    // once reducers are applied, and exchange/subquery reuse silently stops deduplicating them.
     val canonicalized = super.doCanonicalize().asInstanceOf[GroupPartitionsExec]
     canonicalized.copy(reducers = canonicalized.reducers.map { reducerSeqs =>
       reducerSeqs.map { keyReducerOpt =>
         keyReducerOpt.map { keyReducer =>
-          keyReducer.copy(reducedExpression =
-            QueryPlan.normalizeExpressions(keyReducer.reducedExpression, child.output)
-              .asInstanceOf[TransformExpression])
+          val reducer = keyReducer.reducer match {
+            case r: IdentityReducer => r.copy(transform = QueryPlan.normalizeExpressions(
+              r.transform, r.transform.references.toSeq).asInstanceOf[TransformExpression])
+            case other => other
+          }
+          keyReducer.copy(
+            reducer = reducer,
+            reducedExpression = QueryPlan.normalizeExpressions(keyReducer.reducedExpression,
+              keyReducer.reducedExpression.references.toSeq).asInstanceOf[TransformExpression])
         }
       }
     })

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -553,8 +553,7 @@ case class EnsureRequirements(
 
         // in case of compatible but not identical partition expressions, we apply 'reduce'
         // transforms to group one side's partitions as well as the common partition values
-        val leftReducers = leftSpec.reducers(rightSpec)
-        val rightReducers = rightSpec.reducers(leftSpec)
+        val (leftReducers, rightReducers) = leftSpec.reducersBothWays(rightSpec)
         val (leftReducedDataTypes, leftReducedKeys) = leftReducers.fold(
           (leftPartitioning.keyDataTypes, leftPartitioning.partitionKeys)
         )(leftPartitioning.reduceKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -746,7 +746,7 @@ case class EnsureRequirements(
       plan: SparkPlan,
       joinKeyPositions: Option[Seq[Int]],
       mergedPartitionKeys: Seq[(InternalRowComparableWrapper, Int)],
-      reducers: Option[Seq[Option[Reducer[_, _]]]],
+      reducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]],
       distributePartitions: Boolean): SparkPlan = {
     plan match {
       case g: GroupPartitionsExec =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
-import org.apache.spark.sql.connector.catalog.functions.Reducer
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
@@ -746,7 +745,7 @@ case class EnsureRequirements(
       plan: SparkPlan,
       joinKeyPositions: Option[Seq[Int]],
       mergedPartitionKeys: Seq[(InternalRowComparableWrapper, Int)],
-      reducers: Option[Seq[Option[(Reducer[_, _], TransformExpression)]]],
+      reducers: Option[Seq[Option[KeyReducer]]],
       distributePartitions: Boolean): SparkPlan = {
     plan match {
       case g: GroupPartitionsExec =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -810,7 +810,8 @@ class KeyGroupedPartitioningSuite
     // reduced expression is derived from the single spec that `createKeyedShuffleSpec` picks
     // (`collectFirst`). Re-targeting it at each `KeyedPartitioning`'s own key attribute keeps the
     // other sides' partitionings intact - otherwise a GROUP BY on the other side's key no longer
-    // sees a partitioning on it and the query shuffles (0 shuffles on base, 1 after the fix).
+    // sees a partitioning on it and the query shuffles (0 shuffles on base and here, 1 if the
+    // use-site re-targeting is dropped).
     val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
     createTable("b16", cols, Array(bucket(16, "id")))
     createTable("b8", cols, Array(bucket(8, "id")))
@@ -5148,11 +5149,14 @@ class KeyGroupedPartitioningSuite
     }
   }
 
-  test("SPARK-59120: incompatible reduced key types are reported instead of cast") {
-    // The first join reduces the identity side onto the year key space. The third table does not
-    // reduce at all, so the two key spaces genuinely differ, and reading each side's keys at their
-    // own types is what lets `EnsureRequirements` say so. On `master` the merge cast one to the
-    // other and threw `ClassCastException`.
+  test("SPARK-59120: a second join with a non-reducing side plans on the reduced keys") {
+    // The first join reduces the identity side onto the year key space. This PR reports the
+    // reduced expression (`years(a.ts)`), so the second join's identity side reduces onto it as
+    // well and the whole query plans without a shuffle. Under `keyDataTypes` alone (#58420) the
+    // reduced keys were read at their own types but still reported under the stale `identity(ts)`
+    // expression, and this query raised STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES; before
+    // #58420 it threw `ClassCastException`. The error path stays covered by
+    // `SPARK-56046: Reducers with different result types`.
     withTable("t_identity", "t_years", "t_identity2") {
       createTsTable("t_identity", Array(identity("ts")))
       createTsTable("t_years", Array(years("ts")))
@@ -5168,22 +5172,21 @@ class KeyGroupedPartitioningSuite
           SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
           SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
           SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
-        checkError(
-          exception = intercept[SparkException](sql(query).collect()),
-          condition = "STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES",
-          parameters = Map(
-            "leftReducers" -> "[]",
-            "leftReducedDataTypes" -> "[\"INT\"]",
-            "rightReducers" -> "[]",
-            "rightReducedDataTypes" -> "[\"TIMESTAMP\"]"))
+        val df = sql(query)
+        checkAnswer(df, Seq(Row(1, "aa"), Row(2, "bb")))
+        assert(collectAllShuffles(df.queryExecution.executedPlan).isEmpty,
+          "the second join reduces onto the type-correct reported expression")
       }
     }
   }
 
-  test("SPARK-59120: another child is not shuffled onto reducer-rewritten keys") {
-    // `canCreatePartitioning` refuses the reduced side as a layout for the second join, so both of
-    // that join's sides are shuffled. Without the gate the driver dies while assembling that
-    // shuffle's key map, where the stored keys are re-wrapped at the expressions' types.
+  test("SPARK-59120: another child is shuffled onto the type-correct reduced keys") {
+    // This PR reports the reduced side's expression as `years(a.ts)`, which describes the reduced
+    // keys, so `canCreatePartitioning`'s shape gate accepts the reduced layout and only the
+    // unpartitioned side is shuffled onto it. Under `keyDataTypes` alone (#58420) the reduced side
+    // still reported `identity(ts)`, the gate refused it and both of the second join's sides were
+    // shuffled; without the gate the driver died while assembling that shuffle's key map, where
+    // the stored keys are re-wrapped at the expressions' types.
     withTable("t_identity", "t_years", "t_plain") {
       createTsTable("t_identity", Array(identity("ts")))
       createTsTable("t_years", Array(years("ts")))
@@ -5202,8 +5205,8 @@ class KeyGroupedPartitioningSuite
           SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
         val df = sql(query)
         checkAnswer(df, Seq(Row(1, "aa"), Row(2, "bb")))
-        assert(collectAllShuffles(df.queryExecution.executedPlan).size == 2,
-          "the second join shuffles both of its sides")
+        assert(collectAllShuffles(df.queryExecution.executedPlan).size == 1,
+          "the second join shuffles only the unpartitioned side, onto the years(ts) layout")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -860,18 +860,51 @@ class KeyGroupedPartitioningSuite
 
   test("SPARK-59045: canonicalization normalizes the reduced expressions") {
     // `KeyReducer` is a plain case class, not an `Expression`, so plan canonicalization does not
-    // normalize the exprIds inside `reducedExpression`. Two structurally identical
-    // `GroupPartitionsExec`s with value-equal reducers must still compare equal after
-    // canonicalization, or exchange/subquery reuse silently stops deduplicating their subtrees.
+    // normalize the exprIds inside it. Two structurally identical `GroupPartitionsExec`s with
+    // value-equal reducers must still compare equal after canonicalization, or exchange/subquery
+    // reuse silently stops deduplicating their subtrees. The reduced expression is the other join
+    // side's transform, so it references an attribute this node's child does not output; the
+    // identity reducer's transform references this side's own key.
     val a1 = AttributeReference("id", LongType, nullable = true)().withExprId(ExprId(1))
     val a2 = AttributeReference("id", LongType, nullable = true)().withExprId(ExprId(2))
-    def groupPartitions(attr: AttributeReference): GroupPartitionsExec = {
+    val o1 = AttributeReference("oid", LongType, nullable = true)().withExprId(ExprId(11))
+    val o2 = AttributeReference("oid", LongType, nullable = true)().withExprId(ExprId(12))
+    def groupPartitions(
+        attr: AttributeReference,
+        otherAttr: AttributeReference,
+        reducer: Reducer[_, _]): GroupPartitionsExec = {
       val child = new LocalTableScanExec(Seq(attr), Nil, None, false)
-      val reduced = TransformExpression(BucketFunction, Seq(attr), Some(2))
+      val reduced = TransformExpression(BucketFunction, Seq(otherAttr), Some(2))
       GroupPartitionsExec(child,
-        reducers = Some(Seq(Some(physical.KeyReducer(BucketReducer(2), reduced)))))
+        reducers = Some(Seq(Some(physical.KeyReducer(reducer, reduced)))))
     }
-    assert(groupPartitions(a1).canonicalized == groupPartitions(a2).canonicalized)
+    // A value-equal reducer, with the reduced expression over the other side's attribute.
+    assert(groupPartitions(a1, o1, BucketReducer(2)).canonicalized ==
+      groupPartitions(a2, o2, BucketReducer(2)).canonicalized)
+    // The identity-derived reducer, whose transform is over this side's own attribute.
+    assert(groupPartitions(a1, o1, physical.IdentityReducer(
+        TransformExpression(BucketFunction, Seq(a1), Some(2)))).canonicalized ==
+      groupPartitions(a2, o2, physical.IdentityReducer(
+        TransformExpression(BucketFunction, Seq(a2), Some(2)))).canonicalized)
+    // Structurally different reducers stay unequal after canonicalization.
+    assert(groupPartitions(a1, o1, BucketReducer(2)).canonicalized !=
+      groupPartitions(a2, o2, BucketReducer(3)).canonicalized)
+
+    // A multi-key partitioning with a mixed reducer sequence (identity keys are not reducible):
+    // the normalization is per position, and the None entries pass through untouched.
+    val dt1 = AttributeReference("dt", StringType, nullable = true)().withExprId(ExprId(21))
+    val dt2 = AttributeReference("dt", StringType, nullable = true)().withExprId(ExprId(22))
+    def mixedKeyGroupPartitions(
+        attr: AttributeReference,
+        dt: AttributeReference,
+        otherAttr: AttributeReference): GroupPartitionsExec = {
+      val child = new LocalTableScanExec(Seq(attr, dt), Nil, None, false)
+      val reduced = TransformExpression(BucketFunction, Seq(otherAttr), Some(2))
+      GroupPartitionsExec(child,
+        reducers = Some(Seq(None, Some(physical.KeyReducer(BucketReducer(2), reduced)))))
+    }
+    assert(mixedKeyGroupPartitions(a1, dt1, o1).canonicalized ==
+      mixedKeyGroupPartitions(a2, dt2, o2).canonicalized)
   }
 
   test("partitioned join: join with two partition keys and matching & sorted partitions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -748,6 +748,87 @@ class KeyGroupedPartitioningSuite
     }
   }
 
+  test("SPARK-59045: compatible identity and bucket transforms reduce data type") {
+    // `identity(id)` reports a Long partition key while `bucket(4, id)` reports an Integer one.
+    // The identity->bucket reducer maps the Long keys to Integer; the GroupPartitionsExec output
+    // partitioning must report the reduced (Integer) expression, not the original Long identity,
+    // or the key ordering derived from the expressions fails with a ClassCastException.
+    val cols = Array(
+      Column.create("id", LongType),
+      Column.create("data", StringType))
+    createTable("t1", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+    createTable("t2", cols, Array(bucket(4, "id")))
+    sql("INSERT INTO testcat.ns.t2 VALUES (1, 'x'), (2, 'y'), (3, 'z')")
+
+    val df = sql(
+      "SELECT t1.id, t1.data, t2.data FROM testcat.ns.t1 JOIN testcat.ns.t2 ON t1.id = t2.id")
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      checkAnswer(df, Seq(Row(1, "a", "x"), Row(2, "b", "y"), Row(3, "c", "z")))
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "storage-partitioned join should not shuffle")
+    }
+  }
+
+  test("SPARK-59045: compatible transforms reduce multiple times") {
+    // t1 is partitioned by identity(id) (Long), t2 by bucket(4, id), t3 by bucket(2, id). The
+    // first join reduces t1 to bucket(4, id) (data type changes), and the second join reduces the
+    // result to bucket(2, id). The reduced expression reported by the first join must remain a
+    // ReducibleFunction so the second reduction can be computed.
+    val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("t1", cols, Array(identity("id")))
+    createTable("t2", cols, Array(bucket(4, "id")))
+    createTable("t3", cols, Array(bucket(2, "id")))
+    sql("INSERT INTO testcat.ns.t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+    sql("INSERT INTO testcat.ns.t2 VALUES (1, 'x'), (2, 'y'), (3, 'z')")
+    sql("INSERT INTO testcat.ns.t3 VALUES (1, 'p'), (2, 'q'), (3, 'r')")
+
+    val df = sql(
+      "SELECT t1.id, t1.data, t2.data, t3.data FROM testcat.ns.t1 " +
+        "JOIN testcat.ns.t2 ON t1.id = t2.id JOIN testcat.ns.t3 ON t1.id = t3.id")
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      checkAnswer(df, Seq(
+        Row(1, "a", "x", "p"), Row(2, "b", "y", "q"), Row(3, "c", "z", "r")))
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "storage-partitioned join should not shuffle")
+    }
+  }
+
+  test("SPARK-59045: compatible transforms reduce data type with subset join keys") {
+    // The join is on `id`, a subset of the partition keys `[identity(dt), identity(id)]` and
+    // `[identity(dt), bucket(2, id)]`. The identity(id) side is reduced to bucket(2, id), whose
+    // data type differs, while the dt partition key is projected away.
+    val cols = Array(
+      Column.create("id", LongType),
+      Column.create("dt", StringType),
+      Column.create("data", StringType))
+    createTable("t1", cols, Array(identity("dt"), identity("id")))
+    createTable("t2", cols, Array(identity("dt"), bucket(2, "id")))
+    sql("INSERT INTO testcat.ns.t1 VALUES (1, '2020', 'a'), (2, '2020', 'b'), (3, '2021', 'c')")
+    sql("INSERT INTO testcat.ns.t2 VALUES (1, '2020', 'x'), (2, '2020', 'y'), (3, '2021', 'z')")
+
+    val df = sql(
+      "SELECT t1.id, t1.dt, t1.data, t2.dt, t2.data FROM testcat.ns.t1 " +
+        "JOIN testcat.ns.t2 ON t1.id = t2.id")
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      checkAnswer(df, Seq(
+        Row(1, "2020", "a", "2020", "x"), Row(2, "2020", "b", "2020", "y"),
+        Row(3, "2021", "c", "2021", "z")))
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "storage-partitioned join should not shuffle")
+    }
+  }
+
   test("partitioned join: join with two partition keys and matching & sorted partitions") {
     val items_partitions = Array(bucket(8, "id"), days("arrive_time"))
     createTable(items, itemsColumns, items_partitions)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -753,7 +753,9 @@ class KeyGroupedPartitioningSuite
     // `identity(id)` reports a Long partition key while `bucket(4, id)` reports an Integer one.
     // The identity->bucket reducer maps the Long keys to Integer; the GroupPartitionsExec output
     // partitioning must report the reduced (Integer) expression, not the original Long identity,
-    // or the key ordering derived from the expressions fails with a ClassCastException.
+    // so downstream consumers see the keys' real type: another join can reduce onto the reported
+    // transform, and a reduced layout can serve as another child's shuffle target only when the
+    // expressions describe the keys.
     val cols = Array(
       Column.create("id", LongType),
       Column.create("data", StringType))
@@ -3872,18 +3874,29 @@ class KeyGroupedPartitioningSuite
       s"(5, 44.0, cast('2020-01-15' as timestamp)), " +
       s"(7, 46.5, cast('2021-02-08' as timestamp))")
 
+    // A third table partitioned by `identity(time)` joins on the same timestamps: its side
+    // reduces onto the first join's reported `years(arrive_time)`, so the chain plans without a
+    // shuffle only while the reduced keys are reported under the type-correct target transform.
+    val shipments = "shipments"
+    createTable(shipments, purchasesColumns, Array(identity("time")))
+    sql(s"INSERT INTO testcat.ns.$shipments VALUES " +
+      s"(1, 42.0, cast('2020-01-01' as timestamp)), " +
+      s"(9, 46.5, cast('2021-02-08' as timestamp))")
+
     withSQLConf(
         SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
         SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
         Seq(
-          s"testcat.ns.$items i JOIN testcat.ns.$purchases p ON p.time = i.arrive_time",
-          s"testcat.ns.$purchases p JOIN testcat.ns.$items i ON i.arrive_time = p.time"
+          s"testcat.ns.$items i JOIN testcat.ns.$purchases p ON p.time = i.arrive_time " +
+            s"JOIN testcat.ns.$shipments s ON i.arrive_time = s.time",
+          s"testcat.ns.$purchases p JOIN testcat.ns.$items i ON i.arrive_time = p.time " +
+            s"JOIN testcat.ns.$shipments s ON i.arrive_time = s.time"
         ).foreach { joinString =>
           val df = sql(
             s"""
-               |${selectWithMergeJoinHint("i", "p")} id, item_id
+               |${selectWithMergeJoinHint("i", "p")} i.id, p.item_id
                |FROM $joinString
-               |ORDER BY id, item_id
+               |ORDER BY i.id, p.item_id
                |""".stripMargin)
 
           val shuffles = collectShuffles(df.queryExecution.executedPlan)
@@ -5150,10 +5163,10 @@ class KeyGroupedPartitioningSuite
   }
 
   test("SPARK-59120: a second join with a non-reducing side plans on the reduced keys") {
-    // The first join reduces the identity side onto the year key space. This PR reports the
-    // reduced expression (`years(a.ts)`), so the second join's identity side reduces onto it as
-    // well and the whole query plans without a shuffle. Under `keyDataTypes` alone (#58420) the
-    // reduced keys were read at their own types but still reported under the stale `identity(ts)`
+    // The first join reduces the identity side onto the year key space and reports the reduced
+    // expression `years(a.ts)`, so the second join's identity side reduces onto it as well and
+    // the whole query plans without a shuffle. Under `keyDataTypes` alone (#58420) the reduced
+    // keys were read at their own types but still reported under the stale `identity(ts)`
     // expression, and this query raised STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES; before
     // #58420 it threw `ClassCastException`. The error path stays covered by
     // `SPARK-56046: Reducers with different result types`.
@@ -5181,7 +5194,7 @@ class KeyGroupedPartitioningSuite
   }
 
   test("SPARK-59120: another child is shuffled onto the type-correct reduced keys") {
-    // This PR reports the reduced side's expression as `years(a.ts)`, which describes the reduced
+    // The reduced side's expression is reported as `years(a.ts)`, which describes the reduced
     // keys, so `canCreatePartitioning`'s shape gate accepts the reduced layout and only the
     // unpartitioned side is shuffled onto it. Under `keyDataTypes` alone (#58420) the reduced side
     // still reported `identity(ts)`, the gate refused it and both of the second join's sides were

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.rdd.SortedMergeCoalescedRDD
 import org.apache.spark.sql.{DataFrame, ExplainSuiteHelper, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, Literal, TransformExpression}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, Literal, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.physical
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryCatalystRuntimeFilterCatalog, InMemoryTableCatalog}
 import org.apache.spark.sql.connector.catalog.functions._
@@ -33,6 +33,7 @@ import org.apache.spark.sql.connector.expressions.Expressions._
 import org.apache.spark.sql.execution.{
   ExtendedMode,
   FormattedMode,
+  LocalTableScanExec,
   ProjectExec,
   RDDScanExec,
   SimpleMode,
@@ -855,6 +856,22 @@ class KeyGroupedPartitioningSuite
       assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
         "storage-partitioned join should not shuffle")
     }
+  }
+
+  test("SPARK-59045: canonicalization normalizes the reduced expressions") {
+    // `KeyReducer` is a plain case class, not an `Expression`, so plan canonicalization does not
+    // normalize the exprIds inside `reducedExpression`. Two structurally identical
+    // `GroupPartitionsExec`s with value-equal reducers must still compare equal after
+    // canonicalization, or exchange/subquery reuse silently stops deduplicating their subtrees.
+    val a1 = AttributeReference("id", LongType, nullable = true)().withExprId(ExprId(1))
+    val a2 = AttributeReference("id", LongType, nullable = true)().withExprId(ExprId(2))
+    def groupPartitions(attr: AttributeReference): GroupPartitionsExec = {
+      val child = new LocalTableScanExec(Seq(attr), Nil, None, false)
+      val reduced = TransformExpression(BucketFunction, Seq(attr), Some(2))
+      GroupPartitionsExec(child,
+        reducers = Some(Seq(Some(physical.KeyReducer(BucketReducer(2), reduced)))))
+    }
+    assert(groupPartitions(a1).canonicalized == groupPartitions(a2).canonicalized)
   }
 
   test("partitioned join: join with two partition keys and matching & sorted partitions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -5165,11 +5165,7 @@ class KeyGroupedPartitioningSuite
   test("SPARK-59120: a second join with a non-reducing side plans on the reduced keys") {
     // The first join reduces the identity side onto the year key space and reports the reduced
     // expression `years(a.ts)`, so the second join's identity side reduces onto it as well and
-    // the whole query plans without a shuffle. Under `keyDataTypes` alone (#58420) the reduced
-    // keys were read at their own types but still reported under the stale `identity(ts)`
-    // expression, and this query raised STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES; before
-    // #58420 it threw `ClassCastException`. The error path stays covered by
-    // `SPARK-56046: Reducers with different result types`.
+    // the whole query plans without a shuffle.
     withTable("t_identity", "t_years", "t_identity2") {
       createTsTable("t_identity", Array(identity("ts")))
       createTsTable("t_years", Array(years("ts")))
@@ -5196,10 +5192,7 @@ class KeyGroupedPartitioningSuite
   test("SPARK-59120: another child is shuffled onto the type-correct reduced keys") {
     // The reduced side's expression is reported as `years(a.ts)`, which describes the reduced
     // keys, so `canCreatePartitioning`'s shape gate accepts the reduced layout and only the
-    // unpartitioned side is shuffled onto it. Under `keyDataTypes` alone (#58420) the reduced side
-    // still reported `identity(ts)`, the gate refused it and both of the second join's sides were
-    // shuffled; without the gate the driver died while assembling that shuffle's key map, where
-    // the stored keys are re-wrapped at the expressions' types.
+    // unpartitioned side is shuffled onto it.
     withTable("t_identity", "t_years", "t_plain") {
       createTsTable("t_identity", Array(identity("ts")))
       createTsTable("t_years", Array(years("ts")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -779,6 +779,10 @@ class KeyGroupedPartitioningSuite
     // first join reduces t1 to bucket(4, id) (data type changes), and the second join reduces the
     // result to bucket(2, id). The reduced expression reported by the first join must remain a
     // ReducibleFunction so the second reduction can be computed.
+    // This test deliberately leaves `V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS` off: both
+    // joins use the whole partition key, and without the config the failure on base is exercised
+    // through the second, independent trigger (`reduceKeys` at the second join) instead of
+    // `createShuffleSpec` -> `toGrouped`.
     val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
     createTable("t1", cols, Array(identity("id")))
     createTable("t2", cols, Array(bucket(4, "id")))
@@ -792,10 +796,34 @@ class KeyGroupedPartitioningSuite
         "JOIN testcat.ns.t2 ON t1.id = t2.id JOIN testcat.ns.t3 ON t1.id = t3.id")
 
     withSQLConf(
-        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
-        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
       checkAnswer(df, Seq(
         Row(1, "a", "x", "p"), Row(2, "b", "y", "q"), Row(3, "c", "z", "r")))
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "storage-partitioned join should not shuffle")
+    }
+  }
+
+  test("SPARK-59045: reduced expression is retargeted per KeyedPartitioning") {
+    // A chained SPJ's output partitioning reports one `KeyedPartitioning` per join side, but the
+    // reduced expression is derived from the single spec that `createKeyedShuffleSpec` picks
+    // (`collectFirst`). Re-targeting it at each `KeyedPartitioning`'s own key attribute keeps the
+    // other sides' partitionings intact - otherwise a GROUP BY on the other side's key no longer
+    // sees a partitioning on it and the query shuffles (0 shuffles on base, 1 after the fix).
+    val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("b16", cols, Array(bucket(16, "id")))
+    createTable("b8", cols, Array(bucket(8, "id")))
+    createTable("b4", cols, Array(bucket(4, "id")))
+    val values = (0 until 16).map(i => s"($i, 'v$i')").mkString(", ")
+    Seq("b16", "b8", "b4").foreach(t => sql(s"INSERT INTO testcat.ns.$t VALUES $values"))
+
+    val df = sql(
+      "SELECT b8.id, count(*) FROM testcat.ns.b16 " +
+        "JOIN testcat.ns.b8 ON b16.id = b8.id JOIN testcat.ns.b4 ON b16.id = b4.id " +
+        "GROUP BY b8.id")
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      checkAnswer(df, (0 until 16).map(i => Row(i.toLong, 1L)))
       assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
         "storage-partitioned join should not shuffle")
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`KeyedShuffleSpec.reducersBothWays` now pairs each `Reducer` with the reduced partition expression it produces (`KeyReducer`), and `GroupPartitionsExec.outputPartitioning` reports the reduced expression instead of the original partition expressions when reducers are applied. The stored expression is re-targeted at each `KeyedPartitioning`'s own key attribute at the use site via the new `TransformExpression.withReference`, so a chained storage-partitioned join keeps every side's partitioning intact.

`GroupPartitionsExec.doCanonicalize` additionally normalizes the exprIds inside `KeyReducer` - plan canonicalization does not reach into the plain case class - and the reducer applied for an identity-vs-transform pair is a named `IdentityReducer` case class, so structurally identical SPJ subtrees with value-equal reducers still compare equal and exchange/subquery reuse keeps deduplicating them.

### Why are the changes needed?

In a storage-partitioned join with compatible transforms whose result types differ (e.g. `identity(id)` on one side and `bucket(N, id)` on the other), the reducer maps the partition keys to the other side's value type. `GroupPartitionsExec.outputPartitioning` used to report the original expressions with the reduced keys, so the two had different data types and computing the key ordering threw:

```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long
```

This fix covers the reducers where the reduced keys equal a single transform applied to one side (identity-vs-transform and single-side-transform). When both sides of a compatible-transform join reduce their keys, the reduced keys are not expressible as a single transform; that shape is a known gap tracked in SPARK-59121.

### Does this PR introduce _any_ user-facing change?

No by default. Under `spark.sql.sources.v2.bucketing.allowCompatibleTransforms.enabled`, a storage-partitioned join whose reducer changes the partition key data type previously threw `ClassCastException` and now succeeds.

### How was this patch tested?

Added regression tests in `KeyGroupedPartitioningSuite`. On the current base (including #58420), the multi-table reduce through the `reduceKeys` trigger fails with `ClassCastException` - the second reduce's reducer is derived from the stale reported expression, which no type fix reaches - and the two updated `SPARK-59120` tests fail; all pass here. The two `SPARK-59120` tests now pin the combined behavior: a second join with a non-reducing side plans with no shuffle onto the reported expression, and the shape gate accepts the type-correct reduced layout so only the unpartitioned side is shuffled onto it. The identity-vs-bucket reducer and the subset-join-key cases failed on the pre-#58420 base and pass on the current one, where #58420 fixed the read side; they pin this PR's reporting. The per-`KeyedPartitioning` retargeting test passes on base and regresses together with the multi-reduce test if the use-site re-targeting is dropped, and the canonicalization test arrived with `KeyReducer` in this PR. The first three also assert the storage-partitioned join introduces no shuffle.

Ran `KeyGroupedPartitioningSuite`, `GroupPartitionsExecSuite`, `EnsureRequirementsSuite`, `ProjectedOrderingAndPartitioningSuite`, `ShuffleSpecSuite`, `ValidateRequirementsSuite`, and `DistributionSuite`.
