### PR TITLE
[WIP][GRAPHX] Prototype GraphFrames GraphX fork changes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3921,8 +3921,8 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td><code>spark.graphx.pregel.checkpointInterval</code></td>
   <td>-1</td>
   <td>
-    Checkpoint interval for graph and message in Pregel. It used to avoid stackOverflowError due to long lineage chains
-  after lots of iterations. The checkpoint is disabled by default.
+    Checkpoint interval for the graph in Pregel. Message RDDs are not checkpointed. Graph
+    checkpointing is disabled by default.
   </td>
   <td>2.2.0</td>
 </tr>

--- a/docs/graphx-programming-guide.md
+++ b/docs/graphx-programming-guide.md
@@ -723,9 +723,9 @@ messages remaining.
 > messaging function.  These constraints allow additional optimization within GraphX.
 
 The following is the type signature of the [Pregel operator][GraphOps.pregel] as well as a *sketch*
-of its implementation (note: to avoid stackOverflowError due to long lineage chains, pregel support periodically
-checkpoint graph and messages by setting "spark.graphx.pregel.checkpointInterval" to a positive number,
-say 10. And set checkpoint directory as well using SparkContext.setCheckpointDir(directory: String)):
+of its implementation (note: Pregel supports periodically checkpointing the graph by setting
+"spark.graphx.pregel.checkpointInterval" to a positive number, say 10. Message RDDs are not
+checkpointed. Set a checkpoint directory using SparkContext.setCheckpointDir(directory: String)):
 
 {% highlight scala %}
 class GraphOps[VD, ED] {

--- a/graphx/src/main/scala/org/apache/spark/graphx/EdgeDirection.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/EdgeDirection.scala
@@ -30,6 +30,7 @@ class EdgeDirection private (private val name: String) extends Serializable {
     case EdgeDirection.Out => EdgeDirection.In
     case EdgeDirection.Either => EdgeDirection.Either
     case EdgeDirection.Both => EdgeDirection.Both
+    case _ => throw new IllegalArgumentException(s"Unknown edge direction: $this")
   }
 
   override def toString: String = "EdgeDirection." + name

--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -140,6 +140,7 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
       case EdgeDirection.Both =>
         throw new SparkException("collectEdges does not support EdgeDirection.Both. Use" +
           "EdgeDirection.Either instead.")
+      case _ => throw new SparkException("Unknown edge direction")
     }
     graph.vertices.leftJoin(nbrs) { (vid, vdata, nbrsOpt) =>
       nbrsOpt.getOrElse(Array.empty[(VertexId, VD)])
@@ -181,6 +182,7 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
       case EdgeDirection.Both =>
         throw new SparkException("collectEdges does not support EdgeDirection.Both. Use" +
           "EdgeDirection.Either instead.")
+      case _ => throw new SparkException("Unknown edge direction")
     }
   }
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/Pregel.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Pregel.scala
@@ -135,8 +135,9 @@ object Pregel extends Logging {
 
     // compute the messages
     var messages = GraphXUtils.mapReduceTriplets(g, sendMsg, mergeMsg)
+    // Disable periodic checkpoints for messages; the checkpointer still manages persistence.
     val messageCheckpointer = new PeriodicRDDCheckpointer[(VertexId, A)](
-      checkpointInterval, graph.vertices.sparkContext)
+      -1, graph.vertices.sparkContext)
     messageCheckpointer.update(messages.asInstanceOf[RDD[(VertexId, A)]])
     var isActiveMessagesNonEmpty = !messages.isEmpty()
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
@@ -191,7 +191,6 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
       tripletFields: TripletFields,
       activeSetOpt: Option[(VertexRDD[_], EdgeDirection)]): VertexRDD[A] = {
 
-    vertices.cache()
     // For each vertex, replicate its attribute only to partitions where it is
     // in the relevant position in an edge.
     replicatedVertexView.upgrade(vertices, tripletFields.useSrc, tripletFields.useDst)
@@ -250,7 +249,6 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
     // The implicit parameter eq will be populated by the compiler if VD and VD2 are equal, and left
     // null if not
     if (eq != null) {
-      vertices.cache()
       // updateF preserves type, so we can use incremental replication
       val newVerts = vertices.leftJoin(other)(updateF).cache()
       val changedVerts = vertices.asInstanceOf[VertexRDD[VD2]].diff(newVerts)
@@ -316,13 +314,9 @@ object GraphImpl {
   def apply[VD: ClassTag, ED: ClassTag](
       vertices: VertexRDD[VD],
       edges: EdgeRDD[ED]): GraphImpl[VD, ED] = {
-
-    vertices.cache()
-
     // Convert the vertex partitions in edges to the correct type
     val newEdges = edges.asInstanceOf[EdgeRDDImpl[ED, _]]
       .mapEdgePartitions((pid, part) => part.withoutVertexAttributes[VD]())
-      .cache()
 
     GraphImpl.fromExistingRDDs(vertices, newEdges)
   }
@@ -347,11 +341,11 @@ object GraphImpl {
       defaultVertexAttr: VD,
       edgeStorageLevel: StorageLevel,
       vertexStorageLevel: StorageLevel): GraphImpl[VD, ED] = {
-    val edgesCached = edges.withTargetStorageLevel(edgeStorageLevel).cache()
+    val targetEdges = edges.withTargetStorageLevel(edgeStorageLevel)
     val vertices =
-      VertexRDD.fromEdges(edgesCached, edgesCached.partitions.length, defaultVertexAttr)
+      VertexRDD.fromEdges(targetEdges, targetEdges.partitions.length, defaultVertexAttr)
       .withTargetStorageLevel(vertexStorageLevel)
-    fromExistingRDDs(vertices, edgesCached)
+    fromExistingRDDs(vertices, targetEdges)
   }
 
 } // end of object GraphImpl

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.graphx.lib
 
-import scala.collection.{mutable, Map}
 import scala.reflect.ClassTag
 
 import org.apache.spark.graphx._
@@ -47,24 +46,20 @@ object LabelPropagation {
     require(maxSteps > 0, s"Maximum of steps must be greater than 0, but got ${maxSteps}")
 
     val lpaGraph = graph.mapVertices { case (vid, _) => vid }
-    def sendMessage(e: EdgeTriplet[VertexId, ED]): Iterator[(VertexId, Map[VertexId, Long])] = {
-      Iterator((e.srcId, Map(e.dstAttr -> 1L)), (e.dstId, Map(e.srcAttr -> 1L)))
+    def sendMessage(e: EdgeTriplet[VertexId, ED]): Iterator[(VertexId, Vector[VertexId])] = {
+      Iterator((e.srcId, Vector(e.dstAttr)), (e.dstId, Vector(e.srcAttr)))
     }
-    def mergeMessage(count1: Map[VertexId, Long], count2: Map[VertexId, Long])
-      : Map[VertexId, Long] = {
-      // Mimics the optimization of breakOut, not present in Scala 2.13, while working in 2.12
-      val map = mutable.Map[VertexId, Long]()
-      (count1.keySet ++ count2.keySet).foreach { i =>
-        val count1Val = count1.getOrElse(i, 0L)
-        val count2Val = count2.getOrElse(i, 0L)
-        map.put(i, count1Val + count2Val)
+    def mergeMessage(
+        left: Vector[VertexId],
+        right: Vector[VertexId]): Vector[VertexId] = left ++ right
+    def vertexProgram(vid: VertexId, attr: Long, message: Vector[VertexId]): VertexId = {
+      if (message.isEmpty) {
+        attr
+      } else {
+        message.groupBy(identity).minBy { case (label, labels) => (-labels.size, label) }._1
       }
-      map
     }
-    def vertexProgram(vid: VertexId, attr: Long, message: Map[VertexId, Long]): VertexId = {
-      if (message.isEmpty) attr else message.maxBy(_._2)._1
-    }
-    val initialMessage = Map[VertexId, Long]()
+    val initialMessage = Vector.empty[VertexId]
     Pregel(lpaGraph, initialMessage, maxIterations = maxSteps)(
       vprog = vertexProgram,
       sendMsg = sendMessage,

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/ShortestPaths.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/ShortestPaths.scala
@@ -56,7 +56,22 @@ object ShortestPaths extends Serializable {
    * each reachable landmark vertex.
    */
   def run[VD, ED: ClassTag](graph: Graph[VD, ED], landmarks: Seq[VertexId]): Graph[SPMap, ED] = {
-    val spGraph = graph.mapVertices { (vid, attr) =>
+    run(graph, landmarks, isDirected = true)
+  }
+
+  /**
+   * Computes shortest paths to the given set of landmark vertices.
+   *
+   * @param graph the graph for which to compute the shortest paths
+   * @param landmarks the list of landmark vertex ids. Shortest paths will be computed to each
+   * landmark.
+   * @param isDirected whether paths must follow the direction of each edge
+   */
+  def run[VD, ED: ClassTag](
+      graph: Graph[VD, ED],
+      landmarks: Seq[VertexId],
+      isDirected: Boolean): Graph[SPMap, ED] = {
+    val spGraph = graph.mapVertices { (vid, _) =>
       if (landmarks.contains(vid)) makeMap(vid -> 0) else makeMap()
     }
 
@@ -67,9 +82,20 @@ object ShortestPaths extends Serializable {
     }
 
     def sendMessage(edge: EdgeTriplet[SPMap, _]): Iterator[(VertexId, SPMap)] = {
-      val newAttr = incrementMap(edge.dstAttr)
-      if (edge.srcAttr != addMaps(newAttr, edge.srcAttr)) Iterator((edge.srcId, newAttr))
-      else Iterator.empty
+      val toSrc = incrementMap(edge.dstAttr)
+      val srcMessage =
+        if (edge.srcAttr != addMaps(toSrc, edge.srcAttr)) Iterator((edge.srcId, toSrc))
+        else Iterator.empty
+
+      if (isDirected) {
+        srcMessage
+      } else {
+        val toDst = incrementMap(edge.srcAttr)
+        val dstMessage =
+          if (edge.dstAttr != addMaps(toDst, edge.dstAttr)) Iterator((edge.dstId, toDst))
+          else Iterator.empty
+        srcMessage ++ dstMessage
+      }
     }
 
     Pregel(spGraph, initialMessage)(vertexProgram, sendMessage, addMaps)

--- a/graphx/src/test/scala/org/apache/spark/graphx/GraphSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/GraphSuite.scala
@@ -360,11 +360,45 @@ class GraphSuite extends SparkFunSuite with LocalSparkContext {
       val verts = sc.parallelize(List((1: VertexId, "a"), (2: VertexId, "b")), 1)
       val edges = sc.parallelize(List(Edge(1, 2, 0), Edge(2, 1, 0)), 2)
       val graph = Graph(verts, edges, "", StorageLevel.MEMORY_ONLY, StorageLevel.MEMORY_ONLY)
-      // Note: Before caching, graph.vertices is cached, but graph.edges is not (but graph.edges'
-      //       parent RDD is cached).
+      assert(graph.vertices.getStorageLevel == StorageLevel.NONE)
+      assert(graph.edges.getStorageLevel == StorageLevel.NONE)
       graph.cache()
       assert(graph.vertices.getStorageLevel == StorageLevel.MEMORY_ONLY)
       assert(graph.edges.getStorageLevel == StorageLevel.MEMORY_ONLY)
+    }
+  }
+
+  test("selected graph construction and transformation paths avoid implicit persistence") {
+    withSpark { sc =>
+      def newGraph(): Graph[Int, Int] = {
+        val vertices = sc.parallelize(Seq((1L, 1), (2L, 2)))
+        val edges = sc.parallelize(Seq(Edge(1L, 2L, 1)))
+        Graph(vertices, edges)
+      }
+
+      val fromEdges = Graph.fromEdges(sc.parallelize(Seq(Edge(1L, 2L, 1))), 1)
+      fromEdges.vertices.count()
+      fromEdges.edges.count()
+      assert(fromEdges.vertices.getStorageLevel == StorageLevel.NONE)
+      assert(fromEdges.edges.getStorageLevel == StorageLevel.NONE)
+
+      val aggregateInput = newGraph()
+      aggregateInput.aggregateMessages[Int](_.sendToDst(1), _ + _).count()
+      assert(aggregateInput.vertices.getStorageLevel == StorageLevel.NONE)
+
+      val joinInput = newGraph()
+      val joined = joinInput.outerJoinVertices(sc.parallelize(Seq((1L, 1)))) {
+        (_, value, update) => value + update.getOrElse(0)
+      }
+      joined.vertices.count()
+      assert(joinInput.vertices.getStorageLevel == StorageLevel.NONE)
+      joined.unpersist()
+
+      val mapped = newGraph().mapVertices((_, value) => value.toString)
+      mapped.vertices.count()
+      mapped.edges.count()
+      assert(mapped.vertices.getStorageLevel == StorageLevel.NONE)
+      assert(mapped.edges.getStorageLevel == StorageLevel.NONE)
     }
   }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LabelPropagationSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LabelPropagationSuite.scala
@@ -41,4 +41,16 @@ class LabelPropagationSuite extends SparkFunSuite with LocalSparkContext {
       assert(clique1Labels(0) != clique2Labels(0))
     }
   }
+
+  test("Label Propagation chooses the smallest label when counts are tied") {
+    withSpark { sc =>
+      val graph = Graph.fromEdges(
+        sc.parallelize(Seq(Edge(0L, 16L, 1), Edge(0L, 1L, 1))),
+        defaultValue = 1)
+
+      val labels = LabelPropagation.run(graph, maxSteps = 1).vertices.collect().toMap
+
+      assert(labels(0L) === 1L)
+    }
+  }
 }

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/ShortestPathsSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/ShortestPathsSuite.scala
@@ -40,4 +40,22 @@ class ShortestPathsSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  test("directed and undirected shortest paths") {
+    withSpark { sc =>
+      val graph = Graph.fromEdges(sc.parallelize(Seq(Edge(1L, 2L, 1))), defaultValue = 1)
+      val landmarks = Seq(1L)
+
+      val directed = ShortestPaths.run(graph, landmarks, isDirected = true)
+        .vertices.collect().map { case (id, distances) => id -> distances.toMap }.toMap
+      val defaultDirection = ShortestPaths.run(graph, landmarks)
+        .vertices.collect().map { case (id, distances) => id -> distances.toMap }.toMap
+      val undirected = ShortestPaths.run(graph, landmarks, isDirected = false)
+        .vertices.collect().map { case (id, distances) => id -> distances.toMap }.toMap
+
+      assert(directed === Map(1L -> Map(1L -> 0), 2L -> Map.empty[Long, Int]))
+      assert(defaultDirection === directed)
+      assert(undirected === Map(1L -> Map(1L -> 0), 2L -> Map(1L -> 1)))
+    }
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This exploratory draft ports the material runtime differences from GraphFrames' namespaced GraphX fork back onto canonical GraphX so that the changes can be reviewed directly:

- use vector messages in label propagation and resolve equal-frequency labels deterministically by choosing the smallest label;
- remove five implicit `cache()` calls from selected graph construction, aggregation, and join paths;
- retain Pregel's message persistence management but disable periodic message-RDD checkpoints;
- add directed and undirected shortest paths while preserving the existing two-argument JVM method;
- explicitly reject unknown `EdgeDirection` values in three match expressions.

It also adds focused label-propagation, shortest-path, and persistence tests, and updates the Pregel checkpoint documentation.

This does not vendor GraphFrames' GraphX copy. It deliberately retains canonical Spark's logging and newer SVD++ correctness fix, and leaves GraphFrames-specific conversion/unpersist handling in #58302.

Provenance:

- GraphX copy: https://github.com/graphframes/graphframes/pull/680
- label propagation: https://github.com/graphframes/graphframes/pull/681
- persistence/checkpoint changes: https://github.com/graphframes/graphframes/pull/687
- shortest-path direction: https://github.com/graphframes/graphframes/pull/737

### Why are the changes needed?

This is a companion prototype for #58302. Its purpose is to make the private-fork delta visible and independently reviewable; it is not a claim that all of these changes should merge together as-is.

Important questions remain:

- vector label messages retain every neighbor label and violate the stated commutative merge contract, so their shuffle/memory behavior needs benchmarking against the current count maps;
- removing implicit persistence can prevent retained-RDD leaks but can also increase recomputation and changes observable storage behavior;
- graph checkpointing does not obviously truncate the separate active-message dependency, so disabling message checkpoints needs long-lineage validation before merge.

### Does this PR introduce _any_ user-facing change?

Yes. It adds an undirected shortest-path overload, makes label-propagation ties deterministic, changes implicit GraphX persistence, and changes `spark.graphx.pregel.checkpointInterval` to checkpoint only graph RDDs.

### How was this patch tested?

- `./build/sbt graphx/test` (113 tests passed)
- `./dev/lint-scala`
- `git diff --check`

The Pregel checkpoint change does not yet have a direct long-lineage regression test; that is intentionally called out as follow-up work for this exploratory draft.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
