### PR TITLE
[SPARK-58969][K8S] Preserve URI fragment aliases for local dependency uploads

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/SparkRemoteFileTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkRemoteFileTest.scala
@@ -34,6 +34,7 @@ object SparkRemoteFileTest {
       .builder()
       .appName("SparkRemoteFileTest")
       .getOrCreate()
+    println(s"Driver local file ${args(0)} exists: ${new File(args(0)).isFile}")
     val sc = spark.sparkContext
     val rdd = sc.parallelize(Seq(1)).map(_ => {
       val localLocation = SparkFiles.get(args(0))

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -169,25 +169,24 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
       MEMORY_OVERHEAD_FACTOR.key -> defaultOverheadFactor.toString)
     // try upload local, resolvable files to a hadoop compatible file system
     Seq(JARS, FILES, ARCHIVES, SUBMIT_PYTHON_FILES).foreach { key =>
-      val (localUris, remoteUris) =
-        conf.get(key).partition(uri => KubernetesUtils.isLocalAndResolvable(uri))
-      val value = {
-        if (key == ARCHIVES) {
-          localUris.map(Utils.getUriBuilder(_).fragment(null).build()).map(_.toString)
-        } else {
-          localUris
+      val originalUris = conf.get(key)
+      if (originalUris.nonEmpty) {
+        val localFlags = originalUris.map(KubernetesUtils.isLocalAndResolvable)
+        val localUris = originalUris.zip(localFlags).collect { case (uri, true) => uri }
+        val uploadUris = localUris.map { uri =>
+          Utils.getUriBuilder(uri).fragment(null).build().toString
         }
-      }
-      val resolved = KubernetesUtils.uploadAndTransformFileUris(value, Some(conf.sparkConf))
-      if (resolved.nonEmpty) {
-        val resolvedValue = if (key == ARCHIVES) {
-          localUris.zip(resolved).map { case (uri, r) =>
-            Utils.getUriBuilder(r).fragment(new java.net.URI(uri).getFragment).build().toString
-          }
-        } else {
-          resolved
+        val uploadedUris = KubernetesUtils.uploadAndTransformFileUris(
+          uploadUris, Some(conf.sparkConf)).iterator
+        val transformedUris = originalUris.zip(localFlags).map {
+          case (uri, true) =>
+            Utils.getUriBuilder(uploadedUris.next())
+              .fragment(new java.net.URI(uri).getFragment)
+              .build()
+              .toString
+          case (uri, false) => uri
         }
-        additionalProps.put(key.key, (resolvedValue ++ remoteUris).mkString(","))
+        additionalProps.put(key.key, transformedUris.mkString(","))
       }
     }
     additionalProps.toMap

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -16,6 +16,9 @@
  */
 package org.apache.spark.deploy.k8s.features
 
+import java.net.URI
+
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model.{ContainerPort, ContainerPortBuilder, LocalObjectReferenceBuilder, Quantity}
@@ -29,6 +32,7 @@ import org.apache.spark.deploy.k8s.features.KubernetesFeaturesTestUtils.TestReso
 import org.apache.spark.deploy.k8s.submit._
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.resource.ResourceID
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.util.Utils
@@ -38,6 +42,8 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
   private val CUSTOM_DRIVER_LABELS = Map(
     "labelkey" -> "labelvalue",
     "customAppIdLabelKey" -> "{{APP_ID}}")
+  private val FILE_UPLOAD_PATH = "s3a://some-bucket/upload-path"
+  private val DEPENDENCY_CONFIGS = Seq(JARS, FILES, ARCHIVES, SUBMIT_PYTHON_FILES)
   private val CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent"
   private val DRIVER_ANNOTATIONS = Map(
     "customAnnotation" -> "customAnnotationValue",
@@ -50,6 +56,35 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     TEST_IMAGE_PULL_SECRETS.map { secret =>
       new LocalObjectReferenceBuilder().withName(secret).build()
     }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    TestFileSystem.reset()
+  }
+
+  private def additionalProperties(
+      key: ConfigEntry[Seq[String]],
+      uris: Seq[String]): Map[String, String] = {
+    val sparkConf = new SparkConf()
+      .set(CONTAINER_IMAGE, "spark-driver:latest")
+      .set(KUBERNETES_FILE_UPLOAD_PATH, FILE_UPLOAD_PATH)
+      .set("spark.hadoop.fs.s3a.impl", classOf[TestFileSystem].getCanonicalName)
+      .set("spark.hadoop.fs.s3a.impl.disable.cache", "true")
+      .set(key, uris)
+    val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf)
+    new BasicDriverFeatureStep(kubernetesConf).getAdditionalPodSystemProperties()
+  }
+
+  private def uploadedUris(key: ConfigEntry[Seq[String]], uris: Seq[String]): Seq[String] = {
+    Utils.stringToSeq(additionalProperties(key, uris)(key.key))
+  }
+
+  private def dependencySuffix(key: ConfigEntry[Seq[String]]): String = key match {
+    case JARS => ".jar"
+    case SUBMIT_PYTHON_FILES => ".py"
+    case ARCHIVES => ".tgz"
+    case _ => ".txt"
+  }
 
   test("Check the pod respects all configurations from the user.") {
     val resourceID = new ResourceID(SPARK_DRIVER_PREFIX, GPU)
@@ -378,7 +413,6 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
   }
 
   test("SPARK-40817: Check that remote JARs do not get discarded in spark.jars") {
-    val FILE_UPLOAD_PATH = "s3a://some-bucket/upload-path"
     val REMOTE_JAR_URI = "s3a://some-bucket/my-application.jar"
     val LOCAL_JAR_URI = "/tmp/some-local-jar.jar"
 
@@ -402,6 +436,97 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     assert(!sparkJars.contains(LOCAL_JAR_URI))
     assert(sparkJars.exists(path =>
       path.startsWith(FILE_UPLOAD_PATH) && path.endsWith("some-local-jar.jar")))
+  }
+
+  DEPENDENCY_CONFIGS.foreach { key =>
+    test(s"SPARK-58969: Kubernetes upload preserves local aliases for ${key.key}") {
+      val suffix = dependencySuffix(key)
+      val physicalA = s"/tmp/physical-a$suffix"
+      val physicalB = s"/tmp/physical-b$suffix"
+      val physicalC = s"/tmp/physical-c$suffix"
+      val aliasA = s"alias-a$suffix"
+      val aliasC = s"alias-c$suffix"
+      val original = Seq(
+        s"$physicalA#$aliasA",
+        physicalB,
+        s"$physicalC#$aliasC")
+
+      val transformed = uploadedUris(key, original).map(new URI(_))
+
+      assert(transformed.size === original.size)
+      assert(transformed.map(uri => new Path(uri.getPath).getName) === Seq(
+        new Path(physicalA).getName,
+        new Path(physicalB).getName,
+        new Path(physicalC).getName))
+      assert(transformed.map(_.getFragment) === Seq(aliasA, null, aliasC))
+      assert(transformed.forall(_.toString.startsWith(FILE_UPLOAD_PATH)))
+
+      val copies = TestFileSystem.copies
+      assert(copies.map(_._1.getName) === Seq(
+        new Path(physicalA).getName,
+        new Path(physicalB).getName,
+        new Path(physicalC).getName))
+      assert(copies.map(_._2.getName) === copies.map(_._1.getName))
+      assert(copies.forall { case (source, destination) =>
+        source.toUri.getFragment == null && destination.toUri.getFragment == null
+      })
+    }
+
+    test(s"SPARK-58969: mixed local and remote ${key.key} entries preserve order") {
+      val suffix = dependencySuffix(key)
+      val remoteA = s"s3a://remote-bucket/remote-a$suffix"
+      val localA = s"/tmp/local-a$suffix#alias-a$suffix"
+      val remoteB = s"s3a://remote-bucket/remote-b$suffix#alias-b$suffix"
+      val localB = s"/tmp/local-b$suffix"
+      val original = Seq(remoteA, localA, remoteB, localB)
+
+      val transformed = uploadedUris(key, original)
+
+      assert(transformed.size === original.size)
+      assert(transformed.head === remoteA)
+      assert(new URI(transformed(1)).getFragment === s"alias-a$suffix")
+      assert(SparkPath.fromUrlString(transformed(1)).toPath.getName === s"local-a$suffix")
+      assert(transformed(2) === remoteB)
+      assert(new URI(transformed(3)).getFragment === null)
+      assert(SparkPath.fromUrlString(transformed(3)).toPath.getName === s"local-b$suffix")
+      assert(TestFileSystem.copies.map(_._1.getName) === Seq(
+        s"local-a$suffix", s"local-b$suffix"))
+    }
+
+    test(s"SPARK-58969: duplicate local ${key.key} entries remain positional") {
+      val suffix = dependencySuffix(key)
+      val duplicate = s"/tmp/duplicate$suffix#shared-alias$suffix"
+
+      val transformed = uploadedUris(key, Seq(duplicate, duplicate)).map(new URI(_))
+
+      assert(transformed.size === 2)
+      assert(transformed.map(uri => new Path(uri.getPath).getName) === Seq(
+        s"duplicate$suffix", s"duplicate$suffix"))
+      assert(transformed.map(_.getFragment) === Seq(
+        s"shared-alias$suffix", s"shared-alias$suffix"))
+      assert(TestFileSystem.copies.size === 2)
+    }
+
+    test(s"SPARK-58969: remote-only ${key.key} entries remain unchanged") {
+      val suffix = dependencySuffix(key)
+      val original = Seq(
+        s"s3a://remote-bucket/without-fragment$suffix",
+        s"s3a://remote-bucket/with-fragment$suffix#remote-alias$suffix")
+
+      assert(uploadedUris(key, original) === original)
+      assert(TestFileSystem.copies.isEmpty)
+    }
+  }
+
+  test("SPARK-58969: empty or unset dependencies do not add properties") {
+    val sparkConf = new SparkConf().set(CONTAINER_IMAGE, "spark-driver:latest")
+    val unsetProperties = new BasicDriverFeatureStep(
+      KubernetesTestConf.createDriverConf(sparkConf)).getAdditionalPodSystemProperties()
+
+    DEPENDENCY_CONFIGS.foreach { key =>
+      assert(!unsetProperties.contains(key.key))
+      assert(!additionalProperties(key, Seq.empty).contains(key.key))
+    }
   }
 
   test("SPARK-47208: User can override the minimum memory overhead of the driver") {
@@ -524,15 +649,29 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
   private def amountAndFormat(quantity: Quantity): String = quantity.getAmount + quantity.getFormat
 }
 
-/**
- * No-op Hadoop FileSystem
- */
+private object TestFileSystem {
+  private val recordedCopies = mutable.ArrayBuffer.empty[(Path, Path)]
+
+  def record(source: Path, destination: Path): Unit = recordedCopies.synchronized {
+    recordedCopies += source -> destination
+  }
+
+  def copies: Seq[(Path, Path)] = recordedCopies.synchronized {
+    recordedCopies.toSeq
+  }
+
+  def reset(): Unit = recordedCopies.synchronized {
+    recordedCopies.clear()
+  }
+}
+
+/** No-op Hadoop FileSystem that records uploads for assertions. */
 private class TestFileSystem extends LocalFileSystem {
   override def copyFromLocalFile(
     delSrc: Boolean,
     overwrite: Boolean,
     src: Path,
-    dst: Path): Unit = {}
+    dst: Path): Unit = TestFileSystem.record(src, dst)
 
   override def mkdirs(path: Path): Boolean = true
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -176,6 +176,20 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     })
   }
 
+  test("SPARK-58969: Launcher client dependency aliases", k8sTestTag, MinikubeTag) {
+    tryDepsTest({
+      val sourceFileName = Utils.createTempFile(FILE_CONTENTS, HOST_PATH)
+      val expectedAlias = "expected-alias.txt"
+      assert(sourceFileName != expectedAlias)
+      sparkAppConf.set("spark.files", s"$HOST_PATH/$sourceFileName#$expectedAlias")
+      val examplesJar = Utils.getTestFileAbsolutePath(getExamplesJarName(), sparkHomeDir)
+      runSparkRemoteCheckAndVerifyCompletion(
+        appResource = examplesJar,
+        appArgs = Array(expectedAlias),
+        timeout = Option(DEPS_TIMEOUT))
+    })
+  }
+
   test(
     "SPARK-40817: Check that remote files do not get discarded in spark.files",
     k8sTestTag,

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -297,7 +297,9 @@ class KubernetesSuite extends SparkFunSuite
     runSparkApplicationAndVerifyCompletion(
       appResource,
       SPARK_REMOTE_MAIN_CLASS,
-      Seq(s"Mounting of ${appArgs.head} was true"),
+      Seq(
+        s"Driver local file ${appArgs.head} exists: true",
+        s"Mounting of ${appArgs.head} was true"),
       Seq(),
       appArgs,
       driverPodChecker,


### PR DESCRIPTION
### What changes were proposed in this pull request?

  This PR updates Kubernetes dependency upload handling to preserve URI fragment aliases for local dependencies.

  For `spark.jars`, `spark.files`, `spark.archives`, and `spark.submit.pyFiles`, it:

  - Removes the fragment before uploading the physical file.
  - Restores the fragment on the resulting uploaded URI.
  - Preserves the original ordering of mixed local and remote dependencies.
  - Leaves remote dependencies unchanged, including remote-only configurations.

  It also adds unit coverage for all four dependency configurations and a Minikube integration test that verifies a `spark.files` alias is available from both the driver working directory
  and `SparkFiles` on executors.

  ### Why are the changes needed?

  Spark supports dependency URIs in the form `source#alias`. For example:

  ```text
  --files /tmp/query-random.sql#query.sql
```
  The physical file should be uploaded as query-random.sql, while the resulting spark.files entry should retain #query.sql.

  On Kubernetes, locally uploaded files, JARs, and Python files lost this fragment. Consequently, the driver could not access ./query.sql, and executors could not resolve
  SparkFiles.get("query.sql").

  This differs from other cluster managers such as YARN, which preserve the fragment as the application-visible localized name.

  See SPARK-58969 (https://issues.apache.org/jira/browse/SPARK-58969).

  ### Does this PR introduce any user-facing change?

  Yes.

  Local Kubernetes dependencies using source#alias now retain their aliases after upload. Applications can access the aliased name from the driver working directory and through SparkFiles
  on executors.

  Dependencies without aliases and remote dependency URIs retain their existing behavior.

  ### How was this patch tested?

  Added 17 unit test cases covering:

  - Aliased and unaliased local dependencies.
  - JARs, files, archives, and Python files.
  - Mixed local and remote dependency ordering.
  - Duplicate local entries.
  - Remote-only configurations.
  - Empty and unset configurations.
  - Verification that URI fragments are not passed to the physical Hadoop upload.

  Added a Minikube integration test for a local spark.files dependency with an alias. The test verifies the alias in both the driver working directory and executor SparkFiles.

  The focused Maven test suite passed all 41 tests:

  ./build/mvn -Pkubernetes \
    -pl resource-managers/kubernetes/core -am \
    -DwildcardSuites=org.apache.spark.deploy.k8s.features.BasicDriverFeatureStepSuite \
    org.scalatest:scalatest-maven-plugin:2.2.0:test

  Test compilation also passed:

  ./build/mvn -Pkubernetes \
    -pl resource-managers/kubernetes/core -am \
    -DskipTests test-compile

  Scala formatting and style checks passed:

  ./dev/lint-scala

  The Minikube integration test was not run locally because Minikube was unavailable.

  ### Was this patch authored or co-authored using generative AI tooling?

  Generated-by: OpenAI Codex (GPT-5).