### PR TITLE
[SPARK-59047][ML] Avoid retaining random forest tree weights

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -250,11 +250,8 @@ class RandomForestClassificationModel private[ml] (
   @Since("1.4.0")
   override def trees: Array[DecisionTreeClassificationModel] = _trees
 
-  // Note: We may add support for weights (based on tree performance) later on.
-  private lazy val _treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
-
   @Since("1.4.0")
-  override def treeWeights: Array[Double] = _treeWeights
+  override def treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
 
   /**
    * Gets summary of model on training set. An exception is thrown

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -220,11 +220,8 @@ class RandomForestRegressionModel private[ml] (
   @Since("1.4.0")
   override def trees: Array[DecisionTreeRegressionModel] = _trees
 
-  // Note: We may add support for weights (based on tree performance) later on.
-  private lazy val _treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
-
   @Since("1.4.0")
-  override def treeWeights: Array[Double] = _treeWeights
+  override def treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
 
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -527,10 +527,11 @@ private[ml] object EnsembleModelReadWrite {
       sparkSession: SparkSession,
       extraMetadata: JObject): Unit = {
     DefaultParamsWriter.saveMetadata(instance, path, sparkSession, Some(extraMetadata))
+    val treeWeights = instance.treeWeights
     val treesMetadataWeights = instance.trees.zipWithIndex.map { case (tree, treeID) =>
       (treeID,
         DefaultParamsWriter.getMetadataToSave(tree.asInstanceOf[Params], sparkSession),
-        instance.treeWeights(treeID))
+        treeWeights(treeID))
     }
     val treesMetadataPath = new Path(path, "treesMetadata").toString
     ReadWriteUtils.saveArray[(Int, String, Double)](


### PR DESCRIPTION
### What changes were proposed in this pull request?

Generate unit tree weights on demand for random forest classification and regression models instead
of retaining a lazily initialized array. Cache the generated weights locally while saving an
ensemble model to avoid repeated allocation in the per-tree loop.

This also removes the stale comments about possibly supporting weighted random forests later.

### Why are the changes needed?

Random forest tree weights are rarely accessed and are not used during prediction. Generating the
unit weights when requested avoids retaining an otherwise unused array for the lifetime of the
model.

### Does this PR introduce _any_ user-facing change?

No. Random forest tree weights continue to contain one unit weight for every tree.

### How was this patch tested?

The existing classification and regression model persistence tests were run:

```
build/sbt 'mllib/testOnly *RandomForestClassifierSuite -- -z "read/write"'
build/sbt 'mllib/testOnly *RandomForestRegressorSuite -- -z "read/write"'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
