### PR TITLE
[SPARK-59094][CORE] Ignore late successes from invalidated barrier shuffle attempts

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -3604,6 +3604,7 @@ private[spark] class DAGScheduler(
                   // Invalidate this attempt before clearing its outputs, so late completions
                   // cannot skip participants in the replacement barrier stage.
                   failedMapStage.maxFailedBarrierAttemptId = Some(task.stageAttemptId)
+                  // Clear every map output so the retry reruns all barrier tasks.
                   mapOutputTracker.unregisterAllMapAndMergeOutput(
                     failedMapStage.shuffleDep.shuffleId)
 
@@ -3713,6 +3714,7 @@ private[spark] class DAGScheduler(
                 // Invalidate this attempt before clearing its outputs, so late completions
                 // cannot skip participants in the replacement barrier stage.
                 failedMapStage.maxFailedBarrierAttemptId = Some(task.stageAttemptId)
+                // Clear every map output so the retry reruns all barrier tasks.
                 mapOutputTracker.unregisterAllMapAndMergeOutput(failedMapStage.shuffleDep.shuffleId)
 
               case failedResultStage: ResultStage =>

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -3337,7 +3337,7 @@ private[spark] class DAGScheduler(
         // finished if the stage is determinate. Here we notify the task scheduler to skip running
         // tasks for the same partition to save resource.
 
-        // Ignore task completion for old attempt of stages with nondeterministic output.
+        // Ignore task completion from attempts invalidated by rollback or barrier stage failure.
         // This is tracked via maxAttemptIdToIgnore which is set when a stage is rolled back.
         val ignoreOldTaskAttempts =
           stage.maxAttemptIdToIgnore.exists(_ >= task.stageAttemptId)
@@ -3474,7 +3474,8 @@ private[spark] class DAGScheduler(
                 }
               }
             } else {
-              logInfo(log"Ignoring ${MDC(TASK_NAME, smt)} completion from an older attempt of indeterminate stage")
+              logInfo(log"Ignoring ${MDC(TASK_NAME, smt)} completion from " +
+                log"an invalidated stage attempt")
             }
 
             if (runningStages.contains(shuffleStage) && shuffleStage.pendingPartitions.isEmpty) {
@@ -3600,8 +3601,9 @@ private[spark] class DAGScheduler(
             if (failedStage.rdd.isBarrier()) {
               failedStage match {
                 case failedMapStage: ShuffleMapStage =>
-                  // Mark all the map as broken in the map stage, to ensure retry all the tasks on
-                  // resubmitted stage attempt.
+                  // Invalidate this attempt before clearing its outputs, so late completions
+                  // cannot skip participants in the replacement barrier stage.
+                  failedMapStage.markAsRollingBack()
                   mapOutputTracker.unregisterAllMapAndMergeOutput(
                     failedMapStage.shuffleDep.shuffleId)
 
@@ -3708,8 +3710,9 @@ private[spark] class DAGScheduler(
           } else {
             failedStage match {
               case failedMapStage: ShuffleMapStage =>
-                // Mark all the map as broken in the map stage, to ensure retry all the tasks on
-                // resubmitted stage attempt.
+                // Invalidate this attempt before clearing its outputs, so late completions
+                // cannot skip participants in the replacement barrier stage.
+                failedMapStage.markAsRollingBack()
                 mapOutputTracker.unregisterAllMapAndMergeOutput(failedMapStage.shuffleDep.shuffleId)
 
               case failedResultStage: ResultStage =>

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -3338,9 +3338,9 @@ private[spark] class DAGScheduler(
         // tasks for the same partition to save resource.
 
         // Ignore task completion from attempts invalidated by rollback or barrier stage failure.
-        // This is tracked via maxAttemptIdToIgnore which is set when a stage is rolled back.
         val ignoreOldTaskAttempts =
-          stage.maxAttemptIdToIgnore.exists(_ >= task.stageAttemptId)
+          stage.maxAttemptIdToIgnore.exists(_ >= task.stageAttemptId) ||
+            stage.maxFailedBarrierAttemptId.exists(_ >= task.stageAttemptId)
 
         if (!ignoreOldTaskAttempts && task.stageAttemptId < stage.latestInfo.attemptNumber()) {
           taskScheduler.notifyPartitionCompletion(stageId, task.partitionId)
@@ -3603,7 +3603,7 @@ private[spark] class DAGScheduler(
                 case failedMapStage: ShuffleMapStage =>
                   // Invalidate this attempt before clearing its outputs, so late completions
                   // cannot skip participants in the replacement barrier stage.
-                  failedMapStage.markAsRollingBack()
+                  failedMapStage.maxFailedBarrierAttemptId = Some(task.stageAttemptId)
                   mapOutputTracker.unregisterAllMapAndMergeOutput(
                     failedMapStage.shuffleDep.shuffleId)
 
@@ -3712,7 +3712,7 @@ private[spark] class DAGScheduler(
               case failedMapStage: ShuffleMapStage =>
                 // Invalidate this attempt before clearing its outputs, so late completions
                 // cannot skip participants in the replacement barrier stage.
-                failedMapStage.markAsRollingBack()
+                failedMapStage.maxFailedBarrierAttemptId = Some(task.stageAttemptId)
                 mapOutputTracker.unregisterAllMapAndMergeOutput(failedMapStage.shuffleDep.shuffleId)
 
               case failedResultStage: ResultStage =>

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -3340,7 +3340,7 @@ private[spark] class DAGScheduler(
         // Ignore task completion from attempts invalidated by rollback or barrier stage failure.
         val ignoreOldTaskAttempts =
           stage.maxAttemptIdToIgnore.exists(_ >= task.stageAttemptId) ||
-            stage.maxFailedBarrierAttemptId.exists(_ >= task.stageAttemptId)
+            stage.latestFailedBarrierAttemptId.exists(_ >= task.stageAttemptId)
 
         if (!ignoreOldTaskAttempts && task.stageAttemptId < stage.latestInfo.attemptNumber()) {
           taskScheduler.notifyPartitionCompletion(stageId, task.partitionId)
@@ -3601,10 +3601,10 @@ private[spark] class DAGScheduler(
             if (failedStage.rdd.isBarrier()) {
               failedStage match {
                 case failedMapStage: ShuffleMapStage =>
-                  // Invalidate this attempt before clearing its outputs, so late completions
-                  // cannot skip participants in the replacement barrier stage.
-                  failedMapStage.maxFailedBarrierAttemptId = Some(task.stageAttemptId)
-                  // Clear every map output so the retry reruns all barrier tasks.
+                  // Ignore late completions so the replacement barrier stage reruns every task.
+                  failedMapStage.latestFailedBarrierAttemptId = Some(task.stageAttemptId)
+                  // Mark all the map as broken in the map stage, to ensure retry all the tasks on
+                  // resubmitted stage attempt.
                   mapOutputTracker.unregisterAllMapAndMergeOutput(
                     failedMapStage.shuffleDep.shuffleId)
 
@@ -3711,10 +3711,10 @@ private[spark] class DAGScheduler(
           } else {
             failedStage match {
               case failedMapStage: ShuffleMapStage =>
-                // Invalidate this attempt before clearing its outputs, so late completions
-                // cannot skip participants in the replacement barrier stage.
-                failedMapStage.maxFailedBarrierAttemptId = Some(task.stageAttemptId)
-                // Clear every map output so the retry reruns all barrier tasks.
+                // Ignore late completions so the replacement barrier stage reruns every task.
+                failedMapStage.latestFailedBarrierAttemptId = Some(task.stageAttemptId)
+                // Mark all the map as broken in the map stage, to ensure retry all the tasks on
+                // resubmitted stage attempt.
                 mapOutputTracker.unregisterAllMapAndMergeOutput(failedMapStage.shuffleDep.shuffleId)
 
               case failedResultStage: ResultStage =>

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -85,11 +85,15 @@ private[scheduler] abstract class Stage(
   private[scheduler] var maxChecksumMismatchedId: Int = nextAttemptId
 
   /**
-   * The maximum attempt ID whose results should be ignored after this stage is invalidated.
-   * This includes attempts that may have consumed inconsistent parent output and failed barrier
-   * attempts, whose tasks must all be retried.
+   * The maximum attempt ID whose results should be ignored after an indeterminate stage rollback.
    */
   private[scheduler] var maxAttemptIdToIgnore: Option[Int] = None
+
+  /**
+   * The latest failed barrier attempt. Results from this and older attempts must be ignored.
+   * Keep this separate from maxAttemptIdToIgnore, which also deduplicates rollback cleanup.
+   */
+  private[scheduler] var maxFailedBarrierAttemptId: Option[Int] = None
 
   val name: String = callSite.shortForm
   val details: String = callSite.longForm

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -85,10 +85,9 @@ private[scheduler] abstract class Stage(
   private[scheduler] var maxChecksumMismatchedId: Int = nextAttemptId
 
   /**
-   * The max attempt id we should ignore results for this stage, indicating there are ancestor
-   * stages having been detected with checksum mismatches. This stage is probably also
-   * indeterminate, so we need to avoid completing the stage and the job with incorrect result
-   * by ignoring the task output from previous attempts which might consume inconsistent data
+   * The maximum attempt ID whose results should be ignored after this stage is invalidated.
+   * This includes attempts that may have consumed inconsistent parent output and failed barrier
+   * attempts, whose tasks must all be retried.
    */
   private[scheduler] var maxAttemptIdToIgnore: Option[Int] = None
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -85,7 +85,10 @@ private[scheduler] abstract class Stage(
   private[scheduler] var maxChecksumMismatchedId: Int = nextAttemptId
 
   /**
-   * The maximum attempt ID whose results should be ignored after an indeterminate stage rollback.
+   * The max attempt id we should ignore results for this stage, indicating there are ancestor
+   * stages having been detected with checksum mismatches. This stage is probably also
+   * indeterminate, so we need to avoid completing the stage and the job with incorrect result
+   * by ignoring the task output from previous attempts which might consume inconsistent data
    */
   private[scheduler] var maxAttemptIdToIgnore: Option[Int] = None
 
@@ -93,7 +96,7 @@ private[scheduler] abstract class Stage(
    * The latest failed barrier attempt. Results from this and older attempts must be ignored.
    * Keep this separate from maxAttemptIdToIgnore, which also deduplicates rollback cleanup.
    */
-  private[scheduler] var maxFailedBarrierAttemptId: Option[Int] = None
+  private[scheduler] var latestFailedBarrierAttemptId: Option[Int] = None
 
   val name: String = callSite.shortForm
   val details: String = callSite.longForm

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1567,8 +1567,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
   for (completeBeforeRetry <- Seq(true, false); failedAttempts <- 1 to 2) {
     val completionTime = if (completeBeforeRetry) "before" else "after"
-    test(s"Ignore successful tasks from $failedAttempts failed barrier attempts " +
-        s"$completionTime resubmission") {
+    test("SPARK-59094: Ignore successful tasks from failed barrier attempts " +
+        s"$completionTime resubmission (failedAttempts=$failedAttempts)") {
       val mapRdd = new MyRDD(sc, 2, Nil).barrier().mapPartitions(iter => iter)
       val shuffleDep = new ShuffleDependency(mapRdd, new HashPartitioner(2))
       val resultRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
@@ -1618,7 +1618,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
   for (barrier <- Seq(true, false); completeBeforeRetry <- Seq(true, false)) {
     val completionTime = if (completeBeforeRetry) "before" else "after"
-    test(s"Late success $completionTime resubmission after a shuffle fetch failure " +
+    test(s"SPARK-59094: Late success $completionTime resubmission after a shuffle fetch failure " +
         s"in a barrier=$barrier map stage") {
       // The middle stage reads one shuffle and produces a different shuffle.
       val inputRdd = new MyRDD(sc, 2, Nil)
@@ -1679,7 +1679,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     }
   }
 
-  test("A late downstream fetch failure must not discard the running barrier retry's successes") {
+  test("SPARK-59094: accept barrier retry successes after a late consumer fetch failure") {
     val mapRdd = new MyRDD(sc, 2, Nil).barrier().mapPartitions(iter => iter)
     val shuffleDep = new ShuffleDependency(mapRdd, new HashPartitioner(2))
     val resultRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1704,6 +1704,67 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
+  for (fetchFailure <- Seq(false, true)) {
+    val failureType = if (fetchFailure) "fetch failure" else "task failure"
+    test(s"SPARK-59094: retry all indeterminate barrier tasks after $failureType and relocation") {
+      val inputRdd = new MyRDD(sc, 2, Nil)
+      val inputDep = new ShuffleDependency(inputRdd, new HashPartitioner(2))
+      val mapRdd = new MyRDD(sc, 2, List(inputDep), tracker = mapOutputTracker,
+        indeterminate = true).barrier().mapPartitions(iter => iter)
+      val outputDep = new ShuffleDependency(mapRdd, new HashPartitioner(2))
+      val resultRdd = new MyRDD(sc, 2, List(outputDep), tracker = mapOutputTracker)
+      submit(resultRdd, Array(0, 1))
+      assert(!scheduler.shuffleIdToMapStage(inputDep.shuffleId).isStaticallyIndeterminate)
+      complete(taskSet(0, 0), Seq(
+        (Success, makeMapStatus("hostA", 2, mapTaskId = 100L)),
+        (Success, makeMapStatus("hostB", 2, mapTaskId = 101L))))
+      val mapStage = scheduler.shuffleIdToMapStage(outputDep.shuffleId)
+      assert(mapStage.isStaticallyIndeterminate)
+      assert(!outputDep.checksumMismatchFullRetryEnabled)
+      val originalAttempt = taskSet(1, 0)
+      val completedStatus = makeMapStatus("hostC", 2, mapTaskId = 200L)
+
+      // Keep the failure and relocation ahead of any queued retry event.
+      scheduler.handleTaskCompletion(makeCompletionEvent(
+        originalAttempt.tasks(0), Success, completedStatus))
+      assert(mapOutputTracker.findMissingPartitions(outputDep.shuffleId) === Some(Seq(1)))
+      val failureReason: TaskFailedReason = if (fetchFailure) {
+        FetchFailed(makeBlockManagerId("hostA"), inputDep.shuffleId, 100L, 0, 1, "ignored")
+      } else {
+        new ExceptionFailure(new RuntimeException("barrier task failed"), Seq.empty)
+      }
+      scheduler.handleTaskCompletion(makeCompletionEvent(
+        originalAttempt.tasks(1), failureReason, null))
+      assert(mapOutputTracker.findMissingPartitions(outputDep.shuffleId) === Some(Seq(0, 1)))
+
+      // A delayed migration report can restore an output cleared by the barrier failure.
+      val relocatedHost = makeBlockManagerId("hostD")
+      mapOutputTracker.updateMapOutput(outputDep.shuffleId, 200L, relocatedHost)
+      assert(completedStatus.location === relocatedHost)
+      assert(mapOutputTracker.findMissingPartitions(outputDep.shuffleId) === Some(Seq(1)))
+      assert(mapStage.latestInfo.attemptNumber() === 0)
+
+      scheduler.resubmitFailedStages()
+      if (fetchFailure) {
+        val parentRetry = taskSet(0, 1)
+        assert(parentRetry.tasks.map(_.partitionId).toSeq === Seq(0))
+        complete(parentRetry, Seq((Success, makeMapStatus("hostE", 2, mapTaskId = 102L))))
+      }
+      val retry = taskSet(1, 1)
+      assert(retry.tasks.map(_.partitionId).toSeq === Seq(0, 1))
+      assert(retry.tasks.forall(task => task.isBarrier && task.numPartitions == 2))
+      assert(mapStage.pendingPartitions.toSet === Set(0, 1))
+      assert(mapOutputTracker.findMissingPartitions(outputDep.shuffleId) === Some(Seq(0, 1)))
+      complete(retry, Seq(
+        (Success, makeMapStatus("hostF", 2, mapTaskId = 201L)),
+        (Success, makeMapStatus("hostG", 2, mapTaskId = 202L))))
+      assert(taskSets.count(_.stageId == 1) === 2)
+      completeNextResultStageWithSuccess(2, 0)
+      assert(results === Map(0 -> 42, 1 -> 42))
+      assertDataStructuresEmpty()
+    }
+  }
+
   test("SPARK-58887: a barrier job can be cancelled while its slot check is being retried") {
     // 3 barrier tasks on the local[2] backend fail the max concurrent tasks check, so the
     // submission enters the retry window during which the job is registered nowhere but

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1565,6 +1565,145 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
+  for (completeBeforeRetry <- Seq(true, false); failedAttempts <- 1 to 2) {
+    val completionTime = if (completeBeforeRetry) "before" else "after"
+    test(s"Ignore successful tasks from $failedAttempts failed barrier attempts " +
+        s"$completionTime resubmission") {
+      val mapRdd = new MyRDD(sc, 2, Nil).barrier().mapPartitions(iter => iter)
+      val shuffleDep = new ShuffleDependency(mapRdd, new HashPartitioner(2))
+      val resultRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
+      submit(resultRdd, Array(0, 1))
+      val mapStage = scheduler.shuffleIdToMapStage(shuffleDep.shuffleId)
+      assert(!mapStage.isStaticallyIndeterminate)
+
+      val originalAttempts = (0 until failedAttempts).map { attempt =>
+        if (attempt > 0) {
+          scheduler.resubmitFailedStages()
+        }
+        val taskSetToFail = taskSet(0, attempt)
+        // Process completions directly so queued retry events cannot change their ordering.
+        scheduler.handleTaskCompletion(makeCompletionEvent(taskSetToFail.tasks(0),
+          new ExceptionFailure(new RuntimeException("barrier task failed"), Seq.empty), null))
+        taskSetToFail
+      }
+      assert(mapOutputTracker.findMissingPartitions(shuffleDep.shuffleId) === Some(Seq(0, 1)))
+
+      if (!completeBeforeRetry) {
+        scheduler.resubmitFailedStages()
+      }
+      assert(mapStage.latestInfo.attemptNumber() ===
+        (if (completeBeforeRetry) failedAttempts - 1 else failedAttempts))
+      // The other task finished before cancellation, but its success reached the driver late.
+      originalAttempts.foreach { originalAttempt =>
+        scheduler.handleTaskCompletion(makeCompletionEvent(
+          originalAttempt.tasks(1), Success, makeMapStatus("hostB", 2)))
+      }
+      assert(mapOutputTracker.findMissingPartitions(shuffleDep.shuffleId) === Some(Seq(0, 1)))
+      assert(tasksMarkedAsCompleted.isEmpty)
+      if (!completeBeforeRetry) {
+        assert(mapStage.pendingPartitions.toSet === Set(0, 1))
+      }
+
+      if (completeBeforeRetry) {
+        scheduler.resubmitFailedStages()
+      }
+      assert(taskSet(0, failedAttempts).tasks.map(_.partitionId).toSeq === Seq(0, 1))
+      completeShuffleMapStageSuccessfully(0, failedAttempts, 2)
+      assert(taskSets.count(_.stageId == 0) === failedAttempts + 1)
+      completeNextResultStageWithSuccess(1, 0)
+      assert(results === Map(0 -> 42, 1 -> 42))
+      assertDataStructuresEmpty()
+    }
+  }
+
+  for (barrier <- Seq(true, false); completeBeforeRetry <- Seq(true, false)) {
+    val completionTime = if (completeBeforeRetry) "before" else "after"
+    test(s"Late success $completionTime resubmission after a shuffle fetch failure " +
+        s"in a barrier=$barrier map stage") {
+      // The middle stage reads one shuffle and produces a different shuffle.
+      val inputRdd = new MyRDD(sc, 2, Nil)
+      val inputDep = new ShuffleDependency(inputRdd, new HashPartitioner(2))
+      val middleRdd = new MyRDD(sc, 2, List(inputDep), tracker = mapOutputTracker)
+      val mapRdd = if (barrier) middleRdd.barrier().mapPartitions(iter => iter) else middleRdd
+      val outputDep = new ShuffleDependency(mapRdd, new HashPartitioner(2))
+      val resultRdd = new MyRDD(sc, 2, List(outputDep), tracker = mapOutputTracker)
+      submit(resultRdd, Array(0, 1))
+      completeShuffleMapStageSuccessfully(0, 0, 2)
+      val originalAttempt = taskSet(1, 0)
+      assert(!scheduler.shuffleIdToMapStage(outputDep.shuffleId).isStaticallyIndeterminate)
+
+      // Process completions directly so queued retry events cannot change their ordering.
+      scheduler.handleTaskCompletion(makeCompletionEvent(originalAttempt.tasks(0),
+        FetchFailed(makeBlockManagerId("hostA"), inputDep.shuffleId, 0L, 0, 0, "ignored"), null))
+
+      def retryParentStage(): Unit = {
+        scheduler.resubmitFailedStages()
+        completeShuffleMapStageSuccessfully(0, 1, 2, Seq("hostD"))
+      }
+      if (!completeBeforeRetry) {
+        retryParentStage()
+      }
+      assert(scheduler.shuffleIdToMapStage(outputDep.shuffleId).latestInfo.attemptNumber() ===
+        (if (completeBeforeRetry) 0 else 1))
+      // This output is on a healthy executor, so executor-loss filtering cannot hide the race.
+      scheduler.handleTaskCompletion(makeCompletionEvent(
+        originalAttempt.tasks(1), Success, makeMapStatus("hostC", 2)))
+      val missingPartitions = if (barrier) Seq(0, 1) else Seq(0)
+      assert(mapOutputTracker.findMissingPartitions(outputDep.shuffleId) ===
+        Some(missingPartitions))
+      if (barrier || completeBeforeRetry) {
+        assert(tasksMarkedAsCompleted.isEmpty)
+      } else {
+        assert(tasksMarkedAsCompleted.toSeq ===
+          Seq(taskSet(1, 1).tasks.find(_.partitionId == 1).get))
+      }
+      if (barrier && !completeBeforeRetry) {
+        assert(scheduler.shuffleIdToMapStage(outputDep.shuffleId).pendingPartitions.toSet ===
+          Set(0, 1))
+      }
+
+      if (completeBeforeRetry) {
+        retryParentStage()
+      }
+      val retry = taskSet(1, 1)
+      val submittedPartitions = if (completeBeforeRetry) missingPartitions else Seq(0, 1)
+      assert(retry.tasks.map(_.partitionId).toSeq === submittedPartitions)
+      // An ordinary determinate stage may reuse the old success. A barrier stage must rerun both.
+      retry.tasks.filter(task => missingPartitions.contains(task.partitionId)).foreach { task =>
+        runEvent(makeCompletionEvent(task, Success, makeMapStatus("hostD", 2)))
+      }
+      assert(taskSets.count(_.stageId == 1) === 2)
+      completeNextResultStageWithSuccess(2, 0)
+      assert(results === Map(0 -> 42, 1 -> 42))
+      assertDataStructuresEmpty()
+    }
+  }
+
+  test("A late downstream fetch failure must not discard the running barrier retry's successes") {
+    val mapRdd = new MyRDD(sc, 2, Nil).barrier().mapPartitions(iter => iter)
+    val shuffleDep = new ShuffleDependency(mapRdd, new HashPartitioner(2))
+    val resultRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
+    submit(resultRdd, Array(0, 1))
+    completeShuffleMapStageSuccessfully(0, 0, 2)
+    val originalResultAttempt = taskSet(1, 0)
+
+    runEvent(makeCompletionEvent(originalResultAttempt.tasks(0),
+      FetchFailed(makeBlockManagerId("hostA"), shuffleDep.shuffleId, 0L, 0, 0, "ignored"), null))
+    scheduler.resubmitFailedStages()
+    assert(taskSet(0, 1).tasks.map(_.partitionId).toSeq === Seq(0, 1))
+
+    // Another task from the same consumer attempt can fail while the producer is being retried.
+    runEvent(makeCompletionEvent(originalResultAttempt.tasks(1),
+      FetchFailed(makeBlockManagerId("hostB"), shuffleDep.shuffleId, 1L, 1, 1, "ignored"), null))
+    scheduler.resubmitFailedStages()
+    assert(taskSets.count(_.stageId == 0) === 2)
+
+    completeShuffleMapStageSuccessfully(0, 1, 2, Seq("hostC", "hostD"))
+    completeNextResultStageWithSuccess(1, 1)
+    assert(results === Map(0 -> 42, 1 -> 42))
+    assertDataStructuresEmpty()
+  }
+
   test("SPARK-58887: a barrier job can be cancelled while its slot check is being retried") {
     // 3 barrier tasks on the local[2] backend fail the max concurrent tasks check, so the
     // submission enters the retry window during which the job is registered nowhere but


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix [SPARK-59094](https://issues.apache.org/jira/browse/SPARK-59094) by ignoring successful completions from failed barrier shuffle attempts before they can register output or mark a replacement task set's partition complete.

Track barrier failures in `latestFailedBarrierAttemptId`, separate from indeterminate rollback bookkeeping. This preserves rollback cleanup when relocation restores an output before retry. Valid replacement successes and ordinary deterministic, non-barrier output reuse are unchanged.

Producer-side output clearing and asynchronous migration updates are unchanged. The separate case of a late consumer failure clearing an active producer retry's accepted output remains for a follow-up JIRA, which has not yet been filed.

### Why are the changes needed?

Barrier recovery must rerun every participant. Accepting a late success from a failed attempt can omit a partition from the retry or prevent the replacement task set from launching.

### Does this PR introduce _any_ user-facing change?

Yes. Barrier retries retain every required participant in the affected event orderings. No public APIs or configuration options change.

### How was this patch tested?

The eleven added scheduler cases cover both barrier failure paths, before/after resubmission, repeated failed attempts, valid retry results, ordinary non-barrier output reuse, and indeterminate rollback cleanup after relocation. The producer-retry control checks acceptance of subsequent successes after a late consumer fetch failure.

- `DAGSchedulerSuite`: 233 tests passed.
- `TaskSchedulerImplSuite`: 121 tests passed.

Both suites were run with ScalaTest after Maven test compilation.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex

This contribution is original work, licensed to the project under the Apache License, Version 2.0.
