### PR TITLE
[SPARK-55294][PS] Add support for PyArrow-backed dtypes in pandas API

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -250,9 +250,7 @@ def column_op(f: Callable[..., Column]) -> Callable[..., SeriesOrIndex]:
                 use_extension_dtypes=any(
                     handle_dtype_as_extension_dtype(col.dtype) for col in [self] + cols
                 ),
-                use_arrow_dtypes=any(
-                    is_pyarrow_backed_dtype(col.dtype) for col in [self] + cols
-                ),
+                use_arrow_dtypes=any(is_pyarrow_backed_dtype(col.dtype) for col in [self] + cols),
             )
 
             if not field.is_extension_dtype:

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -40,7 +40,10 @@ from pyspark.pandas.internal import (
     InternalFrame,
 )
 from pyspark.pandas.spark.accessors import SparkIndexOpsMethods
-from pyspark.pandas.typedef.typehints import handle_dtype_as_extension_dtype
+from pyspark.pandas.typedef.typehints import (
+    handle_dtype_as_extension_dtype,
+    is_pyarrow_backed_dtype,
+)
 from pyspark.pandas.utils import (
     ERROR_MESSAGE_CANNOT_COMBINE,
     ansi_mode_context,
@@ -246,6 +249,9 @@ def column_op(f: Callable[..., Column]) -> Callable[..., SeriesOrIndex]:
                 self._internal.spark_frame.select(scol).schema[0],
                 use_extension_dtypes=any(
                     handle_dtype_as_extension_dtype(col.dtype) for col in [self] + cols
+                ),
+                use_arrow_dtypes=any(
+                    is_pyarrow_backed_dtype(col.dtype) for col in [self] + cols
                 ),
             )
 

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -40,6 +40,7 @@ from pyspark.pandas.internal import (
     InternalField,
     InternalFrame,
 )
+from pyspark.pandas.typedef.typehints import is_pyarrow_backed_dtype
 from pyspark.pandas.utils import (
     is_name_like_tuple,
     is_name_like_value,
@@ -803,6 +804,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                         new_field = InternalField.from_struct_field(
                             self._internal.spark_frame.select(new_scol).schema[0],
                             use_extension_dtypes=new_field.is_extension_dtype,
+                            use_arrow_dtypes=is_pyarrow_backed_dtype(new_field.dtype),
                         )
                         break
                 new_data_spark_columns.append(new_scol)

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -107,7 +107,10 @@ class InternalField:
 
     @staticmethod
     def from_struct_field(
-        struct_field: StructField, *, use_extension_dtypes: bool = False
+        struct_field: StructField,
+        *,
+        use_extension_dtypes: bool = False,
+        use_arrow_dtypes: bool = False,
     ) -> "InternalField":
         """
         Returns a new InternalField object created from the given StructField.
@@ -120,6 +123,8 @@ class InternalField:
             The StructField used to create a new InternalField object.
         use_extension_dtypes : bool
             If True, try to use the extension dtypes.
+        use_arrow_dtypes : bool
+            If True, try to use PyArrow-backed dtypes.
 
         Returns
         -------
@@ -127,7 +132,9 @@ class InternalField:
         """
         return InternalField(
             dtype=spark_type_to_pandas_dtype(
-                struct_field.dataType, use_extension_dtypes=use_extension_dtypes
+                struct_field.dataType,
+                use_extension_dtypes=use_extension_dtypes,
+                use_arrow_dtypes=use_arrow_dtypes,
             ),
             struct_field=struct_field,
         )

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -24,7 +24,10 @@ from pandas.api.types import CategoricalDtype
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
-from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
+from pyspark.pandas.typedef.typehints import (
+    extension_arrow_dtypes_available,
+    extension_object_dtypes_available,
+)
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 if extension_object_dtypes_available:
@@ -236,6 +239,19 @@ class StringOpsTestsMixin:
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser >= other_pser, psser >= other_psser)
         self.assert_eq(pser >= pser, psser >= psser)
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_pyarrow_backed_string_ops(self):
+        import pyarrow as pa
+        from pandas import ArrowDtype
+
+        s1 = ps.Series(["a", "b", "c"], dtype=ArrowDtype(pa.string()))
+        s2 = ps.Series(["a", "x", "c"], dtype=ArrowDtype(pa.string()))
+        res = s1 == s2
+        self.assertEqual(res.dtype, ArrowDtype(pa.bool_()))
+        self.assertEqual(res.tolist(), [True, False, True])
 
 
 class StringOpsTests(

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -29,11 +29,14 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.typedef import (
     as_spark_type,
+    extension_arrow_dtypes_available,
     extension_dtypes_available,
     extension_float_dtypes_available,
     extension_object_dtypes_available,
     infer_return_type,
+    is_pyarrow_backed_dtype,
     pandas_on_spark_type,
+    spark_type_to_pandas_dtype,
 )
 from pyspark.sql.types import (
     ArrayType,
@@ -472,6 +475,45 @@ class TypeHintTestsMixin:
         for extension_dtype, spark_type in type_mapper.items():
             self.assertEqual(as_spark_type(extension_dtype), spark_type)
             self.assertEqual(pandas_on_spark_type(extension_dtype), (extension_dtype, spark_type))
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_as_spark_type_pyarrow_dtypes(self):
+        import pyarrow as pa
+        from pandas import ArrowDtype
+
+        type_mapper = {
+            ArrowDtype(pa.bool_()): BooleanType(),
+            ArrowDtype(pa.int8()): ByteType(),
+            ArrowDtype(pa.int16()): ShortType(),
+            ArrowDtype(pa.int32()): IntegerType(),
+            ArrowDtype(pa.int64()): LongType(),
+            ArrowDtype(pa.float32()): FloatType(),
+            ArrowDtype(pa.float64()): DoubleType(),
+            ArrowDtype(pa.string()): StringType(),
+        }
+
+        for arrow_dtype, spark_type in type_mapper.items():
+            self.assertEqual(as_spark_type(arrow_dtype), spark_type)
+            self.assertEqual(
+                spark_type_to_pandas_dtype(spark_type, use_arrow_dtypes=True),
+                arrow_dtype,
+            )
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_is_pyarrow_backed_dtype(self):
+        import pyarrow as pa
+        from pandas import ArrowDtype, StringDtype
+
+        self.assertTrue(is_pyarrow_backed_dtype(ArrowDtype(pa.bool_())))
+        self.assertTrue(is_pyarrow_backed_dtype(ArrowDtype(pa.int64())))
+        self.assertTrue(is_pyarrow_backed_dtype(ArrowDtype(pa.string())))
+        self.assertTrue(is_pyarrow_backed_dtype(StringDtype(storage="pyarrow")))
+        self.assertFalse(is_pyarrow_backed_dtype(StringDtype(storage="python")))
+        self.assertFalse(is_pyarrow_backed_dtype(np.dtype("int64")))
 
 
 class TypeHintTests(TypeHintTestsMixin, PandasOnSparkTestCase):

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -56,10 +56,18 @@ try:
     except ImportError:
         extension_float_dtypes_available = False
 
+    try:
+        from pandas import ArrowDtype
+
+        extension_arrow_dtypes_available = True
+    except ImportError:
+        extension_arrow_dtypes_available = False
+
 except ImportError:
     extension_dtypes_available = False
     extension_object_dtypes_available = False
     extension_float_dtypes_available = False
+    extension_arrow_dtypes_available = False
     extension_dtypes = ()
 
 import pyarrow as pa
@@ -253,6 +261,10 @@ def as_spark_type(
             elif isinstance(tpe, Float64Dtype) or (isinstance(tpe, str) and tpe == "Float64"):
                 return types.DoubleType()
 
+        # PyArrow-backed ArrowDtype
+        if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+            return from_arrow_type(tpe.pyarrow_dtype, prefer_timestamp_ntz)
+
     if raise_error:
         raise TypeError("Type %s was not understood." % tpe)
     else:
@@ -260,9 +272,15 @@ def as_spark_type(
 
 
 def spark_type_to_pandas_dtype(
-    spark_type: types.DataType, *, use_extension_dtypes: bool = False
+    spark_type: types.DataType,
+    *,
+    use_extension_dtypes: bool = False,
+    use_arrow_dtypes: bool = False,
 ) -> Dtype:
     """Return the given Spark DataType to pandas dtype."""
+
+    if use_arrow_dtypes and extension_arrow_dtypes_available:
+        return ArrowDtype(to_arrow_type(spark_type))
 
     if use_extension_dtypes and extension_dtypes_available:
         # IntegralType
@@ -335,14 +353,30 @@ def spark_type_to_pandas_dtype(
 def is_str_dtype(tpe: Dtype) -> bool:
     if LooseVersion(pd.__version__) < "3.0.0":
         return False
+    if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+        pyarrow_type = tpe.pyarrow_dtype
+        if pa.types.is_string(pyarrow_type) or pa.types.is_large_string(pyarrow_type):
+            return True
     if extension_object_dtypes_available:
         return isinstance(tpe, StringDtype) and tpe.na_value is np.nan
+    return False
+
+
+def is_pyarrow_backed_dtype(tpe: Dtype) -> bool:
+    """Return whether the given dtype is a PyArrow-backed dtype."""
+    if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+        return True
+    if extension_object_dtypes_available and isinstance(tpe, StringDtype):
+        storage = getattr(tpe, "storage", None)
+        return isinstance(storage, str) and storage.startswith("pyarrow")
     return False
 
 
 def handle_dtype_as_extension_dtype(tpe: Dtype) -> bool:
     if is_str_dtype(tpe):
         return False
+    elif extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+        return True
     else:
         return isinstance(tpe, extension_dtypes)
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -51,7 +51,7 @@ from pyspark.pandas._typing import (
     Label,
     Name,
 )
-from pyspark.pandas.typedef.typehints import as_spark_type
+from pyspark.pandas.typedef.typehints import as_spark_type, is_pyarrow_backed_dtype
 from pyspark.sql import Column, SparkSession
 from pyspark.sql import DataFrame as PySparkDataFrame
 from pyspark.sql import functions as F
@@ -220,6 +220,7 @@ def combine_frames(
         # If the same named index is found, that's used.
         index_column_names = []
         index_use_extension_dtypes = []
+        index_use_arrow_dtypes = []
         for (
             i,
             ((this_column, this_name, this_field), (that_column, that_name, that_field)),
@@ -236,6 +237,9 @@ def combine_frames(
                 index_column_names.append(column_name)
                 index_use_extension_dtypes.append(
                     any(field.is_extension_dtype for field in [this_field, that_field])
+                )
+                index_use_arrow_dtypes.append(
+                    any(is_pyarrow_backed_dtype(field.dtype) for field in [this_field, that_field])
                 )
                 merged_index_scols.append(
                     F.when(this_scol.isNotNull(), this_scol).otherwise(that_scol).alias(column_name)
@@ -277,14 +281,22 @@ def combine_frames(
         schema = joined_df.select(*index_spark_columns, *new_data_columns).schema
 
         index_fields = [
-            InternalField.from_struct_field(struct_field, use_extension_dtypes=use_extension_dtypes)
-            for struct_field, use_extension_dtypes in zip(
-                schema.fields[: len(index_spark_columns)], index_use_extension_dtypes
+            InternalField.from_struct_field(
+                struct_field,
+                use_extension_dtypes=use_extension_dtypes,
+                use_arrow_dtypes=use_arrow_dtypes,
+            )
+            for struct_field, use_extension_dtypes, use_arrow_dtypes in zip(
+                schema.fields[: len(index_spark_columns)],
+                index_use_extension_dtypes,
+                index_use_arrow_dtypes,
             )
         ]
         data_fields = [
             InternalField.from_struct_field(
-                struct_field, use_extension_dtypes=field.is_extension_dtype
+                struct_field,
+                use_extension_dtypes=field.is_extension_dtype,
+                use_arrow_dtypes=is_pyarrow_backed_dtype(field.dtype),
             )
             for struct_field, field in zip(
                 schema.fields[len(index_spark_columns) :],


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for pandas `ArrowDtype` and PyArrow-backed string dtypes in PySpark's pandas API (`pyspark.pandas`).

Key changes:
- `python/pyspark/pandas/typedef/typehints.py`:
  - Added safe import check for `pandas.ArrowDtype` (`extension_arrow_dtypes_available`).
  - Updated `as_spark_type()` to delegate `ArrowDtype` directly to PySpark's existing `from_arrow_type(tpe.pyarrow_dtype, prefer_timestamp_ntz)`.
  - Updated `spark_type_to_pandas_dtype()` to return `ArrowDtype(to_arrow_type(spark_type))` when `use_arrow_dtypes=True`.
  - Added `is_pyarrow_backed_dtype(tpe)` to detect `ArrowDtype` and PyArrow-backed `StringDtype` instances.
  - Extended `is_str_dtype()` and `handle_dtype_as_extension_dtype()` to recognize `ArrowDtype`.
- `python/pyspark/pandas/internal.py`:
  - Added `use_arrow_dtypes: bool = False` parameter to `InternalField.from_struct_field()` and forwarded it to `spark_type_to_pandas_dtype()`.
- `python/pyspark/pandas/base.py`:
  - Updated `column_op()` decorator to inspect input operands via `is_pyarrow_backed_dtype(col.dtype)` and pass `use_arrow_dtypes` to `InternalField.from_struct_field()`.
- `python/pyspark/pandas/utils.py` & `indexing.py`:
  - Propagated `use_arrow_dtypes` through `combine_frames()` and `__setitem__` struct field recreation.

---

### Why are the changes needed?

In pandas 2.0+ and pandas 3.0, PyArrow-backed dtypes (e.g. `int64[pyarrow]`, `string[pyarrow]`, `bool[pyarrow]`) are increasingly used for Series and DataFrames. Without this change, `pyspark.pandas` fails to recognize `ArrowDtype` during `as_spark_type()` schema conversion and drops PyArrow-backed return dtypes back to standard NumPy dtypes during operations like comparisons (`s1 == s2`).

---

### Does this PR introduce _any_ user-facing change?

Yes. Users operating on PyArrow-backed pandas Series/DataFrames will now see their dtypes recognized during type inference and preserved through PySpark pandas operations:

#### 1. Schema Inference & Type Mapping
```python
import pandas as pd
import pyarrow as pa
from pyspark.pandas.typedef import as_spark_type, spark_type_to_pandas_dtype

# Converting PyArrow-backed dtypes to Spark DataType:
as_spark_type(pd.ArrowDtype(pa.int64()))    # -> LongType()
as_spark_type(pd.ArrowDtype(pa.string()))   # -> StringType()
as_spark_type(pd.ArrowDtype(pa.bool_()))    # -> BooleanType()

# Converting Spark DataType back to PyArrow-backed dtypes:
spark_type_to_pandas_dtype(types.LongType(), use_arrow_dtypes=True) # -> int64[pyarrow]
```

#### 2. Dtype Preservation in Operations
```python
import pandas as pd
import pyarrow as pa
import pyspark.pandas as ps

s1 = ps.Series(["a", "b", "c"], dtype=pd.ArrowDtype(pa.string()))
s2 = ps.Series(["a", "x", "c"], dtype=pd.ArrowDtype(pa.string()))
res = s1 == s2

# Before: res.dtype -> boolean (NumPy bool)
# After:  res.dtype -> bool[pyarrow]
```

---

### How was this patch tested?

#### Unit & Integration Tests Added
- `python/pyspark/pandas/tests/test_typedef.py`:
  - `test_as_spark_type_pyarrow_dtypes()`: Validates bidirectional mapping for `bool[pyarrow]`, `int8[pyarrow]`, `int16[pyarrow]`, `int32[pyarrow]`, `int64[pyarrow]`, `float[pyarrow]`, `double[pyarrow]`, `string[pyarrow]`.
  - `test_is_pyarrow_backed_dtype()`: Validates detection of `ArrowDtype` and `StringDtype(storage="pyarrow")`.
- `python/pyspark/pandas/tests/data_type_ops/test_string_ops.py`:
  - `test_pyarrow_backed_string_ops()`: Validates that comparison operations (`s1 == s2`) preserve `bool[pyarrow]` dtypes.

#### Local Test Execution & Verification

1. **Bidirectional Type Mapper Tests**:
```text
PASS: bool[pyarrow]   <-> BooleanType()
PASS: int8[pyarrow]   <-> ByteType()
PASS: int16[pyarrow]  <-> ShortType()
PASS: int32[pyarrow]  <-> IntegerType()
PASS: int64[pyarrow]  <-> LongType()
PASS: float[pyarrow]  <-> FloatType()
PASS: double[pyarrow] <-> DoubleType()
PASS: string[pyarrow] <-> StringType()
```

2. **Dtype Detection & InternalField Propagation**:
```text
PASS: is_pyarrow_backed_dtype(ArrowDtype(pa.int64())) == True
PASS: is_pyarrow_backed_dtype(ArrowDtype(pa.string())) == True
PASS: is_pyarrow_backed_dtype(StringDtype(storage='pyarrow')) == True
PASS: is_pyarrow_backed_dtype(StringDtype(storage='python')) == False
PASS: handle_dtype_as_extension_dtype(ArrowDtype(pa.int64())) == True

Arrow struct field dtype: bool[pyarrow]
SUCCESS: InternalField with use_arrow_dtypes=True returns bool[pyarrow]!
```

---

### Was this patch authored or co-authored using generative AI tooling?

No.
