### PR TITLE
[SPARK-59082][PYTHON][SQL][DOC] Document public configs affecting SQL functions

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -14738,6 +14738,7 @@ def to_timestamp_ntz(
     Affected by these public SQL configurations:
 
     * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -23021,6 +23022,7 @@ def from_json(
 
     * ``spark.sql.columnNameOfCorruptRecord``
     * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -23872,6 +23874,12 @@ def variant_get(v: "ColumnOrName", path: Union[Column, str], targetType: str) ->
         a column of `targetType` representing the extracted result
         Returns a column of the type given by `targetType`.
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.timestampType``
+
     Examples
     --------
     >>> df = spark.createDataFrame([ {'json': '''{ "a" : 1 }''', 'path': '$.a'} ])
@@ -23922,6 +23930,12 @@ def try_variant_get(v: "ColumnOrName", path: Union[Column, str], targetType: str
     :class:`~pyspark.sql.Column`
         a column of `targetType` representing the extracted result
         Returns a column of the type given by `targetType`.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -24172,7 +24186,6 @@ def schema_of_json(json: Union[Column, str], options: Optional[Mapping[str, str]
     -----
     Affected by these public SQL configurations:
 
-    * ``spark.sql.session.timeZone``
     * ``spark.sql.timestampType``
 
     Examples
@@ -24341,6 +24354,7 @@ def from_xml(
 
     * ``spark.sql.columnNameOfCorruptRecord``
     * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
     * ``spark.sql.xml.variant.respectInferSchema``
 
     Examples
@@ -24455,7 +24469,7 @@ def schema_of_xml(xml: Union[Column, str], options: Optional[Mapping[str, str]] 
     -----
     Affected by these public SQL configurations:
 
-    * ``spark.sql.session.timeZone``
+    * ``spark.sql.columnNameOfCorruptRecord``
     * ``spark.sql.timestampType``
 
     Examples
@@ -24623,7 +24637,6 @@ def schema_of_csv(csv: Union[Column, str], options: Optional[Mapping[str, str]] 
     -----
     Affected by these public SQL configurations:
 
-    * ``spark.sql.session.timeZone``
     * ``spark.sql.timestampType``
 
     Examples
@@ -26273,6 +26286,7 @@ def from_csv(
 
     * ``spark.sql.columnNameOfCorruptRecord``
     * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1045,6 +1045,10 @@ def abs(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -1676,6 +1680,10 @@ def sum(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -1740,6 +1748,10 @@ def avg(col: "ColumnOrName") -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -2735,6 +2747,10 @@ def ceil(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Col
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -2795,6 +2811,10 @@ def ceiling(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> 
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -3217,6 +3237,10 @@ def floor(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -8282,6 +8306,10 @@ def round(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -8401,6 +8429,10 @@ def bround(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> C
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -9131,6 +9163,10 @@ def conv(col: "ColumnOrName", fromBase: int, toBase: int) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -9827,6 +9863,10 @@ def curdate() -> Column:
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -9863,6 +9903,10 @@ def current_date() -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -9894,6 +9938,10 @@ def current_timezone() -> Column:
     Returns the current session local timezone.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Returns
     -------
@@ -9946,6 +9994,10 @@ def current_time(precision: Optional[int] = None) -> Column:
     calls of current_time within the same query return the same value.
 
     .. versionadded:: 4.1.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -10071,6 +10123,10 @@ def localtimestamp() -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -10115,6 +10171,10 @@ def date_format(date: "ColumnOrName", format: str) -> Column:
     Notes
     -----
     Whenever possible, use specialized functions like `year`.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -10855,6 +10915,10 @@ def hour(col: "ColumnOrName") -> Column:
     .. versionchanged:: 4.1.0
         Added support for time type.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -10939,6 +11003,10 @@ def minute(col: "ColumnOrName") -> Column:
     .. versionchanged:: 4.1.0
         Added support for time type.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -11022,6 +11090,10 @@ def second(col: "ColumnOrName") -> Column:
 
     .. versionchanged:: 4.1.0
         Added support for time type.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -11616,6 +11688,10 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     year : :class:`~pyspark.sql.Column` or column name
@@ -12069,6 +12145,10 @@ def months_between(date1: "ColumnOrName", date2: "ColumnOrName", roundOff: bool 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     date1 : :class:`~pyspark.sql.Column` or column name
@@ -12132,6 +12212,11 @@ def to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -12577,6 +12662,12 @@ def to_timestamp(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -12722,6 +12813,11 @@ def try_to_timestamp(col: "ColumnOrName", format: Optional["ColumnOrName"] = Non
     consistent with the value of configuration `spark.sql.timestampType`.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Parameters
     ----------
@@ -13175,6 +13271,10 @@ def date_trunc(format: str, timestamp: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     format : literal string
@@ -13232,6 +13332,10 @@ def next_day(date: "ColumnOrName", dayOfWeek: str) -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -13329,6 +13433,10 @@ def from_unixtime(timestamp: "ColumnOrName", format: str = "yyyy-MM-dd HH:mm:ss"
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     timestamp : :class:`~pyspark.sql.Column` or column name
@@ -13392,6 +13500,11 @@ def unix_timestamp(
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -13886,6 +13999,10 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
 
     .. versionadded:: 4.0.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     unit : literal string
@@ -13952,6 +14069,10 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     Adds the specified number of units to the given timestamp
 
     .. versionadded:: 4.0.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -14030,6 +14151,10 @@ def time_bucket(
     calendar-day components of day-time interval buckets align to the session time zone.
 
     .. versionadded:: 4.2.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -14341,6 +14466,11 @@ def to_unix_timestamp(
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     timestamp : :class:`~pyspark.sql.Column` or column name
@@ -14415,6 +14545,10 @@ def to_timestamp_ltz(
     Returns null with invalid input.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -15250,6 +15384,10 @@ def upper(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -15292,6 +15430,10 @@ def lower(col: "ColumnOrName") -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Parameters
     ----------
@@ -15373,6 +15515,10 @@ def base64(col: "ColumnOrName") -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.chunkBase64String.enabled``
 
     Parameters
     ----------
@@ -17829,6 +17975,10 @@ def initcap(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -18715,6 +18865,10 @@ def parse_url(
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     url : :class:`~pyspark.sql.Column` or str
@@ -19509,6 +19663,10 @@ def elt(*inputs: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Parameters
     ----------
     inputs : :class:`~pyspark.sql.Column` or str
@@ -19680,6 +19838,10 @@ def lcase(str: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
+
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
@@ -19711,6 +19873,10 @@ def ucase(str: "ColumnOrName") -> Column:
     Returns `str` with all characters changed to uppercase.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Parameters
     ----------
@@ -19966,6 +20132,10 @@ def create_map(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
+
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or str
@@ -20046,6 +20216,10 @@ def map_from_arrays(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
 
     Parameters
     ----------
@@ -20860,6 +21034,10 @@ def element_at(col: "ColumnOrName", extraction: Any) -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -22699,6 +22877,11 @@ def from_json(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.columnNameOfCorruptRecord``
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -23718,6 +23901,11 @@ def to_json(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) ->
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.jsonGenerator.ignoreNullFields``
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -23838,6 +24026,11 @@ def schema_of_json(json: Union[Column, str], options: Optional[Mapping[str, str]
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Parameters
     ----------
@@ -23998,6 +24191,12 @@ def from_xml(
 
     .. versionadded:: 4.0.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.columnNameOfCorruptRecord``
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.xml.variant.respectInferSchema``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24110,6 +24309,11 @@ def schema_of_xml(xml: Union[Column, str], options: Optional[Mapping[str, str]] 
 
     .. versionadded:: 4.0.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
+
     Parameters
     ----------
     xml : :class:`~pyspark.sql.Column` or str
@@ -24209,6 +24413,10 @@ def to_xml(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) -> 
 
     .. versionadded:: 4.0.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24264,6 +24472,11 @@ def schema_of_csv(csv: Union[Column, str], options: Optional[Mapping[str, str]] 
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Parameters
     ----------
@@ -24357,6 +24570,10 @@ def to_csv(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) -> 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24448,6 +24665,10 @@ def size(col: "ColumnOrName") -> Column:
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -24752,6 +24973,10 @@ def cardinality(col: "ColumnOrName") -> Column:
     Collection function: returns the length of the array or map stored in the column.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -25455,6 +25680,10 @@ def map_from_entries(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -25705,6 +25934,10 @@ def map_concat(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
+
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or str
@@ -25874,6 +26107,11 @@ def from_csv(
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.columnNameOfCorruptRecord``
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -26535,6 +26773,10 @@ def transform_keys(col: "ColumnOrName", f: Callable[[Column, Column], Column]) -
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -26759,6 +27001,10 @@ def str_to_map(
     using delimiters. Both `pairDelim` and `keyValueDelim` are treated as regular expressions.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
 
     Parameters
     ----------
@@ -27036,6 +27282,10 @@ def convert_timezone(
     from the `sourceTz` time zone to `targetTz`.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -27392,6 +27642,10 @@ def make_interval(
     Make interval from years, months, weeks, days, hours, mins and secs.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -27811,6 +28065,12 @@ def make_timestamp(
     .. versionchanged:: 4.1.0
         Added support for creating timestamps from date and time.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
+
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name, optional
@@ -28046,6 +28306,11 @@ def try_make_timestamp(
     .. versionchanged:: 4.1.0
         Added support for creating timestamps from date and time.
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
+
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name, optional
@@ -28256,6 +28521,11 @@ def make_timestamp_ltz(
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or str
@@ -28360,6 +28630,10 @@ def try_make_timestamp_ltz(
     The function returns NULL on invalid inputs.
 
     .. versionadded:: 4.0.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Parameters
     ----------
@@ -28502,6 +28776,10 @@ def make_timestamp_ntz(
 
     .. versionchanged:: 4.1.0
         Added support for creating timestamps from date and time.
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Parameters
     ----------
@@ -32795,6 +33073,10 @@ def reflect(*cols: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.reflect.allowList``
+
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or column name
@@ -32829,6 +33111,10 @@ def java_method(*cols: "ColumnOrName") -> Column:
     Calls a method with reflection.
 
     .. versionadded:: 3.5.0
+
+    The behavior of this function is affected by these public SQL configurations:
+
+    * ``spark.sql.reflect.allowList``
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1825,6 +1825,12 @@ def mean(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         the column for computed results.
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     Examples
     --------
     Example 1: Calculating the average age
@@ -1915,6 +1921,12 @@ def sumDistinct(col: "ColumnOrName") -> Column:
 
     .. deprecated:: 3.2.0
         Use :func:`sum_distinct` instead.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
     """
     warnings.warn("Deprecated in 3.2, use sum_distinct instead.", FutureWarning)
     return sum_distinct(col)
@@ -1939,6 +1951,12 @@ def sum_distinct(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         the column for computed results.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -3419,6 +3437,12 @@ def negative(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         negative value.
         Returns a column of the same type as the input.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -6652,6 +6676,10 @@ def pmod(dividend: Union["ColumnOrName", float], divisor: Union["ColumnOrName", 
     Notes
     -----
     Supports Spark Connect.
+
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -14602,7 +14630,7 @@ def to_timestamp_ltz(
 ) -> Column:
     """
     Parses the `timestamp` with the `format` to a timestamp with time zone.
-    Returns null with invalid input.
+    Returns null with invalid input when ANSI mode is disabled, or raises an error otherwise.
 
     .. versionadded:: 3.5.0
 
@@ -14629,6 +14657,7 @@ def to_timestamp_ltz(
     -----
     Affected by these public SQL configurations:
 
+    * ``spark.sql.ansi.enabled``
     * ``spark.sql.session.timeZone``
 
     Examples
@@ -14681,7 +14710,7 @@ def to_timestamp_ntz(
 ) -> Column:
     """
     Parses the `timestamp` with the `format` to a timestamp without time zone.
-    Returns null with invalid input.
+    Returns null with invalid input when ANSI mode is disabled, or raises an error otherwise.
 
     .. versionadded:: 3.5.0
 
@@ -14703,6 +14732,12 @@ def to_timestamp_ntz(
     :meth:`pyspark.sql.functions.to_unix_timestamp`
     :meth:`pyspark.sql.functions.date_format`
     :meth:`pyspark.sql.functions.try_to_timestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -33308,6 +33343,12 @@ def try_reflect(*cols: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.reflect`
     :meth:`pyspark.sql.functions.java_method`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.reflect.allowList``
 
     Examples
     --------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -10351,6 +10351,13 @@ def year(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.date_part`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     Example 1: Extract the year from a string column representing dates
@@ -10443,6 +10450,13 @@ def quarter(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.extract`
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.date_part`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -10538,6 +10552,13 @@ def month(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.date_part`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     Example 1: Extract the month from a string column representing dates
@@ -10627,6 +10648,13 @@ def dayofweek(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.dayofmonth`
     :meth:`pyspark.sql.functions.weekofyear`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     Example 1: Extract the day of the week from a string column representing dates
@@ -10714,6 +10742,13 @@ def dayofmonth(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         day of the month for given date/timestamp as integer.
         Returns a column that evaluates to an integer.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -10810,6 +10845,13 @@ def day(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.date_part`
     :meth:`pyspark.sql.functions.weekday`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     Example 1: Extract the day of the month from a string column representing dates
@@ -10898,6 +10940,13 @@ def dayofyear(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.dayofmonth`
     :meth:`pyspark.sql.functions.weekofyear`
     :meth:`pyspark.sql.functions.dayofweek`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -10999,6 +11048,7 @@ def hour(col: "ColumnOrName") -> Column:
     -----
     Affected by these public SQL configurations:
 
+    * ``spark.sql.ansi.enabled``
     * ``spark.sql.session.timeZone``
 
     Examples
@@ -11089,6 +11139,7 @@ def minute(col: "ColumnOrName") -> Column:
     -----
     Affected by these public SQL configurations:
 
+    * ``spark.sql.ansi.enabled``
     * ``spark.sql.session.timeZone``
 
     Examples
@@ -11179,6 +11230,7 @@ def second(col: "ColumnOrName") -> Column:
     -----
     Affected by these public SQL configurations:
 
+    * ``spark.sql.ansi.enabled``
     * ``spark.sql.session.timeZone``
 
     Examples
@@ -11258,6 +11310,13 @@ def weekofyear(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.dayofweek`
     :meth:`pyspark.sql.functions.dayofmonth`
     :meth:`pyspark.sql.functions.dayofyear`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -11345,6 +11404,13 @@ def weekday(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.dayofyear`
     :meth:`pyspark.sql.functions.dayofmonth`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     Example 1: Extract the day of the week from a string column representing dates
@@ -11428,6 +11494,13 @@ def monthname(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.month`
     :meth:`pyspark.sql.functions.dayname`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     Example 1: Extract the month name from a string column representing dates
@@ -11510,6 +11583,13 @@ def dayname(col: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.day`
     :meth:`pyspark.sql.functions.monthname`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -23878,6 +23958,7 @@ def variant_get(v: "ColumnOrName", path: Union[Column, str], targetType: str) ->
     -----
     Affected by these public SQL configurations:
 
+    * ``spark.sql.session.timeZone``
     * ``spark.sql.timestampType``
 
     Examples
@@ -23935,6 +24016,7 @@ def try_variant_get(v: "ColumnOrName", path: Union[Column, str], targetType: str
     -----
     Affected by these public SQL configurations:
 
+    * ``spark.sql.session.timeZone``
     * ``spark.sql.timestampType``
 
     Examples
@@ -26200,6 +26282,12 @@ def sequence(
     :class:`~pyspark.sql.Column`
         A new column that contains an array of sequence values.
         Returns a column that evaluates to an array.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1045,10 +1045,6 @@ def abs(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -1060,6 +1056,12 @@ def abs(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         A new column object representing the absolute value of the input.
         Returns a column of the same type as the input.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -1680,10 +1682,6 @@ def sum(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -1700,6 +1698,12 @@ def sum(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.min`
     :meth:`pyspark.sql.functions.max`
     :meth:`pyspark.sql.functions.avg`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -1749,10 +1753,6 @@ def avg(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -1769,6 +1769,12 @@ def avg(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.min`
     :meth:`pyspark.sql.functions.max`
     :meth:`pyspark.sql.functions.sum`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -2747,10 +2753,6 @@ def ceil(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Col
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -2771,6 +2773,12 @@ def ceil(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Col
     See Also
     --------
     :meth:`pyspark.sql.functions.ceiling`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -2812,10 +2820,6 @@ def ceiling(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -2836,6 +2840,12 @@ def ceiling(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> 
     See Also
     --------
     :meth:`pyspark.sql.functions.ceil`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -3238,10 +3248,6 @@ def floor(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -3259,6 +3265,12 @@ def floor(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
     :class:`~pyspark.sql.Column`
         nearest integer that is less than or equal to given value.
         Returns a column that evaluates to a long or decimal.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -8306,10 +8318,6 @@ def round(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -8327,6 +8335,12 @@ def round(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
     :class:`~pyspark.sql.Column`
         A column for the rounded value.
         Returns a column of the same type as the input.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -8430,10 +8444,6 @@ def bround(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> C
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -8451,6 +8461,12 @@ def bround(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> C
     :class:`~pyspark.sql.Column`
         A column for the rounded value.
         Returns a column of the same type as the input.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -9163,10 +9179,6 @@ def conv(col: "ColumnOrName", fromBase: int, toBase: int) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -9184,6 +9196,12 @@ def conv(col: "ColumnOrName", fromBase: int, toBase: int) -> Column:
     :class:`~pyspark.sql.Column`
         logariphm of given value.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -9863,10 +9881,6 @@ def curdate() -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -9878,6 +9892,12 @@ def curdate() -> Column:
     :meth:`pyspark.sql.functions.current_date`
     :meth:`pyspark.sql.functions.current_timestamp`
     :meth:`pyspark.sql.functions.localtimestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -9903,10 +9923,6 @@ def current_date() -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -9918,6 +9934,12 @@ def current_date() -> Column:
     :meth:`pyspark.sql.functions.curdate`
     :meth:`pyspark.sql.functions.current_timestamp`
     :meth:`pyspark.sql.functions.localtimestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -9939,10 +9961,6 @@ def current_timezone() -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -9951,6 +9969,12 @@ def current_timezone() -> Column:
     See Also
     --------
     :meth:`pyspark.sql.functions.convert_timezone`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -9995,10 +10019,6 @@ def current_time(precision: Optional[int] = None) -> Column:
 
     .. versionadded:: 4.1.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     precision: literal int, optional
@@ -10014,6 +10034,12 @@ def current_time(precision: Optional[int] = None) -> Column:
     --------
     :meth:`pyspark.sql.functions.current_date`
     :meth:`pyspark.sql.functions.current_timestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -10123,10 +10149,6 @@ def localtimestamp() -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -10138,6 +10160,12 @@ def localtimestamp() -> Column:
     :meth:`pyspark.sql.functions.curdate`
     :meth:`pyspark.sql.functions.current_date`
     :meth:`pyspark.sql.functions.current_timestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -10170,11 +10198,11 @@ def date_format(date: "ColumnOrName", format: str) -> Column:
 
     Notes
     -----
-    Whenever possible, use specialized functions like `year`.
-
-    The behavior of this function is affected by these public SQL configurations:
+    Affected by these public SQL configurations:
 
     * ``spark.sql.session.timeZone``
+
+    Whenever possible, use specialized functions like `year`.
 
     Parameters
     ----------
@@ -10915,10 +10943,6 @@ def hour(col: "ColumnOrName") -> Column:
     .. versionchanged:: 4.1.0
         Added support for time type.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -10942,6 +10966,12 @@ def hour(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.extract`
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.date_part`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -11003,10 +11033,6 @@ def minute(col: "ColumnOrName") -> Column:
     .. versionchanged:: 4.1.0
         Added support for time type.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -11030,6 +11056,12 @@ def minute(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         minutes part of the timestamp as integer.
         Returns a column that evaluates to an integer.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -11091,10 +11123,6 @@ def second(col: "ColumnOrName") -> Column:
     .. versionchanged:: 4.1.0
         Added support for time type.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -11118,6 +11146,12 @@ def second(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.extract`
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.date_part`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -11688,10 +11722,6 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     year : :class:`~pyspark.sql.Column` or column name
@@ -11715,6 +11745,12 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     :meth:`pyspark.sql.functions.make_timestamp`
     :meth:`pyspark.sql.functions.make_timestamp_ltz`
     :meth:`pyspark.sql.functions.make_timestamp_ntz`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -12145,10 +12181,6 @@ def months_between(date1: "ColumnOrName", date2: "ColumnOrName", roundOff: bool 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     date1 : :class:`~pyspark.sql.Column` or column name
@@ -12166,6 +12198,12 @@ def months_between(date1: "ColumnOrName", date2: "ColumnOrName", roundOff: bool 
     :class:`~pyspark.sql.Column`
         number of months between two dates.
         Returns a column that evaluates to a double.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -12213,11 +12251,6 @@ def to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -12242,6 +12275,13 @@ def to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     :meth:`pyspark.sql.functions.try_to_timestamp`
     :meth:`pyspark.sql.functions.date_format`
     :meth:`pyspark.sql.functions.try_to_date`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -12662,12 +12702,6 @@ def to_timestamp(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -12692,6 +12726,14 @@ def to_timestamp(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     :meth:`pyspark.sql.functions.to_unix_timestamp`
     :meth:`pyspark.sql.functions.try_to_timestamp`
     :meth:`pyspark.sql.functions.date_format`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -12814,11 +12856,6 @@ def try_to_timestamp(col: "ColumnOrName", format: Optional["ColumnOrName"] = Non
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -12836,6 +12873,13 @@ def try_to_timestamp(col: "ColumnOrName", format: Optional["ColumnOrName"] = Non
     :meth:`pyspark.sql.functions.date_format`
     :meth:`pyspark.sql.functions.try_to_date`
     :meth:`pyspark.sql.functions.try_to_time`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -13271,10 +13315,6 @@ def date_trunc(format: str, timestamp: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     format : literal string
@@ -13298,6 +13338,12 @@ def date_trunc(format: str, timestamp: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.trunc`
     :meth:`pyspark.sql.functions.time_trunc`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -13333,10 +13379,6 @@ def next_day(date: "ColumnOrName", dayOfWeek: str) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     date : :class:`~pyspark.sql.Column` or column name
@@ -13352,6 +13394,12 @@ def next_day(date: "ColumnOrName", dayOfWeek: str) -> Column:
     :class:`~pyspark.sql.Column`
         the column of computed results.
         Returns a column that evaluates to a date.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -13433,10 +13481,6 @@ def from_unixtime(timestamp: "ColumnOrName", format: str = "yyyy-MM-dd HH:mm:ss"
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     timestamp : :class:`~pyspark.sql.Column` or column name
@@ -13456,6 +13500,12 @@ def from_unixtime(timestamp: "ColumnOrName", format: str = "yyyy-MM-dd HH:mm:ss"
     --------
     :meth:`pyspark.sql.functions.date_from_unix_date`
     :meth:`pyspark.sql.functions.unix_seconds`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -13501,11 +13551,6 @@ def unix_timestamp(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     timestamp : :class:`~pyspark.sql.Column` or column name, optional
@@ -13520,6 +13565,13 @@ def unix_timestamp(
     :class:`~pyspark.sql.Column`
         unix time as long integer.
         Returns a column that evaluates to a long.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -13999,10 +14051,6 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
 
     .. versionadded:: 4.0.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     unit : literal string
@@ -14024,6 +14072,12 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
     :meth:`pyspark.sql.functions.datediff`
     :meth:`pyspark.sql.functions.date_diff`
     :meth:`pyspark.sql.functions.time_diff`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -14070,10 +14124,6 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
 
     .. versionadded:: 4.0.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     unit : literal string
@@ -14094,6 +14144,12 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     --------
     :meth:`pyspark.sql.functions.dateadd`
     :meth:`pyspark.sql.functions.date_add`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -14152,10 +14208,6 @@ def time_bucket(
 
     .. versionadded:: 4.2.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     bucket_size : :class:`~pyspark.sql.Column`
@@ -14171,6 +14223,12 @@ def time_bucket(
     -------
     :class:`~pyspark.sql.Column`
         The start of the bucket containing ``ts``, as the same type as ``ts``.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -14466,11 +14524,6 @@ def to_unix_timestamp(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     timestamp : :class:`~pyspark.sql.Column` or column name
@@ -14487,6 +14540,13 @@ def to_unix_timestamp(
     :meth:`pyspark.sql.functions.to_timestamp_ltz`
     :meth:`pyspark.sql.functions.to_timestamp_ntz`
     :meth:`pyspark.sql.functions.to_utc_timestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -14546,10 +14606,6 @@ def to_timestamp_ltz(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     timestamp : :class:`~pyspark.sql.Column` or column name
@@ -14568,6 +14624,12 @@ def to_timestamp_ltz(
     :meth:`pyspark.sql.functions.to_unix_timestamp`
     :meth:`pyspark.sql.functions.date_format`
     :meth:`pyspark.sql.functions.try_to_timestamp`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -15384,10 +15446,6 @@ def upper(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.icu.caseMappings.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -15404,6 +15462,12 @@ def upper(col: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.lower`
     :meth:`pyspark.sql.functions.ucase`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Examples
     --------
@@ -15431,10 +15495,6 @@ def lower(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.icu.caseMappings.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -15451,6 +15511,12 @@ def lower(col: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.upper`
     :meth:`pyspark.sql.functions.lcase`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Examples
     --------
@@ -15516,10 +15582,6 @@ def base64(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.chunkBase64String.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -15536,6 +15598,12 @@ def base64(col: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.unbase64`
     :meth:`pyspark.sql.functions.to_base32`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.chunkBase64String.enabled``
 
     Examples
     --------
@@ -17975,10 +18043,6 @@ def initcap(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.icu.caseMappings.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
@@ -17990,6 +18054,12 @@ def initcap(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         string with all first letters are uppercase in each word.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Examples
     --------
@@ -18865,10 +18935,6 @@ def parse_url(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     url : :class:`~pyspark.sql.Column` or str
@@ -18886,6 +18952,12 @@ def parse_url(
     :class:`~pyspark.sql.Column`
         A new column of strings, each representing the value of the extracted part from the URL.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -19663,14 +19735,16 @@ def elt(*inputs: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     inputs : :class:`~pyspark.sql.Column` or str
         Input columns or strings.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -19838,10 +19912,6 @@ def lcase(str: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.icu.caseMappings.enabled``
-
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
@@ -19853,6 +19923,12 @@ def lcase(str: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.lower`
     :meth:`pyspark.sql.functions.ucase`
     :meth:`pyspark.sql.functions.upper`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Examples
     --------
@@ -19874,10 +19950,6 @@ def ucase(str: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.icu.caseMappings.enabled``
-
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
@@ -19889,6 +19961,12 @@ def ucase(str: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.upper`
     :meth:`pyspark.sql.functions.lcase`
     :meth:`pyspark.sql.functions.lower`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.icu.caseMappings.enabled``
 
     Examples
     --------
@@ -20132,10 +20210,6 @@ def create_map(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.mapKeyDedupPolicy``
-
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or str
@@ -20147,6 +20221,12 @@ def create_map(
     :class:`~pyspark.sql.Column`
         A new Column of Map type, where each value is a map formed from the corresponding
         key-value pairs provided in the input arguments.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
 
     Examples
     --------
@@ -20217,10 +20297,6 @@ def map_from_arrays(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.mapKeyDedupPolicy``
-
     Parameters
     ----------
     col1 : :class:`~pyspark.sql.Column` or str
@@ -20238,6 +20314,10 @@ def map_from_arrays(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 
     Notes
     -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
+
     The input arrays for keys and values must have the same length and all elements
     in keys should not be null. If these conditions are not met, an exception will be thrown.
 
@@ -21035,10 +21115,6 @@ def element_at(col: "ColumnOrName", extraction: Any) -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -21056,6 +21132,10 @@ def element_at(col: "ColumnOrName", extraction: Any) -> Column:
 
     Notes
     -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+
     The position is not zero based, but 1 based index.
     If extraction is a string, :meth:`element_at` treats it as a literal string,
     while :meth:`try_element_at` treats it as a column name.
@@ -22877,11 +22957,6 @@ def from_json(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.columnNameOfCorruptRecord``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -22904,6 +22979,13 @@ def from_json(
     :class:`~pyspark.sql.Column`
         a new column of complex type from given JSON object.
         Returns a column that evaluates to a struct, array, or map.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.columnNameOfCorruptRecord``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -23901,11 +23983,6 @@ def to_json(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) ->
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.jsonGenerator.ignoreNullFields``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -23926,6 +24003,13 @@ def to_json(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) ->
     :class:`~pyspark.sql.Column`
         JSON object as string column.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.jsonGenerator.ignoreNullFields``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -24027,11 +24111,6 @@ def schema_of_json(json: Union[Column, str], options: Optional[Mapping[str, str]
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     json : :class:`~pyspark.sql.Column` or str
@@ -24053,6 +24132,13 @@ def schema_of_json(json: Union[Column, str], options: Optional[Mapping[str, str]
     :class:`~pyspark.sql.Column`
         a string representation of a :class:`StructType` parsed from given JSON.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -24191,12 +24277,6 @@ def from_xml(
 
     .. versionadded:: 4.0.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.columnNameOfCorruptRecord``
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.xml.variant.respectInferSchema``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24219,6 +24299,14 @@ def from_xml(
     :class:`~pyspark.sql.Column`
         a new column of complex type from given XML object.
         Returns a column that evaluates to a struct.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.columnNameOfCorruptRecord``
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.xml.variant.respectInferSchema``
 
     Examples
     --------
@@ -24309,11 +24397,6 @@ def schema_of_xml(xml: Union[Column, str], options: Optional[Mapping[str, str]] 
 
     .. versionadded:: 4.0.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     xml : :class:`~pyspark.sql.Column` or str
@@ -24332,6 +24415,13 @@ def schema_of_xml(xml: Union[Column, str], options: Optional[Mapping[str, str]] 
     :class:`~pyspark.sql.Column`
         a string representation of a :class:`StructType` parsed from given XML.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -24413,10 +24503,6 @@ def to_xml(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) -> 
 
     .. versionadded:: 4.0.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24435,6 +24521,12 @@ def to_xml(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) -> 
     :class:`~pyspark.sql.Column`
         a XML string converted from given :class:`StructType`.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -24473,11 +24565,6 @@ def schema_of_csv(csv: Union[Column, str], options: Optional[Mapping[str, str]] 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     csv : :class:`~pyspark.sql.Column` or str
@@ -24496,6 +24583,13 @@ def schema_of_csv(csv: Union[Column, str], options: Optional[Mapping[str, str]] 
     :class:`~pyspark.sql.Column`
         A string representation of a :class:`StructType` parsed from the given CSV.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -24570,10 +24664,6 @@ def to_csv(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) -> 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24592,6 +24682,12 @@ def to_csv(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) -> 
     :class:`~pyspark.sql.Column`
         A CSV string converted from the given :class:`StructType`.
         Returns a column that evaluates to a string.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -24666,10 +24762,6 @@ def size(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24681,6 +24773,12 @@ def size(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         length of the array/map.
         Returns a column that evaluates to an integer.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -24974,10 +25072,6 @@ def cardinality(col: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -24989,6 +25083,12 @@ def cardinality(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         length of the array/map.
         Returns a column that evaluates to an integer.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -25680,10 +25780,6 @@ def map_from_entries(col: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.mapKeyDedupPolicy``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -25693,6 +25789,12 @@ def map_from_entries(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         A map created from the given array of entries.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
 
     Examples
     --------
@@ -25934,10 +26036,6 @@ def map_concat(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.mapKeyDedupPolicy``
-
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or str
@@ -25950,6 +26048,10 @@ def map_concat(
 
     Notes
     -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
+
     For duplicate keys in input maps, the handling is governed by `spark.sql.mapKeyDedupPolicy`.
     By default, it throws an exception. If set to `LAST_WIN`, it uses the last map's value.
 
@@ -26108,11 +26210,6 @@ def from_csv(
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.columnNameOfCorruptRecord``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -26134,6 +26231,13 @@ def from_csv(
     :class:`~pyspark.sql.Column`
         A column of parsed CSV values.
         Returns a column that evaluates to a struct.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.columnNameOfCorruptRecord``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -26773,10 +26877,6 @@ def transform_keys(col: "ColumnOrName", f: Callable[[Column, Column], Column]) -
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.mapKeyDedupPolicy``
-
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -26793,6 +26893,12 @@ def transform_keys(col: "ColumnOrName", f: Callable[[Column, Column], Column]) -
     :class:`~pyspark.sql.Column`
         a new map of entries where new keys were calculated by applying given function to
         each key value argument.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
 
     Examples
     --------
@@ -27002,10 +27108,6 @@ def str_to_map(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.mapKeyDedupPolicy``
-
     Parameters
     ----------
     text : :class:`~pyspark.sql.Column` or str
@@ -27023,6 +27125,12 @@ def str_to_map(
     :class:`~pyspark.sql.Column`
         A new column of map type where each string in the original column is converted into a map.
         Returns a column that evaluates to a map.
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.mapKeyDedupPolicy``
 
     Examples
     --------
@@ -27283,10 +27391,6 @@ def convert_timezone(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     sourceTz : :class:`~pyspark.sql.Column`, optional
@@ -27309,6 +27413,12 @@ def convert_timezone(
     See Also
     --------
     :meth:`pyspark.sql.functions.current_timezone`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -27643,10 +27753,6 @@ def make_interval(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name, optional
@@ -27682,6 +27788,12 @@ def make_interval(
     :meth:`pyspark.sql.functions.make_dt_interval`
     :meth:`pyspark.sql.functions.make_ym_interval`
     :meth:`pyspark.sql.functions.try_make_interval`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -28065,12 +28177,6 @@ def make_timestamp(
     .. versionchanged:: 4.1.0
         Added support for creating timestamps from date and time.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name, optional
@@ -28136,6 +28242,14 @@ def make_timestamp(
     :meth:`pyspark.sql.functions.make_time`
     :meth:`pyspark.sql.functions.make_interval`
     :meth:`pyspark.sql.functions.try_make_interval`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -28306,11 +28420,6 @@ def try_make_timestamp(
     .. versionchanged:: 4.1.0
         Added support for creating timestamps from date and time.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-    * ``spark.sql.timestampType``
-
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name, optional
@@ -28376,6 +28485,13 @@ def try_make_timestamp(
     :meth:`pyspark.sql.functions.make_time`
     :meth:`pyspark.sql.functions.make_interval`
     :meth:`pyspark.sql.functions.try_make_interval`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
+    * ``spark.sql.timestampType``
 
     Examples
     --------
@@ -28521,11 +28637,6 @@ def make_timestamp_ltz(
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or str
@@ -28569,6 +28680,13 @@ def make_timestamp_ltz(
     :meth:`pyspark.sql.functions.make_time`
     :meth:`pyspark.sql.functions.make_interval`
     :meth:`pyspark.sql.functions.try_make_interval`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -28631,10 +28749,6 @@ def try_make_timestamp_ltz(
 
     .. versionadded:: 4.0.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.session.timeZone``
-
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name
@@ -28678,6 +28792,12 @@ def try_make_timestamp_ltz(
     :meth:`pyspark.sql.functions.make_time`
     :meth:`pyspark.sql.functions.make_interval`
     :meth:`pyspark.sql.functions.try_make_interval`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------
@@ -28777,10 +28897,6 @@ def make_timestamp_ntz(
     .. versionchanged:: 4.1.0
         Added support for creating timestamps from date and time.
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.ansi.enabled``
-
     Parameters
     ----------
     years : :class:`~pyspark.sql.Column` or column name, optional
@@ -28843,6 +28959,12 @@ def make_timestamp_ntz(
     :meth:`pyspark.sql.functions.make_time`
     :meth:`pyspark.sql.functions.make_interval`
     :meth:`pyspark.sql.functions.try_make_interval`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
 
     Examples
     --------
@@ -33073,10 +33195,6 @@ def reflect(*cols: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.reflect.allowList``
-
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or column name
@@ -33088,6 +33206,12 @@ def reflect(*cols: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.java_method`
     :meth:`pyspark.sql.functions.try_reflect`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.reflect.allowList``
 
     Examples
     --------
@@ -33112,10 +33236,6 @@ def java_method(*cols: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    The behavior of this function is affected by these public SQL configurations:
-
-    * ``spark.sql.reflect.allowList``
-
     Parameters
     ----------
     cols : :class:`~pyspark.sql.Column` or column name
@@ -33127,6 +33247,12 @@ def java_method(*cols: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.reflect`
     :meth:`pyspark.sql.functions.try_reflect`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.reflect.allowList``
 
     Examples
     --------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -11683,6 +11683,13 @@ def extract(field: Column, source: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.date_part`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     >>> import datetime
@@ -11740,6 +11747,13 @@ def date_part(field: Column, source: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.datepart`
     :meth:`pyspark.sql.functions.extract`
 
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
+
     Examples
     --------
     >>> import datetime
@@ -11796,6 +11810,13 @@ def datepart(field: Column, source: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.second`
     :meth:`pyspark.sql.functions.date_part`
     :meth:`pyspark.sql.functions.extract`
+
+    Notes
+    -----
+    Affected by these public SQL configurations:
+
+    * ``spark.sql.ansi.enabled``
+    * ``spark.sql.session.timeZone``
 
     Examples
     --------

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -355,7 +355,7 @@ object functions {
    *   Returns a column that evaluates to a numeric.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def avg(e: Column): Column = Column.fn("avg", e)
@@ -371,7 +371,7 @@ object functions {
    *   Returns a column that evaluates to a numeric.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def avg(columnName: String): Column = avg(Column(columnName))
@@ -1722,7 +1722,7 @@ object functions {
    *   Returns a column that evaluates to a numeric or interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def sum(e: Column): Column = Column.fn("sum", e)
@@ -1738,7 +1738,7 @@ object functions {
    *   Returns a column that evaluates to a numeric or interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def sum(columnName: String): Column = sum(Column(columnName))
@@ -3708,7 +3708,7 @@ object functions {
    * @since 4.1.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def current_time(): Column = {
@@ -3727,7 +3727,7 @@ object functions {
    * @since 4.1.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def current_time(precision: Int): Column = {
@@ -4312,7 +4312,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   @scala.annotation.varargs
@@ -4347,7 +4347,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   def map_from_arrays(keys: Column, values: Column): Column =
@@ -4371,7 +4371,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   def str_to_map(text: Column, pairDelim: Column, keyValueDelim: Column): Column =
@@ -4392,7 +4392,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   def str_to_map(text: Column, pairDelim: Column): Column =
@@ -4409,7 +4409,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   def str_to_map(text: Column): Column = Column.fn("str_to_map", text)
@@ -4968,7 +4968,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def abs(e: Column): Column = Column.fn("abs", e)
@@ -5283,7 +5283,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def ceil(e: Column, scale: Column): Column = Column.fn("ceil", e, scale)
@@ -5299,7 +5299,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def ceil(e: Column): Column = Column.fn("ceil", e)
@@ -5315,7 +5315,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def ceil(columnName: String): Column = ceil(Column(columnName))
@@ -5334,7 +5334,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def ceiling(e: Column, scale: Column): Column = Column.fn("ceiling", e, scale)
@@ -5350,7 +5350,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def ceiling(e: Column): Column = Column.fn("ceiling", e)
@@ -5370,7 +5370,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def conv(num: Column, fromBase: Int, toBase: Int): Column =
@@ -5528,7 +5528,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def floor(e: Column, scale: Column): Column = Column.fn("floor", e, scale)
@@ -5544,7 +5544,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def floor(e: Column): Column = Column.fn("floor", e)
@@ -5560,7 +5560,7 @@ object functions {
    *   Returns a column that evaluates to a long or decimal.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def floor(columnName: String): Column = floor(Column(columnName))
@@ -6120,7 +6120,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def round(e: Column): Column = round(e, 0)
@@ -6140,7 +6140,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def round(e: Column, scale: Int): Column = Column.fn("round", e, lit(scale))
@@ -6160,7 +6160,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def round(e: Column, scale: Column): Column = Column.fn("round", e, scale)
@@ -6223,7 +6223,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def bround(e: Column): Column = bround(e, 0)
@@ -6243,7 +6243,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def bround(e: Column, scale: Int): Column = Column.fn("bround", e, lit(scale))
@@ -6263,7 +6263,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def bround(e: Column, scale: Column): Column = Column.fn("bround", e, scale)
@@ -7266,7 +7266,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.reflect.allowList`
    */
   @scala.annotation.varargs
@@ -7281,7 +7281,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.reflect.allowList`
    */
   @scala.annotation.varargs
@@ -7610,7 +7610,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.chunkBase64String.enabled`
    */
   def base64(e: Column): Column = Column.fn("base64", e)
@@ -7829,7 +7829,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.icu.caseMappings.enabled`
    */
   def initcap(e: Column): Column = Column.fn("initcap", e)
@@ -8022,7 +8022,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.icu.caseMappings.enabled`
    */
   def lower(e: Column): Column = Column.fn("lower", e)
@@ -8921,7 +8921,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.icu.caseMappings.enabled`
    */
   def upper(e: Column): Column = Column.fn("upper", e)
@@ -9198,7 +9198,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def parse_url(url: Column, partToExtract: Column, key: Column): Column =
@@ -9217,7 +9217,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def parse_url(url: Column, partToExtract: Column): Column =
@@ -9501,7 +9501,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   @scala.annotation.varargs
@@ -9600,7 +9600,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.icu.caseMappings.enabled`
    */
   def lcase(str: Column): Column = Column.fn("lcase", str)
@@ -9616,7 +9616,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.icu.caseMappings.enabled`
    */
   def ucase(str: Column): Column = Column.fn("ucase", str)
@@ -11719,7 +11719,7 @@ object functions {
    *   Returns a column that evaluates to a date.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def curdate(): Column = Column.fn("curdate")
@@ -11734,7 +11734,7 @@ object functions {
    *   Returns a column that evaluates to a date.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def current_date(): Column = Column.fn("current_date")
@@ -11748,7 +11748,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def current_timezone(): Column = Column.fn("current_timezone")
@@ -11785,7 +11785,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def localtimestamp(): Column = Column.fn("localtimestamp")
@@ -11816,7 +11816,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def date_format(dateExpr: Column, format: String): Column =
@@ -12081,7 +12081,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def hour(e: Column): Column = Column.fn("hour", e)
@@ -12169,7 +12169,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def minute(e: Column): Column = Column.fn("minute", e)
@@ -12200,7 +12200,7 @@ object functions {
    * @since 3.3.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_date(year: Column, month: Column, day: Column): Column =
@@ -12236,7 +12236,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def months_between(end: Column, start: Column): Column =
@@ -12262,7 +12262,7 @@ object functions {
    *   Returns a column that evaluates to a double.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def months_between(end: Column, start: Column, roundOff: Boolean): Column =
@@ -12289,7 +12289,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def next_day(date: Column, dayOfWeek: String): Column = next_day(date, lit(dayOfWeek))
@@ -12315,7 +12315,7 @@ object functions {
    * @since 3.2.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def next_day(date: Column, dayOfWeek: Column): Column =
@@ -12335,7 +12335,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def second(e: Column): Column = Column.fn("second", e)
@@ -12372,7 +12372,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def from_unixtime(ut: Column): Column = Column.fn("from_unixtime", ut)
@@ -12397,7 +12397,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def from_unixtime(ut: Column, f: String): Column =
@@ -12416,7 +12416,7 @@ object functions {
    *   Returns a column that evaluates to a long.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -12436,7 +12436,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -12462,7 +12462,7 @@ object functions {
    * @since 1.5.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -12519,7 +12519,7 @@ object functions {
    * @since 2.2.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
@@ -12546,7 +12546,7 @@ object functions {
    * @since 2.2.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
@@ -12602,7 +12602,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -12622,7 +12622,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -12639,7 +12639,7 @@ object functions {
    *   Returns a column that evaluates to a date.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -12665,7 +12665,7 @@ object functions {
    * @since 2.2.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -12806,7 +12806,7 @@ object functions {
    * @since 2.3.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def date_trunc(format: String, timestamp: Column): Column =
@@ -13198,7 +13198,7 @@ object functions {
    *   Returns a column that evaluates to a long.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def timestamp_diff(unit: String, start: Column, end: Column): Column =
@@ -13220,7 +13220,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def timestamp_add(unit: String, quantity: Column, ts: Column): Column =
@@ -13242,7 +13242,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def time_bucket(bucketSize: Column, ts: Column): Column =
@@ -13266,7 +13266,7 @@ object functions {
    *   Returns a column of the same type as the input.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def time_bucket(bucketSize: Column, ts: Column, origin: Column): Column =
@@ -13405,7 +13405,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ltz(timestamp: Column, format: Column): Column =
@@ -13424,7 +13424,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ltz(timestamp: Column): Column =
@@ -13473,7 +13473,7 @@ object functions {
    *   Returns a column that evaluates to a long.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -13491,7 +13491,7 @@ object functions {
    *   Returns a column that evaluates to a long.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -13733,7 +13733,7 @@ object functions {
    *   map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def element_at(column: Column, value: Any): Column = Column.fn("element_at", column, lit(value))
@@ -14216,7 +14216,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   def transform_keys(expr: Column, f: (Column, Column) => Column): Column =
@@ -14424,7 +14424,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14455,7 +14455,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14486,7 +14486,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14517,7 +14517,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14542,7 +14542,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14566,7 +14566,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14595,7 +14595,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14626,7 +14626,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14651,7 +14651,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -14681,7 +14681,7 @@ object functions {
    *   Returns a column of the type given by the schema (a struct, array, or map).
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -15312,7 +15312,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -15330,7 +15330,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -15355,7 +15355,7 @@ object functions {
    * @since 3.0.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -15425,7 +15425,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.jsonGenerator.ignoreNullFields`
    *   - `spark.sql.session.timeZone`
    */
@@ -15455,7 +15455,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.jsonGenerator.ignoreNullFields`
    *   - `spark.sql.session.timeZone`
    */
@@ -15477,7 +15477,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.jsonGenerator.ignoreNullFields`
    *   - `spark.sql.session.timeZone`
    */
@@ -15617,7 +15617,7 @@ object functions {
    *   Returns a column that evaluates to an integer.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def size(e: Column): Column = Column.fn("size", e)
@@ -15637,7 +15637,7 @@ object functions {
    *   Returns a column that evaluates to an integer.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def cardinality(e: Column): Column = Column.fn("cardinality", e)
@@ -15909,7 +15909,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   def map_from_entries(e: Column): Column = Column.fn("map_from_entries", e)
@@ -15937,7 +15937,7 @@ object functions {
    *   Returns a column that evaluates to a map.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.mapKeyDedupPolicy`
    */
   @scala.annotation.varargs
@@ -15965,7 +15965,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -15994,7 +15994,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    */
@@ -16017,7 +16017,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -16035,7 +16035,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -16059,7 +16059,7 @@ object functions {
    * @since 3.0.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -16086,7 +16086,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
@@ -16106,7 +16106,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def to_csv(e: Column): Column = to_csv(e, Map.empty[String, String].asJava)
@@ -16132,7 +16132,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.xml.variant.respectInferSchema`
@@ -16161,7 +16161,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.xml.variant.respectInferSchema`
@@ -16186,7 +16186,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.xml.variant.respectInferSchema`
@@ -16216,7 +16216,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.xml.variant.respectInferSchema`
@@ -16241,7 +16241,7 @@ object functions {
    *   Returns a column that evaluates to a struct.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.xml.variant.respectInferSchema`
@@ -16264,7 +16264,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -16281,7 +16281,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -16306,7 +16306,7 @@ object functions {
    * @since 4.0.0
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -16333,7 +16333,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
@@ -16352,7 +16352,7 @@ object functions {
    *   Returns a column that evaluates to a string.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def to_xml(e: Column): Column = to_xml(e, Map.empty[String, String].asJava)
@@ -16556,7 +16556,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def convert_timezone(sourceTz: Column, targetTz: Column, sourceTs: Column): Column =
@@ -16576,7 +16576,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def convert_timezone(targetTz: Column, sourceTs: Column): Column =
@@ -16716,7 +16716,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(
@@ -16780,7 +16780,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(
@@ -16838,7 +16838,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(
@@ -16886,7 +16886,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column, months: Column, weeks: Column, days: Column): Column =
@@ -16925,7 +16925,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column, months: Column, weeks: Column): Column =
@@ -16960,7 +16960,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column, months: Column): Column =
@@ -16991,7 +16991,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column): Column =
@@ -17006,7 +17006,7 @@ object functions {
    *   Returns a column that evaluates to an interval.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_interval(): Column =
@@ -17039,7 +17039,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
@@ -17079,7 +17079,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
@@ -17108,7 +17108,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
@@ -17129,7 +17129,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
@@ -17163,7 +17163,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -17201,7 +17201,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -17229,7 +17229,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -17249,7 +17249,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
@@ -17282,7 +17282,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -17321,7 +17321,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
@@ -17360,7 +17360,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def try_make_timestamp_ltz(
@@ -17397,7 +17397,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
    */
   def try_make_timestamp_ltz(
@@ -17434,7 +17434,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_timestamp_ntz(
@@ -17459,7 +17459,7 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    *
    * @note
-   *   This function's behavior is affected by these public SQL configurations:
+   *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
    */
   def make_timestamp_ntz(date: Column, time: Column): Column =

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -13481,6 +13481,7 @@ object functions {
    * @note
    *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ntz(timestamp: Column, format: Column): Column =
     Column.fn("to_timestamp_ntz", timestamp, format)
@@ -13500,6 +13501,7 @@ object functions {
    * @note
    *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ntz(timestamp: Column): Column =
     Column.fn("to_timestamp_ntz", timestamp)
@@ -14642,6 +14644,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: String, options: java.util.Map[String, String]): Column = {
@@ -14673,6 +14676,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: String, options: Map[String, String]): Column = {
@@ -14698,6 +14702,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def from_json(e: Column, schema: Column): Column = {
     from_json(e, schema, Map.empty[String, String].asJava)
@@ -14728,6 +14733,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: Column, options: java.util.Map[String, String]): Column = {
@@ -15257,6 +15263,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the type specified by the `targetType` argument.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.timestampType`
    */
   def variant_get(v: Column, path: String, targetType: String): Column =
     Column.fn("variant_get", v, lit(path), lit(targetType))
@@ -15277,6 +15287,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the type specified by the `targetType` argument.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.timestampType`
    */
   def variant_get(v: Column, path: Column, targetType: String): Column =
     Column.fn("variant_get", v, path, lit(targetType))
@@ -15296,6 +15310,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the type specified by the `targetType` argument.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.timestampType`
    */
   def try_variant_get(v: Column, path: String, targetType: String): Column =
     Column.fn("try_variant_get", v, lit(path), lit(targetType))
@@ -15316,6 +15334,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the type specified by the `targetType` argument.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.timestampType`
    */
   def try_variant_get(v: Column, path: Column, targetType: String): Column =
     Column.fn("try_variant_get", v, lit(path), lit(targetType))
@@ -15357,7 +15379,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def schema_of_json(json: String): Column = schema_of_json(lit(json))
@@ -15375,7 +15396,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def schema_of_json(json: Column): Column = Column.fn("schema_of_json", json)
@@ -15400,7 +15420,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
@@ -16041,6 +16060,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def from_csv(e: Column, schema: Column, options: java.util.Map[String, String]): Column =
@@ -16062,7 +16082,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def schema_of_csv(csv: String): Column = schema_of_csv(lit(csv))
@@ -16080,7 +16099,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def schema_of_csv(csv: Column): Column = schema_of_csv(csv, Collections.emptyMap())
@@ -16104,7 +16122,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
@@ -16208,6 +16225,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
@@ -16233,6 +16251,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
@@ -16263,6 +16282,7 @@ object functions {
    *   Affected by these public SQL configurations:
    *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
@@ -16309,7 +16329,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.timestampType`
    */
   def schema_of_xml(xml: String): Column = schema_of_xml(lit(xml))
@@ -16326,7 +16346,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.timestampType`
    */
   def schema_of_xml(xml: Column): Column = Column.fn("schema_of_xml", xml)
@@ -16351,7 +16371,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.columnNameOfCorruptRecord`
    *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
@@ -16598,10 +16618,6 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
-   *
-   * @note
-   *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    */
   def convert_timezone(sourceTz: Column, targetTz: Column, sourceTs: Column): Column =
     Column.fn("convert_timezone", sourceTz, targetTz, sourceTs)

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -353,6 +353,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a numeric.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def avg(e: Column): Column = Column.fn("avg", e)
 
@@ -365,6 +369,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a numeric.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def avg(columnName: String): Column = avg(Column(columnName))
 
@@ -1712,6 +1720,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a numeric or interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def sum(e: Column): Column = Column.fn("sum", e)
 
@@ -1724,6 +1736,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a numeric or interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def sum(columnName: String): Column = sum(Column(columnName))
 
@@ -3690,6 +3706,10 @@ object functions {
    *   A time. Returns a column that evaluates to a time.
    * @group datetime_funcs
    * @since 4.1.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def current_time(): Column = {
     Column.fn("current_time")
@@ -3705,6 +3725,10 @@ object functions {
    *   A time. Returns a column that evaluates to a time.
    * @group datetime_funcs
    * @since 4.1.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def current_time(precision: Int): Column = {
     Column.fn("current_time", lit(precision))
@@ -4286,6 +4310,10 @@ object functions {
    * @since 2.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   @scala.annotation.varargs
   def map(cols: Column*): Column = Column.fn("map", cols: _*)
@@ -4317,6 +4345,10 @@ object functions {
    * @since 2.4
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   def map_from_arrays(keys: Column, values: Column): Column =
     Column.fn("map_from_arrays", keys, values)
@@ -4337,6 +4369,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   def str_to_map(text: Column, pairDelim: Column, keyValueDelim: Column): Column =
     Column.fn("str_to_map", text, pairDelim, keyValueDelim)
@@ -4354,6 +4390,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   def str_to_map(text: Column, pairDelim: Column): Column =
     Column.fn("str_to_map", text, pairDelim)
@@ -4367,6 +4407,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   def str_to_map(text: Column): Column = Column.fn("str_to_map", text)
 
@@ -4922,6 +4966,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def abs(e: Column): Column = Column.fn("abs", e)
 
@@ -5233,6 +5281,10 @@ object functions {
    * @since 3.3.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def ceil(e: Column, scale: Column): Column = Column.fn("ceil", e, scale)
 
@@ -5245,6 +5297,10 @@ object functions {
    * @since 1.4.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def ceil(e: Column): Column = Column.fn("ceil", e)
 
@@ -5257,6 +5313,10 @@ object functions {
    * @since 1.4.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def ceil(columnName: String): Column = ceil(Column(columnName))
 
@@ -5272,6 +5332,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def ceiling(e: Column, scale: Column): Column = Column.fn("ceiling", e, scale)
 
@@ -5284,6 +5348,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def ceiling(e: Column): Column = Column.fn("ceiling", e)
 
@@ -5300,6 +5368,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def conv(num: Column, fromBase: Int, toBase: Int): Column =
     Column.fn("conv", num, lit(fromBase), lit(toBase))
@@ -5454,6 +5526,10 @@ object functions {
    * @since 3.3.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def floor(e: Column, scale: Column): Column = Column.fn("floor", e, scale)
 
@@ -5466,6 +5542,10 @@ object functions {
    * @since 1.4.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def floor(e: Column): Column = Column.fn("floor", e)
 
@@ -5478,6 +5558,10 @@ object functions {
    * @since 1.4.0
    * @return
    *   Returns a column that evaluates to a long or decimal.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def floor(columnName: String): Column = floor(Column(columnName))
 
@@ -6034,6 +6118,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def round(e: Column): Column = round(e, 0)
 
@@ -6050,6 +6138,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def round(e: Column, scale: Int): Column = Column.fn("round", e, lit(scale))
 
@@ -6066,6 +6158,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def round(e: Column, scale: Column): Column = Column.fn("round", e, scale)
 
@@ -6125,6 +6221,10 @@ object functions {
    * @since 2.0.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def bround(e: Column): Column = bround(e, 0)
 
@@ -6141,6 +6241,10 @@ object functions {
    * @since 2.0.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def bround(e: Column, scale: Int): Column = Column.fn("bround", e, lit(scale))
 
@@ -6157,6 +6261,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def bround(e: Column, scale: Column): Column = Column.fn("bround", e, scale)
 
@@ -7156,6 +7264,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.reflect.allowList`
    */
   @scala.annotation.varargs
   def reflect(cols: Column*): Column = Column.fn("reflect", cols: _*)
@@ -7167,6 +7279,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.reflect.allowList`
    */
   @scala.annotation.varargs
   def java_method(cols: Column*): Column = Column.fn("java_method", cols: _*)
@@ -7492,6 +7608,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.chunkBase64String.enabled`
    */
   def base64(e: Column): Column = Column.fn("base64", e)
 
@@ -7707,6 +7827,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.icu.caseMappings.enabled`
    */
   def initcap(e: Column): Column = Column.fn("initcap", e)
 
@@ -7896,6 +8020,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.icu.caseMappings.enabled`
    */
   def lower(e: Column): Column = Column.fn("lower", e)
 
@@ -8791,6 +8919,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.icu.caseMappings.enabled`
    */
   def upper(e: Column): Column = Column.fn("upper", e)
 
@@ -9064,6 +9196,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def parse_url(url: Column, partToExtract: Column, key: Column): Column =
     Column.fn("parse_url", url, partToExtract, key)
@@ -9079,6 +9215,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def parse_url(url: Column, partToExtract: Column): Column =
     Column.fn("parse_url", url, partToExtract)
@@ -9359,6 +9499,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   @scala.annotation.varargs
   def elt(inputs: Column*): Column = Column.fn("elt", inputs: _*)
@@ -9454,6 +9598,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.icu.caseMappings.enabled`
    */
   def lcase(str: Column): Column = Column.fn("lcase", str)
 
@@ -9466,6 +9614,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.icu.caseMappings.enabled`
    */
   def ucase(str: Column): Column = Column.fn("ucase", str)
 
@@ -11565,6 +11717,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a date.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def curdate(): Column = Column.fn("curdate")
 
@@ -11576,6 +11732,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a date.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def current_date(): Column = Column.fn("current_date")
 
@@ -11586,6 +11746,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def current_timezone(): Column = Column.fn("current_timezone")
 
@@ -11619,6 +11783,10 @@ object functions {
    * @since 3.3.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def localtimestamp(): Column = Column.fn("localtimestamp")
 
@@ -11646,6 +11814,10 @@ object functions {
    *   if the `format` pattern is invalid
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def date_format(dateExpr: Column, format: String): Column =
     Column.fn("date_format", dateExpr, lit(format))
@@ -11907,6 +12079,10 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def hour(e: Column): Column = Column.fn("hour", e)
 
@@ -11991,6 +12167,10 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def minute(e: Column): Column = Column.fn("minute", e)
 
@@ -12018,6 +12198,10 @@ object functions {
    *   A date created from year, month and day fields. Returns a column that evaluates to a date.
    * @group datetime_funcs
    * @since 3.3.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_date(year: Column, month: Column, day: Column): Column =
     Column.fn("make_date", year, month, day)
@@ -12050,6 +12234,10 @@ object functions {
    *   double.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def months_between(end: Column, start: Column): Column =
     Column.fn("months_between", end, start)
@@ -12072,6 +12260,10 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to a double.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def months_between(end: Column, start: Column, roundOff: Boolean): Column =
     Column.fn("months_between", end, start, lit(roundOff))
@@ -12095,6 +12287,10 @@ object functions {
    *   was an invalid value. Returns a column that evaluates to a date.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def next_day(date: Column, dayOfWeek: String): Column = next_day(date, lit(dayOfWeek))
 
@@ -12117,6 +12313,10 @@ object functions {
    *   was an invalid value. Returns a column that evaluates to a date.
    * @group datetime_funcs
    * @since 3.2.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def next_day(date: Column, dayOfWeek: Column): Column =
     Column.fn("next_day", date, dayOfWeek)
@@ -12133,6 +12333,10 @@ object functions {
    *   Returns a column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def second(e: Column): Column = Column.fn("second", e)
 
@@ -12166,6 +12370,10 @@ object functions {
    *   column that evaluates to a string.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def from_unixtime(ut: Column): Column = Column.fn("from_unixtime", ut)
 
@@ -12187,6 +12395,10 @@ object functions {
    *   invalid date time pattern. Returns a column that evaluates to a string.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def from_unixtime(ut: Column, f: String): Column =
     Column.fn("from_unixtime", ut, lit(f))
@@ -12202,6 +12414,11 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a long.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def unix_timestamp(): Column = unix_timestamp(current_timestamp())
 
@@ -12217,6 +12434,11 @@ object functions {
    *   evaluates to a long.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def unix_timestamp(s: Column): Column = Column.fn("unix_timestamp", s)
 
@@ -12238,6 +12460,11 @@ object functions {
    *   format. Returns a column that evaluates to a long.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def unix_timestamp(s: Column, p: String): Column =
     Column.fn("unix_timestamp", s, lit(p))
@@ -12290,6 +12517,12 @@ object functions {
    *   Returns a column that evaluates to a timestamp.
    * @group datetime_funcs
    * @since 2.2.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def to_timestamp(s: Column): Column = Column.fn("to_timestamp", s)
 
@@ -12311,6 +12544,12 @@ object functions {
    *   an invalid format. Returns a column that evaluates to a timestamp.
    * @group datetime_funcs
    * @since 2.2.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def to_timestamp(s: Column, fmt: String): Column = Column.fn("to_timestamp", s, lit(fmt))
 
@@ -12361,6 +12600,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def try_to_timestamp(s: Column, format: Column): Column =
     Column.fn("try_to_timestamp", s, format)
@@ -12376,6 +12620,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def try_to_timestamp(s: Column): Column = Column.fn("try_to_timestamp", s)
 
@@ -12388,6 +12637,11 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a date.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def to_date(e: Column): Column = Column.fn("to_date", e)
 
@@ -12409,6 +12663,11 @@ object functions {
    *   invalid format. Returns a column that evaluates to a date.
    * @group datetime_funcs
    * @since 2.2.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def to_date(e: Column, fmt: String): Column = Column.fn("to_date", e, lit(fmt))
 
@@ -12545,6 +12804,10 @@ object functions {
    *   `format` was an invalid value. Returns a column that evaluates to a timestamp.
    * @group datetime_funcs
    * @since 2.3.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def date_trunc(format: String, timestamp: Column): Column =
     Column.fn("date_trunc", lit(format), timestamp)
@@ -12933,6 +13196,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a long.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def timestamp_diff(unit: String, start: Column, end: Column): Column =
     Column.internalFn("timestampdiff", lit(unit), start, end)
@@ -12951,6 +13218,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def timestamp_add(unit: String, quantity: Column, ts: Column): Column =
     Column.internalFn("timestampadd", lit(unit), quantity, ts)
@@ -12969,6 +13240,10 @@ object functions {
    * @since 4.2.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def time_bucket(bucketSize: Column, ts: Column): Column =
     Column.fn("time_bucket", bucketSize, ts)
@@ -12989,6 +13264,10 @@ object functions {
    * @since 4.2.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def time_bucket(bucketSize: Column, ts: Column, origin: Column): Column =
     Column.fn("time_bucket", bucketSize, ts, origin)
@@ -13124,6 +13403,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ltz(timestamp: Column, format: Column): Column =
     Column.fn("to_timestamp_ltz", timestamp, format)
@@ -13139,6 +13422,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ltz(timestamp: Column): Column =
     Column.fn("to_timestamp_ltz", timestamp)
@@ -13184,6 +13471,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a long.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def to_unix_timestamp(timeExp: Column, format: Column): Column =
     Column.fn("to_unix_timestamp", timeExp, format)
@@ -13197,6 +13489,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a long.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def to_unix_timestamp(timeExp: Column): Column =
     Column.fn("to_unix_timestamp", timeExp)
@@ -13434,6 +13731,10 @@ object functions {
    * @return
    *   Returns a column of the element type of the input array, or the value type of the input
    *   map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def element_at(column: Column, value: Any): Column = Column.fn("element_at", column, lit(value))
 
@@ -13913,6 +14214,10 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   def transform_keys(expr: Column, f: (Column, Column) => Column): Column =
     Column.fn("transform_keys", expr, createLambda(f))
@@ -14117,6 +14422,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: StructType, options: Map[String, String]): Column =
@@ -14143,6 +14453,11 @@ object functions {
    * @since 2.2.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: DataType, options: Map[String, String]): Column = {
@@ -14169,6 +14484,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: StructType, options: java.util.Map[String, String]): Column =
@@ -14195,6 +14515,11 @@ object functions {
    * @since 2.2.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: DataType, options: java.util.Map[String, String]): Column = {
@@ -14215,6 +14540,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   def from_json(e: Column, schema: StructType): Column =
     from_json(e, schema, Map.empty[String, String])
@@ -14234,6 +14564,11 @@ object functions {
    * @since 2.2.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   def from_json(e: Column, schema: DataType): Column =
     from_json(e, schema, Map.empty[String, String])
@@ -14258,6 +14593,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: String, options: java.util.Map[String, String]): Column = {
@@ -14284,6 +14624,11 @@ object functions {
    * @since 2.3.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: String, options: Map[String, String]): Column = {
@@ -14304,6 +14649,11 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   def from_json(e: Column, schema: Column): Column = {
     from_json(e, schema, Map.empty[String, String].asJava)
@@ -14329,6 +14679,11 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column of the type given by the schema (a struct, array, or map).
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_json(e: Column, schema: Column, options: java.util.Map[String, String]): Column = {
@@ -14955,6 +15310,11 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def schema_of_json(json: String): Column = schema_of_json(lit(json))
 
@@ -14968,6 +15328,11 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def schema_of_json(json: Column): Column = Column.fn("schema_of_json", json)
 
@@ -14988,6 +15353,11 @@ object functions {
    *
    * @group json_funcs
    * @since 3.0.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def schema_of_json(json: Column, options: java.util.Map[String, String]): Column =
@@ -15053,6 +15423,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.jsonGenerator.ignoreNullFields`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def to_json(e: Column, options: Map[String, String]): Column =
@@ -15078,6 +15453,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.jsonGenerator.ignoreNullFields`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def to_json(e: Column, options: java.util.Map[String, String]): Column =
@@ -15095,6 +15475,11 @@ object functions {
    * @since 2.1.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.jsonGenerator.ignoreNullFields`
+   *   - `spark.sql.session.timeZone`
    */
   def to_json(e: Column): Column =
     to_json(e, Map.empty[String, String])
@@ -15230,6 +15615,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to an integer.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def size(e: Column): Column = Column.fn("size", e)
 
@@ -15246,6 +15635,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an integer.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def cardinality(e: Column): Column = Column.fn("cardinality", e)
 
@@ -15514,6 +15907,10 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   def map_from_entries(e: Column): Column = Column.fn("map_from_entries", e)
 
@@ -15538,6 +15935,10 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to a map.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.mapKeyDedupPolicy`
    */
   @scala.annotation.varargs
   def map_concat(cols: Column*): Column = Column.fn("map_concat", cols: _*)
@@ -15562,6 +15963,11 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_csv(e: Column, schema: StructType, options: Map[String, String]): Column =
@@ -15586,6 +15992,11 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def from_csv(e: Column, schema: Column, options: java.util.Map[String, String]): Column =
@@ -15604,6 +16015,11 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def schema_of_csv(csv: String): Column = schema_of_csv(lit(csv))
 
@@ -15617,6 +16033,11 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def schema_of_csv(csv: Column): Column = schema_of_csv(csv, Collections.emptyMap())
 
@@ -15636,6 +16057,11 @@ object functions {
    *   evaluates to a string.
    * @group csv_funcs
    * @since 3.0.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def schema_of_csv(csv: Column, options: java.util.Map[String, String]): Column =
@@ -15658,6 +16084,10 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def to_csv(e: Column, options: java.util.Map[String, String]): Column =
@@ -15674,6 +16104,10 @@ object functions {
    * @since 3.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def to_csv(e: Column): Column = to_csv(e, Map.empty[String, String].asJava)
 
@@ -15696,6 +16130,12 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
   def from_xml(e: Column, schema: StructType, options: java.util.Map[String, String]): Column =
@@ -15719,6 +16159,12 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
   def from_xml(e: Column, schema: String, options: java.util.Map[String, String]): Column = {
@@ -15738,6 +16184,12 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
   def from_xml(e: Column, schema: Column): Column = {
@@ -15762,6 +16214,12 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.xml.variant.respectInferSchema`
    */
   // scalastyle:on line.size.limit
   def from_xml(e: Column, schema: Column, options: java.util.Map[String, String]): Column =
@@ -15781,6 +16239,12 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a struct.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.columnNameOfCorruptRecord`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.xml.variant.respectInferSchema`
    */
   def from_xml(e: Column, schema: StructType): Column =
     from_xml(e, schema, Map.empty[String, String].asJava)
@@ -15798,6 +16262,11 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def schema_of_xml(xml: String): Column = schema_of_xml(lit(xml))
 
@@ -15810,6 +16279,11 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def schema_of_xml(xml: Column): Column = Column.fn("schema_of_xml", xml)
 
@@ -15830,6 +16304,11 @@ object functions {
    *   evaluates to a string.
    * @group xml_funcs
    * @since 4.0.0
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   // scalastyle:on line.size.limit
   def schema_of_xml(xml: Column, options: java.util.Map[String, String]): Column =
@@ -15852,6 +16331,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   // scalastyle:on line.size.limit
   def to_xml(e: Column, options: java.util.Map[String, String]): Column =
@@ -15867,6 +16350,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def to_xml(e: Column): Column = to_xml(e, Map.empty[String, String].asJava)
 
@@ -16067,6 +16554,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def convert_timezone(sourceTz: Column, targetTz: Column, sourceTs: Column): Column =
     Column.fn("convert_timezone", sourceTz, targetTz, sourceTs)
@@ -16083,6 +16574,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def convert_timezone(targetTz: Column, sourceTs: Column): Column =
     Column.fn("convert_timezone", targetTz, sourceTs)
@@ -16219,6 +16714,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(
       years: Column,
@@ -16279,6 +16778,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(
       years: Column,
@@ -16333,6 +16836,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(
       years: Column,
@@ -16377,6 +16884,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column, months: Column, weeks: Column, days: Column): Column =
     Column.fn("make_interval", years, months, weeks, days)
@@ -16412,6 +16923,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column, months: Column, weeks: Column): Column =
     Column.fn("make_interval", years, months, weeks)
@@ -16443,6 +16958,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column, months: Column): Column =
     Column.fn("make_interval", years, months)
@@ -16470,6 +16989,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(years: Column): Column =
     Column.fn("make_interval", years)
@@ -16481,6 +17004,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an interval.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_interval(): Column =
     Column.fn("make_interval")
@@ -16510,6 +17037,12 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def make_timestamp(
       years: Column,
@@ -16544,6 +17077,12 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def make_timestamp(
       years: Column,
@@ -16567,6 +17106,12 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def make_timestamp(date: Column, time: Column, timezone: Column): Column =
     Column.fn("make_timestamp", date, time, timezone)
@@ -16582,6 +17127,12 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def make_timestamp(date: Column, time: Column): Column =
     Column.fn("make_timestamp", date, time)
@@ -16610,6 +17161,11 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(
       years: Column,
@@ -16643,6 +17199,11 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(
       years: Column,
@@ -16666,6 +17227,11 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(date: Column, time: Column, timezone: Column): Column =
     Column.fn("try_make_timestamp", date, time, timezone)
@@ -16681,6 +17247,11 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
+   *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(date: Column, time: Column): Column =
     Column.fn("try_make_timestamp", date, time)
@@ -16709,6 +17280,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def make_timestamp_ltz(
       years: Column,
@@ -16743,6 +17319,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def make_timestamp_ltz(
       years: Column,
@@ -16777,6 +17358,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def try_make_timestamp_ltz(
       years: Column,
@@ -16810,6 +17395,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def try_make_timestamp_ltz(
       years: Column,
@@ -16843,6 +17432,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_timestamp_ntz(
       years: Column,
@@ -16864,6 +17457,10 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   This function's behavior is affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def make_timestamp_ntz(date: Column, time: Column): Column =
     Column.fn("make_timestamp_ntz", date, time)

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1368,6 +1368,10 @@ object functions {
    * @since 1.4.0
    * @return
    *   Returns a column that evaluates to a double.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def mean(e: Column): Column = avg(e)
 
@@ -1378,6 +1382,10 @@ object functions {
    * @since 1.4.0
    * @return
    *   Returns a column that evaluates to a double.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def mean(columnName: String): Column = avg(columnName)
 
@@ -1750,6 +1758,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a numeric or interval.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   @deprecated("Use sum_distinct", "3.2.0")
   def sumDistinct(e: Column): Column = sum_distinct(e)
@@ -1761,6 +1773,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column that evaluates to a numeric or interval.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   @deprecated("Use sum_distinct", "3.2.0")
   def sumDistinct(columnName: String): Column = sum_distinct(Column(columnName))
@@ -1774,6 +1790,10 @@ object functions {
    * @since 3.2.0
    * @return
    *   Returns a column that evaluates to a numeric or interval.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def sum_distinct(e: Column): Column = Column.fn("sum", isDistinct = true, e)
 
@@ -4558,6 +4578,10 @@ object functions {
    * @since 1.3.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def negate(e: Column): Column = -e
 
@@ -5916,6 +5940,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def negative(e: Column): Column = Column.fn("negative", e)
 
@@ -6080,6 +6108,10 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column of the same type as the input.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def pmod(dividend: Column, divisor: Column): Column = Column.fn("pmod", dividend, divisor)
 
@@ -7295,6 +7327,10 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.reflect.allowList`
    */
   @scala.annotation.varargs
   def try_reflect(cols: Column*): Column = Column.fn("try_reflect", cols: _*)
@@ -12414,11 +12450,6 @@ object functions {
    * @since 1.5.0
    * @return
    *   Returns a column that evaluates to a long.
-   *
-   * @note
-   *   Affected by these public SQL configurations:
-   *   - `spark.sql.ansi.enabled`
-   *   - `spark.sql.session.timeZone`
    */
   def unix_timestamp(): Column = unix_timestamp(current_timestamp())
 
@@ -13393,7 +13424,8 @@ object functions {
 
   /**
    * Parses the `timestamp` expression with the `format` expression to a timestamp with local time
-   * zone. Returns null with invalid input.
+   * zone. Returns null with invalid input when ANSI mode is disabled, or raises an error
+   * otherwise.
    *
    * @param timestamp
    *   the input column or strings. A column that evaluates to a date, timestamp or string.
@@ -13406,6 +13438,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ltz(timestamp: Column, format: Column): Column =
@@ -13414,7 +13447,7 @@ object functions {
   /**
    * Parses the `timestamp` expression with the default format to a timestamp with local time
    * zone. The default format follows casting rules to a timestamp. Returns null with invalid
-   * input.
+   * input when ANSI mode is disabled, or raises an error otherwise.
    *
    * @param timestamp
    *   the input column or strings. A column that evaluates to a date, timestamp or string.
@@ -13425,6 +13458,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
   def to_timestamp_ltz(timestamp: Column): Column =
@@ -13432,7 +13466,8 @@ object functions {
 
   /**
    * Parses the `timestamp_str` expression with the `format` expression to a timestamp without
-   * time zone. Returns null with invalid input.
+   * time zone. Returns null with invalid input when ANSI mode is disabled, or raises an error
+   * otherwise.
    *
    * @param timestamp
    *   the input column or strings. A column that evaluates to a date, timestamp or string.
@@ -13442,13 +13477,18 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def to_timestamp_ntz(timestamp: Column, format: Column): Column =
     Column.fn("to_timestamp_ntz", timestamp, format)
 
   /**
    * Parses the `timestamp` expression with the default format to a timestamp without time zone.
-   * The default format follows casting rules to a timestamp. Returns null with invalid input.
+   * The default format follows casting rules to a timestamp. Returns null with invalid input when
+   * ANSI mode is disabled, or raises an error otherwise.
    *
    * @param timestamp
    *   the input column or strings. A column that evaluates to a date, timestamp or string.
@@ -13456,6 +13496,10 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to a timestamp.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    */
   def to_timestamp_ntz(timestamp: Column): Column =
     Column.fn("to_timestamp_ntz", timestamp)
@@ -17041,7 +17085,6 @@ object functions {
    * @note
    *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def make_timestamp(
@@ -17106,12 +17149,6 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
-   *
-   * @note
-   *   Affected by these public SQL configurations:
-   *   - `spark.sql.ansi.enabled`
-   *   - `spark.sql.session.timeZone`
-   *   - `spark.sql.timestampType`
    */
   def make_timestamp(date: Column, time: Column, timezone: Column): Column =
     Column.fn("make_timestamp", date, time, timezone)
@@ -17130,9 +17167,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
-   *   - `spark.sql.timestampType`
    */
   def make_timestamp(date: Column, time: Column): Column =
     Column.fn("make_timestamp", date, time)
@@ -17164,7 +17199,6 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(
@@ -17227,11 +17261,6 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
-   *
-   * @note
-   *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
-   *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(date: Column, time: Column, timezone: Column): Column =
     Column.fn("try_make_timestamp", date, time, timezone)
@@ -17251,7 +17280,6 @@ object functions {
    * @note
    *   Affected by these public SQL configurations:
    *   - `spark.sql.session.timeZone`
-   *   - `spark.sql.timestampType`
    */
   def try_make_timestamp(date: Column, time: Column): Column =
     Column.fn("try_make_timestamp", date, time)
@@ -17284,7 +17312,6 @@ object functions {
    * @note
    *   Affected by these public SQL configurations:
    *   - `spark.sql.ansi.enabled`
-   *   - `spark.sql.session.timeZone`
    */
   def make_timestamp_ltz(
       years: Column,
@@ -17358,10 +17385,6 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a timestamp.
-   *
-   * @note
-   *   Affected by these public SQL configurations:
-   *   - `spark.sql.session.timeZone`
    */
   def try_make_timestamp_ltz(
       years: Column,
@@ -17457,10 +17480,6 @@ object functions {
    * @since 4.1.0
    * @return
    *   Returns a column that evaluates to a timestamp.
-   *
-   * @note
-   *   Affected by these public SQL configurations:
-   *   - `spark.sql.ansi.enabled`
    */
   def make_timestamp_ntz(date: Column, time: Column): Column =
     Column.fn("make_timestamp_ntz", date, time)

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -12021,6 +12021,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def year(e: Column): Column = Column.fn("year", e)
 
@@ -12034,6 +12039,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def quarter(e: Column): Column = Column.fn("quarter", e)
 
@@ -12047,6 +12057,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def month(e: Column): Column = Column.fn("month", e)
 
@@ -12061,6 +12076,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 2.3.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def dayofweek(e: Column): Column = Column.fn("dayofweek", e)
 
@@ -12074,6 +12094,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def dayofmonth(e: Column): Column = Column.fn("dayofmonth", e)
 
@@ -12087,6 +12112,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 3.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def day(e: Column): Column = Column.fn("day", e)
 
@@ -12100,6 +12130,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def dayofyear(e: Column): Column = Column.fn("dayofyear", e)
 
@@ -12118,6 +12153,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
   def hour(e: Column): Column = Column.fn("hour", e)
@@ -12206,6 +12242,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
   def minute(e: Column): Column = Column.fn("minute", e)
@@ -12220,6 +12257,11 @@ object functions {
    * @since 3.5.0
    * @return
    *   Returns a column that evaluates to an integer.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def weekday(e: Column): Column = Column.fn("weekday", e)
 
@@ -12372,6 +12414,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
    *   - `spark.sql.session.timeZone`
    */
   def second(e: Column): Column = Column.fn("second", e)
@@ -12390,6 +12433,11 @@ object functions {
    *   column that evaluates to an integer.
    * @group datetime_funcs
    * @since 1.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def weekofyear(e: Column): Column = Column.fn("weekofyear", e)
 
@@ -13554,6 +13602,11 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def monthname(timeExp: Column): Column =
     Column.fn("monthname", timeExp)
@@ -13568,6 +13621,11 @@ object functions {
    * @since 4.0.0
    * @return
    *   Returns a column that evaluates to a string.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def dayname(timeExp: Column): Column =
     Column.fn("dayname", timeExp)
@@ -15266,6 +15324,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def variant_get(v: Column, path: String, targetType: String): Column =
@@ -15290,6 +15349,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def variant_get(v: Column, path: Column, targetType: String): Column =
@@ -15313,6 +15373,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def try_variant_get(v: Column, path: String, targetType: String): Column =
@@ -15337,6 +15398,7 @@ object functions {
    *
    * @note
    *   Affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    *   - `spark.sql.timestampType`
    */
   def try_variant_get(v: Column, path: Column, targetType: String): Column =
@@ -15862,6 +15924,10 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to an array.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def sequence(start: Column, stop: Column, step: Column): Column =
     Column.fn("sequence", start, stop, step)
@@ -15880,6 +15946,10 @@ object functions {
    * @since 2.4.0
    * @return
    *   Returns a column that evaluates to an array.
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.session.timeZone`
    */
   def sequence(start: Column, stop: Column): Column = Column.fn("sequence", start, stop)
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -12170,6 +12170,11 @@ object functions {
    *   field to extract, e.g. an integer for `YEAR` and a decimal for `SECOND`.
    * @group datetime_funcs
    * @since 3.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def extract(field: Column, source: Column): Column = {
     Column.fn("extract", field, source)
@@ -12188,6 +12193,11 @@ object functions {
    *   field to extract, e.g. an integer for `YEAR` and a decimal for `SECOND`.
    * @group datetime_funcs
    * @since 3.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def date_part(field: Column, source: Column): Column = {
     Column.fn("date_part", field, source)
@@ -12206,6 +12216,11 @@ object functions {
    *   field to extract, e.g. an integer for `YEAR` and a decimal for `SECOND`.
    * @group datetime_funcs
    * @since 3.5.0
+   *
+   * @note
+   *   Affected by these public SQL configurations:
+   *   - `spark.sql.ansi.enabled`
+   *   - `spark.sql.session.timeZone`
    */
   def datepart(field: Column, source: Column): Column = {
     Column.fn("datepart", field, source)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Document the public SQL configurations that can affect the behavior of functions exposed by
`org.apache.spark.sql.functions` and `pyspark.sql.functions`.

The updated Scala and Python API documentation covers these configurations:

- `spark.sql.ansi.enabled`
- `spark.sql.chunkBase64String.enabled`
- `spark.sql.columnNameOfCorruptRecord`
- `spark.sql.icu.caseMappings.enabled`
- `spark.sql.jsonGenerator.ignoreNullFields`
- `spark.sql.mapKeyDedupPolicy`
- `spark.sql.reflect.allowList`
- `spark.sql.session.timeZone`
- `spark.sql.timestampType`
- `spark.sql.xml.variant.respectInferSchema`

### Why are the changes needed?

Some SQL functions change their behavior based on session configuration, but their API
documentation did not consistently identify those dependencies. Listing the relevant public
configuration keys makes those behavior differences discoverable from both the Scala and Python
function documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests were added because this is a documentation-only change. The patch was validated with:

- `git diff --check`
- Python AST parsing of `python/pyspark/sql/functions/builtin.py`
- changed-line checks for the 100-character limit and non-ASCII characters
- a coverage check that every identified config-sensitive function is documented in both APIs

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
