### PR TITLE
[SPARK-55014][SQL] Split projection for expensive filters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2267,7 +2267,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     //    split the projection around it (see `splitProjectForExpensiveConditions`); whatever is
     //    left over stays above the projection, which is where all of case 3 lands when nothing
     //    is worth splitting.
-    // Note that a given filter may contain parts (sepereated by logical ands) from all cases.
+    // Note that a given filter may contain parts (separated by logical ands) from all cases.
     // We handle each part separately according to the logic above.
     // Additional restriction:
     // SPARK-13473: We can't push the predicate down when the underlying projection output non-

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2263,7 +2263,12 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     //    resulting in double evaluation, but only of inexpensive items -- worth it to filter
     //    records sooner.
     // (Case 1 & 2 are treated as "cheap" predicates)
-    // 3) When an a filter references expensive to compute references we do not push it.
+    // 3) When an a filter references expensive to compute references we do not push it. Instead we
+    //    try to split the projection into a stack of projections with the filter in between, so
+    //    that the expensive references the filter does _not_ need are only computed for the rows
+    //    which survived it (see `splitProjectForExpensiveConditions`). Whatever is left over after
+    //    splitting stays above the projection, which is where all of case 3 lands when there is
+    //    nothing worth splitting.
     // Note that a given filter may contain parts (sepereated by logical ands) from all cases.
     // We handle each part separately according to the logic above.
     // Additional restriction:
@@ -2306,26 +2311,45 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
               false
             }
           }
-        // Short circuit if we do not have any cheap filters return the original filter as is.
-        if (cheapWithUsed.isEmpty) {
-          f
-        } else {
-          val cheap: Seq[Expression] = cheapWithUsed.map(_._3)
-          // Make a base instance which has all of the cheap filters pushed down.
+        // Make a base plan which has all of the cheap filters (cases 1 & 2) pushed down.
+        val baseChild: LogicalPlan = if (cheapWithUsed.nonEmpty) {
           // For all filter which do not reference any expensive aliases then
           // just push the filter while resolving the non-expensive aliases.
-          val combinedCheapFilter = cheap.reduce(And)
-          val baseChild = Filter(combinedCheapFilter, child = grandChild)
-          // Take our projection and place it on top of the pushed filters.
-          val topProjection = project.copy(child = baseChild)
+          val combinedCheapFilter = cheapWithUsed.map(_._3).reduce(And)
+          Filter(combinedCheapFilter, child = grandChild)
+        } else {
+          // If we don't have any inexpensive filters to push it's "just" the grandchild.
+          grandChild
+        }
+        // Case 3: try to split the projection around the expensive conditions so the expensive
+        // expressions a condition does not need are only evaluated on the rows it kept.
+        val (splitChild, splitAliases, stayUp) =
+          if (expensiveWithUsed.nonEmpty && SQLConf.get.splitProjectionForExpensiveFilters) {
+            splitProjectForExpensiveConditions(project, aliasMap, baseChild,
+              expensiveWithUsed.map { case (cond, used, _) => (cond, used) })
+          } else {
+            (baseChild, AttributeSet.empty, expensiveWithUsed.map(_._1))
+          }
+        // Short circuit if we neither pushed nor split anything and return the filter as is.
+        if (cheapWithUsed.isEmpty && splitAliases.isEmpty) {
+          f
+        } else {
+          // Take our projection and place it on top of the pushed filters, referencing the
+          // aliases the split projections already computed instead of computing them twice.
+          // Only the aliases change, so the column ordering (and with it the schema) is kept.
+          val topProjectList = if (splitAliases.isEmpty) {
+            fields
+          } else {
+            fields.map(field => if (splitAliases.contains(field)) field.toAttribute else field)
+          }
+          val topProjection = project.copy(projectList = topProjectList, child = splitChild)
 
-          // If we pushed all the filters we can return the projection
-          if (expensiveWithUsed.isEmpty) {
+          // If we pushed or split all the filters we can return the projection
+          if (stayUp.isEmpty) {
             topProjection
           } else {
-            // Finally add any filters which could not be pushed
-            val remainingConditions = expensiveWithUsed.map(_._1)
-            Filter(remainingConditions.reduce(And), topProjection)
+            // Finally add any filters which could neither be pushed nor split
+            Filter(stayUp.reduce(And), topProjection)
           }
         }
       }
@@ -2482,6 +2506,146 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     } else {
       filter
     }
+  }
+
+  /**
+   * Splits `project` into a stack of [[Project]]s with the expensive conditions in
+   * `expensiveConds` in between them, so that an expensive expression in the projection is only
+   * evaluated on the rows which survived the conditions placed below it (SPARK-55014).
+   *
+   * For example, with both regexes considered expensive and a child producing `a` and `e`:
+   * {{{
+   *   Filter f AND g
+   *     Project a, rlike(e, 'magic') AS f, rlike(e, 'other') AS g
+   *       child
+   * }}}
+   * becomes
+   * {{{
+   *   Filter g
+   *     Project a, f, rlike(e, 'other') AS g
+   *       Filter f
+   *         Project a, e, rlike(e, 'magic') AS f
+   *           child
+   * }}}
+   * so `rlike(e, 'other')` only runs on the rows where `rlike(e, 'magic')` was true.
+   *
+   * The conditions are first grouped by the aliases they reference, since conditions over the same
+   * aliases can only ever be evaluated at the same point of the stack. We then repeatedly pick the
+   * group needing the fewest not-yet-computed aliases -- preferring, on a tie, the group which
+   * makes the most conditions evaluable -- and add a [[Project]] computing exactly those aliases
+   * followed by a [[Filter]] with every condition which has become evaluable. Doing the least
+   * demanding conditions first keeps the expensive expressions as high in the stack, and so over
+   * as few rows, as we can manage.
+   *
+   * Ties are broken towards the group whose first condition came first in the original filter. We
+   * have no selectivity estimates here, so the order the conditions were written in is the only
+   * signal we have, and it is the order they would have been evaluated in anyway: with whole stage
+   * codegen the unsplit plan already defers a projected expression past a filter which does not
+   * need it, in that order (see `CodegenSupport.evaluateRequiredVariables`). What this rule buys
+   * is therefore the same saving on the paths codegen does not cover -- interpreted projections,
+   * operators it bails out of, Python UDF evaluation.
+   *
+   * Two restrictions keep us from splitting where it would cost more than it saves:
+   *  - We only split a [[Project]] off while doing so leaves at least one expensive alias for a
+   *    later layer. An extra operator has a per-row cost of its own, so it has to buy us the
+   *    deferral of an expensive expression to be worth adding.
+   *  - Aliases which share an expensive sub-expression are treated as one indivisible unit.
+   *    Subexpression elimination happens within a single projection and cannot reach across a
+   *    [[Filter]], so evaluating such aliases in different layers would evaluate the shared part
+   *    once for every row below the filter and then again for every row which survived it. A
+   *    struct-returning UDF read field by field is the common shape here.
+   *
+   * The most demanding group of conditions is therefore always left un-placed and handed back to
+   * the caller, which puts it above the projection -- exactly where the expensive conditions go
+   * when there is nothing worth splitting at all.
+   *
+   * Returns the new plan, the alias attributes that plan has already computed, and the conditions
+   * which were not placed (in their original, alias referencing, form).
+   */
+  private def splitProjectForExpensiveConditions(
+      project: Project,
+      aliasMap: AttributeMap[Alias],
+      baseChild: LogicalPlan,
+      expensiveConds: Seq[(Expression, AttributeMap[Alias])])
+    : (LogicalPlan, AttributeSet, Seq[Expression]) = {
+    // The aliases we would rather not evaluate on the rows a condition is going to drop.
+    val expensiveAliases = AttributeSet(
+      aliasMap.collect { case (attr, alias) if alias.child.expensive => attr })
+    // The expensive sub-expressions behind each expensive alias, so that we can tell when two
+    // aliases are really the same piece of work. A cheap alias has none by definition, so we do
+    // not walk (and canonicalize) the rest of what can be a very wide projection.
+    val expensivePartsOf = AttributeMap(expensiveAliases.toSeq.map { attr =>
+      attr -> aliasMap(attr).child.collect { case e if e.expensive => e.canonicalized }.toSet
+    })
+    def expensiveParts(attr: Attribute): Set[Expression] =
+      expensivePartsOf.getOrElse(attr, Set.empty)
+    // ... and which aliases each of those sub-expressions turns up in.
+    val aliasesSharing = expensivePartsOf.toSeq
+      .flatMap { case (attr, parts) => parts.map(part => part -> attr) }
+      .groupBy(_._1)
+      .map { case (part, pairs) => part -> AttributeSet(pairs.map(_._2)) }
+    // Aliases sharing an expensive sub-expression have to be evaluated by the same [[Project]]:
+    // subexpression elimination happens within one projection and cannot reach across the
+    // [[Filter]] we would put between them, so splitting them apart would evaluate the shared
+    // part once for every row below the filter and then again for every row which survived it.
+    // Grow a set of aliases into the whole unit of work it belongs to, transitively.
+    def unitOf(aliases: AttributeSet): AttributeSet = {
+      var unit = aliases
+      var grew = true
+      while (grew) {
+        val next = unit.flatMap(expensiveParts).foldLeft(unit) {
+          case (acc, part) => acc ++ aliasesSharing(part)
+        }
+        grew = next.size > unit.size
+        unit = next
+      }
+      unit
+    }
+    // Each condition with the unit of aliases it needs and its position in the original filter.
+    val indexed = expensiveConds.zipWithIndex.map {
+      case ((cond, used), idx) => (unitOf(AttributeSet(used.keys)), idx, cond)
+    }
+    // Conditions over the same aliases can only ever be evaluated at the same point of the stack,
+    // so group them and treat each group as one unit. We group on the sorted expression ids rather
+    // than on the [[AttributeSet]] so that grouping does not depend on how the latter hashes, and
+    // order the groups by their first condition to keep the plans we build stable and to keep the
+    // order the conditions were written in.
+    var pending: Seq[(AttributeSet, Seq[(Int, Expression)])] = indexed
+      .groupBy { case (used, _, _) => used.toSeq.map(_.exprId.id).sorted }
+      .toSeq
+      .map { case (_, group) => (group.head._1, group.map { case (_, idx, cond) => (idx, cond) }) }
+      .sortBy { case (_, conds) => conds.head._1 }
+    def conditionsOf(groups: Seq[(AttributeSet, Seq[(Int, Expression)])]): Seq[Expression] =
+      groups.flatMap(_._2).sortBy(_._1).map(_._2)
+
+    // The aliases in projection order, which is stable, unlike the alias map's iteration order.
+    val orderedAliases = project.projectList.collect { case a: Alias => a }
+
+    var plan = baseChild
+    var computed = AttributeSet.empty
+    var searching = true
+    while (searching) {
+      // Splitting around a group only pays off while it leaves an expensive alias for a later
+      // layer to compute.
+      val stillToCompute = expensiveAliases -- computed
+      val candidates = pending.filter { case (used, _) => !stillToCompute.subsetOf(used) }
+      if (candidates.isEmpty) {
+        searching = false
+      } else {
+        val (bestUsed, _) = candidates.minBy {
+          case (used, conds) => ((used -- computed).size, -conds.size)
+        }
+        val newAliases = orderedAliases.filter(a => bestUsed.contains(a) && !computed.contains(a))
+        computed ++= AttributeSet(newAliases.map(_.toAttribute))
+        // Everything the plan below already produces stays available, since a later projection in
+        // the stack (or the final one) may still need it. Column pruning drops the extras.
+        val newProject = project.copy(projectList = plan.output ++ newAliases, child = plan)
+        val (evaluable, rest) = pending.partition { case (used, _) => used.subsetOf(computed) }
+        plan = Filter(conditionsOf(evaluable).reduce(And), newProject)
+        pending = rest
+      }
+    }
+    (plan, computed, conditionsOf(pending))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2263,12 +2263,10 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     //    resulting in double evaluation, but only of inexpensive items -- worth it to filter
     //    records sooner.
     // (Case 1 & 2 are treated as "cheap" predicates)
-    // 3) When an a filter references expensive to compute references we do not push it. Instead we
-    //    try to split the projection into a stack of projections with the filter in between, so
-    //    that the expensive references the filter does _not_ need are only computed for the rows
-    //    which survived it (see `splitProjectForExpensiveConditions`). Whatever is left over after
-    //    splitting stays above the projection, which is where all of case 3 lands when there is
-    //    nothing worth splitting.
+    // 3) When a filter references expensive-to-compute references we do not push it. Instead we
+    //    split the projection around it (see `splitProjectForExpensiveConditions`); whatever is
+    //    left over stays above the projection, which is where all of case 3 lands when nothing
+    //    is worth splitting.
     // Note that a given filter may contain parts (sepereated by logical ands) from all cases.
     // We handle each part separately according to the logic above.
     // Additional restriction:
@@ -2311,18 +2309,14 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
               false
             }
           }
-        // Make a base plan which has all of the cheap filters (cases 1 & 2) pushed down.
+        // Cheap filters (cases 1 & 2) pushed below the projection.
         val baseChild: LogicalPlan = if (cheapWithUsed.nonEmpty) {
-          // For all filter which do not reference any expensive aliases then
-          // just push the filter while resolving the non-expensive aliases.
           val combinedCheapFilter = cheapWithUsed.map(_._3).reduce(And)
           Filter(combinedCheapFilter, child = grandChild)
         } else {
-          // If we don't have any inexpensive filters to push it's "just" the grandchild.
           grandChild
         }
-        // Case 3: try to split the projection around the expensive conditions so the expensive
-        // expressions a condition does not need are only evaluated on the rows it kept.
+        // Case 3: split the projection around the expensive conditions.
         val (splitChild, splitAliases, stayUp) =
           if (expensiveWithUsed.nonEmpty && SQLConf.get.splitProjectionForExpensiveFilters) {
             splitProjectForExpensiveConditions(project, aliasMap, baseChild,
@@ -2330,13 +2324,11 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
           } else {
             (baseChild, AttributeSet.empty, expensiveWithUsed.map(_._1))
           }
-        // Short circuit if we neither pushed nor split anything and return the filter as is.
         if (cheapWithUsed.isEmpty && splitAliases.isEmpty) {
           f
         } else {
-          // Take our projection and place it on top of the pushed filters, referencing the
-          // aliases the split projections already computed instead of computing them twice.
-          // Only the aliases change, so the column ordering (and with it the schema) is kept.
+          // Reference the aliases the split already computed; only the aliases change so the
+          // column ordering (and schema) is preserved.
           val topProjectList = if (splitAliases.isEmpty) {
             fields
           } else {
@@ -2344,11 +2336,9 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
           }
           val topProjection = project.copy(projectList = topProjectList, child = splitChild)
 
-          // If we pushed or split all the filters we can return the projection
           if (stayUp.isEmpty) {
             topProjection
           } else {
-            // Finally add any filters which could neither be pushed nor split
             Filter(stayUp.reduce(And), topProjection)
           }
         }
@@ -2510,10 +2500,10 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
 
   /**
    * Splits `project` into a stack of [[Project]]s with the expensive conditions in
-   * `expensiveConds` in between them, so that an expensive expression in the projection is only
-   * evaluated on the rows which survived the conditions placed below it (SPARK-55014).
+   * `expensiveConds` between them, so an expensive expression only runs on the rows the filters
+   * below it kept (SPARK-55014). For example, with both regexes considered expensive and a child
+   * producing `a` and `e`:
    *
-   * For example, with both regexes considered expensive and a child producing `a` and `e`:
    * {{{
    *   Filter f AND g
    *     Project a, rlike(e, 'magic') AS f, rlike(e, 'other') AS g
@@ -2529,38 +2519,28 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
    * }}}
    * so `rlike(e, 'other')` only runs on the rows where `rlike(e, 'magic')` was true.
    *
-   * The conditions are first grouped by the aliases they reference, since conditions over the same
-   * aliases can only ever be evaluated at the same point of the stack. We then repeatedly pick the
-   * group needing the fewest not-yet-computed aliases -- preferring, on a tie, the group which
-   * makes the most conditions evaluable -- and add a [[Project]] computing exactly those aliases
-   * followed by a [[Filter]] with every condition which has become evaluable. Doing the least
-   * demanding conditions first keeps the expensive expressions as high in the stack, and so over
-   * as few rows, as we can manage.
+   * Conditions are grouped by the aliases they reference, then the group needing the fewest
+   * not-yet-computed aliases is split off first -- least demanding first keeps the expensive
+   * expressions as high in the stack, and so over as few rows, as we can manage. On a tie, the
+   * group making the most conditions evaluable wins, falling back to the condition written first
+   * (the only selectivity signal we have). Whole-stage codegen already defers a projected
+   * expression past a filter that does not need it (`CodegenSupport.evaluateRequiredVariables`),
+   * so this rule only buys the same saving on the paths codegen does not cover -- interpreted
+   * projections, operators it bails out of, Python UDFs.
    *
-   * Ties are broken towards the group whose first condition came first in the original filter. We
-   * have no selectivity estimates here, so the order the conditions were written in is the only
-   * signal we have, and it is the order they would have been evaluated in anyway: with whole stage
-   * codegen the unsplit plan already defers a projected expression past a filter which does not
-   * need it, in that order (see `CodegenSupport.evaluateRequiredVariables`). What this rule buys
-   * is therefore the same saving on the paths codegen does not cover -- interpreted projections,
-   * operators it bails out of, Python UDF evaluation.
+   * Two restrictions keep the split from costing more than it saves:
+   *  - Only split a [[Project]] off while it leaves an expensive alias for a later layer; an extra
+   *    operator has to buy a real deferral.
+   *  - Aliases sharing an expensive sub-expression move together. Subexpression elimination
+   *    works within one projection and cannot reach across a [[Filter]], so splitting them apart
+   *    would re-evaluate the shared part on every row below the filter and again on every
+   *    survivor (a struct-returning UDF read field by field is the common shape).
    *
-   * Two restrictions keep us from splitting where it would cost more than it saves:
-   *  - We only split a [[Project]] off while doing so leaves at least one expensive alias for a
-   *    later layer. An extra operator has a per-row cost of its own, so it has to buy us the
-   *    deferral of an expensive expression to be worth adding.
-   *  - Aliases which share an expensive sub-expression are treated as one indivisible unit.
-   *    Subexpression elimination happens within a single projection and cannot reach across a
-   *    [[Filter]], so evaluating such aliases in different layers would evaluate the shared part
-   *    once for every row below the filter and then again for every row which survived it. A
-   *    struct-returning UDF read field by field is the common shape here.
+   * The most demanding group is left un-placed for the caller to put above the projection --
+   * where expensive conditions go when there is nothing worth splitting.
    *
-   * The most demanding group of conditions is therefore always left un-placed and handed back to
-   * the caller, which puts it above the projection -- exactly where the expensive conditions go
-   * when there is nothing worth splitting at all.
-   *
-   * Returns the new plan, the alias attributes that plan has already computed, and the conditions
-   * which were not placed (in their original, alias referencing, form).
+   * Returns the new plan, the alias attributes it has already computed, and the un-placed
+   * conditions (in their original, alias-referencing form).
    */
   private def splitProjectForExpensiveConditions(
       project: Project,
@@ -2568,27 +2548,21 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
       baseChild: LogicalPlan,
       expensiveConds: Seq[(Expression, AttributeMap[Alias])])
     : (LogicalPlan, AttributeSet, Seq[Expression]) = {
-    // The aliases we would rather not evaluate on the rows a condition is going to drop.
     val expensiveAliases = AttributeSet(
       aliasMap.collect { case (attr, alias) if alias.child.expensive => attr })
-    // The expensive sub-expressions behind each expensive alias, so that we can tell when two
-    // aliases are really the same piece of work. A cheap alias has none by definition, so we do
-    // not walk (and canonicalize) the rest of what can be a very wide projection.
+    // Expensive sub-expressions behind each expensive alias, to spot when two aliases are the
+    // same piece of work. Cheap aliases have none, so we skip the (possibly wide) cheap rest.
     val expensivePartsOf = AttributeMap(expensiveAliases.toSeq.map { attr =>
       attr -> aliasMap(attr).child.collect { case e if e.expensive => e.canonicalized }.toSet
     })
     def expensiveParts(attr: Attribute): Set[Expression] =
       expensivePartsOf.getOrElse(attr, Set.empty)
-    // ... and which aliases each of those sub-expressions turns up in.
     val aliasesSharing = expensivePartsOf.toSeq
       .flatMap { case (attr, parts) => parts.map(part => part -> attr) }
       .groupBy(_._1)
       .map { case (part, pairs) => part -> AttributeSet(pairs.map(_._2)) }
-    // Aliases sharing an expensive sub-expression have to be evaluated by the same [[Project]]:
-    // subexpression elimination happens within one projection and cannot reach across the
-    // [[Filter]] we would put between them, so splitting them apart would evaluate the shared
-    // part once for every row below the filter and then again for every row which survived it.
-    // Grow a set of aliases into the whole unit of work it belongs to, transitively.
+    // Grow a set of aliases into the whole unit of shared expensive work it belongs to,
+    // transitively (see the docstring restriction on shared sub-expressions).
     def unitOf(aliases: AttributeSet): AttributeSet = {
       var unit = aliases
       var grew = true
@@ -2601,15 +2575,11 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
       }
       unit
     }
-    // Each condition with the unit of aliases it needs and its position in the original filter.
     val indexed = expensiveConds.zipWithIndex.map {
       case ((cond, used), idx) => (unitOf(AttributeSet(used.keys)), idx, cond)
     }
-    // Conditions over the same aliases can only ever be evaluated at the same point of the stack,
-    // so group them and treat each group as one unit. We group on the sorted expression ids rather
-    // than on the [[AttributeSet]] so that grouping does not depend on how the latter hashes, and
-    // order the groups by their first condition to keep the plans we build stable and to keep the
-    // order the conditions were written in.
+    // Group conditions over the same aliases; group on sorted exprIds (not AttributeSet) for
+    // stable hashing, and order groups by first condition to keep plans stable.
     var pending: Seq[(AttributeSet, Seq[(Int, Expression)])] = indexed
       .groupBy { case (used, _, _) => used.toSeq.map(_.exprId.id).sorted }
       .toSeq
@@ -2618,15 +2588,14 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     def conditionsOf(groups: Seq[(AttributeSet, Seq[(Int, Expression)])]): Seq[Expression] =
       groups.flatMap(_._2).sortBy(_._1).map(_._2)
 
-    // The aliases in projection order, which is stable, unlike the alias map's iteration order.
+    // Projection order is stable, unlike the alias map's iteration order.
     val orderedAliases = project.projectList.collect { case a: Alias => a }
 
     var plan = baseChild
     var computed = AttributeSet.empty
     var searching = true
     while (searching) {
-      // Splitting around a group only pays off while it leaves an expensive alias for a later
-      // layer to compute.
+      // Only split while it leaves an expensive alias for a later layer.
       val stillToCompute = expensiveAliases -- computed
       val candidates = pending.filter { case (used, _) => !stillToCompute.subsetOf(used) }
       if (candidates.isEmpty) {
@@ -2637,8 +2606,8 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
         }
         val newAliases = orderedAliases.filter(a => bestUsed.contains(a) && !computed.contains(a))
         computed ++= AttributeSet(newAliases.map(_.toAttribute))
-        // Everything the plan below already produces stays available, since a later projection in
-        // the stack (or the final one) may still need it. Column pruning drops the extras.
+        // Keep the plan's existing outputs available for later projections; column pruning drops
+        // the extras.
         val newProject = project.copy(projectList = plan.output ++ newAliases, child = plan)
         val (evaluable, rest) = pending.partition { case (used, _) => used.subsetOf(computed) }
         plan = Filter(conditionsOf(evaluable).reduce(And), newProject)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushdownPredicatesAndPruneColumnsForCTEDef.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushdownPredicatesAndPruneColumnsForCTEDef.scala
@@ -186,13 +186,12 @@ object PushdownPredicatesAndPruneColumnsForCTEDef extends Rule[LogicalPlan] with
    * the very same `AliasHelper` utilities, so the two cannot drift apart): through projection
    * and grouping-key aliases, positionally into each branch (`Union`), and unchanged
    * through operators that pass the referenced attributes verbatim (`Join`, `Window`, and
-   * output-preserving unary nodes like `Filter`, `Sort`, `Repartition`). The descent is
-   * recursive because the filter can end up several operators down, in particular in between the
-   * projections `PushPredicateThroughNonJoin` splits a `Project` into when the filter references
-   * expensive projected expressions. Descent stops at operators that remap attributes in other
-   * ways (e.g. `Generate`, `Expand`): if the filter cannot be located, the input plan is returned
-   * unchanged, and the caller re-pushes on top, which is redundant but always
-   * semantics-preserving.
+   * output-preserving unary nodes like `Filter`, `Sort`, `Repartition`). The descent is recursive
+   * because the filter can end up several operators down -- in particular between the projections
+   * `PushPredicateThroughNonJoin` splits a `Project` into for expensive projected expressions.
+   * Descent stops at operators that remap attributes in other ways (e.g. `Generate`, `Expand`):
+   * if the filter cannot be located, the input plan is returned unchanged, and the caller
+   * re-pushes on top, which is redundant but always semantics-preserving.
    *
    * Ancestors of the removed filter are rebuilt with `withNewChildren` rather than direct
    * case-class copies so that `TreeNode` tags (e.g. `Project.hiddenOutputTag`, which the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushdownPredicatesAndPruneColumnsForCTEDef.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushdownPredicatesAndPruneColumnsForCTEDef.scala
@@ -186,10 +186,13 @@ object PushdownPredicatesAndPruneColumnsForCTEDef extends Rule[LogicalPlan] with
    * the very same `AliasHelper` utilities, so the two cannot drift apart): through projection
    * and grouping-key aliases, positionally into each branch (`Union`), and unchanged
    * through operators that pass the referenced attributes verbatim (`Join`, `Window`, and
-   * output-preserving unary nodes like `Filter`, `Sort`, `Repartition`). Descent stops at
-   * operators that remap attributes in other ways (e.g. `Generate`, `Expand`): if the filter
-   * cannot be located, the input plan is returned unchanged, and the caller re-pushes on top,
-   * which is redundant but always semantics-preserving.
+   * output-preserving unary nodes like `Filter`, `Sort`, `Repartition`). The descent is
+   * recursive because the filter can end up several operators down, in particular in between the
+   * projections `PushPredicateThroughNonJoin` splits a `Project` into when the filter references
+   * expensive projected expressions. Descent stops at operators that remap attributes in other
+   * ways (e.g. `Generate`, `Expand`): if the filter cannot be located, the input plan is returned
+   * unchanged, and the caller re-pushes on top, which is redundant but always
+   * semantics-preserving.
    *
    * Ancestors of the removed filter are rebuilt with `withNewChildren` rather than direct
    * case-class copies so that `TreeNode` tags (e.g. `Project.hiddenOutputTag`, which the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -610,6 +610,17 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS =
+    buildConf("spark.sql.optimizer.splitProjectionForExpensiveFilters")
+    .doc("When true, split a projection into several projections with the filters which " +
+      "reference its expensive (UDF, etc.) elements in between, so that an expensive element " +
+      "is only evaluated for the rows which survived the filters below it. This costs an extra " +
+      "operator per split, and only applies when " +
+      s"${AVOID_DOUBLE_FILTER_EVAL.key} is also enabled.")
+    .version("4.4.0")
+    .booleanConf
+    .createWithDefault(true)
+
   val ATTEMPT_TRANSPILATION_OF_PYTHON_UDFS =
     buildConf("spark.sql.experimental.optimizer.transpilePyUDFs")
     .withBindingPolicy(ConfigBindingPolicy.SESSION)
@@ -9730,6 +9741,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def charVarcharStandardSemantics: Boolean = getConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS)
 
   def avoidDoubleFilterEval: Boolean = getConf(AVOID_DOUBLE_FILTER_EVAL)
+
+  def splitProjectionForExpensiveFilters: Boolean =
+    getConf(SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS)
 
   def structPredicateDecomposeEnabled: Boolean = getConf(STRUCT_PREDICATE_DECOMPOSE_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -613,10 +613,9 @@ object SQLConf {
   val SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS =
     buildConf("spark.sql.optimizer.splitProjectionForExpensiveFilters")
     .doc("When true, split a projection into several projections with the filters which " +
-      "reference its expensive (UDF, etc.) elements in between, so that an expensive element " +
-      "is only evaluated for the rows which survived the filters below it. This costs an extra " +
-      "operator per split, and only applies when " +
-      s"${AVOID_DOUBLE_FILTER_EVAL.key} is also enabled.")
+      "reference its expensive (UDF, etc.) elements in between, so an expensive element is only " +
+      "evaluated for the rows which survived the filters below it. Costs an extra operator per " +
+      s"split, and only applies when ${AVOID_DOUBLE_FILTER_EVAL.key} is also enabled.")
     .version("4.4.0")
     .booleanConf
     .createWithDefault(true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -281,8 +281,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // Both regexes are expensive, and neither condition needs both of them, so we compute f
-    // first and only run the 'other' regex on the rows where the 'magic' one matched.
+    // Both regexes are expensive and neither condition needs both, so f is computed first and
+    // 'other' only runs on the rows 'magic' matched.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
       .where($"f")
@@ -301,8 +301,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // g is never filtered on, but it is still expensive, so it is worth deferring it until
-    // after the filter on f.
+    // g is never filtered on but is still expensive, so it is worth deferring past the filter on f.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
       .where($"f")
@@ -321,8 +320,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // Every condition needs a different alias, so we get a projection per condition, minus the
-    // last one -- there is nothing left to defer past it so it goes above the final projection.
+    // One projection per condition except the last -- nothing left to defer past it.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
       .where($"f")
@@ -343,8 +341,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // Splitting here would have to compute both regexes below the filter, which is the plan we
-    // already have plus a redundant projection.
+    // Splitting here would compute both regexes below the filter -- the plan we already have
+    // plus a redundant projection.
     val correctAnswer = originalQuery
 
     comparePlans(optimized, correctAnswer)
@@ -359,8 +357,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // Same condition as the test above, but this time there is a third expensive element to
-    // defer past it, so one projection computes both f and g and j waits until after the filter.
+    // A third expensive element to defer, so f and g compute together below the filter and j
+    // waits above it.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("magic") as "f", $"e".rlike("other") as "g")
       .where($"f" || $"g")
@@ -379,8 +377,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // j needs one alias and (f || g) needs two, so j is evaluated first even though it comes
-    // last in the projection: that leaves two expensive elements to run on its survivors.
+    // j needs one alias and (f || g) needs two, so j goes first even though it is projected
+    // last -- leaving two expensive elements to run on its survivors.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("third") as "j")
       .where($"j")
@@ -399,8 +397,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // sum is cheap so its condition is pushed all the way down (case 2), f is expensive so we
-    // split the projection around it, and g is deferred to the projection on top.
+    // sum is cheap (case 2, pushed down); f is expensive (split around); g deferred on top.
     val correctAnswer = testStringRelation
       .where($"a" + $"b" > 10)
       .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
@@ -419,8 +416,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // A projection is not free, so we only split when it defers something expensive. Recomputing
-    // sum a row later is not worth an extra operator.
+    // A projection is not free; recomputing a cheap sum later is not worth an extra operator.
     val correctAnswer = originalQuery
 
     comparePlans(optimized, correctAnswer)
@@ -434,7 +430,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // f is computed below but still has to come back out in its original position.
+    // f is computed below but must come back out in its original position.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
       .where($"f")
@@ -456,8 +452,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // Conditions over the same aliases can only run at the same point of the stack, so both
-    // conditions on j end up in the same filter, and k is deferred past them.
+    // Conditions over the same aliases run at the same point of the stack, so both on j land in
+    // one filter and k is deferred past them.
     val correctAnswer = testArrayStringRelation
       .select($"a", $"s_arr", joined as "j")
       .where($"j" > "a" && $"j" < "z")
@@ -475,10 +471,9 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // f and g are the same regex. Subexpression elimination evaluates it once for a single
-    // projection but cannot reach across a filter, so splitting f and g apart would run it for
-    // every row below the filter and then again for every row which survived -- more work than
-    // leaving the projection alone.
+    // f and g are the same regex. Subexpression elimination collapses it in one projection but
+    // cannot reach across a filter, so splitting would run it on every row below and again on
+    // every survivor -- more work than leaving the projection alone.
     val correctAnswer = originalQuery
 
     comparePlans(optimized, correctAnswer)
@@ -493,8 +488,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery)
 
-    // j is its own piece of work and needs one alias, while f drags g along with it, so j is
-    // split off first and f and g stay together in the projection on top.
+    // j is its own work needing one alias; f drags g along, so j splits off first and f and g
+    // stay together on top.
     val correctAnswer = testStringRelation
       .select($"a", $"b", $"e", $"e".rlike("other") as "j")
       .where($"j")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -61,6 +61,8 @@ class FilterPushdownSuite extends PlanTest {
 
   val testStringRelation = LocalRelation(attrA, attrB, attrE)
 
+  val testArrayStringRelation = LocalRelation($"a".int, $"s_arr".array(StringType))
+
   val simpleDisjunctivePredicate =
     ("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11)
   val expectedPredicatePushDownResult = {
@@ -269,6 +271,253 @@ class FilterPushdownSuite extends PlanTest {
       .analyze
 
     comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: split the projection so a second expensive element sees fewer rows") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"b")
+      .where($"f" && $"g")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // Both regexes are expensive, and neither condition needs both of them, so we compute f
+    // first and only run the 'other' regex on the rows where the 'magic' one matched.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
+      .where($"f")
+      .select($"a", $"f", $"e".rlike("other") as "g", $"b")
+      .where($"g")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: split the projection even for a single expensive condition") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"b")
+      .where($"f")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // g is never filtered on, but it is still expensive, so it is worth deferring it until
+    // after the filter on f.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
+      .where($"f")
+      .select($"a", $"f", $"e".rlike("other") as "g", $"b")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: split the projection once per group of expensive elements") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"e".rlike("third") as
+        "j")
+      .where($"f" && $"g" && $"j")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // Every condition needs a different alias, so we get a projection per condition, minus the
+    // last one -- there is nothing left to defer past it so it goes above the final projection.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
+      .where($"f")
+      .select($"a", $"b", $"e", $"f", $"e".rlike("other") as "g")
+      .where($"g")
+      .select($"a", $"f", $"g", $"e".rlike("third") as "j")
+      .where($"j")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: a condition needing every expensive element can not be split off") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"b")
+      .where($"f" || $"g")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // Splitting here would have to compute both regexes below the filter, which is the plan we
+    // already have plus a redundant projection.
+    val correctAnswer = originalQuery
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: a condition over several expensive elements can still be split off") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"e".rlike("third") as
+        "j")
+      .where($"f" || $"g")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // Same condition as the test above, but this time there is a third expensive element to
+    // defer past it, so one projection computes both f and g and j waits until after the filter.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("magic") as "f", $"e".rlike("other") as "g")
+      .where($"f" || $"g")
+      .select($"a", $"f", $"g", $"e".rlike("third") as "j")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: the least demanding condition goes lowest") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"e".rlike("third") as
+        "j")
+      .where(($"f" || $"g") && $"j")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // j needs one alias and (f || g) needs two, so j is evaluated first even though it comes
+    // last in the projection: that leaves two expensive elements to run on its survivors.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("third") as "j")
+      .where($"j")
+      .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"j")
+      .where($"f" || $"g")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: split the projection while also pushing the cheap conditions") {
+    val originalQuery = testStringRelation
+      .select($"a" + $"b" as "sum", $"e".rlike("magic") as "f", $"e".rlike("other") as "g")
+      .where($"sum" > 10 && $"f")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // sum is cheap so its condition is pushed all the way down (case 2), f is expensive so we
+    // split the projection around it, and g is deferred to the projection on top.
+    val correctAnswer = testStringRelation
+      .where($"a" + $"b" > 10)
+      .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
+      .where($"f")
+      .select($"a" + $"b" as "sum", $"f", $"e".rlike("other") as "g")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: no split when the only elements left to defer are cheap") {
+    val originalQuery = testStringRelation
+      .select($"a" + $"b" as "sum", $"e".rlike("magic") as "f")
+      .where($"f")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // A projection is not free, so we only split when it defers something expensive. Recomputing
+    // sum a row later is not worth an extra operator.
+    val correctAnswer = originalQuery
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: the projection on top keeps the original column ordering") {
+    val originalQuery = testStringRelation
+      .select($"b", $"e".rlike("magic") as "f", $"a", $"e".rlike("other") as "g")
+      .where($"f" && $"g")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // f is computed below but still has to come back out in its original position.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("magic") as "f")
+      .where($"f")
+      .select($"b", $"f", $"a", $"e".rlike("other") as "g")
+      .where($"g")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+    assert(optimized.schema === originalQuery.schema)
+  }
+
+  test("SPARK-55014: all the conditions over the same elements are applied together") {
+    val joined = ArrayJoin($"s_arr", Literal(","), None)
+    val otherJoined = ArrayJoin($"s_arr", Literal("-"), None)
+    val originalQuery = testArrayStringRelation
+      .select($"a", joined as "j", otherJoined as "k")
+      .where($"j" > "a" && $"j" < "z")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // Conditions over the same aliases can only run at the same point of the stack, so both
+    // conditions on j end up in the same filter, and k is deferred past them.
+    val correctAnswer = testArrayStringRelation
+      .select($"a", $"s_arr", joined as "j")
+      .where($"j" > "a" && $"j" < "z")
+      .select($"a", $"j", otherJoined as "k")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: no split when the expensive work is shared between elements") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", Not($"e".rlike("magic")) as "g")
+      .where($"f" && $"g")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // f and g are the same regex. Subexpression elimination evaluates it once for a single
+    // projection but cannot reach across a filter, so splitting f and g apart would run it for
+    // every row below the filter and then again for every row which survived -- more work than
+    // leaving the projection alone.
+    val correctAnswer = originalQuery
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: elements sharing expensive work are split off together") {
+    val originalQuery = testStringRelation
+      .select($"a", $"e".rlike("magic") as "f", Not($"e".rlike("magic")) as "g",
+        $"e".rlike("other") as "j")
+      .where($"f" && $"j")
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery)
+
+    // j is its own piece of work and needs one alias, while f drags g along with it, so j is
+    // split off first and f and g stay together in the projection on top.
+    val correctAnswer = testStringRelation
+      .select($"a", $"b", $"e", $"e".rlike("other") as "j")
+      .where($"j")
+      .select($"a", $"e".rlike("magic") as "f", Not($"e".rlike("magic")) as "g", $"j")
+      .where($"f")
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-55014: do not split the projection when configured") {
+    withSQLConf(SQLConf.SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS.key -> "false") {
+      val originalQuery = testStringRelation
+        .select($"a", $"e".rlike("magic") as "f", $"e".rlike("other") as "g", $"b")
+        .where($"f" && $"g")
+        .analyze
+
+      val optimized = Optimize.execute(originalQuery)
+
+      val correctAnswer = originalQuery
+
+      comparePlans(optimized, correctAnswer)
+    }
   }
 
   test("nondeterministic: can always push down filter through project with deterministic field") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2826,20 +2826,20 @@ class DataFrameSuite extends SharedSparkSession
       .where($"m" && $"o")
     val expected = Seq(0L, 6L, 12L, 18L, 24L).map(Row(_, true, true))
 
-    // Whole stage codegen already defers a projected expression past a filter which does not need
-    // it (see CodegenSupport.evaluateRequiredVariables), so splitting the projection is what gets
-    // us the same saving on the paths codegen does not cover -- interpreted projections, operators
-    // it bails out of, Python UDF evaluation. Measure the saving with codegen off.
+    // Codegen already defers a projected expression past a filter that does not need it
+    // (CodegenSupport.evaluateRequiredVariables); splitting buys the same saving on the paths
+    // codegen does not cover -- interpreted projections, operators it bails out of, Python UDFs.
+    // Measure with codegen off.
     Seq(true, false).foreach { split =>
       withSQLConf(
         SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
         SQLConf.SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS.key -> split.toString) {
         magicCalls.reset()
         otherCalls.reset()
-        // Collect rather than checkAnswer so that the plan runs exactly once.
+        // Collect, not checkAnswer, so the plan runs exactly once.
         assert(query().collect().toSeq === expected)
         assert(magicCalls.value === 30)
-        // Splitting the projection around the filter on `m` means `other` never sees the odd ids.
+        // Splitting around the filter on `m` means `other` never sees the odd ids.
         assert(otherCalls.value === (if (split) 15 else 30))
       }
     }
@@ -2860,10 +2860,9 @@ class DataFrameSuite extends SharedSparkSession
       calls.add(1)
       i
     })
-    // x and y are one UDF call between them, which subexpression elimination collapses within a
-    // single projection but cannot collapse across a filter. Splitting would evaluate the UDF for
-    // every row below the filter and again for every row which survived it, so we leave the
-    // projection alone and the call count stays at one per input row.
+    // x and y share one UDF call: subexpression elimination collapses it in one projection but
+    // cannot reach across a filter, so splitting would re-run it on every row below and again on
+    // every survivor. Leave the projection alone; the count stays at one per input row.
     def query(): DataFrame = spark.range(0, 30, 1, 1)
       .select($"id", u($"id") as "x", (u($"id") + 1) as "y")
       .where($"x" % 2 === 0 && $"y" % 3 === 0)
@@ -2888,10 +2887,9 @@ class DataFrameSuite extends SharedSparkSession
       lateCalls.add(1)
       i % 2 == 0
     })
-    // `l` is projected before `e` but filtered on after it. Which expensive expression we split
-    // off first has to follow the filter, because the order the conditions were written in is the
-    // only selectivity signal available -- ordering by the projection instead would run `late`
-    // over every row and could end up doing more work than not splitting at all.
+    // `l` is projected before `e` but filtered on after it. Split order must follow the filter:
+    // the condition order is the only selectivity signal we have, and ordering by the projection
+    // would run `late` over every row and could do more work than not splitting at all.
     def query(): DataFrame = spark.range(0, 30, 1, 1)
       .select($"id", late($"id") as "l", early($"id") as "e")
       .where($"e" && $"l")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2808,6 +2808,104 @@ class DataFrameSuite extends SharedSparkSession
     val df = classic.Dataset.ofRows(spark, relation)
     checkAnswer(df.select("b"), Row(2))
   }
+
+  test("SPARK-55014: only evaluate expensive projections for the rows a filter kept") {
+    val magicCalls = sparkContext.longAccumulator("magicCalls")
+    val otherCalls = sparkContext.longAccumulator("otherCalls")
+    val magic = udf((i: Long) => {
+      magicCalls.add(1)
+      i % 2 == 0
+    })
+    val other = udf((i: Long) => {
+      otherCalls.add(1)
+      i % 3 == 0
+    })
+    // A single partition so that the call counts below are exact.
+    def query(): DataFrame = spark.range(0, 30, 1, 1)
+      .select($"id", magic($"id") as "m", other($"id") as "o")
+      .where($"m" && $"o")
+    val expected = Seq(0L, 6L, 12L, 18L, 24L).map(Row(_, true, true))
+
+    // Whole stage codegen already defers a projected expression past a filter which does not need
+    // it (see CodegenSupport.evaluateRequiredVariables), so splitting the projection is what gets
+    // us the same saving on the paths codegen does not cover -- interpreted projections, operators
+    // it bails out of, Python UDF evaluation. Measure the saving with codegen off.
+    Seq(true, false).foreach { split =>
+      withSQLConf(
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+        SQLConf.SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS.key -> split.toString) {
+        magicCalls.reset()
+        otherCalls.reset()
+        // Collect rather than checkAnswer so that the plan runs exactly once.
+        assert(query().collect().toSeq === expected)
+        assert(magicCalls.value === 30)
+        // Splitting the projection around the filter on `m` means `other` never sees the odd ids.
+        assert(otherCalls.value === (if (split) 15 else 30))
+      }
+    }
+
+    // However the plan is built, the answer is the same.
+    for (codegen <- Seq(true, false); split <- Seq(true, false)) {
+      withSQLConf(
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> codegen.toString,
+        SQLConf.SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS.key -> split.toString) {
+        checkAnswer(query(), expected)
+      }
+    }
+  }
+
+  test("SPARK-55014: no split when projected expressions share the expensive work") {
+    val calls = sparkContext.longAccumulator("udfCalls")
+    val u = udf((i: Long) => {
+      calls.add(1)
+      i
+    })
+    // x and y are one UDF call between them, which subexpression elimination collapses within a
+    // single projection but cannot collapse across a filter. Splitting would evaluate the UDF for
+    // every row below the filter and again for every row which survived it, so we leave the
+    // projection alone and the call count stays at one per input row.
+    def query(): DataFrame = spark.range(0, 30, 1, 1)
+      .select($"id", u($"id") as "x", (u($"id") + 1) as "y")
+      .where($"x" % 2 === 0 && $"y" % 3 === 0)
+
+    Seq(true, false).foreach { codegen =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> codegen.toString) {
+        calls.reset()
+        assert(query().collect().length === 5)
+        assert(calls.value === 30)
+      }
+    }
+  }
+
+  test("SPARK-55014: splitting follows the filter's order, not the projection's") {
+    val earlyCalls = sparkContext.longAccumulator("earlyCalls")
+    val lateCalls = sparkContext.longAccumulator("lateCalls")
+    val early = udf((i: Long) => {
+      earlyCalls.add(1)
+      i % 3 == 0
+    })
+    val late = udf((i: Long) => {
+      lateCalls.add(1)
+      i % 2 == 0
+    })
+    // `l` is projected before `e` but filtered on after it. Which expensive expression we split
+    // off first has to follow the filter, because the order the conditions were written in is the
+    // only selectivity signal available -- ordering by the projection instead would run `late`
+    // over every row and could end up doing more work than not splitting at all.
+    def query(): DataFrame = spark.range(0, 30, 1, 1)
+      .select($"id", late($"id") as "l", early($"id") as "e")
+      .where($"e" && $"l")
+    val expected = Seq(0L, 6L, 12L, 18L, 24L).map(Row(_, true, true))
+
+    withSQLConf(
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+      SQLConf.SPLIT_PROJECTION_FOR_EXPENSIVE_FILTERS.key -> "true") {
+      assert(query().collect().toSeq === expected)
+      assert(earlyCalls.value === 30)
+      // Only the ten ids divisible by three reach `late`.
+      assert(lateCalls.value === 10)
+    }
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow up to SPARK-47672. That change stopped `PushPredicateThroughNonJoin` from pushing a filter below a `Project` when the filter references expensive projected aliases, because pushing caused them to be evaluated twice, and parked those conditions above the projection.

This splits the projection into a stack of `Project`/`Filter` layers instead, so that the expensive expressions a condition does not need are only evaluated for the rows that condition kept:

    Filter f AND g                              Filter g
      Project a, rlike(e,'magic') AS f,           Project a, f, rlike(e,'other') AS g
              rlike(e,'other') AS g       -->       Filter f
        child                                         Project a, e, rlike(e,'magic') AS f
                                                        child

Conditions are grouped by the aliases they reference, and the group needing the fewest not-yet-computed aliases is split off first, breaking ties towards the condition written first. Two restrictions keep the rule from costing more than it saves:

- A projection is only split off while doing so leaves an expensive alias for a later layer. An extra operator has a per-row cost of its own, so it has to buy a real deferral.
- Aliases sharing an expensive sub-expression are treated as one indivisible unit. Subexpression elimination works within a single projection and cannot reach across a filter, so splitting such aliases apart would evaluate the shared part once for every row below the filter and again for every row that survived it. A struct-returning UDF read field by field is the common shape.

Gated on the new `spark.sql.optimizer.splitProjectionForExpensiveFilters` (default true), which also requires `spark.sql.optimizer.avoidDoubleFilterEval`.

### Why are the changes needed?

SPARK-47672 stops the double evaluation but leaves the projection computing every expensive element for every row reaching it, even when a filter above it is about to discard most of them. Whole stage codegen already defers a projected expression past a filter that does not need it (`CodegenSupport.evaluateRequiredVariables`), so what this buys is the same saving on the paths codegen does not cover: interpreted projections, operators it bails out of, and Python UDF evaluation.

### Does this PR introduce _any_ user-facing change?

Plans for queries filtering on expensive projected expressions gain projection/filter layers. Results, schemas and column ordering are unchanged.

### How was this patch tested?

Thirteen new plan tests in `FilterPushdownSuite` covering splitting, the ordering heuristic, the no-split cases (a condition needing every expensive element, only cheap elements left to defer, shared expensive work), column ordering, and the config off. Three new end-to-end tests in `DataFrameSuite` count UDF invocations to show the saving is real (30 -> 15), that results match with splitting and codegen each on and off, that the split follows the filter's order rather than the projection's, and that shared expensive work is not split apart.

`PlanStabilitySuite` confirms the TPCDS golden plans are unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5 using my previous work in the original PR as a starting point