### PR TITLE
[SPARK-59011][PS] Fix descending rank first tie ordering

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4321,7 +4321,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             window = (
                 Window.orderBy(
                     asc_func(self.spark.column),
-                    asc_func(F.col(NATURAL_ORDER_COLUMN_NAME)),
+                    F.col(NATURAL_ORDER_COLUMN_NAME).asc(),
                 )
                 .partitionBy(*part_cols)
                 .rowsBetween(Window.unboundedPreceding, Window.currentRow)

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -319,6 +319,10 @@ class SeriesStatMixin:
         self.assert_eq(pser.rank(method="min"), psser.rank(method="min").sort_index())
         self.assert_eq(pser.rank(method="max"), psser.rank(method="max").sort_index())
         self.assert_eq(pser.rank(method="first"), psser.rank(method="first").sort_index())
+        self.assert_eq(
+            pser.rank(method="first", ascending=False),
+            psser.rank(method="first", ascending=False).sort_index(),
+        )
         self.assert_eq(pser.rank(method="dense"), psser.rank(method="dense").sort_index())
 
         non_numeric_pser = pd.Series(["a", "c", "b", "d"], name="x", index=[10, 11, 12, 13])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request fixes the tie-breaking order of pandas-on-Spark `Series.rank(method="first", ascending=False)`.

The value column follows the requested ascending direction, while the natural-order column is always ordered ascending so that equal values are ranked according to their original occurrence order.

A regression test for descending ranking with `method="first"` is added.

### Why are the changes needed?

The existing implementation applies descending order to both the value column and the natural-order tie-breaker. This reverses the original order of equal values and produces results inconsistent with pandas.

For `pd.Series([1, 2, 3, 1])`, pandas returns:

`[3.0, 2.0, 1.0, 4.0]`

The previous pandas-on-Spark result was:

`[4.0, 2.0, 1.0, 3.0]`

### Does this PR introduce _any_ user-facing change?

Yes. `Series.rank(method="first", ascending=False)` now preserves the original occurrence order when breaking ties, matching pandas behavior.

### How was this patch tested?

A regression assertion was added to `SeriesStatTests.test_rank`.

The test failed before the fix with a 50% value difference and passed after the fix:

./python/run-tests --python-executables python3 \
 --testnames 'pyspark.pandas.tests.series.test_stat SeriesStatTests.test_rank' \
  -p 1

The Spark assembly build, Ruff checks, Ruff formatting check, and `git diff --check` also passed.

This contribution was prepared and reviewed by our university project team, including Phan Trung Nhut and Bui Nam Viet. We license this contribution to the project under the Apache License, Version 2.0.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)