### PR TITLE
[SPARK-59042][SQL] Fix PushProjectionThroughUnion failure on correlated scalar subquery over UNION ALL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1114,6 +1114,19 @@ object PushProjectionThroughUnion extends Rule[LogicalPlan] {
     AttributeMap(left.output.zip(right.output))
   }
 
+  private def updateOuterReferencesInSubquery(
+      plan: LogicalPlan,
+      rewrites: AttributeMap[Attribute]): LogicalPlan = {
+    plan.transformDown { case currentFragment =>
+      currentFragment.transformExpressions {
+        case OuterReference(a: Attribute) =>
+          OuterReference(rewrites.getOrElse(a, a))
+        case pe: PlanExpression[LogicalPlan @unchecked] =>
+          pe.withNewPlan(updateOuterReferencesInSubquery(pe.plan, rewrites))
+      }
+    }
+  }
+
   /**
    * Rewrites an expression so that it can be pushed to the right side of a
    * Union or Except operator. This method relies on the fact that the output attributes
@@ -1122,6 +1135,8 @@ object PushProjectionThroughUnion extends Rule[LogicalPlan] {
   private def pushToRight[A <: Expression](e: A, rewrites: AttributeMap[Attribute]) = {
     val result = e transform {
       case a: Attribute => rewrites.getOrElse(a, a)
+      case pe: PlanExpression[LogicalPlan @unchecked] =>
+        pe.withNewPlan(updateOuterReferencesInSubquery(pe.plan, rewrites))
     } match {
       // Make sure exprId is unique in each child of Union.
       case Alias(child, alias) => Alias(child, alias)()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1121,7 +1121,7 @@ object PushProjectionThroughUnion extends Rule[LogicalPlan] {
    */
   private def pushToRight[A <: Expression](e: A, rewrites: AttributeMap[Attribute]) = {
     val result = e transform {
-      case a: Attribute => rewrites(a)
+      case a: Attribute => rewrites.getOrElse(a, a)
     } match {
       // Make sure exprId is unique in each child of Union.
       case Alias(child, alias) => Alias(child, alias)()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectThroughUnionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectThroughUnionSuite.scala
@@ -23,6 +23,8 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
+import org.apache.spark.sql.catalyst.expressions.ScalarSubquery
+
 class PushProjectThroughUnionSuite extends PlanTest {
 
   object Optimize extends RuleExecutor[LogicalPlan] {
@@ -52,20 +54,24 @@ class PushProjectThroughUnionSuite extends PlanTest {
     comparePlans(optimized, expected)
   }
 
-  test("SPARK-59042: PushProjectionThroughUnion handles unmapped/subquery attributes cleanly") {
+  test("SPARK-59042: PushProjectionThroughUnion handles subquery attributes cleanly") {
     val testRelation1 = LocalRelation($"a".int)
     val testRelation2 = LocalRelation($"d".int)
-    val unmappedAttr = $"x".int
+    val subqueryRelation = LocalRelation($"x".int)
+    val subquery = ScalarSubquery(subqueryRelation.where($"x" === $"a").select($"x"))
+
     val query = testRelation1
       .union(testRelation2)
-      .select($"a", unmappedAttr)
+      .select($"a", subquery.as("sub"))
       .analyze
     val optimized = Optimize.execute(query)
 
+    val expectedChild2Sub = ScalarSubquery(subqueryRelation.where($"x" === $"d").select($"x"))
+
     val expected = testRelation1
-      .select($"a", unmappedAttr)
+      .select($"a", subquery.as("sub"))
       .union(testRelation2
-        .select($"d".as("a"), unmappedAttr))
+        .select($"d", expectedChild2Sub.as("sub")))
       .analyze
 
     comparePlans(optimized, expected)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectThroughUnionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectThroughUnionSuite.scala
@@ -19,11 +19,10 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.ScalarSubquery
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-
-import org.apache.spark.sql.catalyst.expressions.ScalarSubquery
 
 class PushProjectThroughUnionSuite extends PlanTest {
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectThroughUnionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushProjectThroughUnionSuite.scala
@@ -51,4 +51,23 @@ class PushProjectThroughUnionSuite extends PlanTest {
 
     comparePlans(optimized, expected)
   }
+
+  test("SPARK-59042: PushProjectionThroughUnion handles unmapped/subquery attributes cleanly") {
+    val testRelation1 = LocalRelation($"a".int)
+    val testRelation2 = LocalRelation($"d".int)
+    val unmappedAttr = $"x".int
+    val query = testRelation1
+      .union(testRelation2)
+      .select($"a", unmappedAttr)
+      .analyze
+    val optimized = Optimize.execute(query)
+
+    val expected = testRelation1
+      .select($"a", unmappedAttr)
+      .union(testRelation2
+        .select($"d".as("a"), unmappedAttr))
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2678,4 +2678,22 @@ class SubquerySuite extends SharedSparkSession
 
     assert(exposedAttribute.exprId == outerReferenceAttribute.exprId)
   }
+
+  test("SPARK-59042: PushProjectionThroughUnion fails on a correlated scalar subquery " +
+    "over UNION ALL") {
+    val df = sql(
+      """
+        |SELECT u.a,
+        |       (SELECT max(r.x)
+        |        FROM (VALUES (1), (2), (3), (NULL)) AS r(x)
+        |        WHERE r.x = u.a) AS m
+        |FROM (
+        |  SELECT a FROM (VALUES (1), (2)) AS l(a)
+        |  UNION ALL
+        |  SELECT a FROM (VALUES (2), (3)) AS q(a)
+        |) u
+        |ORDER BY u.a, m
+        |""".stripMargin)
+    checkAnswer(df, Row(1, 1) :: Row(2, 2) :: Row(2, 2) :: Row(3, 3) :: Nil)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a `java.util.NoSuchElementException` when `PushProjectionThroughUnion` optimizes a `Project` over a `Union` where project expressions contain subqueries or outer references.

Specifically:
- Updated `PushProjectionThroughUnion.pushToRight` to use `rewrites.getOrElse(a, a)` instead of `rewrites(a)` when looking up attribute references. This prevents `NoSuchElementException` when encountering subquery-internal or unmapped attributes.
- Added `updateOuterReferencesInSubquery` helper in `PushProjectionThroughUnion` to recurse into subquery plans (`PlanExpression.plan`) and rewrite inner `OuterReference(a)` references to match the right child's corresponding attributes.

### Why are the changes needed?
When a query contains a correlated scalar subquery (or any expression referencing subquery-internal attributes) over a `UNION ALL`, `PushProjectionThroughUnion` attempts to push project expressions to the children of the `Union`. 

Prior to this fix:
1. `pushToRight` called `rewrites(a)` directly on all attributes. Subquery-internal attributes (e.g. `r.x#7` in `WHERE r.x = u.a`) were absent from `rewrites` (which maps `left.output -> right.output`), throwing `java.util.NoSuchElementException: key not found: x#7`.
2. Outer references inside subquery plans (`OuterReference(a)`) were skipped by `e transform` because `OuterReference` extends `LeafExpression` and `PlanExpression.plan` is a `LogicalPlan` rather than an `Expression` child.

### Does this PR introduce _any_ user-facing change?
No. Fixes an optimization failure exception for correlated subqueries over `UNION ALL`.

### How was this patch tested?
- Added catalyst optimizer unit test in `PushProjectThroughUnionSuite`.
- Added end-to-end SQL query test in `SubquerySuite`.

### Was this patch authored or co-authored using generative AI tooling?
No.
