### PR TITLE
[MINOR][INFRA] Allow "Squash and merge" only

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,9 +30,9 @@ github:
     - sql
     - spark
   enabled_merge_buttons:
+    merge: false
     squash: true
     squash_commit_message: PR_TITLE_AND_DESC
-    merge: false
     rebase: false
   ghp_branch: master
   ghp_path: /docs

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,9 +30,10 @@ github:
     - sql
     - spark
   enabled_merge_buttons:
-    merge: false
     squash: true
-    rebase: true
+    squash_commit_message: PR_TITLE_AND_DESC
+    merge: false
+    rebase: false
   ghp_branch: master
   ghp_path: /docs
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When using GitHub's merge button (which we don't use), allow "Squash and merge" only, where the squashed commit title and message are derived from the PR title and description.

GitHub unfortunately does not allow us to disable the merge button entirely.

Relevant docs are here: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#merge

### Why are the changes needed?

They're not really needed, but if we ever decide to use GitHub's merge button, or if someone uses it by mistake, the updated settings are the closest to what our merge script does. They also match what is [proposed for spark-website](https://github.com/apache/spark-website/pull/707/changes#diff-b4c2a69650f9ac84008ad9f745859a645c9466350ffdfe5f919655039ee2e2c3).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No testing.

### Was this patch authored or co-authored using generative AI tooling?

No.
