### PR TITLE
[SPARK-59114][SQL] ClassCastException while CachedRDDBuilder builds the buffers, with vectorized read flag toggled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -206,7 +206,9 @@ case class ColumnarToRowExec(child: SparkPlan)
   }
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
-    Seq(child.executeColumnar().asInstanceOf[RDD[InternalRow]]) // Hack because of type erasure
+    // SPARK-59114: We are in the ColumnToRowExec node, which implies that the underlying child
+    // should always return and RDD of ColumnarBatch (assuming batch is supported by the scan)
+     Seq(child.executeColumnar().asInstanceOf[RDD[InternalRow]]) // Hack because of type erasure
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ColumnarToRowExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -738,7 +738,7 @@ case class FileSourceScanExec(
     val requiredWholeStageCodegenSettings =
       conf.wholeStageEnabled && !WholeStageCodegenExec.isTooManyFields(conf, schema)
     requiredWholeStageCodegenSettings &&
-      relation.fileFormat.supportBatch(relation.sparkSession, schema)
+      relation.fileFormat.supportBatch(relation.sparkSession, schema, strictlyColumnar = false)
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {
@@ -749,7 +749,15 @@ case class FileSourceScanExec(
     }
   }
 
-  lazy val inputRDD: RDD[InternalRow] = {
+  lazy val inputRDD: RDD[InternalRow] = createInputRDD(strictlyColumnar = false)
+
+  lazy val inputRDDStrictlyColumnar: RDD[InternalRow] = createInputRDD(strictlyColumnar = true)
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    inputRDD :: Nil
+  }
+
+  private def createInputRDD(strictlyColumnar: Boolean): RDD[InternalRow] = {
     val options = relation.options +
       (FileFormat.OPTION_RETURNING_BATCH -> supportsColumnar.toString)
     val readFile: (PartitionedFile) => Iterator[InternalRow] =
@@ -760,7 +768,8 @@ case class FileSourceScanExec(
         requiredSchema = requiredSchema,
         filters = pushedDownFilters,
         options = options,
-        hadoopConf = getHadoopConf(relation.sparkSession, relation.options))
+        hadoopConf = getHadoopConf(relation.sparkSession, relation.options),
+        strictlyColumnar)
 
     val readRDD = if (bucketedScan) {
       createBucketedReadRDD(relation.bucketSpec.get, readFile, dynamicallySelectedPartitions)
@@ -771,9 +780,15 @@ case class FileSourceScanExec(
     readRDD
   }
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
-    inputRDD :: Nil
-  }
+  /**
+   * The input RDD, coalesced to a single partition when this scan runs in single-task mode. This
+   * enforces the `SinglePartition` output partitioning reported by `outputPartitioning`, which is
+   * estimated from the statically-selected files and may not correspond exactly to the number of
+   * partitions the input RDD produces after dynamic pruning. Coalescing here keeps the query
+   * correct in either case.
+   */
+  private[spark] lazy val maybeCoalesceInputRDD: RDD[InternalRow] =
+    createMaybeCoalesceInputRDD(inputRDD)
 
   /**
    * The input RDD, coalesced to a single partition when this scan runs in single-task mode. This
@@ -782,14 +797,17 @@ case class FileSourceScanExec(
    * partitions the input RDD produces after dynamic pruning. Coalescing here keeps the query
    * correct in either case.
    */
-  private[spark] lazy val maybeCoalesceInputRDD: RDD[InternalRow] = {
-    if (useSingleTaskExecution && inputRDD.getNumPartitions > 1) {
-      inputRDD.coalesce(1)
-    } else if (useSingleTaskExecution && inputRDD.getNumPartitions == 0) {
+  private[spark] lazy val maybeCoalesceStrictlyColumnarInputRDD: RDD[InternalRow] =
+    createMaybeCoalesceInputRDD(inputRDDStrictlyColumnar)
+
+  private def createMaybeCoalesceInputRDD(rdd: RDD[InternalRow]) : RDD[InternalRow] = {
+    if (useSingleTaskExecution && rdd.getNumPartitions > 1) {
+      rdd.coalesce(1)
+    } else if (useSingleTaskExecution && rdd.getNumPartitions == 0) {
       // All files were pruned away; produce a single empty partition to match `SinglePartition`.
       sparkContext.parallelize[InternalRow](Nil, 1)
     } else {
-      inputRDD
+      rdd
     }
   }
 
@@ -817,7 +835,8 @@ case class FileSourceScanExec(
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val numOutputRows = longMetric("numOutputRows")
     val scanTime = longMetric("scanTime")
-    maybeCoalesceInputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal { batches =>
+    maybeCoalesceStrictlyColumnarInputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal {
+      batches =>
       new Iterator[ColumnarBatch] {
 
         override def hasNext: Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -138,7 +138,7 @@ trait FileFormat {
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration,
-      strictlyColumnar: Boolean,
+      strictlyColumnar: Boolean
       ): PartitionedFile => Iterator[InternalRow] = {
     val dataReader = buildReader(
       sparkSession, dataSchema, partitionSchema, requiredSchema, filters, options, hadoopConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -69,7 +69,11 @@ trait FileFormat {
    *
    * TODO: we should just have different traits for the different formats.
    */
-  def supportBatch(sparkSession: SparkSession, dataSchema: StructType): Boolean = {
+  def supportBatch(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      strictlyColumnar: Boolean): Boolean = {
+    assert(!strictlyColumnar)
     false
   }
 
@@ -133,7 +137,9 @@ trait FileFormat {
       requiredSchema: StructType,
       filters: Seq[Filter],
       options: Map[String, String],
-      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+      hadoopConf: Configuration,
+      strictlyColumnar: Boolean,
+      ): PartitionedFile => Iterator[InternalRow] = {
     val dataReader = buildReader(
       sparkSession, dataSchema, partitionSchema, requiredSchema, filters, options, hadoopConf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -220,7 +220,7 @@ class OrcFileFormat
         val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
         val taskAttemptContext = new TaskAttemptContextImpl(taskConf, attemptId)
 
-        if (enableVectorizedReader || strictlyColumnar) {
+        if (enableVectorizedReader) {
           val batchReader = new OrcColumnarBatchReader(capacity, memoryMode)
           // SPARK-23399 Register a task completion listener first to call `close()` in all cases.
           // There is a possibility that `initialize` and `initBatch` hit some errors (like OOM)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -108,9 +108,12 @@ class OrcFileFormat
     }
   }
 
-  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
+  override def supportBatch(
+      sparkSession: SparkSession,
+      schema: StructType,
+      strictlyColumnar: Boolean): Boolean = {
     val sqlConf = getSqlConf(sparkSession)
-    sqlConf.orcVectorizedReaderEnabled &&
+    (sqlConf.orcVectorizedReaderEnabled || strictlyColumnar) &&
       schema.forall(s => OrcUtils.supportColumnarReads(
         s.dataType, sqlConf.orcVectorizedReaderNestedColumnEnabled))
   }
@@ -145,7 +148,8 @@ class OrcFileFormat
       requiredSchema: StructType,
       filters: Seq[Filter],
       options: Map[String, String],
-      hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+      hadoopConf: Configuration,
+      strictlyColumnar: Boolean): (PartitionedFile) => Iterator[InternalRow] = {
 
     val resultSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
     val sqlConf = getSqlConf(sparkSession)
@@ -153,7 +157,7 @@ class OrcFileFormat
 
     // Should always be set by FileSourceScanExec creating this.
     // Check conf before checking option, to allow working around an issue by changing conf.
-    val enableVectorizedReader = sqlConf.orcVectorizedReaderEnabled &&
+    val enableVectorizedReader = (sqlConf.orcVectorizedReaderEnabled || strictlyColumnar) &&
       options.getOrElse(FileFormat.OPTION_RETURNING_BATCH,
         throw new IllegalArgumentException(
           "OPTION_RETURNING_BATCH should always be set for OrcFileFormat. " +
@@ -162,7 +166,7 @@ class OrcFileFormat
     if (enableVectorizedReader) {
       // If the passed option said that we are to return batches, we need to also be able to
       // do this based on config and resultSchema.
-      assert(supportBatch(sparkSession, resultSchema))
+      assert(supportBatch(sparkSession, resultSchema, strictlyColumnar))
     }
 
     val memoryMode = if (sqlConf.offHeapColumnVectorEnabled) {
@@ -216,7 +220,7 @@ class OrcFileFormat
         val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
         val taskAttemptContext = new TaskAttemptContextImpl(taskConf, attemptId)
 
-        if (enableVectorizedReader) {
+        if (enableVectorizedReader || strictlyColumnar) {
           val batchReader = new OrcColumnarBatchReader(capacity, memoryMode)
           // SPARK-23399 Register a task completion listener first to call `close()` in all cases.
           // There is a possibility that `initialize` and `initBatch` hit some errors (like OOM)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -97,8 +97,11 @@ class ParquetFileFormat
   /**
    * Returns whether the reader can return the rows as batch or not.
    */
-  override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
-    ParquetUtils.isBatchReadSupportedForSchema(getSqlConf(sparkSession), schema)
+  override def supportBatch(
+      sparkSession: SparkSession,
+      schema: StructType,
+      strictlyColumnar: Boolean): Boolean = {
+    ParquetUtils.isBatchReadSupportedForSchema(getSqlConf(sparkSession), schema, strictlyColumnar)
   }
 
   override def vectorTypes(
@@ -186,7 +189,8 @@ class ParquetFileFormat
       requiredSchema: StructType,
       filters: Seq[Filter],
       options: Map[String, String],
-      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+      hadoopConf: Configuration,
+      strictlyColumnar: Boolean): PartitionedFile => Iterator[InternalRow] = {
     val sqlConf = getSqlConf(sparkSession)
     setupHadoopConf(hadoopConf, sqlConf, requiredSchema)
 
@@ -199,7 +203,7 @@ class ParquetFileFormat
     val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
     val enableOffHeapColumnVector = sqlConf.offHeapColumnVectorEnabled
     val enableVectorizedReader: Boolean =
-      ParquetUtils.isBatchReadSupportedForSchema(sqlConf, resultSchema)
+      ParquetUtils.isBatchReadSupportedForSchema(sqlConf, resultSchema, strictlyColumnar)
     val enableRecordFilter: Boolean = sqlConf.parquetRecordFilterEnabled
     val timestampConversion: Boolean = sqlConf.isParquetINT96TimestampConversion
     val capacity = sqlConf.parquetVectorizedReaderBatchSize
@@ -229,7 +233,7 @@ class ParquetFileFormat
 
     // Should always be set by FileSourceScanExec creating this.
     // Check conf before checking option, to allow working around an issue by changing conf.
-    val returningBatch = sqlConf.parquetVectorizedReaderEnabled &&
+    val returningBatch = (sqlConf.parquetVectorizedReaderEnabled || strictlyColumnar) &&
       options.getOrElse(FileFormat.OPTION_RETURNING_BATCH,
         throw new IllegalArgumentException(
           "OPTION_RETURNING_BATCH should always be set for ParquetFileFormat. " +
@@ -238,7 +242,7 @@ class ParquetFileFormat
     if (returningBatch) {
       // If the passed option said that we are to return batches, we need to also be able to
       // do this based on config and resultSchema.
-      assert(supportBatch(sparkSession, resultSchema))
+      assert(supportBatch(sparkSession, resultSchema, strictlyColumnar))
     }
 
     val readSingleFile: PartitionedFile => Iterator[InternalRow] = (file: PartitionedFile) => {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -206,8 +206,11 @@ object ParquetUtils extends Logging {
   /**
    * Whether columnar read is supported for the input `schema`.
    */
-  def isBatchReadSupportedForSchema(sqlConf: SQLConf, schema: StructType): Boolean =
-    sqlConf.parquetVectorizedReaderEnabled &&
+  def isBatchReadSupportedForSchema(
+      sqlConf: SQLConf,
+      schema: StructType,
+      strictlyColumnar: Boolean): Boolean =
+    (sqlConf.parquetVectorizedReaderEnabled || strictlyColumnar) &&
       schema.forall(f => isBatchReadSupported(sqlConf, f.dataType))
 
   def isBatchReadSupported(sqlConf: SQLConf, dt: DataType): Boolean =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetPartitionReaderFactory.scala
@@ -71,7 +71,7 @@ case class ParquetPartitionReaderFactory(
   private val resultSchema = StructType(partitionSchema.fields ++ readDataSchema.fields)
   private val enableOffHeapColumnVector = sqlConf.offHeapColumnVectorEnabled
   private val enableVectorizedReader: Boolean =
-    ParquetUtils.isBatchReadSupportedForSchema(sqlConf, resultSchema)
+    ParquetUtils.isBatchReadSupportedForSchema(sqlConf, resultSchema, strictlyColumnar = false)
   private val supportsColumnar = enableVectorizedReader && sqlConf.wholeStageEnabled &&
     !WholeStageCodegenExec.isTooManyFields(sqlConf, resultSchema)
   private val enableRecordFilter: Boolean = sqlConf.parquetRecordFilterEnabled

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -2755,7 +2755,7 @@ class CachedTableSuite extends SharedSparkSession
             // since the cached buffers are lazily initialized, they will be empty
           }
           withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-            val df = spark.table(t1).where($"c1_2" > 10)
+            val df = spark.table(t1).select($"c1_1", $"c1_2").where($"c1_2" > 10)
             df.collect()
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -34,16 +34,11 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListe
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.AsOfVersion
 import org.apache.spark.sql.catalyst.analysis.TempTableAlreadyExistsException
-import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, GenericRow, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, Join, JoinStrategyHint, SHUFFLE_HASH}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
-import org.apache.spark.sql.connector.catalog.BasicInMemoryTableCatalog
-import org.apache.spark.sql.connector.catalog.CatalogPlugin
+import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, BufferedRows, CatalogPlugin, Identifier, InMemoryCatalog, TableWritePrivilege, TruncatableTable}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
-import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.connector.catalog.InMemoryCatalog
-import org.apache.spark.sql.connector.catalog.TableWritePrivilege
-import org.apache.spark.sql.connector.catalog.TruncatableTable
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ExecSubqueryExpression, RDDScanExec, SparkPlan, SparkPlanInfo}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEPropagateEmptyRelation}
 import org.apache.spark.sql.execution.columnar._
@@ -2727,6 +2722,46 @@ class CachedTableSuite extends SharedSparkSession
     }
   }
 
+  test("SPARK-59114: Class Cast Exception when disabling vectorized read after caching relation") {
+    def createCachedTable(
+        tablename: String,
+        schema: StructType,
+        location: String): Unit = {
+      val data = new BufferedRows(Seq.empty, schema)
+      for (i <- 1 to 10) {
+        data.withRow(new GenericInternalRow (Array[Any](i, i * 2)))
+      }
+      val loc = s"$location/$tablename"
+      val rows = data.rows.map[Row](i => new GenericRow(i.toSeq(schema).toArray))
+      import scala.jdk.CollectionConverters._
+      val df = spark.createDataFrame(new util.LinkedList[Row](rows.asJavaCollection), schema)
+      df.write.mode(SaveMode.Overwrite).parquet(loc)
+      spark.sql(
+        s"""
+           |CREATE TABLE $tablename USING PARQUET LOCATION '$loc'
+           |""".stripMargin
+      )
+      spark.catalog.cacheTable(tablename)
+    }
+    val t1 = "t1"
+    val t1_schema = StructType.fromDDL("c1_1 INT, c1_2 INT")
+    withTempPath { location =>
+      withTable(t1) {
+        withCache(t1) {
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key-> "true") {
+            createCachedTable(t1, t1_schema, location.getPath)
+            // the cached plan will be created with FileScanExec node wrapped with ColumnToRowExec
+            // as the parquet vector read is enabled
+            // since the cached buffers are lazily initialized, they will be empty
+          }
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            val df = spark.table(t1).where($"c1_2" > 10)
+            df.collect()
+          }
+        }
+      }
+    }
+  }
   private def cacheManager = spark.sharedState.cacheManager
 
   private def pinTable(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -2723,7 +2723,6 @@ class CachedTableSuite extends SharedSparkSession
   }
 
   test("SPARK-59114: Class Cast Exception when disabling vectorized read after caching relation") {
-    sql("USE spark_catalog")
     def createCachedTable(
         tablename: String,
         schema: StructType,
@@ -2744,7 +2743,7 @@ class CachedTableSuite extends SharedSparkSession
       )
       spark.catalog.cacheTable(tablename)
     }
-    val t1 = "tbl_59114"
+    val t1 = "spark_catalog.default.tbl"
     val t1_schema = StructType.fromDDL("c1_1 INT, c1_2 INT")
     withTempPath { location =>
       withTable(t1) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -2723,6 +2723,7 @@ class CachedTableSuite extends SharedSparkSession
   }
 
   test("SPARK-59114: Class Cast Exception when disabling vectorized read after caching relation") {
+    sql("USE spark_catalog")
     def createCachedTable(
         tablename: String,
         schema: StructType,
@@ -2743,7 +2744,7 @@ class CachedTableSuite extends SharedSparkSession
       )
       spark.catalog.cacheTable(tablename)
     }
-    val t1 = "t1"
+    val t1 = "tbl_59114"
     val t1_schema = StructType.fromDDL("c1_1 INT, c1_2 INT")
     withTempPath { location =>
       withTable(t1) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -278,7 +278,8 @@ class BinaryFileFormatSuite extends SharedSparkSession {
         requiredSchema = schema,
         filters = filters,
         options = Map.empty,
-        hadoopConf = spark.sessionState.newHadoopConf())
+        hadoopConf = spark.sessionState.newHadoopConf(),
+        strictlyColumnar = false)
       val partitionedFile = mock(classOf[PartitionedFile])
       when(partitionedFile.toPath).thenReturn(fileStatus.getPath)
       assert(reader(partitionedFile).nonEmpty === expected,
@@ -304,7 +305,8 @@ class BinaryFileFormatSuite extends SharedSparkSession {
       requiredSchema = requiredSchema,
       filters = Seq.empty,
       options = Map.empty,
-      hadoopConf = spark.sessionState.newHadoopConf()
+      hadoopConf = spark.sessionState.newHadoopConf(),
+      strictlyColumnar = false
     )
     val partitionedFile = mock(classOf[PartitionedFile])
     when(partitionedFile.toPath).thenReturn(new Path(file.toURI))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -215,7 +215,8 @@ abstract class ParquetFileFormatSuite
           Seq(StructField("f1", IntegerType), StructField("f2", ArrayType(IntegerType))) -> enabled,
           Seq(StructField("f1", BooleanType), StructField("f2", testUDT)) -> enabled
         ).foreach { case (schema, expected) =>
-          assert(ParquetUtils.isBatchReadSupportedForSchema(conf, StructType(schema)) == expected)
+          assert(ParquetUtils.isBatchReadSupportedForSchema(conf, StructType(schema),
+            strictlyColumnar = false) == expected)
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the FileSourceScanExec, having two flavours of FileScanRDD .
1) The first one is the existing flavour which respects the boolean flag of enableParquetVectorRead or enableORCVectorRead and any other property in the SQLConf , present at the instant of execution.
2) The second flavour always overrides the flags of vector read as true, by using a boolean strictlyColumnar.
This RDD will always produce Columnar Output  and will be used when the invoking function needs a ColumnarBatchRow or ColumnarBatch. ( for eg when invoked from ColumnToRowExec)
 

### Why are the changes needed?
To fix the bug  SPARK-59114.  The issue is that if a table is cached , such that the cached plan is generated using default configs ( vector reads enabled), the FileSourceScanExec is wrapped rightly by ColumnToRowExec.
But if the query is executed later with vector read flag disabled, then at the time of building the cached plan's buffers, FileScanRDD outputs Row, instead of ColumnBatch, while the iterator in the buffer builder expects it to be ColumnBatch, resulting in ClassCastException.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
a new  bug test in CachedTableSuite is added.


### Was this patch authored or co-authored using generative AI tooling?
No