### PR TITLE
[SPARK-59090][SQL] Drop unresolved transpiled Python UDF options

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
@@ -38,8 +38,9 @@ import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, DecimalTyp
  * Matching is strict by category (a numeric option only for numeric columns, a string option only
  * for string columns). We deliberately do not lean on implicit type coercion, which would, e.g.,
  * make a numeric `Add` "valid" over a string column and silently diverge from Python's
- * `TypeError`. When no option matches, the list is emptied and `ConvertToCatalyst` falls back to
- * the original Python UDF.
+ * `TypeError`. An option that still does not resolve is dropped for the same reason: otherwise
+ * `CheckAnalysis` rejects the whole query before the fallback can run. When no option remains, the
+ * list is emptied and `ConvertToCatalyst` falls back to the original Python UDF.
  */
 object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
@@ -55,7 +56,8 @@ object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
                 if t.optionInputCategories.nonEmpty && t.pythonUDFExpr.childrenResolved =>
               val argTypes = t.pythonUDFExpr.children.map(_.dataType)
               val kept = t.transpiledOptions.zip(t.optionInputCategories).collect {
-                case (option, categories) if optionMatchesTypes(categories, argTypes) => option
+                case (option, categories)
+                    if optionMatchesTypes(categories, argTypes) && option.resolved => option
               }
               t.copy(transpiledOptions = kept, optionInputCategories = Nil)
           }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptionsSuite.scala
@@ -77,6 +77,16 @@ class ResolveTranspiledPythonUDFOptionsSuite extends PlanTest {
     assert(pruned.optionInputCategories.isEmpty)
   }
 
+  test("drops a matching option that does not resolve (falls back to Python UDF)") {
+    val a = $"a".long
+    val unresolvedOpt = UnresolvedAttribute("missing")
+    val node = TranspiledPythonUDF("udf", pyUDF(Seq(a)),
+      List(unresolvedOpt), List(List("numeric")))
+    val pruned = prune(node, LocalRelation(a))
+    assert(pruned.transpiledOptions.isEmpty)
+    assert(pruned.optionInputCategories.isEmpty)
+  }
+
   test("matches binary columns against neither category (string is StringType only)") {
     val a = $"a".binary
     val node = TranspiledPythonUDF("udf", pyUDF(Seq(a)),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request makes `ResolveTranspiledPythonUDFOptions` keep a category-matching transpiled option only when the option expression is also resolved.

If no resolved option remains, the rule clears the options and lets `ConvertToCatalyst` use the original interpreted Python UDF. A Catalyst unit test covers a matching option that contains an unresolved attribute.

### Why are the changes needed?

The rule currently filters options only by their declared input categories. A matching option can still contain an expression that does not resolve. Because transpiled options are children of `TranspiledPythonUDF`, `CheckAnalysis` then rejects the entire query before the normal interpreted-Python fallback can run.

Dropping that option preserves the existing fail-closed behavior used for category mismatches.

### Does this PR introduce _any_ user-facing change?

Yes. With the experimental Python UDF transpiler enabled, a transpiled option that cannot resolve now falls back to the interpreted Python UDF instead of failing the query during analysis.

### How was this patch tested?

Added a regression case to `ResolveTranspiledPythonUDFOptionsSuite` and ran:

```
build/sbt "catalyst/Test/testOnly org.apache.spark.sql.catalyst.analysis.ResolveTranspiledPythonUDFOptionsSuite"
dev/lint-scala
git diff --check
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
