### PR TITLE
[SPARK-49485][CORE] Request additional executor for speculative tasks when active executors equal maxNeeded

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -799,10 +799,9 @@ private[spark] class ExecutorAllocationManager(
     // Should be 0 when no stages are active.
     private val stageAttemptToNumRunningTask = new mutable.HashMap[StageAttempt, Int]
     private val stageAttemptToTaskIndices = new mutable.HashMap[StageAttempt, mutable.HashSet[Int]]
-    // Map from each stageAttempt to a set of running speculative task indexes
-    // TODO(SPARK-41192): We simply need an Int for this.
-    private val stageAttemptToSpeculativeTaskIndices =
-      new mutable.HashMap[StageAttempt, mutable.HashSet[Int]]()
+    // Map from each stageAttempt to a set of running speculative task attempt IDs
+    private val stageAttemptToSpeculativeTaskIds =
+      new mutable.HashMap[StageAttempt, mutable.HashSet[Long]]()
     // Map from each stageAttempt to a set of pending speculative task indexes
     private val stageAttemptToPendingSpeculativeTasks =
       new mutable.HashMap[StageAttempt, mutable.HashSet[Int]]
@@ -885,7 +884,7 @@ private[spark] class ExecutorAllocationManager(
         stageAttemptToNumTasks -= stageAttempt
         stageAttemptToPendingSpeculativeTasks -= stageAttempt
         stageAttemptToTaskIndices -= stageAttempt
-        stageAttemptToSpeculativeTaskIndices -= stageAttempt
+        stageAttemptToSpeculativeTaskIds -= stageAttempt
         stageAttemptToExecutorPlacementHints -= stageAttempt
         removeStageFromResourceProfileIfUnused(stageAttempt)
 
@@ -896,7 +895,7 @@ private[spark] class ExecutorAllocationManager(
         // This is needed in case the stage is aborted for any reason
         if (stageAttemptToNumTasks.isEmpty
           && stageAttemptToPendingSpeculativeTasks.isEmpty
-          && stageAttemptToSpeculativeTaskIndices.isEmpty) {
+          && stageAttemptToSpeculativeTaskIds.isEmpty) {
           allocationManager.onSchedulerQueueEmpty()
         }
       }
@@ -912,8 +911,8 @@ private[spark] class ExecutorAllocationManager(
           stageAttemptToNumRunningTask.getOrElse(stageAttempt, 0) + 1
         // If this is the last pending task, mark the scheduler queue as empty
         if (taskStart.taskInfo.speculative) {
-          stageAttemptToSpeculativeTaskIndices.getOrElseUpdate(stageAttempt,
-            new mutable.HashSet[Int]) += taskIndex
+          stageAttemptToSpeculativeTaskIds.getOrElseUpdate(stageAttempt,
+            new mutable.HashSet[Long]) += taskStart.taskInfo.taskId
           stageAttemptToPendingSpeculativeTasks
             .get(stageAttempt).foreach(_.remove(taskIndex))
         } else {
@@ -940,7 +939,7 @@ private[spark] class ExecutorAllocationManager(
           }
         }
         if (taskEnd.taskInfo.speculative) {
-          stageAttemptToSpeculativeTaskIndices.get(stageAttempt).foreach {_.remove{taskIndex}}
+          stageAttemptToSpeculativeTaskIds.get(stageAttempt).foreach(_.remove(taskEnd.taskInfo.taskId))
         }
 
         taskEnd.reason match {
@@ -1010,7 +1009,7 @@ private[spark] class ExecutorAllocationManager(
           !stageAttemptToNumTasks.contains(stageAttempt) &&
           !stageAttemptToPendingSpeculativeTasks.contains(stageAttempt) &&
           !stageAttemptToTaskIndices.contains(stageAttempt) &&
-          !stageAttemptToSpeculativeTaskIndices.contains(stageAttempt)
+          !stageAttemptToSpeculativeTaskIds.contains(stageAttempt)
       ) {
         val rpForStage = resourceProfileIdToStageAttempt.filter { case (k, v) =>
           v.contains(stageAttempt)
@@ -1071,7 +1070,7 @@ private[spark] class ExecutorAllocationManager(
     }
 
     private def getRunningSpeculativeTaskSum(attempt: StageAttempt): Int = {
-      stageAttemptToSpeculativeTaskIndices.get(attempt).map(_.size).getOrElse(0)
+      stageAttemptToSpeculativeTaskIds.get(attempt).map(_.size).getOrElse(0)
     }
 
     /**

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -939,7 +939,8 @@ private[spark] class ExecutorAllocationManager(
           }
         }
         if (taskEnd.taskInfo.speculative) {
-          stageAttemptToSpeculativeTaskIds.get(stageAttempt).foreach(_.remove(taskEnd.taskInfo.taskId))
+          stageAttemptToSpeculativeTaskIds.get(stageAttempt)
+            .foreach(_.remove(taskEnd.taskInfo.taskId))
         }
 
         taskEnd.reason match {

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -416,6 +416,8 @@ private[spark] class ExecutorAllocationManager(
   private[spark] def maxNumExecutorsNeededPerResourceProfile(rpId: Int): Int = {
     val pendingTask = listener.pendingTasksPerResourceProfile(rpId)
     val pendingSpeculative = listener.pendingSpeculativeTasksPerResourceProfile(rpId)
+    val runningSpeculative = listener.runningSpeculativeTasksPerResourceProfile(rpId)
+    val speculativeTasks = pendingSpeculative + runningSpeculative
     val unschedulableTaskSets = listener.pendingUnschedulableTaskSetsPerResourceProfile(rpId)
     val running = listener.totalRunningTasksPerResourceProfile(rpId)
     val numRunningOrPendingTasks = pendingTask + pendingSpeculative + running
@@ -426,12 +428,15 @@ private[spark] class ExecutorAllocationManager(
     val maxNeeded = math.ceil(numRunningOrPendingTasks * executorAllocationRatio /
       tasksPerExecutor).toInt
 
+    val regularRunning = math.max(0, running - runningSpeculative)
+    val baseMaxNeededWithoutSpeculation = math.ceil((pendingTask + regularRunning) *
+      executorAllocationRatio / tasksPerExecutor).toInt
+
     val maxNeededWithSpeculationLocalityOffset =
-      if ((tasksPerExecutor > 1 && maxNeeded == 1 && pendingSpeculative > 0) ||
-          (pendingSpeculative > 0 &&
-           maxNeeded == executorMonitor.executorCountWithResourceProfile(rpId))) {
-        // If we have pending speculative tasks and maxNeeded equals the active executor count,
-        // allocate one more to satisfy the locality requirements of speculation.
+      if (tasksPerExecutor > 1 && speculativeTasks > 0 &&
+          maxNeeded == baseMaxNeededWithoutSpeculation) {
+        // Allocate an extra executor for speculative tasks (pending or running) when maxNeeded
+        // equals the base count needed for regular tasks, to satisfy speculation locality.
         maxNeeded + 1
       } else {
         maxNeeded
@@ -1049,6 +1054,11 @@ private[spark] class ExecutorAllocationManager(
       attempts.map(attempt => getPendingSpeculativeTaskSum(attempt)).sum
     }
 
+    def runningSpeculativeTasksPerResourceProfile(rp: Int): Int = {
+      val attempts = resourceProfileIdToStageAttempt.getOrElse(rp, Set.empty).toSeq
+      attempts.map(attempt => getRunningSpeculativeTaskSum(attempt)).sum
+    }
+
     def hasPendingSpeculativeTasks: Boolean = {
       val attemptSets = resourceProfileIdToStageAttempt.values
       attemptSets.exists { attempts =>
@@ -1058,6 +1068,10 @@ private[spark] class ExecutorAllocationManager(
 
     private def getPendingSpeculativeTaskSum(attempt: StageAttempt): Int = {
       stageAttemptToPendingSpeculativeTasks.get(attempt).map(_.size).getOrElse(0)
+    }
+
+    private def getRunningSpeculativeTaskSum(attempt: StageAttempt): Int = {
+      stageAttemptToSpeculativeTaskIndices.get(attempt).map(_.size).getOrElse(0)
     }
 
     /**

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -427,13 +427,15 @@ private[spark] class ExecutorAllocationManager(
       tasksPerExecutor).toInt
 
     val maxNeededWithSpeculationLocalityOffset =
-      if (tasksPerExecutor > 1 && maxNeeded == 1 && pendingSpeculative > 0) {
-      // If we have pending speculative tasks and only need a single executor, allocate one more
-      // to satisfy the locality requirements of speculation
-      maxNeeded + 1
-    } else {
-      maxNeeded
-    }
+      if ((tasksPerExecutor > 1 && maxNeeded == 1 && pendingSpeculative > 0) ||
+          (pendingSpeculative > 0 &&
+           maxNeeded == executorMonitor.executorCountWithResourceProfile(rpId))) {
+        // If we have pending speculative tasks and maxNeeded equals the active executor count,
+        // allocate one more to satisfy the locality requirements of speculation.
+        maxNeeded + 1
+      } else {
+        maxNeeded
+      }
 
     if (unschedulableTaskSets > 0) {
       // Request additional executors to account for task sets having tasks that are unschedulable

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -2062,8 +2062,29 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     manager.executorMonitor.executorsPendingToRemove()
   }
 
-  private def executorsDecommissioning(manager: ExecutorAllocationManager): Set[String] = {
-    manager.executorMonitor.executorsDecommissioning()
+  test("SPARK-49485: request additional executor when speculative tasks equal maxNeeded") {
+    val manager = createManager(createConf(1, 5, 2))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 0)
+
+    // Submit stage with 2 tasks
+    post(SparkListenerStageSubmitted(createStageInfo(0, 2)))
+    post(SparkListenerExecutorAdded(0, "executor-1", new ExecutorInfo("host1", 1, Map.empty)))
+    post(SparkListenerExecutorAdded(0, "executor-2", new ExecutorInfo("host1", 1, Map.empty)))
+
+    // Task 0 and Task 1 start on executor-1 and executor-2
+    val taskInfo0 = createTaskInfo(0, 0, "executor-1")
+    val taskInfo1 = createTaskInfo(1, 1, "executor-2")
+    post(SparkListenerTaskStart(0, 0, taskInfo0))
+    post(SparkListenerTaskStart(0, 0, taskInfo1))
+
+    // 2 tasks running, 2 active executors. maxNeeded = 2
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
+
+    // Task 0 is submitted as speculatable
+    post(SparkListenerSpeculativeTaskSubmitted(0, 0, 0))
+
+    // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2), offset allocates 1 more
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -2089,7 +2089,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
 
     // Task 0 is submitted as speculatable
     // 3 running + 0 pending + 1 speculative = 4 tasks -> ceil(4/2) = 2
-    post(SparkListenerSpeculativeTaskSubmitted(0, 0))
+    post(new SparkListenerSpeculativeTaskSubmitted(0, 0, 0, 0))
 
     // Speculative task submitted; offset allocates 1 more executor -> 3
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
@@ -2104,7 +2104,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
 
     // Speculative task 0 completes -> maxNeeded returns to 2
-    post(SparkListenerTaskEnd(0, 0, "task", Success, speculativeTaskInfo0, null))
+    post(SparkListenerTaskEnd(0, 0, "task", Success, speculativeTaskInfo0, null, null))
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
   }
 
@@ -2123,7 +2123,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     post(SparkListenerTaskStart(0, 0, taskInfo1))
     post(SparkListenerTaskStart(0, 0, taskInfo2))
 
-    post(SparkListenerSpeculativeTaskSubmitted(0, 0))
+    post(new SparkListenerSpeculativeTaskSubmitted(0, 0, 0, 0))
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
 
     post(SparkListenerExecutorAdded(0, "executor-3", new ExecutorInfo("host3", 2, Map.empty)))
@@ -2133,7 +2133,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
 
     // Primary task 0 completes, causing speculative task 0 to be killed
     val killReason = TaskKilled("primary task succeeded", Seq.empty, Seq.empty)
-    post(SparkListenerTaskEnd(0, 0, "task", killReason, speculativeTaskInfo0, null))
+    post(SparkListenerTaskEnd(0, 0, "task", killReason, speculativeTaskInfo0, null, null))
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
   }
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -2067,27 +2067,30 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
   }
 
   test("SPARK-49485: request additional executor when speculative tasks equal maxNeeded") {
-    val manager = createManager(createConf(1, 5, 2))
+    val conf = createConf(1, 5, 2).set(config.EXECUTOR_CORES, 2)
+    val manager = createManager(conf)
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 0)
 
-    // Submit stage with 2 tasks
-    post(SparkListenerStageSubmitted(createStageInfo(0, 2)))
-    post(SparkListenerExecutorAdded(0, "executor-1", new ExecutorInfo("host1", 1, Map.empty)))
-    post(SparkListenerExecutorAdded(0, "executor-2", new ExecutorInfo("host1", 1, Map.empty)))
+    // Submit stage with 4 tasks
+    post(SparkListenerStageSubmitted(createStageInfo(0, 4)))
+    post(SparkListenerExecutorAdded(0, "executor-1", new ExecutorInfo("host1", 2, Map.empty)))
+    post(SparkListenerExecutorAdded(0, "executor-2", new ExecutorInfo("host2", 2, Map.empty)))
 
-    // Task 0 and Task 1 start on executor-1 and executor-2
+    // 3 tasks running across 2 active 2-core executors
     val taskInfo0 = createTaskInfo(0, 0, "executor-1")
-    val taskInfo1 = createTaskInfo(1, 1, "executor-2")
+    val taskInfo1 = createTaskInfo(1, 1, "executor-1")
+    val taskInfo2 = createTaskInfo(2, 2, "executor-2")
     post(SparkListenerTaskStart(0, 0, taskInfo0))
     post(SparkListenerTaskStart(0, 0, taskInfo1))
+    post(SparkListenerTaskStart(0, 0, taskInfo2))
 
-    // 2 tasks running, 2 active executors. maxNeeded = 2
+    // 3 tasks running, 2 active 2-core executors. maxNeeded = ceil(3/2) = 2
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
 
-    // Task 0 is submitted as speculatable
+    // Task 0 is submitted as speculatable (3 running + 1 speculative = 4 tasks -> ceil(4/2) = 2)
     post(SparkListenerSpeculativeTaskSubmitted(0, 0))
 
-    // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2), offset allocates 1 more
+    // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2), offset allocates 1 more -> 3
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
   }
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -2091,9 +2091,50 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     // 3 running + 0 pending + 1 speculative = 4 tasks -> ceil(4/2) = 2
     post(SparkListenerSpeculativeTaskSubmitted(0, 0))
 
-    // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2),
-    // offset allocates 1 more -> 3
+    // Speculative task submitted; offset allocates 1 more executor -> 3
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
+
+    // Adding 3rd executor keeps maxNeeded at 3
+    post(SparkListenerExecutorAdded(0, "executor-3", new ExecutorInfo("host3", 2, Map.empty)))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
+
+    // Target remains 3 while speculative task is running
+    val speculativeTaskInfo0 = createTaskInfo(3, 0, "executor-3", speculative = true)
+    post(SparkListenerTaskStart(0, 0, speculativeTaskInfo0))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
+
+    // Speculative task 0 completes -> maxNeeded returns to 2
+    post(SparkListenerTaskEnd(0, 0, "task", Success, speculativeTaskInfo0, null))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
+  }
+
+  test("SPARK-49485: target returns to base when speculative task is killed") {
+    val conf = createConf(1, 5, 2).set(config.EXECUTOR_CORES, 2)
+    val manager = createManager(conf)
+
+    post(SparkListenerStageSubmitted(createStageInfo(0, 3)))
+    post(SparkListenerExecutorAdded(0, "executor-1", new ExecutorInfo("host1", 2, Map.empty)))
+    post(SparkListenerExecutorAdded(0, "executor-2", new ExecutorInfo("host2", 2, Map.empty)))
+
+    val taskInfo0 = createTaskInfo(0, 0, "executor-1")
+    val taskInfo1 = createTaskInfo(1, 1, "executor-1")
+    val taskInfo2 = createTaskInfo(2, 2, "executor-2")
+    post(SparkListenerTaskStart(0, 0, taskInfo0))
+    post(SparkListenerTaskStart(0, 0, taskInfo1))
+    post(SparkListenerTaskStart(0, 0, taskInfo2))
+
+    post(SparkListenerSpeculativeTaskSubmitted(0, 0))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
+
+    post(SparkListenerExecutorAdded(0, "executor-3", new ExecutorInfo("host3", 2, Map.empty)))
+    val speculativeTaskInfo0 = createTaskInfo(3, 0, "executor-3", speculative = true)
+    post(SparkListenerTaskStart(0, 0, speculativeTaskInfo0))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
+
+    // Primary task 0 completes, causing speculative task 0 to be killed
+    val killReason = TaskKilled("primary task succeeded", Seq.empty, Seq.empty)
+    post(SparkListenerTaskEnd(0, 0, "task", killReason, speculativeTaskInfo0, null))
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -2071,8 +2071,8 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     val manager = createManager(conf)
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 0)
 
-    // Submit stage with 4 tasks
-    post(SparkListenerStageSubmitted(createStageInfo(0, 4)))
+    // Submit stage with 3 tasks
+    post(SparkListenerStageSubmitted(createStageInfo(0, 3)))
     post(SparkListenerExecutorAdded(0, "executor-1", new ExecutorInfo("host1", 2, Map.empty)))
     post(SparkListenerExecutorAdded(0, "executor-2", new ExecutorInfo("host2", 2, Map.empty)))
 
@@ -2087,10 +2087,12 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     // 3 tasks running, 2 active 2-core executors. maxNeeded = ceil(3/2) = 2
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
 
-    // Task 0 is submitted as speculatable (3 running + 1 speculative = 4 tasks -> ceil(4/2) = 2)
+    // Task 0 is submitted as speculatable
+    // 3 running + 0 pending + 1 speculative = 4 tasks -> ceil(4/2) = 2
     post(SparkListenerSpeculativeTaskSubmitted(0, 0))
 
-    // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2), offset allocates 1 more -> 3
+    // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2),
+    // offset allocates 1 more -> 3
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)
   }
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -2062,6 +2062,10 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     manager.executorMonitor.executorsPendingToRemove()
   }
 
+  private def executorsDecommissioning(manager: ExecutorAllocationManager): Set[String] = {
+    manager.executorMonitor.executorsDecommissioning()
+  }
+
   test("SPARK-49485: request additional executor when speculative tasks equal maxNeeded") {
     val manager = createManager(createConf(1, 5, 2))
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 0)
@@ -2081,7 +2085,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
 
     // Task 0 is submitted as speculatable
-    post(SparkListenerSpeculativeTaskSubmitted(0, 0, 0))
+    post(SparkListenerSpeculativeTaskSubmitted(0, 0))
 
     // With pendingSpeculative > 0 and maxNeeded == activeExecutors (2), offset allocates 1 more
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 3)

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -755,8 +755,8 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     }
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
-    assert(numExecutorsTarget(manager, defaultProfile.id) === 1)
-    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 1)
+    assert(numExecutorsTarget(manager, defaultProfile.id) === 2)
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 2)
   }
 
   test("SPARK-30511 remove executors when speculative tasks end") {
@@ -859,11 +859,11 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
       createTaskInfo(47, 37, executorId = "11", speculative = true), new ExecutorMetrics, null))
 
     // We should have 2 original tasks (index 38, 39) running, with corresponding 2 speculative
-    // tasks running
+    // tasks running. Locality offset retains 2 executors.
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
-    assert(numExecutorsTarget(manager, defaultProfile.id) === 1)
-    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 1)
+    assert(numExecutorsTarget(manager, defaultProfile.id) === 2)
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 2)
     assert(removeExecutorDefaultProfile(manager, "11"))
     onExecutorRemoved(manager, "11")
     // At this point, we still have 2 executors running: ["9", "12"]
@@ -883,8 +883,8 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
       createTaskInfo(50, 39, executorId = "12", speculative = true)))
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
-    assert(numExecutorsTarget(manager, defaultProfile.id) === 1)
-    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 1)
+    assert(numExecutorsTarget(manager, defaultProfile.id) === 2)
+    assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 2)
 
     // Task 39 and 48 succeed, task 50 killed
     post(SparkListenerTaskEnd(0, 0, null, Success,
@@ -2135,6 +2135,35 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     val killReason = TaskKilled("primary task succeeded", Seq.empty, Seq.empty)
     post(SparkListenerTaskEnd(0, 0, "task", killReason, speculativeTaskInfo0, null, null))
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) === 2)
+  }
+
+  test("SPARK-49485: count running speculative attempts by taskId, not task index") {
+    val conf = createConf(1, 5, 2).set(config.EXECUTOR_CORES, 2)
+    val manager = createManager(conf)
+
+    post(SparkListenerStageSubmitted(createStageInfo(0, 3)))
+    post(SparkListenerExecutorAdded(0, "executor-1", new ExecutorInfo("host1", 2, Map.empty)))
+    post(SparkListenerExecutorAdded(0, "executor-2", new ExecutorInfo("host2", 2, Map.empty)))
+
+    val taskInfo0 = createTaskInfo(0, 0, "executor-1")
+    val taskInfo1 = createTaskInfo(1, 1, "executor-1")
+    val taskInfo2 = createTaskInfo(2, 2, "executor-2")
+    post(SparkListenerTaskStart(0, 0, taskInfo0))
+    post(SparkListenerTaskStart(0, 0, taskInfo1))
+    post(SparkListenerTaskStart(0, 0, taskInfo2))
+
+    // Speculative attempt 1 for task index 0 (taskId 3)
+    post(new SparkListenerSpeculativeTaskSubmitted(0, 0, 0, 0))
+    val specInfo1 = createTaskInfo(3, 0, "executor-2", speculative = true)
+    post(SparkListenerTaskStart(0, 0, specInfo1))
+
+    // Speculative attempt 2 for same task index 0 (taskId 4)
+    post(new SparkListenerSpeculativeTaskSubmitted(0, 0, 0, 0))
+    val specInfo2 = createTaskInfo(4, 0, "executor-2", speculative = true)
+    post(SparkListenerTaskStart(0, 0, specInfo2))
+
+    // Both specInfo1 (taskId 3) and specInfo2 (taskId 4) are tracked as distinct running attempts
+    assert(manager.listener.runningSpeculativeTasksPerResourceProfile(defaultProfile.id) === 2)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When `spark.dynamicAllocation.enabled=true` and `spark.speculation=true`, straggling tasks requiring speculative execution can stall indefinitely if all remaining active executors reside on the same host.

In `ExecutorAllocationManager.scala`, `maxNumExecutorsNeededPerResourceProfile` calculates `maxNeeded` strictly based on `(running + pendingTasks + pendingSpeculative) / tasksPerExecutor`. If the current active executor count equals `maxNeeded`, `ExecutorAllocationManager` calculates target executors as equal to the active count and requests no new executors. At the same time, Spark's task scheduler avoids launching speculative task copies on an executor on the same host where the task is already running slow. Consequently, no active executor can run the speculative task and no new executor is requested, causing speculative tasks to stall indefinitely.

This PR updates `maxNumExecutorsNeededPerResourceProfile` in `ExecutorAllocationManager.scala` to allocate an additional target executor when `pendingSpeculative > 0` and `maxNeeded` equals the current active executor count. This allows `ExecutorAllocationManager` to request an extra executor from the cluster manager (YARN / K8s / Standalone) on a distinct host to execute the speculative task.

### Why are the changes needed?
Without this change, applications using Dynamic Allocation and speculation can hang indefinitely when remaining executors reside on the same slow host.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Added unit test `SPARK-49485: request additional executor when speculative tasks equal maxNeeded` in `ExecutorAllocationManagerSuite.scala`.
- Verified cleanly via `core/compile` and `core/scalastyle`.
