### PR TITLE
[SPARK-46306][PS] Fix LocIndexer to raise KeyError when index keys ar…

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -1211,6 +1211,17 @@ class LocIndexer(LocIndexerLike):
         elif self._internal.index_level == 1:
             index_column = self._psdf_or_psser.index.to_series()
             index_data_type = index_column.spark.data_type
+            sdf = self._internal.spark_frame
+            index_scol = index_column.spark.column
+            isin_cond = index_scol.isin(
+                [F.lit(r).cast(index_data_type) for r in rows_sel]
+            )
+            found_keys = {
+                row[0] for row in sdf.filter(isin_cond).select(index_scol).distinct().collect()
+            }
+            missing_keys = [r for r in rows_sel if r not in found_keys]
+            if len(missing_keys) > 0:
+                raise KeyError(f"{missing_keys} not in index")
             if len(rows_sel) == 1:
                 return (
                     index_column.spark.column == F.lit(rows_sel[0]).cast(index_data_type),

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -1222,6 +1222,7 @@ class LocIndexer(LocIndexerLike):
             missing_keys = [r for r in rows_sel if r not in found_keys]
             if len(missing_keys) > 0:
                 raise KeyError(f"{missing_keys} not in index")
+            
             if len(rows_sel) == 1:
                 return (
                     index_column.spark.column == F.lit(rows_sel[0]).cast(index_data_type),


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `pyspark.pandas`, selecting rows using `.loc[]` with a list-like key (e.g. `psdf.loc[[key1, key2]]`) delegates to an underlying Spark SQL `.isin()` filter. Because `.isin()` functions purely as a row filter, keys in the requested iterable that do not exist in the DataFrame index are silently discarded, and the matching subset is returned without any warning or error.

This behavior diverges from standard `pandas`, where passing a list of keys containing any missing key raises a `KeyError` (e.g. `KeyError: '[4] not in index'`).

An earlier attempt (PR #44236) attempted to resolve this by collecting all index values via `.tolist()` / `.drop_duplicates().to_pandas()`. However, collecting the full distributed index onto the driver causes severe network bottlenecks and leads to Driver Out-Of-Memory (OOM) errors on large datasets.

This PR introduces a distributed set-validation approach with a bounded memory footprint on the driver:

1. Filters the underlying Spark DataFrame using `index_col.isin(requested_keys)` and evaluates `.distinct().collect()` solely on the matched index column.
2. Because only keys present in `requested_keys` can match, the data transferred to the driver is strictly bounded by $O(K)$, where $K = |\mathrm{requested\_keys}| \ll N$.
3. Verifies set difference on the driver: `missing_keys = [k for k in requested_keys if k not in found_keys]`. If `missing_keys` is non-empty, a `KeyError` is raised, achieving parity with standard pandas behavior.

Fixes [\[SPARK-46306\]](https://issues.apache.org/jira/browse/SPARK-46306).

### Why are the changes needed?

To ensure API consistency and behavioral parity between `pyspark.pandas` and standard `pandas` when performing label-based indexing with missing keys, while avoiding driver OOM risks on large distributed datasets.

### Does this PR introduce *any* user-facing change?

Yes.

**Previous behavior:**

```python
psdf = ps.DataFrame({"A": [10, 20, 30]}, index=[1, 2, 3])
psdf.loc[[2, 4]]
# Returns:
#     A
# 2  20
# (Key 4 is silently ignored)

```

**New behavior:**

```python
psdf = ps.DataFrame({"A": [10, 20, 30]}, index=[1, 2, 3])
psdf.loc[[2, 4]]
# Raises: KeyError: '[4] not in index'

```

### How was this patch tested?

* Added unit tests in `python/pyspark/pandas/tests/indexes/test_indexing.py` covering:
* Indexing with fully existing keys.
* Indexing with partially missing keys (asserting `KeyError`).
* Indexing with entirely missing keys (asserting `KeyError`).
* Indexing with a single missing key in a list-like structure `[key]` (asserting `KeyError`).


* Verified existing indexing test suite passes locally.

### Was this patch authored or co-authored using generative AI tooling?

No.