### PR TITLE
[SPARK-59048][ML] Optimize ProbabilisticClassificationModel by reducing closure size and accelerating transform

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -97,10 +97,6 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
    * The default wraps [[predictRaw]] in a UDF. Models may override this with a native expression or
    * a UDF that snapshots prediction state.
    *
-   * [[ClassificationModel.transform]] uses this when [[rawPredictionCol]] is set. When
-   * [[predictionCol]] is also set, it is used together with [[raw2predictionColumn]].
-   * Subclasses may use it together with additional output-column conversion methods.
-   *
    * @param features input features column
    * @return raw-prediction column of type `Vector`
    */
@@ -111,9 +107,6 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
   /**
    * Returns an expression that produces a predicted label from a raw-prediction vector column.
    *
-   * [[ClassificationModel.transform]] uses this when both [[rawPredictionCol]] and
-   * [[predictionCol]] are set. It consumes the output of [[predictRawColumn]].
-   *
    * @param rawPrediction input raw-prediction column
    * @return prediction column of type `Double`
    */
@@ -123,10 +116,6 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
 
   /**
    * Returns an expression that produces a predicted label directly from a features column.
-   *
-   * [[ClassificationModel.transform]] uses this when [[predictionCol]] is set and
-   * [[rawPredictionCol]] is not set. It is used without another prediction conversion method.
-   * Subclasses with additional output columns may further restrict when this method is used.
    *
    * @param features input features column
    * @return prediction column of type `Double`

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -97,6 +97,10 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
    * The default wraps [[predictRaw]] in a UDF. Models may override this with a native expression or
    * a UDF that snapshots prediction state.
    *
+   * [[ClassificationModel.transform]] uses this when [[rawPredictionCol]] is set. When
+   * [[predictionCol]] is also set, it is used together with [[raw2predictionColumn]].
+   * Subclasses may use it together with additional output-column conversion methods.
+   *
    * @param features input features column
    * @return raw-prediction column of type `Vector`
    */
@@ -107,6 +111,9 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
   /**
    * Returns an expression that produces a predicted label from a raw-prediction vector column.
    *
+   * [[ClassificationModel.transform]] uses this when both [[rawPredictionCol]] and
+   * [[predictionCol]] are set. It consumes the output of [[predictRawColumn]].
+   *
    * @param rawPrediction input raw-prediction column
    * @return prediction column of type `Double`
    */
@@ -116,6 +123,10 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
 
   /**
    * Returns an expression that produces a predicted label directly from a features column.
+   *
+   * [[ClassificationModel.transform]] uses this when [[predictionCol]] is set and
+   * [[rawPredictionCol]] is not set. It is used without another prediction conversion method.
+   * Subclasses with additional output columns may further restrict when this method is used.
    *
    * @param features input features column
    * @return prediction column of type `Double`

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1135,11 +1135,6 @@ class LogisticRegressionModel private[spark] (
   @Since("1.5.0")
   override def getThresholds: Array[Double] = super.getThresholds
 
-  /** Score (probability) for class label 1.  For binary classification only. */
-  private def score(features: Vector): Double = {
-    LogisticRegressionModel.score(features, _coefficients, interceptVector(0))
-  }
-
   override protected def predictRawColumn(features: Column): Column = if (isMultinomial) {
     val localCoefficientMatrix = coefficientMatrix
     val localInterceptVector = interceptVector.toDense
@@ -1155,11 +1150,11 @@ class LogisticRegressionModel private[spark] (
   override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
     if (isMultinomial) {
       udf((rawPrediction: Vector) =>
-        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = true)
+        LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
       ).apply(rawPrediction)
     } else {
       udf((rawPrediction: Vector) =>
-        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = false)
+        LogisticRegressionModel.raw2probabilityBinary(rawPrediction)
       ).apply(rawPrediction)
     }
   }
@@ -1171,7 +1166,7 @@ class LogisticRegressionModel private[spark] (
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
-        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = true)
+        LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
       }).apply(features)
     } else {
       val localCoefficients = _coefficients
@@ -1179,7 +1174,7 @@ class LogisticRegressionModel private[spark] (
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficients, localIntercept)
-        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = false)
+        LogisticRegressionModel.raw2probabilityBinary(rawPrediction)
       }).apply(features)
     }
   }
@@ -1226,8 +1221,7 @@ class LogisticRegressionModel private[spark] (
       if (localThresholds == null) {
         rawPrediction.argmax.toDouble
       } else {
-        val probability = LogisticRegressionModel.raw2probability(
-          rawPrediction, isMultinomial = true)
+        val probability = LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
         ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
       }
     }).apply(features)
@@ -1237,8 +1231,8 @@ class LogisticRegressionModel private[spark] (
     val localProbabilityThreshold = getThreshold
     udf((features: Any) => {
       val featureVector = features.asInstanceOf[Vector]
-      if (LogisticRegressionModel.score(
-          featureVector, localCoefficients, localIntercept) > localProbabilityThreshold) {
+      val margin = BLAS.dot(featureVector, localCoefficients) + localIntercept
+      if (1.0 / (1.0 + math.exp(-margin)) > localProbabilityThreshold) {
         1.0
       } else {
         0.0
@@ -1295,11 +1289,16 @@ class LogisticRegressionModel private[spark] (
     super.predict(features)
   } else {
     // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
-    if (score(features) > getThreshold) 1 else 0
+    val margin = BLAS.dot(features, _coefficients) + interceptVector(0)
+    if (1.0 / (1.0 + math.exp(-margin)) > getThreshold) 1 else 0
   }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
-    LogisticRegressionModel.raw2probabilityInPlace(rawPrediction, isMultinomial)
+    if (isMultinomial) {
+      LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
+    } else {
+      LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction)
+    }
   }
 
   @Since("3.0.0")
@@ -1414,24 +1413,6 @@ class LogisticRegressionModel private[spark] (
 
 @Since("1.6.0")
 object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
-  private def margin(features: Vector, coefficients: Vector, intercept: Double): Double = {
-    BLAS.dot(features, coefficients) + intercept
-  }
-
-  private def margins(
-      features: Vector,
-      coefficientMatrix: Matrix,
-      interceptVector: DenseVector): Vector = {
-    val result = interceptVector.copy
-    BLAS.gemv(1.0, coefficientMatrix, features, 1.0, result)
-    result
-  }
-
-  private def score(features: Vector, coefficients: Vector, intercept: Double): Double = {
-    val m = margin(features, coefficients, intercept)
-    1.0 / (1.0 + math.exp(-m))
-  }
-
   private def rawThreshold(threshold: Double): Double = {
     if (threshold == 0.0) {
       Double.NegativeInfinity
@@ -1446,39 +1427,48 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
       features: Vector,
       coefficients: Vector,
       intercept: Double): Vector = {
-    val m = margin(features, coefficients, intercept)
-    Vectors.dense(-m, m)
+    val margin = BLAS.dot(features, coefficients) + intercept
+    Vectors.dense(-margin, margin)
   }
 
   private def predictRaw(
       features: Vector,
       coefficientMatrix: Matrix,
       interceptVector: DenseVector): Vector = {
-    margins(features, coefficientMatrix, interceptVector)
+    val margins = interceptVector.copy
+    BLAS.gemv(1.0, coefficientMatrix, features, 1.0, margins)
+    margins
   }
 
-  private def raw2probability(rawPrediction: Vector, isMultinomial: Boolean): Vector = {
+  private def raw2probabilityBinary(rawPrediction: Vector): Vector = {
     val probability = rawPrediction.copy
-    raw2probabilityInPlace(probability, isMultinomial)
+    raw2probabilityInPlaceBinary(probability)
   }
 
-  private def raw2probabilityInPlace(
-      rawPrediction: Vector,
-      isMultinomial: Boolean): Vector = {
-    rawPrediction match {
-      case dv: DenseVector =>
-        val values = dv.values
-        if (isMultinomial) {
-          Utils.softmax(values)
-        } else {
-          values(0) = 1.0 / (1.0 + math.exp(-values(0)))
-          values(1) = 1.0 - values(0)
-        }
-        dv
-      case _: SparseVector =>
-        throw new RuntimeException("Unexpected error in LogisticRegressionModel:" +
-          " raw2probabilitiesInPlace encountered SparseVector")
-    }
+  private def raw2probabilityMultinomial(rawPrediction: Vector): Vector = {
+    val probability = rawPrediction.copy
+    raw2probabilityInPlaceMultinomial(probability)
+  }
+
+  private def raw2probabilityInPlaceBinary(rawPrediction: Vector): Vector = {
+    val probability = requireDenseRawPrediction(rawPrediction)
+    val values = probability.values
+    values(0) = 1.0 / (1.0 + math.exp(-values(0)))
+    values(1) = 1.0 - values(0)
+    probability
+  }
+
+  private def raw2probabilityInPlaceMultinomial(rawPrediction: Vector): Vector = {
+    val probability = requireDenseRawPrediction(rawPrediction)
+    Utils.softmax(probability.values)
+    probability
+  }
+
+  private def requireDenseRawPrediction(rawPrediction: Vector): DenseVector = rawPrediction match {
+    case dv: DenseVector => dv
+    case _: SparseVector =>
+      throw new RuntimeException("Unexpected error in LogisticRegressionModel:" +
+        " raw2probabilitiesInPlace encountered SparseVector")
   }
 
   private[ml] case class Data(

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1177,7 +1177,11 @@ class LogisticRegressionModel private[spark] (
   override protected def raw2predictionColumn(rawPrediction: Column): Column = if (isMultinomial) {
     if (isDefined(thresholds)) {
       val localThresholds = getThresholds.clone()
-      probability2predictionColumn(raw2probabilityColumn(rawPrediction), localThresholds)
+      udf((rawPrediction: Vector) => {
+        val probability = LogisticRegressionModel.raw2probabilityInPlaceMultinomial(
+          rawPrediction.copy)
+        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+      }).apply(rawPrediction)
     } else {
       udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1162,41 +1162,56 @@ class LogisticRegressionModel private[spark] (
     LogisticRegressionModel.score(features, _coefficients, _intercept)
   }
 
-  private def predictRawFunction: Vector => Vector = if (isMultinomial) {
+  override protected def predictRawColumn(features: Column): Column = if (isMultinomial) {
     val localCoefficientMatrix = coefficientMatrix
     val localInterceptVector = _interceptVector
-    features => LogisticRegressionModel.predictRaw(
-      features, localCoefficientMatrix, localInterceptVector)
+    udf((features: Any) => LogisticRegressionModel.predictRaw(
+      features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)).apply(features)
   } else {
     val localCoefficients = _coefficients
     val localIntercept = _intercept
-    features => LogisticRegressionModel.predictRaw(features, localCoefficients, localIntercept)
-  }
-
-  override protected def predictRawColumn(features: Column): Column = {
-    udf(predictRawFunction).apply(features)
+    udf((features: Any) => LogisticRegressionModel.predictRaw(
+      features.asInstanceOf[Vector], localCoefficients, localIntercept)).apply(features)
   }
 
   override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
-    val localIsMultinomial = isMultinomial
-    udf((rawPrediction: Vector) =>
-      LogisticRegressionModel.raw2probability(rawPrediction, localIsMultinomial)
-    ).apply(rawPrediction)
+    if (isMultinomial) {
+      udf((rawPrediction: Vector) =>
+        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = true)
+      ).apply(rawPrediction)
+    } else {
+      udf((rawPrediction: Vector) =>
+        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = false)
+      ).apply(rawPrediction)
+    }
   }
 
   override protected def predictProbabilityColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunction
-    val localIsMultinomial = isMultinomial
-    udf((features: Any) => LogisticRegressionModel.raw2probability(
-      localPredictRaw(features.asInstanceOf[Vector]), localIsMultinomial)).apply(features)
+    if (isMultinomial) {
+      val localCoefficientMatrix = coefficientMatrix
+      val localInterceptVector = _interceptVector
+      udf((features: Any) => {
+        val rawPrediction = LogisticRegressionModel.predictRaw(
+          features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
+        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = true)
+      }).apply(features)
+    } else {
+      val localCoefficients = _coefficients
+      val localIntercept = _intercept
+      udf((features: Any) => {
+        val rawPrediction = LogisticRegressionModel.predictRaw(
+          features.asInstanceOf[Vector], localCoefficients, localIntercept)
+        LogisticRegressionModel.raw2probability(rawPrediction, isMultinomial = false)
+      }).apply(features)
+    }
   }
 
   override protected def raw2predictionColumn(rawPrediction: Column): Column = if (isMultinomial) {
-    val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
-    if (localThresholds == null) {
-      udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
-    } else {
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
       probability2predictionColumn(raw2probabilityColumn(rawPrediction), localThresholds)
+    } else {
+      udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
     }
   } else {
     val localRawThreshold = _binaryThresholds(1)
@@ -1224,10 +1239,12 @@ class LogisticRegressionModel private[spark] (
   }
 
   override protected def predictionColumn(features: Column): Column = if (isMultinomial) {
-    val localPredictRaw = predictRawFunction
+    val localCoefficientMatrix = coefficientMatrix
+    val localInterceptVector = _interceptVector
     val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
-    udf((features: Vector) => {
-      val rawPrediction = localPredictRaw(features)
+    udf((features: Any) => {
+      val rawPrediction = LogisticRegressionModel.predictRaw(
+        features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
       if (localThresholds == null) {
         rawPrediction.argmax.toDouble
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1125,25 +1125,6 @@ class LogisticRegressionModel private[spark] (
 
   private val _interceptVector = if (isMultinomial) interceptVector.toDense else null
   private val _intercept = if (!isMultinomial) interceptVector(0) else Double.NaN
-  // Array(0.5, 0.0) is the value for default threshold (0.5) and thresholds (unset)
-  private var _binaryThresholds: Array[Double] = if (!isMultinomial) Array(0.5, 0.0) else null
-
-  private[ml] override def onParamChange(param: Param[_]): Unit = {
-    if (!isMultinomial && (param.name == "threshold" || param.name == "thresholds")) {
-      if (isDefined(threshold) || isDefined(thresholds)) {
-        val _threshold = getThreshold
-        if (_threshold == 0.0) {
-          _binaryThresholds = Array(_threshold, Double.NegativeInfinity)
-        } else if (_threshold == 1.0) {
-          _binaryThresholds = Array(_threshold, Double.PositiveInfinity)
-        } else {
-          _binaryThresholds = Array(_threshold, math.log(_threshold / (1.0 - _threshold)))
-        }
-      } else {
-        _binaryThresholds = null
-      }
-    }
-  }
 
   @Since("1.5.0")
   override def setThreshold(value: Double): this.type = super.setThreshold(value)
@@ -1214,7 +1195,7 @@ class LogisticRegressionModel private[spark] (
       udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
     }
   } else {
-    val localRawThreshold = _binaryThresholds(1)
+    val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
     val rawScore = MLFunctions.vector_get(rawPrediction, lit(1))
     when(!isnan(rawScore) && rawScore > localRawThreshold, 1.0).otherwise(0.0)
   }
@@ -1224,7 +1205,7 @@ class LogisticRegressionModel private[spark] (
     val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
     probability2predictionColumn(probability, localThresholds)
   } else {
-    val localProbabilityThreshold = _binaryThresholds(0)
+    val localProbabilityThreshold = getThreshold
     val probabilityScore = MLFunctions.vector_get(probability, lit(1))
     when(!isnan(probabilityScore) && probabilityScore > localProbabilityThreshold, 1.0)
       .otherwise(0.0)
@@ -1256,7 +1237,7 @@ class LogisticRegressionModel private[spark] (
   } else {
     val localCoefficients = _coefficients
     val localIntercept = _intercept
-    val localProbabilityThreshold = _binaryThresholds(0)
+    val localProbabilityThreshold = getThreshold
     udf((features: Any) => {
       val featureVector = features.asInstanceOf[Vector]
       if (LogisticRegressionModel.score(
@@ -1316,8 +1297,8 @@ class LogisticRegressionModel private[spark] (
   override def predict(features: Vector): Double = if (isMultinomial) {
     super.predict(features)
   } else {
-    // Note: We should use _threshold instead of $(threshold) since getThreshold is overridden.
-    if (score(features) > _binaryThresholds(0)) 1 else 0
+    // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
+    if (score(features) > getThreshold) 1 else 0
   }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
@@ -1355,8 +1336,9 @@ class LogisticRegressionModel private[spark] (
     if (isMultinomial) {
       super.raw2prediction(rawPrediction)
     } else {
-      // Note: We should use _threshold instead of $(threshold) since getThreshold is overridden.
-      if (rawPrediction(1) > _binaryThresholds(1)) 1.0 else 0.0
+      // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
+      val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
+      if (rawPrediction(1) > localRawThreshold) 1.0 else 0.0
     }
   }
 
@@ -1364,8 +1346,8 @@ class LogisticRegressionModel private[spark] (
     if (isMultinomial) {
       super.probability2prediction(probability)
     } else {
-      // Note: We should use _threshold instead of $(threshold) since getThreshold is overridden.
-      if (probability(1) > _binaryThresholds(0)) 1.0 else 0.0
+      // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
+      if (probability(1) > getThreshold) 1.0 else 0.0
     }
   }
 
@@ -1451,6 +1433,16 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
   private def score(features: Vector, coefficients: Vector, intercept: Double): Double = {
     val m = margin(features, coefficients, intercept)
     1.0 / (1.0 + math.exp(-m))
+  }
+
+  private def rawThreshold(threshold: Double): Double = {
+    if (threshold == 0.0) {
+      Double.NegativeInfinity
+    } else if (threshold == 1.0) {
+      Double.PositiveInfinity
+    } else {
+      math.log(threshold / (1.0 - threshold))
+    }
   }
 
   private def predictRaw(

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -30,7 +30,6 @@ import org.apache.spark.SparkException
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.LogKeys.{COUNT, RANGE}
-import org.apache.spark.ml.{functions => MLFunctions}
 import org.apache.spark.ml.feature._
 import org.apache.spark.ml.impl.Utils
 import org.apache.spark.ml.linalg._
@@ -45,7 +44,7 @@ import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.functions.{get => arrayGet, _}
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util._
@@ -1187,8 +1186,8 @@ class LogisticRegressionModel private[spark] (
     }
   } else {
     val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
-    val rawScore = MLFunctions.vector_get(rawPrediction, lit(1))
-    when(!isnan(rawScore) && rawScore > localRawThreshold, 1.0).otherwise(0.0)
+    val rawScore = arrayGet(unwrap_udt(rawPrediction).getField("values"), lit(1))
+    when(rawScore > localRawThreshold && !isnan(rawScore), 1.0).otherwise(0.0)
   }
 
   override protected def probability2predictionColumn(
@@ -1201,8 +1200,8 @@ class LogisticRegressionModel private[spark] (
     }
   } else {
     val localProbabilityThreshold = getThreshold
-    val probabilityScore = MLFunctions.vector_get(probability, lit(1))
-    when(!isnan(probabilityScore) && probabilityScore > localProbabilityThreshold, 1.0)
+    val probabilityScore = arrayGet(unwrap_udt(probability).getField("values"), lit(1))
+    when(probabilityScore > localProbabilityThreshold && !isnan(probabilityScore), 1.0)
       .otherwise(0.0)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -44,7 +44,7 @@ import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{get => arrayGet, _}
+import org.apache.spark.sql.functions.{get => fget, _}
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util._
@@ -1186,7 +1186,7 @@ class LogisticRegressionModel private[spark] (
     }
   } else {
     val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
-    val rawScore = arrayGet(unwrap_udt(rawPrediction).getField("values"), lit(1))
+    val rawScore = fget(unwrap_udt(rawPrediction).getField("values"), lit(1))
     when(rawScore > localRawThreshold && !isnan(rawScore), 1.0).otherwise(0.0)
   }
 
@@ -1200,7 +1200,7 @@ class LogisticRegressionModel private[spark] (
     }
   } else {
     val localProbabilityThreshold = getThreshold
-    val probabilityScore = arrayGet(unwrap_udt(probability).getField("values"), lit(1))
+    val probabilityScore = fget(unwrap_udt(probability).getField("values"), lit(1))
     when(probabilityScore > localProbabilityThreshold && !isnan(probabilityScore), 1.0)
       .otherwise(0.0)
   }
@@ -1235,10 +1235,10 @@ class LogisticRegressionModel private[spark] (
   } else {
     val localCoefficients = coefficients
     val localIntercept = interceptVector(0)
-    val localProbabilityThreshold = getThreshold
+    val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
     udf((features: Vector) => {
       val margin = BLAS.dot(features, localCoefficients) + localIntercept
-      if (1.0 / (1.0 + math.exp(-margin)) > localProbabilityThreshold) {
+      if (margin > localRawThreshold) {
         1.0
       } else {
         0.0
@@ -1419,6 +1419,11 @@ class LogisticRegressionModel private[spark] (
 
 @Since("1.6.0")
 object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
+  /**
+   * Converts a binary probability threshold to the equivalent raw margin threshold.
+   * Probability thresholds 0 and 1 map to negative and positive infinity, respectively,
+   * where the log-odds formula is undefined.
+   */
   private def rawThreshold(threshold: Double): Double = {
     if (threshold == 0.0) {
       Double.NegativeInfinity

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1295,9 +1295,9 @@ class LogisticRegressionModel private[spark] (
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
     if (isMultinomial) {
-      LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
+      LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction.toDense)
     } else {
-      LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction)
+      LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction.toDense)
     }
   }
 
@@ -1441,34 +1441,23 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
   }
 
   private def raw2probabilityBinary(rawPrediction: Vector): Vector = {
-    val probability = rawPrediction.copy
-    raw2probabilityInPlaceBinary(probability)
+    raw2probabilityInPlaceBinary(rawPrediction.toDense)
   }
 
   private def raw2probabilityMultinomial(rawPrediction: Vector): Vector = {
-    val probability = rawPrediction.copy
-    raw2probabilityInPlaceMultinomial(probability)
+    raw2probabilityInPlaceMultinomial(rawPrediction.toDense)
   }
 
-  private def raw2probabilityInPlaceBinary(rawPrediction: Vector): Vector = {
-    val probability = requireDenseRawPrediction(rawPrediction)
+  private def raw2probabilityInPlaceBinary(probability: DenseVector): Vector = {
     val values = probability.values
     values(0) = 1.0 / (1.0 + math.exp(-values(0)))
     values(1) = 1.0 - values(0)
     probability
   }
 
-  private def raw2probabilityInPlaceMultinomial(rawPrediction: Vector): Vector = {
-    val probability = requireDenseRawPrediction(rawPrediction)
+  private def raw2probabilityInPlaceMultinomial(probability: DenseVector): Vector = {
     Utils.softmax(probability.values)
     probability
-  }
-
-  private def requireDenseRawPrediction(rawPrediction: Vector): DenseVector = rawPrediction match {
-    case dv: DenseVector => dv
-    case _: SparseVector =>
-      throw new RuntimeException("Unexpected error in LogisticRegressionModel:" +
-        " raw2probabilitiesInPlace encountered SparseVector")
   }
 
   private[ml] case class Data(

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1120,11 +1120,8 @@ class LogisticRegressionModel private[spark] (
     throw new SparkException("Multinomial models contain a vector of intercepts, use " +
       "interceptVector instead.")
   } else {
-    _intercept
+    interceptVector(0)
   }
-
-  private val _interceptVector = if (isMultinomial) interceptVector.toDense else null
-  private val _intercept = if (!isMultinomial) interceptVector(0) else Double.NaN
 
   @Since("1.5.0")
   override def setThreshold(value: Double): this.type = super.setThreshold(value)
@@ -1140,17 +1137,17 @@ class LogisticRegressionModel private[spark] (
 
   /** Score (probability) for class label 1.  For binary classification only. */
   private def score(features: Vector): Double = {
-    LogisticRegressionModel.score(features, _coefficients, _intercept)
+    LogisticRegressionModel.score(features, _coefficients, interceptVector(0))
   }
 
   override protected def predictRawColumn(features: Column): Column = if (isMultinomial) {
     val localCoefficientMatrix = coefficientMatrix
-    val localInterceptVector = _interceptVector
+    val localInterceptVector = interceptVector.toDense
     udf((features: Any) => LogisticRegressionModel.predictRaw(
       features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)).apply(features)
   } else {
     val localCoefficients = _coefficients
-    val localIntercept = _intercept
+    val localIntercept = interceptVector(0)
     udf((features: Any) => LogisticRegressionModel.predictRaw(
       features.asInstanceOf[Vector], localCoefficients, localIntercept)).apply(features)
   }
@@ -1170,7 +1167,7 @@ class LogisticRegressionModel private[spark] (
   override protected def predictProbabilityColumn(features: Column): Column = {
     if (isMultinomial) {
       val localCoefficientMatrix = coefficientMatrix
-      val localInterceptVector = _interceptVector
+      val localInterceptVector = interceptVector.toDense
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
@@ -1178,7 +1175,7 @@ class LogisticRegressionModel private[spark] (
       }).apply(features)
     } else {
       val localCoefficients = _coefficients
-      val localIntercept = _intercept
+      val localIntercept = interceptVector(0)
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficients, localIntercept)
@@ -1221,7 +1218,7 @@ class LogisticRegressionModel private[spark] (
 
   override protected def predictionColumn(features: Column): Column = if (isMultinomial) {
     val localCoefficientMatrix = coefficientMatrix
-    val localInterceptVector = _interceptVector
+    val localInterceptVector = interceptVector.toDense
     val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
     udf((features: Any) => {
       val rawPrediction = LogisticRegressionModel.predictRaw(
@@ -1236,7 +1233,7 @@ class LogisticRegressionModel private[spark] (
     }).apply(features)
   } else {
     val localCoefficients = _coefficients
-    val localIntercept = _intercept
+    val localIntercept = interceptVector(0)
     val localProbabilityThreshold = getThreshold
     udf((features: Any) => {
       val featureVector = features.asInstanceOf[Vector]
@@ -1308,9 +1305,9 @@ class LogisticRegressionModel private[spark] (
   @Since("3.0.0")
   override def predictRaw(features: Vector): Vector = {
     if (isMultinomial) {
-      LogisticRegressionModel.predictRaw(features, coefficientMatrix, _interceptVector)
+      LogisticRegressionModel.predictRaw(features, coefficientMatrix, interceptVector.toDense)
     } else {
-      LogisticRegressionModel.predictRaw(features, _coefficients, _intercept)
+      LogisticRegressionModel.predictRaw(features, _coefficients, interceptVector(0))
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1194,8 +1194,12 @@ class LogisticRegressionModel private[spark] (
 
   override protected def probability2predictionColumn(
       probability: Column): Column = if (isMultinomial) {
-    val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
-    probability2predictionColumn(probability, localThresholds)
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
+      probability2predictionColumn(probability, localThresholds)
+    } else {
+      udf((probability: Vector) => probability.argmax.toDouble).apply(probability)
+    }
   } else {
     val localProbabilityThreshold = getThreshold
     val probabilityScore = MLFunctions.vector_get(probability, lit(1))
@@ -1214,17 +1218,21 @@ class LogisticRegressionModel private[spark] (
   override protected def predictionColumn(features: Column): Column = if (isMultinomial) {
     val localCoefficientMatrix = coefficientMatrix
     val localInterceptVector = interceptVector.toDense
-    val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
-    udf((features: Any) => {
-      val rawPrediction = LogisticRegressionModel.predictRaw(
-        features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
-      if (localThresholds == null) {
-        rawPrediction.argmax.toDouble
-      } else {
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
+      udf((features: Any) => {
+        val rawPrediction = LogisticRegressionModel.predictRaw(
+          features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
         val probability = LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
         ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
-      }
-    }).apply(features)
+      }).apply(features)
+    } else {
+      udf((features: Any) => {
+        val rawPrediction = LogisticRegressionModel.predictRaw(
+          features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
+        rawPrediction.argmax.toDouble
+      }).apply(features)
+    }
   } else {
     val localCoefficients = _coefficients
     val localIntercept = interceptVector(0)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1303,9 +1303,9 @@ class LogisticRegressionModel private[spark] (
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
     if (isMultinomial) {
-      LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction.toDense)
+      LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
     } else {
-      LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction.toDense)
+      LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction)
     }
   }
 
@@ -1449,23 +1449,24 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
   }
 
   private def raw2probabilityBinary(rawPrediction: Vector): Vector = {
-    raw2probabilityInPlaceBinary(rawPrediction.toDense)
+    raw2probabilityInPlaceBinary(rawPrediction)
   }
 
   private def raw2probabilityMultinomial(rawPrediction: Vector): Vector = {
-    raw2probabilityInPlaceMultinomial(rawPrediction.toDense)
+    raw2probabilityInPlaceMultinomial(rawPrediction)
   }
 
-  private def raw2probabilityInPlaceBinary(probability: DenseVector): Vector = {
-    val values = probability.values
+  private def raw2probabilityInPlaceBinary(rawPrediction: Vector): Vector = {
+    val values = rawPrediction.toArray
     values(0) = 1.0 / (1.0 + math.exp(-values(0)))
     values(1) = 1.0 - values(0)
-    probability
+    Vectors.dense(values)
   }
 
-  private def raw2probabilityInPlaceMultinomial(probability: DenseVector): Vector = {
-    Utils.softmax(probability.values)
-    probability
+  private def raw2probabilityInPlaceMultinomial(rawPrediction: Vector): Vector = {
+    val values = rawPrediction.toArray
+    Utils.softmax(values)
+    Vectors.dense(values)
   }
 
   private[ml] case class Data(

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1187,8 +1187,8 @@ class LogisticRegressionModel private[spark] (
   override protected def predictProbabilityColumn(features: Column): Column = {
     val localPredictRaw = predictRawFunction
     val localIsMultinomial = isMultinomial
-    udf((features: Vector) => LogisticRegressionModel.raw2probability(
-      localPredictRaw(features), localIsMultinomial)).apply(features)
+    udf((features: Any) => LogisticRegressionModel.raw2probability(
+      localPredictRaw(features.asInstanceOf[Vector]), localIsMultinomial)).apply(features)
   }
 
   override protected def raw2predictionColumn(rawPrediction: Column): Column = if (isMultinomial) {
@@ -1240,9 +1240,10 @@ class LogisticRegressionModel private[spark] (
     val localCoefficients = _coefficients
     val localIntercept = _intercept
     val localProbabilityThreshold = _binaryThresholds(0)
-    udf((features: Vector) => {
+    udf((features: Any) => {
+      val featureVector = features.asInstanceOf[Vector]
       if (LogisticRegressionModel.score(
-          features, localCoefficients, localIntercept) > localProbabilityThreshold) {
+          featureVector, localCoefficients, localIntercept) > localProbabilityThreshold) {
         1.0
       } else {
         0.0

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1150,11 +1150,11 @@ class LogisticRegressionModel private[spark] (
   override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
     if (isMultinomial) {
       udf((rawPrediction: Vector) =>
-        LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
+        LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
       ).apply(rawPrediction)
     } else {
       udf((rawPrediction: Vector) =>
-        LogisticRegressionModel.raw2probabilityBinary(rawPrediction)
+        LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction)
       ).apply(rawPrediction)
     }
   }
@@ -1166,7 +1166,7 @@ class LogisticRegressionModel private[spark] (
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
-        LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
+        LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
       }).apply(features)
     } else {
       val localCoefficients = _coefficients
@@ -1174,7 +1174,7 @@ class LogisticRegressionModel private[spark] (
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficients, localIntercept)
-        LogisticRegressionModel.raw2probabilityBinary(rawPrediction)
+        LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction)
       }).apply(features)
     }
   }
@@ -1223,7 +1223,8 @@ class LogisticRegressionModel private[spark] (
       udf((features: Any) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
           features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
-        val probability = LogisticRegressionModel.raw2probabilityMultinomial(rawPrediction)
+        val probability =
+          LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
         ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
       }).apply(features)
     } else {
@@ -1446,14 +1447,6 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
     val margins = interceptVector.copy
     BLAS.gemv(1.0, coefficientMatrix, features, 1.0, margins)
     margins
-  }
-
-  private def raw2probabilityBinary(rawPrediction: Vector): Vector = {
-    raw2probabilityInPlaceBinary(rawPrediction)
-  }
-
-  private def raw2probabilityMultinomial(rawPrediction: Vector): Vector = {
-    raw2probabilityInPlaceMultinomial(rawPrediction)
   }
 
   private def raw2probabilityInPlaceBinary(rawPrediction: Vector): Vector = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -30,6 +30,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.LogKeys.{COUNT, RANGE}
+import org.apache.spark.ml.{functions => MLFunctions}
 import org.apache.spark.ml.feature._
 import org.apache.spark.ml.impl.Utils
 import org.apache.spark.ml.linalg._
@@ -44,6 +45,7 @@ import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util._
@@ -1155,22 +1157,97 @@ class LogisticRegressionModel private[spark] (
   @Since("1.5.0")
   override def getThresholds: Array[Double] = super.getThresholds
 
-  /** Margin (rawPrediction) for class label 1.  For binary classification only. */
-  private val margin: Vector => Double = (features) => {
-    BLAS.dot(features, _coefficients) + _intercept
-  }
-
-  /** Margin (rawPrediction) for each class label. */
-  private val margins: Vector => Vector = (features) => {
-    val m = _interceptVector.copy
-    BLAS.gemv(1.0, coefficientMatrix, features, 1.0, m)
-    m
-  }
-
   /** Score (probability) for class label 1.  For binary classification only. */
-  private val score: Vector => Double = (features) => {
-    val m = margin(features)
-    1.0 / (1.0 + math.exp(-m))
+  private def score(features: Vector): Double = {
+    LogisticRegressionModel.score(features, _coefficients, _intercept)
+  }
+
+  private def predictRawFunction: Vector => Vector = if (isMultinomial) {
+    val localCoefficientMatrix = coefficientMatrix
+    val localInterceptVector = _interceptVector
+    features => LogisticRegressionModel.predictRaw(
+      features, localCoefficientMatrix, localInterceptVector)
+  } else {
+    val localCoefficients = _coefficients
+    val localIntercept = _intercept
+    features => LogisticRegressionModel.predictRaw(features, localCoefficients, localIntercept)
+  }
+
+  override protected def predictRawColumn(features: Column): Column = {
+    udf(predictRawFunction).apply(features)
+  }
+
+  override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
+    val localIsMultinomial = isMultinomial
+    udf((rawPrediction: Vector) =>
+      LogisticRegressionModel.raw2probability(rawPrediction, localIsMultinomial)
+    ).apply(rawPrediction)
+  }
+
+  override protected def predictProbabilityColumn(features: Column): Column = {
+    val localPredictRaw = predictRawFunction
+    val localIsMultinomial = isMultinomial
+    udf((features: Vector) => LogisticRegressionModel.raw2probability(
+      localPredictRaw(features), localIsMultinomial)).apply(features)
+  }
+
+  override protected def raw2predictionColumn(rawPrediction: Column): Column = if (isMultinomial) {
+    val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
+    if (localThresholds == null) {
+      udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
+    } else {
+      probability2predictionColumn(raw2probabilityColumn(rawPrediction), localThresholds)
+    }
+  } else {
+    val localRawThreshold = _binaryThresholds(1)
+    val rawScore = MLFunctions.vector_get(rawPrediction, lit(1))
+    when(!isnan(rawScore) && rawScore > localRawThreshold, 1.0).otherwise(0.0)
+  }
+
+  override protected def probability2predictionColumn(
+      probability: Column): Column = if (isMultinomial) {
+    val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
+    probability2predictionColumn(probability, localThresholds)
+  } else {
+    val localProbabilityThreshold = _binaryThresholds(0)
+    val probabilityScore = MLFunctions.vector_get(probability, lit(1))
+    when(!isnan(probabilityScore) && probabilityScore > localProbabilityThreshold, 1.0)
+      .otherwise(0.0)
+  }
+
+  private def probability2predictionColumn(
+      probability: Column,
+      localThresholds: Array[Double]): Column = {
+    udf((probability: Vector) =>
+      ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+    ).apply(probability)
+  }
+
+  override protected def predictionColumn(features: Column): Column = if (isMultinomial) {
+    val localPredictRaw = predictRawFunction
+    val localThresholds = if (isDefined(thresholds)) getThresholds.clone() else null
+    udf((features: Vector) => {
+      val rawPrediction = localPredictRaw(features)
+      if (localThresholds == null) {
+        rawPrediction.argmax.toDouble
+      } else {
+        val probability = LogisticRegressionModel.raw2probability(
+          rawPrediction, isMultinomial = true)
+        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+      }
+    }).apply(features)
+  } else {
+    val localCoefficients = _coefficients
+    val localIntercept = _intercept
+    val localProbabilityThreshold = _binaryThresholds(0)
+    udf((features: Vector) => {
+      if (LogisticRegressionModel.score(
+          features, localCoefficients, localIntercept) > localProbabilityThreshold) {
+        1.0
+      } else {
+        0.0
+      }
+    }).apply(features)
   }
 
   @Since("1.6.0")
@@ -1226,29 +1303,15 @@ class LogisticRegressionModel private[spark] (
   }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
-    rawPrediction match {
-      case dv: DenseVector =>
-        val values = dv.values
-        if (isMultinomial) {
-          Utils.softmax(values)
-        } else {
-          values(0) = 1.0 / (1.0 + math.exp(-values(0)))
-          values(1) = 1.0 - values(0)
-        }
-        dv
-      case sv: SparseVector =>
-        throw new RuntimeException("Unexpected error in LogisticRegressionModel:" +
-          " raw2probabilitiesInPlace encountered SparseVector")
-    }
+    LogisticRegressionModel.raw2probabilityInPlace(rawPrediction, isMultinomial)
   }
 
   @Since("3.0.0")
   override def predictRaw(features: Vector): Vector = {
     if (isMultinomial) {
-      margins(features)
+      LogisticRegressionModel.predictRaw(features, coefficientMatrix, _interceptVector)
     } else {
-      val m = margin(features)
-      Vectors.dense(-m, m)
+      LogisticRegressionModel.predictRaw(features, _coefficients, _intercept)
     }
   }
 
@@ -1354,6 +1417,63 @@ class LogisticRegressionModel private[spark] (
 
 @Since("1.6.0")
 object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
+  private def margin(features: Vector, coefficients: Vector, intercept: Double): Double = {
+    BLAS.dot(features, coefficients) + intercept
+  }
+
+  private def margins(
+      features: Vector,
+      coefficientMatrix: Matrix,
+      interceptVector: DenseVector): Vector = {
+    val result = interceptVector.copy
+    BLAS.gemv(1.0, coefficientMatrix, features, 1.0, result)
+    result
+  }
+
+  private def score(features: Vector, coefficients: Vector, intercept: Double): Double = {
+    val m = margin(features, coefficients, intercept)
+    1.0 / (1.0 + math.exp(-m))
+  }
+
+  private def predictRaw(
+      features: Vector,
+      coefficients: Vector,
+      intercept: Double): Vector = {
+    val m = margin(features, coefficients, intercept)
+    Vectors.dense(-m, m)
+  }
+
+  private def predictRaw(
+      features: Vector,
+      coefficientMatrix: Matrix,
+      interceptVector: DenseVector): Vector = {
+    margins(features, coefficientMatrix, interceptVector)
+  }
+
+  private def raw2probability(rawPrediction: Vector, isMultinomial: Boolean): Vector = {
+    val probability = rawPrediction.copy
+    raw2probabilityInPlace(probability, isMultinomial)
+  }
+
+  private def raw2probabilityInPlace(
+      rawPrediction: Vector,
+      isMultinomial: Boolean): Vector = {
+    rawPrediction match {
+      case dv: DenseVector =>
+        val values = dv.values
+        if (isMultinomial) {
+          Utils.softmax(values)
+        } else {
+          values(0) = 1.0 / (1.0 + math.exp(-values(0)))
+          values(1) = 1.0 - values(0)
+        }
+        dv
+      case _: SparseVector =>
+        throw new RuntimeException("Unexpected error in LogisticRegressionModel:" +
+          " raw2probabilitiesInPlace encountered SparseVector")
+    }
+  }
+
   private[ml] case class Data(
     numClasses: Int,
     numFeatures: Int,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1238,11 +1238,7 @@ class LogisticRegressionModel private[spark] (
     val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
     udf((features: Vector) => {
       val margin = BLAS.dot(features, localCoefficients) + localIntercept
-      if (margin > localRawThreshold) {
-        1.0
-      } else {
-        0.0
-      }
+      if (margin > localRawThreshold) 1.0 else 0.0
     }).apply(features)
   }
 
@@ -1295,8 +1291,9 @@ class LogisticRegressionModel private[spark] (
     super.predict(features)
   } else {
     // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
+    val localRawThreshold = LogisticRegressionModel.rawThreshold(getThreshold)
     val margin = BLAS.dot(features, coefficients) + interceptVector(0)
-    if (1.0 / (1.0 + math.exp(-margin)) > getThreshold) 1 else 0
+    if (margin > localRawThreshold) 1 else 0
   }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1096,11 +1096,6 @@ class LogisticRegressionModel private[spark] (
     throw new SparkException("Multinomial models contain a matrix of coefficients, use " +
       "coefficientMatrix instead.")
   } else {
-    _coefficients
-  }
-
-  // convert to appropriate vector representation without replicating data
-  private lazy val _coefficients: Vector = {
     require(coefficientMatrix.isTransposed,
       "LogisticRegressionModel coefficients should be row major for binomial model.")
     coefficientMatrix match {
@@ -1138,13 +1133,13 @@ class LogisticRegressionModel private[spark] (
   override protected def predictRawColumn(features: Column): Column = if (isMultinomial) {
     val localCoefficientMatrix = coefficientMatrix
     val localInterceptVector = interceptVector.toDense
-    udf((features: Any) => LogisticRegressionModel.predictRaw(
-      features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)).apply(features)
+    udf((features: Vector) => LogisticRegressionModel.predictRaw(
+      features, localCoefficientMatrix, localInterceptVector)).apply(features)
   } else {
-    val localCoefficients = _coefficients
+    val localCoefficients = coefficients
     val localIntercept = interceptVector(0)
-    udf((features: Any) => LogisticRegressionModel.predictRaw(
-      features.asInstanceOf[Vector], localCoefficients, localIntercept)).apply(features)
+    udf((features: Vector) => LogisticRegressionModel.predictRaw(
+      features, localCoefficients, localIntercept)).apply(features)
   }
 
   override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
@@ -1163,17 +1158,17 @@ class LogisticRegressionModel private[spark] (
     if (isMultinomial) {
       val localCoefficientMatrix = coefficientMatrix
       val localInterceptVector = interceptVector.toDense
-      udf((features: Any) => {
+      udf((features: Vector) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
-          features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
+          features, localCoefficientMatrix, localInterceptVector)
         LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
       }).apply(features)
     } else {
-      val localCoefficients = _coefficients
+      val localCoefficients = coefficients
       val localIntercept = interceptVector(0)
-      udf((features: Any) => {
+      udf((features: Vector) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
-          features.asInstanceOf[Vector], localCoefficients, localIntercept)
+          features, localCoefficients, localIntercept)
         LogisticRegressionModel.raw2probabilityInPlaceBinary(rawPrediction)
       }).apply(features)
     }
@@ -1220,27 +1215,26 @@ class LogisticRegressionModel private[spark] (
     val localInterceptVector = interceptVector.toDense
     if (isDefined(thresholds)) {
       val localThresholds = getThresholds.clone()
-      udf((features: Any) => {
+      udf((features: Vector) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
-          features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
+          features, localCoefficientMatrix, localInterceptVector)
         val probability =
           LogisticRegressionModel.raw2probabilityInPlaceMultinomial(rawPrediction)
         ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
       }).apply(features)
     } else {
-      udf((features: Any) => {
+      udf((features: Vector) => {
         val rawPrediction = LogisticRegressionModel.predictRaw(
-          features.asInstanceOf[Vector], localCoefficientMatrix, localInterceptVector)
+          features, localCoefficientMatrix, localInterceptVector)
         rawPrediction.argmax.toDouble
       }).apply(features)
     }
   } else {
-    val localCoefficients = _coefficients
+    val localCoefficients = coefficients
     val localIntercept = interceptVector(0)
     val localProbabilityThreshold = getThreshold
-    udf((features: Any) => {
-      val featureVector = features.asInstanceOf[Vector]
-      val margin = BLAS.dot(featureVector, localCoefficients) + localIntercept
+    udf((features: Vector) => {
+      val margin = BLAS.dot(features, localCoefficients) + localIntercept
       if (1.0 / (1.0 + math.exp(-margin)) > localProbabilityThreshold) {
         1.0
       } else {
@@ -1298,7 +1292,7 @@ class LogisticRegressionModel private[spark] (
     super.predict(features)
   } else {
     // Note: We should use getThreshold instead of $(threshold) since getThreshold is overridden.
-    val margin = BLAS.dot(features, _coefficients) + interceptVector(0)
+    val margin = BLAS.dot(features, coefficients) + interceptVector(0)
     if (1.0 / (1.0 + math.exp(-margin)) > getThreshold) 1 else 0
   }
 
@@ -1315,7 +1309,7 @@ class LogisticRegressionModel private[spark] (
     if (isMultinomial) {
       LogisticRegressionModel.predictRaw(features, coefficientMatrix, interceptVector.toDense)
     } else {
-      LogisticRegressionModel.predictRaw(features, _coefficients, interceptVector(0))
+      LogisticRegressionModel.predictRaw(features, coefficients, interceptVector(0))
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -123,7 +123,7 @@ abstract class ProbabilisticClassifier[
  *     <td>Set</td>
  *     <td>Set</td>
  *     <td>Set</td>
- *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> and
+ *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> =>
  *       <code>raw2predictionColumn</code></td>
  *   </tr>
  * </table>
@@ -190,6 +190,7 @@ abstract class ProbabilisticClassificationModel[
    *
    * @param probability input probability column
    * @return prediction column of type `Double`
+   * @note This method honors [[thresholds]] when they are set.
    */
   protected def probability2predictionColumn(probability: Column): Column = {
     udf(probability2prediction _).apply(probability)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -23,7 +23,7 @@ import org.apache.spark.ml.linalg.{DenseVector, SQLDataTypes, Vector}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
-import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.{Column, DataFrame, Dataset}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -75,6 +75,26 @@ abstract class ProbabilisticClassificationModel[
     M <: ProbabilisticClassificationModel[FeaturesType, M]]
   extends ClassificationModel[FeaturesType, M] with ProbabilisticClassifierParams {
 
+  /** Additional column expressions used by probabilistic classification models. */
+  protected def raw2probabilityColumn(rawPrediction: Column): Column = {
+    udf(raw2probability _).apply(rawPrediction)
+  }
+
+  protected def predictProbabilityColumn(features: Column): Column = {
+    val localPredictProbability = predictProbability _
+    udf { value: Any =>
+      localPredictProbability(value.asInstanceOf[FeaturesType])
+    }.apply(features)
+  }
+
+  override protected def raw2predictionColumn(rawPrediction: Column): Column = {
+    udf(raw2prediction _).apply(rawPrediction)
+  }
+
+  protected def probability2predictionColumn(probability: Column): Column = {
+    udf(probability2prediction _).apply(probability)
+  }
+
   /** @group setParam */
   def setProbabilityCol(value: String): M = set(probabilityCol, value).asInstanceOf[M]
 
@@ -118,21 +138,16 @@ abstract class ProbabilisticClassificationModel[
     var outputData = dataset
     var numColsOutput = 0
     if ($(rawPredictionCol).nonEmpty) {
-      val predictRawUDF = udf { features: Any =>
-        predictRaw(features.asInstanceOf[FeaturesType])
-      }
-      outputData = outputData.withColumn(getRawPredictionCol, predictRawUDF(col(getFeaturesCol)),
+      outputData = outputData.withColumn(getRawPredictionCol,
+        predictRawColumn(col(getFeaturesCol)),
         outputSchema($(rawPredictionCol)).metadata)
       numColsOutput += 1
     }
     if ($(probabilityCol).nonEmpty) {
       val probCol = if ($(rawPredictionCol).nonEmpty) {
-        udf(raw2probability _).apply(col($(rawPredictionCol)))
+        raw2probabilityColumn(col($(rawPredictionCol)))
       } else {
-        val probabilityUDF = udf { features: Any =>
-          predictProbability(features.asInstanceOf[FeaturesType])
-        }
-        probabilityUDF(col($(featuresCol)))
+        predictProbabilityColumn(col($(featuresCol)))
       }
       outputData = outputData.withColumn($(probabilityCol), probCol,
         outputSchema($(probabilityCol)).metadata)
@@ -140,14 +155,11 @@ abstract class ProbabilisticClassificationModel[
     }
     if ($(predictionCol).nonEmpty) {
       val predCol = if ($(rawPredictionCol).nonEmpty) {
-        udf(raw2prediction _).apply(col($(rawPredictionCol)))
+        raw2predictionColumn(col($(rawPredictionCol)))
       } else if ($(probabilityCol).nonEmpty) {
-        udf(probability2prediction _).apply(col($(probabilityCol)))
+        probability2predictionColumn(col($(probabilityCol)))
       } else {
-        val predictUDF = udf { features: Any =>
-          predict(features.asInstanceOf[FeaturesType])
-        }
-        predictUDF(col($(featuresCol)))
+        predictionColumn(col($(featuresCol)))
       }
       outputData = outputData.withColumn($(predictionCol), predCol,
         outputSchema($(predictionCol)).metadata)
@@ -208,28 +220,8 @@ abstract class ProbabilisticClassificationModel[
    * @return  predicted label
    */
   protected def probability2prediction(probability: Vector): Double = {
-    if (!isDefined(thresholds)) {
-      probability.argmax
-    } else {
-      val thresholds = getThresholds
-      var argMax = 0
-      var max = Double.NegativeInfinity
-      var i = 0
-      val probabilitySize = probability.size
-      while (i < probabilitySize) {
-        // Thresholds are all > 0, excepting that at most one may be 0.
-        // The single class whose threshold is 0, if any, will always be predicted
-        // ('scaled' = +Infinity). However in the case that this class also has
-        // 0 probability, the class will not be selected ('scaled' is NaN).
-        val scaled = probability(i) / thresholds(i)
-        if (scaled > max) {
-          max = scaled
-          argMax = i
-        }
-        i += 1
-      }
-      argMax
-    }
+    val localThresholds = if (isDefined(thresholds)) getThresholds else null
+    ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
   }
 
   /**
@@ -255,6 +247,30 @@ abstract class ProbabilisticClassificationModel[
 }
 
 private[ml] object ProbabilisticClassificationModel {
+
+  def probability2prediction(probability: Vector, thresholds: Array[Double]): Double = {
+    if (thresholds == null) {
+      probability.argmax
+    } else {
+      var argMax = 0
+      var max = Double.NegativeInfinity
+      var i = 0
+      val probabilitySize = probability.size
+      while (i < probabilitySize) {
+        // Thresholds are all > 0, excepting that at most one may be 0.
+        // The single class whose threshold is 0, if any, will always be predicted
+        // ('scaled' = +Infinity). However in the case that this class also has
+        // 0 probability, the class will not be selected ('scaled' is NaN).
+        val scaled = probability(i) / thresholds(i)
+        if (scaled > max) {
+          max = scaled
+          argMax = i
+        }
+        i += 1
+      }
+      argMax
+    }
+  }
 
   /**
    * Normalize a vector of raw predictions to be a multinomial probability vector, in place.

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -141,10 +141,11 @@ abstract class ProbabilisticClassificationModel[
    *
    * `transform` uses this when both [[rawPredictionCol]] and
    * [[probabilityCol]] are set. It consumes the output of [[predictRawColumn]].
-   * Thresholds do not affect this conversion; they are applied only when producing a prediction.
    *
    * @param rawPrediction input raw-prediction column
    * @return probability column of type `Vector`
+   * @note Thresholds do not affect this conversion; they are applied only when producing a
+   *       prediction.
    */
   protected def raw2probabilityColumn(rawPrediction: Column): Column = {
     udf(raw2probability _).apply(rawPrediction)
@@ -169,11 +170,12 @@ abstract class ProbabilisticClassificationModel[
    *
    * `transform` uses this when both [[rawPredictionCol]] and
    * [[predictionCol]] are set. It consumes the output of [[predictRawColumn]].
-   * Unlike the default classification behavior, probabilistic classification honors
-   * [[thresholds]] by converting raw predictions to probabilities before selecting a prediction.
    *
    * @param rawPrediction input raw-prediction column
    * @return prediction column of type `Double`
+   * @note Unlike the default classification behavior, probabilistic classification honors
+   *       [[thresholds]] by converting raw predictions to probabilities before selecting a
+   *       prediction.
    */
   override protected def raw2predictionColumn(rawPrediction: Column): Column = {
     udf(raw2prediction _).apply(rawPrediction)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -70,6 +70,7 @@ abstract class ProbabilisticClassifier[
  * `transform` selects column-producing methods based on which output columns are set:
  *
  * <table>
+ *   <caption>Column-producing methods by requested output columns</caption>
  *   <tr>
  *     <th>Raw prediction</th>
  *     <th>Probability</th>

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -81,10 +81,7 @@ abstract class ProbabilisticClassificationModel[
   }
 
   protected def predictProbabilityColumn(features: Column): Column = {
-    val localPredictProbability = predictProbability _
-    udf { value: Any =>
-      localPredictProbability(value.asInstanceOf[FeaturesType])
-    }.apply(features)
+    udf { value: Any => predictProbability(value.asInstanceOf[FeaturesType]) }.apply(features)
   }
 
   override protected def raw2predictionColumn(rawPrediction: Column): Column = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -78,6 +78,9 @@ abstract class ProbabilisticClassificationModel[
   /**
    * Returns an expression that converts a raw-prediction vector column to a probability vector.
    *
+   * [[ProbabilisticClassificationModel.transform]] uses this when both [[rawPredictionCol]] and
+   * [[probabilityCol]] are set. It consumes the output of [[predictRawColumn]].
+   *
    * @param rawPrediction input raw-prediction column
    * @return probability column of type `Vector`
    */
@@ -87,6 +90,10 @@ abstract class ProbabilisticClassificationModel[
 
   /**
    * Returns an expression that produces a probability vector directly from a features column.
+   *
+   * [[ProbabilisticClassificationModel.transform]] uses this when [[probabilityCol]] is set and
+   * [[rawPredictionCol]] is not set. When [[predictionCol]] is also set, it is used
+   * together with [[probability2predictionColumn]].
    *
    * @param features input features column
    * @return probability column of type `Vector`
@@ -98,6 +105,9 @@ abstract class ProbabilisticClassificationModel[
   /**
    * Returns an expression that produces a predicted label from a raw-prediction vector column.
    *
+   * [[ProbabilisticClassificationModel.transform]] uses this when both [[rawPredictionCol]] and
+   * [[predictionCol]] are set. It consumes the output of [[predictRawColumn]].
+   *
    * @param rawPrediction input raw-prediction column
    * @return prediction column of type `Double`
    */
@@ -107,6 +117,10 @@ abstract class ProbabilisticClassificationModel[
 
   /**
    * Returns an expression that produces a predicted label from a probability vector column.
+   *
+   * [[ProbabilisticClassificationModel.transform]] uses this when [[predictionCol]] and
+   * [[probabilityCol]] are set and [[rawPredictionCol]] is not set. It consumes the output of
+   * [[predictProbabilityColumn]].
    *
    * @param probability input probability column
    * @return prediction column of type `Double`

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -240,8 +240,11 @@ abstract class ProbabilisticClassificationModel[
    * @return  predicted label
    */
   protected def probability2prediction(probability: Vector): Double = {
-    val localThresholds = if (isDefined(thresholds)) getThresholds else null
-    ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+    if (isDefined(thresholds)) {
+      ProbabilisticClassificationModel.probability2prediction(probability, getThresholds)
+    } else {
+      probability.argmax
+    }
   }
 
   /**
@@ -269,27 +272,23 @@ abstract class ProbabilisticClassificationModel[
 private[ml] object ProbabilisticClassificationModel {
 
   def probability2prediction(probability: Vector, thresholds: Array[Double]): Double = {
-    if (thresholds == null) {
-      probability.argmax
-    } else {
-      var argMax = 0
-      var max = Double.NegativeInfinity
-      var i = 0
-      val probabilitySize = probability.size
-      while (i < probabilitySize) {
-        // Thresholds are all > 0, excepting that at most one may be 0.
-        // The single class whose threshold is 0, if any, will always be predicted
-        // ('scaled' = +Infinity). However in the case that this class also has
-        // 0 probability, the class will not be selected ('scaled' is NaN).
-        val scaled = probability(i) / thresholds(i)
-        if (scaled > max) {
-          max = scaled
-          argMax = i
-        }
-        i += 1
+    var argMax = 0
+    var max = Double.NegativeInfinity
+    var i = 0
+    val probabilitySize = probability.size
+    while (i < probabilitySize) {
+      // Thresholds are all > 0, excepting that at most one may be 0.
+      // The single class whose threshold is 0, if any, will always be predicted
+      // ('scaled' = +Infinity). However in the case that this class also has
+      // 0 probability, the class will not be selected ('scaled' is NaN).
+      val scaled = probability(i) / thresholds(i)
+      if (scaled > max) {
+        max = scaled
+        argMax = i
       }
-      argMax
+      i += 1
     }
+    argMax
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -67,6 +67,67 @@ abstract class ProbabilisticClassifier[
  * Model produced by a [[ProbabilisticClassifier]].
  * Classes are indexed {0, 1, ..., numClasses - 1}.
  *
+ * `transform` selects column-producing methods based on which output columns are set:
+ *
+ * <table>
+ *   <tr>
+ *     <th>Raw prediction</th>
+ *     <th>Probability</th>
+ *     <th>Prediction</th>
+ *     <th>Column-producing methods</th>
+ *   </tr>
+ *   <tr>
+ *     <td>Not set</td>
+ *     <td>Not set</td>
+ *     <td>Not set</td>
+ *     <td>None</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Set</td>
+ *     <td>Not set</td>
+ *     <td>Not set</td>
+ *     <td><code>predictRawColumn</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Not set</td>
+ *     <td>Set</td>
+ *     <td>Not set</td>
+ *     <td><code>predictProbabilityColumn</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Not set</td>
+ *     <td>Not set</td>
+ *     <td>Set</td>
+ *     <td><code>predictionColumn</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Set</td>
+ *     <td>Set</td>
+ *     <td>Not set</td>
+ *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Set</td>
+ *     <td>Not set</td>
+ *     <td>Set</td>
+ *     <td><code>predictRawColumn</code> => <code>raw2predictionColumn</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Not set</td>
+ *     <td>Set</td>
+ *     <td>Set</td>
+ *     <td><code>predictProbabilityColumn</code> =>
+ *       <code>probability2predictionColumn</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Set</td>
+ *     <td>Set</td>
+ *     <td>Set</td>
+ *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> and
+ *       <code>raw2predictionColumn</code></td>
+ *   </tr>
+ * </table>
+ *
  * @tparam FeaturesType  Type of input features.  E.g., `Vector`
  * @tparam M  Concrete Model type
  */
@@ -78,8 +139,9 @@ abstract class ProbabilisticClassificationModel[
   /**
    * Returns an expression that converts a raw-prediction vector column to a probability vector.
    *
-   * [[ProbabilisticClassificationModel.transform]] uses this when both [[rawPredictionCol]] and
+   * `transform` uses this when both [[rawPredictionCol]] and
    * [[probabilityCol]] are set. It consumes the output of [[predictRawColumn]].
+   * Thresholds do not affect this conversion; they are applied only when producing a prediction.
    *
    * @param rawPrediction input raw-prediction column
    * @return probability column of type `Vector`
@@ -91,7 +153,7 @@ abstract class ProbabilisticClassificationModel[
   /**
    * Returns an expression that produces a probability vector directly from a features column.
    *
-   * [[ProbabilisticClassificationModel.transform]] uses this when [[probabilityCol]] is set and
+   * `transform` uses this when [[probabilityCol]] is set and
    * [[rawPredictionCol]] is not set. When [[predictionCol]] is also set, it is used
    * together with [[probability2predictionColumn]].
    *
@@ -105,8 +167,10 @@ abstract class ProbabilisticClassificationModel[
   /**
    * Returns an expression that produces a predicted label from a raw-prediction vector column.
    *
-   * [[ProbabilisticClassificationModel.transform]] uses this when both [[rawPredictionCol]] and
+   * `transform` uses this when both [[rawPredictionCol]] and
    * [[predictionCol]] are set. It consumes the output of [[predictRawColumn]].
+   * Unlike the default classification behavior, probabilistic classification honors
+   * [[thresholds]] by converting raw predictions to probabilities before selecting a prediction.
    *
    * @param rawPrediction input raw-prediction column
    * @return prediction column of type `Double`
@@ -118,7 +182,7 @@ abstract class ProbabilisticClassificationModel[
   /**
    * Returns an expression that produces a predicted label from a probability vector column.
    *
-   * [[ProbabilisticClassificationModel.transform]] uses this when [[predictionCol]] and
+   * `transform` uses this when [[predictionCol]] and
    * [[probabilityCol]] are set and [[rawPredictionCol]] is not set. It consumes the output of
    * [[predictProbabilityColumn]].
    *

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -75,19 +75,42 @@ abstract class ProbabilisticClassificationModel[
     M <: ProbabilisticClassificationModel[FeaturesType, M]]
   extends ClassificationModel[FeaturesType, M] with ProbabilisticClassifierParams {
 
-  /** Additional column expressions used by probabilistic classification models. */
+  /**
+   * Returns an expression that converts a raw-prediction vector column to a probability vector.
+   *
+   * @param rawPrediction input raw-prediction column
+   * @return probability column of type `Vector`
+   */
   protected def raw2probabilityColumn(rawPrediction: Column): Column = {
     udf(raw2probability _).apply(rawPrediction)
   }
 
+  /**
+   * Returns an expression that produces a probability vector directly from a features column.
+   *
+   * @param features input features column
+   * @return probability column of type `Vector`
+   */
   protected def predictProbabilityColumn(features: Column): Column = {
     udf { value: Any => predictProbability(value.asInstanceOf[FeaturesType]) }.apply(features)
   }
 
+  /**
+   * Returns an expression that produces a predicted label from a raw-prediction vector column.
+   *
+   * @param rawPrediction input raw-prediction column
+   * @return prediction column of type `Double`
+   */
   override protected def raw2predictionColumn(rawPrediction: Column): Column = {
     udf(raw2prediction _).apply(rawPrediction)
   }
 
+  /**
+   * Returns an expression that produces a predicted label from a probability vector column.
+   *
+   * @param probability input probability column
+   * @return prediction column of type `Double`
+   */
   protected def probability2predictionColumn(probability: Column): Column = {
     udf(probability2prediction _).apply(probability)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ProbabilisticClassifierSuite.scala
@@ -22,9 +22,11 @@ import org.scalatest.Assertions._
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.ml.util.MLTest
+import org.apache.spark.ml.util.{Identifiable, MLTest}
 import org.apache.spark.ml.util.TestingUtils._
-import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.sql.{Column, Dataset, Row}
+import org.apache.spark.sql.functions.udf
 
 final class TestProbabilisticClassificationModel(
     override val uid: String,
@@ -47,8 +49,71 @@ final class TestProbabilisticClassificationModel(
   }
 }
 
+final class MockProbabilisticClassificationModelWithColumnFunctions(override val uid: String)
+  extends ProbabilisticClassificationModel[
+    Vector, MockProbabilisticClassificationModelWithColumnFunctions] {
 
-class ProbabilisticClassifierSuite extends SparkFunSuite {
+  def this() = this(Identifiable.randomUID("mockprobabilisticmodelwithcolumnfunctions"))
+
+  private def vectorColumn(input: Column): Column = udf((value: Vector) => value).apply(input)
+
+  private def predictionFromVector(input: Column): Column = {
+    udf((value: Vector) => value.argmax.toDouble).apply(input)
+  }
+
+  override protected def predictRawColumn(features: Column): Column = vectorColumn(features)
+
+  override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
+    vectorColumn(rawPrediction)
+  }
+
+  override protected def predictProbabilityColumn(features: Column): Column = vectorColumn(features)
+
+  override protected def raw2predictionColumn(rawPrediction: Column): Column = {
+    predictionFromVector(rawPrediction)
+  }
+
+  override protected def probability2predictionColumn(probability: Column): Column = {
+    predictionFromVector(probability)
+  }
+
+  override protected def predictionColumn(features: Column): Column = predictionFromVector(features)
+
+  override def predict(features: Vector): Double = throw new UnsupportedOperationException()
+
+  override def predictRaw(features: Vector): Vector = throw new UnsupportedOperationException()
+
+  override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
+    throw new UnsupportedOperationException()
+  }
+
+  override protected def raw2probability(rawPrediction: Vector): Vector = {
+    throw new UnsupportedOperationException()
+  }
+
+  override def predictProbability(features: Vector): Vector = {
+    throw new UnsupportedOperationException()
+  }
+
+  override protected def raw2prediction(rawPrediction: Vector): Double = {
+    throw new UnsupportedOperationException()
+  }
+
+  override protected def probability2prediction(probability: Vector): Double = {
+    throw new UnsupportedOperationException()
+  }
+
+  override def copy(extra: ParamMap): MockProbabilisticClassificationModelWithColumnFunctions = {
+    throw new UnsupportedOperationException()
+  }
+
+  override def numClasses: Int = 2
+}
+
+
+class ProbabilisticClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  import testImplicits._
 
   test("test thresholding") {
     val testModel = new TestProbabilisticClassificationModel("myuid", 2, 2)
@@ -100,6 +165,35 @@ class ProbabilisticClassifierSuite extends SparkFunSuite {
     intercept[IllegalArgumentException] {
       ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(vec3)
     }
+  }
+
+  test("transform uses probabilistic column prediction hooks") {
+    val expected = Vectors.dense(0.25, 0.75)
+    val data = Seq(Tuple1(expected)).toDF("features")
+
+    val allOutputs = new MockProbabilisticClassificationModelWithColumnFunctions()
+      .transform(data)
+      .select("rawPrediction", "probability", "prediction")
+      .head()
+    assert(allOutputs.getAs[Vector](0) === expected)
+    assert(allOutputs.getAs[Vector](1) === expected)
+    assert(allOutputs.getDouble(2) === 1.0)
+
+    val probabilityAndPrediction = new MockProbabilisticClassificationModelWithColumnFunctions()
+      .setRawPredictionCol("")
+      .transform(data)
+      .select("probability", "prediction")
+      .head()
+    assert(probabilityAndPrediction.getAs[Vector](0) === expected)
+    assert(probabilityAndPrediction.getDouble(1) === 1.0)
+
+    val predictionOnly = new MockProbabilisticClassificationModelWithColumnFunctions()
+      .setRawPredictionCol("")
+      .setProbabilityCol("")
+      .transform(data)
+      .select("prediction")
+      .head()
+    assert(predictionOnly.getDouble(0) === 1.0)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds protected column-expression hooks to `ClassificationModel` and
`ProbabilisticClassificationModel`. The shared transform implementations use these hooks to build
raw prediction, probability, and prediction columns. Their default implementations preserve the
existing row-based UDF behavior, while individual models can provide native Catalyst expressions or
UDFs backed by compact prediction state.

`LogisticRegressionModel` uses the new hooks to snapshot only coefficients, intercepts, mode, and
thresholds needed by each expression. Binary raw/probability thresholding uses native column
expressions, while the remaining UDFs call companion-object helpers without retaining the model.

### Why are the changes needed?

The previous classifier transform UDFs invoked bound model methods. As a result, their closures
retained the full model, including its parameter graph, even when a prediction stage needed only a
small subset of immutable scoring state.

The column-expression hooks provide a common design for classifiers to reduce those closures and to
use native Spark expressions where possible. This lowers driver memory pressure from retained query
plans on long-lived Spark Connect servers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The following checks were run locally:

```
build/sbt mllib/compile
build/sbt mllib/scalastyle
build/sbt 'mllib/testOnly org.apache.spark.ml.classification.ClassifierSuite org.apache.spark.ml.classification.LogisticRegressionSuite'
build/sbt 'mllib/testOnly org.apache.spark.ml.classification.ProbabilisticClassifierSuite org.apache.spark.ml.classification.LogisticRegressionSuite'
```

The focused test run completed 66 tests successfully, with one existing ignored test.

A temporary local probe compared the new implementation with a model subclass that recreated the
previous bound-method UDF expressions and cached binary prediction state. It serialized each
`ScalaUDF.function` with Spark's closure serializer for binary models with 64 and 4,096 features:

| Features | Output columns | Before | After | Delta |
|---:|---|---:|---:|---:|
| 64 | raw prediction | 9,869 B | 2,877 B | -70.8% |
| 64 | probability | 9,877 B | 2,885 B | -70.8% |
| 64 | prediction | 9,665 B | 2,866 B | -70.3% |
| 64 | raw + probability + prediction | 29,418 B (3 UDFs) | 4,969 B (2 UDFs) | -83.1% |
| 4,096 | raw prediction | 42,125 B | 35,133 B | -16.6% |
| 4,096 | probability | 42,133 B | 35,141 B | -16.6% |
| 4,096 | prediction | 41,921 B | 35,122 B | -16.2% |
| 4,096 | raw + probability + prediction | 126,186 B (3 UDFs) | 37,225 B (2 UDFs) | -70.5% |

The same in-process probe excluded SparkSession setup, ran 3 alternating warm-up pairs, and then
measured 10 alternating before/after action pairs for each workload. Both workloads used 3,000,000
rows. The input was left uncached because caching the 4,096-feature workload would materialize
about 98 GB of vector values. Mean execution times were:

| Features | Transform path | Before | After | Change |
|---:|---|---:|---:|---:|
| 64 | prediction only | 278.127 ms | 241.504 ms | 1.15x faster |
| 64 | raw prediction to prediction | 629.430 ms | 599.644 ms | 1.05x faster |
| 64 | probability to prediction | 595.218 ms | 562.201 ms | 1.06x faster |
| 4,096 | prediction only | 7,551.752 ms | 7,515.061 ms | 0.5% faster |
| 4,096 | raw prediction to prediction | 8,191.263 ms | 7,988.399 ms | 1.03x faster |
| 4,096 | probability to prediction | 8,167.511 ms | 8,026.213 ms | 1.02x faster |

Feature dimensionality changes where transform time is spent. With 4,096 features, vector
computation dominates the total duration, so avoiding per-row parameter lookup has a smaller
relative effect. With 64 features, vector computation is cheaper and parameter lookup contributes
more to the total duration, making the optimization more visible.

The probe was used only for measurement and is not included in this PR.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
