### PR TITLE
[SPARK-59069][PYTHON] Transpile Python UDFs with explicit positional-only parameters

### DIFF
--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -891,6 +891,56 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             "both parameters are supplied at the call site, so both get placeholders",
         )
 
+    def test_udf_transpile_positional_only_params(self):
+        from pyspark.errors import PythonException
+
+        def subtract(a: int, /, b: int):
+            return a - b
+
+        def repeat(value: str, /, count: int):
+            return value * count
+
+        def with_default(value=1, /):
+            return value + 1
+
+        positional_lambda = lambda a, b, /: a - b  # noqa: E731
+
+        with self.sql_conf(_TRANSPILE_ON):
+            subtract_udf = self._transpiled_udf(subtract, LongType())
+            self.assertEqual(subtract_udf._transpiled_param_names, ["a", "b"])
+            self.assertEqual(subtract_udf._transpiled_positional_only_names, {"a"})
+
+            numbers = self.spark.createDataFrame([(5, 3)], "a long, b long")
+            mixed_call = numbers.select(subtract_udf("a", b="b"))
+            self.assertEqual(mixed_call.first()[0], 2)
+            self.assertEqual(self._eval_python_count(mixed_call), 0)
+
+            with self.assertRaises(PythonException) as ctx:
+                numbers.select(subtract_udf(a="a", b="b")).collect()
+            self.assertIn("positional-only", str(ctx.exception))
+
+            repeat_udf = self._transpiled_udf(repeat, StringType())
+            self.assertTrue(
+                all(
+                    categories == ["string", "numeric"]
+                    for categories in repeat_udf._transpiled_input_categories
+                )
+            )
+            repeated = self.spark.createDataFrame([("ab", 3)], "value string, count long").select(
+                repeat_udf("value", "count")
+            )
+            self.assertEqual(repeated.first()[0], "ababab")
+            self.assertEqual(self._eval_python_count(repeated), 0)
+
+            self.assertEqual(
+                self._vals(positional_lambda, LongType(), "a long, b long", [(7, 2)]),
+                [5],
+            )
+
+            default_udf, reasons = self._udf_and_warnings(with_default, LongType())
+            self.assertEqual(default_udf.transpiled, [])
+            self.assertIn("default", reasons)
+
     def test_udf_transpile_falls_back_for_wraps_decorated_function(self):
         # inspect.getsource follows __wrapped__, so a functools.wraps-decorated
         # UDF previously transpiled the WRAPPED function's source while the

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -51,7 +51,7 @@ import sys
 import textwrap
 import threading
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple, Union
 
 from pyspark.errors import UnsupportedOperationException
 from pyspark.sql.column import Column
@@ -839,6 +839,11 @@ def _annotation_category(annotation: Optional[ast.AST]) -> Optional[str]:
     return None
 
 
+def _positional_args(node: Union[ast.FunctionDef, ast.Lambda]) -> List[ast.arg]:
+    """Return positional-only and positional-or-keyword arguments in call order."""
+    return [*node.args.posonlyargs, *node.args.args]
+
+
 def _param_category_combos(function_ast: ast.FunctionDef, public_params: List[str]) -> List[dict]:
     """Per-variant maps ``{public_param_index -> category}`` where category is
     one of ``"numeric"``/``"string"``/``"bool"``/``"binary"``.
@@ -850,7 +855,8 @@ def _param_category_combos(function_ast: ast.FunctionDef, public_params: List[st
     matrix small) while keeping every typed param pinned.
     """
     n = len(public_params)
-    public_args = function_ast.args.args[len(function_ast.args.args) - n :]
+    positional_args = _positional_args(function_ast)
+    public_args = positional_args[-n:] if n else []
     candidates: List[List[str]] = []
     untyped = 0
     for arg in public_args:
@@ -984,7 +990,7 @@ def _get_src_ast_from_func(func: Callable) -> Tuple[Optional[str], Optional[ast.
 
 def _get_parameter_list(node: ast.FunctionDef) -> list[str]:
     """Return the positional argument names in order."""
-    return [arg.arg for arg in node.args.args]
+    return [arg.arg for arg in _positional_args(node)]
 
 
 def _get_function_from_ast(body: ast.AST, held_code: Any) -> Tuple[Optional[ast.FunctionDef], str]:
@@ -1040,7 +1046,7 @@ def _get_function_from_ast(body: ast.AST, held_code: Any) -> Tuple[Optional[ast.
         # be the UDF) from one that RETURNED the lambda we hold, as in the one-line
         # ``make_adder = lambda n: lambda x: x + n`` -- there the outer lambda is
         # located and the inner is held, and lowering the outer would be wrong.
-        located_args = [arg.arg for arg in stmt.args.args]
+        located_args = [arg.arg for arg in _positional_args(stmt)]
         if located_args != list(held_code.co_varnames[: held_code.co_argcount]):
             return None, (
                 "the lambda defined in the source read for this one takes different "
@@ -1084,7 +1090,7 @@ def _transpile_func(
     session: "SparkSession",
     func: Callable[..., Any],
     returnType: "DataTypeOrString",
-) -> Tuple[List[Column], List[str], List[str], List[List[str]]]:
+) -> Tuple[List[Column], List[str], List[str], List[str], List[List[str]]]:
     """
     An experimental internal function that attempts to transpile a callable function.
 
@@ -1096,6 +1102,8 @@ def _transpile_func(
     method or callable instance) -- needed so the caller can resolve named-argument
     invocations to positional order at call time, since the ``_udf_param_N``
     substitution in :class:`UserDefinedPythonFunction` is positional.
+    list of caller-facing positional-only parameter names -- named invocations of these
+    parameters must stay unresolved so the interpreted path raises Python's ``TypeError``.
     list of per-option input-type categories (``"numeric"`` / ``"string"`` per
     public param) -- the JVM picks the option whose categories match the bound
     column types, or falls back to the Python UDF when none match.
@@ -1126,6 +1134,7 @@ def _transpile_func(
                 ],
                 [],
                 [],
+                [],
             )
         # A functools.wraps-style decorator makes ``inspect.getsource`` return
         # the WRAPPED function's source (getsource follows ``__wrapped__``),
@@ -1147,22 +1156,21 @@ def _transpile_func(
                 ],
                 [],
                 [],
+                [],
             )
         # Not ``ast``: that name would shadow the module for this whole function.
         src, ast_info = _get_src_ast_from_func(func)
         if ast_info is None:
-            return ([], ["Error getting ast for function, cannot transpile"], [], [])
+            return ([], ["Error getting ast for function, cannot transpile"], [], [], [])
         # Get the lambda body and parameters
         function_ast, extraction_error = _get_function_from_ast(ast_info, _held_code(func))
         if function_ast is None:
-            return ([], [extraction_error], [], [])
-        # Default, variadic (``*args`` / ``**kwargs``), keyword-only, and
-        # positional-only parameters can't be represented by the positional
-        # ``_udf_param_N`` placeholder scheme: a call site may omit a
-        # defaulted argument, leaving the placeholder referencing a position
-        # the call never bound, and ``_get_parameter_list`` only reads
-        # ``args``. Fall back to interpreted Python rather than emit an
-        # invalid plan.
+            return ([], [extraction_error], [], [], [])
+        # Default, variadic (``*args`` / ``**kwargs``), and keyword-only parameters
+        # can't be represented by the positional ``_udf_param_N`` placeholder scheme:
+        # a call site may omit a defaulted argument, leaving the placeholder referencing
+        # a position the call never bound. Fall back to interpreted Python rather than
+        # emit an invalid plan.
         fn_args = function_ast.args
         if (
             fn_args.defaults
@@ -1170,14 +1178,14 @@ def _transpile_func(
             or fn_args.kwonlyargs
             or fn_args.vararg is not None
             or fn_args.kwarg is not None
-            or fn_args.posonlyargs
         ):
             return (
                 [],
                 [
-                    "functions with default, variadic, keyword-only, or "
-                    "positional-only arguments are not supported by the transpiler"
+                    "functions with default, variadic, or keyword-only arguments "
+                    "are not supported by the transpiler"
                 ],
+                [],
                 [],
                 [],
             )
@@ -1217,6 +1225,7 @@ def _transpile_func(
                     ],
                     [],
                     [],
+                    [],
                 )
             spoken_for = int(
                 inspect.isfunction(call_entry) or isinstance(call_entry, classmethod)
@@ -1226,11 +1235,21 @@ def _transpile_func(
             # prepends the class ON TOP of the method's own ``__self__`` -- or one with
             # no parameter to hold it. Python raises for whatever the call site passes,
             # so there is nothing correct to lower.
-            return ([], ["callable leaves no parameter for the call site to bind"], [], [])
+            return (
+                [],
+                ["callable leaves no parameter for the call site to bind"],
+                [],
+                [],
+                [],
+            )
         # Caller-facing params: callers match user-supplied kwargs against this,
         # and the receiver is not named at the call site. Everything downstream
         # indexes off THIS list, so the placeholder numbering needs no offset.
         public_params = params[spoken_for:]
+        positional_only_names = {arg.arg for arg in fn_args.posonlyargs}
+        public_positional_only_params = [
+            name for name in public_params if name in positional_only_names
+        ]
         transpiled: list[Column] = []
         input_categories: list[list[str]] = []
         errors = []
@@ -1253,9 +1272,15 @@ def _transpile_func(
                         )
                 except Exception as e:
                     errors.append(str(e))
-        return (transpiled, errors, public_params, input_categories)
+        return (
+            transpiled,
+            errors,
+            public_params,
+            public_positional_only_params,
+            input_categories,
+        )
     except Exception as e:
         # Don't re-raise: an inability to transpile must never break a
         # working UDF. The caller treats an empty ``transpiled`` list as a
         # silent fall-back to interpreted Python.
-        return ([], [str(e)], [], [])
+        return ([], [str(e)], [], [], [])

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -222,6 +222,7 @@ class UserDefinedFunction:
         # Extract Python UDF details if transpilation is enabled.
         self.transpiled: list = []
         self._transpiled_param_names: list[str] = []
+        # A keyword call naming one of these must retain interpreted Python semantics.
         self._transpiled_positional_only_names: set[str] = set()
         # Per-option input-type categories ("numeric"/"string" per public param),
         # parallel to ``self.transpiled``; the JVM picks the option matching the

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -222,6 +222,7 @@ class UserDefinedFunction:
         # Extract Python UDF details if transpilation is enabled.
         self.transpiled: list = []
         self._transpiled_param_names: list[str] = []
+        self._transpiled_positional_only_names: set[str] = set()
         # Per-option input-type categories ("numeric"/"string" per public param),
         # parallel to ``self.transpiled``; the JVM picks the option matching the
         # actual column types or falls back to interpreted Python.
@@ -295,8 +296,10 @@ class UserDefinedFunction:
                     self.transpiled,
                     errors,
                     self._transpiled_param_names,
+                    positional_only_names,
                     self._transpiled_input_categories,
                 ) = _transpile_func(session, func, self.returnType)
+                self._transpiled_positional_only_names = set(positional_only_names)
                 if not self.transpiled:
                     detail = f": {errors}" if errors else ""
                     warnings.warn(f"Unable to transpile UDF {func}{detail}")
@@ -310,6 +313,7 @@ class UserDefinedFunction:
             warnings.warn(f"Exception transpiling UDF {func}: {e}")
             self.transpiled = []
             self._transpiled_param_names = []
+            self._transpiled_positional_only_names = set()
             self._transpiled_input_categories = []
 
     @staticmethod
@@ -565,7 +569,12 @@ class UserDefinedFunction:
         # rejects named arguments). Resolve kwargs to positional here
         # using the parameter list captured at transpilation time so the
         # rewritten expression sees plain column refs in declared order.
-        if kwargs and self.transpiled and self._transpiled_param_names:
+        if (
+            kwargs
+            and self.transpiled
+            and self._transpiled_param_names
+            and self._transpiled_positional_only_names.isdisjoint(kwargs)
+        ):
             params = self._transpiled_param_names
             ordered: list = list(args)
             remaining_kwargs = dict(kwargs)
@@ -736,6 +745,7 @@ class UserDefinedFunction:
         # nondeterministic UDF always runs as interpreted Python.
         self.transpiled = []
         self._transpiled_param_names = []
+        self._transpiled_positional_only_names = set()
         self._transpiled_input_categories = []
         return self
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request allows the experimental Python UDF transpiler to handle functions and lambdas with explicit positional-only parameters.

The change:

* reads `posonlyargs` together with regular positional arguments when building parameter lists, type-category variants, and lambda source checks;
* records caller-facing positional-only names so an invalid keyword call remains on the interpreted Python path and raises Python's normal `TypeError`;
* continues to reject defaulted positional-only parameters, because omitted defaults cannot be represented by the positional placeholder scheme; and
* adds positive and negative regression coverage for functions, lambdas, annotations, mixed positional/keyword calls, and defaults.

### Why are the changes needed?

Explicit positional-only parameters without defaults are always supplied positionally and map directly to the transpiler's `_udf_param_N` placeholders. Rejecting every function that uses `/` unnecessarily prevents valid UDFs from being transpiled.

At the same time, calls that incorrectly pass a positional-only parameter by keyword must not be rewritten into a valid positional call. Leaving those calls unresolved preserves the same error behavior as interpreted Python.

### Does this PR introduce _any_ user-facing change?

Yes. With the experimental Python UDF transpiler enabled, UDFs and lambdas with required positional-only parameters can now be transpiled. Invalid keyword calls for those parameters continue to raise Python's positional-only argument error, and positional-only parameters with defaults continue to fall back to interpreted Python.

### How was this patch tested?

New unit coverage was added to `UDFTranspileUnitTests.test_udf_transpile_positional_only_params`.

The following commands passed locally:

```
build/sbt -Phive package
python/run-tests --testnames pyspark.sql.tests.test_udf_transpile_unit
dev/lint-python --ruff
dev/lint-python --compile --custom-pyspark-error
git diff --check
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
