### PR TITLE
[SPARK-59050][SQL] SPJ one-side shuffle with out-of-set keys produces wrong results in multi-joins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -601,15 +601,14 @@ case class CoalescedNullAwareHashPartitioning(
  *                                 whether it coarsens it (key-dropping projection, reducer,
  *                                 join-key projection) or expands it over a marked leg (a union,
  *                                 where another leg may declare exactly the key that leg holds
- *                                 out-of-set); (2) a marked member beside an unmarked sibling is
- *                                 agreement is enforced by `PartitioningCollection`: the
- *                                 constructor requires it and `fromPartitionings` normalizes by
- *                                 OR, so members are uniformly marked or unmarked and consumers
- *                                 may read one member. `ShuffledJoin`'s `InnerLike` arm, the
- *                                 only site that meets a marked input with an unmarked one,
- *                                 clears the markers first -- precision, so the OR spreads a
- *                                 spurious marker onto the accurate side instead of a genuine
- *                                 one.
+ *                                 out-of-set); (2) marker agreement is enforced by
+ *                                 `PartitioningCollection`: the constructor requires it and
+ *                                 `fromPartitionings` normalizes by OR, so members are
+ *                                 uniformly marked or unmarked and consumers may read one
+ *                                 member. `ShuffledJoin`'s `InnerLike` arm, the only site that
+ *                                 meets a marked input with an unmarked one, clears the markers
+ *                                 first. That is precision, not the guarantee: without it the
+ *                                 OR would spread the spurious marker onto the accurate side.
  */
 case class KeyedPartitioning(
     expressions: Seq[Expression],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -591,24 +591,25 @@ case class CoalescedNullAwareHashPartitioning(
  *                                 same keys in the same order and using the same partition
  *                                 function per position still pair (equal undeclared keys hash
  *                                 to the same partition), but a row of an undeclared key sits in
- *                                 the partition of some other declared key, away from rows
- *                                 sharing a subset of its columns. `satisfies` and
- *                                 `KeyedShuffleSpec.areKeysCompatible` therefore accept a marked
- *                                 partitioning only for full-key clustering, never for a subset
- *                                 of its partition columns and never for a global ordering
- *                                 across several partitions. Two carry rules: (1) a node that
- *                                 changes the declared key set must drop the keyed partitioning,
- *                                 whether it coarsens it (key-dropping projection, reducer,
- *                                 join-key projection) or expands it over a marked leg (a union,
- *                                 where another leg may declare exactly the key that leg holds
- *                                 out-of-set); (2) marker agreement is enforced by
- *                                 `PartitioningCollection`: the constructor requires it and
- *                                 `fromPartitionings` normalizes by OR, so members are
- *                                 uniformly marked or unmarked and consumers may read one
- *                                 member. `ShuffledJoin`'s `InnerLike` arm, the only site that
- *                                 meets a marked input with an unmarked one, clears the markers
- *                                 first. That is precision, not the guarantee: without it the
- *                                 OR would spread the spurious marker onto the accurate side.
+ *                                 the partition of some other declared key and need not be
+ *                                 co-located with rows sharing only a subset of its columns.
+ *                                 `satisfies` and `KeyedShuffleSpec.areKeysCompatible` therefore
+ *                                 accept a marked partitioning only for full-key clustering,
+ *                                 never for a subset of its partition columns and never for a
+ *                                 global ordering across several partitions. Two carry rules:
+ *                                 (1) a node that changes the declared key set must drop the
+ *                                 keyed partitioning, whether it coarsens it (a key-dropping
+ *                                 projection, a key-changing reduction, a join-key projection)
+ *                                 or expands it over a marked leg (a union, where another leg
+ *                                 may declare exactly the key that leg holds out-of-set);
+ *                                 (2) marker agreement is enforced by `PartitioningCollection`:
+ *                                 the constructor requires it and `fromPartitionings` normalizes
+ *                                 by OR, so members are uniformly marked or unmarked and
+ *                                 consumers may read one member. `ShuffledJoin`'s `InnerLike`
+ *                                 arm, the only site that meets a marked input with an unmarked
+ *                                 one, clears the markers first. That is precision, not the
+ *                                 guarantee: without it the OR would spread the spurious marker
+ *                                 onto the accurate side.
  */
 case class KeyedPartitioning(
     expressions: Seq[Expression],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -584,19 +584,26 @@ case class CoalescedNullAwareHashPartitioning(
  *                    what it gates and how it travels.
  * @param mayContainUnknownPartitionKeys Whether the data may contain rows whose partition key is
  *                                 not among the declared `partitionKeys`. `KeyGroupedPartitioner`
- *                                 routes such rows to arbitrary partitions when a side is
+ *                                 routes such rows by a deterministic hash when a side is
  *                                 re-shuffled onto this partitioning (see
- *                                 `KeyedShuffleSpec.createPartitioning`), so only the declared
- *                                 keys are guaranteed to be co-located;
- *                                 `KeyedShuffleSpec.areKeysCompatible` reflects this. Two carry
- *                                 rules: the claim survives only a node that keeps the declared
- *                                 key set verbatim -- a node that coarsens it (key-dropping
- *                                 projection, union merge, reducer, join-key projection) must
- *                                 drop the keyed partitioning, as an out-of-set key can coarsen
- *                                 into the smaller set; and it is spurious on a
- *                                 `PartitioningCollection` member next to an unmarked sibling --
- *                                 only `ShuffledJoin`'s `InnerLike` arm merges one in, and its
- *                                 join filtered the unknown rows.
+ *                                 `KeyedShuffleSpec.createPartitioning`), so co-location holds
+ *                                 for whole keys only: two marked partitionings declaring the
+ *                                 same keys in the same order still pair (equal undeclared keys
+ *                                 hash to the same partition), but a row of an undeclared key
+ *                                 sits in the partition of some other declared key, away from
+ *                                 rows sharing a subset of its columns. `satisfies` and
+ *                                 `KeyedShuffleSpec.areKeysCompatible` therefore accept a marked
+ *                                 partitioning only for full-key clustering, never for a subset
+ *                                 of its partition columns and never for a global ordering
+ *                                 across several partitions. Two carry rules: (1) a node that
+ *                                 changes the declared key set must drop the keyed partitioning,
+ *                                 whether it coarsens it (key-dropping projection, reducer,
+ *                                 join-key projection) or expands it over a marked leg (a union,
+ *                                 where another leg may declare exactly the key that leg holds
+ *                                 out-of-set); (2) a marked member beside an unmarked sibling is
+ *                                 spurious, and `ShuffledJoin`'s `InnerLike` arm, the only site
+ *                                 that mixes them, clears it at construction, so members are
+ *                                 uniformly marked or unmarked everywhere downstream.
  */
 case class KeyedPartitioning(
     expressions: Seq[Expression],
@@ -765,7 +772,11 @@ case class KeyedPartitioning(
           // We'll need to find leaf attributes from the partition expressions first.
           val attributes = AttributeSet.fromAttributeSets(expressions.map(_.references))
 
-          if (SQLConf.get.v2BucketingAllowKeysSubsetOfPartitionKeys) {
+          if (mayContainUnknownPartitionKeys) {
+            // Whole keys co-locate, subsets do not (see the `@param`): a window or aggregate
+            // keyed on a strict subset of the partition columns must still shuffle.
+            attributes.forall(x => requiredClustering.exists(_.semanticEquals(x)))
+          } else if (SQLConf.get.v2BucketingAllowKeysSubsetOfPartitionKeys) {
             // The operation keys may be a subset of the partition keys, so one partition expression
             // covering one of them is enough. Partitions can then still hold rows that share an
             // operation key. What makes the distribution true is the projection onto the covering
@@ -786,7 +797,10 @@ case class KeyedPartitioning(
         // keys. This is the local gate. A reduced position always carries a transform and an
         // `ORDER BY` cannot name one, so the match below already refuses every case a query can
         // reach. Do not read the first clause as redundant.
-        expressionsDescribeKeys && o.areAllClusterKeysMatched(expressions)
+        // An out-of-set key can break the ascending sequence of the declared keys, so a marked
+        // layout keeps a global ordering claim only for a single partition (see the `@param`).
+        expressionsDescribeKeys && o.areAllClusterKeysMatched(expressions) &&
+          (!mayContainUnknownPartitionKeys || numPartitions == 1)
 
       case _ =>
         false
@@ -816,10 +830,10 @@ case class KeyedPartitioning(
     val result = KeyedShuffleSpec(this, distribution)
     if (SQLConf.get.v2BucketingAllowKeysSubsetOfPartitionKeys) {
       val joinKeyPositions = result.keyPositions.map(_.nonEmpty).zipWithIndex.filter(_._1).map(_._2)
-      // The projection coarsens the declared key set, which an unknown-keyed claim cannot
-      // survive (see `mayContainUnknownPartitionKeys`). Return the unprojected spec instead: it
-      // disagrees on arity with every other spec, so co-location is refused and the child falls
-      // back to the ordinary shuffle path.
+      // The projection coarsens the declared set, which a marked claim cannot survive (see the
+      // `@param`). Return the unprojected spec: its extra expressions map to no clustering key,
+      // so `areKeysCompatible` refuses it as a partner and `canCreatePartitioning` refuses it as
+      // a shuffle template, and the child falls back to the ordinary shuffle.
       if (mayContainUnknownPartitionKeys && joinKeyPositions.length < expressions.length) {
         return result
       }
@@ -1654,10 +1668,9 @@ case class KeyedShuffleSpec(
     } && expressions.zip(otherExpressions).forall {
       case (l, r) => isExpressionCompatible(l, r)
     } && {
-      // An unknown-keyed side (see `KeyedPartitioning.mayContainUnknownPartitionKeys`) guarantees
-      // co-location only for its declared keys, and `KeyGroupedPartitioner`'s out-of-set routing
-      // is a deterministic hash -- so it can pair only with a side whose keys are a subset of the
-      // declared keys.
+      // An unknown-keyed side co-locates only its declared keys, and the out-of-set routing is
+      // a deterministic hash, so it can pair only with a side whose keys are a subset of those
+      // declared keys (see `KeyedPartitioning.mayContainUnknownPartitionKeys`).
       //
       // The key comparison below must also happen in a single domain: `isExpressionCompatible`
       // admits an `AttributeReference` against a `TransformExpression` (and two different-but-
@@ -1828,9 +1841,8 @@ case class KeyedShuffleSpec(
       // clause as redundant.
       partitioning.isGrouped &&
       // Every partition expression must map to a clustering key, otherwise `createPartitioning`
-      // cannot rewrite it into the clustering key. This also keeps the unprojected spec returned
-      // by `createShuffleSpec` for an unknown-keyed narrowed projection -- whose extra partition
-      // expressions map to no clustering key -- from being chosen as the best spec.
+      // cannot rewrite it. This also keeps the unprojected spec returned by `createShuffleSpec`
+      // for a marked narrowing projection from being chosen as the best spec.
       keyPositions.forall(_.nonEmpty) &&
       partitioning.expressions.forall { e =>
         e.isInstanceOf[AttributeReference] || e.isInstanceOf[TransformExpression]
@@ -1853,15 +1865,10 @@ case class KeyedShuffleSpec(
     // grouping of the shared key set carries the collapsed side's risk.
     //
     // The child re-shuffled onto this layout may hold keys outside the declared set, so every
-    // partitioning produced here carries the unknown-keys marker too (see
-    // `KeyedPartitioning.mayContainUnknownPartitionKeys`). `createPartitioning` is only reached
-    // from `EnsureRequirements`' shuffle loop to re-shuffle a join child onto the best spec's
-    // layout, and the re-shuffled child's keys are never provably a subset of the declared keys:
-    // a non-keyed (v1) child's keys are unknown to the planner, and a keyed child with an
-    // incompatible partitioning is re-evaluated in this spec's key space, which the planner
-    // cannot bound. Marking every such partitioning is therefore
-    // sound (conservative only when the two sides happen to share a transform and the re-shuffled
-    // keys are a known subset).
+    // partitioning produced here carries the marker (see the `@param`). Only the shuffle loop
+    // reaches this call, and it carries no same-domain subset proof, so marking is sound; it is
+    // conservative where the child's keys are in fact a known subset (identity key [1] inside
+    // declared [1, 2]), a precision this path does not attempt.
     partitioning.copy(expressions = newExpressions, mayContainUnknownPartitionKeys = true)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -588,10 +588,11 @@ case class CoalescedNullAwareHashPartitioning(
  *                                 re-shuffled onto this partitioning (see
  *                                 `KeyedShuffleSpec.createPartitioning`), so co-location holds
  *                                 for whole keys only: two marked partitionings declaring the
- *                                 same keys in the same order still pair (equal undeclared keys
- *                                 hash to the same partition), but a row of an undeclared key
- *                                 sits in the partition of some other declared key, away from
- *                                 rows sharing a subset of its columns. `satisfies` and
+ *                                 same keys in the same order and using the same partition
+ *                                 function per position still pair (equal undeclared keys hash
+ *                                 to the same partition), but a row of an undeclared key sits in
+ *                                 the partition of some other declared key, away from rows
+ *                                 sharing a subset of its columns. `satisfies` and
  *                                 `KeyedShuffleSpec.areKeysCompatible` therefore accept a marked
  *                                 partitioning only for full-key clustering, never for a subset
  *                                 of its partition columns and never for a global ordering
@@ -1194,6 +1195,15 @@ object PartitioningCollection {
    */
   private[sql] def numKeyedPartitions(partitioning: Partitioning): Option[Int] =
     representativeOf(partitioning).map(_.numPartitions)
+
+  /**
+   * Whether `p` or any nested [[KeyedPartitioning]] may contain unknown partition keys, read
+   * from its first keyed member, the same one `checkKeyedPartitioningInvariant` compares
+   * against. Keyless inputs answer false: `EnsureRequirements` normalizes a shuffled join's
+   * children onto one template, so they never meet a keyed sibling here.
+   */
+  private[sql] def mayContainUnknownPartitionKeys(p: Partitioning): Boolean =
+    representativeOf(p).exists(_.mayContainUnknownPartitionKeys)
 
   /**
    * Builds a [[PartitioningCollection]], unifying the `partitionKeys` reference across all

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -455,6 +455,10 @@ case class CoalescedNullAwareHashPartitioning(
  *   lands in the same partitions as the side that declared the keys. This is also why a consumer
  *   must keep the order given here.
  *
+ * One exception to "partition `i` holds key `partitionKeys(i)`": when
+ * `mayContainUnknownPartitionKeys` is set, a partition may also hold rows whose key is not
+ * declared at all (see the `@param` below).
+ *
  * == Grouping State ==
  * A KeyedPartitioning can be in two states:
  *
@@ -578,12 +582,29 @@ case class CoalescedNullAwareHashPartitioning(
  *                    partitioning this one was derived from onto the same key, so one key here can
  *                    stand for several of the original ones. Sticky. See "Key Collapse" above for
  *                    what it gates and how it travels.
+ * @param mayContainUnknownPartitionKeys Whether the data may contain rows whose partition key is
+ *                                 not among the declared `partitionKeys`. `KeyGroupedPartitioner`
+ *                                 routes such rows to arbitrary partitions when a side is
+ *                                 re-shuffled onto this partitioning (see
+ *                                 `KeyedShuffleSpec.createPartitioning`), so only the declared
+ *                                 keys are guaranteed to be co-located;
+ *                                 `KeyedShuffleSpec.areKeysCompatible` reflects this. Two carry
+ *                                 rules: the claim survives only a node that keeps the declared
+ *                                 key set verbatim -- a node that coarsens it (key-dropping
+ *                                 projection, union merge, reducer, join-key projection) must
+ *                                 drop the keyed partitioning, as an out-of-set key can coarsen
+ *                                 into the smaller set; and it is spurious on a
+ *                                 `PartitioningCollection` member next to an unmarked sibling --
+ *                                 only `ShuffledJoin`'s `InnerLike` arm merges one in, and its
+ *                                 join filtered the unknown rows.
  */
 case class KeyedPartitioning(
     expressions: Seq[Expression],
     @transient partitionKeys: Seq[InternalRowComparableWrapper],
     isGrouped: Boolean,
-    isCollapsed: Boolean) extends Expression with Partitioning with Unevaluable {
+    isCollapsed: Boolean,
+    mayContainUnknownPartitionKeys: Boolean = false)
+  extends Expression with Partitioning with Unevaluable {
   override val numPartitions = partitionKeys.length
 
   override def children: Seq[Expression] = expressions
@@ -794,15 +815,23 @@ case class KeyedPartitioning(
   override def createShuffleSpec(distribution: ClusteredDistribution): ShuffleSpec = {
     val result = KeyedShuffleSpec(this, distribution)
     if (SQLConf.get.v2BucketingAllowKeysSubsetOfPartitionKeys) {
+      val joinKeyPositions = result.keyPositions.map(_.nonEmpty).zipWithIndex.filter(_._1).map(_._2)
+      // The projection coarsens the declared key set, which an unknown-keyed claim cannot
+      // survive (see `mayContainUnknownPartitionKeys`). Return the unprojected spec instead: it
+      // disagrees on arity with every other spec, so co-location is refused and the child falls
+      // back to the ordinary shuffle path.
+      if (mayContainUnknownPartitionKeys && joinKeyPositions.length < expressions.length) {
+        return result
+      }
       // If allowing operation keys to be a subset of partition keys, create a new
       // `KeyedPartitioning` grouped on the operation keys, and use that as
       // the returned shuffle spec.
-      val joinKeyPositions = result.keyPositions.map(_.nonEmpty).zipWithIndex.filter(_._1).map(_._2)
       // `toGrouped` sorts the keys the same way `GroupPartitionsExec` does (both sort with
       // `KeyedPartitioning.groupedKeyRowOrdering`). Otherwise, when only the keyed side is
       // grouped and the other side is re-shuffled using this spec, the two `KeyedPartitioning`s
       // carry the same keys in a different order and `PartitioningCollection.fromPartitionings`
-      // rejects them.
+      // rejects them. `project` carries the unknown-keys marker across: only an identity
+      // projection reaches here when it is set, the refusal above turns away the narrowing one.
       val projectedPartitioning = project(joinKeyPositions).toGrouped
       result.copy(partitioning = projectedPartitioning, joinKeyPositions = Some(joinKeyPositions))
     } else {
@@ -1624,6 +1653,45 @@ case class KeyedShuffleSpec(
       }
     } && expressions.zip(otherExpressions).forall {
       case (l, r) => isExpressionCompatible(l, r)
+    } && {
+      // An unknown-keyed side (see `KeyedPartitioning.mayContainUnknownPartitionKeys`) guarantees
+      // co-location only for its declared keys, and `KeyGroupedPartitioner`'s out-of-set routing
+      // is a deterministic hash -- so it can pair only with a side whose keys are a subset of the
+      // declared keys.
+      //
+      // The key comparison below must also happen in a single domain: `isExpressionCompatible`
+      // admits an `AttributeReference` against a `TransformExpression` (and two different-but-
+      // compatible transforms) when `v2BucketingAllowCompatibleTransforms` is on, and in those
+      // cases the two sides' `partitionKeys` hold raw values on one side and transform outputs on
+      // the other, so the subset test would compare unrelated values. Require the partition
+      // expressions to be the same function per position before comparing keys.
+      //
+      // Two unknown-keyed sides are compatible only when they agree on the declared keys *and*
+      // their order: the out-of-set keys hash to the same-index partition on both sides, and a
+      // `GroupPartitionsExec` regrouping re-labels each partition by that side's declared key, so
+      // a differing declared order would push the out-of-set keys into different output
+      // partitions and lose their matches.
+      if (partitioning.mayContainUnknownPartitionKeys ||
+          other.partitioning.mayContainUnknownPartitionKeys) {
+        expressions.zip(otherExpressions).forall {
+          case (_: AttributeReference, _: AttributeReference) => true
+          case (l: TransformExpression, r: TransformExpression) => l.isSameFunction(r)
+          case _ => false
+        } && {
+          if (partitioning.mayContainUnknownPartitionKeys &&
+              other.partitioning.mayContainUnknownPartitionKeys) {
+            partitioning.partitionKeys == other.partitioning.partitionKeys
+          } else if (partitioning.mayContainUnknownPartitionKeys) {
+            val declared = partitioning.partitionKeys.toSet
+            other.partitioning.partitionKeys.forall(declared.contains)
+          } else {
+            val declared = other.partitioning.partitionKeys.toSet
+            partitioning.partitionKeys.forall(declared.contains)
+          }
+        }
+      } else {
+        true
+      }
     }
   }
 
@@ -1759,6 +1827,11 @@ case class KeyedShuffleSpec(
       // distribution in a `GroupPartitionsExec` before it builds any spec -- so do not read this
       // clause as redundant.
       partitioning.isGrouped &&
+      // Every partition expression must map to a clustering key, otherwise `createPartitioning`
+      // cannot rewrite it into the clustering key. This also keeps the unprojected spec returned
+      // by `createShuffleSpec` for an unknown-keyed narrowed projection -- whose extra partition
+      // expressions map to no clustering key -- from being chosen as the best spec.
+      keyPositions.forall(_.nonEmpty) &&
       partitioning.expressions.forall { e =>
         e.isInstanceOf[AttributeReference] || e.isInstanceOf[TransformExpression]
       } &&
@@ -1778,7 +1851,18 @@ case class KeyedShuffleSpec(
     // The shuffled side is laid out on this side's partition keys, so it inherits the flag. That
     // is conservative rather than strictly true, and it can only ever add a shuffle: a later
     // grouping of the shared key set carries the collapsed side's risk.
-    partitioning.copy(expressions = newExpressions)
+    //
+    // The child re-shuffled onto this layout may hold keys outside the declared set, so every
+    // partitioning produced here carries the unknown-keys marker too (see
+    // `KeyedPartitioning.mayContainUnknownPartitionKeys`). `createPartitioning` is only reached
+    // from `EnsureRequirements`' shuffle loop to re-shuffle a join child onto the best spec's
+    // layout, and the re-shuffled child's keys are never provably a subset of the declared keys:
+    // a non-keyed (v1) child's keys are unknown to the planner, and a keyed child with an
+    // incompatible partitioning is re-evaluated in this spec's key space, which the planner
+    // cannot bound. Marking every such partitioning is therefore
+    // sound (conservative only when the two sides happen to share a transform and the re-shuffled
+    // keys are a known subset).
+    partitioning.copy(expressions = newExpressions, mayContainUnknownPartitionKeys = true)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -602,12 +602,14 @@ case class CoalescedNullAwareHashPartitioning(
  *                                 join-key projection) or expands it over a marked leg (a union,
  *                                 where another leg may declare exactly the key that leg holds
  *                                 out-of-set); (2) a marked member beside an unmarked sibling is
- *                                 spurious, and `ShuffledJoin`'s `InnerLike` arm, the only site
- *                                 that mixes them, clears it at construction;
- *                                 `PartitioningCollection` additionally normalizes the marker by
- *                                 OR in `fromPartitionings` and requires agreement in its
- *                                 constructor, so members are uniformly marked or unmarked
- *                                 everywhere and consumers may read one member.
+ *                                 agreement is enforced by `PartitioningCollection`: the
+ *                                 constructor requires it and `fromPartitionings` normalizes by
+ *                                 OR, so members are uniformly marked or unmarked and consumers
+ *                                 may read one member. `ShuffledJoin`'s `InnerLike` arm, the
+ *                                 only site that meets a marked input with an unmarked one,
+ *                                 clears the markers first -- precision, so the OR spreads a
+ *                                 spurious marker onto the accurate side instead of a genuine
+ *                                 one.
  */
 case class KeyedPartitioning(
     expressions: Seq[Expression],
@@ -1197,13 +1199,13 @@ object PartitioningCollection {
     representativeOf(partitioning).map(_.numPartitions)
 
   /**
-   * Whether `p` or any nested [[KeyedPartitioning]] may contain unknown partition keys, read
-   * from its first keyed member, the same one `checkKeyedPartitioningInvariant` compares
-   * against. Keyless inputs answer false: `EnsureRequirements` normalizes a shuffled join's
-   * children onto one template, so they never meet a keyed sibling here.
+   * The uniform `mayContainUnknownPartitionKeys` marker of `p`'s keyed members, read from its
+   * first keyed member, the same one `checkKeyedPartitioningInvariant` compares against.
+   * `None` when `p` holds no [[KeyedPartitioning]] at all, distinct from the `Some(false)` of
+   * an unmarked keyed one: there is no claim there to answer about.
    */
-  private[sql] def mayContainUnknownPartitionKeys(p: Partitioning): Boolean =
-    representativeOf(p).exists(_.mayContainUnknownPartitionKeys)
+  private[sql] def keyedMarkerOf(p: Partitioning): Option[Boolean] =
+    representativeOf(p).map(_.mayContainUnknownPartitionKeys)
 
   /**
    * Builds a [[PartitioningCollection]], unifying the `partitionKeys` reference across all

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -602,8 +602,11 @@ case class CoalescedNullAwareHashPartitioning(
  *                                 where another leg may declare exactly the key that leg holds
  *                                 out-of-set); (2) a marked member beside an unmarked sibling is
  *                                 spurious, and `ShuffledJoin`'s `InnerLike` arm, the only site
- *                                 that mixes them, clears it at construction, so members are
- *                                 uniformly marked or unmarked everywhere downstream.
+ *                                 that mixes them, clears it at construction;
+ *                                 `PartitioningCollection` additionally normalizes the marker by
+ *                                 OR in `fromPartitionings` and requires agreement in its
+ *                                 constructor, so members are uniformly marked or unmarked
+ *                                 everywhere and consumers may read one member.
  */
 case class KeyedPartitioning(
     expressions: Seq[Expression],
@@ -1070,11 +1073,13 @@ case class RangePartitioning(ordering: Seq[SortOrder], numPartitions: Int)
  * Outer Join operators.
  *
  * [[KeyedPartitioning]]s within a `PartitioningCollection` describe the same physical partitioning.
- * The constructor therefore requires all of them to share the same `partitionKeys` reference and
- * `isCollapsed` flag, and to have matching expression arity. Only their `expressions` differ.
+ * The constructor therefore requires all of them to share the same `partitionKeys` reference,
+ * `isCollapsed` flag and `mayContainUnknownPartitionKeys` marker, and to have matching
+ * expression arity. Only their `expressions` differ.
  *
  * Use [[PartitioningCollection.fromPartitionings]] to build one from independently-computed
- * partitionings, such as a join's `outputPartitioning`. Its inputs need not agree on `isCollapsed`.
+ * partitionings, such as a join's `outputPartitioning`. Its inputs need not agree on `isCollapsed`
+ * or on the unknown-keys marker.
  * Each member carries the history of the child it came from, so one side can have collapsed its
  * keys in a projection while the other reports what its source declared. `fromPartitionings` ORs
  * the flags, including across nested collections, which is right because the members name one
@@ -1130,6 +1135,10 @@ case class PartitioningCollection(partitionings: Seq[Partitioning])
               "partitionKeys reference")
           require(rep.isCollapsed == first.isCollapsed,
             "All KeyedPartitionings in a PartitioningCollection must agree on isCollapsed")
+          require(
+            rep.mayContainUnknownPartitionKeys == first.mayContainUnknownPartitionKeys,
+            "All KeyedPartitionings in a PartitioningCollection must agree on " +
+              "mayContainUnknownPartitionKeys")
         }
       }
     }
@@ -1195,14 +1204,16 @@ object PartitioningCollection {
    * Note: this can't be implemented with `TreeNode.transform`.
    */
   def fromPartitionings(partitionings: Seq[Partitioning]): PartitioningCollection = {
-    // See the class doc for why the flag is normalized by OR rather than required to agree. One
-    // representative per member is enough, because every collection agrees on the flag internally
-    // by this same construction, and only a member that disagrees is rebuilt.
+    // See the class doc for why the flags are normalized by OR rather than required to agree. One
+    // representative per member is enough, because every collection agrees on the flags
+    // internally by this same construction, and only a member that disagrees is rebuilt.
     val anyCollapsed = partitionings.exists(representativeOf(_).exists(_.isCollapsed))
+    val anyUnknownKeys =
+      partitionings.exists(representativeOf(_).exists(_.mayContainUnknownPartitionKeys))
 
     var canonicalKeys: Seq[InternalRowComparableWrapper] = null
     // A partitioning with no `KeyedPartitioning` in it has nothing to normalize, and one that
-    // already agrees on both the keys and the flag is returned as it is. That is what keeps
+    // already agrees on the keys and both flags is returned as it is. That is what keeps
     // repeated `outputPartitioning` computations over deeply nested collections (e.g. chains of
     // same-key joins) O(1) per level.
     def intern(p: Partitioning): Partitioning = representativeOf(p) match {
@@ -1210,14 +1221,16 @@ object PartitioningCollection {
       case Some(representative) =>
         if (canonicalKeys == null) canonicalKeys = representative.partitionKeys
         if ((representative.partitionKeys eq canonicalKeys) &&
-            representative.isCollapsed == anyCollapsed) {
+            representative.isCollapsed == anyCollapsed &&
+            representative.mayContainUnknownPartitionKeys == anyUnknownKeys) {
           p
         } else {
           require(representative.partitionKeys == canonicalKeys,
             "All KeyedPartitionings in a PartitioningCollection must have equal partitionKeys")
           p match {
             case keyed: KeyedPartitioning =>
-              keyed.copy(partitionKeys = canonicalKeys, isCollapsed = anyCollapsed)
+              keyed.copy(partitionKeys = canonicalKeys, isCollapsed = anyCollapsed,
+                mayContainUnknownPartitionKeys = anyUnknownKeys)
             case pc: PartitioningCollection =>
               new PartitioningCollection(pc.partitionings.map(intern))
           }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql.catalyst
 import org.apache.spark.SparkFunSuite
 /* Implicit conversions */
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, CollationAwareMurmur3Hash, Expression, Literal, Pmod}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, CollationAwareMurmur3Hash, Expression, Literal, Pmod, SortOrder}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.physical._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.IntegerType
 
 class DistributionSuite extends SparkFunSuite with SQLHelper {
@@ -454,21 +455,14 @@ class DistributionSuite extends SparkFunSuite with SQLHelper {
     // two partitions can (the e2e `ORDER BY` repro measures that). Positive control: an
     // always-false gate would shuffle these plans for nothing.
     val a = AttributeReference("a", IntegerType)()
-    val ordered = OrderedDistribution(
-      Seq(org.apache.spark.sql.catalyst.expressions.SortOrder(a,
-        org.apache.spark.sql.catalyst.expressions.Ascending)))
-    val markedOne = KeyedPartitioning(Seq(a), Seq(org.apache.spark.sql.catalyst.InternalRow(1)))
+    val ordered = OrderedDistribution(Seq(SortOrder(a, Ascending)))
+    val markedOne = KeyedPartitioning(Seq(a), Seq(InternalRow(1)))
       .copy(mayContainUnknownPartitionKeys = true)
-    val markedTwo = KeyedPartitioning(Seq(a),
-      Seq(org.apache.spark.sql.catalyst.InternalRow(1),
-        org.apache.spark.sql.catalyst.InternalRow(2)))
+    val markedTwo = KeyedPartitioning(Seq(a), Seq(InternalRow(1), InternalRow(2)))
       .copy(mayContainUnknownPartitionKeys = true)
-    withSQLConf(
-        org.apache.spark.sql.internal.SQLConf.V2_BUCKETING_SORTING_ENABLED.key -> "true") {
-      assert(markedOne.satisfies(ordered),
-        "a marked layout with a single partition is trivially globally ordered")
-      assert(!markedTwo.satisfies(ordered),
-        "the multi-partition case stays refused, pairing the positive above")
+    withSQLConf(SQLConf.V2_BUCKETING_SORTING_ENABLED.key -> "true") {
+      checkSatisfied(markedOne, ordered, true)
+      checkSatisfied(markedTwo, ordered, false)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -495,6 +495,42 @@ class DistributionSuite extends SparkFunSuite with SQLHelper {
     assert(err.getMessage.contains("agree on mayContainUnknownPartitionKeys"))
   }
 
+  test("SPARK-59050: fromPartitionings normalizes the unknown-keys marker through nesting") {
+    val x = AttributeReference("x", IntegerType)()
+    val y = AttributeReference("y", IntegerType)()
+    val keys = Seq(InternalRow(1), InternalRow(2))
+    val marked = KeyedPartitioning(Seq(x), keys).copy(mayContainUnknownPartitionKeys = true)
+    val plainNested = PartitioningCollection.fromPartitionings(
+      Seq(KeyedPartitioning(Seq(y), keys)))
+    val combined = PartitioningCollection.fromPartitionings(Seq(marked, plainNested))
+    // The nested collection must be rebuilt with the OR'd-on marker, not excused: only the
+    // recursive arm of `fromPartitionings` carries the flag into it.
+    val leaves = PartitioningCollection.flatten(combined)
+      .collect { case k: KeyedPartitioning => k }
+    assert(leaves.length === 2, combined.toString)
+    assert(leaves.forall(_.mayContainUnknownPartitionKeys), leaves.toString)
+    assert(leaves.forall(_.partitionKeys eq leaves.head.partitionKeys),
+      "the interned keys must survive the rebuild")
+  }
+
+  test("SPARK-59050: PartitioningCollection requires a nested collection to agree on the " +
+    "marker") {
+    val x = AttributeReference("x", IntegerType)()
+    val y = AttributeReference("y", IntegerType)()
+    val keys = Seq(InternalRow(1), InternalRow(2))
+    val base = KeyedPartitioning(Seq(x), keys)
+    val markedNested = PartitioningCollection.fromPartitionings(Seq(
+      base.copy(mayContainUnknownPartitionKeys = true)))
+    val plain = base.copy(expressions = Seq(y))
+    // The nested collection is internally uniform, so its own construction passes; the outer
+    // constructor must still catch its representative against the unmarked sibling. Same keys
+    // reference, arity and isCollapsed, only the marker disagrees.
+    val err = intercept[IllegalArgumentException] {
+      PartitioningCollection(Seq(markedNested, plain))
+    }
+    assert(err.getMessage.contains("agree on mayContainUnknownPartitionKeys"))
+  }
+
   test("SPARK-56877: PartitioningCollection enforces the invariant through nesting") {
     val x = AttributeReference("x", IntegerType)()
     val y = AttributeReference("y", IntegerType)()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -21,10 +21,11 @@ import org.apache.spark.SparkFunSuite
 /* Implicit conversions */
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, CollationAwareMurmur3Hash, Expression, Literal, Pmod}
+import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.types.IntegerType
 
-class DistributionSuite extends SparkFunSuite {
+class DistributionSuite extends SparkFunSuite with SQLHelper {
 
   protected def checkSatisfied(
       inputPartitioning: Partitioning,
@@ -445,6 +446,30 @@ class DistributionSuite extends SparkFunSuite {
     val combined = PartitioningCollection.fromPartitionings(Seq(nested, kpY))
     val interned = combined.partitionings.last.asInstanceOf[KeyedPartitioning]
     assert(interned.partitionKeys eq kpX.partitionKeys)
+  }
+
+  test("SPARK-59050: a marked one-partition layout keeps the global ordering claim") {
+    // The one-partition exemption inside `keysSatisfy`'s ordered branch: a single partition
+    // holds every row, so an out-of-set key cannot break the cross-partition sequence, while
+    // two partitions can (the e2e `ORDER BY` repro measures that). Positive control: an
+    // always-false gate would shuffle these plans for nothing.
+    val a = AttributeReference("a", IntegerType)()
+    val ordered = OrderedDistribution(
+      Seq(org.apache.spark.sql.catalyst.expressions.SortOrder(a,
+        org.apache.spark.sql.catalyst.expressions.Ascending)))
+    val markedOne = KeyedPartitioning(Seq(a), Seq(org.apache.spark.sql.catalyst.InternalRow(1)))
+      .copy(mayContainUnknownPartitionKeys = true)
+    val markedTwo = KeyedPartitioning(Seq(a),
+      Seq(org.apache.spark.sql.catalyst.InternalRow(1),
+        org.apache.spark.sql.catalyst.InternalRow(2)))
+      .copy(mayContainUnknownPartitionKeys = true)
+    withSQLConf(
+        org.apache.spark.sql.internal.SQLConf.V2_BUCKETING_SORTING_ENABLED.key -> "true") {
+      assert(markedOne.satisfies(ordered),
+        "a marked layout with a single partition is trivially globally ordered")
+      assert(!markedTwo.satisfies(ordered),
+        "the multi-partition case stays refused, pairing the positive above")
+    }
   }
 
   test("SPARK-59050: fromPartitionings normalizes the unknown-keys marker by OR") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -447,6 +447,35 @@ class DistributionSuite extends SparkFunSuite {
     assert(interned.partitionKeys eq kpX.partitionKeys)
   }
 
+  test("SPARK-59050: fromPartitionings normalizes the unknown-keys marker by OR") {
+    val x = AttributeReference("x", IntegerType)()
+    val y = AttributeReference("y", IntegerType)()
+    val marked = KeyedPartitioning(Seq(x), Seq(InternalRow(1), InternalRow(2)))
+      .copy(mayContainUnknownPartitionKeys = true)
+    val plain = KeyedPartitioning(Seq(y), Seq(InternalRow(1), InternalRow(2)))
+    val combined = PartitioningCollection.fromPartitionings(Seq(marked, plain))
+    // The conservative direction: an unmarked member must never excuse marked data, because
+    // the OR'd-on marker only costs a shuffle while the AND'd-off one could cost correctness.
+    val members = combined.partitionings.map(_.asInstanceOf[KeyedPartitioning])
+    assert(members.forall(_.mayContainUnknownPartitionKeys), members.toString)
+    assert(members.last.partitionKeys eq members.head.partitionKeys)
+  }
+
+  test("SPARK-59050: PartitioningCollection requires members to agree on the marker") {
+    val x = AttributeReference("x", IntegerType)()
+    val y = AttributeReference("y", IntegerType)()
+    val keys = Seq(InternalRow(1), InternalRow(2))
+    val base = KeyedPartitioning(Seq(x), keys)
+    val marked = base.copy(mayContainUnknownPartitionKeys = true)
+    // Same keys reference, arity and isCollapsed, only the marker disagrees: it has to reach
+    // the marker require rather than the reference check ahead of it.
+    val disagree = marked.copy(expressions = Seq(y), mayContainUnknownPartitionKeys = false)
+    val err = intercept[IllegalArgumentException] {
+      PartitioningCollection(Seq(marked, disagree))
+    }
+    assert(err.getMessage.contains("agree on mayContainUnknownPartitionKeys"))
+  }
+
   test("SPARK-56877: PartitioningCollection enforces the invariant through nesting") {
     val x = AttributeReference("x", IntegerType)()
     val y = AttributeReference("y", IntegerType)()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
+import org.apache.spark.sql.types.{DataType, IntegerType, LongType, StructType}
 
 class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
   private val passThrough_a_10 = ShufflePartitionIdPassThrough(DirectShufflePartitionID($"a"), 10)
@@ -510,6 +510,120 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
       assert(spec.joinKeyPositions === Some(Seq(0)))
       assert(spec.partitioning.partitionKeys.map(_.row.getInt(0)) === Seq(2020, 2021))
     }
+  }
+
+  test("areKeysCompatible: unknown partition keys only allow a subset of the declared keys") {
+    val a = $"a".int
+    val distribution = ClusteredDistribution(Seq(a))
+    def keyedSpec(
+        keys: Seq[Int],
+        hasUnknown: Boolean = false): KeyedShuffleSpec = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(a), keys.map(k => InternalRow(k)))
+        .copy(mayContainUnknownPartitionKeys = hasUnknown), distribution)
+
+    // A partitioning with unknown partition keys (e.g. a side re-shuffled onto a keyed layout by
+    // `KeyedShuffleSpec.createPartitioning`) only guarantees co-location for its declared keys, so
+    // it can only be co-partitioned with a side whose keys are a subset of the declared keys.
+    val unknown12 = keyedSpec(Seq(1, 2), hasUnknown = true)
+    // hasUnknown=true is still compatible with a subset (or equal) partner: every such key is
+    // co-located on both sides.
+    assert(unknown12.areKeysCompatible(keyedSpec(Seq(1))), "subset keys must be compatible")
+    assert(unknown12.areKeysCompatible(keyedSpec(Seq(2))), "another subset key must be compatible")
+    assert(unknown12.areKeysCompatible(keyedSpec(Seq(1, 2))), "equal keys must be compatible")
+    assert(keyedSpec(Seq(1)).areKeysCompatible(unknown12),
+      "compatibility must be symmetric for a subset partner")
+
+    // A larger partner's keys are not all covered by the declared keys.
+    assert(!unknown12.areKeysCompatible(keyedSpec(Seq(1, 2, 3))),
+      "a larger key set must not be compatible with an unknown-keyed partitioning")
+    assert(!keyedSpec(Seq(1, 2, 3)).areKeysCompatible(unknown12),
+      "an unknown-keyed partitioning cannot cover a larger partner's keys")
+
+    // Both sides unknown with the same declared keys: `KeyGroupedPartitioner`'s out-of-set-key
+    // fallback is a deterministic hash of the key, so both sides route those keys to the same
+    // partition and stay compatible -- but only when the declared key order also agrees, since a
+    // GroupPartitionsExec regrouping re-labels partitions by each side's declared order. Different
+    // declared keys or a different order are rejected.
+    assert(unknown12.areKeysCompatible(keyedSpec(Seq(1, 2), hasUnknown = true)),
+      "two unknown-keyed partitionings with the same declared keys must be compatible")
+    assert(!unknown12.areKeysCompatible(keyedSpec(Seq(2, 1), hasUnknown = true)),
+      "two unknown-keyed partitionings must agree on the declared key order")
+    assert(!unknown12.areKeysCompatible(keyedSpec(Seq(1, 2, 3), hasUnknown = true)),
+      "two unknown-keyed partitionings with different declared keys must not be compatible")
+
+    // Without unknown keys, key sets are not compared -- only the partition expressions are.
+    assert(keyedSpec(Seq(1, 2)).areKeysCompatible(keyedSpec(Seq(1, 2, 3))),
+      "without unknown keys, different key sets remain expression-compatible")
+  }
+
+  test("areKeysCompatible: unknown partition keys require the same partition functions") {
+    // A stand-in for a connector partition function such as `bucket`: only the canonical name
+    // matters here, since `TransformExpression.isSameFunction` compares names and bucket counts.
+    val bucketFn = new ScalarFunction[Int] {
+      override def inputTypes(): Array[DataType] = Array(LongType)
+      override def resultType(): DataType = IntegerType
+      override def name(): String = "test.bucket"
+      override def canonicalName(): String = "test.bucket"
+    }
+    def bucket(numBuckets: Int, expr: Expression): TransformExpression =
+      TransformExpression(bucketFn, Seq(expr), Some(numBuckets))
+
+    val a = $"a".long
+    val distribution = ClusteredDistribution(Seq(a))
+    def bucketSpec(
+        keys: Seq[Long],
+        hasUnknown: Boolean = false): KeyedShuffleSpec = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(bucket(4, a)), keys.map(k => InternalRow(k)))
+        .copy(mayContainUnknownPartitionKeys = hasUnknown), distribution)
+    def keyedSpec(
+        keys: Seq[Long],
+        hasUnknown: Boolean = false): KeyedShuffleSpec = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(a), keys.map(k => InternalRow(k)))
+        .copy(mayContainUnknownPartitionKeys = hasUnknown), distribution)
+
+    // `isExpressionCompatible` admits an identity-vs-transform pair when compatible transforms
+    // are allowed, but then the two sides' partition keys live in different domains: raw values
+    // on the identity side and bucket ids on the transform side. The unknown-keyed subset test
+    // would compare unrelated numbers, so the marker path must require the same partition
+    // function per position instead.
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "false",
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      assert(!keyedSpec(Seq(1), hasUnknown = true).areKeysCompatible(bucketSpec(Seq(0, 1))),
+        "an unknown-keyed identity partitioning must not pair with a transform partitioning")
+      assert(!bucketSpec(Seq(0, 1)).areKeysCompatible(keyedSpec(Seq(1), hasUnknown = true)),
+        "the incompatibility must be symmetric")
+      assert(!keyedSpec(Seq(1), hasUnknown = true).areKeysCompatible(
+          bucketSpec(Seq(0, 1), hasUnknown = true)),
+        "the identity-vs-transform pair must not pair even when both sides are unknown-keyed")
+      // Two unmarked sides keep the pre-existing behavior: the pair stays admissible, and
+      // `EnsureRequirements` computes reducers to reconcile the two key domains.
+      assert(keyedSpec(Seq(1)).areKeysCompatible(bucketSpec(Seq(0, 1))),
+        "unmarked identity-vs-transform pairs remain admissible")
+    }
+  }
+
+  test("areKeysCompatible: incompatibility without unknown partition keys") {
+    val a = $"a".int
+    val b = $"b".int
+    val distribution = ClusteredDistribution(Seq(a))
+
+    // Different arity: the two partitionings partition on a different number of keys.
+    val single = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(a), Seq(InternalRow(1), InternalRow(2))), distribution)
+    val double = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(a, b), Seq(InternalRow(1, 1), InternalRow(2, 2))), distribution)
+    assert(!single.areKeysCompatible(double), "different arity must not be compatible")
+
+    // Non-overlapping key positions: the partition keys map to disjoint clustering key positions.
+    val ab = ClusteredDistribution(Seq(a, b))
+    val onA = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(a), Seq(InternalRow(1), InternalRow(2))), ab)
+    val onB = KeyedShuffleSpec(
+      KeyedPartitioning(Seq(b), Seq(InternalRow(1), InternalRow(2))), ab)
+    assert(!onA.areKeysCompatible(onB),
+      "partition keys must overlap on the clustering keys to be compatible")
   }
 
   test("createPartitioning: HashShuffleSpec") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, DirectShufflePartitionID, Expression, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
+import org.apache.spark.sql.connector.catalog.functions.{Reducer, ReducibleFunction, ScalarFunction}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, IntegerType, LongType, StructType}
 
@@ -541,7 +541,7 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
 
     // Both sides unknown with the same declared keys: `KeyGroupedPartitioner`'s out-of-set-key
     // fallback is a deterministic hash of the key, so both sides route those keys to the same
-    // partition and stay compatible -- but only when the declared key order also agrees, since a
+    // partition and stay compatible, but only when the declared key order also agrees, since a
     // GroupPartitionsExec regrouping re-labels partitions by each side's declared order. Different
     // declared keys or a different order are rejected.
     assert(unknown12.areKeysCompatible(keyedSpec(Seq(1, 2), hasUnknown = true)),
@@ -551,7 +551,7 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
     assert(!unknown12.areKeysCompatible(keyedSpec(Seq(1, 2, 3), hasUnknown = true)),
       "two unknown-keyed partitionings with different declared keys must not be compatible")
 
-    // Without unknown keys, key sets are not compared -- only the partition expressions are.
+    // Without the marker, key sets are not compared, only the partition expressions are.
     assert(keyedSpec(Seq(1, 2)).areKeysCompatible(keyedSpec(Seq(1, 2, 3))),
       "without unknown keys, different key sets remain expression-compatible")
   }
@@ -604,26 +604,76 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("areKeysCompatible: incompatibility without unknown partition keys") {
+  test("createShuffleSpec: a marked narrowing projection yields an unusable spec") {
     val a = $"a".int
     val b = $"b".int
-    val distribution = ClusteredDistribution(Seq(a))
+    val marked = KeyedPartitioning(Seq(a, b), Seq(InternalRow(1, 2), InternalRow(3, 4)))
+      .copy(mayContainUnknownPartitionKeys = true)
+    withSQLConf(
+        SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val spec = marked.createShuffleSpec(ClusteredDistribution(Seq(a)))
+        .asInstanceOf[KeyedShuffleSpec]
+      // The refusal returns the unprojected spec whose `b` expression maps to no clustering
+      // key; that position must make the spec unusable as a shuffle template, or
+      // `createPartitioning` would index an empty position set.
+      assert(spec.joinKeyPositions.isEmpty)
+      assert(!spec.canCreatePartitioning)
+    }
+  }
 
-    // Different arity: the two partitionings partition on a different number of keys.
-    val single = KeyedShuffleSpec(
-      KeyedPartitioning(Seq(a), Seq(InternalRow(1), InternalRow(2))), distribution)
-    val double = KeyedShuffleSpec(
-      KeyedPartitioning(Seq(a, b), Seq(InternalRow(1, 1), InternalRow(2, 2))), distribution)
-    assert(!single.areKeysCompatible(double), "different arity must not be compatible")
+  test("areKeysCompatible: unknown keys require the same function, not just a compatible one") {
+    // A bucket-like reducible function: like the built-in `bucket`, a pair of the same function
+    // with coarser/finer bucket counts is compatible (a reducer exists) but not the same
+    // function. Local to the suite because catalyst has no BucketFunction.
+    class FakeBucket extends ScalarFunction[java.lang.Long]
+        with ReducibleFunction[java.lang.Long, java.lang.Long] {
+      override def inputTypes(): Array[DataType] = Array(LongType)
+      override def resultType(): DataType = LongType
+      override def name(): String = "test.fakeBucket"
+      override def canonicalName(): String = name()
+      override def produceResult(input: InternalRow): java.lang.Long = input.getLong(0)
+      override def reducer(
+          thisNumBuckets: Int,
+          other: ReducibleFunction[_, _],
+          otherNumBuckets: Int): Reducer[java.lang.Long, java.lang.Long] =
+        if (other.isInstanceOf[FakeBucket] && thisNumBuckets != otherNumBuckets &&
+            thisNumBuckets % otherNumBuckets == 0) {
+          new Reducer[java.lang.Long, java.lang.Long] {
+            override def reduce(v: java.lang.Long): java.lang.Long = v % otherNumBuckets
+            override def resultType(): DataType = LongType
+          }
+        } else {
+          null
+        }
+    }
+    val fn = new FakeBucket
+    val a = $"a".long
+    def bucketSpec(numBuckets: Int, hasUnknown: Boolean): KeyedShuffleSpec =
+      KeyedShuffleSpec(
+        KeyedPartitioning(
+          Seq(TransformExpression(fn, Seq(a), Some(numBuckets))),
+          Seq(InternalRow(0L), InternalRow(1L)))
+          .copy(mayContainUnknownPartitionKeys = hasUnknown),
+        ClusteredDistribution(Seq(a)))
 
-    // Non-overlapping key positions: the partition keys map to disjoint clustering key positions.
-    val ab = ClusteredDistribution(Seq(a, b))
-    val onA = KeyedShuffleSpec(
-      KeyedPartitioning(Seq(a), Seq(InternalRow(1), InternalRow(2))), ab)
-    val onB = KeyedShuffleSpec(
-      KeyedPartitioning(Seq(b), Seq(InternalRow(1), InternalRow(2))), ab)
-    assert(!onA.areKeysCompatible(onB),
-      "partition keys must overlap on the clustering keys to be compatible")
+    // `allowCompatibleTransforms` lets a differing-bucket-count pair through
+    // `isExpressionCompatible`, and both specs declare the key set {0, 1}, so any
+    // refusal below can only come from the same-function gate on the marker path, not the keys.
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "false",
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      assert(!bucketSpec(4, true).areKeysCompatible(bucketSpec(8, true)),
+        "two marked sides must agree on the exact function, not just a compatible one")
+      assert(!bucketSpec(4, true).areKeysCompatible(bucketSpec(8, false)),
+        "a marked side must not pair across bucket counts")
+      assert(!bucketSpec(8, false).areKeysCompatible(bucketSpec(4, true)),
+        "the refusal must be symmetric")
+      // Unmarked, the compatible-transform relaxation still pairs them (pre-existing behavior).
+      assert(bucketSpec(4, false).areKeysCompatible(bucketSpec(8, false)),
+        "unmarked compatible transforms remain admissible")
+    }
   }
 
   test("createPartitioning: HashShuffleSpec") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
@@ -673,6 +673,10 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
       // Unmarked, the compatible-transform relaxation still pairs them (pre-existing behavior).
       assert(bucketSpec(4, false).areKeysCompatible(bucketSpec(8, false)),
         "unmarked compatible transforms remain admissible")
+      // Positive control: the same marked function with the same keys must stay compatible, so
+      // the refusals above are the function difference's doing, not the marker path always false.
+      assert(bucketSpec(4, true).areKeysCompatible(bucketSpec(4, true)),
+        "identical marked functions remain compatible")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
@@ -131,8 +131,8 @@ trait PartitioningPreservingUnaryExecNode extends UnaryExecNode
 
     if (projectablePositions.isEmpty) return LazyList.empty
 
-    // Collection members carry a uniform marker (mixed collections are cleared at
-    // construction by `ShuffledJoin`), so the head represents them all.
+    // `PartitioningCollection` requires its members to agree on the marker, so the head
+    // represents them all.
     val mayContainUnknownPartitionKeys = kps.head.mayContainUnknownPartitionKeys
 
     // Dropping a key position coarsens the declared set, which an unknown-keyed claim cannot

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
@@ -131,11 +131,9 @@ trait PartitioningPreservingUnaryExecNode extends UnaryExecNode
 
     if (projectablePositions.isEmpty) return LazyList.empty
 
-    // Only an input collection whose KPs are all unknown-keyed genuinely holds unknown keys --
-    // a mixed one comes from a `ShuffledJoin` `InnerLike` arm and its marker is spurious (see
-    // `KeyedPartitioning.mayContainUnknownPartitionKeys`; `kps` is non-empty by the early
-    // return above).
-    val mayContainUnknownPartitionKeys = kps.forall(_.mayContainUnknownPartitionKeys)
+    // Collection members carry a uniform marker (mixed collections are cleared at
+    // construction by `ShuffledJoin`), so the head represents them all.
+    val mayContainUnknownPartitionKeys = kps.head.mayContainUnknownPartitionKeys
 
     // Dropping a key position coarsens the declared set, which an unknown-keyed claim cannot
     // survive.
@@ -143,13 +141,11 @@ trait PartitioningPreservingUnaryExecNode extends UnaryExecNode
       return LazyList.empty
     }
 
-    // All input KPs share the same partitionKeys and isCollapsed flag by invariant, so the first
-    // one projects the keys and both flags for every combination below. Only the expressions
-    // differ. The marker is re-stamped rather than carried by `project`: `project` would inherit
-    // the head KP's own value, and the scoped answer above turns a spurious one off.
-    val projected = kps.head
-      .project(projectablePositions)
-      .copy(mayContainUnknownPartitionKeys = mayContainUnknownPartitionKeys)
+    // All input KPs share the same partitionKeys and flags by invariant, so the first one
+    // projects the keys for every combination below; only the expressions differ. The marker
+    // rides the copies unchanged: the guard above turned away the one shape that could not, a
+    // narrowing projection of a marked collection.
+    val projected = kps.head.project(projectablePositions)
 
     // Cross-product the per-position alternatives to produce all concrete KPs.
     // Note: generateCartesianProduct expects thunks () => Seq[T], but wrapping LazyLists in thunks

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
@@ -131,10 +131,25 @@ trait PartitioningPreservingUnaryExecNode extends UnaryExecNode
 
     if (projectablePositions.isEmpty) return LazyList.empty
 
+    // Only an input collection whose KPs are all unknown-keyed genuinely holds unknown keys --
+    // a mixed one comes from a `ShuffledJoin` `InnerLike` arm and its marker is spurious (see
+    // `KeyedPartitioning.mayContainUnknownPartitionKeys`; `kps` is non-empty by the early
+    // return above).
+    val mayContainUnknownPartitionKeys = kps.forall(_.mayContainUnknownPartitionKeys)
+
+    // Dropping a key position coarsens the declared set, which an unknown-keyed claim cannot
+    // survive.
+    if (projectablePositions.length < numPositions && mayContainUnknownPartitionKeys) {
+      return LazyList.empty
+    }
+
     // All input KPs share the same partitionKeys and isCollapsed flag by invariant, so the first
     // one projects the keys and both flags for every combination below. Only the expressions
-    // differ.
-    val projected = kps.head.project(projectablePositions)
+    // differ. The marker is re-stamped rather than carried by `project`: `project` would inherit
+    // the head KP's own value, and the scoped answer above turns a spurious one off.
+    val projected = kps.head
+      .project(projectablePositions)
+      .copy(mayContainUnknownPartitionKeys = mayContainUnknownPartitionKeys)
 
     // Cross-product the per-position alternatives to produce all concrete KPs.
     // Note: generateCartesianProduct expects thunks () => Seq[T], but wrapping LazyLists in thunks

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -984,13 +984,19 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan with CodegenSup
     if (partitionings.forall(_.isInstanceOf[KeyedPartitioning])) {
       val kps = partitionings.map(_.asInstanceOf[KeyedPartitioning])
       val headKp = kps.head
-      // The `KeyedPartitioning`s must agree on the partition expressions to merge.
-      val compatible = kps.forall(comparePartitioning(_, headKp))
+      // To merge, the `KeyedPartitioning`s must agree on the partition expressions, and no leg
+      // may carry the unknown-keys marker (see
+      // `KeyedPartitioning.mayContainUnknownPartitionKeys`): the merged keys concatenate the
+      // legs' declared sets, so another leg may declare exactly the key an unknown-keyed leg
+      // holds out-of-set. Unlike a join's mixed `PartitioningCollection`, an unmarked leg does
+      // not excuse the marker here -- every leg's rows are kept, so an unknown-keyed leg's
+      // out-of-set keys really do reach the union output.
+      val compatible = kps.forall(kp =>
+        !kp.mayContainUnknownPartitionKeys && comparePartitioning(kp, headKp))
       if (compatible) {
         return KeyedPartitioning.concat(kps)
-      } else {
-        return super.outputPartitioning
       }
+      return super.outputPartitioning
     }
 
     // Case B: treat each child's partitioning as a set of candidate partitionings (a

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -988,7 +988,7 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan with CodegenSup
       // may carry the marker: the merged set declares the other legs' keys, so an out-of-set row
       // can sit in the wrong partition for the merged claim (rule (1) of the
       // `KeyedPartitioning.mayContainUnknownPartitionKeys` doc). Unlike a join, a union keeps
-      // every leg's rows, so an unmarked leg excuses a marked one nothing.
+      // every leg's rows: an unmarked leg does not excuse a marked one.
       val compatible = kps.forall(kp =>
         !kp.mayContainUnknownPartitionKeys && comparePartitioning(kp, headKp))
       if (compatible) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -984,13 +984,11 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan with CodegenSup
     if (partitionings.forall(_.isInstanceOf[KeyedPartitioning])) {
       val kps = partitionings.map(_.asInstanceOf[KeyedPartitioning])
       val headKp = kps.head
-      // To merge, the `KeyedPartitioning`s must agree on the partition expressions, and no leg
-      // may carry the unknown-keys marker (see
-      // `KeyedPartitioning.mayContainUnknownPartitionKeys`): the merged keys concatenate the
-      // legs' declared sets, so another leg may declare exactly the key an unknown-keyed leg
-      // holds out-of-set. Unlike a join's mixed `PartitioningCollection`, an unmarked leg does
-      // not excuse the marker here -- every leg's rows are kept, so an unknown-keyed leg's
-      // out-of-set keys really do reach the union output.
+      // To merge, the `KeyedPartitioning`s must agree on the partition expressions and no leg
+      // may carry the marker: the merged set declares the other legs' keys, so an out-of-set row
+      // can sit in the wrong partition for the merged claim (rule (1) of the
+      // `KeyedPartitioning.mayContainUnknownPartitionKeys` doc). Unlike a join, a union keeps
+      // every leg's rows, so an unmarked leg excuses a marked one nothing.
       val compatible = kps.forall(kp =>
         !kp.mayContainUnknownPartitionKeys && comparePartitioning(kp, headKp))
       if (compatible) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -78,19 +78,19 @@ case class GroupPartitionsExec(
         // data types match the reduced partition keys for the identity-vs-transform and
         // single-side-transform reducers; for the both-sides-reduce shape no single transform
         // describes the keys (see `KeyedShuffleSpec.reducersBothWays`).
-        val partitionKeys = grouping.partitions.map(_._1)
-        // A reduction coarsens the declared set, which a marked claim cannot survive (see
-        // `KeyedPartitioning.mayContainUnknownPartitionKeys`), and the regrouping rewrites the
-        // layout, so no child claim remains to fall back to: give up the keyed partitioning at
-        // the physical output count (one per group, padding included) that a parent's
-        // `PartitioningCollection` requires for uniformity. The reducer check comes first, so
-        // the marker lookup runs only when a reduction is applied. No planner path with built-in
-        // transforms reaches this (see the gates in `createShuffleSpec` and
-        // `areKeysCompatible`); the branch guards third-party `ReducibleFunction`s with a
-        // self-reducer and is pinned directly in `GroupPartitionsExecSuite`.
-        if (reducers.isDefined && PartitioningCollection.keyedMarkerOf(p).contains(true)) {
+        //
+        // A marked claim pins undeclared rows to hash(key) % numPartitions (see
+        // `KeyedPartitioning.mayContainUnknownPartitionKeys`). Only an identity grouping keeps
+        // that relationship: any other grouping -- a reorder, a coalesce, a resize, or the
+        // collapse a reduction applies -- moves those rows. Clearing only the marker would
+        // misreport the undeclared rows that remain, so give up the keyed partitioning at the
+        // physical output count (one per group, padding included) that a parent's
+        // `PartitioningCollection` requires for uniformity. `identityGrouping` is a lazy val, so
+        // repeated `outputPartitioning` calls scan it at most once.
+        if (PartitioningCollection.keyedMarkerOf(p).contains(true) && !identityGrouping) {
           return UnknownPartitioning(grouping.partitions.size)
         }
+        val partitionKeys = grouping.partitions.map(_._1)
         p.transform {
           case k: KeyedPartitioning =>
             val projectedExpressions = joinKeyPositions.fold(k.expressions)(_.map(k.expressions))
@@ -231,6 +231,18 @@ case class GroupPartitionsExec(
     }
     PartitionGrouping(partitions, isGrouped, isCollapsed)
   }
+
+  /**
+   * Whether this node's grouping leaves every partition where it was, i.e. output partition i
+   * holds exactly input partition i. That is the only grouping that keeps a marked layout's
+   * undeclared rows at hash(key) % numPartitions. The `forall` stops at the first moved
+   * partition, so a reorder or coalesce is rejected without a full scan.
+   */
+  @transient private lazy val identityGrouping: Boolean =
+    grouping.partitions.zipWithIndex.forall {
+      case ((_, Seq(single)), outputIndex) => single == outputIndex
+      case _ => false
+    }
 
   @transient lazy val groupedPartitions: Seq[(InternalRowComparableWrapper, Seq[Int])] =
     grouping.partitions

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -85,8 +85,12 @@ case class GroupPartitionsExec(
         // collapse a reduction applies -- moves those rows. Clearing only the marker would
         // misreport the undeclared rows that remain, so give up the keyed partitioning at the
         // physical output count (one per group, padding included) that a parent's
-        // `PartitioningCollection` requires for uniformity. `identityGrouping` is a lazy val, so
-        // repeated `outputPartitioning` calls scan it at most once.
+        // `PartitioningCollection` requires for uniformity. The give-up deliberately
+        // under-reports: the node still physically groups the partitions but no longer claims a
+        // keyed layout, so a join planned over it does not see its required distribution
+        // satisfied and a plan containing it does not pass `ValidateRequirements`.
+        // `identityGrouping` is a lazy val, so repeated `outputPartitioning` calls scan it at
+        // most once.
         if (PartitioningCollection.keyedMarkerOf(p).contains(true) && !identityGrouping) {
           return UnknownPartitioning(grouping.partitions.size)
         }
@@ -233,16 +237,19 @@ case class GroupPartitionsExec(
   }
 
   /**
-   * Whether this node's grouping leaves every partition where it was, i.e. output partition i
-   * holds exactly input partition i. That is the only grouping that keeps a marked layout's
-   * undeclared rows at hash(key) % numPartitions. The `forall` stops at the first moved
-   * partition, so a reorder or coalesce is rejected without a full scan.
+   * Whether this node's grouping leaves every partition where it was and keeps all of them, i.e.
+   * output partition i holds exactly input partition i and there is one output per input. That is
+   * the only grouping that keeps a marked layout's undeclared rows at hash(key) % numPartitions:
+   * a grouping that drops trailing declared keys still reads identity for every group it keeps,
+   * but the partition count shrinks and the hash modulus with it. The `forall` stops at the first
+   * moved partition, so a reorder or coalesce is rejected without a full scan.
    */
   @transient private lazy val identityGrouping: Boolean =
-    grouping.partitions.zipWithIndex.forall {
-      case ((_, Seq(single)), outputIndex) => single == outputIndex
-      case _ => false
-    }
+    grouping.partitions.size == child.outputPartitioning.numPartitions &&
+      grouping.partitions.zipWithIndex.forall {
+        case ((_, Seq(single)), outputIndex) => single == outputIndex
+        case _ => false
+      }
 
   @transient lazy val groupedPartitions: Seq[(InternalRowComparableWrapper, Seq[Int])] =
     grouping.partitions

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{IdentityReducer, KeyedPartitioning, KeyReducer, Partitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{IdentityReducer, KeyedPartitioning, KeyReducer, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf
@@ -79,6 +79,29 @@ case class GroupPartitionsExec(
         // single-side-transform reducers; for the both-sides-reduce shape no single transform
         // describes the keys (see `KeyedShuffleSpec.reducersBothWays`).
         val partitionKeys = grouping.partitions.map(_._1)
+        // Only a collection whose KPs are all unknown-keyed genuinely holds unknown keys; a
+        // mixed one comes from a `ShuffledJoin` `InnerLike` arm and its marker is spurious
+        // (see `KeyedPartitioning.mayContainUnknownPartitionKeys`).
+        val kps = p.collect { case k: KeyedPartitioning => k }
+        val mayContainUnknownKeys = kps.nonEmpty && kps.forall(_.mayContainUnknownPartitionKeys)
+        // The output declares reduced keys (when `reducers` is defined) or keys projected to
+        // `joinKeyPositions` -- either coarsens the declared set, which an unknown-keyed claim
+        // cannot survive. Drop the keyed partitioning entirely: the regrouping rewrote the
+        // layout, so there is no child claim to fall back to. No planner path reaches this with
+        // the built-in transforms: `createShuffleSpec` refuses a narrowing projection of an
+        // unknown-keyed partitioning one hop earlier, so `joinKeyPositions` can only arrive
+        // un-narrowed, and `areKeysCompatible` pairs an unknown-keyed spec only with a
+        // same-function partner, which the built-in transforms give no reducer. The `reducers`
+        // term therefore guards third-party `ReducibleFunction`s whose reducer is defined
+        // against themselves; `GroupPartitionsExecSuite` exercises the branch directly.
+        val narrowsDeclaredKeys = kps.headOption.exists { kp =>
+          joinKeyPositions.exists(_.length < kp.expressions.length)
+        }
+        if (mayContainUnknownKeys && (reducers.isDefined || narrowsDeclaredKeys)) {
+          // Report the physical output partition count (one per group, padding included) so a
+          // parent's `PartitioningCollection` stays uniform in numPartitions.
+          return UnknownPartitioning(grouping.partitions.size)
+        }
         p.transform {
           case k: KeyedPartitioning =>
             val projectedExpressions = joinKeyPositions.fold(k.expressions)(_.map(k.expressions))
@@ -96,7 +119,8 @@ case class GroupPartitionsExec(
               case None => projectedExpressions
             }
             KeyedPartitioning(
-              effectiveExpressions, partitionKeys, grouping.isGrouped, grouping.isCollapsed)
+              effectiveExpressions, partitionKeys, grouping.isGrouped, grouping.isCollapsed,
+              mayContainUnknownPartitionKeys = k.mayContainUnknownPartitionKeys)
         }.asInstanceOf[Partitioning]
       case o => o
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -88,7 +88,7 @@ case class GroupPartitionsExec(
         // transforms reaches this (see the gates in `createShuffleSpec` and
         // `areKeysCompatible`); the branch guards third-party `ReducibleFunction`s with a
         // self-reducer and is pinned directly in `GroupPartitionsExecSuite`.
-        if (reducers.isDefined && PartitioningCollection.mayContainUnknownPartitionKeys(p)) {
+        if (reducers.isDefined && PartitioningCollection.keyedMarkerOf(p).contains(true)) {
           return UnknownPartitioning(grouping.partitions.size)
         }
         p.transform {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -79,27 +79,21 @@ case class GroupPartitionsExec(
         // single-side-transform reducers; for the both-sides-reduce shape no single transform
         // describes the keys (see `KeyedShuffleSpec.reducersBothWays`).
         val partitionKeys = grouping.partitions.map(_._1)
-        // Only a collection whose KPs are all unknown-keyed genuinely holds unknown keys; a
-        // mixed one comes from a `ShuffledJoin` `InnerLike` arm and its marker is spurious
-        // (see `KeyedPartitioning.mayContainUnknownPartitionKeys`).
-        val kps = p.collect { case k: KeyedPartitioning => k }
-        val mayContainUnknownKeys = kps.nonEmpty && kps.forall(_.mayContainUnknownPartitionKeys)
-        // The output declares reduced keys (when `reducers` is defined) or keys projected to
-        // `joinKeyPositions` -- either coarsens the declared set, which an unknown-keyed claim
-        // cannot survive. Drop the keyed partitioning entirely: the regrouping rewrote the
-        // layout, so there is no child claim to fall back to. No planner path reaches this with
-        // the built-in transforms: `createShuffleSpec` refuses a narrowing projection of an
-        // unknown-keyed partitioning one hop earlier, so `joinKeyPositions` can only arrive
-        // un-narrowed, and `areKeysCompatible` pairs an unknown-keyed spec only with a
-        // same-function partner, which the built-in transforms give no reducer. The `reducers`
-        // term therefore guards third-party `ReducibleFunction`s whose reducer is defined
-        // against themselves; `GroupPartitionsExecSuite` exercises the branch directly.
-        val narrowsDeclaredKeys = kps.headOption.exists { kp =>
-          joinKeyPositions.exists(_.length < kp.expressions.length)
+        // Members carry a uniform marker (mixed collections are cleared at construction by
+        // `ShuffledJoin`), so any member answers for all of them.
+        val mayContainUnknownKeys = p.exists {
+          case k: KeyedPartitioning => k.mayContainUnknownPartitionKeys
+          case _ => false
         }
-        if (mayContainUnknownKeys && (reducers.isDefined || narrowsDeclaredKeys)) {
-          // Report the physical output partition count (one per group, padding included) so a
-          // parent's `PartitioningCollection` stays uniform in numPartitions.
+        // A reduction coarsens the declared set, which a marked claim cannot survive (see
+        // `KeyedPartitioning.mayContainUnknownPartitionKeys`), and the regrouping rewrites the
+        // layout, so no child claim remains to fall back to: give up the keyed partitioning at
+        // the physical output count (one per group, padding included) that a parent's
+        // `PartitioningCollection` requires for uniformity. No planner path with built-in
+        // transforms reaches this (see the gates in `createShuffleSpec` and
+        // `areKeysCompatible`); the branch guards third-party `ReducibleFunction`s with a
+        // self-reducer and is pinned directly in `GroupPartitionsExecSuite`.
+        if (mayContainUnknownKeys && reducers.isDefined) {
           return UnknownPartitioning(grouping.partitions.size)
         }
         p.transform {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -214,11 +214,15 @@ case class GroupPartitionsExec(
 
     // Both cheap terms come first, so the scan below runs only where a merge is possible. A
     // grouping that left the keys as they are groups the child's own key values, and one of those
-    // groups can only ever cover the one key it was built from. `keysChanged` also feeds
-    // `identityGrouping`: a projection or reduction re-labels the groups into a different key
-    // space, which no index alignment can undo.
+    // groups can only ever cover the one key it was built from.
     val keysChanged =
       joinKeyPositions.exists(_.length < childKp.expressions.length) || reducers.isDefined
+    // `identityGrouping` asks the stronger question: a projection that only reorders the key
+    // columns merges no key, but it still re-labels the groups into a different key space,
+    // which no index alignment can undo. No producer of `joinKeyPositions` emits anything but
+    // ascending positions today, so this only matters as defence in depth.
+    val keysRewritten =
+      joinKeyPositions.exists(_ != childKp.expressions.indices) || reducers.isDefined
     val isCollapsed = childKp.isCollapsed || keysChanged && {
       // The groups this node keeps are the ones that can merge keys of the child, and asking the
       // child's keys rather than its partitions is what tells such a merge from a source that
@@ -235,7 +239,7 @@ case class GroupPartitionsExec(
         group.tail.exists(childKeys(_) != first)
       }
     }
-    PartitionGrouping(partitions, isGrouped, isCollapsed, keysChanged)
+    PartitionGrouping(partitions, isGrouped, isCollapsed, keysRewritten)
   }
 
   /**
@@ -244,15 +248,16 @@ case class GroupPartitionsExec(
    * partition i, and there is one output per input. That is the only grouping that keeps a
    * marked layout's undeclared rows at hash(key) % numPartitions. A projection or reduction
    * re-labels the groups into a different key space, so even a grouping whose indices line up
-   * would pin the claim to keys it no longer declares; `keysChanged` rejects it up front. A
-   * reducer slot is treated as key-changing: a conforming self-reducer cannot rewrite a
-   * reachable key value, so the give-up there loses at most an optimization. A grouping that
-   * drops trailing declared keys still reads identity for every group it keeps, but the
-   * partition count shrinks and the hash modulus with it. The `forall` stops at the first moved
-   * partition, so a reorder or coalesce is rejected without a full scan.
+   * would pin the claim to keys it no longer declares; `keysRewritten` rejects it up front --
+   * it covers a narrowing projection, a reordering one, and any reducer slot. A reducer slot
+   * is treated as key-changing: a conforming self-reducer cannot rewrite a reachable key
+   * value, so the give-up there loses at most an optimization. A grouping that drops trailing
+   * declared keys still reads identity for every group it keeps, but the partition count
+   * shrinks and the hash modulus with it. The `forall` stops at the first moved partition, so
+   * a reorder or coalesce is rejected without a full scan.
    */
   @transient private lazy val identityGrouping: Boolean =
-    !grouping.keysChanged &&
+    !grouping.keysRewritten &&
       grouping.partitions.size == child.outputPartitioning.numPartitions &&
       grouping.partitions.zipWithIndex.forall {
         case ((_, Seq(single)), outputIndex) => single == outputIndex
@@ -445,7 +450,7 @@ private case class PartitionGrouping(
     partitions: Seq[(InternalRowComparableWrapper, Seq[Int])],
     isGrouped: Boolean,
     isCollapsed: Boolean,
-    keysChanged: Boolean)
+    keysRewritten: Boolean)
 
 /**
  * A PartitionCoalescer that groups partitions according to a pre-computed grouping plan.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -259,7 +259,7 @@ case class GroupPartitionsExec(
   @transient private lazy val identityGrouping: Boolean =
     !grouping.keysRewritten &&
       grouping.partitions.size == child.outputPartitioning.numPartitions &&
-      grouping.partitions.zipWithIndex.forall {
+      grouping.partitions.iterator.zipWithIndex.forall {
         case ((_, Seq(single)), outputIndex) => single == outputIndex
         case _ => false
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{IdentityReducer, KeyedPartitioning, KeyReducer, Partitioning, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{IdentityReducer, KeyedPartitioning, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.internal.SQLConf
@@ -79,21 +79,16 @@ case class GroupPartitionsExec(
         // single-side-transform reducers; for the both-sides-reduce shape no single transform
         // describes the keys (see `KeyedShuffleSpec.reducersBothWays`).
         val partitionKeys = grouping.partitions.map(_._1)
-        // Members carry a uniform marker (mixed collections are cleared at construction by
-        // `ShuffledJoin`), so any member answers for all of them.
-        val mayContainUnknownKeys = p.exists {
-          case k: KeyedPartitioning => k.mayContainUnknownPartitionKeys
-          case _ => false
-        }
         // A reduction coarsens the declared set, which a marked claim cannot survive (see
         // `KeyedPartitioning.mayContainUnknownPartitionKeys`), and the regrouping rewrites the
         // layout, so no child claim remains to fall back to: give up the keyed partitioning at
         // the physical output count (one per group, padding included) that a parent's
-        // `PartitioningCollection` requires for uniformity. No planner path with built-in
+        // `PartitioningCollection` requires for uniformity. The reducer check comes first, so
+        // the marker lookup runs only when a reduction is applied. No planner path with built-in
         // transforms reaches this (see the gates in `createShuffleSpec` and
         // `areKeysCompatible`); the branch guards third-party `ReducibleFunction`s with a
         // self-reducer and is pinned directly in `GroupPartitionsExecSuite`.
-        if (mayContainUnknownKeys && reducers.isDefined) {
+        if (reducers.isDefined && PartitioningCollection.mayContainUnknownPartitionKeys(p)) {
           return UnknownPartitioning(grouping.partitions.size)
         }
         p.transform {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -81,16 +81,16 @@ case class GroupPartitionsExec(
         //
         // A marked claim pins undeclared rows to hash(key) % numPartitions (see
         // `KeyedPartitioning.mayContainUnknownPartitionKeys`). Only an identity grouping keeps
-        // that relationship: any other grouping -- a reorder, a coalesce, a resize, or the
-        // collapse a reduction applies -- moves those rows. Clearing only the marker would
-        // misreport the undeclared rows that remain, so give up the keyed partitioning at the
-        // physical output count (one per group, padding included) that a parent's
-        // `PartitioningCollection` requires for uniformity. The give-up deliberately
-        // under-reports: the node still physically groups the partitions but no longer claims a
-        // keyed layout, so a join planned over it does not see its required distribution
-        // satisfied and a plan containing it does not pass `ValidateRequirements`.
-        // `identityGrouping` is a lazy val, so repeated `outputPartitioning` calls scan it at
-        // most once.
+        // that relationship: a reorder, a coalesce, or a resize moves those rows, and a
+        // projection or reduction rewrites the keys the claim speaks for (see
+        // `identityGrouping`). Clearing only the marker would misreport the undeclared rows
+        // that remain, so give up the keyed partitioning at the physical output count (one per
+        // group, padding included) that a parent's `PartitioningCollection` requires for
+        // uniformity. The give-up deliberately under-reports: the node still physically groups
+        // the partitions but no longer claims a keyed layout, so a join planned over it does
+        // not see its required distribution satisfied and a plan containing it does not pass
+        // `ValidateRequirements`. `identityGrouping` is a lazy val, so repeated
+        // `outputPartitioning` calls scan it at most once.
         if (PartitioningCollection.keyedMarkerOf(p).contains(true) && !identityGrouping) {
           return UnknownPartitioning(grouping.partitions.size)
         }
@@ -214,7 +214,9 @@ case class GroupPartitionsExec(
 
     // Both cheap terms come first, so the scan below runs only where a merge is possible. A
     // grouping that left the keys as they are groups the child's own key values, and one of those
-    // groups can only ever cover the one key it was built from.
+    // groups can only ever cover the one key it was built from. `keysChanged` also feeds
+    // `identityGrouping`: a projection or reduction re-labels the groups into a different key
+    // space, which no index alignment can undo.
     val keysChanged =
       joinKeyPositions.exists(_.length < childKp.expressions.length) || reducers.isDefined
     val isCollapsed = childKp.isCollapsed || keysChanged && {
@@ -233,19 +235,25 @@ case class GroupPartitionsExec(
         group.tail.exists(childKeys(_) != first)
       }
     }
-    PartitionGrouping(partitions, isGrouped, isCollapsed)
+    PartitionGrouping(partitions, isGrouped, isCollapsed, keysChanged)
   }
 
   /**
-   * Whether this node's grouping leaves every partition where it was and keeps all of them, i.e.
-   * output partition i holds exactly input partition i and there is one output per input. That is
-   * the only grouping that keeps a marked layout's undeclared rows at hash(key) % numPartitions:
-   * a grouping that drops trailing declared keys still reads identity for every group it keeps,
-   * but the partition count shrinks and the hash modulus with it. The `forall` stops at the first
-   * moved partition, so a reorder or coalesce is rejected without a full scan.
+   * Whether this node's grouping leaves the declared keys and every partition where they were:
+   * no projection or reduction rewrote the keys, output partition i holds exactly input
+   * partition i, and there is one output per input. That is the only grouping that keeps a
+   * marked layout's undeclared rows at hash(key) % numPartitions. A projection or reduction
+   * re-labels the groups into a different key space, so even a grouping whose indices line up
+   * would pin the claim to keys it no longer declares; `keysChanged` rejects it up front. A
+   * reducer slot is treated as key-changing: a conforming self-reducer cannot rewrite a
+   * reachable key value, so the give-up there loses at most an optimization. A grouping that
+   * drops trailing declared keys still reads identity for every group it keeps, but the
+   * partition count shrinks and the hash modulus with it. The `forall` stops at the first moved
+   * partition, so a reorder or coalesce is rejected without a full scan.
    */
   @transient private lazy val identityGrouping: Boolean =
-    grouping.partitions.size == child.outputPartitioning.numPartitions &&
+    !grouping.keysChanged &&
+      grouping.partitions.size == child.outputPartitioning.numPartitions &&
       grouping.partitions.zipWithIndex.forall {
         case ((_, Seq(single)), outputIndex) => single == outputIndex
         case _ => false
@@ -436,7 +444,8 @@ case class GroupPartitionsExec(
 private case class PartitionGrouping(
     partitions: Seq[(InternalRowComparableWrapper, Seq[Int])],
     isGrouped: Boolean,
-    isCollapsed: Boolean)
+    isCollapsed: Boolean,
+    keysChanged: Boolean)
 
 /**
  * A PartitionCoalescer that groups partitions according to a pre-computed grouping plan.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -420,14 +420,14 @@ case class EnsureRequirements(
         reorder(leftKeys.toIndexedSeq, rightKeys.toIndexedSeq, rightExpressions, rightKeys)
           .orElse(reorderJoinKeysRecursively(
             leftKeys, rightKeys, leftPartitioning, None))
-      case (Some(KeyedPartitioning(clustering, _, _, _)), _) =>
+      case (Some(KeyedPartitioning(clustering, _, _, _, _)), _) =>
         // The single-column invariant in KeyedPartitioning.supportsExpressions guarantees one
         // attribute per partition expression.
         val leafExprs = clustering.flatMap(_.references)
         reorder(leftKeys.toIndexedSeq, rightKeys.toIndexedSeq, leafExprs, leftKeys)
             .orElse(reorderJoinKeysRecursively(
               leftKeys, rightKeys, None, rightPartitioning))
-      case (_, Some(KeyedPartitioning(clustering, _, _, _))) =>
+      case (_, Some(KeyedPartitioning(clustering, _, _, _, _))) =>
         // The single-column invariant in KeyedPartitioning.supportsExpressions guarantees one
         // attribute per partition expression.
         val leafExprs = clustering.flatMap(_.references)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -73,7 +73,7 @@ trait ShuffledJoin extends JoinCodegenSupport {
       // `PartitioningCollection` invariant), and `keysSatisfy` admits a marked side into it only
       // for full-key join keys, where the join equality ties every column of its claim: a row of
       // an undeclared key matches nothing on the accurate side and is filtered, so a marked
-      // member among an unmarked one is spurious. Clear it at the one site that can mix them, so
+      // member alongside an unmarked one is spurious. Clear it at the one site that can mix them, so
       // consumers can take members' markers at face value (see
       // `KeyedPartitioning.mayContainUnknownPartitionKeys`).
       PartitioningCollection.fromPartitionings(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -95,15 +95,20 @@ trait ShuffledJoin extends JoinCodegenSupport {
    */
   private def clearUnknownPartitionKeys(
       partitionings: Seq[Partitioning]): Seq[Partitioning] = {
-    val members = partitionings.flatMap(PartitioningCollection.flatten)
+    // Only a marked member among an unmarked one needs the rebuild. On the common all-unmarked
+    // path, even a no-op `copy` is not free: `transform`'s `fastEquals` would fall through to
+    // comparing every partition key.
+    val marked = partitionings.view.flatMap(PartitioningCollection.flatten)
       .collect { case k: KeyedPartitioning => k }
-    if (members.isEmpty || members.forall(_.mayContainUnknownPartitionKeys)) {
+    if (!marked.exists(_.mayContainUnknownPartitionKeys) ||
+        marked.forall(_.mayContainUnknownPartitionKeys)) {
       partitionings
     } else {
       partitionings.map {
         case e: Expression =>
           e.transform {
-            case k: KeyedPartitioning => k.copy(mayContainUnknownPartitionKeys = false)
+            case k: KeyedPartitioning if k.mayContainUnknownPartitionKeys =>
+              k.copy(mayContainUnknownPartitionKeys = false)
           }.asInstanceOf[Partitioning]
         case p => p
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -89,22 +89,23 @@ trait ShuffledJoin extends JoinCodegenSupport {
 
   /**
    * Clears the `mayContainUnknownPartitionKeys` marker of every `KeyedPartitioning` in
-   * `partitionings` when marked and unmarked members meet. Only `ShuffledJoin`'s `InnerLike` arm
-   * can mix the two; see the call site for the argument. The subsequent interning in
-   * `fromPartitionings` does not change any markers.
+   * `partitionings` when marked and unmarked keyed inputs meet; within a collection the
+   * constructor makes that unrepresentable. Only `ShuffledJoin`'s `InnerLike` arm can mix
+   * inputs this way; see the call site for the argument.
    */
   private def clearUnknownPartitionKeys(
       partitionings: Seq[Partitioning]): Seq[Partitioning] = {
-    // Marker uniformity is a constructor invariant, so one cached representative answers per
-    // input instead of re-flattening a left-deep join chain. The all-unmarked path must reach no
-    // `copy`: `transform`'s `fastEquals` would compare every partition key.
-    val markers = partitionings.map(PartitioningCollection.mayContainUnknownPartitionKeys)
-    if (markers.forall(_ == markers.head)) {
+    // One cached keyed member answers per input instead of re-flattening a left-deep join
+    // chain, and keyless inputs drop out of the `flatMap` rather than reading as unmarked. The
+    // all-unmarked path must reach no `copy`: `transform`'s `fastEquals` would compare every
+    // partition key.
+    val markers = partitionings.flatMap(PartitioningCollection.keyedMarkerOf)
+    if (markers.isEmpty || markers.forall(_ == markers.head)) {
       partitionings
     } else {
       partitionings.map {
         case partitioning: Partitioning with Expression
-            if PartitioningCollection.mayContainUnknownPartitionKeys(partitioning) =>
+            if PartitioningCollection.keyedMarkerOf(partitioning).contains(true) =>
           partitioning.transform {
             case k: KeyedPartitioning if k.mayContainUnknownPartitionKeys =>
               k.copy(mayContainUnknownPartitionKeys = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -89,24 +89,23 @@ trait ShuffledJoin extends JoinCodegenSupport {
 
   /**
    * Clears the `mayContainUnknownPartitionKeys` marker of every `KeyedPartitioning` in
-   * `partitionings` when at least one member is unmarked. Only `ShuffledJoin`'s `InnerLike` arm
-   * can mix the two; see the call site for the argument. The interning `fromPartitionings` does
-   * afterwards changes no marker.
+   * `partitionings` when marked and unmarked members meet. Only `ShuffledJoin`'s `InnerLike` arm
+   * can mix the two; see the call site for the argument. The subsequent interning in
+   * `fromPartitionings` does not change any markers.
    */
   private def clearUnknownPartitionKeys(
       partitionings: Seq[Partitioning]): Seq[Partitioning] = {
-    // Only a marked member among an unmarked one needs the rebuild. On the common all-unmarked
-    // path, even a no-op `copy` is not free: `transform`'s `fastEquals` would fall through to
-    // comparing every partition key.
-    val marked = partitionings.view.flatMap(PartitioningCollection.flatten)
-      .collect { case k: KeyedPartitioning => k }
-    if (!marked.exists(_.mayContainUnknownPartitionKeys) ||
-        marked.forall(_.mayContainUnknownPartitionKeys)) {
+    // Marker uniformity is a constructor invariant, so one cached representative answers per
+    // input instead of re-flattening a left-deep join chain. The all-unmarked path must reach no
+    // `copy`: `transform`'s `fastEquals` would compare every partition key.
+    val markers = partitionings.map(PartitioningCollection.mayContainUnknownPartitionKeys)
+    if (markers.forall(_ == markers.head)) {
       partitionings
     } else {
       partitionings.map {
-        case e: Expression =>
-          e.transform {
+        case partitioning: Partitioning with Expression
+            if PartitioningCollection.mayContainUnknownPartitionKeys(partitioning) =>
+          partitioning.transform {
             case k: KeyedPartitioning if k.mayContainUnknownPartitionKeys =>
               k.copy(mayContainUnknownPartitionKeys = false)
           }.asInstanceOf[Partitioning]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.execution.joins
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, LeftAnti, LeftExistence, LeftOuter, LeftSingle, RightOuter}
-import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, Partitioning, PartitioningCollection, UnknownPartitioning, UnspecifiedDistribution}
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, KeyedPartitioning, Partitioning, PartitioningCollection, UnknownPartitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -69,8 +69,15 @@ trait ShuffledJoin extends JoinCodegenSupport {
 
   override def outputPartitioning: Partitioning = joinType match {
     case _: InnerLike =>
+      // Every `KeyedPartitioning` in the joined collection speaks the same declared key set (the
+      // `PartitioningCollection` invariant), and `keysSatisfy` admits a marked side into it only
+      // for full-key join keys, where the join equality ties every column of its claim: a row of
+      // an undeclared key matches nothing on the accurate side and is filtered, so a marked
+      // member among an unmarked one is spurious. Clear it at the one site that can mix them, so
+      // consumers can take members' markers at face value (see
+      // `KeyedPartitioning.mayContainUnknownPartitionKeys`).
       PartitioningCollection.fromPartitionings(
-        Seq(left.outputPartitioning, right.outputPartitioning))
+        clearUnknownPartitionKeys(Seq(left.outputPartitioning, right.outputPartitioning)))
     case LeftOuter | LeftSingle => left.outputPartitioning
     case RightOuter => right.outputPartitioning
     case FullOuter => UnknownPartitioning(left.outputPartitioning.numPartitions)
@@ -78,6 +85,29 @@ trait ShuffledJoin extends JoinCodegenSupport {
     case x =>
       throw new IllegalArgumentException(
         s"ShuffledJoin should not take $x as the JoinType")
+  }
+
+  /**
+   * Clears the `mayContainUnknownPartitionKeys` marker of every `KeyedPartitioning` in
+   * `partitionings` when at least one member is unmarked. Only `ShuffledJoin`'s `InnerLike` arm
+   * can mix the two; see the call site for the argument. The interning `fromPartitionings` does
+   * afterwards changes no marker.
+   */
+  private def clearUnknownPartitionKeys(
+      partitionings: Seq[Partitioning]): Seq[Partitioning] = {
+    val members = partitionings.flatMap(PartitioningCollection.flatten)
+      .collect { case k: KeyedPartitioning => k }
+    if (members.isEmpty || members.forall(_.mayContainUnknownPartitionKeys)) {
+      partitionings
+    } else {
+      partitionings.map {
+        case e: Expression =>
+          e.transform {
+            case k: KeyedPartitioning => k.copy(mayContainUnknownPartitionKeys = false)
+          }.asInstanceOf[Partitioning]
+        case p => p
+      }
+    }
   }
 
   override def output: Seq[Attribute] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -73,8 +73,8 @@ trait ShuffledJoin extends JoinCodegenSupport {
       // `PartitioningCollection` invariant), and `keysSatisfy` admits a marked side into it only
       // for full-key join keys, where the join equality ties every column of its claim: a row of
       // an undeclared key matches nothing on the accurate side and is filtered, so a marked
-      // member alongside an unmarked one is spurious. Clear it at the one site that can mix them, so
-      // consumers can take members' markers at face value (see
+      // member alongside an unmarked one is spurious. Clear it at the one site that can mix
+      // them, so consumers can take members' markers at face value (see
       // `KeyedPartitioning.mayContainUnknownPartitionKeys`).
       PartitioningCollection.fromPartitionings(
         clearUnknownPartitionKeys(Seq(left.outputPartitioning, right.outputPartitioning)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -6852,13 +6852,46 @@ class KeyGroupedPartitioningSuite
     }
   }
 
+  test("SPARK-59050: SPJ: inner join keeps the marker beside a keyless sibling") {
+    // A keyless sibling makes no keyed claim about its rows, so it cannot prove the marked
+    // side's out-of-set rows away: the join equality can still match them, and they stay where
+    // the claim pins them. `keyedMarkerOf` answers `None` for such an input and the clearing
+    // must read that as "no unmarked keyed member", not as "unmarked" -- mapping `None` to
+    // `false` would clear the marker here while every sibling that carries a
+    // `KeyedPartitioning` stays green.
+    val attrA = AttributeReference("a", IntegerType)()
+    val attrB = AttributeReference("b", IntegerType)()
+    val keys = Seq(InternalRow(1), InternalRow(2))
+    def markedExchange(e: AttributeReference): ShuffleExchangeExec =
+      ShuffleExchangeExec(
+        KeyedPartitioning(Seq(e), keys).copy(mayContainUnknownPartitionKeys = true),
+        new LocalTableScanExec(Seq(e), Nil, None, false))
+    def keylessExchange(e: AttributeReference): ShuffleExchangeExec =
+      ShuffleExchangeExec(physical.HashPartitioning(Seq(e), keys.length),
+        new LocalTableScanExec(Seq(e), Nil, None, false))
+    val joins = Seq(
+      SortMergeJoinExec(attrA :: Nil, attrB :: Nil, Inner, None,
+        markedExchange(attrA), keylessExchange(attrB)),
+      SortMergeJoinExec(attrA :: Nil, attrB :: Nil, Inner, None,
+        keylessExchange(attrB), markedExchange(attrA)))
+    joins.zipWithIndex.foreach { case (join, idx) =>
+      val leaves = physical.PartitioningCollection.flatten(join.outputPartitioning)
+        .collect { case k: KeyedPartitioning => k }
+      assert(leaves.size == 1, s"order $idx: $leaves")
+      assert(leaves.forall(_.mayContainUnknownPartitionKeys),
+        s"order $idx: a keyless sibling must not clear the marker: $leaves")
+    }
+  }
+
   test("SPARK-59050: SPJ: inner join marker clearing reaches nested collections") {
     // `ShuffledJoin`'s `InnerLike` arm passes each child's partitioning into the joined
     // collection as reported, so the next inner join can find marked members nested inside a
-    // collection inherited from an all-marked inner join below. SQL cannot produce that shape:
-    // every inner join clears the markers of the mixed collection it builds, so an all-marked
-    // collection only ever appears beside marked siblings, never an unmarked one. The nodes are
-    // hand-built here, through the same exchange-leaf idiom used above.
+    // collection inherited from an all-marked inner join below. SQL can produce that shape:
+    // two one-side-shuffled RIGHT OUTER joins with the same declared keys each expose a marked
+    // output, joining those two keeps an all-marked collection, and a following join against an
+    // accurate keyed table supplies the unmarked sibling (the end-to-end counterpart below
+    // pins that path). The nodes are hand-built here to isolate the shape from planner
+    // choices, through the same exchange-leaf idiom used above.
     val attrA = AttributeReference("a", IntegerType)()
     val attrB = AttributeReference("b", IntegerType)()
     val keys = Seq(InternalRow(1), InternalRow(2))
@@ -6889,6 +6922,71 @@ class KeyGroupedPartitioningSuite
     assert(kept.size == 3, kept.toString)
     assert(kept.forall(_.mayContainUnknownPartitionKeys),
       s"an all-marked chain must keep its markers: $kept")
+  }
+
+  test("SPARK-59050: SPJ: marker clearing reaches a nested all-marked collection built by SQL") {
+    // End-to-end counterpart to the hand-built test above. The first two RIGHT OUTER joins
+    // one-side-shuffle `t` and `u` onto `a`'s and `b`'s declared keys {1, 2}; their id=3 rows
+    // are out-of-set, so both join outputs are marked. The inner join of those two outputs
+    // pairs marked against marked on equal key sequences, so its collection stays all-marked.
+    // The final join against the accurate keyed table `w` then supplies the unmarked sibling:
+    // the clearing must reach inside the nested collection, and id=3's rows, dropped by `w`,
+    // must not cost the plan its storage-partitioned final join.
+    createTable("a", columns, Array(identity("id")))
+    createTable("b", columns, Array(identity("id")))
+    createTable("w", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.b VALUES (1, 'b1', NULL), (2, 'b2', NULL)")
+    sql("INSERT INTO testcat.ns.w VALUES (1, 'w1', NULL), (2, 'w2', NULL)")
+
+    withTable("t", "u") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+      sql("CREATE TABLE u (id INT, data STRING) USING parquet")
+      sql("INSERT INTO u VALUES (1, 'u1'), (2, 'u2'), (3, 'u3')")
+
+      val query =
+        """
+          |SELECT r3.id, w.data
+          |FROM (
+          |  SELECT r1.id FROM (
+          |    SELECT tt.id AS id FROM testcat.ns.a RIGHT OUTER JOIN t tt ON a.id = tt.id
+          |  ) r1
+          |  JOIN (
+          |    SELECT uu.id AS id FROM testcat.ns.b RIGHT OUTER JOIN u uu ON b.id = uu.id
+          |  ) r2 ON r1.id = r2.id
+          |) r3
+          |JOIN testcat.ns.w ON r3.id = w.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "w1"), Row(2, "w2"))
+
+      // Baseline without SPJ.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // Only the two one-side shuffles carry the marker: the final join storage-partitions
+        // without a re-shuffle (a third shuffle here would mean the marked-vs-marked pairing
+        // was refused).
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        // The clearing reached the nested collection: every keyed leaf of the final output is
+        // unmarked.
+        val leaves = physical.PartitioningCollection
+          .flatten(df.queryExecution.executedPlan.outputPartitioning)
+          .collect { case k: KeyedPartitioning => k }
+        assert(leaves.nonEmpty, s"expected keyed leaves in the final output: " +
+          df.queryExecution.executedPlan)
+        assert(leaves.forall(!_.mayContainUnknownPartitionKeys),
+          s"the unmarked sibling must clear the nested collection: $leaves")
+      }
+    }
   }
 
   test("SPARK-59050: SPJ: inner join drops out-of-set rows before the cleared marker is trusted") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -7111,6 +7111,123 @@ class KeyGroupedPartitioningSuite
     }
   }
 
+  test("SPARK-59050: SPJ: regrouping a marked layout must not keep the unknown-keyed claim") {
+    // The union declares keys in child order [3, 4, 1, 2]; the first join one-side-shuffles rt's
+    // out-of-set id=5 onto it at hash(5) % 4 and marks the layout. The second join aligns that
+    // marked side to rs's sorted keys [1, 2, 3, 4] with a GroupPartitionsExec, which reorders the
+    // partitions and moves the id=5 row, so the regrouped layout may no longer claim the
+    // hash-routing contract. b is an independent one-side-shuffled marked layout [1, 2, 3, 4] with
+    // id=5 at hash(5) % 4. If the regrouped side kept the claim, the final marked-vs-marked join
+    // would skip the shuffle and the two id=5 rows (at different partitions) would never meet.
+    val cols = Array(Column.create("id", IntegerType), Column.create("data", StringType))
+    createTable("rp", cols, Array(identity("id")))
+    createTable("rq", cols, Array(identity("id")))
+    createTable("rs", cols, Array(identity("id")))
+    createTable("ra2", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.rp VALUES (3, 'p3'), (4, 'p4')")
+    sql("INSERT INTO testcat.ns.rq VALUES (1, 'q1'), (2, 'q2')")
+    sql("INSERT INTO testcat.ns.rs VALUES (1, 's1'), (2, 's2'), (3, 's3'), (4, 's4')")
+    sql("INSERT INTO testcat.ns.ra2 VALUES (1, 'x1'), (2, 'x2'), (3, 'x3'), (4, 'x4')")
+
+    withTable("rt", "rt2") {
+      sql("CREATE TABLE rt (id INT, data STRING) USING parquet")
+      sql("INSERT INTO rt VALUES (1,'t1'),(2,'t2'),(3,'t3'),(4,'t4'),(5,'t5')")
+      sql("CREATE TABLE rt2 (id INT, data STRING) USING parquet")
+      sql("INSERT INTO rt2 VALUES (1,'y1'),(2,'y2'),(3,'y3'),(4,'y4'),(5,'y5')")
+
+      val query =
+        """
+          |SELECT r2.id, b.data
+          |FROM (
+          |  SELECT r1.id FROM (
+          |    SELECT tt.id AS id FROM (
+          |      SELECT id FROM testcat.ns.rp UNION ALL SELECT id FROM testcat.ns.rq
+          |    ) u RIGHT OUTER JOIN rt tt ON u.id = tt.id
+          |  ) r1 LEFT OUTER JOIN testcat.ns.rs ss ON r1.id = ss.id
+          |) r2
+          |JOIN (
+          |  SELECT tt2.id AS id, tt2.data AS data FROM testcat.ns.ra2 aa
+          |  RIGHT OUTER JOIN rt2 tt2 ON aa.id = tt2.id
+          |) b ON r2.id = b.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "y1"), Row(2, "y2"), Row(3, "y3"), Row(4, "y4"), Row(5, "y5"))
+
+      // Baseline: no SPJ -> all five rows.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // The regrouped marked side can no longer claim the hash-routing contract, so the final
+        // join re-shuffles it instead of storage-partitioning. Three one-side shuffles, all keyed
+        // with unknown partition keys: rt onto the union, rt2 onto ra2, and the final join's
+        // re-shuffle of the regrouped side. Before the fix the final join storage-partitioned
+        // (only the first two shuffles) and silently lost the id=5 row.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true, true))
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: a reducer-free identity regrouping keeps the unknown-keyed claim") {
+    // Positive counterpart to the regrouping test above. The first join one-side-shuffles pt
+    // onto pa's sorted keys [1, 2, 3] and marks the layout (pt's id=4 is out-of-set). The second
+    // join aligns that marked [1, 2, 3] superset with pb's [1, 2] by pushing the merged keys
+    // [1, 2, 3] to both sides. The marked side already holds exactly the merged keys, so its
+    // GroupPartitionsExec is a reducer-free identity grouping and must keep the claim; only the
+    // subset side pads. This pins that the identity branch is reachable, not dead code.
+    val cols = Array(Column.create("id", IntegerType), Column.create("data", StringType))
+    createTable("pa", cols, Array(identity("id")))
+    createTable("pb", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.pa VALUES (1, 'a1'), (2, 'a2'), (3, 'a3')")
+    sql("INSERT INTO testcat.ns.pb VALUES (1, 'b1'), (2, 'b2')")
+    withTable("pt") {
+      sql("CREATE TABLE pt (id INT, data STRING) USING parquet")
+      sql("INSERT INTO pt VALUES (1, 't1'), (2, 't2'), (3, 't3'), (4, 't4')")
+      val query =
+        """
+          |SELECT r.id, pb.data
+          |FROM (SELECT pt.id AS id FROM testcat.ns.pa RIGHT OUTER JOIN pt ON pa.id = pt.id) r
+          |JOIN testcat.ns.pb ON r.id = pb.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "b1"), Row(2, "b2"))
+
+      // Baseline: no SPJ.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        val plan = df.queryExecution.executedPlan
+        // A GroupPartitionsExec with no reducers whose output partition i holds exactly input
+        // partition i is an identity grouping; the fix keeps the unknown-keyed claim for it.
+        val identityGpe = collectAllGroupPartitions(plan).find { g =>
+          g.reducers.isEmpty && g.groupedPartitions.zipWithIndex.forall {
+            case ((_, inputIndices), outputIndex) =>
+              inputIndices.lengthCompare(1) == 0 && inputIndices.head == outputIndex
+          }
+        }
+        assert(identityGpe.isDefined,
+          s"expected a reducer-free identity GroupPartitionsExec, got:\n$plan")
+        identityGpe.get.outputPartitioning match {
+          case k: KeyedPartitioning =>
+            assert(k.mayContainUnknownPartitionKeys,
+              "the identity grouping must keep the unknown-keyed claim")
+          case other =>
+            fail(s"expected a KeyedPartitioning output, got $other")
+        }
+      }
+    }
+  }
+
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.rdd.SortedMergeCoalescedRDD
 import org.apache.spark.sql.{DataFrame, ExplainSuiteHelper, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, Literal, TransformExpression}
-import org.apache.spark.sql.catalyst.plans.{Cross, ExistenceJoin, JoinType, LeftAnti, LeftSemi, LeftSingle}
+import org.apache.spark.sql.catalyst.plans.{Cross, ExistenceJoin, Inner, JoinType, LeftAnti, LeftSemi, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.physical
 import org.apache.spark.sql.catalyst.plans.physical.KeyedPartitioning
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryCatalystRuntimeFilterCatalog, InMemoryTableCatalog}
@@ -6121,12 +6121,11 @@ class KeyGroupedPartitioningSuite
     // semantics call for. items is partitioned by (id, name) with *unique* ids, so projecting
     // `name` away drops a key position but loses no distinct key, so nothing collapsed. purchases
     // reports no partitioning, so with v2BucketingShuffleEnabled its side is shuffled using the
-    // projected partitioning as the template -- still true under SPARK-59050, which only marks the
-    // shuffled output as possibly holding unknown keys. The join's right-outer arm then exposes
-    // only that marked shuffled side, and the union with t3 drops the keyed merge outright (see
-    // `KeyedPartitioning.mayContainUnknownPartitionKeys`), so the final aggregate re-shuffles
-    // instead of grouping the union's partitions. What stays exercised for 58316: the template
-    // carries no collapse and needs no opt-in either way.
+    // projected partitioning as the template, still true under SPARK-59050: the shuffled output
+    // carries the unknown-keys marker, the join's right-outer arm exposes it, and the union drops
+    // the keyed merge, so the final aggregate re-shuffles instead of grouping the union's
+    // partitions. What stays exercised for 58316: the template carries no collapse and needs no
+    // opt-in either way.
     createTable(items, itemsColumns, Array(identity("id"), identity("name")))
     sql(s"INSERT INTO testcat.ns.$items VALUES " +
       s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
@@ -6165,8 +6164,8 @@ class KeyGroupedPartitioningSuite
         checkAnswer(df, Seq(Row(1L, 2L), Row(2L, 2L), Row(3L, 1L)))
         val plan = df.queryExecution.executedPlan
 
-        // The template the shuffled side is laid out on carries no collapse -- the point this
-        // test was written for, and independent of the opt-in.
+        // The template the shuffled side is laid out on carries no collapse, the point this
+        // test was written for, independent of the opt-in.
         val keyed = collectAllShuffles(plan).map(_.outputPartitioning).collect {
           case kp: physical.KeyedPartitioning => kp
         }
@@ -6299,7 +6298,7 @@ class KeyGroupedPartitioningSuite
   private def assertShuffleMayContainUnknownPartitionKeys(
       plan: SparkPlan,
       expected: Seq[Boolean]): Unit = {
-    val shuffles = collect(plan) { case s: ShuffleExchangeExec => s }
+    val shuffles = collectAllShuffles(plan)
     assert(shuffles.size === expected.size,
       s"expected ${expected.size} shuffles, got ${shuffles.size}:\n$plan")
     shuffles.zip(expected).foreach { case (shuffle, hasUnknown) =>
@@ -6409,7 +6408,7 @@ class KeyGroupedPartitioningSuite
         assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
           Seq(true, true))
         // The downstream join must not storage-partition on the first join's unknown-keyed
-        // layout -- FULL OUTER keeps it safe only because the join output exposes
+        // layout; FULL OUTER keeps it safe only because the join output exposes
         // UnknownPartitioning.
         assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
           s"downstream join must not storage-partition on an unknown-keyed layout, got: " +
@@ -6474,7 +6473,7 @@ class KeyGroupedPartitioningSuite
   test("SPARK-59050: SPJ: one-side shuffle with out-of-set keys loses matches in a following " +
       "SPJ join (bucket)") {
     // Same hazard as the identity variant, but the keyed sides are partitioned by bucket(4, id):
-    // a covers buckets {0, 1, 2} (ids 0, 1, 2), while t holds id 3 -- bucket 3 -- which a does
+    // a covers buckets {0, 1, 2} (ids 0, 1, 2), while t holds id 3 (bucket 3), which a does
     // not, so the one-side shuffle misplaces t's bucket-3 row while still declaring a's layout.
     // `id` is LONG because `BucketFunction` binds its value argument to LongType.
     val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
@@ -6551,7 +6550,7 @@ class KeyGroupedPartitioningSuite
   test("SPARK-59050: SPJ: project dropping a key position drops the unknown-keyed claim") {
     // The first join's output is keyed on (id, k) and may contain unknown keys (t's rows are all
     // out-of-set: a holds k=x, t holds k=z). The Project below the second join drops the k
-    // position, so the declared key set coarsens from {(1, x) ... (4, x)} to {1, 2, 3, 4} -- and
+    // position, so the declared key set coarsens from {(1, x) ... (4, x)} to {1, 2, 3, 4}, and
     // an out-of-set (id, k) can then land inside the projected declared set. The keyed claim must
     // be dropped entirely, otherwise the second join trusts the coarsened layout and silently
     // loses the misplaced rows' matches.
@@ -6601,7 +6600,7 @@ class KeyGroupedPartitioningSuite
   }
 
   test("SPARK-59050: SPJ: union of an unknown-keyed leg drops the merged keyed partitioning") {
-    // The union's merged keys are the concatenation of every leg's keys -- a superset of each
+    // The union's merged keys concatenate every leg's keys, a superset of each
     // leg's declared set. When a leg's partitioning may contain unknown partition keys, another
     // leg can declare exactly the key the unknown-keyed leg holds out-of-set, so the merged
     // claim would promise co-location the unknown-keyed leg cannot honor. The union must drop
@@ -6649,7 +6648,7 @@ class KeyGroupedPartitioningSuite
 
     // Overlapping second leg: s declares exactly the key {3} that the unknown-keyed leg holds
     // out-of-set, so the union's merged keys {1, 2, 3} equal u's keys and the second join would
-    // storage-partition with no exchange -- silently losing t's id=3 match.
+    // storage-partition with no exchange, silently losing t's id=3 match.
     sql("DROP TABLE IF EXISTS testcat.ns.s")
     sql("DROP TABLE IF EXISTS testcat.ns.u")
     createTable("s", columns, Array(identity("id")))
@@ -6734,12 +6733,11 @@ class KeyGroupedPartitioningSuite
   }
 
   test("SPARK-59050: SPJ: spurious marker of an inner join keeps the reduced SPJ") {
-    // The inner join's PartitioningCollection holds the keyed side's own (unmarked) KP next to
-    // the re-shuffled side's unknown-keyed one. The marker is spurious -- the inner join
-    // dropped every out-of-set row -- so a following reduced storage-partitioned join (bucket(4)
-    // reduced onto bucket(2)) must still work. Reading the marker off the collection with
-    // `exists` used to make the GroupPartitionsExec give up with a zero-partition
-    // UnknownPartitioning, which threw at planning when a parent asked for the partitioning.
+    // The spurious marker on the inner join's collection is cleared at construction (see
+    // `ShuffledJoin`), so a following reduced storage-partitioned join (bucket(4) onto
+    // bucket(2)) must still work. Reading the marker with `exists` used to make the
+    // GroupPartitionsExec give up with a zero-partition UnknownPartitioning, which threw at
+    // planning when a parent asked for the partitioning.
     val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
     createTable("a", cols, Array(bucket(4, "id")))
     createTable("u", cols, Array(bucket(2, "id")))
@@ -6772,10 +6770,8 @@ class KeyGroupedPartitioningSuite
 
   test("SPARK-59050: SPJ: inner join with in-set rows keeps the sound SPJ downstream") {
     // Same shape as the one-side-shuffle repro, but the inner join's second side holds only
-    // in-set rows: the join's PartitioningCollection carries the keyed side's own (unmarked) KP
-    // next to the re-shuffled side's unknown-keyed one, and the join has already dropped every
-    // out-of-set row, so the marker is spurious and the following storage-partitioned join must
-    // not pay a shuffle for it.
+    // in-set rows: the marker is spurious and cleared at construction (see `ShuffledJoin`), so
+    // the following storage-partitioned join must not pay a shuffle for it.
     val cols = Array(
       Column.create("id", IntegerType),
       Column.create("k", StringType),
@@ -6812,61 +6808,93 @@ class KeyGroupedPartitioningSuite
   }
 
   test("SPARK-59050: SPJ: inner join clears the spurious marker on both member orders") {
-    // The inner join's output collection pairs the re-shuffled side's unknown-keyed KP with
-    // the keyed side's own unmarked KP. The join already dropped every out-of-set row, so the
-    // marker is spurious and must be cleared when the collection is built -- the downstream join
-    // matches the join key against the unknown-keyed member's expressions (the re-shuffled side
-    // is the join key's attribute origin), so a sibling-order preference in
-    // `createKeyedShuffleSpec` could not rescue the SPJ here. Both join orders must plan the
-    // single first-join shuffle.
-    val cols = Array(
-      Column.create("id", IntegerType),
-      Column.create("k", StringType),
-      Column.create("data", StringType))
-    createTable("a", cols, Array(identity("id"), identity("k")))
-    createTable("u", cols, Array(identity("id")))
-    sql("INSERT INTO testcat.ns.a VALUES " +
-      "(1, 'x', 'a1'), (2, 'x', 'a2'), (3, 'x', 'a3'), (4, 'x', 'a4')")
-    sql("INSERT INTO testcat.ns.u VALUES " +
-      "(1, NULL, 'u1'), (2, NULL, 'u2'), (3, NULL, 'u3'), (4, NULL, 'u4')")
+    // `t`'s id=3 can match nothing on `a` (keys {1, 2}), so the inner join's marker is spurious
+    // and cleared at construction (see `ShuffledJoin`). If it survived, the subset gate in
+    // `areKeysCompatible` would refuse `u`'s wider key set and cost a shuffle no sibling order
+    // can rescue. Both join orders must plan master's shape: the single first-join shuffle
+    // plus a `GroupPartitionsExec` on each side of the storage-partitioned second join.
+    createTable("a", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL), (2, 'u2', NULL), (3, 'u3', NULL)")
 
     withTable("t") {
-      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
-      sql("INSERT INTO t VALUES (1, 'x', 't1'), (2, 'x', 't2'), (3, 'x', 't3'), (4, 'x', 't4')")
-      val expected = Seq(Row(1, "x", "u1"), Row(2, "x", "u2"), Row(3, "x", "u3"), Row(4, "x", "u4"))
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
 
-      // `t` first: the collection lists the unknown-keyed member before its unmarked sibling;
-      // `a` first: the mirror order (the negative control pinning order-insensitivity).
+      // `t` first puts the marked member ahead of its unmarked sibling in the collection;
+      // `a` first is the mirror order.
       for (side <- Seq("t", "a")) {
         val query = if (side == "t") {
           """
-            |SELECT t.id, a.k, u.data
-            |FROM t JOIN testcat.ns.a a ON a.id = t.id AND a.k = t.k
+            |SELECT t.id, u.data
+            |FROM t JOIN testcat.ns.a a ON a.id = t.id
             |JOIN testcat.ns.u u ON t.id = u.id
             |""".stripMargin
         } else {
           """
-            |SELECT a.id, a.k, u.data
-            |FROM testcat.ns.a a JOIN t ON a.id = t.id AND a.k = t.k
+            |SELECT a.id, u.data
+            |FROM testcat.ns.a a JOIN t ON a.id = t.id
             |JOIN testcat.ns.u u ON a.id = u.id
             |""".stripMargin
         }
         withSQLConf(
             SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
-            SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+            "spark.sql.autoBroadcastJoinThreshold" -> "-1",
             SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
           val df = sql(query)
-          checkAnswer(df, expected)
+          checkAnswer(df, Seq(Row(1, "u1"), Row(2, "u2")))
           assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan, Seq(true))
+          assert(collectGroupPartitions(df.queryExecution.executedPlan).nonEmpty,
+            s"side=$side: the second join should storage-partition, got: " +
+              df.queryExecution.executedPlan)
         }
       }
     }
   }
 
+  test("SPARK-59050: SPJ: inner join marker clearing reaches nested collections") {
+    // `ShuffledJoin`'s `InnerLike` arm passes each child's partitioning into the joined
+    // collection as reported, so the next inner join can find marked members nested inside a
+    // collection inherited from an all-marked inner join below. That nesting cannot be planned
+    // through SQL (an inner join's own clearing already flattens what SQL puts in it), so the
+    // nodes are hand-built here through the same exchange-leaf idiom used above.
+    val attrA = AttributeReference("a", IntegerType)()
+    val attrB = AttributeReference("b", IntegerType)()
+    val keys = Seq(InternalRow(1), InternalRow(2))
+    def markedKP(e: AttributeReference): KeyedPartitioning =
+      KeyedPartitioning(Seq(e), keys).copy(mayContainUnknownPartitionKeys = true)
+    def markedExchange(e: AttributeReference): ShuffleExchangeExec =
+      ShuffleExchangeExec(markedKP(e), new LocalTableScanExec(Seq(e), Nil, None, false))
+    def plainExchange(e: AttributeReference): ShuffleExchangeExec =
+      ShuffleExchangeExec(KeyedPartitioning(Seq(e), keys),
+        new LocalTableScanExec(Seq(e), Nil, None, false))
+    // The first join: two marked children, no unmarked sibling -> its collection stays marked.
+    val inner1 = SortMergeJoinExec(attrA :: Nil, attrA :: Nil, Inner, None,
+      markedExchange(attrA), markedExchange(attrA))
+    // The second join nests that collection next to an unmarked sibling -> the clearing must
+    // reach inside it.
+    val inner2 = SortMergeJoinExec(attrA :: Nil, attrB :: Nil, Inner, None,
+      inner1, plainExchange(attrB))
+    val cleared = physical.PartitioningCollection.flatten(inner2.outputPartitioning)
+      .collect { case k: KeyedPartitioning => k }
+    assert(cleared.size == 3, cleared.toString)
+    assert(cleared.forall(!_.mayContainUnknownPartitionKeys),
+      s"the unmarked sibling must clear every marked member: $cleared")
+    // And a marked sibling of an all-marked nested collection excuses nothing: all stay marked.
+    val inner3 = SortMergeJoinExec(attrA :: Nil, attrB :: Nil, Inner, None,
+      markedExchange(attrA), inner1)
+    val kept = physical.PartitioningCollection.flatten(inner3.outputPartitioning)
+      .collect { case k: KeyedPartitioning => k }
+    assert(kept.size == 3, kept.toString)
+    assert(kept.forall(_.mayContainUnknownPartitionKeys),
+      s"an all-marked chain must keep its markers: $kept")
+  }
+
   test("SPARK-59050: SPJ: inner join drops out-of-set rows before the cleared marker is trusted") {
     // Data-level companion to the spurious-marker tests: `t` here genuinely holds an out-of-set
     // row (5, 'z') that a's declared keys cannot match. The inner join drops it, so every row
-    // reaching the cleared-marker layout carries a declared key -- the downstream storage-
+    // reaching the cleared-marker layout carries a declared key; the downstream storage-
     // partitioned join must then return exactly the matched rows: ids 1..4, and NOT id=5 even
     // though u holds it. If the marker were cleared for a shape that keeps out-of-set rows,
     // this query would silently lose or misplace matches.
@@ -6915,9 +6943,10 @@ class KeyGroupedPartitioningSuite
   test("SPARK-59050: SPJ: genuine unknown keys survive an inner join on a key subset") {
     // Adversarial shape against the spurious-marker clearing: the RIGHT OUTER output `r` is a
     // single unknown-keyed KP carrying a GENUINE unknown row (1, 'zz'); it inner-joins `x`
-    // (a keyed table declaring the same key set) on a strict subset of the key columns; `u`
-    // above matches on the full (id, k). The (1,'zz','xa','uz') match must survive: clearing
-    // markers only applies to mixed collections where every row already carries a declared key,
+    // (a keyed table declaring the same key set) on a strict subset of the key columns; the
+    // join to `u` below matches on the full (id, k). The (1,'zz','xa','uz') match must survive:
+    // clearing markers only applies to mixed collections where every row already carries a
+    // declared key,
     // and here the planner re-shuffles `r`'s side onto u's layout (the (id)-only claim cannot
     // pair with the (id,k) spec), routing (1,'zz') by its full tuple into its own partition.
     val cols = Array(
@@ -6955,6 +6984,129 @@ class KeyGroupedPartitioningSuite
           SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
         val df = sql(query)
         checkAnswer(df, expected)
+        // Pin the total exchange count so later silent shuffles surface: the marked (id, k)
+        // side refuses to pair on the subset key, cascading one-side shuffles around it.
+        val plan = df.queryExecution.executedPlan
+        val shuffles = collectAllShuffles(plan)
+        assert(shuffles.size == 4, s"expected 4 exchanges, got ${shuffles.size}:\n$plan")
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: a window keyed on a subset of an unknown-keyed layout must shuffle") {
+    // The right-outer join preserves pt's out-of-set row (1, 9): the surviving layout declares
+    // (id, k) pairs (1, 0)..(4, 0) only. A window keyed on `id` alone must not run
+    // partition-locally on it: the declared (1, 0) row and the hash-placed (1, 9) row can
+    // sit in different partitions, splitting the count for id=1 into two groups of 1.
+    // `keysSatisfy` refuses the subset relaxation for an unknown-keyed layout.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", IntegerType),
+      Column.create("data", StringType))
+    createTable("pa", cols, Array(identity("id"), identity("k")))
+    sql("INSERT INTO testcat.ns.pa VALUES " +
+      "(1, 0, 'a1'), (2, 0, 'a2'), (3, 0, 'a3'), (4, 0, 'a4')")
+    withTable("pt") {
+      sql("CREATE TABLE pt (id INT, k INT, data STRING) USING parquet")
+      sql("INSERT INTO pt VALUES " +
+        "(1, 0, 't1'), (2, 0, 't2'), (3, 0, 't3'), (4, 0, 't4'), (1, 9, 'u1')")
+      val query =
+        """
+          |SELECT id, k, COUNT(*) OVER (PARTITION BY id) FROM (
+          |  SELECT /*+ MERGE */ pt.id AS id, pt.k AS k FROM testcat.ns.pa pa
+          |  RIGHT OUTER JOIN pt ON pa.id = pt.id AND pa.k = pt.k) r
+          |""".stripMargin
+      // AQE off pins the plan shape; AQE on replans the same query over stage outputs and must
+      // still return correct counts (the marker survives `ShuffleQueryStageExec`).
+      for (adaptive <- Seq(false, true)) {
+        withSQLConf(
+            SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+            SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+            "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString) {
+          val df = sql(query)
+          checkAnswer(df, Seq(Row(1, 0, 2), Row(2, 0, 1), Row(3, 0, 1), Row(4, 0, 1),
+            Row(1, 9, 2)))
+          if (!adaptive) {
+            // Two shuffles: the first join's one-side shuffle plus the window's exchange.
+            val plan = df.queryExecution.executedPlan
+            val shuffles = collectAllShuffles(plan)
+            assert(shuffles.size == 2, s"the window must pay an exchange, got:\n$plan")
+            assert(shuffles.exists(!_.outputPartitioning.isInstanceOf[KeyedPartitioning]),
+              s"expected a non-keyed (window) exchange, got:\n$plan")
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: a window keyed on the full key of an unknown-keyed layout does not " +
+    "shuffle") {
+    // Positive control for the marked branch of `keysSatisfy`: whole declared keys co-locate, so
+    // a window keyed on the COMPLETE partition key of a marked layout still runs
+    // partition-locally. A gate that over-rejects (e.g. also refusing full-key clustering) keeps
+    // every wrong-results test green and only silently adds shuffles; this test would not.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", IntegerType),
+      Column.create("data", StringType))
+    createTable("qa", cols, Array(identity("id"), identity("k")))
+    sql("INSERT INTO testcat.ns.qa VALUES (1, 0, 'a1'), (2, 0, 'a2'), (3, 0, 'a3')")
+    withTable("qt") {
+      sql("CREATE TABLE qt (id INT, k INT, data STRING) USING parquet")
+      sql("INSERT INTO qt VALUES (1, 0, 't1'), (2, 0, 't2'), (3, 0, 't3'), (1, 9, 'u1')")
+      val query =
+        """
+          |SELECT id, k, COUNT(*) OVER (PARTITION BY id, k) FROM (
+          |  SELECT /*+ MERGE */ qt.id AS id, qt.k AS k FROM testcat.ns.qa qa
+          |  RIGHT OUTER JOIN qt ON qa.id = qt.id AND qa.k = qt.k) r
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, Seq(Row(1, 0, 1), Row(2, 0, 1), Row(3, 0, 1), Row(1, 9, 1)))
+        val plan = df.queryExecution.executedPlan
+        val shuffles = collectAllShuffles(plan)
+        // Only the first join's one-side shuffle; the window rides the marked layout.
+        assert(shuffles.size == 1, s"the full-key window must not shuffle, got:\n$plan")
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: a global ORDER BY over an unknown-keyed layout must " +
+    "range-partition") {
+    // The right-outer join preserves obt's out-of-set id=4, which the KeyGroupedPartitioner
+    // hash-placed into the partition declaring id=1; without a range exchange the global sort
+    // degrades to per-partition sorting and emits [1, 4, 2]. `keysSatisfy` rejects the ordering
+    // claim of a marked layout with more than one partition.
+    createTable("oba", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.oba VALUES (1, 'x', NULL), (2, 'x', NULL)")
+    withTable("obt") {
+      sql("CREATE TABLE obt (id INT, data STRING) USING parquet")
+      sql("INSERT INTO obt VALUES (1, 'p1'), (2, 'p2'), (4, 'p4')")
+      val query =
+        """
+          |SELECT /*+ MERGE */ obt.id FROM testcat.ns.oba ba RIGHT OUTER JOIN obt
+          |ON ba.id = obt.id
+          |ORDER BY id
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_SORTING_ENABLED.key -> "true",
+          "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        // compare `collect` directly: checkAnswer would sort both sides and hide the order.
+        val ordered = df.collect().map(_.getInt(0)).toSeq
+        assert(ordered == Seq(1, 2, 4), s"global order broken: $ordered")
+        val plan = df.queryExecution.executedPlan
+        val shuffles = collectAllShuffles(plan)
+        // Two exchanges: the first join's one-side shuffle plus the range partitioning.
+        assert(shuffles.size == 2, s"expected 2 exchanges, got ${shuffles.size}:\n$plan")
+        assert(shuffles.exists(_.outputPartitioning.isInstanceOf[physical.RangePartitioning]),
+          s"a range exchange must precede the global sort, got:\n$plan")
       }
     }
   }
@@ -6990,3 +7142,5 @@ class KeyGroupedPartitioningCatalystRuntimeFilterSuite
     catalog.clearTables()
   }
 }
+
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -6855,9 +6855,10 @@ class KeyGroupedPartitioningSuite
   test("SPARK-59050: SPJ: inner join marker clearing reaches nested collections") {
     // `ShuffledJoin`'s `InnerLike` arm passes each child's partitioning into the joined
     // collection as reported, so the next inner join can find marked members nested inside a
-    // collection inherited from an all-marked inner join below. That nesting cannot be planned
-    // through SQL (an inner join's own clearing already flattens what SQL puts in it), so the
-    // nodes are hand-built here through the same exchange-leaf idiom used above.
+    // collection inherited from an all-marked inner join below. SQL cannot produce that shape:
+    // every inner join clears the markers of the mixed collection it builds, so an all-marked
+    // collection only ever appears beside marked siblings, never an unmarked one. The nodes are
+    // hand-built here, through the same exchange-leaf idiom used above.
     val attrA = AttributeReference("a", IntegerType)()
     val attrB = AttributeReference("b", IntegerType)()
     val keys = Seq(InternalRow(1), InternalRow(2))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, Literal, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.{Cross, ExistenceJoin, JoinType, LeftAnti, LeftSemi, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.physical
+import org.apache.spark.sql.catalyst.plans.physical.KeyedPartitioning
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryCatalystRuntimeFilterCatalog, InMemoryTableCatalog}
 import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.connector.distributions.Distributions
@@ -6120,10 +6121,12 @@ class KeyGroupedPartitioningSuite
     // semantics call for. items is partitioned by (id, name) with *unique* ids, so projecting
     // `name` away drops a key position but loses no distinct key, so nothing collapsed. purchases
     // reports no partitioning, so with v2BucketingShuffleEnabled its side is shuffled using the
-    // projected partitioning as the template. A RIGHT OUTER join then exposes only that shuffled
-    // side, and the union with t3 (overlapping keys) makes the merged partitioning ungrouped. The
-    // duplicate keys there come from the two children holding the same ids, not from the
-    // projection, so the final aggregate may group them with the opt-in off.
+    // projected partitioning as the template -- still true under SPARK-59050, which only marks the
+    // shuffled output as possibly holding unknown keys. The join's right-outer arm then exposes
+    // only that marked shuffled side, and the union with t3 drops the keyed merge outright (see
+    // `KeyedPartitioning.mayContainUnknownPartitionKeys`), so the final aggregate re-shuffles
+    // instead of grouping the union's partitions. What stays exercised for 58316: the template
+    // carries no collapse and needs no opt-in either way.
     createTable(items, itemsColumns, Array(identity("id"), identity("name")))
     sql(s"INSERT INTO testcat.ns.$items VALUES " +
       s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
@@ -6158,18 +6161,28 @@ class KeyGroupedPartitioningSuite
           SQLConf.UNION_OUTPUT_PARTITIONING.key -> "true",
           SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
           SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> allowSubset.toString) {
-        val plan = sql(query).queryExecution.executedPlan
+        val df = sql(query)
+        checkAnswer(df, Seq(Row(1L, 2L), Row(2L, 2L), Row(3L, 1L)))
+        val plan = df.queryExecution.executedPlan
 
+        // The template the shuffled side is laid out on carries no collapse -- the point this
+        // test was written for, and independent of the opt-in.
+        val keyed = collectAllShuffles(plan).map(_.outputPartitioning).collect {
+          case kp: physical.KeyedPartitioning => kp
+        }
+        assert(keyed.size == 1,
+          s"allowSubset=$allowSubset: the purchases side re-shuffles onto the template")
+        assert(!keyed.head.isCollapsed,
+          "the ids were unique, so dropping `name` collapsed nothing for the template")
+        assert(keyed.head.mayContainUnknownPartitionKeys,
+          "the re-shuffled output may hold keys outside the declared set (SPARK-59050)")
+        // The marked leg reaches the union through the right-outer arm, so the keyed merge is
+        // dropped and the final aggregate pays its own exchange.
         val union = collect(plan) { case u: UnionExec => u }.head
-        val kp = union.outputPartitioning.asInstanceOf[physical.KeyedPartitioning]
-        assert(!kp.isGrouped, "keys 1 and 2 repeat across the union children")
-        assert(!kp.isCollapsed,
-          "the ids were unique, so dropping `name` collapsed nothing to carry down this chain")
-        assert(collectAllGroupPartitions(plan).nonEmpty,
-          s"allowSubset=$allowSubset: grouping merges only partitions that already shared a key")
-        assert(collectAllShuffles(plan).size == 1,
-          s"allowSubset=$allowSubset: only the purchases side shuffles")
-        checkAnswer(sql(query), Seq(Row(1L, 2L), Row(2L, 2L), Row(3L, 1L)))
+        assert(union.outputPartitioning.isInstanceOf[physical.UnknownPartitioning],
+          s"the unknown-keyed leg drops the keyed merge, got ${union.outputPartitioning}")
+        assert(collectAllShuffles(plan).size == 2,
+          s"allowSubset=$allowSubset: template re-shuffle plus the aggregate's exchange")
       }
     }
   }
@@ -6274,6 +6287,675 @@ class KeyGroupedPartitioningSuite
       assert(keyed.exists(_.isCollapsed),
         "the side whose keys were reduced onto a coarser transform reports a collapse")
       checkAnswer(df, Seq(Row(0, 42.0), Row(4, 44.0)))
+    }
+  }
+
+
+  /**
+   * Asserts that the plan's shuffles (in tree order) are all `KeyedPartitioning`s carrying the
+   * given `mayContainUnknownPartitionKeys` flags (a `KeyedPartitioning` produced by
+   * `KeyedShuffleSpec.createPartitioning` always carries the marker).
+   */
+  private def assertShuffleMayContainUnknownPartitionKeys(
+      plan: SparkPlan,
+      expected: Seq[Boolean]): Unit = {
+    val shuffles = collect(plan) { case s: ShuffleExchangeExec => s }
+    assert(shuffles.size === expected.size,
+      s"expected ${expected.size} shuffles, got ${shuffles.size}:\n$plan")
+    shuffles.zip(expected).foreach { case (shuffle, hasUnknown) =>
+      shuffle.outputPartitioning match {
+        case k: KeyedPartitioning =>
+          assert(k.mayContainUnknownPartitionKeys === hasUnknown,
+            s"expected shuffle output mayContainUnknownPartitionKeys=$hasUnknown, got " +
+              s"${k.mayContainUnknownPartitionKeys}:\n$plan")
+        case p =>
+          fail(s"expected a KeyedPartitioning shuffle, got $p:\n$plan")
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: one-side shuffle with out-of-set keys loses matches in a following " +
+    "SPJ join") {
+    // a: keyed on id, keys {1, 2}. t: v1 parquet, keys {1, 2, 3}. u: keyed on id, keys {1, 2, 3}.
+    // With shuffle.enabled, a RIGHT OUTER JOIN t shuffles t onto a's declared keys {1, 2}; t's
+    // id=3 row is out-of-set, so the join output's partitioning has unknown keys. A following
+    // storage-partitioned join against u must not trust it and falls back to a shuffle.
+    createTable("a", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL), (2, 'u2', NULL), (3, 'u3', NULL)")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"))
+
+      // Baseline: no SPJ -> all three rows.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // Two one-side shuffles: t onto a's keys, then the first join's output (unknown-keyed)
+        // onto u's keys. Both are keyed with unknown partition keys; neither join GPEs.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"second join must not storage-partition on an unknown-keyed layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: preserved non-keyed side of outer join falls back to shuffle " +
+    "downstream") {
+    // Same hazard for every outer join type whose preserved side is the non-keyed table: the
+    // one-side shuffle marks the preserved side's partitioning as having unknown keys, so a
+    // downstream storage-partitioned join against a larger key set must fall back to a shuffle.
+    createTable("a", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL), (2, 'u2', NULL), (3, 'u3', NULL)")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"))
+
+      // RIGHT OUTER preserves the non-keyed t on the right.
+      val rightQuery =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(rightQuery)
+        checkAnswer(df, expected)
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"downstream join must not storage-partition on an unknown-keyed layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+
+      // FULL OUTER exposes UnknownPartitioning, so it is already safe regardless of the shuffle
+      // direction; correctness is the guard.
+      val fullQuery =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a FULL OUTER JOIN t ON a.id = t.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(fullQuery)
+        checkAnswer(df, expected)
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        // The downstream join must not storage-partition on the first join's unknown-keyed
+        // layout -- FULL OUTER keeps it safe only because the join output exposes
+        // UnknownPartitioning.
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"downstream join must not storage-partition on an unknown-keyed layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+
+      // t LEFT OUTER JOIN a preserves the non-keyed t on the left.
+      val leftQuery =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM t LEFT OUTER JOIN testcat.ns.a a ON t.id = a.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(leftQuery)
+        checkAnswer(df, expected)
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"downstream join must not storage-partition on an unknown-keyed layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: keyed preserved side of outer join still uses the one-side shuffle") {
+    // a (keyed) preserved on the left, t (non-keyed) nullable on the right: t is shuffled onto
+    // a's keys (its partitioning is marked as having unknown keys), but the LEFT OUTER join exposes
+    // only a's accurate partitioning, so the one-side shuffle stays sound and the downstream SPJ
+    // still runs (no shuffle for the second join).
+    createTable("a", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL), (2, 'u2', NULL), (3, 'u3', NULL)")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT a.id AS id FROM testcat.ns.a a LEFT OUTER JOIN t ON a.id = t.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, Seq(Row(1, "u1"), Row(2, "u2")))
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).nonEmpty,
+          s"downstream join should storage-partition on the accurate keyed layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: one-side shuffle with out-of-set keys loses matches in a following " +
+      "SPJ join (bucket)") {
+    // Same hazard as the identity variant, but the keyed sides are partitioned by bucket(4, id):
+    // a covers buckets {0, 1, 2} (ids 0, 1, 2), while t holds id 3 -- bucket 3 -- which a does
+    // not, so the one-side shuffle misplaces t's bucket-3 row while still declaring a's layout.
+    // `id` is LONG because `BucketFunction` binds its value argument to LongType.
+    val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("a", cols, Array(bucket(4, "id")))
+    createTable("u", cols, Array(bucket(4, "id")))
+    sql("INSERT INTO testcat.ns.a VALUES (0, 'a0'), (1, 'a1'), (2, 'a2')")
+    sql("INSERT INTO testcat.ns.u VALUES (0, 'u0'), (1, 'u1'), (2, 'u2'), (3, 'u3')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id BIGINT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (0, 't0'), (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(0L, "u0"), Row(1L, "u1"), Row(2L, "u2"), Row(3L, "u3"))
+
+      // Baseline: no SPJ -> all four rows.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"second join must not storage-partition on an unknown-keyed layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: unknown-keyed partitioning still joins a subset-keyed partner") {
+    // r (from a RIGHT OUTER JOIN t) has unknown partition keys {1, 2}, but the downstream u is
+    // keyed on a subset {1}, so the storage-partitioned join stays compatible and works: every
+    // key u can have is co-located on r's declared layout.
+    createTable("a", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL)")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, Seq(Row(1, "u1")))
+        // Only the first join's one-side shuffle remains; the second join storage-partitions.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).nonEmpty,
+          s"subset-keyed partner should still storage-partition join, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: project dropping a key position drops the unknown-keyed claim") {
+    // The first join's output is keyed on (id, k) and may contain unknown keys (t's rows are all
+    // out-of-set: a holds k=x, t holds k=z). The Project below the second join drops the k
+    // position, so the declared key set coarsens from {(1, x) ... (4, x)} to {1, 2, 3, 4} -- and
+    // an out-of-set (id, k) can then land inside the projected declared set. The keyed claim must
+    // be dropped entirely, otherwise the second join trusts the coarsened layout and silently
+    // loses the misplaced rows' matches.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", StringType),
+      Column.create("data", StringType))
+    createTable("a", cols, Array(identity("id"), identity("k")))
+    createTable("u", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES " +
+      "(1, 'x', 'a1'), (2, 'x', 'a2'), (3, 'x', 'a3'), (4, 'x', 'a4')")
+    sql("INSERT INTO testcat.ns.u VALUES " +
+      "(1, NULL, 'u1'), (2, NULL, 'u2'), (3, NULL, 'u3'), (4, NULL, 'u4')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 'z', 't1'), (2, 'z', 't2'), (3, 'z', 't3'), (4, 'z', 't4')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t
+          |      ON a.id = t.id AND a.k = t.k) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"), Row(4, "u4"))
+
+      // Baseline: no SPJ -> all four rows.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // The projection drops the unknown-keyed claim, so the second join shuffles: two one-side
+        // shuffles, both keyed with unknown partition keys, and no GroupPartitionsExec.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"second join must not storage-partition on the coarsened layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: union of an unknown-keyed leg drops the merged keyed partitioning") {
+    // The union's merged keys are the concatenation of every leg's keys -- a superset of each
+    // leg's declared set. When a leg's partitioning may contain unknown partition keys, another
+    // leg can declare exactly the key the unknown-keyed leg holds out-of-set, so the merged
+    // claim would promise co-location the unknown-keyed leg cannot honor. The union must drop
+    // the keyed partitioning entirely (with multiple legs the merged set is always larger than
+    // any single leg's, so there is no sound way to keep it).
+    createTable("a", columns, Array(identity("id")))
+    createTable("s", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'a1', NULL), (2, 'a2', NULL)")
+    sql("INSERT INTO testcat.ns.s VALUES (4, 's4', NULL), (5, 's5', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL), (2, 'u2', NULL), (3, 'u3', NULL), " +
+      "(4, 'u4', NULL), (5, 'u5', NULL)")
+
+    // Disjoint-keyed second leg: the union's merged keys {1, 2, 4, 5} do not cover t's out-of-set
+    // id=3, but the merged claim would still be a superset of the unknown-keyed leg's
+    // declared keys.
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id
+          |      UNION ALL
+          |      SELECT id FROM testcat.ns.s) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"), Row(4, "u4"), Row(5, "u5"))
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // The first join's one-side shuffle, then the union side re-shuffles onto u's layout for
+        // the second join: the union exposes no keyed partitioning, so no GroupPartitionsExec.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"second join must not storage-partition on the merged layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+
+    // Overlapping second leg: s declares exactly the key {3} that the unknown-keyed leg holds
+    // out-of-set, so the union's merged keys {1, 2, 3} equal u's keys and the second join would
+    // storage-partition with no exchange -- silently losing t's id=3 match.
+    sql("DROP TABLE IF EXISTS testcat.ns.s")
+    sql("DROP TABLE IF EXISTS testcat.ns.u")
+    createTable("s", columns, Array(identity("id")))
+    createTable("u", columns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.s VALUES (3, 's3', NULL)")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'u1', NULL), (2, 'u2', NULL), (3, 'u3', NULL)")
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id
+          |      UNION ALL
+          |      SELECT id FROM testcat.ns.s) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      // id=3 matches u once via t and once via s.
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"), Row(3, "u3"))
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+        assert(collectGroupPartitions(df.queryExecution.executedPlan).isEmpty,
+          s"second join must not storage-partition on the merged layout, got: " +
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: join-key projection of an unknown-keyed layout drops the claim") {
+    // Like the key-dropping-project repro, but the projection keeps both key positions: the
+    // coarsening happens when the second join projects the declared keys down to its join key
+    // (`id`) instead. A key that was out-of-set in the full key space lands inside the projected
+    // declared set, so the unknown-keyed spec must be refused and the second join must shuffle.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", StringType),
+      Column.create("data", StringType))
+    createTable("a", cols, Array(identity("id"), identity("k")))
+    createTable("u", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES " +
+      "(1, 'x', 'a1'), (2, 'x', 'a2'), (3, 'x', 'a3'), (4, 'x', 'a4')")
+    sql("INSERT INTO testcat.ns.u VALUES " +
+      "(1, NULL, 'u1'), (2, NULL, 'u2'), (3, NULL, 'u3'), (4, NULL, 'u4')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 'z', 't1'), (2, 'z', 't2'), (3, 'z', 't3'), (4, 'z', 't4')")
+
+      val query =
+        """
+          |SELECT r.id, r.k, u.data
+          |FROM (SELECT t.id AS id, t.k AS k FROM testcat.ns.a a RIGHT OUTER JOIN t
+          |      ON a.id = t.id AND a.k = t.k) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "z", "u1"), Row(2, "z", "u2"), Row(3, "z", "u3"), Row(4, "z", "u4"))
+
+      // Baseline: no SPJ -> all four rows.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // The second join refuses the projected unknown-keyed spec and shuffles instead: the
+        // first join's one-side shuffle plus the re-shuffle of the first join's output.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan,
+          Seq(true, true))
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: spurious marker of an inner join keeps the reduced SPJ") {
+    // The inner join's PartitioningCollection holds the keyed side's own (unmarked) KP next to
+    // the re-shuffled side's unknown-keyed one. The marker is spurious -- the inner join
+    // dropped every out-of-set row -- so a following reduced storage-partitioned join (bucket(4)
+    // reduced onto bucket(2)) must still work. Reading the marker off the collection with
+    // `exists` used to make the GroupPartitionsExec give up with a zero-partition
+    // UnknownPartitioning, which threw at planning when a parent asked for the partitioning.
+    val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("a", cols, Array(bucket(4, "id")))
+    createTable("u", cols, Array(bucket(2, "id")))
+    sql("INSERT INTO testcat.ns.a VALUES (0, 'a0'), (1, 'a1'), (2, 'a2'), (3, 'a3')")
+    sql("INSERT INTO testcat.ns.u VALUES (0, 'u0'), (1, 'u1'), (2, 'u2'), (3, 'u3')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id BIGINT, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (0, 't0'), (1, 't1'), (2, 't2'), (3, 't3')")
+
+      val query =
+        """
+          |SELECT a.id, u.data
+          |FROM testcat.ns.a a JOIN t ON a.id = t.id
+          |JOIN testcat.ns.u u ON a.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(0L, "u0"), Row(1L, "u1"), Row(2L, "u2"), Row(3L, "u3"))
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // The reduced SPJ still runs: the first join's one-side shuffle is the only shuffle.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan, Seq(true))
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: inner join with in-set rows keeps the sound SPJ downstream") {
+    // Same shape as the one-side-shuffle repro, but the inner join's second side holds only
+    // in-set rows: the join's PartitioningCollection carries the keyed side's own (unmarked) KP
+    // next to the re-shuffled side's unknown-keyed one, and the join has already dropped every
+    // out-of-set row, so the marker is spurious and the following storage-partitioned join must
+    // not pay a shuffle for it.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", StringType),
+      Column.create("data", StringType))
+    createTable("a", cols, Array(identity("id"), identity("k")))
+    createTable("u", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES " +
+      "(1, 'x', 'a1'), (2, 'x', 'a2'), (3, 'x', 'a3'), (4, 'x', 'a4')")
+    sql("INSERT INTO testcat.ns.u VALUES " +
+      "(1, NULL, 'u1'), (2, NULL, 'u2'), (3, NULL, 'u3'), (4, NULL, 'u4')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 'x', 't1'), (2, 'x', 't2'), (3, 'x', 't3'), (4, 'x', 't4')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM testcat.ns.a a JOIN t ON a.id = t.id AND a.k = t.k) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"), Row(4, "u4"))
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // Only the first join's one-side shuffle: the second join co-partitions on the
+        // spurious-marker-free layout without paying a shuffle.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan, Seq(true))
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: inner join clears the spurious marker on both member orders") {
+    // The inner join's output collection pairs the re-shuffled side's unknown-keyed KP with
+    // the keyed side's own unmarked KP. The join already dropped every out-of-set row, so the
+    // marker is spurious and must be cleared when the collection is built -- the downstream join
+    // matches the join key against the unknown-keyed member's expressions (the re-shuffled side
+    // is the join key's attribute origin), so a sibling-order preference in
+    // `createKeyedShuffleSpec` could not rescue the SPJ here. Both join orders must plan the
+    // single first-join shuffle.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", StringType),
+      Column.create("data", StringType))
+    createTable("a", cols, Array(identity("id"), identity("k")))
+    createTable("u", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES " +
+      "(1, 'x', 'a1'), (2, 'x', 'a2'), (3, 'x', 'a3'), (4, 'x', 'a4')")
+    sql("INSERT INTO testcat.ns.u VALUES " +
+      "(1, NULL, 'u1'), (2, NULL, 'u2'), (3, NULL, 'u3'), (4, NULL, 'u4')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 'x', 't1'), (2, 'x', 't2'), (3, 'x', 't3'), (4, 'x', 't4')")
+      val expected = Seq(Row(1, "x", "u1"), Row(2, "x", "u2"), Row(3, "x", "u3"), Row(4, "x", "u4"))
+
+      // `t` first: the collection lists the unknown-keyed member before its unmarked sibling;
+      // `a` first: the mirror order (the negative control pinning order-insensitivity).
+      for (side <- Seq("t", "a")) {
+        val query = if (side == "t") {
+          """
+            |SELECT t.id, a.k, u.data
+            |FROM t JOIN testcat.ns.a a ON a.id = t.id AND a.k = t.k
+            |JOIN testcat.ns.u u ON t.id = u.id
+            |""".stripMargin
+        } else {
+          """
+            |SELECT a.id, a.k, u.data
+            |FROM testcat.ns.a a JOIN t ON a.id = t.id AND a.k = t.k
+            |JOIN testcat.ns.u u ON a.id = u.id
+            |""".stripMargin
+        }
+        withSQLConf(
+            SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+            SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+          val df = sql(query)
+          checkAnswer(df, expected)
+          assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan, Seq(true))
+        }
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: inner join drops out-of-set rows before the cleared marker is trusted") {
+    // Data-level companion to the spurious-marker tests: `t` here genuinely holds an out-of-set
+    // row (5, 'z') that a's declared keys cannot match. The inner join drops it, so every row
+    // reaching the cleared-marker layout carries a declared key -- the downstream storage-
+    // partitioned join must then return exactly the matched rows: ids 1..4, and NOT id=5 even
+    // though u holds it. If the marker were cleared for a shape that keeps out-of-set rows,
+    // this query would silently lose or misplace matches.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", StringType),
+      Column.create("data", StringType))
+    createTable("a", cols, Array(identity("id"), identity("k")))
+    createTable("u", cols, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.a VALUES " +
+      "(1, 'x', 'a1'), (2, 'x', 'a2'), (3, 'x', 'a3'), (4, 'x', 'a4')")
+    sql("INSERT INTO testcat.ns.u VALUES (1, NULL, 'u1'), (2, NULL, 'u2'), (3, NULL, 'u3'), " +
+      "(4, NULL, 'u4'), (5, NULL, 'u5')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 'x', 't1'), (2, 'x', 't2'), (3, 'x', 't3'), " +
+        "(4, 'x', 't4'), (5, 'z', 't5')")
+
+      val query =
+        """
+          |SELECT r.id, u.data
+          |FROM (SELECT t.id AS id FROM t JOIN testcat.ns.a a ON a.id = t.id AND a.k = t.k) r
+          |JOIN testcat.ns.u u ON r.id = u.id
+          |""".stripMargin
+      // id=5 dropped by the inner join (a has no (5, *)); u's id=5 row has no partner.
+      val expected = Seq(Row(1, "u1"), Row(2, "u2"), Row(3, "u3"), Row(4, "u4"))
+
+      // Baseline without SPJ.
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+        // The marker cleared, so the second join storage-partitions: only the first join's
+        // one-side shuffle remains.
+        assertShuffleMayContainUnknownPartitionKeys(df.queryExecution.executedPlan, Seq(true))
+      }
+    }
+  }
+
+  test("SPARK-59050: SPJ: genuine unknown keys survive an inner join on a key subset") {
+    // Adversarial shape against the spurious-marker clearing: the RIGHT OUTER output `r` is a
+    // single unknown-keyed KP carrying a GENUINE unknown row (1, 'zz'); it inner-joins `x`
+    // (a keyed table declaring the same key set) on a strict subset of the key columns; `u`
+    // above matches on the full (id, k). The (1,'zz','xa','uz') match must survive: clearing
+    // markers only applies to mixed collections where every row already carries a declared key,
+    // and here the planner re-shuffles `r`'s side onto u's layout (the (id)-only claim cannot
+    // pair with the (id,k) spec), routing (1,'zz') by its full tuple into its own partition.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("k", StringType),
+      Column.create("data", StringType))
+    createTable("a", cols, Array(identity("id"), identity("k")))
+    createTable("x", cols, Array(identity("id"), identity("k")))
+    createTable("u", cols, Array(identity("id"), identity("k")))
+    sql("INSERT INTO testcat.ns.a VALUES (1, 'x', 'a1'), (2, 'x', 'a2')")
+    sql("INSERT INTO testcat.ns.x VALUES (1, 'x', 'xa'), (2, 'x', 'xb')")
+    sql("INSERT INTO testcat.ns.u VALUES (1, 'x', 'ux'), (2, 'x', 'ub'), (1, 'zz', 'uz')")
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, k STRING, data STRING) USING parquet")
+      sql("INSERT INTO t VALUES (1, 'x', 't1'), (2, 'x', 't2'), (1, 'zz', 't3')")
+
+      val query =
+        """
+          |SELECT r.id, r.k, x.data, u.data
+          |FROM (SELECT t.id AS id, t.k AS k FROM testcat.ns.a a RIGHT OUTER JOIN t
+          |      ON a.id = t.id AND a.k = t.k) r
+          |JOIN testcat.ns.x x ON r.id = x.id
+          |JOIN testcat.ns.u u ON r.id = u.id AND r.k = u.k
+          |""".stripMargin
+      val expected = Seq(Row(1, "x", "xa", "ux"), Row(2, "x", "xb", "ub"),
+        Row(1, "zz", "xa", "uz"))
+
+      withSQLConf(SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
+        checkAnswer(sql(query), expected)
+      }
+      withSQLConf(
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkAnswer(df, expected)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -6289,7 +6289,6 @@ class KeyGroupedPartitioningSuite
     }
   }
 
-
   /**
    * Asserts that the plan's shuffles (in tree order) are all `KeyedPartitioning`s carrying the
    * given `mayContainUnknownPartitionKeys` flags (a `KeyedPartitioning` produced by
@@ -6600,12 +6599,12 @@ class KeyGroupedPartitioningSuite
   }
 
   test("SPARK-59050: SPJ: union of an unknown-keyed leg drops the merged keyed partitioning") {
-    // The union's merged keys concatenate every leg's keys, a superset of each
-    // leg's declared set. When a leg's partitioning may contain unknown partition keys, another
-    // leg can declare exactly the key the unknown-keyed leg holds out-of-set, so the merged
-    // claim would promise co-location the unknown-keyed leg cannot honor. The union must drop
-    // the keyed partitioning entirely (with multiple legs the merged set is always larger than
-    // any single leg's, so there is no sound way to keep it).
+    // The union's merged keys concatenate every leg's keys, a superset, possibly equal, of each
+    // leg's declared set. When a leg may contain unknown partition keys, another leg can declare
+    // exactly the key that leg holds out-of-set, so the merged claim would promise co-location
+    // the marked leg cannot honor. Legs that declare the same key set would in fact tolerate
+    // keeping the marker (its out-of-set row rides its own leg's partition into that partition's
+    // group); this check does not try to tell that case from the rest, and refuses.
     createTable("a", columns, Array(identity("id")))
     createTable("s", columns, Array(identity("id")))
     createTable("u", columns, Array(identity("id")))
@@ -7142,5 +7141,3 @@ class KeyGroupedPartitioningCatalystRuntimeFilterSuite
     catalog.clearTables()
   }
 }
-
-

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -223,6 +223,35 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     assert(gpe.outputOrdering === Nil)
   }
 
+  test("SPARK-59050: unknown-keyed child with reducers gives up the keyed claim at the real " +
+    "count") {
+    // No planner path reaches the give-up branch with the built-in transforms --
+    // `createShuffleSpec` refuses a narrowing projection of an unknown-keyed partitioning one
+    // hop earlier, and `areKeysCompatible` pairs it only with same-function partners that have
+    // no reducer (see `GroupPartitionsExec.outputPartitioning`) -- so pin the contract
+    // directly: the node must report `UnknownPartitioning` with its physical grouped count.
+    // Reporting zero partitions is what threw once a parent join built a
+    // `PartitioningCollection` over both sides.
+    val partitionKeys = Seq(row(1), row(2), row(1))
+    val child = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), partitionKeys)
+        .copy(mayContainUnknownPartitionKeys = true))
+    val gpe = GroupPartitionsExec(child, reducers = Some(Seq(None)))
+
+    assert(gpe.groupedPartitions.size === 2, "expected coalescing into 2 groups")
+    gpe.outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail(s"expected the unknown-keyed claim to be dropped on reduction, got $other")
+    }
+    // A parent join merges the two sides' partitionings into a collection: a count of 0 fails
+    // the uniform-numPartitions requirement, the round-2 planning throw reproduced -- this call
+    // throwing fails the test.
+    val partner = KeyedPartitioning(Seq(exprB), Seq(row(1), row(2)))
+    PartitioningCollection.fromPartitionings(Seq(gpe.outputPartitioning, partner))
+  }
+
   test("SPARK-55715: sorted merge config enabled but child not SafeForKWayMerge falls back " +
       "to key-expression ordering") {
     // DummySparkPlan does not extend SafeForKWayMerge, so childIsSafeForKWayMerge = false and

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -260,6 +260,28 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-59050: an identity grouping that shrinks the partition count drops the claim") {
+    // `alignToExpectedKeys` emits only the expected keys, so a declared key the merged set
+    // does not carry is never emitted. When the dropped key is trailing, every kept group
+    // still reads as the identity, but the partition count shrank and the hash modulus with
+    // it: the child's undeclared rows sit at hash(key) % 3 while the retained claim would
+    // promise hash(key) % 2. The count check catches what the per-group check cannot.
+    val child = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(3)))
+        .copy(mayContainUnknownPartitionKeys = true))
+    def keyOf(a: Int): InternalRowComparableWrapper =
+      InternalRowComparableWrapper(row(a), Seq(exprA))
+    val gpe = GroupPartitionsExec(child,
+      expectedPartitionKeys = Some(Seq(keyOf(1) -> 1, keyOf(2) -> 1)))
+    assert(gpe.groupedPartitions.size === 2, "the trailing key 3 is dropped")
+    gpe.outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail(s"expected the unknown-keyed claim to be dropped on a shrink, got $other")
+    }
+  }
+
   test("SPARK-59050: unknown-keyed child with reducers gives up the keyed claim at the real " +
     "count") {
     // The reducer instance of the give-up: a reduction regroups by the reduced keys, a

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -22,11 +22,11 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, KeyedPartitioning, KeyedShuffleSpec, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
-import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, BucketReducer}
+import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, BucketReducer, Reducer}
 import org.apache.spark.sql.execution.{DummySparkPlan, LeafExecNode, SafeForKWayMerge}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{DataType, IntegerType}
 
 class GroupPartitionsExecSuite extends SharedSparkSession {
 
@@ -223,22 +223,44 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     assert(gpe.outputOrdering === Nil)
   }
 
+  test("SPARK-59050: grouping without reducers keeps the child's marker") {
+    // Without a reduction the layout is regrouped, not rewritten: the output keys match the
+    // child's declared set verbatim, so the marker (and the honesty of "may contain") must
+    // ride the transform rather than be dropped or invented.
+    val child = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(1)))
+        .copy(mayContainUnknownPartitionKeys = true))
+    val out = GroupPartitionsExec(child)
+      .outputPartitioning.asInstanceOf[KeyedPartitioning]
+    assert(out.mayContainUnknownPartitionKeys, "the marker must survive plain grouping")
+  }
+
   test("SPARK-59050: unknown-keyed child with reducers gives up the keyed claim at the real " +
     "count") {
-    // No planner path reaches the give-up branch with the built-in transforms --
+    // No planner path reaches the give-up branch with the built-in transforms:
     // `createShuffleSpec` refuses a narrowing projection of an unknown-keyed partitioning one
     // hop earlier, and `areKeysCompatible` pairs it only with same-function partners that have
-    // no reducer (see `GroupPartitionsExec.outputPartitioning`) -- so pin the contract
-    // directly: the node must report `UnknownPartitioning` with its physical grouped count.
-    // Reporting zero partitions is what threw once a parent join built a
-    // `PartitioningCollection` over both sides.
-    val partitionKeys = Seq(row(1), row(2), row(1))
+    // no reducer (see `GroupPartitionsExec.outputPartitioning`). Pin the contract directly: the
+    // node must report `UnknownPartitioning` with its physical grouped count. Reporting zero
+    // partitions is what threw once a parent join built a `PartitioningCollection` over both
+    // sides.
+    // The reducer must be real: `Some(Seq(None))` keeps `reducers.isDefined` true but leaves
+    // every key unchanged, testing none of the collapse that motivates the branch. Keys
+    // [1, 2, 3] reduced mod 2 give [1, 0, 1]: the node emits 2 grouped partitions where the
+    // child had 3, and the give-up count has to be that physical 2.
+    val mod2 = new Reducer[Int, Int] {
+      override def reduce(v: Int): Int = v % 2
+      override def resultType(): DataType = IntegerType
+      override def displayName(): String = "mod2"
+    }
+    val reducer = KeyReducer(mod2, TransformExpression(BucketFunction, Seq(exprA), Some(2)))
+    val partitionKeys = Seq(row(1), row(2), row(3))
     val child = DummySparkPlan(
       outputPartitioning = KeyedPartitioning(Seq(exprA), partitionKeys)
         .copy(mayContainUnknownPartitionKeys = true))
-    val gpe = GroupPartitionsExec(child, reducers = Some(Seq(None)))
+    val gpe = GroupPartitionsExec(child, reducers = Some(Seq(Some(reducer))))
 
-    assert(gpe.groupedPartitions.size === 2, "expected coalescing into 2 groups")
+    assert(gpe.groupedPartitions.size === 2, "mod 2 collapses keys 1 and 3")
     gpe.outputPartitioning match {
       case u: UnknownPartitioning =>
         assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
@@ -246,7 +268,7 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
         fail(s"expected the unknown-keyed claim to be dropped on reduction, got $other")
     }
     // A parent join merges the two sides' partitionings into a collection: a count of 0 fails
-    // the uniform-numPartitions requirement, the round-2 planning throw reproduced -- this call
+    // the uniform-numPartitions requirement, the planning throw reproduced; this call
     // throwing fails the test.
     val partner = KeyedPartitioning(Seq(exprB), Seq(row(1), row(2)))
     PartitioningCollection.fromPartitionings(Seq(gpe.outputPartitioning, partner))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -291,8 +291,9 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     // `PartitioningCollection` over both sides. (`areKeysCompatible` pairs a marked layout
     // only with same-function partners that need no reducer, so no planner path applies a
     // reducer to a marked layout; this pins the contract directly.)
-    // The reducer must be real: `Some(Seq(None))` leaves every key unchanged, an identity
-    // grouping that keeps the claim, testing none of the collapse that motivates the give-up.
+    // The reducer must be real: it is the collapse of [1, 2, 3] to two groups that exercises
+    // the regrouping the give-up answers. A reducer slot that rewrites no key is pinned by the
+    // next test, where it is the slot itself, not a merge, that drops the claim.
     // Keys [1, 2, 3] reduced mod 2 give [1, 0, 1]: the node emits 2 grouped partitions where
     // the child had 3, and the give-up count has to be that physical 2.
     val mod2 = new Reducer[Int, Int] {
@@ -319,6 +320,41 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     // throwing fails the test.
     val partner = KeyedPartitioning(Seq(exprB), Seq(row(1), row(2)))
     PartitioningCollection.fromPartitionings(Seq(gpe.outputPartitioning, partner))
+  }
+
+  test("SPARK-59050: a grouping that rewrites the declared keys drops the claim") {
+    // `identityGrouping` also asks whether the grouping rewrote the keys: the claim the node
+    // goes on to declare lives in the projected or reduced key space, while the child's
+    // undeclared rows still sit at hash(originalKey) % numPartitions. A reducer slot or a
+    // narrowing projection therefore gives up the claim even when every group keeps its index
+    // and the count is unchanged. A conforming self-reducer cannot rewrite a reachable key
+    // (its contract is r(f(x)) = f(x)), so the give-up there loses at most an optimization;
+    // no planner path applies a reducer or a narrowing projection to a marked layout, so these
+    // shapes are pinned here directly.
+    val child = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA, exprB), Seq(row(1, 10), row(2, 20)))
+        .copy(mayContainUnknownPartitionKeys = true))
+
+    // Reducer slots: `Some(Seq(None, None))` leaves every key and every index unchanged.
+    val reduced = GroupPartitionsExec(child, reducers = Some(Seq(None, None)))
+    assert(reduced.groupedPartitions.size === 2)
+    reduced.outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail(s"expected the unknown-keyed claim to be dropped with reducer slots, got $other")
+    }
+
+    // Narrowing projection: position 0 of keys [(1, 10), (2, 20)] keeps both groups in order.
+    val projected = GroupPartitionsExec(child, joinKeyPositions = Some(Seq(0)))
+    assert(projected.groupedPartitions.size === 2)
+    projected.outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail("expected the unknown-keyed claim to be dropped on a narrowing projection, " +
+          s"got $other")
+    }
   }
 
   test("SPARK-55715: sorted merge config enabled but child not SafeForKWayMerge falls back " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -223,31 +223,56 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     assert(gpe.outputOrdering === Nil)
   }
 
-  test("SPARK-59050: grouping without reducers keeps the child's marker") {
-    // Without a reduction the layout is regrouped, not rewritten: the output keys match the
-    // child's declared set verbatim, so the marker (and the honesty of "may contain") must
-    // ride the transform rather than be dropped or invented.
+  test("SPARK-59050: identity grouping without reducers keeps the child's marker") {
+    // An identity grouping (output partition i holds exactly input partition i) keeps the
+    // unknown-key hash-routing relationship intact, so the marker rides the transform.
     val child = DummySparkPlan(
-      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(1)))
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(row(1), row(2)))
         .copy(mayContainUnknownPartitionKeys = true))
     val out = GroupPartitionsExec(child)
       .outputPartitioning.asInstanceOf[KeyedPartitioning]
-    assert(out.mayContainUnknownPartitionKeys, "the marker must survive plain grouping")
+    assert(out.mayContainUnknownPartitionKeys, "the marker must survive identity grouping")
+  }
+
+  test("SPARK-59050: non-identity grouping without reducers drops the unknown-keyed claim") {
+    // A regrouping that reorders or coalesces the partitions moves the rows an unknown-key claim
+    // pins to hash(key) % numPartitions, so the claim cannot survive; clearing only the marker
+    // would misreport the undeclared rows that remain.
+    // Coalesce: keys [1, 2, 1] merge the two key-1 partitions.
+    val coalesced = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(1)))
+        .copy(mayContainUnknownPartitionKeys = true))
+    GroupPartitionsExec(coalesced).outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail(s"expected the unknown-keyed claim to be dropped on coalesce, got $other")
+    }
+    // Reorder: keys [2, 1] sort to [1, 2], swapping partitions 0 and 1.
+    val reordered = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(row(2), row(1)))
+        .copy(mayContainUnknownPartitionKeys = true))
+    GroupPartitionsExec(reordered).outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail(s"expected the unknown-keyed claim to be dropped on reorder, got $other")
+    }
   }
 
   test("SPARK-59050: unknown-keyed child with reducers gives up the keyed claim at the real " +
     "count") {
-    // No planner path reaches the give-up branch with the built-in transforms:
-    // `createShuffleSpec` refuses a narrowing projection of an unknown-keyed partitioning one
-    // hop earlier, and `areKeysCompatible` pairs it only with same-function partners that have
-    // no reducer (see `GroupPartitionsExec.outputPartitioning`). Pin the contract directly: the
-    // node must report `UnknownPartitioning` with its physical grouped count. Reporting zero
-    // partitions is what threw once a parent join built a `PartitioningCollection` over both
-    // sides.
-    // The reducer must be real: `Some(Seq(None))` keeps `reducers.isDefined` true but leaves
-    // every key unchanged, testing none of the collapse that motivates the branch. Keys
-    // [1, 2, 3] reduced mod 2 give [1, 0, 1]: the node emits 2 grouped partitions where the
-    // child had 3, and the give-up count has to be that physical 2.
+    // The reducer instance of the give-up: a reduction regroups by the reduced keys, a
+    // non-identity grouping, so the unknown-keyed claim is dropped at the physical grouped
+    // count. The node must report `UnknownPartitioning` with its physical grouped count;
+    // reporting zero partitions is what threw once a parent join built a
+    // `PartitioningCollection` over both sides. (`areKeysCompatible` pairs a marked layout
+    // only with same-function partners that need no reducer, so no planner path applies a
+    // reducer to a marked layout; this pins the contract directly.)
+    // The reducer must be real: `Some(Seq(None))` leaves every key unchanged, an identity
+    // grouping that keeps the claim, testing none of the collapse that motivates the give-up.
+    // Keys [1, 2, 3] reduced mod 2 give [1, 0, 1]: the node emits 2 grouped partitions where
+    // the child had 3, and the give-up count has to be that physical 2.
     val mod2 = new Reducer[Int, Int] {
       override def reduce(v: Int): Int = v % 2
       override def resultType(): DataType = IntegerType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -325,12 +325,12 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
   test("SPARK-59050: a grouping that rewrites the declared keys drops the claim") {
     // `identityGrouping` also asks whether the grouping rewrote the keys: the claim the node
     // goes on to declare lives in the projected or reduced key space, while the child's
-    // undeclared rows still sit at hash(originalKey) % numPartitions. A reducer slot or a
-    // narrowing projection therefore gives up the claim even when every group keeps its index
-    // and the count is unchanged. A conforming self-reducer cannot rewrite a reachable key
-    // (its contract is r(f(x)) = f(x)), so the give-up there loses at most an optimization;
-    // no planner path applies a reducer or a narrowing projection to a marked layout, so these
-    // shapes are pinned here directly.
+    // undeclared rows still sit at hash(originalKey) % numPartitions. A reducer slot, a
+    // narrowing projection, or a reordering projection therefore gives up the claim even when
+    // every group keeps its index and the count is unchanged. A conforming self-reducer cannot
+    // rewrite a reachable key (its contract is r(f(x)) = f(x)), so the give-up there loses at
+    // most an optimization; no planner path applies a reducer or a non-identity projection to
+    // a marked layout, so these shapes are pinned here directly.
     val child = DummySparkPlan(
       outputPartitioning = KeyedPartitioning(Seq(exprA, exprB), Seq(row(1, 10), row(2, 20)))
         .copy(mayContainUnknownPartitionKeys = true))
@@ -353,6 +353,23 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
         assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
       case other =>
         fail("expected the unknown-keyed claim to be dropped on a narrowing projection, " +
+          s"got $other")
+    }
+
+    // Reordering projection: positions Seq(1, 0) re-label every group into the swapped key
+    // space while each group keeps its index and the count, so only the rewrite clause can
+    // catch it. No producer of joinKeyPositions emits anything but ascending positions today;
+    // this pins the predicate directly.
+    val reordered = GroupPartitionsExec(child, joinKeyPositions = Some(Seq(1, 0)))
+    assert(reordered.groupedPartitions.size === 2)
+    assert(reordered.groupedPartitions.zipWithIndex.forall {
+      case ((_, inputIndices), outputIndex) => inputIndices == Seq(outputIndex)
+    }, "the reordering keeps every group at its index")
+    reordered.outputPartitioning match {
+      case u: UnknownPartitioning =>
+        assert(u.numPartitions === 2, "the give-up count must match the physical partitions")
+      case other =>
+        fail("expected the unknown-keyed claim to be dropped on a reordering projection, " +
           s"got $other")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -1161,7 +1161,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       EnsureRequirements.apply(smjExec) match {
         case ShuffledHashJoinExec(_, _, _, _, _,
         DummySparkPlan(_, _, left: KeyedPartitioning, _, _),
-        ShuffleExchangeExec(KeyedPartitioning(attrs, pks, _, _),
+        ShuffleExchangeExec(KeyedPartitioning(attrs, pks, _, _, _),
         DummySparkPlan(_, _, SinglePartition, _, _), _, _, _), _) =>
           assert(left.expressions == a1 :: Nil)
           assert(attrs == a1 :: Nil)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The one-side shuffle optimization (`spark.sql.sources.v2.bucketing.shuffle.enabled`) re-shuffles a join side onto the keyed side's declared `KeyedPartitioning`. `KeyGroupedPartitioner` silently routes rows whose key is not among the declared partition keys to arbitrary partitions, so the re-shuffled side's `KeyedPartitioning` may not actually cover all its rows.

- Add `KeyedPartitioning.mayContainUnknownPartitionKeys`, set on every partitioning produced by `KeyedShuffleSpec.createPartitioning`, and require `KeyedShuffleSpec.areKeysCompatible` to only co-partition such a partitioning with a side whose keys are a subset of the declared keys, or, when both sides carry the marker, with a side declaring the very same key sequence (a subset would differ in numPartitions, and hence in the hash modulus the claim pins). Since the subset test compares key values, it is only applied between partitionings using the same partition function per position: an identity-vs-transform pair holds raw values on one side and transform outputs on the other, so their key sets are not comparable.
- Propagate the marker through `PartitioningPreservingUnaryExecNode`, `GroupPartitionsExec` and `UnionExec`. Because a boolean marker cannot express which keys are trustworthy, a node that coarsens the declared key set or moves the rows it pins drops the keyed claim entirely: a projection that drops a key position; a union whose merged keys declare the other legs' keys too; a `GroupPartitionsExec` regrouping that is not the identity mapping -- a reorder, coalesce, resize, or reduction moves the undeclared rows off `hash(key) % numPartitions`, so only an identity regrouping keeps the claim; and `KeyedPartitioning.createShuffleSpec`, which refuses to project an unknown-keyed partitioning down to a strict subset of its join keys, leaving the child to the ordinary shuffle.
- Gate the marker on every consumer, not only join pairing: `KeyedPartitioning.keysSatisfy` gives an unknown-keyed layout the full-key rules only -- no subset clustering (a window or aggregate keyed on a strict subset of the partition columns must still shuffle; whole keys co-locate, prefixes do not) and no global ordering beyond a single partition. `SPARK-58968` fixed the same shape for unmarked partitionings by inserting a projecting `GroupPartitionsExec`; that projection is exactly what a marked claim cannot survive, and every admission route funnels through `keysSatisfy`.
- Clear the marker at construction where it is provably spurious: `ShuffledJoin`'s `InnerLike` arm, the only site that merges a marked member with an unmarked sibling (nested collections included), clears it because its join already filtered every undeclared row -- so consumers take members' markers at face value and sound storage-partitioned plans above inner joins are kept.

### Why are the changes needed?

A storage-partitioned join where the preserved side is one-side-shuffled (e.g. `a RIGHT OUTER JOIN t` with a keyed `a` and a non-keyed `t` holding keys `a` does not) produces an output whose declared partitioning omits those keys. A following storage-partitioned join trusts the declaration and silently loses the matches -- wrong results with no error.

#### Reproduction

Only `spark.sql.sources.v2.bucketing.shuffle.enabled` is needed (the other SPJ toggles are at their defaults). The keyed tables need a catalog that reports partitioning (here `testcat` is the in-memory test catalog).

```sql
-- 1) config
SET spark.sql.sources.v2.bucketing.shuffle.enabled = true;

-- 2) tables + data
-- a: keyed on id, keys {1, 2}
CREATE TABLE testcat.ns.a (id BIGINT, data STRING) PARTITIONED BY (id);
INSERT INTO testcat.ns.a VALUES (1, 'a1'), (2, 'a2');

-- t: v1 parquet, keys {1, 2, 3}  (contains a key `a` does not have)
CREATE TABLE t (id BIGINT, data STRING) USING parquet;
INSERT INTO t VALUES (1, 't1'), (2, 't2'), (3, 't3');

-- u: keyed on id, keys {1, 2, 3}
CREATE TABLE testcat.ns.u (id BIGINT, data STRING) PARTITIONED BY (id);
INSERT INTO testcat.ns.u VALUES (1, 'u1'), (2, 'u2'), (3, 'u3');

-- 3) query: the RIGHT OUTER join preserves t's id=3 row; the following
--    storage-partitioned join must still match it against u.
SELECT r.id, u.data
FROM (
  SELECT t.id AS id
  FROM testcat.ns.a a RIGHT OUTER JOIN t ON a.id = t.id
) r
JOIN testcat.ns.u u ON r.id = u.id;
```

**Result**

| | id |
|---|---|
| Expected | 1, 2, 3 |
| Actual (before this PR) | 1, 2  <- **id=3's match silently lost** |

Turning `spark.sql.sources.v2.bucketing.shuffle.enabled` off (or disabling SPJ entirely) returns all three rows, confirming this is an SPJ-path bug rather than a query semantics issue.

**Mechanism**

1. The first join one-side-shuffles `t` onto `a`'s declared keys `{1, 2}`. `t`'s id=3 is not among the declared keys, so `KeyGroupedPartitioner` silently routes it to an arbitrary partition, while the shuffle still declares the `{1, 2}` layout.
2. `a RIGHT OUTER JOIN t` preserves that misplaced id=3 row, so the join output's declared partitioning (`{1, 2}`) no longer matches its data.
3. The second join trusts the declared layout when planning its storage-partitioned join against `u` (`{1, 2, 3}`) and never co-locates the id=3 rows, silently dropping the match.

The fix marks such one-side-shuffled partitionings with `mayContainUnknownPartitionKeys` and restricts `areKeysCompatible` to only co-partition them with a side whose keys are a subset of the declared keys, and with another flagged side only when the two key sequences are equal, so the second join falls back to a shuffle and returns correct results. Downstream nodes that coarsen the declared key set or move the rows it pins (a key-dropping projection, a union with several legs, a non-identity `GroupPartitionsExec` regrouping such as a reorder, coalesce, resize, or reduction, and the join-key projection in `KeyedPartitioning.createShuffleSpec`) drop or refuse the keyed claim, since the marker alone cannot express which keys the claim still covers.

Further wrong-results shapes, each with a repro test: a `Project` that drops a key position coarsens the declared key set (4 expected, 2 returned); a `UNION ALL` leg that declares exactly the out-of-set key (4 expected, 3 returned); a join-key projection of an unknown-keyed layout under `allowKeysSubsetOfPartitionKeys` (4 expected, 0 returned); and a `GroupPartitionsExec` that re-sorts an unknown-keyed layout onto a differently-ordered declared key set, moving the out-of-set rows off the hash routing while the marker is retained, so a later marked-vs-marked join loses the match. Two regressions introduced while fixing these and also pinned by tests: a zero-partition `UnknownPartitioning` from `GroupPartitionsExec` throwing at planning when a parent builds a `PartitioningCollection`, and a spurious marker on an inner join's mixed collection costing a shuffle a sound storage-partitioned join could have avoided; and a window or a global sort trusting an unknown-keyed layout directly (a partitioned subset-keyed window splitting one group across partitions, a global `ORDER BY` degrading to per-partition sorting).

### Does this PR introduce _any_ user-facing change?

Yes: it fixes a wrong-results bug in `spark.sql.sources.v2.bucketing.shuffle.enabled`. Storage-partitioned joins whose preserved side is one-side-shuffled against a smaller keyed side, followed by another storage-partitioned join on a larger key set, now fall back to shuffles and return correct results. Previously they could silently lose matches.

The buggy config ships since 4.0.0, so this is a candidate for backporting to the 4.x lines.

### How was this patch tested?

- `KeyGroupedPartitioningSuite` (21 `SPARK-59050:` tests): repros that fail on the pre-fix code (identity/bucket one-side shuffle, key-dropping project, union with disjoint and overlapping legs, join-key projection, a `GroupPartitionsExec` re-sort of a marked layout onto a differently-ordered key set, inner join with in-set and out-of-set rows, outer-join variants, the reduced-SPJ planning throw, subset-keyed window, global `ORDER BY`), plus pins for invariants that must not regress (full-key window keeping its shuffle-free plan, marker clearing across nested collections, against a keyless sibling, and along an end-to-end SQL path that builds the nested shape, marker retention for all-marked chains, an identity regrouping keeping the claim, spurious-marker collections in both member orders, genuine unknown keys surviving an inner join on a key subset, subset-keyed partner compatibility, keyed-preserved side still using the one-side shuffle). Repro tests assert answers, exchange counts and marker flags, order-sensitive ones compare `collect()` directly, and plan inspection runs after materialization; the window repro runs for AQE on and off.
- `ShuffleSpecSuite`: unit tests for the `areKeysCompatible` subset/order and same-function rules (including a compatible-but-not-same bucket pair marked and unmarked) and the refused-spec unit for `createShuffleSpec`/`canCreatePartitioning`.
- `GroupPartitionsExecSuite`: marker retention for an identity grouping, give-up for a reorder and a coalesce, the give-up-count pin with a real (coalescing) reducer, and the give-up when a grouping rewrites the declared keys.
- `DistributionSuite`: the marked `keysSatisfy` gates (a one-partition marked layout keeps the global-ordering claim), `fromPartitionings` OR-normalizing the marker through nested collections, and the `PartitioningCollection` members-agree invariant, also against a nested member.
- Confirmed the bug-repro tests fail without the fix (wrong results, counts splitting, [1, 4, 2] ordering) and pass with it.
- Regression suites all pass: `KeyGroupedPartitioningSuite`, `GroupPartitionsExecSuite`, `ShuffleSpecSuite`, `DistributionSuite`, `EnsureRequirementsSuite`, `ValidateRequirementsSuite`, `ProjectedOrderingAndPartitioningSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code.





