### PR TITLE
[SPARK-59079][CORE] Use Option.when in LiveEntity

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -497,7 +497,7 @@ private class LiveStage(var info: StageInfo) extends LiveEntity {
 
       submissionTime = info.submissionTime.map(new Date(_)),
       firstTaskLaunchedTime =
-        if (firstLaunchTime < Long.MaxValue) Some(new Date(firstLaunchTime)) else None,
+        Option.when(firstLaunchTime < Long.MaxValue)(new Date(firstLaunchTime)),
       completionTime = info.completionTime.map(new Date(_)),
       failureReason = info.failureReason,
 
@@ -627,10 +627,10 @@ private class LiveRDDDistribution(exec: LiveExecutor) {
         memoryUsed,
         exec.maxMemory - exec.memoryUsed,
         diskUsed,
-        if (exec.hasMemoryInfo) Some(onHeapUsed) else None,
-        if (exec.hasMemoryInfo) Some(offHeapUsed) else None,
-        if (exec.hasMemoryInfo) Some(exec.totalOnHeap - exec.usedOnHeap) else None,
-        if (exec.hasMemoryInfo) Some(exec.totalOffHeap - exec.usedOffHeap) else None)
+        Option.when(exec.hasMemoryInfo)(onHeapUsed),
+        Option.when(exec.hasMemoryInfo)(offHeapUsed),
+        Option.when(exec.hasMemoryInfo)(exec.totalOnHeap - exec.usedOnHeap),
+        Option.when(exec.hasMemoryInfo)(exec.totalOffHeap - exec.usedOffHeap))
     }
     lastUpdate
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`LiveEntity.scala` builds several `Option` values with the `if (cond) Some(x) else None` idiom. This replaces the five such occurrences with the more idiomatic `Option.when(cond)(x)`:

- `firstTaskLaunchedTime` in `LiveStage`;
- the four on-/off-heap memory fields in `LiveRDDDistribution` (each guarded by `exec.hasMemoryInfo`).

### Why are the changes needed?

`Option.when` reads more directly than the `if`/`else` form and is already used across the codebase (e.g. `InjectRuntimeFilter`, `ParquetSchemaConverter`). This is a small readability cleanup.

### Does this PR introduce _any_ user-facing change?

No. `Option.when(cond)(x)` evaluates its by-name value only when the condition holds, exactly like `if (cond) Some(x) else None`, so the produced `Option` values are identical.

### How was this patch tested?

Existing tests. This is a behavior-preserving refactor; `core` compiles cleanly and its tests are unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
