### PR TITLE
[SPARK-59066][CORE] Fix History Server Event Log `Download` button to use a Bootstrap 5 class

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -223,7 +223,8 @@ $(document).ready(function() {
           {
             name: 'eventLog',
             data: 'log',
-            render: (log, _ignored_type, _ignored_row) => `<a href="${log}" class="btn btn-info btn-mini">Download</a>`
+            render: (log, _ignored_type, _ignored_row) =>
+              `<a href="${log}" class="btn btn-sm btn-outline-secondary">Download</a>`
           },
         ],
         "aoColumnDefs": [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the Bootstrap 2 class `btn-mini` with the Bootstrap 5 equivalent in the History Server application list's `Event Log` column:

```js
// before
`<a href="${log}" class="btn btn-info btn-mini">Download</a>`
// after
`<a href="${log}" class="btn btn-sm btn-outline-secondary">Download</a>`
```

### Why are the changes needed?

At Spark 3.1.0, SPARK-30654 upgraded to Bootstrap v4.4.1 from Bootstrap v2.3.2.
- #27370

`btn-mini` is a Bootstrap 2 class and does not exist in the bundled Bootstrap 5.3.8:

```
$ grep -c "btn-mini" core/src/main/resources/org/apache/spark/ui/static/bootstrap.min.css
0
```

As a result, the class is silently ignored and the `Download` control renders as a
full-size solid blue button instead of the intended compact one, making the row
taller than necessary and visually dominating the application list.

`btn btn-sm btn-outline-secondary` is already the convention used elsewhere in the
Spark Web UI, for example in `executorspage.js` and `PagedTable.scala`.

### Does this PR introduce _any_ user-facing change?

No behavior change. Only on the History Server page, the `Event Log` column's `Download` button is now
rendered as a compact outline button instead of a full-size solid blue button.
The link target and behavior are unchanged.

**BEFORE (Apache Spark 4.2.0)**

<img width="131" height="87" alt="Screenshot 2026-08-27 at 17 44 04" src="https://github.com/user-attachments/assets/ff7a0751-cb02-48e1-bda3-1959880904c6" />

<img width="119" height="87" alt="Screenshot 2026-08-27 at 17 46 10" src="https://github.com/user-attachments/assets/b29eee59-1da9-4f43-9cab-0eb4e59d663d" />

**AFTER (This PR)**

<img width="112" height="84" alt="Screenshot 2026-08-27 at 17 47 49" src="https://github.com/user-attachments/assets/60303bef-31e8-4edd-be36-397aab21959e" />

<img width="113" height="83" alt="Screenshot 2026-08-27 at 17 50 33" src="https://github.com/user-attachments/assets/704a2f49-2366-414a-ac20-f7cc6280876e" />

<img width="114" height="82" alt="Screenshot 2026-08-27 at 17 47 56" src="https://github.com/user-attachments/assets/d0ef891f-7e6f-48d5-8d72-6956b938490a" />

<img width="117" height="80" alt="Screenshot 2026-08-27 at 17 50 21" src="https://github.com/user-attachments/assets/f492758d-c3ce-4b00-a459-4ee163515b8c" />

### How was this patch tested?

Pass the CIs with `dev/lint-js`.

Manually verified the rendering of the `Event Log` column in both light and dark
themes (`data-bs-theme` on the `html` element).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5