### PR TITLE
[SPARK-59081][SQL] HiveSessionStateBuilder does not apply injectHintResolutionRule

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -85,6 +85,9 @@ class HiveSessionStateBuilder(
    * A logical query plan `Analyzer` with rules specific to Hive.
    */
   override protected def analyzer: Analyzer = new Analyzer(catalogManager, sharedRelationCache) {
+    override val hintResolutionRules: Seq[Rule[LogicalPlan]] =
+      customHintResolutionRules
+
     override val singlePassResolverExtensions: Seq[ResolverExtension] = Seq(
       new LogicalRelationResolver,
       new HiveTableRelationNoopResolver

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSessionExtensionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSessionExtensionSuite.scala
@@ -32,8 +32,8 @@ import org.apache.spark.util.Utils
  * from BaseSessionStateBuilder. Without hintResolutionRules, injectHintResolutionRule
  * is a no-op under enableHiveSupport() (Hive Thrift / jdbc:hive2).
  *
- * Do not use TestHiveSingleton: that session is already built, so withExtensions
- * on a new builder is required.
+ * SPARK-59081: Do not use TestHiveSingleton: that session is already built, so
+ * withExtensions on a new builder is required.
  */
 class HiveSparkSessionExtensionSuite extends SparkFunSuite {
 
@@ -80,7 +80,7 @@ class HiveSparkSessionExtensionSuite extends SparkFunSuite {
       }
   }
 
-  test("inject custom hint rule") {
+  test("SPARK-59081: inject custom hint rule") {
     withHiveSession(Seq(_.injectHintResolutionRule(MyHintRule))) { session =>
       assert(session.sessionState.catalog.getClass.getName.contains("HiveSessionCatalog"))
       assert(session.sessionState.analyzer.hintResolutionRules.contains(MyHintRule(session)))
@@ -90,7 +90,7 @@ class HiveSparkSessionExtensionSuite extends SparkFunSuite {
     }
   }
 
-  test("hint rule sees UnresolvedRelation for path SQL before ResolveSQLOnFile") {
+  test("SPARK-59081: hint rule sees UnresolvedRelation for path SQL before ResolveSQLOnFile") {
     var hintSawUnresolved = false
     var resolutionSawUnresolved = false
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSessionExtensionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSessionExtensionSuite.scala
@@ -20,7 +20,7 @@ import java.util.Locale
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.config.UI
-import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.{SparkSession => SqlSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, UnresolvedHint}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -36,6 +36,9 @@ import org.apache.spark.util.Utils
  * on a new builder is required.
  */
 class HiveSparkSessionExtensionSuite extends SparkFunSuite {
+
+  // Isolated sessions leave a SparkContext running; do not treat that as a leak.
+  override protected val enableAutoThreadAudit = false
 
   private def withHiveSession(
       builders: Seq[SparkSessionExtensions => Unit])(f: SparkSession => Unit): Unit = {
@@ -67,7 +70,7 @@ class HiveSparkSessionExtensionSuite extends SparkFunSuite {
     }
   }
 
-  case class MyHintRule(spark: SparkSession) extends Rule[LogicalPlan] {
+  case class MyHintRule(spark: SqlSession) extends Rule[LogicalPlan] {
     val myHintName = Set("CONVERT_TO_EMPTY")
 
     override def apply(plan: LogicalPlan): LogicalPlan =
@@ -91,7 +94,7 @@ class HiveSparkSessionExtensionSuite extends SparkFunSuite {
     var hintSawUnresolved = false
     var resolutionSawUnresolved = false
 
-    case class PathSqlHintRule(spark: SparkSession) extends Rule[LogicalPlan] {
+    case class PathSqlHintRule(spark: SqlSession) extends Rule[LogicalPlan] {
       override def apply(plan: LogicalPlan): LogicalPlan = {
         plan.foreach {
           case r: UnresolvedRelation
@@ -104,7 +107,7 @@ class HiveSparkSessionExtensionSuite extends SparkFunSuite {
       }
     }
 
-    case class PathSqlResolutionRule(spark: SparkSession) extends Rule[LogicalPlan] {
+    case class PathSqlResolutionRule(spark: SqlSession) extends Rule[LogicalPlan] {
       override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
         case r: UnresolvedRelation
             if r.multipartIdentifier.size == 2 &&
@@ -119,8 +122,9 @@ class HiveSparkSessionExtensionSuite extends SparkFunSuite {
         _.injectResolutionRule(PathSqlResolutionRule))) { session =>
       val dir = Utils.createTempDir()
       try {
-        session.range(1).write.parquet(dir.getCanonicalPath)
-        val df = session.sql(s"SELECT * FROM parquet.`${dir.getCanonicalPath}`")
+        val path = new java.io.File(dir, "data").getCanonicalPath
+        session.range(1).write.parquet(path)
+        val df = session.sql(s"SELECT * FROM parquet.`$path`")
         df.queryExecution.analyzed
         assert(hintSawUnresolved,
           "injectHintResolutionRule must run before ResolveSQLOnFile")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSessionExtensionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSessionExtensionSuite.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive
+
+import java.util.Locale
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.config.UI
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, UnresolvedHint}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.util.Utils
+
+/**
+ * HiveSessionStateBuilder replaces Analyzer and must copy extension hook lists
+ * from BaseSessionStateBuilder. Without hintResolutionRules, injectHintResolutionRule
+ * is a no-op under enableHiveSupport() (Hive Thrift / jdbc:hive2).
+ *
+ * Do not use TestHiveSingleton: that session is already built, so withExtensions
+ * on a new builder is required.
+ */
+class HiveSparkSessionExtensionSuite extends SparkFunSuite {
+
+  private def withHiveSession(
+      builders: Seq[SparkSessionExtensions => Unit])(f: SparkSession => Unit): Unit = {
+    val savedActive = SparkSession.getActiveSession
+    val savedDefault = SparkSession.getDefaultSession
+    val builder = SparkSession.builder()
+      .master("local[1]")
+      .config(UI.UI_ENABLED.key, false)
+      .enableHiveSupport()
+    HiveUtils.newTemporaryConfiguration(useInMemoryDerby = true).foreach {
+      case (k, v) => builder.config(k, v)
+    }
+    builders.foreach(builder.withExtensions)
+    val session = try {
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+      builder.create()
+    } finally {
+      savedDefault.foreach(SparkSession.setDefaultSession)
+      savedActive.foreach(SparkSession.setActiveSession)
+    }
+    try {
+      f(session)
+    } finally {
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+      savedDefault.foreach(SparkSession.setDefaultSession)
+      savedActive.foreach(SparkSession.setActiveSession)
+    }
+  }
+
+  case class MyHintRule(spark: SparkSession) extends Rule[LogicalPlan] {
+    val myHintName = Set("CONVERT_TO_EMPTY")
+
+    override def apply(plan: LogicalPlan): LogicalPlan =
+      plan.resolveOperators {
+        case h: UnresolvedHint if myHintName.contains(h.name.toUpperCase(Locale.ROOT)) =>
+          LocalRelation(h.output, data = Seq.empty, isStreaming = h.isStreaming)
+      }
+  }
+
+  test("inject custom hint rule") {
+    withHiveSession(Seq(_.injectHintResolutionRule(MyHintRule))) { session =>
+      assert(session.sessionState.catalog.getClass.getName.contains("HiveSessionCatalog"))
+      assert(session.sessionState.analyzer.hintResolutionRules.contains(MyHintRule(session)))
+      assert(
+        session.range(1).hint("CONVERT_TO_EMPTY").logicalPlan.isInstanceOf[LocalRelation],
+        "plan is expected to be a local relation")
+    }
+  }
+
+  test("hint rule sees UnresolvedRelation for path SQL before ResolveSQLOnFile") {
+    var hintSawUnresolved = false
+    var resolutionSawUnresolved = false
+
+    case class PathSqlHintRule(spark: SparkSession) extends Rule[LogicalPlan] {
+      override def apply(plan: LogicalPlan): LogicalPlan = {
+        plan.foreach {
+          case r: UnresolvedRelation
+              if r.multipartIdentifier.size == 2 &&
+                r.multipartIdentifier.head.equalsIgnoreCase("parquet") =>
+            hintSawUnresolved = true
+          case _ =>
+        }
+        plan
+      }
+    }
+
+    case class PathSqlResolutionRule(spark: SparkSession) extends Rule[LogicalPlan] {
+      override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+        case r: UnresolvedRelation
+            if r.multipartIdentifier.size == 2 &&
+              r.multipartIdentifier.head.equalsIgnoreCase("parquet") =>
+          resolutionSawUnresolved = true
+          r
+      }
+    }
+
+    withHiveSession(Seq(
+        _.injectHintResolutionRule(PathSqlHintRule),
+        _.injectResolutionRule(PathSqlResolutionRule))) { session =>
+      val dir = Utils.createTempDir()
+      try {
+        session.range(1).write.parquet(dir.getCanonicalPath)
+        val df = session.sql(s"SELECT * FROM parquet.`${dir.getCanonicalPath}`")
+        df.queryExecution.analyzed
+        assert(hintSawUnresolved,
+          "injectHintResolutionRule must run before ResolveSQLOnFile")
+        assert(!resolutionSawUnresolved,
+          "injectResolutionRule is after ResolveSQLOnFile and must not see the path relation")
+      } finally {
+        Utils.deleteRecursively(dir)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-59081

`HiveSessionStateBuilder` constructs its own `Analyzer` and does not override `hintResolutionRules`. The Catalyst default is `Nil`, so `SparkSessionExtensions.injectHintResolutionRule` is ignored when Hive support is enabled (`enableHiveSupport()`, Hive Thrift Server / `jdbc:hive2`).

`BaseSessionStateBuilder` already wires:

```scala
override val hintResolutionRules: Seq[Rule[LogicalPlan]] =
  customHintResolutionRules
```

This PR copies that override onto the Hive analyzer.

`injectResolutionRule` is not a substitute: Hive's `extendedResolutionRules` run `ResolveSQLOnFile` *before* `customResolutionRules`. This is the same class of miss as SPARK-56453 (Hive analyzer lists not updated when the in-memory builder was).

### Why are the changes needed?

With `enableHiveSupport()`, extensions that inject analyzer rules into the Hints batch never run. That includes any early-analysis work that must happen before `ResolveSQLOnFile` (for example path SQL such as `SELECT * FROM parquet.\`s3://...\``). In-memory sessions and Spark Connect without Hive are unaffected.

### Does this PR introduce _any_ user-facing change?

Yes. `SparkSession.builder.enableHiveSupport().withExtensions(_.injectHintResolutionRule(...))` now applies those rules, matching the non-Hive session builder. Previously they were silently dropped.

### How was this patch tested?

Added `HiveSparkSessionExtensionSuite` (isolated Hive `SparkSession`, no `TestHiveSingleton`):

- SPARK-59081: inject custom hint rule (`CONVERT_TO_EMPTY` -> `LocalRelation`), mirroring `SparkSessionExtensionSuite`.
- SPARK-59081: path SQL `SELECT * FROM parquet.\`...\``: a hint rule sees `UnresolvedRelation`; an `injectResolutionRule` does not (because Hive places `ResolveSQLOnFile` before `customResolutionRules`).

Locally: `build/sbt -Phive 'hive/testOnly org.apache.spark.sql.hive.HiveSparkSessionExtensionSuite'` (Java 17) — both tests passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6
