### PR TITLE
[SPARK-59070][PYTHON][ML] Guard TorchDistributor log socket getpeername() against OSError

### DIFF
--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -485,14 +485,21 @@ class TorchDistributor(Distributor):
                 decoded = line.decode("utf-8")
                 tail.append(decoded)
                 if redirect_to_stdout:
-                    if (
-                        log_streaming_client
-                        and not log_streaming_client.failed
-                        and (
-                            log_streaming_client.sock.getsockname()[0]
-                            == log_streaming_client.sock.getpeername()[0]
-                        )
-                    ):
+                    same_node = False
+                    if log_streaming_client and not log_streaming_client.failed:
+                        try:
+                            same_node = (
+                                log_streaming_client.sock.getsockname()[0]
+                                == log_streaming_client.sock.getpeername()[0]
+                            )
+                        except OSError:
+                            # The log-streaming socket is best effort and can be
+                            # dropped (e.g. a cloud-provider idle-timeout) while
+                            # torch/NCCL initializes. getpeername() then raises
+                            # OSError; a barrier task must not die over log
+                            # redirection, so fall back to writing to stdout.
+                            same_node = False
+                    if same_node:
                         # If log_streaming_client and log_stream_server are in the same
                         # node (typical case is spark local mode),
                         # server side will redirect the log to STDOUT,

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -27,7 +27,7 @@ import time
 import unittest
 from io import StringIO
 from typing import Any, Callable, Dict
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pyspark import SparkConf, SparkContext
 from pyspark.ml.torch.distributor import TorchDistributor, _get_gpus_owned
@@ -256,6 +256,24 @@ class TorchDistributorBaselineUnitTestsMixin:
         with self.assertRaisesRegex(RuntimeError, "abcdef"):
             error_command = ["bash", "-c", "'abc''def'"]
             TorchDistributor._execute_command(error_command)
+
+    def test_execute_command_survives_log_socket_drop(self) -> None:
+        """A dropped log-streaming socket must not kill the task.
+
+        The socket is best effort and can be closed (e.g. a cloud-provider
+        idle-timeout) mid-run, making getpeername() raise OSError. The command
+        must still complete and its logs fall back to stdout.
+        """
+        client = MagicMock()
+        client.failed = False
+        client.sock.getsockname.return_value = ("10.0.0.1", 12345)
+        client.sock.getpeername.side_effect = OSError(107, "Transport endpoint is not connected")
+
+        with patch_stdout() as output:
+            TorchDistributor._execute_command(
+                ["echo", "hello_after_socket_drop"], log_streaming_client=client
+            )
+        self.assertIn("hello_after_socket_drop", output.getvalue().strip())
 
     def test_create_torchrun_command(self) -> None:
         train_path = "train.py"


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `TorchDistributor._execute_command`, the loop that streams subprocess output compares `log_streaming_client.sock.getsockname()[0]` with `log_streaming_client.sock.getpeername()[0]` to decide whether to echo each log line to stdout (avoiding duplication when client and server run on the same node). This comparison is now wrapped in a `try/except OSError` block. If the socket call raises, `same_node` falls back to `False`, and the line is written to stdout.

### Why are the changes needed?

The log-streaming socket is best effort and can be dropped by a cloud-provider idle-timeout while torch/NCCL initializes (roughly 24 seconds of silence). The next log line then calls `getpeername()` on the dead socket, raising `OSError: [Errno 107] Transport endpoint is not connected`. Because `_execute_command` runs inside a barrier task, this uncaught error aborts the entire multi-node training job approximately 30 seconds in.

`LogStreamingClient.send()` in `log_communication.py` already guards against this case (try/except → mark client failed); the getsockname/getpeername comparison was the only remaining unguarded call site.

Reproduced on Databricks Runtime 17.3.19 ML GPU against Apache Spark 4.0.

### Does this PR introduce _any_ user-facing change?

No API change. Multi-node `TorchDistributor` training that previously crashed with `OSError: [Errno 107] Transport endpoint is not connected` ~30 s into a run will now degrade the best-effort log socket gracefully and continue training.

### How was this patch tested?

Added `TorchDistributorBaselineUnitTests.test_execute_command_survives_log_socket_drop` in `python/pyspark/ml/torch/tests/test_distributor.py`. The test configures a mock `LogStreamingClient` whose `getpeername()` raises `OSError(107, ...)`, then asserts that `_execute_command` still completes and the output line reaches stdout.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (claude-sonnet-4-6)