### PR TITLE
[SPARK-59084][CORE] Fix anchors styled as buttons to keep the button hover style

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -62,6 +62,10 @@ a:not([href]):not([class]):hover {
   text-decoration:underline
 }
 
+/* An anchor styled as a button must not pick up the link underline above. */
+a.btn:hover {
+  text-decoration: none;
+}
 
 
 .form-inline label {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an `a.btn:hover` rule to `webui.css` so that an anchor styled as a Bootstrap button keeps the button hover style instead of the link underline.

### Why are the changes needed?

Bootstrap 5 resets the underline on the `.btn` base rule, whose specificity `(0,1,0)` loses to the global `a:hover` rule in `webui.css` at `(0,1,1)`, and `.btn:hover` declares only `color`, `background-color`, and `border-color`. So every `<a class="btn ...">` is underlined on hover. The new rule is `(0,2,1)` and wins, while leaving plain links untouched.

This is a regression from SPARK-55753 (Bootstrap 4.6.2 to 5.3.8) at Apache Spark 4.2.0; Bootstrap 4 declared `text-decoration: none` on `.btn:hover` itself, at a specificity that won.
- https://github.com/apache/spark/pull/54552

Two buttons are affected: "Open in new tab" in the executor detail offcanvas (`executorspage.js`) and `Download` in the History Server's Event Log column (`historypage.js`). All other `btn` usages are `<button>` elements, which were never affected.

### Does this PR introduce _any_ user-facing change?

Yes. Hovering an anchor styled as a button no longer underlines its label; it now renders the standard Bootstrap button hover state. Compared to released versions, this fixes "Open in new tab" in the executor detail offcanvas, underlined on hover since Spark 4.2.0.

### How was this patch tested?

Manually verified.

**BEFORE (Apache Spark 4.2.0)**

<img width="337" height="116" alt="Screenshot 2026-08-28 at 08 40 39" src="https://github.com/user-attachments/assets/ed7bb371-9891-404c-ba1b-816a52e887cf" />

**AFTER (This PR)**

<img width="338" height="114" alt="Screenshot 2026-08-28 at 08 41 43" src="https://github.com/user-attachments/assets/74796e7e-bb42-47ae-9ee6-6908997bc847" />

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5