### PR TITLE
[SPARK-59069][PYTHON] Transpile Python UDFs with positional-only params

### DIFF
--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -891,6 +891,61 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             "both parameters are supplied at the call site, so both get placeholders",
         )
 
+    def test_udf_transpile_positional_only_params_lower(self):
+        # No placeholder-omission hazard -- always bound by position -- so this
+        # lowers now, unlike default/variadic/keyword-only params. Typed str/int
+        # and value-dependent on both, so a swapped placeholder or category
+        # fails on the result, not just a missing lowering.
+        def two_posonly(a: str, b: int, /):
+            return a if b > 0 else "-"
+
+        def mixed_posonly(a: str, /, b: int):
+            return a if b > 0 else "-"
+
+        posonly_lambda = lambda x, /, y: y - x  # noqa: E731
+
+        self.assertEqual(
+            self._vals(two_posonly, StringType(), "a string, b long", [("xy", 5)]), ["xy"]
+        )
+        self.assertEqual(
+            self._vals(mixed_posonly, StringType(), "a string, b long", [("xy", 5)]), ["xy"]
+        )
+        self.assertEqual(self._vals(posonly_lambda, LongType(), "a long, b long", [(2, 5)]), [3])
+
+    def test_udf_transpile_positional_only_param_with_default_still_falls_back(self):
+        # A default's a default whether it's positional-only or not.
+        def posonly_with_default(a, b=1, /):
+            return a + b
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(posonly_with_default, LongType())
+            self.assertEqual([], pudf.transpiled)
+            df = self.spark.createDataFrame([(2,)], "a long")
+            self.assertEqual(df.select(pudf("a")).first()[0], 3)
+
+    def test_udf_transpile_positional_only_receiver_and_public_params(self):
+        # self/a/b all land in posonlyargs here, none in args.args -- the slice
+        # _param_category_combos used to miss. Typed str/int so a reversed
+        # slice (self swapped in for a public param) fails on the result.
+        class Adder:
+            def __call__(self, a: str, b: int, /):
+                return a if b > 0 else "-"
+
+        self.assertEqual(self._vals(Adder(), StringType(), "a string, b long", [("xy", 3)]), ["xy"])
+
+    def test_udf_transpile_positional_only_kwarg_call_raises_like_python(self):
+        # A kwarg naming a positional-only param must still raise -- the
+        # transpile candidacy shim resolves kwargs to positions and must not
+        # paper over a call Python itself rejects.
+        def posonly(a, b, /):
+            return a + b
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(posonly, LongType())
+            df = self.spark.createDataFrame([(2, 3)], "a long, b long")
+            with self.assertRaisesRegex(Exception, "positional-only arguments"):
+                df.select(pudf(a=df.a, b=df.b)).collect()
+
     def test_udf_transpile_falls_back_for_wraps_decorated_function(self):
         # inspect.getsource follows __wrapped__, so a functools.wraps-decorated
         # UDF previously transpiled the WRAPPED function's source while the

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -51,7 +51,7 @@ import sys
 import textwrap
 import threading
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple, Union
 
 from pyspark.errors import UnsupportedOperationException
 from pyspark.sql.column import Column
@@ -850,7 +850,8 @@ def _param_category_combos(function_ast: ast.FunctionDef, public_params: List[st
     matrix small) while keeping every typed param pinned.
     """
     n = len(public_params)
-    public_args = function_ast.args.args[len(function_ast.args.args) - n :]
+    all_args = _positional_args(function_ast)
+    public_args = all_args[len(all_args) - n :]
     candidates: List[List[str]] = []
     untyped = 0
     for arg in public_args:
@@ -982,9 +983,14 @@ def _get_src_ast_from_func(func: Callable) -> Tuple[Optional[str], Optional[ast.
     return src, ast_info
 
 
-def _get_parameter_list(node: ast.FunctionDef) -> list[str]:
-    """Return the positional argument names in order."""
-    return [arg.arg for arg in node.args.args]
+def _positional_args(node: Union[ast.FunctionDef, ast.Lambda]) -> List[ast.arg]:
+    """Return the positional argument nodes in order, positional-only first."""
+    return node.args.posonlyargs + node.args.args
+
+
+def _get_parameter_list(node: Union[ast.FunctionDef, ast.Lambda]) -> list[str]:
+    """Return the positional argument names in order, positional-only first."""
+    return [arg.arg for arg in _positional_args(node)]
 
 
 def _get_function_from_ast(body: ast.AST, held_code: Any) -> Tuple[Optional[ast.FunctionDef], str]:
@@ -1040,7 +1046,7 @@ def _get_function_from_ast(body: ast.AST, held_code: Any) -> Tuple[Optional[ast.
         # be the UDF) from one that RETURNED the lambda we hold, as in the one-line
         # ``make_adder = lambda n: lambda x: x + n`` -- there the outer lambda is
         # located and the inner is held, and lowering the outer would be wrong.
-        located_args = [arg.arg for arg in stmt.args.args]
+        located_args = _get_parameter_list(stmt)
         if located_args != list(held_code.co_varnames[: held_code.co_argcount]):
             return None, (
                 "the lambda defined in the source read for this one takes different "
@@ -1084,7 +1090,7 @@ def _transpile_func(
     session: "SparkSession",
     func: Callable[..., Any],
     returnType: "DataTypeOrString",
-) -> Tuple[List[Column], List[str], List[str], List[List[str]]]:
+) -> Tuple[List[Column], List[str], List[str], List[List[str]], List[str]]:
     """
     An experimental internal function that attempts to transpile a callable function.
 
@@ -1099,6 +1105,9 @@ def _transpile_func(
     list of per-option input-type categories (``"numeric"`` / ``"string"`` per
     public param) -- the JVM picks the option whose categories match the bound
     column types, or falls back to the Python UDF when none match.
+    list of the public parameter names Python forbids calling by keyword
+    (positional-only) -- the caller must NOT resolve a kwarg matching one of these
+    to a position, since Python itself rejects that call.
     """
     try:
         # The transpiler lowers to atomic (numeric/string/boolean/binary)
@@ -1126,6 +1135,7 @@ def _transpile_func(
                 ],
                 [],
                 [],
+                [],
             )
         # A functools.wraps-style decorator makes ``inspect.getsource`` return
         # the WRAPPED function's source (getsource follows ``__wrapped__``),
@@ -1147,22 +1157,23 @@ def _transpile_func(
                 ],
                 [],
                 [],
+                [],
             )
         # Not ``ast``: that name would shadow the module for this whole function.
         src, ast_info = _get_src_ast_from_func(func)
         if ast_info is None:
-            return ([], ["Error getting ast for function, cannot transpile"], [], [])
+            return ([], ["Error getting ast for function, cannot transpile"], [], [], [])
         # Get the lambda body and parameters
         function_ast, extraction_error = _get_function_from_ast(ast_info, _held_code(func))
         if function_ast is None:
-            return ([], [extraction_error], [], [])
-        # Default, variadic (``*args`` / ``**kwargs``), keyword-only, and
-        # positional-only parameters can't be represented by the positional
-        # ``_udf_param_N`` placeholder scheme: a call site may omit a
-        # defaulted argument, leaving the placeholder referencing a position
-        # the call never bound, and ``_get_parameter_list`` only reads
-        # ``args``. Fall back to interpreted Python rather than emit an
-        # invalid plan.
+            return ([], [extraction_error], [], [], [])
+        # Default, variadic (``*args`` / ``**kwargs``) and keyword-only params
+        # can't be represented by the positional ``_udf_param_N`` placeholder
+        # scheme: a call site may omit a defaulted argument, leaving the
+        # placeholder referencing a position the call never bound. A
+        # positional-only param has no such gap -- it is always bound by
+        # position -- so it is not refused here; a DEFAULTED one still hits
+        # ``fn_args.defaults`` above.
         fn_args = function_ast.args
         if (
             fn_args.defaults
@@ -1170,14 +1181,14 @@ def _transpile_func(
             or fn_args.kwonlyargs
             or fn_args.vararg is not None
             or fn_args.kwarg is not None
-            or fn_args.posonlyargs
         ):
             return (
                 [],
                 [
-                    "functions with default, variadic, keyword-only, or "
-                    "positional-only arguments are not supported by the transpiler"
+                    "functions with default, variadic, or keyword-only "
+                    "arguments are not supported by the transpiler"
                 ],
+                [],
                 [],
                 [],
             )
@@ -1217,6 +1228,7 @@ def _transpile_func(
                     ],
                     [],
                     [],
+                    [],
                 )
             spoken_for = int(
                 inspect.isfunction(call_entry) or isinstance(call_entry, classmethod)
@@ -1226,11 +1238,16 @@ def _transpile_func(
             # prepends the class ON TOP of the method's own ``__self__`` -- or one with
             # no parameter to hold it. Python raises for whatever the call site passes,
             # so there is nothing correct to lower.
-            return ([], ["callable leaves no parameter for the call site to bind"], [], [])
+            return ([], ["callable leaves no parameter for the call site to bind"], [], [], [])
         # Caller-facing params: callers match user-supplied kwargs against this,
         # and the receiver is not named at the call site. Everything downstream
         # indexes off THIS list, so the placeholder numbering needs no offset.
         public_params = params[spoken_for:]
+        # Subset of ``public_params`` Python forbids calling by keyword. The
+        # call-site kwargs-to-positional rewrite in ``udf.py`` must not "fix" a
+        # keyword call to one of these, since Python itself would reject it.
+        posonly_names = {arg.arg for arg in function_ast.args.posonlyargs}
+        positional_only_public_params = [p for p in public_params if p in posonly_names]
         transpiled: list[Column] = []
         input_categories: list[list[str]] = []
         errors = []
@@ -1253,9 +1270,15 @@ def _transpile_func(
                         )
                 except Exception as e:
                     errors.append(str(e))
-        return (transpiled, errors, public_params, input_categories)
+        return (
+            transpiled,
+            errors,
+            public_params,
+            input_categories,
+            positional_only_public_params,
+        )
     except Exception as e:
         # Don't re-raise: an inability to transpile must never break a
         # working UDF. The caller treats an empty ``transpiled`` list as a
         # silent fall-back to interpreted Python.
-        return ([], [str(e)], [], [])
+        return ([], [str(e)], [], [], [])

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -222,6 +222,10 @@ class UserDefinedFunction:
         # Extract Python UDF details if transpilation is enabled.
         self.transpiled: list = []
         self._transpiled_param_names: list[str] = []
+        # The subset of the names above that Python forbids calling by keyword.
+        # The kwargs rewrite in ``__call__`` must leave these alone rather than
+        # silently coerce them to positional -- see the note there.
+        self._positional_only_param_names: frozenset = frozenset()
         # Per-option input-type categories ("numeric"/"string" per public param),
         # parallel to ``self.transpiled``; the JVM picks the option matching the
         # actual column types or falls back to interpreted Python.
@@ -296,7 +300,9 @@ class UserDefinedFunction:
                     errors,
                     self._transpiled_param_names,
                     self._transpiled_input_categories,
+                    positional_only,
                 ) = _transpile_func(session, func, self.returnType)
+                self._positional_only_param_names = frozenset(positional_only)
                 if not self.transpiled:
                     detail = f": {errors}" if errors else ""
                     warnings.warn(f"Unable to transpile UDF {func}{detail}")
@@ -311,6 +317,7 @@ class UserDefinedFunction:
             self.transpiled = []
             self._transpiled_param_names = []
             self._transpiled_input_categories = []
+            self._positional_only_param_names = frozenset()
 
     @staticmethod
     def _check_return_type(returnType: DataType, evalType: int) -> None:
@@ -565,12 +572,19 @@ class UserDefinedFunction:
         # rejects named arguments). Resolve kwargs to positional here
         # using the parameter list captured at transpilation time so the
         # rewritten expression sees plain column refs in declared order.
+        #
+        # A positional-only param is never resolved here -- Python itself
+        # rejects calling one by keyword, and rewriting would paper over that.
+        # Left unresolved, its kwarg reaches the JVM as a
+        # ``NamedArgumentExpression``, which drops the transpiled expression and
+        # falls back to interpreted Python, so the worker's own keyword call
+        # raises the same ``TypeError`` Python would.
         if kwargs and self.transpiled and self._transpiled_param_names:
             params = self._transpiled_param_names
             ordered: list = list(args)
             remaining_kwargs = dict(kwargs)
             for pname in params[len(args) :]:
-                if pname in remaining_kwargs:
+                if pname in remaining_kwargs and pname not in self._positional_only_param_names:
                     ordered.append(remaining_kwargs.pop(pname))
                 else:
                     # Caller didn't supply this param positionally or by
@@ -737,6 +751,7 @@ class UserDefinedFunction:
         self.transpiled = []
         self._transpiled_param_names = []
         self._transpiled_input_categories = []
+        self._positional_only_param_names = frozenset()
         return self
 
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Transpile position only UDFs.

### Why are the changes needed?
Position only UDFs were previously rejected


### Does this PR introduce _any_ user-facing change?
Positional only UDFs can now transpile

### How was this patch tested?
New tests with position only UDFs.

### Was this patch authored or co-authored using generative AI tooling?
Yes, claude 5