### PR TITLE
[SPARK-58969][K8S] Preserve URI fragments for uploaded dependencies

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.features
 
+import java.net.URI
+
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
@@ -171,17 +173,19 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
     Seq(JARS, FILES, ARCHIVES, SUBMIT_PYTHON_FILES).foreach { key =>
       val (localUris, remoteUris) =
         conf.get(key).partition(uri => KubernetesUtils.isLocalAndResolvable(uri))
-      val value = {
-        if (key == ARCHIVES) {
-          localUris.map(Utils.getUriBuilder(_).fragment(null).build()).map(_.toString)
-        } else {
-          localUris
-        }
+      val localUrisWithFragments = localUris.map { uri =>
+        (uri, Option(new URI(uri).getFragment))
       }
-      val resolved = KubernetesUtils.uploadAndTransformFileUris(value, Some(conf.sparkConf))
+      val uploadUris = localUrisWithFragments.map {
+        case (uri, Some(_)) => Utils.getUriBuilder(uri).fragment(null).build().toString
+        case (uri, None) => uri
+      }
+      val resolved = KubernetesUtils.uploadAndTransformFileUris(uploadUris, Some(conf.sparkConf))
       if (resolved.nonEmpty) {
-        val resolvedValue = localUris.zip(resolved).map { case (uri, r) =>
-          Utils.getUriBuilder(r).fragment(new java.net.URI(uri).getFragment).build().toString
+        val resolvedValue = localUrisWithFragments.zip(resolved).map {
+          case ((_, Some(fragment)), r) =>
+            Utils.getUriBuilder(r).fragment(fragment).build().toString
+          case ((_, None), r) => r
         }
         additionalProps.put(key.key, (resolvedValue ++ remoteUris).mkString(","))
       }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -180,12 +180,8 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
       }
       val resolved = KubernetesUtils.uploadAndTransformFileUris(value, Some(conf.sparkConf))
       if (resolved.nonEmpty) {
-        val resolvedValue = if (key == ARCHIVES) {
-          localUris.zip(resolved).map { case (uri, r) =>
-            Utils.getUriBuilder(r).fragment(new java.net.URI(uri).getFragment).build().toString
-          }
-        } else {
-          resolved
+        val resolvedValue = localUris.zip(resolved).map { case (uri, r) =>
+          Utils.getUriBuilder(r).fragment(new java.net.URI(uri).getFragment).build().toString
         }
         additionalProps.put(key.key, (resolvedValue ++ remoteUris).mkString(","))
       }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.features
 
+import java.net.URI
+
 import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model.{ContainerPort, ContainerPortBuilder, LocalObjectReferenceBuilder, Quantity}
@@ -405,13 +407,14 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
   }
 
   test("SPARK-58969: Local dependency uploads preserve URI fragments") {
-    val fileUploadPath = "s3a://some-bucket/upload-path"
+    val FILE_UPLOAD_PATH = "s3a://some-bucket/upload-path"
     val sparkConf = new SparkConf()
       .set(CONTAINER_IMAGE, "spark-driver:latest")
       .set(JARS, Seq("/tmp/library-random.jar#library.jar"))
       .set(FILES, Seq("/tmp/query-random.sql#query.sql"))
+      .set(ARCHIVES, Seq("/tmp/archive-random.zip#archive"))
       .set(SUBMIT_PYTHON_FILES, Seq("/tmp/module-random.py#module.py"))
-      .set(KUBERNETES_FILE_UPLOAD_PATH, fileUploadPath)
+      .set(KUBERNETES_FILE_UPLOAD_PATH, FILE_UPLOAD_PATH)
       .set("spark.hadoop.fs.s3a.impl", classOf[TestFileSystem].getCanonicalName)
       .set("spark.hadoop.fs.s3a.impl.disable.cache", "true")
     val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
@@ -421,9 +424,10 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     Seq(
       (JARS.key, "library-random.jar", "library.jar"),
       (FILES.key, "query-random.sql", "query.sql"),
+      (ARCHIVES.key, "archive-random.zip", "archive"),
       (SUBMIT_PYTHON_FILES.key, "module-random.py", "module.py")
     ).foreach { case (key, physicalName, alias) =>
-      val uploaded = new java.net.URI(properties(key))
+      val uploaded = new URI(properties(key))
       assert(new Path(uploaded.getPath).getName === physicalName)
       assert(uploaded.getFragment === alias)
     }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -404,6 +404,31 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
       path.startsWith(FILE_UPLOAD_PATH) && path.endsWith("some-local-jar.jar")))
   }
 
+  test("SPARK-58969: Local dependency uploads preserve URI fragments") {
+    val fileUploadPath = "s3a://some-bucket/upload-path"
+    val sparkConf = new SparkConf()
+      .set(CONTAINER_IMAGE, "spark-driver:latest")
+      .set(JARS, Seq("/tmp/library-random.jar#library.jar"))
+      .set(FILES, Seq("/tmp/query-random.sql#query.sql"))
+      .set(SUBMIT_PYTHON_FILES, Seq("/tmp/module-random.py#module.py"))
+      .set(KUBERNETES_FILE_UPLOAD_PATH, fileUploadPath)
+      .set("spark.hadoop.fs.s3a.impl", classOf[TestFileSystem].getCanonicalName)
+      .set("spark.hadoop.fs.s3a.impl.disable.cache", "true")
+    val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
+
+    val properties = new BasicDriverFeatureStep(kubernetesConf)
+      .getAdditionalPodSystemProperties()
+    Seq(
+      (JARS.key, "library-random.jar", "library.jar"),
+      (FILES.key, "query-random.sql", "query.sql"),
+      (SUBMIT_PYTHON_FILES.key, "module-random.py", "module.py")
+    ).foreach { case (key, physicalName, alias) =>
+      val uploaded = new java.net.URI(properties(key))
+      assert(new Path(uploaded.getPath).getName === physicalName)
+      assert(uploaded.getFragment === alias)
+    }
+  }
+
   test("SPARK-47208: User can override the minimum memory overhead of the driver") {
     val sparkConf = new SparkConf()
       .set(KUBERNETES_DRIVER_POD_NAME, "spark-driver-pod")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Preserve each local dependency's URI fragment across the Kubernetes upload step. Fragments are removed before the physical upload and restored on the resulting remote URI only when the original dependency had one, leaving fragment-less URIs untouched.

The existing archive behavior is generalized to JARs, files, and Python files. A regression test covers all four dependency types and checks both the uploaded physical name and the restored fragment.

### Why are the changes needed?

Spark uses URI fragments in dependency paths as application-visible aliases, for example `--files /tmp/query-random.sql#query.sql`. The Kubernetes upload path returned a remote URI without `#query.sql`. As a result, the driver-side `SparkSubmit` download could not copy the dependency into the driver's working directory under the requested alias; executors subsequently saw only the physical filename through the normal distribution path.

### Does this PR introduce _any_ user-facing change?

Yes. In the normal Kubernetes dependency-download path, locally uploaded dependencies now retain their `#alias` fragments in `spark.jars`, `spark.files`, and `spark.submit.pyFiles`, allowing the driver to localize them under the requested names. Existing archive alias behavior is unchanged.

### How was this patch tested?

- Verified the new regression test fails before the fix and passes after it.
- `build/sbt -Pkubernetes "kubernetes/Test/testOnly org.apache.spark.deploy.k8s.features.BasicDriverFeatureStepSuite"` (25 tests passed)
- `dev/lint-scala`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
