### PR TITLE
[MINOR][ML][TEST] Add tests for vector UDFs with null inputs

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestSuite.scala
@@ -17,12 +17,31 @@
 
 package org.apache.spark.ml.util
 
+import org.apache.spark.SparkException
 import org.apache.spark.ml.feature.StringIndexer
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.udf
 
 class MLTestSuite extends MLTest {
 
   import testImplicits._
+
+  test("UDF with vector input containing null") {
+    val data = Seq(
+      Tuple1(Vectors.dense(1.0, 2.0)),
+      Tuple1(null.asInstanceOf[Vector])).toDF("vec")
+    val constantUDF = udf { vec: Vector => 1.0 }
+    val sizeUDF = udf { vec: Vector => vec.size }
+
+    checkAnswer(data.select(constantUDF($"vec")), Seq(Row(1.0), Row(1.0)))
+
+    val exception = intercept[SparkException] {
+      data.select(sizeUDF($"vec")).collect()
+    }
+    assert(exception.getCondition === "FAILED_EXECUTE_UDF")
+    assert(exception.getCause.isInstanceOf[NullPointerException])
+  }
 
   test("test transformer on stream data") {
 

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestSuite.scala
@@ -30,11 +30,14 @@ class MLTestSuite extends MLTest {
   test("UDF with vector input containing null") {
     val data = Seq(
       Tuple1(Vectors.dense(1.0, 2.0)),
+      Tuple1(Vectors.sparse(2, Seq(0 -> 1.0))),
       Tuple1(null.asInstanceOf[Vector])).toDF("vec")
     val constantUDF = udf { vec: Vector => 1.0 }
+    val isNullUDF = udf { vec: Vector => vec == null }
     val sizeUDF = udf { vec: Vector => vec.size }
 
-    checkAnswer(data.select(constantUDF($"vec")), Seq(Row(1.0), Row(1.0)))
+    checkAnswer(data.select(constantUDF($"vec")), Seq(Row(1.0), Row(1.0), Row(1.0)))
+    checkAnswer(data.select(isNullUDF($"vec")), Seq(Row(false), Row(false), Row(true)))
 
     val exception = intercept[SparkException] {
       data.select(sizeUDF($"vec")).collect()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ML test coverage for Scala UDFs applied to datasets containing dense, sparse, and null vectors.
The test verifies constant-returning and null-checking UDF behavior, and verifies that dereferencing
a null vector reports `FAILED_EXECUTE_UDF` with a `NullPointerException` cause.

### Why are the changes needed?

The tests document the null-input behavior of Scala UDFs whose input is an ML `Vector`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 build/sbt 'mllib/testOnly org.apache.spark.ml.util.MLTestSuite'`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
