### PR TITLE
[SPARK-59063][SQL] Use a byte-length guard in LikeSimplification for 'prefix%suffix'

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -830,13 +830,30 @@ object LikeSimplification extends Rule[LogicalPlan] with PredicateHelper {
         case endsWith(postfix) =>
           Some(EndsWith(input, Literal.create(postfix, input.dataType)))
         // 'a%a' pattern is basically same with 'a%' && '%a'.
-        // However, the additional `Length` condition is required to prevent 'a' match 'a%a'.
+        // However, the additional length condition is required to prevent 'a' match 'a%a'.
         case startsAndEndsWith(prefix, postfix) =>
-          Some(And(GreaterThanOrEqual(Length(input),
-            Literal.create(prefix.codePointCount(0, prefix.length)
-              + postfix.codePointCount(0, postfix.length))),
-          And(StartsWith(input, Literal.create(prefix, input.dataType)),
-            EndsWith(input, Literal.create(postfix, input.dataType)))))
+          // The length guard only rejects inputs too short to hold both the prefix and the
+          // suffix. When the collation matches raw bytes (supportsBinaryEquality),
+          // StartsWith/EndsWith pin the literal bytes of the prefix and suffix, so a
+          // byte-length guard (OctetLength, O(1) via the stored numBytes) accepts exactly the
+          // same inputs as the code-point guard and is cheaper. Otherwise the anchors are
+          // collation-aware (LIKE reaches this only for UTF8_LCASE) and can match a code point
+          // whose UTF-8 length differs from the pattern's -- a single multibyte code point
+          // could then satisfy both anchors and clear the byte guard -- so the code-point
+          // (Length) guard must be kept for correctness.
+          val lengthGuard = input.dataType match {
+            case st: StringType if st.supportsBinaryEquality =>
+              GreaterThanOrEqual(OctetLength(input),
+                Literal.create(UTF8String.fromString(prefix).numBytes
+                  + UTF8String.fromString(postfix).numBytes))
+            case _ =>
+              GreaterThanOrEqual(Length(input),
+                Literal.create(prefix.codePointCount(0, prefix.length)
+                  + postfix.codePointCount(0, postfix.length)))
+          }
+          Some(And(lengthGuard,
+            And(StartsWith(input, Literal.create(prefix, input.dataType)),
+              EndsWith(input, Literal.create(postfix, input.dataType)))))
         case contains(infix) =>
           Some(Contains(input, Literal.create(infix, input.dataType)))
         case equalTo(str) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
@@ -24,6 +25,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.types.{BooleanType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
 
 class LikeSimplificationSuite extends PlanTest {
 
@@ -69,7 +71,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .where(($"a" like "abc\\%def") ||
-        (Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))))
+        (OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))))
       .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -142,7 +144,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized3 = Optimize.execute(originalQuery3.analyze)
     val correctAnswer3 = testRelation
       .where(($"a" like ("@bc%def", '@')) ||
-        (Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))))
+        (OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))))
       .analyze
     comparePlans(optimized3, correctAnswer3)
 
@@ -190,7 +192,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized3 = Optimize.execute(originalQuery3.analyze)
     val correctAnswer3 = testRelation
       .where(
-        (Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))))
+        (OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))))
       .analyze
     comparePlans(optimized3, correctAnswer3)
 
@@ -222,7 +224,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .where((((((StartsWith($"a", "abc") && EndsWith($"a", "xyz")) &&
-        (Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")))) &&
+        (OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")))) &&
         Contains($"a", "mn")) && ($"a" === "")) && ($"a" === "abc")) &&
         ($"a" likeAll("abc\\%", "abc\\%def", "%mn\\%")))
       .analyze
@@ -239,7 +241,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .where((((((Not(StartsWith($"a", "abc")) && Not(EndsWith($"a", "xyz"))) &&
-        Not(Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")))) &&
+        Not(OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")))) &&
         Not(Contains($"a", "mn"))) && Not($"a" === "")) && Not($"a" === "abc")) &&
         ($"a" notLikeAll("abc\\%", "abc\\%def", "%mn\\%")))
       .analyze
@@ -256,7 +258,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .where(((StartsWith($"a", "abc") || EndsWith($"a", "xyz")) ||
-        (Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")) ||
+        (OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")) ||
           Contains($"a", "mn")) || (($"a" === "") || ($"a" === "abc")) ||
         ($"a" likeAny("abc\\%", "abc\\%def", "%mn\\%"))))
       .analyze
@@ -273,7 +275,7 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .where((((Not(StartsWith($"a", "abc")) || Not(EndsWith($"a", "xyz"))) ||
-        (Not(Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))) ||
+        (Not(OctetLength($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def"))) ||
           Not(Contains($"a", "mn")))) || (Not($"a" === "") || Not($"a" === "abc"))) ||
         ($"a" notLikeAny("abc\\%", "abc\\%def", "%mn\\%")))
       .analyze
@@ -311,6 +313,63 @@ class LikeSimplificationSuite extends PlanTest {
   }
 
   // scalastyle:off nonascii
+  test("SPARK-59063: LikeSimplification preserves LIKE semantics under non-binary collation") {
+    // Under UTF8_LCASE, StartsWith/EndsWith are collation-aware, so a single code point
+    // whose case-folded form equals the anchor satisfies BOTH StartsWith(prefix) and
+    // EndsWith(suffix). The Kelvin sign (U+212A) is one code point of three UTF-8 bytes
+    // that folds to 'k'. LIKE 'k%k' is false for it -- the pattern requires two 'k's --
+    // so the rewrite's length guard must reject it. A byte-length guard (OctetLength >=
+    // numBytes("k") + numBytes("k") = 2) is satisfied by the 3-byte Kelvin sign and would
+    // wrongly accept it; the code-point guard kept for non-binary collations rejects it.
+    val lcase = StringType("UTF8_LCASE")
+    val relation = LocalRelation(AttributeReference("a", lcase)())
+    val attr = relation.output.head
+    val like = Like(attr, Literal.create("k%k", lcase), '\\')
+
+    val optimized = Optimize.execute(relation.where(like).analyze)
+    val simplified = optimized.asInstanceOf[Filter].condition
+
+    // A single Kelvin sign: one code point, three UTF-8 bytes.
+    val row = InternalRow(UTF8String.fromString("\u212a"))
+    val likeResult = BindReferences.bindReference(like, relation.output).eval(row)
+    val simplifiedResult = BindReferences.bindReference(simplified, relation.output).eval(row)
+
+    assert(likeResult === false,
+      "LIKE 'k%k' should not match a single Kelvin sign under UTF8_LCASE")
+    // The rewrite must be behavior-preserving: it must reject the single Kelvin sign too.
+    assert(simplifiedResult === likeResult,
+      s"LikeSimplification changed the LIKE 'k%k' result under UTF8_LCASE: expected " +
+        s"$likeResult but the rewritten predicate returned $simplifiedResult")
+  }
+
+  test("SPARK-59063: LikeSimplification preserves LIKE semantics for multibyte UTF8_BINARY") {
+    // The byte-length guard exists to reject inputs too short to hold both the prefix and
+    // the suffix (a single code point must not match 'x%x'). Confirm the rewrite evaluates
+    // exactly like LIKE for a multibyte UTF8_BINARY pattern: the a-umlaut U+00E4 is one code
+    // point of two UTF-8 bytes, so 'a-umlaut % a-umlaut' rewrites to OctetLength >= 4 guarded
+    // by StartsWith/EndsWith.
+    val relation = LocalRelation($"a".string) // default StringType is UTF8_BINARY
+    val attr = relation.output.head
+    val like = Like(attr, Literal.create("\u00e4%\u00e4", StringType), '\\')
+
+    val optimized = Optimize.execute(relation.where(like).analyze)
+    val simplified = optimized.asInstanceOf[Filter].condition
+    val boundLike = BindReferences.bindReference(like, relation.output)
+    val boundSimplified = BindReferences.bindReference(simplified, relation.output)
+
+    // A single a-umlaut: one code point, two UTF-8 bytes -- too short to match the pattern.
+    val single = InternalRow(UTF8String.fromString("\u00e4"))
+    assert(boundLike.eval(single) === false)
+    assert(boundSimplified.eval(single) === boundLike.eval(single),
+      "the rewrite must reject a single a-umlaut, matching LIKE")
+
+    // Two a-umlauts: two code points, four UTF-8 bytes -- long enough to match.
+    val pair = InternalRow(UTF8String.fromString("\u00e4\u00e4"))
+    assert(boundLike.eval(pair) === true)
+    assert(boundSimplified.eval(pair) === boundLike.eval(pair),
+      "the rewrite must accept two a-umlauts, matching LIKE")
+  }
+
   test("LikeSimplification with emojis") {
     val originalQuery =
       testRelation
@@ -319,7 +378,10 @@ class LikeSimplificationSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-      .where(Length($"a") >= 2 && (StartsWith($"a", "😀") && EndsWith($"a", "🥑")))
+      // Byte-length guard: '😀' and '🥑' are 4 UTF-8 bytes each, so the threshold is 8
+      // bytes rather than 2 code points. This is equivalent to the char-length guard
+      // because StartsWith/EndsWith already pin the prefix and suffix at byte boundaries.
+      .where(OctetLength($"a") >= 8 && (StartsWith($"a", "😀") && EndsWith($"a", "🥑")))
       .analyze
     comparePlans(optimized, correctAnswer)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`LikeSimplification` rewrites `col LIKE 'prefix%suffix'` into a length guard plus
`StartsWith`/`EndsWith`:

```
Length(col) >= numChars(prefix) + numChars(suffix)
  && StartsWith(col, prefix) && EndsWith(col, suffix)
```

The guard exists only to reject strings too short to hold both the prefix and the suffix
(e.g. `'a'` must not match `'a%a'`). `Length` is `numChars`, an O(N) code-point scan of the
input string.

This PR replaces that guard with `OctetLength` (the stored `numBytes`, O(1)) **only when the
input collation matches raw bytes** (`StringType.supportsBinaryEquality`, i.e. `UTF8_BINARY`):

```
OctetLength(col) >= numBytes(prefix) + numBytes(suffix)
  && StartsWith(col, prefix) && EndsWith(col, suffix)
```

For any other collation the original code-point `Length` guard is kept. `LIKE` accepts only the
collations in `StringTypeBinaryLcase` (which excludes trim/ICU collations), so the only
non-binary case that reaches this rule is `UTF8_LCASE`, and that is where the `Length` guard is
retained.

### Why are the changes needed?

The character-length guard runs per row in the residual filter and performs an O(N) code-point
count, whereas the byte length is already stored on `UTF8String` and is O(1).

Under `UTF8_BINARY`, `StartsWith`/`EndsWith` match the literal bytes of the prefix and suffix, so
the byte-length floor accepts exactly the same strings as the code-point floor. For a string that
already passes both anchors:

```
numBytes(s) >= numBytes(prefix) + numBytes(suffix)
  <=>  numChars(s) >= numChars(prefix) + numChars(suffix)
```

This equivalence does **not** hold under a collation-aware collation, because the anchors can
match a code point whose UTF-8 byte length differs from the pattern's. For example, under
`UTF8_LCASE` the Kelvin sign `U+212A` is a single 3-byte code point that case-folds to `k`, so it
satisfies both `StartsWith('k')` and `EndsWith('k')` and clears `OctetLength >= 2`, yet
`LIKE 'k%k'` must be `false` (the pattern needs two `k`s). Gating the byte-length guard on
`supportsBinaryEquality` keeps the O(1) optimization where it is valid and preserves correctness
elsewhere. Thanks to @uros-b for catching this.

### Does this PR introduce _any_ user-facing change?

No. The rewrite accepts the same rows as before; only the internal guard expression changes, and
only for `UTF8_BINARY` (`length` -> `octet_length`).

### How was this patch tested?

`LikeSimplificationSuite` (20/20 passing). Alongside the existing plan-shape tests, two new tests
evaluate the rewritten predicate against `LIKE` to confirm the rewrite is behavior-preserving at
runtime:

- **multibyte `UTF8_BINARY`** -- pattern `'ä%ä'` (a-umlaut, 2 bytes each): correctly rejects a
  single `ä` (too short) and accepts `ää`.
- **`UTF8_LCASE`** -- pattern `'k%k'`: correctly rejects a single Kelvin sign `U+212A` (matching
  `LIKE`), which the byte-length guard would have wrongly accepted.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
