### PR TITLE
[SPARK-36082][SQL][FOLLOWUP] Preserve NAAJ broadcast fallback behavior

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -184,8 +184,8 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
               // For a left semi join, the non-pushable part of the condition is kept as a Filter
               // above the join.
               case LeftSemi => Filter(stayUp.reduce(And), newPlan)
-              // In case of left-anti join, the join is pushed down only when the entire join
-              // condition is eligible to be pushed down to preserve the semantics of left-anti
+              // In the case of a left anti join, the join is pushed down only when the entire join
+              // condition is eligible to be pushed down to preserve the semantics of the left anti
               // join.
               case _ => join
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -64,8 +64,7 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
     case join @ Join(agg: Aggregate, rightOp, LeftSemiOrAnti(_), joinCond, _)
         if agg.aggregateExpressions.forall(_.deterministic) && agg.groupingExpressions.nonEmpty &&
           !agg.aggregateExpressions.exists(ScalarSubquery.hasCorrelatedScalarSubquery) &&
-          canPushThroughCondition(agg.children, joinCond, rightOp) &&
-          canPlanAsBroadcastHashJoin(join, conf) =>
+          canPushThroughCondition(agg.children, joinCond, rightOp) =>
       val aliasMap = getAliasMap(agg)
       val canPushDownPredicate = (predicate: Expression) => {
         val replaced = replaceAlias(predicate, aliasMap)
@@ -75,7 +74,11 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
       val makeJoinCondition = (predicates: Seq[Expression]) => {
         replaceAlias(predicates.reduce(And), aliasMap)
       }
-      pushDownJoin(join, canPushDownPredicate, makeJoinCondition)
+      pushDownJoin(
+        join,
+        canPushDownPredicate,
+        makeJoinCondition,
+        canPlanAsBroadcastHashJoin(_, conf))
 
     // LeftSemi/LeftAnti over Window
     case join @ Join(w: Window, rightOp, LeftSemiOrAnti(_), _, _)
@@ -133,11 +136,17 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
   private def pushDownJoin(
       join: Join,
       canPushDownPredicate: Expression => Boolean,
-      makeJoinCondition: Seq[Expression] => Expression): LogicalPlan = {
+      makeJoinCondition: Seq[Expression] => Expression,
+      canPushDownJoin: Join => Boolean = _ => true): LogicalPlan = {
     assert(join.left.children.length == 1)
 
     if (join.condition.isEmpty) {
-      join.left.withNewChildren(Seq(join.copy(left = join.left.children.head)))
+      val pushedJoin = join.copy(left = join.left.children.head)
+      if (canPushDownJoin(pushedJoin)) {
+        join.left.withNewChildren(Seq(pushedJoin))
+      } else {
+        join
+      }
     } else {
       val (pushDown, stayUp) = splitConjunctivePredicates(join.condition.get)
         .partition(canPushDownPredicate)
@@ -151,19 +160,25 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
       if (pushDown.isEmpty || referRightSideCols)  {
         join
       } else {
-        val newPlan = join.left.withNewChildren(Seq(join.copy(
-          left = join.left.children.head, condition = Some(makeJoinCondition(pushDown)))))
-        // If there is no more filter to stay up, return the new plan that has join pushed down.
-        if (stayUp.isEmpty) {
-          newPlan
+        val pushedJoin = join.copy(
+          left = join.left.children.head, condition = Some(makeJoinCondition(pushDown)))
+        if (!canPushDownJoin(pushedJoin)) {
+          join
         } else {
-          join.joinType match {
-            // In case of Left semi join, the part of the join condition which does not refer to
-            // to attributes of the grandchild are kept as a Filter above.
-            case LeftSemi => Filter(stayUp.reduce(And), newPlan)
-            // In case of left-anti join, the join is pushed down only when the entire join
-            // condition is eligible to be pushed down to preserve the semantics of left-anti join.
-            case _ => join
+          val newPlan = join.left.withNewChildren(Seq(pushedJoin))
+          // If there is no more filter to stay up, return the new plan that has join pushed down.
+          if (stayUp.isEmpty) {
+            newPlan
+          } else {
+            join.joinType match {
+              // In case of Left semi join, the part of the join condition which does not refer to
+              // to attributes of the grandchild are kept as a Filter above.
+              case LeftSemi => Filter(stayUp.reduce(And), newPlan)
+              // In case of left-anti join, the join is pushed down only when the entire join
+              // condition is eligible to be pushed down to preserve the semantics of left-anti
+              // join.
+              case _ => join
+            }
           }
         }
       }
@@ -273,5 +288,4 @@ object PushLeftSemiLeftAntiThroughJoin extends Rule[LogicalPlan] with PredicateH
       }
   }
 }
-
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -82,7 +82,7 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
           NullAwareAntiJoinPlanning.decide(pushedJoin, conf) ==
             NullAwareAntiJoinPlanning.BroadcastHash
       } else {
-        (_: Join) => true
+        (_: Join) => canPlanAsBroadcastHashJoin(join, conf)
       }
       pushDownJoin(
         join,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.planning.ExtractSingleColumnNullAwareAntiJoin
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -60,12 +61,11 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
         }
       }
 
-    // LeftSemi/LeftAnti over Aggregate, only push down if join can be planned as broadcast join.
+    // LeftSemi/LeftAnti over Aggregate
     case join @ Join(agg: Aggregate, rightOp, LeftSemiOrAnti(_), joinCond, _)
         if agg.aggregateExpressions.forall(_.deterministic) && agg.groupingExpressions.nonEmpty &&
           !agg.aggregateExpressions.exists(ScalarSubquery.hasCorrelatedScalarSubquery) &&
-          canPushThroughCondition(agg.children, joinCond, rightOp) &&
-          canPlanAsBroadcastHashJoin(join, conf) =>
+          canPushThroughCondition(agg.children, joinCond, rightOp) =>
       val aliasMap = getAliasMap(agg)
       val canPushDownPredicate = (predicate: Expression) => {
         val replaced = replaceAlias(predicate, aliasMap)
@@ -75,11 +75,20 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
       val makeJoinCondition = (predicates: Seq[Expression]) => {
         replaceAlias(predicates.reduce(And), aliasMap)
       }
+      val canPushDownJoin = if (ExtractSingleColumnNullAwareAntiJoin.extract(join).isDefined) {
+        val originalIsBroadcastHash =
+          NullAwareAntiJoinPlanning.decide(join, conf) == NullAwareAntiJoinPlanning.BroadcastHash
+        (pushedJoin: Join) => originalIsBroadcastHash &&
+          NullAwareAntiJoinPlanning.decide(pushedJoin, conf) ==
+            NullAwareAntiJoinPlanning.BroadcastHash
+      } else {
+        (_: Join) => true
+      }
       pushDownJoin(
         join,
         canPushDownPredicate,
         makeJoinCondition,
-        canPlanAsBroadcastHashJoin(_, conf))
+        canPushDownJoin)
 
     // LeftSemi/LeftAnti over Window
     case join @ Join(w: Window, rightOp, LeftSemiOrAnti(_), _, _)
@@ -167,13 +176,13 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
           join
         } else {
           val newPlan = join.left.withNewChildren(Seq(pushedJoin))
-          // If there is no more filter to stay up, return the new plan that has join pushed down.
+          // If no predicates remain above the join, return the plan with the join pushed down.
           if (stayUp.isEmpty) {
             newPlan
           } else {
             join.joinType match {
-              // In case of Left semi join, the part of the join condition which does not refer to
-              // to attributes of the grandchild are kept as a Filter above.
+              // For a left semi join, the non-pushable part of the condition is kept as a Filter
+              // above the join.
               case LeftSemi => Filter(stayUp.reduce(And), newPlan)
               // In case of left-anti join, the join is pushed down only when the entire join
               // condition is eligible to be pushed down to preserve the semantics of left-anti

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -64,7 +64,8 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
     case join @ Join(agg: Aggregate, rightOp, LeftSemiOrAnti(_), joinCond, _)
         if agg.aggregateExpressions.forall(_.deterministic) && agg.groupingExpressions.nonEmpty &&
           !agg.aggregateExpressions.exists(ScalarSubquery.hasCorrelatedScalarSubquery) &&
-          canPushThroughCondition(agg.children, joinCond, rightOp) =>
+          canPushThroughCondition(agg.children, joinCond, rightOp) &&
+          canPlanAsBroadcastHashJoin(join, conf) =>
       val aliasMap = getAliasMap(agg)
       val canPushDownPredicate = (predicate: Expression) => {
         val replaced = replaceAlias(predicate, aliasMap)
@@ -288,4 +289,3 @@ object PushLeftSemiLeftAntiThroughJoin extends Rule[LogicalPlan] with PredicateH
       }
   }
 }
-

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -498,11 +498,13 @@ trait JoinSelectionHelper extends Logging {
       getBroadcastBuildSide(join, hintOnly = true, conf).orElse {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
-    // The null-aware hash join only supports BuildRight. Preserve a generic BuildLeft fallback.
-    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
-        if canBroadcastBySize(j.right, conf) &&
-          getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight =>
-      Some(BuildRight)
+    case j if ExtractSingleColumnNullAwareAntiJoin.extract(j).isDefined =>
+      if (NullAwareAntiJoinPlanning.decide(j, conf) ==
+          NullAwareAntiJoinPlanning.BroadcastHash) {
+        Some(BuildRight)
+      } else {
+        None
+      }
     case _ => None
   }
 
@@ -624,5 +626,21 @@ trait JoinSelectionHelper extends Logging {
   private def forceApplyShuffledHashJoin(conf: SQLConf): Boolean = {
     Utils.isTesting &&
       conf.getConfString("spark.sql.join.forceApplyShuffledHashJoin", "false") == "true"
+  }
+}
+
+private[sql] object NullAwareAntiJoinPlanning extends JoinSelectionHelper {
+  sealed trait Decision
+  case object BroadcastHash extends Decision
+  case object BroadcastNestedLoop extends Decision
+
+  def decide(join: Join, conf: SQLConf): Decision = {
+    if (conf.optimizeNullAwareAntiJoin &&
+        canBroadcastBySize(join.right, conf) &&
+        getBroadcastNestedLoopJoinBuildSide(join, conf) == BuildRight) {
+      BroadcastHash
+    } else {
+      BroadcastNestedLoop
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -296,10 +296,13 @@ trait JoinSelectionHelper extends Logging {
 
   private def canBuildNullAwareAntiJoinHashRelation(
       rightKeys: Seq[Expression],
-      right: LogicalPlan): Boolean = {
+      right: LogicalPlan,
+      conf: SQLConf): Boolean = {
     val usesLongHashedRelation =
       rightKeys.length == 1 && rightKeys.head.dataType.isInstanceOf[IntegralType]
-    usesLongHashedRelation || right.stats.rowCount.forall(_ < maxBroadcastHashRows)
+    usesLongHashedRelation || right.stats.rowCount.fold(canBroadcastBySize(right, conf)) {
+      _ < maxBroadcastHashRows
+    }
   }
 
   def getBroadcastBuildSide(
@@ -381,27 +384,36 @@ trait JoinSelectionHelper extends Logging {
       join: Join,
       hintOnly: Boolean,
       conf: SQLConf): Option[BuildSide] = {
-    val buildLeft = if (hintOnly) {
+    lazy val buildLeft = if (hintOnly) {
       hintToBroadcastLeft(join.hint)
     } else {
       canBroadcastBySize(join.left, conf) &&
         !hintToNotBroadcastAndReplicateLeft(join.hint)
     }
-    val buildRight = if (hintOnly) {
+    lazy val buildRight = if (hintOnly) {
       hintToBroadcastRight(join.hint)
     } else {
       canBroadcastBySize(join.right, conf) &&
         !hintToNotBroadcastAndReplicateRight(join.hint)
     }
 
-    if (buildLeft && buildRight) {
-      Some(getBroadcastNestedLoopJoinDesiredBuildSide(join))
-    } else if (buildLeft) {
-      Some(BuildLeft)
-    } else if (buildRight) {
-      Some(BuildRight)
+    if (join.joinType.isInstanceOf[InnerLike] || join.joinType == FullOuter) {
+      if (buildLeft && buildRight) {
+        Some(getBroadcastNestedLoopJoinDesiredBuildSide(join))
+      } else if (buildLeft) {
+        Some(BuildLeft)
+      } else if (buildRight) {
+        Some(BuildRight)
+      } else {
+        None
+      }
     } else {
-      None
+      getBroadcastNestedLoopJoinDesiredBuildSide(join) match {
+        case BuildLeft =>
+          if (buildLeft) Some(BuildLeft) else if (buildRight) Some(BuildRight) else None
+        case BuildRight =>
+          if (buildRight) Some(BuildRight) else if (buildLeft) Some(BuildLeft) else None
+      }
     }
   }
 
@@ -505,7 +517,7 @@ trait JoinSelectionHelper extends Logging {
     // The null-aware hash join only supports BuildRight. Preserve a generic BuildLeft fallback.
     case j @ ExtractSingleColumnNullAwareAntiJoin(_, rightKeys)
         if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight &&
-          canBuildNullAwareAntiJoinHashRelation(rightKeys, j.right) =>
+          canBuildNullAwareAntiJoinHashRelation(rightKeys, j.right, conf) =>
       Some(BuildRight)
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -438,9 +438,10 @@ trait JoinSelectionHelper extends Logging {
       getBroadcastBuildSide(join, hintOnly = true, conf).orElse {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
-    // `JoinSelection` always builds from the right for this shape.
-    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _) =>
-      if (canBroadcastBySize(j.right, conf)) Some(BuildRight) else None
+    // `JoinSelection` always builds from the right for this shape. Its generic fallback is a
+    // broadcast nested loop join that also builds from the right, so prefer the hash join even
+    // when the right side exceeds the automatic broadcast threshold.
+    case ExtractSingleColumnNullAwareAntiJoin(_, _) => Some(BuildRight)
     case _ => None
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -32,8 +32,6 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.IntegralType
-import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.util.Utils
 
 /**
@@ -291,20 +289,6 @@ case object BuildLeft extends BuildSide
 
 trait JoinSelectionHelper extends Logging {
 
-  // Keep this synchronized with BroadcastExchangeExec's non-Long hashed relation limit.
-  private val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
-
-  private def canBuildNullAwareAntiJoinHashRelation(
-      rightKeys: Seq[Expression],
-      right: LogicalPlan,
-      conf: SQLConf): Boolean = {
-    val usesLongHashedRelation =
-      rightKeys.length == 1 && rightKeys.head.dataType.isInstanceOf[IntegralType]
-    usesLongHashedRelation || right.stats.rowCount.fold(canBroadcastBySize(right, conf)) {
-      _ < maxBroadcastHashRows
-    }
-  }
-
   def getBroadcastBuildSide(
       join: Join,
       hintOnly: Boolean,
@@ -515,9 +499,9 @@ trait JoinSelectionHelper extends Logging {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
     // The null-aware hash join only supports BuildRight. Preserve a generic BuildLeft fallback.
-    case j @ ExtractSingleColumnNullAwareAntiJoin(_, rightKeys)
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
         if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight &&
-          canBuildNullAwareAntiJoinHashRelation(rightKeys, j.right, conf) =>
+          canBroadcastBySize(j.right, conf) =>
       Some(BuildRight)
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.util.Utils
 
 /**
@@ -289,6 +291,16 @@ case object BuildLeft extends BuildSide
 
 trait JoinSelectionHelper extends Logging {
 
+  // Keep this synchronized with BroadcastExchangeExec's non-Long hashed relation limit.
+  private val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
+
+  private def canBuildNullAwareAntiJoinHashRelation(
+      rightKeys: Seq[Expression],
+      right: LogicalPlan): Boolean = {
+    val usesLongHashedRelation = rightKeys.length == 1 && rightKeys.head.dataType == LongType
+    usesLongHashedRelation || right.stats.rowCount.forall(_ < maxBroadcastHashRows)
+  }
+
   def getBroadcastBuildSide(
       join: Join,
       hintOnly: Boolean,
@@ -490,8 +502,9 @@ trait JoinSelectionHelper extends Logging {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
     // The null-aware hash join only supports BuildRight. Preserve a generic BuildLeft fallback.
-    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
-        if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight =>
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, rightKeys)
+        if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight &&
+          canBuildNullAwareAntiJoinHashRelation(rightKeys, j.right) =>
       Some(BuildRight)
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -500,8 +500,8 @@ trait JoinSelectionHelper extends Logging {
       }
     // The null-aware hash join only supports BuildRight. Preserve a generic BuildLeft fallback.
     case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
-        if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight &&
-          canBroadcastBySize(j.right, conf) =>
+        if canBroadcastBySize(j.right, conf) &&
+          getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight =>
       Some(BuildRight)
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.IntegralType
 import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.util.Utils
 
@@ -297,7 +297,8 @@ trait JoinSelectionHelper extends Logging {
   private def canBuildNullAwareAntiJoinHashRelation(
       rightKeys: Seq[Expression],
       right: LogicalPlan): Boolean = {
-    val usesLongHashedRelation = rightKeys.length == 1 && rightKeys.head.dataType == LongType
+    val usesLongHashedRelation =
+      rightKeys.length == 1 && rightKeys.head.dataType.isInstanceOf[IntegralType]
     usesLongHashedRelation || right.stats.rowCount.forall(_ < maxBroadcastHashRows)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -353,6 +353,57 @@ trait JoinSelectionHelper extends Logging {
     }
   }
 
+  def getBroadcastNestedLoopJoinDesiredBuildSide(join: Join): BuildSide = {
+    if (join.joinType.isInstanceOf[InnerLike] || join.joinType == FullOuter) {
+      getSmallerSide(join.left, join.right)
+    } else {
+      // For perf reasons, BroadcastNestedLoopJoinExec prefers to broadcast the left side for a
+      // right join and the right side for a left join. If one side is much smaller, revisiting
+      // that preference may be worthwhile.
+      if (canBuildBroadcastLeft(join.joinType)) BuildLeft else BuildRight
+    }
+  }
+
+  def getBroadcastNestedLoopJoinBuildSide(
+      join: Join,
+      hintOnly: Boolean,
+      conf: SQLConf): Option[BuildSide] = {
+    val buildLeft = if (hintOnly) {
+      hintToBroadcastLeft(join.hint)
+    } else {
+      canBroadcastBySize(join.left, conf) &&
+        !hintToNotBroadcastAndReplicateLeft(join.hint)
+    }
+    val buildRight = if (hintOnly) {
+      hintToBroadcastRight(join.hint)
+    } else {
+      canBroadcastBySize(join.right, conf) &&
+        !hintToNotBroadcastAndReplicateRight(join.hint)
+    }
+
+    if (buildLeft && buildRight) {
+      Some(getBroadcastNestedLoopJoinDesiredBuildSide(join))
+    } else if (buildLeft) {
+      Some(BuildLeft)
+    } else if (buildRight) {
+      Some(BuildRight)
+    } else {
+      None
+    }
+  }
+
+  def getBroadcastNestedLoopJoinBuildSide(join: Join, conf: SQLConf): BuildSide = {
+    val hintedBuildSide = if (join.hint.isEmpty) {
+      None
+    } else {
+      getBroadcastNestedLoopJoinBuildSide(join, hintOnly = true, conf)
+    }
+    hintedBuildSide
+      .orElse(getBroadcastNestedLoopJoinBuildSide(join, hintOnly = false, conf))
+      .orElse(getBroadcastNestedLoopJoinBuildSide(join.hint, join.joinType))
+      .getOrElse(getBroadcastNestedLoopJoinDesiredBuildSide(join))
+  }
+
   def getSmallerSide(left: LogicalPlan, right: LogicalPlan): BuildSide = {
     if (right.stats.sizeInBytes <= left.stats.sizeInBytes) BuildRight else BuildLeft
   }
@@ -438,10 +489,10 @@ trait JoinSelectionHelper extends Logging {
       getBroadcastBuildSide(join, hintOnly = true, conf).orElse {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
-    // `JoinSelection` always builds from the right for this shape. Its generic fallback is a
-    // broadcast nested loop join that also builds from the right, so prefer the hash join even
-    // when the right side exceeds the automatic broadcast threshold.
-    case ExtractSingleColumnNullAwareAntiJoin(_, _) => Some(BuildRight)
+    // The null-aware hash join only supports BuildRight. Preserve a generic BuildLeft fallback.
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
+        if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight =>
+      Some(BuildRight)
     case _ => None
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -404,12 +404,11 @@ object ExtractSingleColumnNullAwareAntiJoin extends JoinSelectionHelper with Pre
    * But if it's a single column case O(M*N) calculation could be optimized into O(M)
    * using hash lookup instead of loop lookup.
    */
-  def unapply(join: Join): Option[ReturnType] = join match {
+  private[sql] def extract(join: Join): Option[ReturnType] = join match {
     case Join(left, right, LeftAnti,
       Some(Or(e @ EqualTo(leftAttr: Expression, rightAttr: Expression),
         IsNull(e2 @ EqualTo(_, _)))), _)
-        if SQLConf.get.optimizeNullAwareAntiJoin &&
-          e.semanticEquals(e2) =>
+        if e.semanticEquals(e2) =>
       if (canEvaluate(leftAttr, left) && canEvaluate(rightAttr, right)) {
         Some(Seq(leftAttr), Seq(rightAttr))
       } else if (canEvaluate(leftAttr, right) && canEvaluate(rightAttr, left)) {
@@ -418,6 +417,10 @@ object ExtractSingleColumnNullAwareAntiJoin extends JoinSelectionHelper with Pre
         None
       }
     case _ => None
+  }
+
+  def unapply(join: Join): Option[ReturnType] = {
+    if (SQLConf.get.optimizeNullAwareAntiJoin) extract(join) else None
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, EqualTo, IsNull, Or}
-import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest}
+import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint, LeafNode, NO_BROADCAST_HASH, SHUFFLE_HASH, Statistics}
 import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.internal.SQLConf
@@ -164,10 +164,15 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     val leftStatsAccessed = new AtomicBoolean(false)
     val uncachedLeft = TrackingStatsTestPlan(Seq($"uncachedLeft".int), leftStatsAccessed)
     val leftAntiJoin = Join(uncachedLeft, right, LeftAnti, None, JoinHint.NONE)
+    val rightStatsAccessed = new AtomicBoolean(false)
+    val uncachedRight = TrackingStatsTestPlan(Seq($"uncachedRight".int), rightStatsAccessed)
+    val rightOuterJoin = Join(right, uncachedRight, RightOuter, None, JoinHint.NONE)
 
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(getBroadcastNestedLoopJoinBuildSide(leftAntiJoin, SQLConf.get) === BuildRight)
       assert(!leftStatsAccessed.get())
+      assert(getBroadcastNestedLoopJoinBuildSide(rightOuterJoin, SQLConf.get) === BuildLeft)
+      assert(!rightStatsAccessed.get())
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -156,7 +156,7 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     }
   }
 
-  test("canPlanAsBroadcastHashJoin should respect size for single-column null-aware anti join") {
+  test("canPlanAsBroadcastHashJoin should detect single-column null-aware anti join") {
     val leftKey = left.output.head
     val rightKey = right.output.head
     val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
@@ -167,7 +167,7 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
-      assert(!canPlanAsBroadcastHashJoin(nullAwareAntiJoin.copy(right = largeRight), SQLConf.get))
+      assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin.copy(right = largeRight), SQLConf.get))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -25,15 +25,8 @@ import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint, LeafNode, NO_BROADCAST_HASH, SHUFFLE_HASH, Statistics}
 import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.unsafe.map.BytesToBytesMap
 
 class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
-
-  private case class UnknownRowCountTestPlan(
-      override val output: Seq[Attribute],
-      sizeInBytes: BigInt = 1000) extends LeafNode {
-    override def computeStats(): Statistics = Statistics(sizeInBytes = sizeInBytes)
-  }
 
   private case class TrackingStatsTestPlan(
       override val output: Seq[Attribute],
@@ -185,7 +178,7 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     }
   }
 
-  test("canPlanAsBroadcastHashJoin should respect NAAJ nested-loop build side") {
+  test("canPlanAsBroadcastHashJoin should respect NAAJ size and nested-loop build side") {
     val leftKey = left.output.head
     val rightKey = right.output.head
     val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
@@ -197,68 +190,12 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
-      assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin.copy(right = largeRight), SQLConf.get))
+      assert(!canPlanAsBroadcastHashJoin(
+        nullAwareAntiJoin.copy(right = largeRight.copy(rowCount = 1)), SQLConf.get))
       assert(!canPlanAsBroadcastHashJoin(
         nullAwareAntiJoin.copy(left = smallLeft, right = largeRight), SQLConf.get))
       assert(!canPlanAsBroadcastHashJoin(
         nullAwareAntiJoin.copy(hint = JoinHint(hintBroadcast, None)), SQLConf.get))
-    }
-  }
-
-  test("canPlanAsBroadcastHashJoin should respect the NAAJ hashed relation row limit") {
-    val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
-    val leftKey = left.output.head
-    val rightKey = right.output.head
-    val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
-    val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
-    val rightAtLimit = right.copy(rowCount = maxBroadcastHashRows)
-
-    val booleanLeft = StatsTestPlan(
-      Seq($"booleanLeft".boolean), 20000000, AttributeMap(Seq()), Some(20000000))
-    val booleanRight = StatsTestPlan(
-      Seq($"booleanRight".boolean), maxBroadcastHashRows - 1, AttributeMap(Seq()), Some(1000))
-    val booleanCondition = Or(
-      EqualTo(booleanLeft.output.head, booleanRight.output.head),
-      IsNull(EqualTo(booleanLeft.output.head, booleanRight.output.head)))
-    val booleanKeyJoin = Join(
-      booleanLeft, booleanRight, LeftAnti, Some(booleanCondition), JoinHint.NONE)
-
-    val unknownRight = UnknownRowCountTestPlan(Seq($"unknownRight".boolean))
-    val unknownCondition = Or(
-      EqualTo(booleanLeft.output.head, unknownRight.output.head),
-      IsNull(EqualTo(booleanLeft.output.head, unknownRight.output.head)))
-    val unknownRowCountJoin = Join(
-      booleanLeft, unknownRight, LeftAnti, Some(unknownCondition), JoinHint.NONE)
-    val largeUnknownRight = UnknownRowCountTestPlan(
-      Seq($"largeUnknownRight".boolean), sizeInBytes = 20000000)
-    val largeUnknownCondition = Or(
-      EqualTo(booleanLeft.output.head, largeUnknownRight.output.head),
-      IsNull(EqualTo(booleanLeft.output.head, largeUnknownRight.output.head)))
-    val largeUnknownRowCountJoin = Join(
-      booleanLeft, largeUnknownRight, LeftAnti, Some(largeUnknownCondition), JoinHint.NONE)
-
-    val longLeft = StatsTestPlan(
-      Seq($"longLeft".long), 20000000, AttributeMap(Seq()), Some(20000000))
-    val longRight = StatsTestPlan(
-      Seq($"longRight".long), maxBroadcastHashRows, AttributeMap(Seq()), Some(1000))
-    val longCondition = Or(
-      EqualTo(longLeft.output.head, longRight.output.head),
-      IsNull(EqualTo(longLeft.output.head, longRight.output.head)))
-    val longKeyJoin = Join(longLeft, longRight, LeftAnti, Some(longCondition), JoinHint.NONE)
-
-    withSQLConf(
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
-      assert(canPlanAsBroadcastHashJoin(booleanKeyJoin, SQLConf.get))
-      val booleanKeyJoinAtLimit = booleanKeyJoin.copy(
-        right = booleanRight.copy(rowCount = maxBroadcastHashRows))
-      assert(!canPlanAsBroadcastHashJoin(
-        booleanKeyJoinAtLimit, SQLConf.get))
-      assert(canPlanAsBroadcastHashJoin(
-        nullAwareAntiJoin.copy(right = rightAtLimit), SQLConf.get))
-      assert(canPlanAsBroadcastHashJoin(unknownRowCountJoin, SQLConf.get))
-      assert(!canPlanAsBroadcastHashJoin(largeUnknownRowCountJoin, SQLConf.get))
-      assert(canPlanAsBroadcastHashJoin(longKeyJoin, SQLConf.get))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -197,6 +197,12 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       assert(!canPlanAsBroadcastHashJoin(
         nullAwareAntiJoin.copy(hint = JoinHint(hintBroadcast, None)), SQLConf.get))
     }
+
+    withSQLConf(
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "false",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      assert(!canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
+    }
   }
 
   test("canPlanAsBroadcastHashJoin checks the NAAJ right-size short circuit") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -200,12 +200,12 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     val booleanKeyJoin = Join(
       booleanLeft, booleanRight, LeftAnti, Some(booleanCondition), JoinHint.NONE)
 
-    val unknownRight = UnknownRowCountTestPlan(Seq($"unknownRight".int))
+    val unknownRight = UnknownRowCountTestPlan(Seq($"unknownRight".boolean))
     val unknownCondition = Or(
-      EqualTo(leftKey, unknownRight.output.head),
-      IsNull(EqualTo(leftKey, unknownRight.output.head)))
+      EqualTo(booleanLeft.output.head, unknownRight.output.head),
+      IsNull(EqualTo(booleanLeft.output.head, unknownRight.output.head)))
     val unknownRowCountJoin = Join(
-      left, unknownRight, LeftAnti, Some(unknownCondition), JoinHint.NONE)
+      booleanLeft, unknownRight, LeftAnti, Some(unknownCondition), JoinHint.NONE)
 
     val longLeft = StatsTestPlan(
       Seq($"longLeft".long), 20000000, AttributeMap(Seq()), Some(20000000))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -156,11 +156,12 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     }
   }
 
-  test("canPlanAsBroadcastHashJoin should detect single-column null-aware anti join") {
+  test("canPlanAsBroadcastHashJoin should respect NAAJ nested-loop build side") {
     val leftKey = left.output.head
     val rightKey = right.output.head
     val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
     val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
+    val smallLeft = left.copy(rowCount = 1000, size = Some(1000))
     val largeRight = right.copy(rowCount = 20000000, size = Some(20000000))
 
     withSQLConf(
@@ -168,6 +169,10 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
       assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin.copy(right = largeRight), SQLConf.get))
+      assert(!canPlanAsBroadcastHashJoin(
+        nullAwareAntiJoin.copy(left = smallLeft, right = largeRight), SQLConf.get))
+      assert(!canPlanAsBroadcastHashJoin(
+        nullAwareAntiJoin.copy(hint = JoinHint(hintBroadcast, None)), SQLConf.get))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -188,8 +188,17 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     val rightKey = right.output.head
     val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
     val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
-    val rightBelowLimit = right.copy(rowCount = maxBroadcastHashRows - 1)
     val rightAtLimit = right.copy(rowCount = maxBroadcastHashRows)
+
+    val booleanLeft = StatsTestPlan(
+      Seq($"booleanLeft".boolean), 20000000, AttributeMap(Seq()), Some(20000000))
+    val booleanRight = StatsTestPlan(
+      Seq($"booleanRight".boolean), maxBroadcastHashRows - 1, AttributeMap(Seq()), Some(1000))
+    val booleanCondition = Or(
+      EqualTo(booleanLeft.output.head, booleanRight.output.head),
+      IsNull(EqualTo(booleanLeft.output.head, booleanRight.output.head)))
+    val booleanKeyJoin = Join(
+      booleanLeft, booleanRight, LeftAnti, Some(booleanCondition), JoinHint.NONE)
 
     val unknownRight = UnknownRowCountTestPlan(Seq($"unknownRight".int))
     val unknownCondition = Or(
@@ -210,9 +219,12 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     withSQLConf(
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
-      assert(canPlanAsBroadcastHashJoin(
-        nullAwareAntiJoin.copy(right = rightBelowLimit), SQLConf.get))
+      assert(canPlanAsBroadcastHashJoin(booleanKeyJoin, SQLConf.get))
+      val booleanKeyJoinAtLimit = booleanKeyJoin.copy(
+        right = booleanRight.copy(rowCount = maxBroadcastHashRows))
       assert(!canPlanAsBroadcastHashJoin(
+        booleanKeyJoinAtLimit, SQLConf.get))
+      assert(canPlanAsBroadcastHashJoin(
         nullAwareAntiJoin.copy(right = rightAtLimit), SQLConf.get))
       assert(canPlanAsBroadcastHashJoin(unknownRowCountJoin, SQLConf.get))
       assert(canPlanAsBroadcastHashJoin(longKeyJoin, SQLConf.get))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -199,6 +199,24 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     }
   }
 
+  test("canPlanAsBroadcastHashJoin checks the NAAJ right-size short circuit") {
+    val leftStatsAccessed = new AtomicBoolean(false)
+    val uncachedLeft = TrackingStatsTestPlan(Seq($"uncachedLeft".int), leftStatsAccessed)
+    val largeRight = right.copy(rowCount = 20000000, size = Some(20000000))
+    val leftKey = uncachedLeft.output.head
+    val rightKey = largeRight.output.head
+    val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
+    val nullAwareAntiJoin = Join(
+      uncachedLeft, largeRight, LeftAnti, Some(condition), JoinHint.NONE)
+
+    withSQLConf(
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      assert(!canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
+      assert(!leftStatsAccessed.get())
+    }
+  }
+
   test("getBroadcastHashJoinBuildSide returns the hinted side") {
     val equiJoin = join.copy(condition = Some(EqualTo(left.output.head, right.output.head)))
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -18,13 +18,19 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{AttributeMap, EqualTo, IsNull, Or}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, EqualTo, IsNull, Or}
 import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint, NO_BROADCAST_HASH, SHUFFLE_HASH}
+import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint, LeafNode, NO_BROADCAST_HASH, SHUFFLE_HASH, Statistics}
 import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.unsafe.map.BytesToBytesMap
 
 class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
+
+  private case class UnknownRowCountTestPlan(override val output: Seq[Attribute])
+      extends LeafNode {
+    override def computeStats(): Statistics = Statistics(sizeInBytes = 1000)
+  }
 
   private val left = StatsTestPlan(
     outputList = Seq($"a".int, $"b".int, $"c".int),
@@ -173,6 +179,43 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
         nullAwareAntiJoin.copy(left = smallLeft, right = largeRight), SQLConf.get))
       assert(!canPlanAsBroadcastHashJoin(
         nullAwareAntiJoin.copy(hint = JoinHint(hintBroadcast, None)), SQLConf.get))
+    }
+  }
+
+  test("canPlanAsBroadcastHashJoin should respect the NAAJ hashed relation row limit") {
+    val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
+    val leftKey = left.output.head
+    val rightKey = right.output.head
+    val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
+    val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
+    val rightBelowLimit = right.copy(rowCount = maxBroadcastHashRows - 1)
+    val rightAtLimit = right.copy(rowCount = maxBroadcastHashRows)
+
+    val unknownRight = UnknownRowCountTestPlan(Seq($"unknownRight".int))
+    val unknownCondition = Or(
+      EqualTo(leftKey, unknownRight.output.head),
+      IsNull(EqualTo(leftKey, unknownRight.output.head)))
+    val unknownRowCountJoin = Join(
+      left, unknownRight, LeftAnti, Some(unknownCondition), JoinHint.NONE)
+
+    val longLeft = StatsTestPlan(
+      Seq($"longLeft".long), 20000000, AttributeMap(Seq()), Some(20000000))
+    val longRight = StatsTestPlan(
+      Seq($"longRight".long), maxBroadcastHashRows, AttributeMap(Seq()), Some(1000))
+    val longCondition = Or(
+      EqualTo(longLeft.output.head, longRight.output.head),
+      IsNull(EqualTo(longLeft.output.head, longRight.output.head)))
+    val longKeyJoin = Join(longLeft, longRight, LeftAnti, Some(longCondition), JoinHint.NONE)
+
+    withSQLConf(
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      assert(canPlanAsBroadcastHashJoin(
+        nullAwareAntiJoin.copy(right = rightBelowLimit), SQLConf.get))
+      assert(!canPlanAsBroadcastHashJoin(
+        nullAwareAntiJoin.copy(right = rightAtLimit), SQLConf.get))
+      assert(canPlanAsBroadcastHashJoin(unknownRowCountJoin, SQLConf.get))
+      assert(canPlanAsBroadcastHashJoin(longKeyJoin, SQLConf.get))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, EqualTo, IsNull, Or}
 import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest}
@@ -27,9 +29,19 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
 
 class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
 
-  private case class UnknownRowCountTestPlan(override val output: Seq[Attribute])
-      extends LeafNode {
-    override def computeStats(): Statistics = Statistics(sizeInBytes = 1000)
+  private case class UnknownRowCountTestPlan(
+      override val output: Seq[Attribute],
+      sizeInBytes: BigInt = 1000) extends LeafNode {
+    override def computeStats(): Statistics = Statistics(sizeInBytes = sizeInBytes)
+  }
+
+  private case class TrackingStatsTestPlan(
+      override val output: Seq[Attribute],
+      statsAccessed: AtomicBoolean) extends LeafNode {
+    override def computeStats(): Statistics = {
+      statsAccessed.set(true)
+      Statistics(sizeInBytes = 20000000)
+    }
   }
 
   private val left = StatsTestPlan(
@@ -155,6 +167,17 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     assert(getSmallerSide(left, right) === BuildRight)
   }
 
+  test("getBroadcastNestedLoopJoinBuildSide checks the fixed desired side first") {
+    val leftStatsAccessed = new AtomicBoolean(false)
+    val uncachedLeft = TrackingStatsTestPlan(Seq($"uncachedLeft".int), leftStatsAccessed)
+    val leftAntiJoin = Join(uncachedLeft, right, LeftAnti, None, JoinHint.NONE)
+
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      assert(getBroadcastNestedLoopJoinBuildSide(leftAntiJoin, SQLConf.get) === BuildRight)
+      assert(!leftStatsAccessed.get())
+    }
+  }
+
   test("canBroadcastBySize should return true if the plan size is less than 10MB") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(canBroadcastBySize(left, SQLConf.get) === false)
@@ -206,6 +229,13 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       IsNull(EqualTo(booleanLeft.output.head, unknownRight.output.head)))
     val unknownRowCountJoin = Join(
       booleanLeft, unknownRight, LeftAnti, Some(unknownCondition), JoinHint.NONE)
+    val largeUnknownRight = UnknownRowCountTestPlan(
+      Seq($"largeUnknownRight".boolean), sizeInBytes = 20000000)
+    val largeUnknownCondition = Or(
+      EqualTo(booleanLeft.output.head, largeUnknownRight.output.head),
+      IsNull(EqualTo(booleanLeft.output.head, largeUnknownRight.output.head)))
+    val largeUnknownRowCountJoin = Join(
+      booleanLeft, largeUnknownRight, LeftAnti, Some(largeUnknownCondition), JoinHint.NONE)
 
     val longLeft = StatsTestPlan(
       Seq($"longLeft".long), 20000000, AttributeMap(Seq()), Some(20000000))
@@ -227,6 +257,7 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       assert(canPlanAsBroadcastHashJoin(
         nullAwareAntiJoin.copy(right = rightAtLimit), SQLConf.get))
       assert(canPlanAsBroadcastHashJoin(unknownRowCountJoin, SQLConf.get))
+      assert(!canPlanAsBroadcastHashJoin(largeUnknownRowCountJoin, SQLConf.get))
       assert(canPlanAsBroadcastHashJoin(longKeyJoin, SQLConf.get))
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -110,17 +110,17 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("Aggregate: NAAJ no pushdown when the rewritten join would build left") {
+  test("Aggregate: NAAJ no pushdown when the original join would build left") {
     val leftKey = $"leftKey".int
     val leftKeyStats = ColumnStat(
-      distinctCount = Some(1000),
+      distinctCount = Some(1),
       min = Some(0),
-      max = Some(999),
+      max = Some(0),
       nullCount = Some(0),
       avgLen = Some(4),
       maxLen = Some(4))
     val child = StatsTestPlan(
-      Seq(leftKey), 1000, AttributeMap(Seq(leftKey -> leftKeyStats)), Some(1))
+      Seq(leftKey), 1000, AttributeMap(Seq(leftKey -> leftKeyStats)), Some(1000))
     val aggregate = Aggregate(Seq(leftKey), Seq(leftKey), child)
     val right = StatsTestPlan(
       Seq($"rightKey".int), 1000, AttributeMap(Seq()), Some(1000))
@@ -134,11 +134,19 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
       SQLConf.CBO_ENABLED.key -> "true",
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
-      assert(aggregate.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
-      assert(child.stats.sizeInBytes <= SQLConf.get.autoBroadcastJoinThreshold)
+      assert(aggregate.stats.sizeInBytes <= SQLConf.get.autoBroadcastJoinThreshold)
+      assert(child.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
       assert(right.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
       comparePlans(Optimize.execute(originalQuery), originalQuery)
     }
+  }
+
+  test("Aggregate: LeftSemi join no pushdown - empty join condition") {
+    val originalQuery = testRelation
+      .groupBy($"b")($"b", sum($"c"))
+      .join(testRelation1, joinType = LeftSemi, condition = None)
+
+    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
   }
 
   test("Aggregate: LeftSemi join no pushdown - non-deterministic aggr expressions") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -524,7 +524,7 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
   }
 
   Seq(LeftSemi, LeftAnti).foreach { jt =>
-    test(s"SPARK-34081: ordinary $jt pushdown does not require broadcast eligibility") {
+    test(s"SPARK-34081: ordinary $jt only pushes down when broadcast-eligible") {
       Seq(-1, 100000).foreach { threshold =>
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
           val originalQuery = testRelation
@@ -532,10 +532,14 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
             .join(testRelation1, joinType = jt, condition = Some($"b" <=> $"d"))
 
           val optimized = Optimize.execute(originalQuery.analyze)
-          val correctAnswer = testRelation
-            .join(testRelation1, joinType = jt, condition = Some($"b" <=> $"d"))
-            .groupBy($"b")($"b")
-            .analyze
+          val correctAnswer = if (threshold > 0) {
+            testRelation
+              .join(testRelation1, joinType = jt, condition = Some($"b" <=> $"d"))
+              .groupBy($"b")($"b")
+              .analyze
+          } else {
+            originalQuery.analyze
+          }
 
           comparePlans(optimized, correctAnswer)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -130,23 +130,6 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     }
   }
 
-  test("Aggregate: ordinary semi and anti pushdown does not require broadcast eligibility") {
-    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      Seq(LeftSemi, LeftAnti).foreach { joinType =>
-        val originalQuery = testRelation
-          .groupBy($"b")($"b", sum($"c"))
-          .join(testRelation1, joinType = joinType, condition = Some($"b" === $"d"))
-        val optimized = Optimize.execute(originalQuery.analyze)
-        val correctAnswer = testRelation
-          .join(testRelation1, joinType = joinType, condition = Some($"b" === $"d"))
-          .groupBy($"b")($"b", sum($"c"))
-          .analyze
-
-        comparePlans(optimized, correctAnswer)
-      }
-    }
-  }
-
   test("Aggregate: NAAJ no pushdown when the original join would build left") {
     val leftKey = $"leftKey".int
     val leftKeyStats = ColumnStat(
@@ -541,7 +524,7 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
   }
 
   Seq(LeftSemi, LeftAnti).foreach { jt =>
-    test(s"SPARK-34081: $jt only push down if join can be planned as broadcast join") {
+    test(s"SPARK-34081: ordinary $jt pushdown does not require broadcast eligibility") {
       Seq(-1, 100000).foreach { threshold =>
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
           val originalQuery = testRelation
@@ -549,14 +532,10 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
             .join(testRelation1, joinType = jt, condition = Some($"b" <=> $"d"))
 
           val optimized = Optimize.execute(originalQuery.analyze)
-          val correctAnswer = if (threshold > 0) {
-            testRelation
-              .join(testRelation1, joinType = jt, condition = Some($"b" <=> $"d"))
-              .groupBy($"b")($"b")
-              .analyze
-          } else {
-            originalQuery.analyze
-          }
+          val correctAnswer = testRelation
+            .join(testRelation1, joinType = jt, condition = Some($"b" <=> $"d"))
+            .groupBy($"b")($"b")
+            .analyze
 
           comparePlans(optimized, correctAnswer)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -130,6 +130,23 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     }
   }
 
+  test("Aggregate: ordinary semi and anti pushdown does not require broadcast eligibility") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      Seq(LeftSemi, LeftAnti).foreach { joinType =>
+        val originalQuery = testRelation
+          .groupBy($"b")($"b", sum($"c"))
+          .join(testRelation1, joinType = joinType, condition = Some($"b" === $"d"))
+        val optimized = Optimize.execute(originalQuery.analyze)
+        val correctAnswer = testRelation
+          .join(testRelation1, joinType = joinType, condition = Some($"b" === $"d"))
+          .groupBy($"b")($"b", sum($"c"))
+          .analyze
+
+        comparePlans(optimized, correctAnswer)
+      }
+    }
+  }
+
   test("Aggregate: NAAJ no pushdown when the original join would build left") {
     val leftKey = $"leftKey".int
     val leftKeyStats = ColumnStat(
@@ -161,12 +178,16 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     }
   }
 
-  test("Aggregate: LeftSemi join no pushdown - empty join condition") {
+  test("Aggregate: ordinary LeftSemi join pushdown - empty join condition") {
     val originalQuery = testRelation
       .groupBy($"b")($"b", sum($"c"))
       .join(testRelation1, joinType = LeftSemi, condition = None)
+    val correctAnswer = testRelation
+      .join(testRelation1, joinType = LeftSemi, condition = None)
+      .groupBy($"b")($"b", sum($"c"))
+      .analyze
 
-    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
   }
 
   test("Aggregate: LeftSemi join no pushdown - non-deterministic aggr expressions") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -165,10 +165,7 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     val originalQuery = testRelation
       .groupBy($"b")($"b", sum($"c"))
       .join(testRelation1, joinType = LeftSemi, condition = None)
-    val correctAnswer = testRelation
-      .join(testRelation1, joinType = LeftSemi, condition = None)
-      .groupBy($"b")($"b", sum($"c"))
-      .analyze
+    val correctAnswer = originalQuery.analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -161,7 +161,7 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     }
   }
 
-  test("Aggregate: ordinary LeftSemi join pushdown - empty join condition") {
+  test("Aggregate: ordinary LeftSemi join no pushdown - empty join condition") {
     val originalQuery = testRelation
       .groupBy($"b")($"b", sum($"c"))
       .join(testRelation1, joinType = LeftSemi, condition = None)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -110,6 +110,26 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
+  test("Aggregate: NAAJ pushdown when original and rewritten joins can build right") {
+    val condition = Or($"b" === $"d", IsNull($"b" === $"d"))
+    val originalQuery = testRelation
+      .groupBy($"b")($"b", sum($"c"))
+      .join(testRelation1, joinType = LeftAnti, condition = Some(condition))
+    val correctAnswer = testRelation
+      .join(testRelation1, joinType = LeftAnti, condition = Some(condition))
+      .groupBy($"b")($"b", sum($"c"))
+
+    withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true") {
+      val analyzedOriginal = originalQuery.analyze
+      val analyzedCorrectAnswer = correctAnswer.analyze
+      val originalJoin = analyzedOriginal.asInstanceOf[Join]
+      val pushedJoin = analyzedCorrectAnswer.asInstanceOf[Aggregate].child.asInstanceOf[Join]
+      assert(PushDownLeftSemiAntiJoin.canPlanAsBroadcastHashJoin(originalJoin, SQLConf.get))
+      assert(PushDownLeftSemiAntiJoin.canPlanAsBroadcastHashJoin(pushedJoin, SQLConf.get))
+      comparePlans(Optimize.execute(analyzedOriginal), analyzedCorrectAnswer)
+    }
+  }
+
   test("Aggregate: NAAJ no pushdown when the original join would build left") {
     val leftKey = $"leftKey".int
     val leftKeyStats = ColumnStat(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.IntegerType
 
@@ -107,6 +108,37 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
       .analyze
 
     comparePlans(optimized, correctAnswer)
+  }
+
+  test("Aggregate: NAAJ no pushdown when the rewritten join would build left") {
+    val leftKey = $"leftKey".int
+    val leftKeyStats = ColumnStat(
+      distinctCount = Some(1000),
+      min = Some(0),
+      max = Some(999),
+      nullCount = Some(0),
+      avgLen = Some(4),
+      maxLen = Some(4))
+    val child = StatsTestPlan(
+      Seq(leftKey), 1000, AttributeMap(Seq(leftKey -> leftKeyStats)), Some(1))
+    val aggregate = Aggregate(Seq(leftKey), Seq(leftKey), child)
+    val right = StatsTestPlan(
+      Seq($"rightKey".int), 1000, AttributeMap(Seq()), Some(1000))
+    val condition = Or(
+      EqualTo(aggregate.output.head, right.output.head),
+      IsNull(EqualTo(aggregate.output.head, right.output.head)))
+    val originalQuery = Join(
+      aggregate, right, LeftAnti, Some(condition), JoinHint.NONE)
+
+    withSQLConf(
+      SQLConf.CBO_ENABLED.key -> "true",
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      assert(aggregate.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
+      assert(child.stats.sizeInBytes <= SQLConf.get.autoBroadcastJoinThreshold)
+      assert(right.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
+      comparePlans(Optimize.execute(originalQuery), originalQuery)
+    }
   }
 
   test("Aggregate: LeftSemi join no pushdown - non-deterministic aggr expressions") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -341,7 +341,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         }
 
       case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
-          if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight =>
+          if canPlanAsBroadcastHashJoin(j, conf) =>
         Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
           None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NamedRelation}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.optimizer.{BuildRight, BuildSide, JoinSelectionHelper, NormalizeFloatingNumbers}
+import org.apache.spark.sql.catalyst.optimizer.{BuildRight, BuildSide, JoinSelectionHelper, NormalizeFloatingNumbers, NullAwareAntiJoinPlanning}
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -340,10 +340,18 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             .getOrElse(createJoinWithoutHint())
         }
 
-      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
-          if canPlanAsBroadcastHashJoin(j, conf) =>
-        Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
-          None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
+      case j: logical.Join if ExtractSingleColumnNullAwareAntiJoin.extract(j).isDefined =>
+        val (leftKeys, rightKeys) = ExtractSingleColumnNullAwareAntiJoin.extract(j).get
+        NullAwareAntiJoinPlanning.decide(j, conf) match {
+          case NullAwareAntiJoinPlanning.BroadcastHash =>
+            Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
+              None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
+          case NullAwareAntiJoinPlanning.BroadcastNestedLoop =>
+            checkHintNonEquiJoin(j.hint)
+            val buildSide = getBroadcastNestedLoopJoinBuildSide(j, conf)
+            Seq(joins.BroadcastNestedLoopJoinExec(
+              planLater(j.left), planLater(j.right), buildSide, LeftAnti, j.condition))
+        }
 
       // If it is not an equi-join, we first look at the join hints w.r.t. the following order:
       //   1. broadcast hint: pick broadcast nested loop join. If both sides have the broadcast

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NamedRelation}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper, NormalizeFloatingNumbers}
+import org.apache.spark.sql.catalyst.optimizer.{BuildRight, BuildSide, JoinSelectionHelper, NormalizeFloatingNumbers}
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -340,7 +340,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             .getOrElse(createJoinWithoutHint())
         }
 
-      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys) =>
+      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
+          if getBroadcastNestedLoopJoinBuildSide(j, conf) == BuildRight =>
         Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
           None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 
@@ -360,42 +361,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       //   3. Pick broadcast nested loop join as the final solution. It may OOM but we don't have
       //      other choice. It broadcasts the smaller side for inner and full joins, broadcasts the
       //      left side for right join, and broadcasts right side for left join.
-      case logical.Join(left, right, joinType, condition, hint) =>
+      case j @ logical.Join(left, right, joinType, condition, hint) =>
         checkHintNonEquiJoin(hint)
-        val desiredBuildSide = if (joinType.isInstanceOf[InnerLike] || joinType == FullOuter) {
-          getSmallerSide(left, right)
-        } else {
-          // For perf reasons, `BroadcastNestedLoopJoinExec` prefers to broadcast left side if
-          // it's a right join, and broadcast right side if it's a left join.
-          // TODO: revisit it. If left side is much smaller than the right side, it may be better
-          // to broadcast the left side even if it's a left join.
-          if (canBuildBroadcastLeft(joinType)) BuildLeft else BuildRight
-        }
+        val desiredBuildSide = getBroadcastNestedLoopJoinDesiredBuildSide(j)
 
         def createBroadcastNLJoin(onlyLookingAtHint: Boolean) = {
-          val buildLeft = if (onlyLookingAtHint) {
-            hintToBroadcastLeft(hint)
-          } else {
-            canBroadcastBySize(left, conf) && !hintToNotBroadcastAndReplicateLeft(hint)
-          }
-
-          val buildRight = if (onlyLookingAtHint) {
-            hintToBroadcastRight(hint)
-          } else {
-            canBroadcastBySize(right, conf) && !hintToNotBroadcastAndReplicateRight(hint)
-          }
-
-          val maybeBuildSide = if (buildLeft && buildRight) {
-            Some(desiredBuildSide)
-          } else if (buildLeft) {
-            Some(BuildLeft)
-          } else if (buildRight) {
-            Some(BuildRight)
-          } else {
-            None
-          }
-
-          maybeBuildSide.map { buildSide =>
+          getBroadcastNestedLoopJoinBuildSide(j, onlyLookingAtHint, conf).map { buildSide =>
             Seq(joins.BroadcastNestedLoopJoinExec(
               planLater(left), planLater(right), buildSide, joinType, condition))
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -340,8 +340,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             .getOrElse(createJoinWithoutHint())
         }
 
-      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
-          if canBroadcastBySize(j.right, conf) =>
+      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys) =>
         Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
           None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1299,14 +1299,13 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
-  test("SPARK-36082: only use SingleColumn Null Aware Anti Join when right side " +
-      "can broadcast") {
+  test("SPARK-36082: keep SingleColumn Null Aware Anti Join above broadcast threshold") {
     withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
       val joinExec = assertJoin((
         "select * from testData where key not in (select b from testData3)",
-        classOf[BroadcastNestedLoopJoinExec]))
-      assert(!joinExec.isInstanceOf[BroadcastHashJoinExec])
+        classOf[BroadcastHashJoinExec]))
+      assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1333,16 +1333,16 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
-  test("SPARK-36082: keep NAAJ identity broadcast at the hashed relation row limit") {
+  test("SPARK-36082: keep NAAJ identity broadcast at the non-integral hash row limit") {
     val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
 
     withSQLConf(
       SQLConf.CBO_ENABLED.key -> "true",
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      val left = spark.range(1).selectExpr("CAST(id AS INT) AS key")
+      val left = spark.range(1).selectExpr("id = 0 AS key")
       val right = spark.range(maxBroadcastHashRows)
-        .selectExpr("IF(id = 0, CAST(NULL AS INT), CAST(id AS INT)) AS b")
+        .selectExpr("IF(id = 0, CAST(NULL AS BOOLEAN), id % 2 = 0) AS b")
 
       withTempView("naajLeft", "naajRightAtHashLimit") {
         left.createOrReplaceTempView("naajLeft")
@@ -1363,6 +1363,36 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
         assert(joinExec.head.buildSide === BuildRight)
         assert(joinExec.head.requiredChildDistribution(1) ===
           BroadcastDistribution(IdentityBroadcastMode))
+      }
+    }
+  }
+
+  test("SPARK-36082: keep NAAJ hash join for integral keys at the non-integral row limit") {
+    val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
+
+    withSQLConf(
+      SQLConf.CBO_ENABLED.key -> "true",
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
+      val left = spark.range(1).selectExpr("CAST(id AS INT) AS key")
+      val right = spark.range(maxBroadcastHashRows)
+        .selectExpr("IF(id = 0, CAST(NULL AS INT), CAST(id AS INT)) AS b")
+
+      withTempView("naajLeft", "naajIntegralRightAtHashLimit") {
+        left.createOrReplaceTempView("naajLeft")
+        right.createOrReplaceTempView("naajIntegralRightAtHashLimit")
+        val queryExecution = sql(
+          "select * from naajLeft " +
+            "where key not in (select b from naajIntegralRightAtHashLimit)").queryExecution
+        val logicalJoins = queryExecution.optimizedPlan.collect { case join: Join => join }
+        assert(logicalJoins.size === 1)
+        val logicalJoin = logicalJoins.head
+        assert(logicalJoin.right.stats.rowCount.contains(maxBroadcastHashRows))
+        assert(canPlanAsBroadcastHashJoin(logicalJoin, conf))
+
+        val joinExec = queryExecution.sparkPlan.collect { case join: BroadcastHashJoinExec => join }
+        assert(joinExec.size === 1)
+        assert(joinExec.head.isNullAwareAntiJoin)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{Ascending, GenericRow, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, JoinSelectionHelper}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, HintInfo, Join, JoinHint, NO_BROADCAST_AND_REPLICATION}
-import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, IdentityBroadcastMode}
 import org.apache.spark.sql.execution.{BinaryExecNode, FilterExec, ProjectExec, SortExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike}
@@ -39,7 +38,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
-import org.apache.spark.unsafe.map.BytesToBytesMap
 
 @SlowSQLTest
 class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
@@ -1301,13 +1299,23 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
-  test("SPARK-36082: keep NAAJ hash join when the fallback builds right") {
+  test("SPARK-36082: keep in-threshold NAAJ hash join when the fallback builds right") {
     withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       val joinExec = assertJoin((
         "select * from testData where key not in (select b from testData3)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+    }
+  }
+
+  test("SPARK-36082: keep over-threshold NAAJ nested-loop join when fallback builds right") {
+    withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
+      val joinExec = assertJoin((
+        "select * from testData where key not in (select b from testData3)",
+        classOf[BroadcastNestedLoopJoinExec]))
+      assert(joinExec.asInstanceOf[BroadcastNestedLoopJoinExec].buildSide === BuildRight)
     }
   }
 
@@ -1333,66 +1341,26 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
-  test("SPARK-36082: keep NAAJ identity broadcast at the non-integral hash row limit") {
-    val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
-
+  test("SPARK-36082: threshold-disabled NAAJ preserves floating-point equality") {
     withSQLConf(
-      SQLConf.CBO_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      val left = spark.range(1).selectExpr("id = 0 AS key")
-      val right = spark.range(maxBroadcastHashRows)
-        .selectExpr("IF(id = 0, CAST(NULL AS BOOLEAN), id % 2 = 0) AS b")
+      withTempView("naajFloatingLeft", "naajFloatingRight") {
+        Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
+          .createOrReplaceTempView("naajFloatingLeft")
+        Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
+          .createOrReplaceTempView("naajFloatingRight")
 
-      withTempView("naajLeft", "naajRightAtHashLimit") {
-        left.createOrReplaceTempView("naajLeft")
-        right.createOrReplaceTempView("naajRightAtHashLimit")
-        val queryExecution = sql(
-          "select * from naajLeft where key not in (select b from naajRightAtHashLimit)")
-          .queryExecution
-        val logicalJoins = queryExecution.optimizedPlan.collect { case join: Join => join }
-        assert(logicalJoins.size === 1)
-        val logicalJoin = logicalJoins.head
-        assert(logicalJoin.right.stats.rowCount.contains(maxBroadcastHashRows))
-        assert(!canPlanAsBroadcastHashJoin(logicalJoin, conf))
-
-        val joinExec = queryExecution.sparkPlan.collect {
+        val result = sql(
+          "select * from naajFloatingLeft " +
+            "where key not in (select key from naajFloatingRight)")
+        val joinExec = result.queryExecution.sparkPlan.collect {
           case join: BroadcastNestedLoopJoinExec => join
         }
         assert(joinExec.size === 1)
         assert(joinExec.head.buildSide === BuildRight)
-        assert(joinExec.head.requiredChildDistribution(1) ===
-          BroadcastDistribution(IdentityBroadcastMode))
-      }
-    }
-  }
-
-  test("SPARK-36082: keep NAAJ hash join for integral keys at the non-integral row limit") {
-    val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
-
-    withSQLConf(
-      SQLConf.CBO_ENABLED.key -> "true",
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      val left = spark.range(1).selectExpr("CAST(id AS INT) AS key")
-      val right = spark.range(maxBroadcastHashRows)
-        .selectExpr("IF(id = 0, CAST(NULL AS INT), CAST(id AS INT)) AS b")
-
-      withTempView("naajLeft", "naajIntegralRightAtHashLimit") {
-        left.createOrReplaceTempView("naajLeft")
-        right.createOrReplaceTempView("naajIntegralRightAtHashLimit")
-        val queryExecution = sql(
-          "select * from naajLeft " +
-            "where key not in (select b from naajIntegralRightAtHashLimit)").queryExecution
-        val logicalJoins = queryExecution.optimizedPlan.collect { case join: Join => join }
-        assert(logicalJoins.size === 1)
-        val logicalJoin = logicalJoins.head
-        assert(logicalJoin.right.stats.rowCount.contains(maxBroadcastHashRows))
-        assert(canPlanAsBroadcastHashJoin(logicalJoin, conf))
-
-        val joinExec = queryExecution.sparkPlan.collect { case join: BroadcastHashJoinExec => join }
-        assert(joinExec.size === 1)
-        assert(joinExec.head.isNullAwareAntiJoin)
+        checkAnswer(result, Row(2.0d))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1332,11 +1332,14 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
       withSQLConf(
         SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
-        val joinExec = sql(
+        val result = sql(
           "select * from naajSmallLeft where key not in (select b from naajLargeRight)")
-          .queryExecution.sparkPlan.collect { case j: BroadcastNestedLoopJoinExec => j }
+        val joinExec = result.queryExecution.sparkPlan.collect {
+          case j: BroadcastNestedLoopJoinExec => j
+        }
         assert(joinExec.size === 1)
         assert(joinExec.head.buildSide === BuildLeft)
+        checkAnswer(result, Seq.empty)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1309,6 +1309,17 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
+  test("SPARK-36082: disabled NAAJ hash optimization uses nested-loop fallback") {
+    withSQLConf(
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "false",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
+      val joinExec = assertJoin((
+        "select * from testData where key not in (select b from testData3)",
+        classOf[BroadcastNestedLoopJoinExec]))
+      assert(joinExec.asInstanceOf[BroadcastNestedLoopJoinExec].buildSide === BuildRight)
+    }
+  }
+
   test("SPARK-36082: keep over-threshold NAAJ nested-loop join when fallback builds right") {
     withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1299,13 +1299,35 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
-  test("SPARK-36082: keep SingleColumn Null Aware Anti Join above broadcast threshold") {
+  test("SPARK-36082: keep NAAJ hash join when the fallback builds right") {
     withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
       val joinExec = assertJoin((
         "select * from testData where key not in (select b from testData3)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+    }
+  }
+
+  test("SPARK-36082: keep NAAJ nested-loop join when the fallback builds left") {
+    val smallLeft = spark.range(1).selectExpr("id AS key")
+    val largeRight = spark.range(100)
+      .selectExpr("IF(id = 0, CAST(NULL AS BIGINT), id) AS b")
+    val threshold = statisticSizeInByte(smallLeft)
+    assert(threshold < statisticSizeInByte(largeRight))
+
+    withTempView("naajSmallLeft", "naajLargeRight") {
+      smallLeft.createOrReplaceTempView("naajSmallLeft")
+      largeRight.createOrReplaceTempView("naajLargeRight")
+      withSQLConf(
+        SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
+        val joinExec = sql(
+          "select * from naajSmallLeft where key not in (select b from naajLargeRight)")
+          .queryExecution.sparkPlan.collect { case j: BroadcastNestedLoopJoinExec => j }
+        assert(joinExec.size === 1)
+        assert(joinExec.head.buildSide === BuildLeft)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{Ascending, GenericRow, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, JoinSelectionHelper}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, HintInfo, Join, JoinHint, NO_BROADCAST_AND_REPLICATION}
+import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, IdentityBroadcastMode}
 import org.apache.spark.sql.execution.{BinaryExecNode, FilterExec, ProjectExec, SortExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike}
@@ -38,6 +39,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
+import org.apache.spark.unsafe.map.BytesToBytesMap
 
 @SlowSQLTest
 class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
@@ -1327,6 +1329,40 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
           .queryExecution.sparkPlan.collect { case j: BroadcastNestedLoopJoinExec => j }
         assert(joinExec.size === 1)
         assert(joinExec.head.buildSide === BuildLeft)
+      }
+    }
+  }
+
+  test("SPARK-36082: keep NAAJ identity broadcast at the hashed relation row limit") {
+    val maxBroadcastHashRows = (BytesToBytesMap.MAX_CAPACITY / 1.5).toLong
+
+    withSQLConf(
+      SQLConf.CBO_ENABLED.key -> "true",
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
+      val left = spark.range(1).selectExpr("CAST(id AS INT) AS key")
+      val right = spark.range(maxBroadcastHashRows)
+        .selectExpr("IF(id = 0, CAST(NULL AS INT), CAST(id AS INT)) AS b")
+
+      withTempView("naajLeft", "naajRightAtHashLimit") {
+        left.createOrReplaceTempView("naajLeft")
+        right.createOrReplaceTempView("naajRightAtHashLimit")
+        val queryExecution = sql(
+          "select * from naajLeft where key not in (select b from naajRightAtHashLimit)")
+          .queryExecution
+        val logicalJoins = queryExecution.optimizedPlan.collect { case join: Join => join }
+        assert(logicalJoins.size === 1)
+        val logicalJoin = logicalJoins.head
+        assert(logicalJoin.right.stats.rowCount.contains(maxBroadcastHashRows))
+        assert(!canPlanAsBroadcastHashJoin(logicalJoin, conf))
+
+        val joinExec = queryExecution.sparkPlan.collect {
+          case join: BroadcastNestedLoopJoinExec => join
+        }
+        assert(joinExec.size === 1)
+        assert(joinExec.head.buildSide === BuildRight)
+        assert(joinExec.head.requiredChildDistribution(1) ===
+          BroadcastDistribution(IdentityBroadcastMode))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1341,6 +1341,37 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
+  test("SPARK-36082: left-broadcast NAAJ fallback uses nested-loop join") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
+      withTempView("naajHintedLeft", "naajHintedRight") {
+        Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
+          .createOrReplaceTempView("naajHintedLeft")
+        Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
+          .createOrReplaceTempView("naajHintedRight")
+
+        val result = sql(
+          "select /*+ BROADCAST(naajHintedLeft) */ naajHintedLeft.* " +
+            "from naajHintedLeft left anti join naajHintedRight on " +
+            "naajHintedLeft.key = naajHintedRight.key or " +
+            "isnull(naajHintedLeft.key = naajHintedRight.key)")
+        val plan = result.queryExecution.sparkPlan
+        val nestedLoopJoins = plan.collect {
+          case join: BroadcastNestedLoopJoinExec => join
+        }
+        val nullAwareHashJoins = plan.collect {
+          case join: BroadcastHashJoinExec if join.isNullAwareAntiJoin => join
+        }
+        assert(nestedLoopJoins.size === 1)
+        assert(nestedLoopJoins.head.buildSide === BuildLeft)
+        assert(nullAwareHashJoins.isEmpty)
+        checkAnswer(result, Row(2.0d))
+      }
+    }
+  }
+
   test("SPARK-36082: threshold-disabled NAAJ preserves floating-point equality") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to [#55678](https://github.com/apache/spark/pull/55678). It preserves the
optimized single-column null-aware anti join (NAAJ) hash path without making the fallback worse
than it was before that change.

The patch recognizes the structural single-column NAAJ form independently of whether the hash
optimization is enabled. `SparkStrategies.JoinSelection` then owns the complete physical decision
for that form. A shared `NullAwareAntiJoinPlanning` decision selects:

1. the specialized null-aware `BroadcastHashJoinExec`, which only supports `BuildRight`, when the
   optimization is enabled, the right side is within `spark.sql.autoBroadcastJoinThreshold`, and
   the generic broadcast nested-loop fallback would also build the right side; or
2. `BroadcastNestedLoopJoinExec` with the exact build side selected by the generic fallback.

The size boundary is checked before fallback build-side selection. Therefore, an over-threshold
right side rejects the hash path without computing irrelevant statistics for an uncached left
subtree. For non-inner/full joins, the nested-loop helper also checks the fixed preferred side
before consulting the opposite side's statistics.

Logical eligibility checks delegate to the same decision used by physical planning. This avoids
reimplementing physical hint precedence and build-side rules in the optimizer while still letting
the optimizer ask whether a plan will use the specialized hash operator.

Aggregate pushdown keeps separate stability guards. Structural NAAJs require both the original and
the pushed form to select the specialized hash outcome. Ordinary semi and anti joins preserve the
SPARK-34081 broadcast-eligibility gate: when the original join cannot use broadcast hash join, the
join remains above the Aggregate so the Aggregate can reduce its input first.

### Why are the changes needed?

The null-aware hash operator always builds the right side, while the generic broadcast nested-loop
join can build either side. If the fallback chooses `BuildLeft`, forcing the specialized hash path
can require broadcasting a much larger right side and regress a query that previously had a valid
plan.

An over-threshold `BuildRight` input also used the nested-loop fallback before #55678. Planner
estimates do not provide a reliable proof that every such input fits the runtime hash
representation, so this follow-up keeps the hash optimization inside the existing broadcast-size
boundary. This also preserves the nested-loop equality semantics for threshold-disabled
floating-point NAAJs, including `-0.0` versus `0.0`.

Making the final choice in the physical planner gives the structural NAAJ exactly one owner. It
also ensures that disabling the hash optimization takes the explicit nested-loop fallback instead
of depending on the ordinary join-selection path to rediscover the right behavior.

The optimizer must also preserve the existing SPARK-34081 behavior for ordinary semi and anti
joins. Unconditionally moving such a join below an Aggregate when broadcasting is disabled makes a
shuffle join consume the ungrouped source rows and reintroduces the performance regression that
SPARK-34081 avoided. The ordinary branch therefore retains its broadcast-eligibility guard without
changing the structural NAAJ decision.

### Does this PR introduce _any_ user-facing change?

Yes. Relative to #55678 on unreleased branches, a recognized single-column NAAJ uses the null-aware
broadcast hash join only when the generic fallback would build the right side and that side is
within the normal broadcast-size threshold.

If the optimization is disabled, the fallback would build the left side, or the right side exceeds
the threshold, Spark retains the broadcast nested-loop join. Ordinary semi and anti Aggregate
pushdown also retains its released broadcast-eligibility behavior. Released Spark behavior is not
changed.

### How was this patch tested?

The NAAJ changes were tested with these focused checks:

```
build/sbt \
  "catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.JoinSelectionHelperSuite" \
  "catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.LeftSemiAntiJoinPushDownSuite" \
  "sql/testOnly org.apache.spark.sql.JoinSuite -- -z SPARK-36082"
```

After restoring the ordinary-join gate, the final head also passed:

```
build/sbt 'catalyst/testOnly *LeftSemiAntiJoinPushDownSuite -- -z "SPARK-34081"'
```

The tests cover the in-threshold `BuildRight` hash path, disabled optimization, the `BuildLeft`
fallback, the over-threshold `BuildRight` fallback, uncached-left statistics short-circuiting,
floating-point signed-zero correctness, structural-NAAJ Aggregate stability, and broadcast-eligible
versus disabled ordinary semi/anti Aggregate pushdown.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
