### PR TITLE
[SPARK-59125][CONNECT] Skip exit cleanup after session release

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -968,6 +968,7 @@ class SparkConnectClient(object):
         self._plan_compression_algorithm: Optional[str] = None  # Will be fetched lazily
 
         self._release_futures: weakref.WeakSet[concurrent.futures.Future] = weakref.WeakSet()
+        self._session_released = False
 
         self._release_session_on_exit = os.getenv(
             "SPARK_CONNECT_RELEASE_SESSION_ON_EXIT", "false"
@@ -2202,6 +2203,7 @@ class SparkConnectClient(object):
                         timeout=self._rpc_deadlines.release_session,
                     )
                     self._verify_response_integrity(resp)
+                    self._session_released = True
                     return
             raise SparkConnectException("Invalid state during retry exception handling.")
         except Exception as error:
@@ -2604,11 +2606,10 @@ class SparkConnectClient(object):
             return []
 
     def _on_exit(self) -> None:
-        # If the client has already been explicitly closed, skip all cleanup RPCs.
-        # The server-side resources were released by close(); reissuing them here
-        # is wasted work and, if the server has since become unreachable, can
-        # block process exit on the gRPC call.
-        if self._closed:
+        # If the client has already been explicitly closed or its server-side session was
+        # released, skip all cleanup RPCs. Reissuing them here is wasted work and, if the server
+        # has since become unreachable, can block process exit on the gRPC call.
+        if self._closed or self._session_released:
             return
 
         self._cleanup_ml_cache()

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -623,6 +623,31 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertEqual(call_tracker["release_session"], 1)
         self.assertEqual(call_tracker["close"], 1)
 
+    def test_on_exit_does_not_call_when_session_released(self):
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        client._release_session_on_exit = True
+        client._session_released = True
+
+        call_tracker = {"cleanup_ml_cache": 0, "release_session": 0, "close": 0}
+
+        def mock_cleanup_ml_cache():
+            call_tracker["cleanup_ml_cache"] += 1
+
+        def mock_release_session():
+            call_tracker["release_session"] += 1
+
+        def mock_close():
+            call_tracker["close"] += 1
+
+        client._cleanup_ml_cache = mock_cleanup_ml_cache
+        client.release_session = mock_release_session
+        client.close = mock_close
+        client._on_exit()
+
+        self.assertEqual(call_tracker["cleanup_ml_cache"], 0)
+        self.assertEqual(call_tracker["release_session"], 0)
+        self.assertEqual(call_tracker["close"], 0)
+
     def test_on_exit_does_not_call_when_release_disabled(self):
         """Test _on_exit does nothing when _release_session_on_exit is False."""
         client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
@@ -964,6 +989,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
 
         client.release_session()
         self.assertEqual(mock.captured_timeouts["ReleaseSession"], 44.0)
+        self.assertTrue(client._session_released)
 
         client._get_operation_statuses()
         self.assertEqual(mock.captured_timeouts["GetStatus"], 55.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR records when `SparkConnectClient.release_session()` completes successfully and
makes the registered `atexit` handler a no-op for an already released session, which was introduced in [SPARK-59125](https://issues.apache.org/jira/browse/SPARK-59125).

It also adds regression coverage that verifies successful release updates the client state and
that `_on_exit()` does not issue ML cache cleanup, release, or close RPCs afterward.

This follows SPARK-55326 and the cleanup-after-close fix in #56140.

### Why are the changes needed?

`_on_exit()` currently skips cleanup only when the client channel has been explicitly closed.
Calling `release_session()` releases all server-side resources but leaves the client channel open.
At process exit, the client therefore sends an unnecessary ML cache cleanup command to a session
that was already released. Besides being redundant, that RPC can delay process exit when the
server is unavailable.

### Does this PR introduce _any_ user-facing change?

Yes. A process that exits after explicitly releasing its Spark Connect session no longer sends
additional cleanup RPCs for that released session.

### How was this patch tested?

Added unit coverage and ran:

```bash
PYTHONPATH=python python -m unittest pyspark.sql.tests.connect.client.test_client
```

All 43 tests passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
