### PR TITLE
[MINOR][BUILD] Give run-in-container a shebang

### DIFF
--- a/dev/spark-test-image-util/docs/build-docs
+++ b/dev/spark-test-image-util/docs/build-docs
@@ -47,7 +47,7 @@ docker buildx build \
 docker run \
   --mount type=bind,source="${SPARK_HOME}",target="${DOCKER_MOUNT_SPARK_HOME}" \
   --interactive --tty "${IMG_URL}" \
-  /bin/bash -c "sh ${BUILD_DOCS_SCRIPT_PATH}"
+  "${BUILD_DOCS_SCRIPT_PATH}"
 
 if [[ "$SKIP_RDOC" != "1" ]]; then
   # 4.Build docs on host: `r doc`.

--- a/dev/spark-test-image-util/docs/run-in-container
+++ b/dev/spark-test-image-util/docs/run-in-container
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
### What changes were proposed in this pull request?

Give `run-in-container` a shebang and update its one invocation accordingly.

### Why are the changes needed?

It's not common (or IMO appropriate) for a shell script to have neither an extension nor a shebang. IDEs don't know how to highlight the code, and invoking the script becomes more complicated than necessary.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

TODO:
- [ ] Local test run. (CI does not call these scripts.)

### Was this patch authored or co-authored using generative AI tooling?

No.