### PR TITLE
[SPARK-59067][CORE] Fix `Download` to be a button aligned with the other buttons

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -93,18 +93,18 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             }
           }
           <div id="plan-viz-download-btn-container">
-            <select id="plan-viz-format-select">
+            <select id="plan-viz-format-select" aria-label="Plan visualization download format">
               <option value="svg">SVG</option>
               <option value="dot">DOT</option>
               <option value="txt">TXT</option>
             </select>
-            <label for="plan-viz-format-select">
-              <a id="plan-viz-download-btn" class="downloadbutton">Download</a>
-            </label>
+            <button id="plan-viz-download-btn" class="btn btn-sm btn-outline-secondary ms-2"
+                    type="button" title="Download plan visualization">
+              &#x2b07;&#xfe0f; Download</button>
             <button id="copy-plan-btn" class="btn btn-sm btn-outline-secondary ms-2"
                     type="button" title="Copy physical plan to clipboard">
               &#x1f4cb; Copy Plan</button>
-            <button id="copy-link-btn" class="btn btn-sm btn-outline-secondary ms-1"
+            <button id="copy-link-btn" class="btn btn-sm btn-outline-secondary ms-2"
                     type="button" title="Copy shareable link to this execution">
               &#x1f517; Copy Link</button>
           </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the `Download` control of the SQL execution page a real button, aligned with the neighboring `Copy Plan` and `Copy Link` buttons.

- Replace the `<label>`-wrapped `<a class="downloadbutton">` with a `<button>` using the same classes as the other buttons, and add a download icon and a `title` tooltip.
- Change `Copy Link` from `ms-1` to `ms-2` so that all three buttons are evenly spaced.
- Add an `aria-label` to the format `<select>`, which lost its accessible name with the removed `<label>`.

### Why are the changes needed?

`Download` was a plain text link next to two Bootstrap buttons, so it was shorter than them, and `margin-right: 10px` from `a.downloadbutton` made the gaps between the three controls uneven after Apache Spark 4.2.0 added the other buttons.

- https://github.com/apache/spark/pull/54886

**BEFORE (Apache Spark 4.2.0)**

<img width="425" height="268" alt="Screenshot 2026-08-27 at 18 26 46" src="https://github.com/user-attachments/assets/1d6f4c23-ca43-46d5-8e77-4181f2c4185a" />

**AFTER**

<img width="452" height="269" alt="Screenshot 2026-08-27 at 18 25 38" src="https://github.com/user-attachments/assets/798cabcd-6ef0-49f4-a4ae-b5d6f14ca3ca" />

### Does this PR introduce _any_ user-facing change?

Yes, but it is a UI-only change in the unreleased master branch. `Download` is now a button with an icon, and its functionality is unchanged.

### How was this patch tested?

Manually checked the SQL execution page in a browser. No test was added because this only changes the Web UI markup.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5