### PR TITLE
[SPARK-59087][CONNECT] Authenticate before the other gRPC interceptors run

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -437,12 +437,14 @@ object SparkConnectService extends Logging {
       sb.permitKeepAliveWithoutCalls(true)
       sb.addService(sparkConnectService)
 
+      // Add all registered interceptors to the server builder.
+      SparkConnectInterceptorRegistry.chainInterceptors(sb, configuredInterceptors)
+
+      // A ServerBuilder invokes interceptors in the reverse of the order they were added so add
+      // auth at the end so it runs first.
       getAuthenticateToken.foreach { token =>
         sb.intercept(new PreSharedKeyAuthenticationInterceptor(token))
       }
-
-      // Add all registered interceptors to the server builder.
-      SparkConnectInterceptorRegistry.chainInterceptors(sb, configuredInterceptors)
 
       // If debug mode is configured, load the ProtoReflection service so that tools like
       // grpcurl can introspect the API for debugging.

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectAuthInterceptorOrderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectAuthInterceptorOrderSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.service
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
+
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.connect.{SparkConnectServerTest, SparkSession}
+import org.apache.spark.sql.connect.config.Connect
+
+/**
+ * Counts the calls it is handed, so a test can tell whether it ran at all. Needs a no-argument
+ * constructor to be loadable from `spark.connect.grpc.interceptor.classes`.
+ */
+class CallCountingInterceptor extends ServerInterceptor {
+  override def interceptCall[ReqT, RespT](
+      call: ServerCall[ReqT, RespT],
+      headers: Metadata,
+      next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+    CallCountingInterceptor.calls.incrementAndGet()
+    next.startCall(call, headers)
+  }
+}
+
+object CallCountingInterceptor {
+  val calls = new AtomicInteger(0)
+}
+
+/**
+ * Tests that authentication runs ahead of the other interceptors, rather than behind them.
+ *
+ * A `ServerBuilder` invokes interceptors in the reverse of the order they were added, so where
+ * `PreSharedKeyAuthenticationInterceptor` is registered decides how much of the pipeline an
+ * unauthenticated caller can drive before being turned away.
+ */
+class SparkConnectAuthInterceptorOrderSuite extends SparkConnectServerTest {
+
+  private val token = "deadbeef"
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(Connect.CONNECT_AUTHENTICATE_TOKEN.key, token)
+
+  override protected def extraServerConfs: Seq[(String, String)] = Seq(
+    Connect.CONNECT_GRPC_INTERCEPTOR_CLASSES.key -> classOf[CallCountingInterceptor].getName)
+
+  test("an unauthenticated call is rejected before the configured interceptors run") {
+    CallCountingInterceptor.calls.set(0)
+
+    val anonymous = SparkSession
+      .builder()
+      .remote(s"sc://localhost:${SparkConnectService.localPort}/")
+      .create()
+    val e = intercept[SparkException](anonymous.range(5).collect())
+    assert(e.getMessage.contains("No authentication token provided"))
+    assert(
+      CallCountingInterceptor.calls.get() === 0,
+      "a configured interceptor ran for a call that failed authentication")
+
+    // Without this the assertion above would also hold if the interceptor were simply never
+    // wired up, so prove it does run once the caller authenticates.
+    val authenticated = SparkSession
+      .builder()
+      .remote(s"sc://localhost:${SparkConnectService.localPort}/;token=$token")
+      .create()
+    assert(authenticated.range(5).collect().length === 5)
+    assert(
+      CallCountingInterceptor.calls.get() > 0,
+      "the configured interceptor never ran, so this suite proves nothing")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`startGRPCService` registers `PreSharedKeyAuthenticationInterceptor` after the entries from `SparkConnectInterceptorRegistry` rather than before them. A `ServerBuilder` invokes interceptors in the reverse of the order they were added, so the one added last is the outermost and runs first. That is the documented contract of `ServerBuilder.intercept` -- "Interceptors run in the reverse order in which they are added, just as with consecutive calls to `ServerInterceptors.intercept()`":

https://github.com/grpc/grpc-java/blob/v1.76.0/api/src/main/java/io/grpc/ServerBuilder.java#L134-L144

Adds `SparkConnectAuthInterceptorOrderSuite`, which configures an interceptor through `spark.connect.grpc.interceptor.classes` and asserts it does not run for a call that fails authentication, then that it does run for a call that passes -- so the first assertion cannot hold merely because the interceptor was never wired up.

### Why are the changes needed?

Authentication was the innermost interceptor, so it ran last. Everything registered after it -- `RequestDecompressionInterceptor` and whatever an operator names in `spark.connect.grpc.interceptor.classes` -- had its `interceptCall` invoked on behalf of callers that were about to be rejected as unauthenticated. Verified with the new suite: on the previous order it fails with "1 did not equal 0 a configured interceptor ran for a call that failed authentication".

Message payloads were not exposed, because gRPC stops delivering messages once the interceptor closes the call, so nothing attacker-supplied reached a listener. The exposure was the per-call setup work in the outer interceptors, and the fragility of an order in which any future interceptor doing real work in `interceptCall` or `onMessage` would run pre-authentication by default.

### Does this PR introduce _any_ user-facing change?

Yes, for a server that configures both an authentication token and `spark.connect.grpc.interceptor.classes`: those interceptors no longer see calls that fail authentication. An interceptor that supplied the `Authorization` header itself, for example translating another scheme into a bearer token, relied on running ahead of authentication and no longer does. That ordering was never specified.

### How was this patch tested?

`SparkConnectAuthInterceptorOrderSuite` plus `SparkConnectAuthSuite`, `InterceptorRegistrySuite` and `SparkConnectServiceKeepAliveSuite`: 16 tests, all passing, scalastyle clean. Reverting just the registration order and rerunning the new suite reproduces the failure quoted above, so the assertion is load-bearing.

The reverse-invocation order and the fact that a closed call stops message delivery were both confirmed against grpc 1.76.0 with a standalone in-process harness: with the old registration order the outer interceptor's `interceptCall` ran once for an unauthenticated call while its listener saw zero `onMessage` and zero `onHalfClose` callbacks and the service handler was never invoked; with the new order it did not run at all, and on an authenticated call it ran and saw the message.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)