### PR TITLE
[SPARK-59112][SQL] Treat CHAR/VARCHAR as string family at exact StringType matches

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
@@ -112,7 +112,7 @@ private[sql] class ProtobufSerializer(
         (getter, ordinal) => getter.getFloat(ordinal)
       case (DoubleType, DOUBLE) =>
         (getter, ordinal) => getter.getDouble(ordinal)
-      case (StringType, ENUM) =>
+      case (_: StringType, ENUM) =>
         val enumSymbols: Set[String] =
           fieldDescriptor.getEnumType.getValues.asScala.map(e => e.toString).toSet
         (getter, ordinal) =>
@@ -138,7 +138,7 @@ private[sql] class ProtobufSerializer(
               enumValues.mkString(", "))
           }
           fieldDescriptor.getEnumType.findValueByNumber(data)
-      case (StringType, STRING) =>
+      case (_: StringType, STRING) =>
         (getter, ordinal) => {
           String.valueOf(getter.getUTF8String(ordinal))
         }
@@ -215,7 +215,7 @@ private[sql] class ProtobufSerializer(
         (getter, ordinal) =>
           UInt64Value.of(getter.getLong(ordinal))
 
-      case (StringType, MESSAGE)
+      case (_: StringType, MESSAGE)
         if fieldDescriptor.getMessageType.getFullName == StringValue.getDescriptor.getFullName =>
         (getter, ordinal) =>
           StringValue.of(getter.getUTF8String(ordinal).toString)

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufDescriptorFileReadSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufDescriptorFileReadSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.util.ProtobufDescriptorFileReader
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.protobuf.utils.{ProtobufUtils => ConnectorProtobufUtils}
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -77,6 +78,26 @@ class ProtobufDescriptorFileReadSuite extends SharedSparkSession with ProtobufTe
       s"SELECT to_protobuf(value, '$messageName', '$fileUri', map()) IS NOT NULL AS r " +
       "FROM t_pb_struct").head().getBoolean(0)
     assert(r)
+  }
+
+  test("SPARK-59112: CHAR/VARCHAR descriptor paths use the three-argument overload") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val fileUri = new File(descPath).getCanonicalFile.toURI.toString
+      spark.range(1).selectExpr("CAST(NULL AS BINARY) AS value").createOrReplaceTempView("t_pb")
+      spark.range(1)
+        .selectExpr("named_struct('id', id) AS value")
+        .createOrReplaceTempView("t_pb_struct")
+
+      Seq("CHAR", "VARCHAR").foreach { typeName =>
+        val descriptorPath = s"CAST('$fileUri' AS $typeName(${fileUri.length}))"
+        assert(spark.sql(
+          s"SELECT from_protobuf(value, '$messageName', $descriptorPath) IS NULL FROM t_pb")
+          .head().getBoolean(0))
+        assert(spark.sql(
+          s"SELECT to_protobuf(value, '$messageName', $descriptorPath) IS NOT NULL " +
+            "FROM t_pb_struct").head().getBoolean(0))
+      }
+    }
   }
 
   test("missing descriptor file raises PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND") {

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufDescriptorFileReadSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufDescriptorFileReadSuite.scala
@@ -24,7 +24,7 @@ import java.nio.file.Files
 import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.util.ProtobufDescriptorFileReader
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.protobuf.utils.{ProtobufUtils => ConnectorProtobufUtils}
@@ -83,16 +83,33 @@ class ProtobufDescriptorFileReadSuite extends SharedSparkSession with ProtobufTe
   test("SPARK-59112: CHAR/VARCHAR descriptor paths use the three-argument overload") {
     withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
       val fileUri = new File(descPath).getCanonicalFile.toURI.toString
-      spark.range(1).selectExpr("CAST(NULL AS BINARY) AS value").createOrReplaceTempView("t_pb")
-      spark.range(1)
-        .selectExpr("named_struct('id', id) AS value")
+      spark.range(1).selectExpr(
+        """named_struct(
+          |'id', 1L,
+          |'string_value', 'test_string',
+          |'int32_value', 32,
+          |'int64_value', 64L,
+          |'double_value', CAST(123.456 AS DOUBLE),
+          |'float_value', CAST(789.01 AS FLOAT),
+          |'bool_value', true,
+          |'bytes_value', CAST('sample_bytes' AS BINARY)
+          |) AS value""".stripMargin)
         .createOrReplaceTempView("t_pb_struct")
+      spark.sql(
+        s"SELECT to_protobuf(value, '$messageName', '$fileUri', map()) AS protobuf_data " +
+          "FROM t_pb_struct")
+        .createOrReplaceTempView("t_pb_bytes")
+
+      val expected = Row(
+        1L, "test_string", 32, 64L, 123.456, 789.01F, true, "sample_bytes".getBytes)
 
       Seq("CHAR", "VARCHAR").foreach { typeName =>
         val descriptorPath = s"CAST('$fileUri' AS $typeName(${fileUri.length}))"
-        assert(spark.sql(
-          s"SELECT from_protobuf(value, '$messageName', $descriptorPath) IS NULL FROM t_pb")
-          .head().getBoolean(0))
+        checkAnswer(
+          spark.sql(
+            s"SELECT from_protobuf(protobuf_data, '$messageName', $descriptorPath) AS decoded " +
+              "FROM t_pb_bytes"),
+          Seq(Row(expected)))
         assert(spark.sql(
           s"SELECT to_protobuf(value, '$messageName', $descriptorPath) IS NOT NULL " +
             "FROM t_pb_struct").head().getBoolean(0))

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufSerdeSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufSerdeSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.protobuf
 
+import com.google.protobuf.{DynamicMessage, StringValue}
 import com.google.protobuf.Descriptors.Descriptor
-import com.google.protobuf.DynamicMessage
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters}
@@ -40,6 +40,9 @@ class ProtobufSerdeSuite extends SharedSparkSession with ProtobufTestBase {
 
   private val testFileDescFile = protobufDescriptorFile("serde_suite.desc")
   private val testFileDesc = CommonProtobufUtils.readDescriptorFileContent(testFileDescFile)
+
+  private val functionsDescFile = protobufDescriptorFile("functions_suite.desc")
+  private val functionsDesc = CommonProtobufUtils.readDescriptorFileContent(functionsDescFile)
 
   private val javaClassNamePrefix = "org.apache.spark.sql.protobuf.protos.SerdeSuiteProtos$"
 
@@ -69,19 +72,53 @@ class ProtobufSerdeSuite extends SharedSparkSession with ProtobufTestBase {
     }
   }
 
-  test("SPARK-59112: serialize CHAR/VARCHAR fields as Protobuf strings") {
-    val descriptor =
+  test("SPARK-59112: serialize CHAR/VARCHAR with Protobuf string-family converters") {
+    val stringDescriptor =
       ProtobufUtils.buildDescriptor("SimpleMessageJavaTypes", Some(testFileDesc)).descriptor
+    val enumDescriptor =
+      ProtobufUtils.buildDescriptor("SimpleMessageEnum", Some(functionsDesc)).descriptor
+    val wrapperDescriptor =
+      ProtobufUtils.buildDescriptor("WellKnownWrapperTypes", Some(functionsDesc)).descriptor
 
     Seq(CharType(3), VarcharType(3)).foreach { stringType =>
-      val serializer = new ProtobufSerializer(
+      val stringSerializer = new ProtobufSerializer(
         new StructType().add("string_value", stringType),
-        descriptor,
+        stringDescriptor,
         nullable = false)
-      val message = serializer.serialize(InternalRow(UTF8String.fromString("abc")))
+      val stringMessage = stringSerializer.serialize(InternalRow(UTF8String.fromString("abc")))
         .asInstanceOf[DynamicMessage]
+      assert(
+        stringMessage.getField(stringDescriptor.findFieldByName("string_value")) === "abc")
 
-      assert(message.getField(descriptor.findFieldByName("string_value")) === "abc")
+      val enumSerializer = new ProtobufSerializer(
+        new StructType().add("basic_enum", stringType),
+        enumDescriptor,
+        nullable = false)
+      val enumMessage = enumSerializer.serialize(InternalRow(UTF8String.fromString("FIRST")))
+        .asInstanceOf[DynamicMessage]
+      assert(
+        enumMessage.getField(enumDescriptor.findFieldByName("basic_enum")).toString === "FIRST")
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          enumSerializer.serialize(InternalRow(UTF8String.fromString("INVALID_VALUE")))
+        },
+        condition = "CANNOT_CONVERT_SQL_VALUE_TO_PROTOBUF_ENUM_TYPE",
+        parameters = Map(
+          "sqlColumn" -> "`basic_enum`",
+          "protobufColumn" -> "field 'basic_enum'",
+          "data" -> "INVALID_VALUE",
+          "enumString" -> "\"NOTHING\", \"FIRST\", \"SECOND\""))
+
+      val wrapperSerializer = new ProtobufSerializer(
+        new StructType().add("string_val", stringType),
+        wrapperDescriptor,
+        nullable = false)
+      val wrapperMessage = wrapperSerializer.serialize(InternalRow(UTF8String.fromString("abc")))
+        .asInstanceOf[DynamicMessage]
+      assert(
+        wrapperMessage.getField(wrapperDescriptor.findFieldByName("string_val")) ===
+          StringValue.of("abc"))
     }
   }
 

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufSerdeSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufSerdeSuite.scala
@@ -25,8 +25,9 @@ import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters}
 import org.apache.spark.sql.catalyst.expressions.Cast.toSQLType
 import org.apache.spark.sql.protobuf.utils.ProtobufUtils
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.types.{CharType, IntegerType, StructType, VarcharType}
 import org.apache.spark.sql.util.{ProtobufUtils => CommonProtobufUtils}
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Tests for [[ProtobufSerializer]] and [[ProtobufDeserializer]] with a more specific focus on
@@ -65,6 +66,22 @@ class ProtobufSerdeSuite extends SharedSparkSession with ProtobufTestBase {
 
       assert(
         serializer.serialize(deserializer.deserialize(dynamicMessage).get) === dynamicMessage)
+    }
+  }
+
+  test("SPARK-59112: serialize CHAR/VARCHAR fields as Protobuf strings") {
+    val descriptor =
+      ProtobufUtils.buildDescriptor("SimpleMessageJavaTypes", Some(testFileDesc)).descriptor
+
+    Seq(CharType(3), VarcharType(3)).foreach { stringType =>
+      val serializer = new ProtobufSerializer(
+        new StructType().add("string_value", stringType),
+        descriptor,
+        nullable = false)
+      val message = serializer.serialize(InternalRow(UTF8String.fromString("abc")))
+        .asInstanceOf[DynamicMessage]
+
+      assert(message.getField(descriptor.findFieldByName("string_value")) === "abc")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UpCastResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UpCastResolution.scala
@@ -47,7 +47,7 @@ object UpCastResolution extends SQLConfHelper {
 
     case UpCast(child, target: AtomicType, _)
         if conf.getConf(SQLConf.LEGACY_LOOSE_UPCAST) &&
-        child.dataType == StringType =>
+        child.dataType.isInstanceOf[StringType] =>
       Cast(child, target.asNullable)
 
     case unresolvedUpCast @ UpCast(child, _, walkedTypePath)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/toFromProtobufSqlFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/toFromProtobufSqlFunctions.scala
@@ -83,9 +83,9 @@ case class FromProtobuf(
     this(
       data,
       messageName,
-      descFilePathOrOptions match {
-        case lit: Literal
-          if lit.dataType == StringType || lit.dataType == BinaryType => descFilePathOrOptions
+      descFilePathOrOptions.dataType match {
+        case _: StringType | BinaryType =>
+          descFilePathOrOptions
         case _ => Literal(null)
       },
       descFilePathOrOptions.dataType match {
@@ -232,9 +232,9 @@ case class ToProtobuf(
     this(
       data,
       messageName,
-      descFilePathOrOptions match {
-        case lit: Literal
-          if lit.dataType == StringType || lit.dataType == BinaryType => descFilePathOrOptions
+      descFilePathOrOptions.dataType match {
+        case _: StringType | BinaryType =>
+          descFilePathOrOptions
         case _ => Literal(null)
       },
       descFilePathOrOptions.dataType match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/toFromProtobufSqlFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/toFromProtobufSqlFunctions.scala
@@ -22,7 +22,9 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ProtobufDescriptorFileReader}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{BinaryType, MapType, NullType, StringType, StructType}
+import org.apache.spark.sql.types.{
+  BinaryType, CharType, MapType, NullType, StringType, StructType, VarcharType
+}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
@@ -83,8 +85,14 @@ case class FromProtobuf(
     this(
       data,
       messageName,
-      descFilePathOrOptions.dataType match {
-        case _: StringType | BinaryType =>
+      descFilePathOrOptions match {
+        case lit: Literal
+            if lit.dataType == StringType || lit.dataType == BinaryType ||
+              lit.dataType.isInstanceOf[CharType] || lit.dataType.isInstanceOf[VarcharType] =>
+          descFilePathOrOptions
+        case expression if expression.foldable &&
+            (expression.dataType.isInstanceOf[CharType] ||
+              expression.dataType.isInstanceOf[VarcharType]) =>
           descFilePathOrOptions
         case _ => Literal(null)
       },
@@ -232,8 +240,14 @@ case class ToProtobuf(
     this(
       data,
       messageName,
-      descFilePathOrOptions.dataType match {
-        case _: StringType | BinaryType =>
+      descFilePathOrOptions match {
+        case lit: Literal
+            if lit.dataType == StringType || lit.dataType == BinaryType ||
+              lit.dataType.isInstanceOf[CharType] || lit.dataType.isInstanceOf[VarcharType] =>
+          descFilePathOrOptions
+        case expression if expression.foldable &&
+            (expression.dataType.isInstanceOf[CharType] ||
+              expression.dataType.isInstanceOf[VarcharType]) =>
           descFilePathOrOptions
         case _ => Literal(null)
       },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReusableBroadcastValueProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReusableBroadcastValueProjection.scala
@@ -39,7 +39,8 @@ private[sql] object ReusableBroadcastValueProjection extends PredicateHelper {
       case _ => false
     } && (expression match {
       case attribute: Attribute =>
-        UnsafeRow.isFixedLength(attribute.dataType) || attribute.dataType == StringType
+        UnsafeRow.isFixedLength(attribute.dataType) ||
+          attribute.dataType.isInstanceOf[StringType]
       case _: Literal => true
       case DateAdd(startDate, days: Literal) =>
         isSafeValueExpression(startDate) && isSafeValueExpression(days)
@@ -47,7 +48,7 @@ private[sql] object ReusableBroadcastValueProjection extends PredicateHelper {
           (cast.dataType == TimestampType || cast.dataType == TimestampNTZType) =>
         isSafeValueExpression(cast.child)
       case DateFormatClass(timestamp, format: Literal, Some(_))
-          if format.dataType == StringType && format.value != null =>
+          if format.dataType.isInstanceOf[StringType] && format.value != null =>
         isSafeValueExpression(timestamp)
       case _ => false
     })

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -315,7 +315,7 @@ object SpecialDatetimeValues extends Rule[LogicalPlan] {
 
   private val specialDatetimeRewrite: PartialFunction[Expression, Expression] = {
     case cast @ Cast(e, dt @ (DateType | TimestampType | TimestampNTZType), _, _)
-      if e.foldable && e.dataType == StringType =>
+      if e.foldable && e.dataType.isInstanceOf[StringType] =>
       Option(e.eval())
         .flatMap(s => conv(dt)(s.toString, cast.zoneId))
         .map(Literal(_, dt))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3849,7 +3849,9 @@ class AstBuilder extends DataTypeAstBuilder
             }
             val expressions = expressionList(ctx.expression)
             if (expressions.forall(_.foldable) &&
-                expressions.forall(_.dataType.isInstanceOf[StringType])) {
+                expressions.forall(
+                  expression => expression.resolved &&
+                    DataTypeUtils.isDefaultStringCharOrVarcharType(expression.dataType))) {
               // If there are many pattern expressions, will throw StackOverflowError.
               // So we use LikeAny or NotLikeAny instead.
               val patterns = expressions.map(_.eval(EmptyRow).asInstanceOf[UTF8String])
@@ -3868,7 +3870,9 @@ class AstBuilder extends DataTypeAstBuilder
             }
             val expressions = expressionList(ctx.expression)
             if (expressions.forall(_.foldable) &&
-                expressions.forall(_.dataType.isInstanceOf[StringType])) {
+                expressions.forall(
+                  expression => expression.resolved &&
+                    DataTypeUtils.isDefaultStringCharOrVarcharType(expression.dataType))) {
               // If there are many pattern expressions, will throw StackOverflowError.
               // So we use LikeAll or NotLikeAll instead.
               val patterns = expressions.map(_.eval(EmptyRow).asInstanceOf[UTF8String])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3848,7 +3848,8 @@ class AstBuilder extends DataTypeAstBuilder
               throw QueryParsingErrors.emptyQuantifiedPatternError(ctx)
             }
             val expressions = expressionList(ctx.expression)
-            if (expressions.forall(_.foldable) && expressions.forall(_.dataType == StringType)) {
+            if (expressions.forall(_.foldable) &&
+                expressions.forall(_.dataType.isInstanceOf[StringType])) {
               // If there are many pattern expressions, will throw StackOverflowError.
               // So we use LikeAny or NotLikeAny instead.
               val patterns = expressions.map(_.eval(EmptyRow).asInstanceOf[UTF8String])
@@ -3866,7 +3867,8 @@ class AstBuilder extends DataTypeAstBuilder
               throw QueryParsingErrors.emptyQuantifiedPatternError(ctx)
             }
             val expressions = expressionList(ctx.expression)
-            if (expressions.forall(_.foldable) && expressions.forall(_.dataType == StringType)) {
+            if (expressions.forall(_.foldable) &&
+                expressions.forall(_.dataType.isInstanceOf[StringType])) {
               // If there are many pattern expressions, will throw StackOverflowError.
               // So we use LikeAll or NotLikeAll instead.
               val patterns = expressions.map(_.eval(EmptyRow).asInstanceOf[UTF8String])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3810,7 +3810,8 @@ class AstBuilder extends DataTypeAstBuilder
         expr: Expression,
         patterns: Seq[UTF8String]): (Expression, Seq[UTF8String]) = ctx.kind.getType match {
       // scalastyle:off caselocale
-      case SqlBaseParser.ILIKE => (Lower(expr), patterns.map(_.toLowerCase))
+      case SqlBaseParser.ILIKE =>
+        (Lower(expr), patterns.map(pattern => Option(pattern).map(_.toLowerCase).orNull))
       // scalastyle:on caselocale
       case _ => (expr, patterns)
     }
@@ -3818,6 +3819,18 @@ class AstBuilder extends DataTypeAstBuilder
     def getLike(expr: Expression, pattern: Expression): Expression = ctx.kind.getType match {
       case SqlBaseParser.ILIKE => new ILike(expr, pattern)
       case _ => new Like(expr, pattern)
+    }
+
+    def buildBalanced(
+        expressions: Seq[Expression],
+        combine: (Expression, Expression) => Expression): Expression = {
+      assert(expressions.nonEmpty)
+      if (expressions.length == 1) {
+        expressions.head
+      } else {
+        val (left, right) = expressions.splitAt(expressions.length / 2)
+        combine(buildBalanced(left, combine), buildBalanced(right, combine))
+      }
     }
 
     val withNot = blockBang(ctx.errorCapturingNot)
@@ -3861,8 +3874,9 @@ class AstBuilder extends DataTypeAstBuilder
                 case _ => NotLikeAny(expr, pat)
               }
             } else {
-              ctx.expression.asScala.map(expression)
-                .map(p => invertIfNotDefined(getLike(e, p))).toSeq.reduceLeft(Or)
+              buildBalanced(
+                expressions.map(p => invertIfNotDefined(getLike(e, p))),
+                Or.apply)
             }
           case Some(SqlBaseParser.ALL) =>
             if (ctx.expression.isEmpty) {
@@ -3882,8 +3896,9 @@ class AstBuilder extends DataTypeAstBuilder
                 case _ => NotLikeAll(expr, pat)
               }
             } else {
-              ctx.expression.asScala.map(expression)
-                .map(p => invertIfNotDefined(getLike(e, p))).toSeq.reduceLeft(And)
+              buildBalanced(
+                expressions.map(p => invertIfNotDefined(getLike(e, p))),
+                And.apply)
             }
           case _ =>
             val escapeChar = Option(ctx.escapeChar)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -62,6 +63,19 @@ class EncoderResolutionSuite extends PlanTest {
     // int type can be up cast to string type
     val attrs2 = Seq($"a".int, $"b".long)
     testFromRow(encoder, attrs2, InternalRow(1, 2L))
+  }
+
+  test("SPARK-59112: legacy loose upcast accepts CHAR/VARCHAR inputs") {
+    withSQLConf(
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true",
+        SQLConf.LEGACY_LOOSE_UPCAST.key -> "true") {
+      Seq(CharType(1), VarcharType(1)).foreach { stringType =>
+        val encoder = ExpressionEncoder[Int]()
+        val attributes = Seq(AttributeReference("value", stringType)())
+        val deserializer = encoder.resolveAndBind(attributes).createDeserializer()
+        assert(deserializer(InternalRow(UTF8String.fromString("1"))) === 1)
+      }
+    }
   }
 
   test("real type doesn't match encoder schema but they are compatible: nested product") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSubquerySuite.scala
@@ -23,7 +23,8 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.optimizer.ReusableBroadcastValueProjection
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint, LocalRelation, Project}
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{CharType, IntegerType, TimestampType, VarcharType}
+import org.apache.spark.unsafe.types.UTF8String
 
 class DynamicPruningSubquerySuite extends SparkFunSuite {
   private val pruningKeyExpression = Literal(1)
@@ -185,5 +186,45 @@ class DynamicPruningSubquerySuite extends SparkFunSuite {
     val nullSafeJoin = Join(
       left, right, Inner, Some(And(EqualNullSafe(leftKey, rightKey), residual)), JoinHint.NONE)
     assert(ReusableBroadcastValueProjection.find(leftValue, nullSafeJoin, excluded).isEmpty)
+  }
+
+  test("SPARK-59112: extract broadcast values from CHAR/VARCHAR attributes") {
+    Seq(CharType(4), VarcharType(4)).foreach { stringType =>
+      val leftKey = AttributeReference("left_key", IntegerType)()
+      val leftValue = AttributeReference("left_value", stringType)()
+      val rightKey = AttributeReference("right_key", IntegerType)()
+      val rightValue = AttributeReference("right_value", stringType)()
+      val left = LocalRelation(leftKey, leftValue)
+      val right = LocalRelation(rightKey, rightValue)
+      val excluded = LocalRelation(AttributeReference("excluded", IntegerType)())
+      val join = Join(
+        left,
+        right,
+        Inner,
+        Some(And(EqualTo(leftKey, rightKey), LessThanOrEqual(leftValue, rightValue))),
+        JoinHint.NONE)
+
+      assert(ReusableBroadcastValueProjection.find(leftValue, join, excluded).contains(
+        BroadcastValueProjection(left, Seq(leftKey), leftValue)))
+      assert(ReusableBroadcastValueProjection.find(rightValue, join, excluded).contains(
+        BroadcastValueProjection(right, Seq(rightKey), rightValue)))
+    }
+  }
+
+  test("SPARK-59112: extract date formats with CHAR/VARCHAR format literals") {
+    Seq(CharType(4), VarcharType(4)).foreach { stringType =>
+      val leftKey = AttributeReference("left_key", IntegerType)()
+      val timestamp = AttributeReference("timestamp", TimestampType)()
+      val rightKey = AttributeReference("right_key", IntegerType)()
+      val left = LocalRelation(leftKey, timestamp)
+      val right = LocalRelation(rightKey)
+      val excluded = LocalRelation(AttributeReference("excluded", IntegerType)())
+      val join = Join(left, right, Inner, Some(EqualTo(leftKey, rightKey)), JoinHint.NONE)
+      val format = Literal.create(UTF8String.fromString("yyyy"), stringType)
+      val value = DateFormatClass(timestamp, format, Some("UTC"))
+
+      assert(ReusableBroadcastValueProjection.find(value, join, excluded).contains(
+        BroadcastValueProjection(left, Seq(leftKey), value)))
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
@@ -26,7 +26,9 @@ import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, 
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_MINUTE
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{instantToMicros, localDateTimeToMicros}
-import org.apache.spark.sql.types.{AtomicType, DateType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 class SpecialDatetimeValuesSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
@@ -73,6 +75,28 @@ class SpecialDatetimeValuesSuite extends PlanTest {
     val cast = Cast(Literal("2021-01-01"), DateType, Some("UTC"))
     assert(SpecialDatetimeValues.applyForExpression(cast) == cast)
     assert(SpecialDatetimeValues.applyForExpression(Literal(1)) == Literal(1))
+  }
+
+  test("SPARK-59112: special datetime values from CHAR/VARCHAR") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val stringTypes = Seq(CharType(10), VarcharType(10))
+      val datetimeTypes = Seq(DateType, TimestampType, TimestampNTZType)
+      val expressions = for {
+        stringType <- stringTypes
+        datetimeType <- datetimeTypes
+      } yield {
+        val value = if (stringType.isInstanceOf[CharType]) "epoch     " else "epoch"
+        Alias(
+          Cast(
+            Literal.create(UTF8String.fromString(value), stringType),
+            datetimeType,
+            Some("UTC")),
+          "v")()
+      }
+      val plan = Optimize.execute(Project(expressions, LocalRelation()))
+
+      assert(plan.expressions.flatMap(_.collect { case cast: Cast => cast }).isEmpty)
+    }
   }
 
   private def testSpecialTs(tsType: AtomicType, expected: Set[Long], zoneId: ZoneId): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -258,6 +258,15 @@ class ExpressionParserSuite extends AnalysisTest {
     assertEqual("a not like all ('foo%', 'b%')", $"a" notLikeAll("foo%", "b%"))
     assertEqual("not (a like all ('foo%', 'b%'))", !($"a" likeAll("foo%", "b%")))
 
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      assertEqual(
+        "a like any (cast('foo%' as char(4)), cast('b%' as varchar(2)))",
+        $"a" likeAny("foo%", "b%"))
+      assertEqual(
+        "a like all (cast('foo%' as varchar(4)), cast('b%' as char(2)))",
+        $"a" likeAll("foo%", "b%"))
+    }
+
     Seq("any", "some", "all").foreach { quantifier =>
       checkError(
         exception = parseException(s"a like $quantifier()"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLRegexpSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLRegexpSuite.scala
@@ -349,6 +349,32 @@ class CollationSQLRegexpSuite
     }
   }
 
+  test("SPARK-59112: quantified ILIKE preserves null CHAR/VARCHAR patterns") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      Seq("CHAR(3)", "VARCHAR(3)").foreach { dataType =>
+        checkAnswer(
+          sql(s"SELECT 'foo' ILIKE ANY (CAST(NULL AS $dataType), 'f%')"),
+          Row(true))
+        checkAnswer(
+          sql(s"SELECT 'foo' ILIKE ALL ('f%', CAST(NULL AS $dataType))"),
+          Row(null))
+      }
+    }
+  }
+
+  test("SPARK-59112: explicit binary quantified patterns use balanced trees") {
+    val patterns = Seq.fill(2048)("'z%' COLLATE UTF8_BINARY").mkString(", ")
+    Seq("LIKE", "ILIKE").foreach { operator =>
+      Seq("ANY", "SOME", "ALL").foreach { quantifier =>
+        Seq("" -> false, "NOT " -> true).foreach { case (not, expected) =>
+          checkAnswer(
+            sql(s"SELECT 'foo' $not$operator $quantifier ($patterns)"),
+            Row(expected))
+        }
+      }
+    }
+  }
+
   test("Support RLike string expression with collation") {
     // Supported collations
     case class RLikeTestCase[R](l: String, r: String, c: String, result: R)

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLRegexpSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLRegexpSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.collation
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, StringType}
 
@@ -320,6 +321,32 @@ class CollationSQLRegexpSuite
           stop = 63)
       )
     })
+  }
+
+  test("SPARK-59112: quantified LIKE preserves pattern-side collation") {
+    Seq("LIKE", "ILIKE").foreach { operator =>
+      Seq("ANY", "SOME", "ALL").foreach { quantifier =>
+        val pattern = "'foo%' COLLATE UTF8_LCASE"
+        val predicate =
+          s"'FOO' $operator $quantifier ($pattern)"
+        val expected = sql(s"SELECT 'FOO' $operator ($pattern)").head().getBoolean(0)
+        checkAnswer(sql(s"SELECT $predicate"), Row(expected))
+        checkAnswer(sql(s"SELECT NOT ($predicate)"), Row(!expected))
+
+        withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+          Seq("CHAR(4)", "VARCHAR(4)").foreach { dataType =>
+            val charVarcharPattern =
+              s"CAST('foo%' AS $dataType COLLATE UTF8_LCASE)"
+            val charVarcharPredicate =
+              s"'FOO' $operator $quantifier " +
+                s"($charVarcharPattern)"
+            val charVarcharExpected =
+              sql(s"SELECT 'FOO' $operator ($charVarcharPattern)").head().getBoolean(0)
+            checkAnswer(sql(s"SELECT $charVarcharPredicate"), Row(charVarcharExpected))
+          }
+        }
+      }
+    }
   }
 
   test("Support RLike string expression with collation") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

`CharType` and `VarcharType` extend `StringType`, but equality includes the length constraint, so `dt == StringType` and `case StringType =>` match only unconstrained STRING. Under `spark.sql.charVarchar.standardSemantics.enabled`, first-class CHAR/VARCHAR therefore miss several production paths that already accept STRING.

This PR replaces those exact matches with string-family checks (`isInstanceOf[StringType]` / `case _: StringType`) at:

- `UpCastResolution` (legacy loose Dataset upcast)
- `SpecialDatetimeValues` (foldable `CAST(... AS DATE/TIMESTAMP)`)
- `AstBuilder` LIKE ANY/ALL (`LikeAny` / `LikeAll` for foldable CHAR/VARCHAR patterns)
- `ReusableBroadcastValueProjection` (UTF8 attributes and date-format literals)
- `from_protobuf` / `to_protobuf` 3-arg descriptor routing
- `ProtobufSerializer` STRING / ENUM / `StringValue` fields

Exact `== StringType` is left in place where unconstrained STRING is intentional (for example annotated-STRING `SimplifyCasts`, `StringHelper.isPlainString`, JDBC dialect mapping, default-collation STRING).

Variant UUID-to-string is not changed: `VariantGet.checkDataType` already rejects CHAR/VARCHAR, so that equality is unreachable and widening it would skip length enforcement.

### Why are the changes needed?

Without the family match, CHAR/VARCHAR skip STRING-only branches: special datetime strings are not folded, LIKE ANY/ALL miss the `LikeAny`/`LikeAll` plan, DPP broadcast projection is skipped, protobuf descriptor paths are dropped, and `to_protobuf` cannot serialize CHAR/VARCHAR string fields.

This is the remaining OSS exact-`StringType` slice of [SPARK-58794](https://issues.apache.org/jira/browse/SPARK-58794).

### Does this PR introduce _any_ user-facing change?

Yes. First-class CHAR/VARCHAR follow the STRING branches above when either `spark.sql.charVarchar.standardSemantics.enabled` or the experimental `spark.sql.preserveCharVarcharTypeInfo` mode makes those types visible. The widened family checks also cover collated STRING where the branch accepts every string subtype. Quantified LIKE keeps explicitly collated patterns on the ordinary expansion path, and Protobuf retains literal-only routing for ordinary STRING/BINARY while additionally accepting foldable CHAR/VARCHAR descriptor expressions. `spark.sql.legacy.doLooseUpcast` also treats CHAR/VARCHAR like STRING for Dataset encoder upcast.

### How was this patch tested?

Added SPARK-59112 cases in:

- `EncoderResolutionSuite`
- `SpecialDatetimeValuesSuite`
- `ExpressionParserSuite`
- `CollationSQLRegexpSuite`
- `DynamicPruningSubquerySuite`
- `ProtobufDescriptorFileReadSuite`
- `ProtobufSerdeSuite`

Ran those suites plus Catalyst/protobuf scalastyle locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Grok 4.6