### PR TITLE
[SPARK-59028][PYTHON] Make UDF category inference linear

### DIFF
--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -1363,6 +1363,38 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         # require the column name appears somewhere in the message.
         self.assertIn("a", message)
 
+    def test_udf_transpile_category_inference_is_linear(self):
+        import ast
+
+        from pyspark.sql.transpile import CatalystTranspiler
+
+        class CountingCatalystTranspiler(CatalystTranspiler):
+            def __init__(self):
+                super().__init__()
+                self.category_calls = 0
+
+            def _category_uncached(self, params, node):
+                self.category_calls += 1
+                return super()._category_uncached(params, node)
+
+        expression = " + ".join(["a"] * 161)
+        source = f"def f(a):\n    return {expression}\n"
+        function_ast = ast.parse(source).body[0]
+        self.assertIsInstance(function_ast, ast.FunctionDef)
+
+        transpiler = CountingCatalystTranspiler()
+        converted = transpiler._transpile_from_ast(
+            source,
+            function_ast,
+            function_ast,
+            ["a"],
+            LongType(),
+            {0: "numeric"},
+        )
+
+        self.assertIsNotNone(converted)
+        self.assertLessEqual(transpiler.category_calls, len(list(ast.walk(function_ast))))
+
     # ------------------------------------------------------------------
     # Edge cases (SPARK-55206 follow-up). Helpers build a UDF with
     # transpilation on; `_vals` runs it and returns outputs (asserting it

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -168,6 +168,10 @@ class CatalystTranspiler(AbstractTranspiler):
 
     variety = "catalyst"
 
+    def __init__(self) -> None:
+        self._param_categories: dict[int, str] = {}
+        self._category_cache: dict[int, str] = {}
+
     # TODO (SPARK-55218): handle implicit-None return bodies like
     # ``def f(x): x + x`` -- no return statement means return None;
     # we should lower to lit(None) and optionally warn since it's
@@ -382,6 +386,15 @@ class CatalystTranspiler(AbstractTranspiler):
         operands are type-incompatible, so the caller drops that variant and the
         JVM picks another option / falls back to the Python UDF.
         """
+        cache_key = id(node)
+        cached = self._category_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        category = self._category_uncached(params, node)
+        self._category_cache[cache_key] = category
+        return category
+
+    def _category_uncached(self, params: List[str], node: ast.AST) -> str:
         match node:
             case ast.Constant(value=v):
                 # bool subclasses int, so classify it first: int/float -> numeric,
@@ -740,6 +753,9 @@ class CatalystTranspiler(AbstractTranspiler):
         # Per-variant input-type assumption ({public_param_index -> category}),
         # read by ``_category`` to choose str vs numeric operators.
         self._param_categories = param_categories or {}
+        # Category inference depends on the per-variant assumptions above. Cache
+        # each AST node only for this lowering so recursive conversion stays linear.
+        self._category_cache = {}
         function_body = function_ast.body
         if len(function_body) != 1:
             raise UnsupportedOperationException(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cache Catalyst UDF category inference by AST node while lowering each transpilation variant. The cache is reset for every variant because parameter-category assumptions can differ between variants.

The pull request also adds a regression test with a long addition expression and verifies that uncached category computations are bounded by the AST size.

### Why are the changes needed?

Category inference recursively revisited the same subtrees while converting nested expressions. For a left-deep expression, this made transpilation quadratic in the expression size. Memoizing each node keeps inference linear without changing the generated Catalyst expression.

### Does this PR introduce _any_ user-facing change?

No. It improves the performance of Python UDF transpilation only.

### How was this patch tested?

- `build/sbt -Phive package`
- `python/run-tests --testnames pyspark.sql.tests.test_udf_transpile_unit`
- `dev/lint-python --ruff`
- `dev/lint-python --compile --custom-pyspark-error`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
