### PR TITLE
[SPARK-41416][SQL] Rewrite existence-only inequality self-joins as MIN/MAX

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -669,6 +669,18 @@ object SQLConf {
         "for using switch statements in InSet must be non-negative and less than or equal to 600")
       .createWithDefault(400)
 
+  val REWRITE_SELF_JOIN_INEQUALITY_TO_AGGREGATE_ENABLED =
+    buildConf("spark.sql.optimizer.rewriteSelfJoinInequalityToAggregate.enabled")
+      .internal()
+      .doc("When true, rewrites a supported existence-only inequality self-join inside an " +
+        "uncorrelated IN subquery into a GROUP BY with HAVING COUNT(DISTINCT) > 1 over a single " +
+        "copy of the relation, removing the self-join cross-product. The rewrite fails closed " +
+        "unless the self-join sides are proven to be the same repeatable relation.")
+      .version("4.4.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(false)
+
   private val VALID_LOG_LEVELS: Array[String] = Level.values.map(_.toString)
 
   val PLAN_CHANGE_LOG_LEVEL = buildConf("spark.sql.planChangeLog.level")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -673,9 +673,14 @@ object SQLConf {
     buildConf("spark.sql.optimizer.rewriteSelfJoinInequalityToAggregate.enabled")
       .internal()
       .doc("When true, rewrites a supported existence-only inequality self-join inside an " +
-        "uncorrelated IN subquery into a GROUP BY with HAVING COUNT(DISTINCT) > 1 over a single " +
+        "uncorrelated IN subquery into a GROUP BY with HAVING MIN(v) <> MAX(v) over a single " +
         "copy of the relation, removing the self-join cross-product. The rewrite fails closed " +
-        "unless the self-join sides are proven to be the same repeatable relation.")
+        "unless the self-join sides are proven to read the same repeatable source -- currently " +
+        "stock Parquet scans, Range, and local relations -- so it never changes results for " +
+        "non-repeatable inputs. This is experimental and off by default: there is no cost " +
+        "model, and the benefit depends on per-key multiplicity because the eliminated " +
+        "self-join can generate quadratically many candidate pairs. Enable it only for " +
+        "workloads known to contain such high-multiplicity self-joins.")
       .version("4.4.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregate.scala
@@ -1,0 +1,746 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.IN_SUBQUERY
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+/**
+ * Rewrites a self-join with an inequality into GROUP BY + HAVING COUNT(DISTINCT) > 1.
+ *
+ * Targets the two uncorrelated InSubquery shapes exercised by TPC-DS Q95:
+ *
+ *   - Pattern A': the subquery top-level InnerJoin is a direct self-join.
+ *   - Pattern A2: the subquery contains an outer InnerJoin with a self-join child; only the
+ *     self-join child is replaced with Aggregate and the outer join is preserved.
+ *
+ * Both patterns require an existence-only membership context so row-count multiplicity from the
+ * original self-join cross-product does not affect semantics. Correlated InSubquery expressions are
+ * intentionally fail-closed because the ExprId remapping performed here does not rewrite correlated
+ * predicates.
+ *
+ * This rule runs in `extendedOperatorOptimizationRules`, which is part of the operator optimization
+ * batch and therefore executes before `RewritePredicateSubquery` turns the predicate subquery into
+ * a semi/anti/existence join. It only observes the uncorrelated `InSubquery` shape at that phase,
+ * so there is no separate LeftSemi/LeftAnti ("Pattern A") or `Exists` handling.
+ *
+ * Both patterns share:
+ *   - [[buildAggregateHavingDistinctGt1]] to construct `Filter(cnt > 1, Aggregate)`
+ *   - [[canonicalizeWrapper]] to rebuild a wrapping Project so every equi-key reference points to
+ *     the sjLeft-side attribute, with **fresh exprIds** (Spark's SPARK-21835 style -- no reuse of
+ *     original exprIds), returning an old->new attribute remap for downstream rewrite.
+ *
+ * Controlled by `spark.sql.optimizer.rewriteSelfJoinInequalityToAggregate.enabled`
+ * (default false, opt-in).
+ */
+object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with PredicateHelper {
+
+  private val CountDistinctAliasName = "_rewrite_selfjoin_inequality_cnt_distinct"
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!conf.getConf(SQLConf.REWRITE_SELF_JOIN_INEQUALITY_TO_AGGREGATE_ENABLED)) {
+      return plan
+    }
+
+    // Pattern A' / A2: rewrite uncorrelated InSubquery plans.
+    // Correlated subqueries carry outer references / correlated join conditions in
+    // `SubqueryExpression.children`; fail closed because this rule does not remap them.
+    val rewritten = plan.transformAllExpressionsWithPruning(_.containsPattern(IN_SUBQUERY)) {
+      case in @ InSubquery(_, lq: ListQuery) if lq.children.isEmpty =>
+        rewriteSubqueryPlan(lq.plan) match {
+          case Some(newSub) => in.copy(query = lq.copy(plan = newSub))
+          case None => in
+        }
+    }
+    if (!(rewritten eq plan)) {
+      logDebug(
+        "RewriteSelfJoinInequalityToAggregate: rewrote self-join to " +
+          "GROUP BY + HAVING COUNT(DISTINCT) > 1")
+    }
+    rewritten
+  }
+  // ============================================================================
+  //  Shared helpers
+  // ============================================================================
+
+  /**
+   * Build `Filter(cnt > 1, Aggregate(equiKeys, [equiKeys, cnt_alias], Filter(IsNotNull(equiKeys),
+   * child)))`. Returns the Filter node whose output is `equiKeys ++ [count_alias_attr]`.
+   *
+   * The extra `IsNotNull(equiKeys)` filter is essential to preserve the original equi-join's NULL
+   * semantics. Under SQL 3VL, `left.k = right.k` never matches when either side is NULL, so the
+   * original self-join drops rows with NULL equi-keys. Aggregate, in contrast, groups NULL keys
+   * together into a single "NULL group" -- if that group has >= 2 distinct non-null neq values,
+   * COUNT(DISTINCT) > 1 fires and injects NULL into the subquery output. That leaked NULL then
+   * turns `NOT IN` into a spurious empty result (Spark's null-aware anti-join uses
+   * `Or(equi, IsNull(equi))` which any NULL sub-row satisfies) and can flip IN/NOT IN outcomes. The
+   * neq column needs no such filter: `COUNT(DISTINCT col)` already ignores NULL.
+   */
+  private def buildAggregateHavingDistinctGt1(
+      equiKeys: Seq[Attribute],
+      neqCol: Attribute,
+      child: LogicalPlan): LogicalPlan = {
+    val countExpr = AggregateExpression(
+      Count(Seq(neqCol)),
+      mode = Complete,
+      isDistinct = true,
+      filter = None,
+      NamedExpression.newExprId)
+    val countAlias = Alias(countExpr, CountDistinctAliasName)()
+    // Seq[Attribute] is a Seq[NamedExpression] via covariance; no cast needed.
+    val aggExprs: Seq[NamedExpression] = equiKeys :+ countAlias
+    val nonNullChild = equiKeys
+      .map(a => IsNotNull(a): Expression)
+      .reduceOption(And)
+      .map(Filter(_, child))
+      .getOrElse(child)
+    val agg = Aggregate(equiKeys, aggExprs, nonNullChild)
+    Filter(GreaterThan(countAlias.toAttribute, Literal(1L, LongType)), agg)
+  }
+
+  /**
+   * Canonicalize a Project so every equi-key reference points at the sjLeft-side attribute.
+   * [[parseSelfJoinCondition]] has already verified that each pair refers to the same output
+   * position on the two structurally identical self-join sides. Uses **fresh exprIds** (no reuse of
+   * original wrapper output exprIds) -- the same technique Spark's own `dedupSubqueryOnSelfJoin`
+   * uses when it needs to change subquery output.
+   *
+   * Returns the rebuilt Project and a map `oldWrapperOutputExprId -> newWrapperOutputAttr`, so
+   * downstream references (outer join condition, top-level Project) can be updated consistently.
+   *
+   * `equiPairs` provides the definitive ExprId-based lookup: `equiPair (l, r)` binds
+   * `l.exprId -> l` (identity) and `r.exprId -> l` (sjRight -> sjLeft). Attribute identity in
+   * Catalyst is ExprId, not name; two columns can share a name with distinct ExprIds. Name-based
+   * lookup would silently drop such entries via `.toMap`.
+   *
+   * Fails (returns None) when a projectList entry is neither an equi-key Attribute (by ExprId) nor
+   * `Alias(equi-key Attribute, _)`. Fail-closed.
+   */
+  private def canonicalizeWrapper(
+      projectList: Seq[NamedExpression],
+      equiPairs: Seq[(Attribute, Attribute)],
+      newChild: LogicalPlan): Option[(Project, Map[ExprId, Attribute])] = {
+    // ExprId-based canonical map: any equi-key attribute (either side) -> sjLeft attribute.
+    val exprIdToLeft: Map[ExprId, Attribute] =
+      equiPairs.flatMap { case (l, r) => Seq(l.exprId -> l, r.exprId -> l) }.toMap
+    val oldOutput: Seq[Attribute] = projectList.map(_.toAttribute)
+    val mapped: Seq[Option[NamedExpression]] = projectList.map {
+      case a: Attribute if exprIdToLeft.contains(a.exprId) =>
+        // Wrap every rewritten output slot in a fresh Alias.
+        //
+        // When a wrapper reprojects BOTH sides of the same equi pair (e.g.
+        // `SELECT s1.k, s2.k FROM T s1 JOIN T s2 ON s1.k = s2.k AND s1.v <> s2.v`),
+        // both entries collapse to the same sjLeft Attribute after the self-join is
+        // rewritten. Duplicate output ExprIds are not illegal in Spark (`SELECT a, a`
+        // is a valid Project), but fresh Aliases give each output slot an independent
+        // identity, which keeps the `oldOutput -> newOutput` remap 1-to-1 and lets
+        // downstream references (outer join condition, top-level Project) be updated
+        // unambiguously via ExprId.
+        //
+        // The fresh ExprId is on the Alias ITSELF; the referenced child keeps its
+        // original ExprId. Spark's logical-plan integrity checks reject reusing a
+        // referenced ExprId as the Alias's own ExprId, not duplication across slots.
+        Some(Alias(exprIdToLeft(a.exprId), a.name)(): NamedExpression)
+      case al @ Alias(a: Attribute, _) if exprIdToLeft.contains(a.exprId) =>
+        // Fresh exprId; do NOT reuse `al.exprId`. Reusing another expression's exprId
+        // is the pattern that Spark 3.3 flags via structural-integrity checks.
+        Some(Alias(exprIdToLeft(a.exprId), al.name)(): NamedExpression)
+      case _ => None
+    }
+    if (mapped.exists(_.isEmpty)) {
+      None
+    } else {
+      val newProjectList = mapped.flatten
+      val newWrapper = Project(newProjectList, newChild)
+      val newOutput = newWrapper.output
+      val remap: Map[ExprId, Attribute] =
+        oldOutput.zip(newOutput).map { case (o, n) => o.exprId -> n }.toMap
+      Some((newWrapper, remap))
+    }
+  }
+
+  /**
+   * Replace equi-key attribute references inside a NamedExpression according to `remap`, while
+   * preserving the NamedExpression shape.
+   *
+   * `Expression.transformUp` returns `Expression`, not `NamedExpression`. We avoid a blanket
+   * `asInstanceOf[NamedExpression]` by handling the two shapes that can appear in a Project's
+   * `projectList` explicitly: a bare Attribute (whose top-level may itself be replaced) and an
+   * Alias (which stays an Alias while its child is transformed). Any other NamedExpression shape we
+   * do not rewrite is left as-is ONLY if it does not reference a replaced self-join output;
+   * otherwise it would carry a stale ExprId, so returns None to fail the whole rewrite closed.
+   */
+  private def remapNamedExpressionAttributes(
+      ne: NamedExpression,
+      remap: Map[ExprId, Attribute]): Option[NamedExpression] = ne match {
+    case a: Attribute if remap.contains(a.exprId) => Some(remap(a.exprId))
+    case a: Attribute => Some(a)
+    case al: Alias =>
+      val newChild = al.child.transformUp {
+        case a: Attribute if remap.contains(a.exprId) => remap(a.exprId)
+      }
+      Some(
+        if (newChild eq al.child) al
+        else Alias(newChild, al.name)(al.exprId, al.qualifier, al.explicitMetadata))
+    case other if other.references.exists(a => remap.contains(a.exprId)) =>
+      // Fail-closed: a NamedExpression we do not rewrite (neither a bare Attribute nor an Alias)
+      // that still references a replaced self-join output would be left with a dangling ExprId.
+      // Refuse the rewrite rather than emit a plan with a stale reference.
+      None
+    case other => Some(other)
+  }
+
+  // ============================================================================
+  //  Pattern A' / A2 dispatch (subquery plans of InSubquery)
+  // ============================================================================
+
+  private def rewriteSubqueryPlan(plan: LogicalPlan): Option[LogicalPlan] = {
+    // Candidate-level nondeterminism guard: reject if ANY node in the whole subquery plan
+    // is non-repeatable (Rand, LIMIT-without-ORDER-BY, Sample, Offset, streaming). This catches
+    // nondeterminism that lives ABOVE the self-join rather than on either side -- e.g. a Pattern
+    // A2 outer join whose condition is `d.k = sj.k AND rand() < 0.5`. Both self-join sides stay
+    // repeatable there, so the per-side `isSameBaseRelation` check would pass, yet the enclosing
+    // subquery is not repeatable.
+    if (!isRepeatablePlan(plan)) return None
+
+    val (projectListOpt, innerJoin): (Option[Seq[NamedExpression]], Join) = plan match {
+      case Project(pl, j: Join) if j.joinType == Inner && j.condition.isDefined =>
+        (Some(pl), j)
+      case j: Join if j.joinType == Inner && j.condition.isDefined =>
+        (None, j)
+      case _ => return None
+    }
+
+    if (isSameBaseRelation(innerJoin.left, innerJoin.right)) {
+      rewriteDirectSelfJoin(projectListOpt, innerJoin)
+    } else {
+      rewriteNestedSelfJoin(projectListOpt, innerJoin)
+    }
+  }
+
+  // ============================================================================
+  //  Pattern A' : direct self-join at subquery top level
+  // ============================================================================
+
+  private def rewriteDirectSelfJoin(
+      projectListOpt: Option[Seq[NamedExpression]],
+      innerJoin: Join): Option[LogicalPlan] = {
+    val innerLeft = innerJoin.left
+    val innerRight = innerJoin.right
+    val innerCond = innerJoin.condition.get
+
+    val parsed = parseSelfJoinCondition(innerCond, innerLeft, innerRight)
+    if (parsed.isEmpty) return None
+    // parseSelfJoinCondition has validated column correspondence and equi-key uniqueness.
+    val (equiPairs, neqPairs) = parsed.get
+
+    val innerLeftEquiAttrs: Seq[Attribute] = equiPairs.map(_._1)
+    val innerLeftNeqAttr: Attribute = neqPairs.head._1
+    val filtered = buildAggregateHavingDistinctGt1(innerLeftEquiAttrs, innerLeftNeqAttr, innerLeft)
+
+    // Fail-closed on bare-Join subqueries: without a wrapping Project the subquery output
+    // is the full self-join output (both sides' columns). Replacing that with
+    // `Project(equiKeys, filtered)` shrinks the output; if the enclosing InSubquery
+    // referenced a non-equi column by position, `values.zip(sub.output).map(EqualTo.tupled)`
+    // inside RewritePredicateSubquery would build an incorrect semi condition. Q95's
+    // subqueries all have an explicit Project wrapper, so this branch does not affect it.
+    projectListOpt match {
+      case None =>
+        None
+      case Some(pl) =>
+        canonicalizeWrapper(pl, equiPairs, filtered).map {
+          case (newWrapper, _) =>
+            logDebug(
+              s"Pattern A' - equiKeys=[${innerLeftEquiAttrs.map(_.name).mkString(",")}]" +
+                s", neqCol=${innerLeftNeqAttr.name}" +
+                s", outCols=[${newWrapper.projectList.map(_.name).mkString(",")}]")
+            newWrapper
+        }
+    }
+  }
+
+  // ============================================================================
+  //  Pattern A2 : self-join nested inside another InnerJoin in the subquery
+  // ============================================================================
+
+  private def rewriteNestedSelfJoin(
+      projectListOpt: Option[Seq[NamedExpression]],
+      outerJoin: Join): Option[LogicalPlan] = {
+    val outerCond = outerJoin.condition.get
+
+    val (selfJoinSide, selfJoinOnRight) =
+      tryExtractSelfJoin(outerJoin.right) match {
+        case Some(_) => (outerJoin.right, true)
+        case None =>
+          tryExtractSelfJoin(outerJoin.left) match {
+            case Some(_) => (outerJoin.left, false)
+            case None => return None
+          }
+      }
+
+    val (selfJoinProjectOpt, selfJoin) = selfJoinSide match {
+      case p @ Project(_, j: Join) if j.joinType == Inner && j.condition.isDefined =>
+        (Some(p), j)
+      case j: Join if j.joinType == Inner && j.condition.isDefined =>
+        (None, j)
+      case _ => return None
+    }
+
+    val sjLeft = selfJoin.left
+    val sjRight = selfJoin.right
+    val sjCond = selfJoin.condition.get
+    if (!isSameBaseRelation(sjLeft, sjRight)) return None
+
+    val parsed = parseSelfJoinCondition(sjCond, sjLeft, sjRight)
+    if (parsed.isEmpty) return None
+    // parseSelfJoinCondition has validated column correspondence and equi-key uniqueness.
+    val (equiPairs, neqPairs) = parsed.get
+
+    val sjLeftEquiAttrs: Seq[Attribute] = equiPairs.map(_._1)
+    val sjLeftNeqAttr: Attribute = neqPairs.head._1
+
+    val selfJoinOutputSet = selfJoinSide.outputSet
+    val sjEquiExprIds: Set[ExprId] =
+      equiPairs.flatMap { case (l, r) => Seq(l.exprId, r.exprId) }.toSet
+    // wrapper Project may reproject equi-keys under fresh alias exprIds; include those.
+    val wrapperEquiExprIds: Set[ExprId] = selfJoinProjectOpt.toSeq.flatMap {
+      p =>
+        p.projectList.flatMap {
+          case a: Attribute if sjEquiExprIds.contains(a.exprId) => Some(a.exprId)
+          case al @ Alias(a: Attribute, _) if sjEquiExprIds.contains(a.exprId) => Some(al.exprId)
+          case _ => None
+        }
+    }.toSet
+    val allEquiExprIds = sjEquiExprIds ++ wrapperEquiExprIds
+
+    // Outer join condition may reference only equi-key attrs from the self-join side.
+    val outerCondRefs = outerCond.references.filter(selfJoinOutputSet.contains)
+    if (!outerCondRefs.forall(a => allEquiExprIds.contains(a.exprId))) return None
+
+    // Top-level subquery Project may reference only equi-key attrs from the self-join side.
+    val projectOk = projectListOpt.forall {
+      pl =>
+        val refs = pl.flatMap(_.references).filter(selfJoinOutputSet.contains)
+        refs.forall(a => allEquiExprIds.contains(a.exprId))
+    }
+    if (!projectOk) return None
+
+    val filtered = buildAggregateHavingDistinctGt1(sjLeftEquiAttrs, sjLeftNeqAttr, sjLeft)
+
+    val (newSelfJoinSide, outputRemap): (LogicalPlan, Map[ExprId, Attribute]) =
+      selfJoinProjectOpt match {
+        case Some(wp) =>
+          canonicalizeWrapper(wp.projectList, equiPairs, filtered) match {
+            case Some((newWrapper, remap)) => (newWrapper, remap)
+            case None => return None
+          }
+        case None if projectListOpt.isEmpty =>
+          // Fail-closed: with neither a wrapper Project around the self-join nor a top-level
+          // subquery Project, the outer join currently exposes every self-join column, and
+          // replacing the self-join with `Project(equiKeys, filtered)` would shrink the outer
+          // join's right-hand output arity. RewritePredicateSubquery's positional zip
+          // (`values.zip(sub.output).map(EqualTo.tupled)`) would then bind semi predicates to
+          // the wrong attributes -- silently dropping components of a tuple IN. A
+          // top-level Project (`projectListOpt`) is what would let the arity be preserved
+          // by the top-level rewrite loop; without one, refuse to rewrite.
+          return None
+        case None =>
+          // No wrapper Project but there IS a top-level subquery Project: shrinking the outer
+          // join's self-join-side output is safe because the top-level Project is rewritten
+          // consistently via `outputRemap` below and the top-level rewrite loop ensures
+          // subquery output arity matches what the enclosing InSubquery expects.
+          // Outer references may point at sjRight equi-attributes; remap them to sjLeft
+          // (same output position in a valid self-join).
+          val newP = Project(sjLeftEquiAttrs, filtered)
+          val remap: Map[ExprId, Attribute] =
+            equiPairs.map { case (l, r) => r.exprId -> l }.toMap
+          (newP, remap)
+      }
+
+    // Rewrite outer join condition to use new wrapper output attributes.
+    val newOuterCond = outerCond.transformUp {
+      case a: Attribute if outputRemap.contains(a.exprId) => outputRemap(a.exprId)
+    }
+
+    val newOuterJoin = if (selfJoinOnRight) {
+      outerJoin.copy(right = newSelfJoinSide, condition = Some(newOuterCond))
+    } else {
+      outerJoin.copy(left = newSelfJoinSide, condition = Some(newOuterCond))
+    }
+
+    // Rewrite top-level Project references.
+    val result = projectListOpt match {
+      case Some(pl) =>
+        val remapped = pl.map(ne => remapNamedExpressionAttributes(ne, outputRemap))
+        if (remapped.exists(_.isEmpty)) return None
+        Project(remapped.flatten, newOuterJoin)
+      case None => newOuterJoin
+    }
+
+    logDebug(
+      s"Pattern A2 - equiKeys=[${sjLeftEquiAttrs.map(_.name).mkString(",")}]" +
+        s", neqCol=${sjLeftNeqAttr.name}")
+    Some(result)
+  }
+
+  private def tryExtractSelfJoin(plan: LogicalPlan): Option[Join] = {
+    val join = plan match {
+      case Project(_, j: Join) if j.joinType == Inner && j.condition.isDefined => j
+      case j: Join if j.joinType == Inner && j.condition.isDefined => j
+      case _ => return None
+    }
+    if (!isSameBaseRelation(join.left, join.right)) return None
+    val parsed = parseSelfJoinCondition(join.condition.get, join.left, join.right)
+    if (parsed.isEmpty) return None
+    Some(join)
+  }
+
+  // ============================================================================
+  //  parseSelfJoinCondition + isSameBaseRelation
+  // ============================================================================
+
+  private def outputOrdinal(plan: LogicalPlan, attr: Attribute): Int =
+    plan.output.indexWhere(_.exprId == attr.exprId)
+
+  private def sameOutputPosition(
+      leftPlan: LogicalPlan,
+      rightPlan: LogicalPlan,
+      leftAttr: Attribute,
+      rightAttr: Attribute): Boolean = {
+    val leftPos = outputOrdinal(leftPlan, leftAttr)
+    val rightPos = outputOrdinal(rightPlan, rightAttr)
+    leftPos >= 0 && rightPos >= 0 && leftPos == rightPos
+  }
+
+  /**
+   * Parse a join condition into equi-pairs and inequality-pairs. Accepts only:
+   *   - `EqualTo(attr, attr)` where the two attrs come from opposite sides,
+   *   - `Not(EqualTo(attr, attr))` -- same side rule,
+   *   - `IsNotNull(attr)` where the attr is one of the join columns.
+   * Anything else in the condition disqualifies the whole rewrite (fail-closed).
+   */
+  private def parseSelfJoinCondition(
+      condition: Expression,
+      leftPlan: LogicalPlan,
+      rightPlan: LogicalPlan)
+      : Option[(Seq[(Attribute, Attribute)], Seq[(Attribute, Attribute)])] = {
+
+    val leftOutput = leftPlan.outputSet
+    val rightOutput = rightPlan.outputSet
+    val predicates = splitConjunctivePredicates(condition)
+
+    val equiPairs = predicates.collect {
+      case EqualTo(l: Attribute, r: Attribute)
+          if leftOutput.contains(l) && rightOutput.contains(r) =>
+        (l, r)
+      case EqualTo(r: Attribute, l: Attribute)
+          if leftOutput.contains(l) && rightOutput.contains(r) =>
+        (l, r)
+    }
+
+    val neqPairs = predicates.collect {
+      case Not(EqualTo(l: Attribute, r: Attribute))
+          if leftOutput.contains(l) && rightOutput.contains(r) =>
+        (l, r)
+      case Not(EqualTo(r: Attribute, l: Attribute))
+          if leftOutput.contains(l) && rightOutput.contains(r) =>
+        (l, r)
+    }
+
+    // Only IsNotNull predicates on join columns are safe to drop -- they're redundant with
+    // the join semantics or auto-added by InferFiltersFromConstraints. IsNotNull on other
+    // columns changes semantics if we drop it; bail out.
+    val joinAttrIds: Set[ExprId] =
+      (equiPairs ++ neqPairs).flatMap { case (l, r) => Seq(l.exprId, r.exprId) }.toSet
+    val isNotNullOnJoinCols = predicates.count {
+      case IsNotNull(a: Attribute) if joinAttrIds.contains(a.exprId) => true
+      case _ => false
+    }
+
+    val totalMatched = equiPairs.size + neqPairs.size + isNotNullOnJoinCols
+    if (totalMatched != predicates.size) return None
+
+    if (equiPairs.isEmpty || neqPairs.isEmpty) return None
+
+    // Only rewrite the single-inequality case. Multiple inequality conjuncts cannot be represented
+    // by COUNT(DISTINCT) over a single column.
+    if (neqPairs.size != 1) return None
+
+    // The rewrite swaps SQL comparison equality for grouping/DISTINCT equality: `<>` becomes
+    // COUNT(DISTINCT neqCol) and `=` becomes GROUP BY equiKey. It is only sound on types where
+    // those two notions of equality coincide, so gate every equi-key and the neq column on a
+    // positive `isSafeComparisonGroupingType` allowlist rather than `RowOrdering.isOrderable`:
+    // orderable only proves an order/hash exists, not that comparison and grouping agree. Fail
+    // closed on anything not proven safe (float -0.0/NaN, complex types, non-binary collations,
+    // and future/unknown types).
+    //
+    // Check BOTH ends of every pair, not just the sjLeft attribute. `isSameBaseRelation` proves
+    // the two sides are canonically equal, but `AttributeReference.canonicalized` rewrites the
+    // reference to drop metadata, so canonical equality does NOT prove the sjRight attribute
+    // carries the same CHAR/VARCHAR metadata that `isSafeComparisonGroupingAttribute` reads. Gate
+    // each side independently rather than assume they match.
+    val keyAttrs =
+      (equiPairs ++ neqPairs).flatMap { case (left, right) => Seq(left, right) }
+    if (!keyAttrs.forall(isSafeComparisonGroupingAttribute)) return None
+
+    // Canonicalization intentionally erases cosmetic Alias names, so name equality cannot prove
+    // that the two predicate ends refer to the same underlying column. Resolve each end by its own
+    // ExprId against its child output and require matching output ordinals instead.
+    val equiValid = equiPairs.forall {
+      case (l, r) => sameOutputPosition(leftPlan, rightPlan, l, r)
+    }
+    val neqValid = neqPairs.forall {
+      case (l, r) => sameOutputPosition(leftPlan, rightPlan, l, r)
+    }
+    if (!equiValid || !neqValid) return None
+
+    // Equi-key output positions must be distinct across pairs. Keep the same positional identity
+    // here so swapped or duplicate aliases cannot make two different underlying columns look equal.
+    val leftEquiOrdinals = equiPairs.map { case (l, _) => outputOrdinal(leftPlan, l) }
+    if (leftEquiOrdinals.exists(_ < 0)) return None
+    if (leftEquiOrdinals.distinct.size != leftEquiOrdinals.size) return None
+
+    // Defensive: reject when the neq column overlaps an equi-key column
+    // (e.g. `t1.k = t2.k AND t1.k <> t2.k`).
+    val neqLeftOrdinal = outputOrdinal(leftPlan, neqPairs.head._1)
+    if (neqLeftOrdinal < 0 || leftEquiOrdinals.contains(neqLeftOrdinal)) return None
+    Some((equiPairs, neqPairs))
+  }
+
+  /**
+   * Attribute-aware gate applied to the equi keys and the neq column. A CHAR/VARCHAR column reaches
+   * the optimizer as StringType with its declared type recorded in the attribute metadata
+   * (CharVarcharUtils stamps it when the relation output is built), so checking `attr.dataType`
+   * alone would let it through the StringType branch of [[isSafeComparisonGroupingType]]. Recover
+   * the declared raw type from the metadata (falling back to `dataType` when there is no marker)
+   * and run it through the datatype allowlist, so CHAR/VARCHAR fail closed there in every config.
+   */
+  private def isSafeComparisonGroupingAttribute(attr: Attribute): Boolean = {
+    val rawType = CharVarcharUtils.getRawType(attr.metadata).getOrElse(attr.dataType)
+    isSafeComparisonGroupingType(rawType)
+  }
+
+  /**
+   * Types whose SQL comparison equality (`=` / `<>`) is provably identical to grouping / DISTINCT
+   * equality (and hashing). The rewrite turns `<>` into COUNT(DISTINCT) and `=` into GROUP BY, so
+   * it must never be applied to a type where those two notions of equality can diverge. This is a
+   * conservative positive allowlist: it admits only the types where the equivalence is well
+   * established and fails closed on everything else, including any new type a future version might
+   * add.
+   *
+   * Deliberately rejected:
+   *   - Float / Double: this rewrite relies on comparison equality (`=` / `<>`) and
+   *     grouping/DISTINCT equality having exactly the same contract. Signed zero and NaN are the
+   *     representative edge cases that make that contract non-trivial for floating point, and
+   *     whether the two paths agree rests on normalization details (e.g. NormalizeFloatingNumbers).
+   *     Rather than depend on that, floats fail closed. Complex types are rejected wholesale below,
+   *     which also covers floats nested inside a struct/array/map.
+   *   - Complex types (Array / Struct / Map) and UDTs / Variant: their equality-vs-grouping
+   *     equivalence is harder to prove and can itself embed floats.
+   *   - Char / Varchar: CHAR / VARCHAR have dedicated declared-type semantics and are
+   *     conservatively kept outside this rewrite. Table columns may reach the optimizer as
+   *     annotated StringType, so the caller ([[isSafeComparisonGroupingAttribute]]) recovers their
+   *     declared type from metadata first; this branch is the single rejection point for both that
+   *     path and first-class CHAR/VARCHAR types.
+   *   - Non-binary collated strings: comparison and grouping can route through different collation
+   *     code paths, so only byte-wise `supportsBinaryEquality` strings are admitted.
+   */
+  private def isSafeComparisonGroupingType(dt: DataType): Boolean = dt match {
+    case ByteType | ShortType | IntegerType | LongType => true
+    case _: DecimalType => true
+    case BooleanType => true
+    case DateType => true
+    case TimestampType | TimestampNTZType => true
+    case BinaryType => true
+
+    case _: CharType | _: VarcharType => false
+    case st: StringType if st.supportsBinaryEquality => true
+
+    case _ => false
+  }
+
+  /**
+   * True iff `plan` produces the same row bag on every evaluation.
+   *
+   * This is the primary safety guard for the rewrite, which folds two occurrences of the same
+   * subtree into one aggregate -- sound only when both occurrences produce identical row bags. We
+   * check it at TWO levels:
+   *   - candidate level: the enclosing subquery, before descending into the self-join. Catches
+   *     nondeterminism that lives above the self-join rather than on either side -- e.g. a Pattern
+   *     A2 outer join whose condition is `d.k = sj.k AND rand() < 0.5`. Without this,
+   *     `isSameBaseRelation(sjLeft, sjRight)` could pass (both sides look deterministic) while the
+   *     enclosing plan still contains `Rand`.
+   *   - relation level: [[isSameBaseRelation]] additionally requires the two sides to be
+   *     structurally identical.
+   *
+   * Attribute-level `plan.deterministic` alone is NOT sufficient. Catalyst's
+   * `Expression.deterministic` only checks explicit `Nondeterministic` annotation; several
+   * operators produce a runtime-nondeterministic row bag even though every expression they contain
+   * is `deterministic == true`:
+   *   - `Aggregate` with `First` / `Last` / `collect_list` / `min_by` / `max_by` (tie order),
+   *   - `Window` with `row_number()` / `rank()` over a non-total order,
+   *   - `Limit` / `LocalLimit` / `Sample` / `Offset` (row-bag operator-level nondeterminism),
+   *   - streaming sources.
+   *
+   * This rule collapses two evaluations of the same subtree into one aggregate; repeatability must
+   * be provable, not assumed. That is why both the operator check and the expression check below
+   * are WHITELISTS rather than blacklists -- unknown operators and unknown expression types default
+   * to reject.
+   *
+   * Expression support is allowlisted, not blacklisted. `plan.deterministic` relies on each
+   * expression's reported `deterministic` contract; that is necessary but insufficient for unknown
+   * expression types whose repeatability has not been established -- a builtin that carries hidden
+   * state yet reports `deterministic == true` would otherwise be trusted silently. For a rewrite
+   * that folds two evaluations of a subtree into one aggregate we prefer to miss an optimization
+   * than to misapply one, so new expression types are added to [[isRepeatableExpression]] only
+   * after their repeatability has been established. `plan.deterministic` is kept as a cheap
+   * fast-reject, but the expression allowlist is what actually proves repeatability.
+   *
+   * `plan.subqueriesAll.isEmpty` additionally fail-closes on any embedded expression subquery
+   * (scalar / IN / EXISTS). `plan.exists` in `isRowBagRepeatable` walks only the operator tree and
+   * does not descend into expression subqueries, and `plan.deterministic` does not prove a nested
+   * subquery is row-bag repeatable (e.g. an uncorrelated `LIMIT 1` without `ORDER BY`). Rejecting
+   * any embedded subquery keeps the repeatability proof confined to the operator whitelist below.
+   */
+  private def isRepeatablePlan(plan: LogicalPlan): Boolean = {
+    // The operator/source whitelist is checked before the expression whitelist so that a plan whose
+    // operator is itself unknown -- e.g. Aggregate (carries AggregateExpression) or Window (carries
+    // WindowExpression / SortOrder) -- is attributed to isRowBagRepeatable rather than being masked
+    // by the fact that those operators also carry non-allowlisted expressions.
+    plan.deterministic &&
+    !plan.isStreaming &&
+    plan.subqueriesAll.isEmpty &&
+    isRowBagRepeatable(plan) &&
+    hasRepeatableExpressions(plan)
+  }
+
+  /**
+   * Operator whitelist for `isRepeatablePlan`. A plan is row-bag repeatable only when every node is
+   * known to produce a repeatable output row bag from repeatable children. Unknown operators and
+   * unknown leaf sources fail closed.
+   *
+   * Kept intentionally narrow -- the target workload (Q95-shape self-join in a subquery) only needs
+   * a Parquet relation scan optionally wrapped in Project / Filter / SubqueryAlias plus the
+   * self-join itself. Range and LocalRelation are also trusted deterministic leaves. Adding an
+   * operator here requires proving that its output row values and multiplicities are repeatable.
+   * Pure row ordering is irrelevant to the row-bag contract, but operators not needed by the
+   * target shape remain fail-closed until explicitly reviewed.
+   *
+   * Arbitrary `LeafNode`s are intentionally not trusted. For example, `LogicalRDD` may wrap an
+   * arbitrary RDD lineage whose runtime behavior is invisible to Catalyst's `plan.deterministic`;
+   * `InMemoryRelation`, `DataSourceV2Relation` and custom leaves are likewise rejected until
+   * proven. Streaming sources reach here as `LeafNode`s but are already filtered upstream by
+   * `plan.isStreaming` in [[isRepeatablePlan]].
+   *
+   * `LogicalRelation` is trusted only when its underlying relation is a `HadoopFsRelation` whose
+   * `fileFormat` is EXACTLY `ParquetFileFormat` (`getClass == classOf[ParquetFileFormat]`, not
+   * `isInstanceOf`). `HadoopFsRelation.fileFormat` can be any `FileFormat`, including custom
+   * formats whose scan is not provably a repeatable row bag; `ParquetFileFormat` is also non-final,
+   * so a third-party subclass could override its scan. The target workload only needs stock
+   * Parquet, so every other `FileFormat` -- subclasses of `ParquetFileFormat` included -- and every
+   * non-`HadoopFsRelation` fail closed.
+   *
+   * This helper checks operators and leaf sources only; expression-type repeatability is a separate
+   * concern handled by [[hasRepeatableExpressions]], and both are joined in [[isRepeatablePlan]].
+   */
+  private def isRowBagRepeatable(plan: LogicalPlan): Boolean = !plan.exists {
+    // TreeNode exposes `exists` but not `forall`, so invert: a whitelisted operator maps to `false`
+    // ("does not break repeatability") and everything else to `true`; negating the whole `exists`
+    // then means "every operator is whitelisted".
+    case _: Project => false
+    case _: Filter => false
+    case _: SubqueryAlias => false
+    // Join is included because our target pattern IS a Join; both children get recursed into.
+    case _: Join => false
+    // Explicitly trusted leaves.
+    case _: Range => false
+    case _: LocalRelation => false
+    case relation: LogicalRelation =>
+      relation.relation match {
+        case h: HadoopFsRelation if h.fileFormat.getClass == classOf[ParquetFileFormat] => false
+        case _ => true
+      }
+    // Everything else -- Aggregate, Window, Limit, Sample, Offset, Distinct, Union, Except,
+    // Intersect, Sort, Expand, Generate, and opaque leaf sources -- is conservatively
+    // unsupported and fails closed. (Row ordering itself is irrelevant to the row-bag contract;
+    // these are rejected because their row values/multiplicities are not proven repeatable, or
+    // simply because the target shape does not need them.)
+    case _ => true
+  }
+
+  /**
+   * Expression-type check for [[isRepeatablePlan]], kept separate from the operator whitelist in
+   * [[isRowBagRepeatable]] so the two safety layers read independently. A plan passes only when
+   * every expression carried by every operator node is repeatable per [[isRepeatableExpression]]; a
+   * whitelisted operator holding an unknown expression -- e.g. `Project(Abs(v))` -- fails closed.
+   */
+  private def hasRepeatableExpressions(plan: LogicalPlan): Boolean = {
+    !plan.exists(node => node.expressions.exists(expr => !isRepeatableExpression(expr)))
+  }
+
+  /**
+   * Expression repeatability is allowlisted, consistently with the operator whitelist in
+   * [[isRowBagRepeatable]]. Only expression types whose result is determined entirely by repeatable
+   * children are accepted; unknown expression types fail closed. This rule folds two evaluations of
+   * the same subtree into one, so missing an optimization is preferable to assuming repeatability
+   * for an expression whose runtime behavior has not been proven.
+   *
+   * The whole tree is checked: an expression is repeatable only when its root type is on the
+   * allowlist AND all of its children are themselves repeatable, so e.g. `Add(v, Abs(w))` is
+   * rejected even though `Add` is allowlisted.
+   *
+   * The initial set covers what TPC-DS Q95 and the tests need: column / literal references, Alias,
+   * Cast, basic arithmetic, boolean connectives, the six comparisons plus null-safe equality, and
+   * null checks. Expressions such as `Abs` / `Coalesce` / `CaseWhen` are intentionally absent -- a
+   * self-join over them is simply not rewritten (a missed optimization, not a correctness bug)
+   * until each is added here after its repeatability has been established. Decimal wrappers such as
+   * `PromotePrecision` / `CheckOverflow` are likewise absent and may fail closed; that is
+   * acceptable and must not be worked around by trusting them just to make an arithmetic variant
+   * fire.
+   */
+  private def isRepeatableExpression(expr: Expression): Boolean = expr match {
+    case _: Attribute | _: Literal =>
+      true
+    case _: Alias | _: Cast | _: Add | _: Subtract | _: Multiply | _: Divide | _: Remainder |
+        _: And | _: Or | _: Not | _: EqualTo | _: EqualNullSafe | _: LessThan |
+        _: LessThanOrEqual | _: GreaterThan | _: GreaterThanOrEqual | _: IsNull | _: IsNotNull =>
+      expr.children.forall(isRepeatableExpression)
+    case _ =>
+      false
+  }
+
+  /**
+   * True iff `left` and `right` are the same plan modulo canonicalization AND each side is a
+   * repeatable plan. See [[isRepeatablePlan]] for the repeatability contract.
+   */
+  private def isSameBaseRelation(left: LogicalPlan, right: LogicalPlan): Boolean = {
+    left.sameResult(right) &&
+    isRepeatablePlan(left) && isRepeatablePlan(right)
+  }
+
+  // splitConjunctivePredicates is provided by the mixed-in PredicateHelper trait.
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregate.scala
@@ -30,29 +30,16 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 /**
- * Rewrites a self-join with an inequality into GROUP BY + HAVING COUNT(DISTINCT) > 1.
+ * Rewrites supported uncorrelated IN-subquery inequality self-joins into
+ * `GROUP BY + HAVING COUNT(DISTINCT) > 1`, avoiding the self-join cross-product.
  *
- * Targets the two uncorrelated InSubquery shapes exercised by TPC-DS Q95:
+ * Supports a direct self-join (Pattern A') and a self-join nested under an outer inner join
+ * (Pattern A2, where only the self-join child becomes an Aggregate). Unsupported and correlated
+ * shapes fail closed.
  *
- *   - Pattern A': the subquery top-level InnerJoin is a direct self-join.
- *   - Pattern A2: the subquery contains an outer InnerJoin with a self-join child; only the
- *     self-join child is replaced with Aggregate and the outer join is preserved.
- *
- * Both patterns require an existence-only membership context so row-count multiplicity from the
- * original self-join cross-product does not affect semantics. Correlated InSubquery expressions are
- * intentionally fail-closed because the ExprId remapping performed here does not rewrite correlated
- * predicates.
- *
- * This rule runs in `extendedOperatorOptimizationRules`, which is part of the operator optimization
- * batch and therefore executes before `RewritePredicateSubquery` turns the predicate subquery into
- * a semi/anti/existence join. It only observes the uncorrelated `InSubquery` shape at that phase,
- * so there is no separate LeftSemi/LeftAnti ("Pattern A") or `Exists` handling.
- *
- * Both patterns share:
- *   - [[buildAggregateHavingDistinctGt1]] to construct `Filter(cnt > 1, Aggregate)`
- *   - [[canonicalizeWrapper]] to rebuild a wrapping Project so every equi-key reference points to
- *     the sjLeft-side attribute, with **fresh exprIds** (Spark's SPARK-21835 style -- no reuse of
- *     original exprIds), returning an old->new attribute remap for downstream rewrite.
+ * Runs in `extendedOperatorOptimizationRules`, before `RewritePredicateSubquery` turns the
+ * predicate subquery into a semi/anti/existence join, so it only sees the uncorrelated
+ * `InSubquery` shape.
  *
  * Controlled by `spark.sql.optimizer.rewriteSelfJoinInequalityToAggregate.enabled`
  * (default false, opt-in).
@@ -66,52 +53,34 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
       return plan
     }
 
-    // Pattern A' / A2: rewrite uncorrelated InSubquery plans.
-    // Correlated subqueries carry outer references / correlated join conditions in
-    // `SubqueryExpression.children`; fail closed because this rule does not remap them.
-    val rewritten = plan.transformAllExpressionsWithPruning(_.containsPattern(IN_SUBQUERY)) {
+    // Fail closed on correlated subqueries: `lq.children` holds the outer references this rule
+    // does not remap.
+    plan.transformAllExpressionsWithPruning(_.containsPattern(IN_SUBQUERY)) {
       case in @ InSubquery(_, lq: ListQuery) if lq.children.isEmpty =>
         rewriteSubqueryPlan(lq.plan) match {
           case Some(newSub) => in.copy(query = lq.copy(plan = newSub))
           case None => in
         }
     }
-    if (!(rewritten eq plan)) {
-      logDebug(
-        "RewriteSelfJoinInequalityToAggregate: rewrote self-join to " +
-          "GROUP BY + HAVING COUNT(DISTINCT) > 1")
-    }
-    rewritten
   }
+
   // ============================================================================
   //  Shared helpers
   // ============================================================================
 
   /**
-   * Build `Filter(cnt > 1, Aggregate(equiKeys, [equiKeys, cnt_alias], Filter(IsNotNull(equiKeys),
-   * child)))`. Returns the Filter node whose output is `equiKeys ++ [count_alias_attr]`.
+   * Build `Filter(cnt > 1, Aggregate(equiKeys, child))` with a `COUNT(DISTINCT neqCol)`.
    *
-   * The extra `IsNotNull(equiKeys)` filter is essential to preserve the original equi-join's NULL
-   * semantics. Under SQL 3VL, `left.k = right.k` never matches when either side is NULL, so the
-   * original self-join drops rows with NULL equi-keys. Aggregate, in contrast, groups NULL keys
-   * together into a single "NULL group" -- if that group has >= 2 distinct non-null neq values,
-   * COUNT(DISTINCT) > 1 fires and injects NULL into the subquery output. That leaked NULL then
-   * turns `NOT IN` into a spurious empty result (Spark's null-aware anti-join uses
-   * `Or(equi, IsNull(equi))` which any NULL sub-row satisfies) and can flip IN/NOT IN outcomes. The
-   * neq column needs no such filter: `COUNT(DISTINCT col)` already ignores NULL.
+   * The `IsNotNull(equiKeys)` filter preserves the equi-join's NULL semantics: `=` never matches a
+   * NULL key, but GROUP BY would fold all NULL keys into one group that can leak NULL into a
+   * `NOT IN`. The neq column needs no filter -- `COUNT(DISTINCT)` already ignores NULL.
    */
   private def buildAggregateHavingDistinctGt1(
       equiKeys: Seq[Attribute],
       neqCol: Attribute,
       child: LogicalPlan): LogicalPlan = {
-    val countExpr = AggregateExpression(
-      Count(Seq(neqCol)),
-      mode = Complete,
-      isDistinct = true,
-      filter = None,
-      NamedExpression.newExprId)
+    val countExpr = Count(Seq(neqCol)).toAggregateExpression(isDistinct = true)
     val countAlias = Alias(countExpr, CountDistinctAliasName)()
-    // Seq[Attribute] is a Seq[NamedExpression] via covariance; no cast needed.
     val aggExprs: Seq[NamedExpression] = equiKeys :+ countAlias
     val nonNullChild = equiKeys
       .map(a => IsNotNull(a): Expression)
@@ -123,52 +92,31 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   }
 
   /**
-   * Canonicalize a Project so every equi-key reference points at the sjLeft-side attribute.
-   * [[parseSelfJoinCondition]] has already verified that each pair refers to the same output
-   * position on the two structurally identical self-join sides. Uses **fresh exprIds** (no reuse of
-   * original wrapper output exprIds) -- the same technique Spark's own `dedupSubqueryOnSelfJoin`
-   * uses when it needs to change subquery output.
-   *
-   * Returns the rebuilt Project and a map `oldWrapperOutputExprId -> newWrapperOutputAttr`, so
-   * downstream references (outer join condition, top-level Project) can be updated consistently.
-   *
-   * `equiPairs` provides the definitive ExprId-based lookup: `equiPair (l, r)` binds
-   * `l.exprId -> l` (identity) and `r.exprId -> l` (sjRight -> sjLeft). Attribute identity in
-   * Catalyst is ExprId, not name; two columns can share a name with distinct ExprIds. Name-based
-   * lookup would silently drop such entries via `.toMap`.
-   *
-   * Fails (returns None) when a projectList entry is neither an equi-key Attribute (by ExprId) nor
-   * `Alias(equi-key Attribute, _)`. Fail-closed.
+   * Rebuild the wrapper Project so every equi-key reference points at the sjLeft attribute with a
+   * fresh output ExprId, returning `oldOutputExprId -> newOutputAttr` for downstream references
+   * (outer join condition, top-level Project). Lookup is by ExprId (Catalyst attribute identity),
+   * not name. Fails closed when an entry is neither an equi-key Attribute nor `Alias(equi-key, _)`.
    */
   private def canonicalizeWrapper(
       projectList: Seq[NamedExpression],
       equiPairs: Seq[(Attribute, Attribute)],
       newChild: LogicalPlan): Option[(Project, Map[ExprId, Attribute])] = {
-    // ExprId-based canonical map: any equi-key attribute (either side) -> sjLeft attribute.
     val exprIdToLeft: Map[ExprId, Attribute] =
       equiPairs.flatMap { case (l, r) => Seq(l.exprId -> l, r.exprId -> l) }.toMap
     val oldOutput: Seq[Attribute] = projectList.map(_.toAttribute)
     val mapped: Seq[Option[NamedExpression]] = projectList.map {
       case a: Attribute if exprIdToLeft.contains(a.exprId) =>
-        // Wrap every rewritten output slot in a fresh Alias.
-        //
-        // When a wrapper reprojects BOTH sides of the same equi pair (e.g.
-        // `SELECT s1.k, s2.k FROM T s1 JOIN T s2 ON s1.k = s2.k AND s1.v <> s2.v`),
-        // both entries collapse to the same sjLeft Attribute after the self-join is
-        // rewritten. Duplicate output ExprIds are not illegal in Spark (`SELECT a, a`
-        // is a valid Project), but fresh Aliases give each output slot an independent
-        // identity, which keeps the `oldOutput -> newOutput` remap 1-to-1 and lets
-        // downstream references (outer join condition, top-level Project) be updated
-        // unambiguously via ExprId.
-        //
-        // The fresh ExprId is on the Alias ITSELF; the referenced child keeps its
-        // original ExprId. Spark's logical-plan integrity checks reject reusing a
-        // referenced ExprId as the Alias's own ExprId, not duplication across slots.
-        Some(Alias(exprIdToLeft(a.exprId), a.name)(): NamedExpression)
+        // Fresh exprId, but carry over qualifier / metadata so this branch stays consistent with
+        // the Alias branch and a column keeps its metadata.
+        Some(
+          Alias(exprIdToLeft(a.exprId), a.name)(
+            qualifier = a.qualifier,
+            explicitMetadata = Some(a.metadata)): NamedExpression)
       case al @ Alias(a: Attribute, _) if exprIdToLeft.contains(a.exprId) =>
-        // Fresh exprId; do NOT reuse `al.exprId`. Reusing another expression's exprId
-        // is the pattern that Spark 3.3 flags via structural-integrity checks.
-        Some(Alias(exprIdToLeft(a.exprId), al.name)(): NamedExpression)
+        // withNewChild preserves name/qualifier/metadata and exprId; newInstance then re-stamps a
+        // fresh exprId, so Alias keeps ownership of its own metadata contract instead of us
+        // re-listing its fields (which drift when Alias gains one).
+        Some(al.withNewChild(exprIdToLeft(a.exprId)).newInstance())
       case _ => None
     }
     if (mapped.exists(_.isEmpty)) {
@@ -176,23 +124,16 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
     } else {
       val newProjectList = mapped.flatten
       val newWrapper = Project(newProjectList, newChild)
-      val newOutput = newWrapper.output
       val remap: Map[ExprId, Attribute] =
-        oldOutput.zip(newOutput).map { case (o, n) => o.exprId -> n }.toMap
+        oldOutput.zip(newWrapper.output).map { case (o, n) => o.exprId -> n }.toMap
       Some((newWrapper, remap))
     }
   }
 
   /**
-   * Replace equi-key attribute references inside a NamedExpression according to `remap`, while
-   * preserving the NamedExpression shape.
-   *
-   * `Expression.transformUp` returns `Expression`, not `NamedExpression`. We avoid a blanket
-   * `asInstanceOf[NamedExpression]` by handling the two shapes that can appear in a Project's
-   * `projectList` explicitly: a bare Attribute (whose top-level may itself be replaced) and an
-   * Alias (which stays an Alias while its child is transformed). Any other NamedExpression shape we
-   * do not rewrite is left as-is ONLY if it does not reference a replaced self-join output;
-   * otherwise it would carry a stale ExprId, so returns None to fail the whole rewrite closed.
+   * Replace equi-key references inside a NamedExpression per `remap`, preserving Attribute/Alias
+   * shape. Any other expression still referencing a replaced output returns None (fail-closed) to
+   * avoid a dangling ExprId.
    */
   private def remapNamedExpressionAttributes(
       ne: NamedExpression,
@@ -203,13 +144,9 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
       val newChild = al.child.transformUp {
         case a: Attribute if remap.contains(a.exprId) => remap(a.exprId)
       }
-      Some(
-        if (newChild eq al.child) al
-        else Alias(newChild, al.name)(al.exprId, al.qualifier, al.explicitMetadata))
+      // withNewChild preserves the same exprId/qualifier/metadata the manual copy did.
+      Some(if (newChild eq al.child) al else al.withNewChild(newChild))
     case other if other.references.exists(a => remap.contains(a.exprId)) =>
-      // Fail-closed: a NamedExpression we do not rewrite (neither a bare Attribute nor an Alias)
-      // that still references a replaced self-join output would be left with a dangling ExprId.
-      // Refuse the rewrite rather than emit a plan with a stale reference.
       None
     case other => Some(other)
   }
@@ -219,14 +156,10 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   // ============================================================================
 
   private def rewriteSubqueryPlan(plan: LogicalPlan): Option[LogicalPlan] = {
-    // Candidate-level nondeterminism guard: reject if ANY node in the whole subquery plan
-    // is non-repeatable (Rand, LIMIT-without-ORDER-BY, Sample, Offset, streaming). This catches
-    // nondeterminism that lives ABOVE the self-join rather than on either side -- e.g. a Pattern
-    // A2 outer join whose condition is `d.k = sj.k AND rand() < 0.5`. Both self-join sides stay
-    // repeatable there, so the per-side `isSameBaseRelation` check would pass, yet the enclosing
-    // subquery is not repeatable.
-    if (!isRepeatablePlan(plan)) return None
-
+    // Match the candidate shape first -- a top-level Inner Join, optionally under one wrapper
+    // Project. This structural match is cheap, so run it before the whole-subquery
+    // `isRepeatablePlan` walk and skip that walk entirely for the many subqueries that are not
+    // even shaped like a self-join.
     val (projectListOpt, innerJoin): (Option[Seq[NamedExpression]], Join) = plan match {
       case Project(pl, j: Join) if j.joinType == Inner && j.condition.isDefined =>
         (Some(pl), j)
@@ -234,6 +167,10 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
         (None, j)
       case _ => return None
     }
+
+    // Candidate-level guard: reject if any node in the whole subquery is non-repeatable, catching
+    // nondeterminism hoisted above the self-join that the per-side `isSameBaseRelation` misses.
+    if (!isRepeatablePlan(plan)) return None
 
     if (isSameBaseRelation(innerJoin.left, innerJoin.right)) {
       rewriteDirectSelfJoin(projectListOpt, innerJoin)
@@ -249,37 +186,27 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   private def rewriteDirectSelfJoin(
       projectListOpt: Option[Seq[NamedExpression]],
       innerJoin: Join): Option[LogicalPlan] = {
+    // Fail closed on an explicit join hint: it is a directive about the join this rule deletes.
+    if (!innerJoin.hint.isEmpty) return None
+
     val innerLeft = innerJoin.left
-    val innerRight = innerJoin.right
     val innerCond = innerJoin.condition.get
 
-    val parsed = parseSelfJoinCondition(innerCond, innerLeft, innerRight)
+    val parsed = parseSelfJoinCondition(innerCond, innerLeft, innerJoin.right)
     if (parsed.isEmpty) return None
-    // parseSelfJoinCondition has validated column correspondence and equi-key uniqueness.
     val (equiPairs, neqPairs) = parsed.get
 
     val innerLeftEquiAttrs: Seq[Attribute] = equiPairs.map(_._1)
     val innerLeftNeqAttr: Attribute = neqPairs.head._1
     val filtered = buildAggregateHavingDistinctGt1(innerLeftEquiAttrs, innerLeftNeqAttr, innerLeft)
 
-    // Fail-closed on bare-Join subqueries: without a wrapping Project the subquery output
-    // is the full self-join output (both sides' columns). Replacing that with
-    // `Project(equiKeys, filtered)` shrinks the output; if the enclosing InSubquery
-    // referenced a non-equi column by position, `values.zip(sub.output).map(EqualTo.tupled)`
-    // inside RewritePredicateSubquery would build an incorrect semi condition. Q95's
-    // subqueries all have an explicit Project wrapper, so this branch does not affect it.
+    // Fail closed on a bare-Join subquery: with no wrapper Project, replacing the self-join output
+    // with `Project(equiKeys, filtered)` shrinks arity and RewritePredicateSubquery's positional
+    // `values.zip(sub.output)` would misbind semi predicates. Q95 subqueries always have a Project.
     projectListOpt match {
-      case None =>
-        None
+      case None => None
       case Some(pl) =>
-        canonicalizeWrapper(pl, equiPairs, filtered).map {
-          case (newWrapper, _) =>
-            logDebug(
-              s"Pattern A' - equiKeys=[${innerLeftEquiAttrs.map(_.name).mkString(",")}]" +
-                s", neqCol=${innerLeftNeqAttr.name}" +
-                s", outCols=[${newWrapper.projectList.map(_.name).mkString(",")}]")
-            newWrapper
-        }
+        canonicalizeWrapper(pl, equiPairs, filtered).map { case (newWrapper, _) => newWrapper }
     }
   }
 
@@ -311,13 +238,11 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
     }
 
     val sjLeft = selfJoin.left
-    val sjRight = selfJoin.right
     val sjCond = selfJoin.condition.get
-    if (!isSameBaseRelation(sjLeft, sjRight)) return None
+    if (!isSameBaseRelation(sjLeft, selfJoin.right)) return None
 
-    val parsed = parseSelfJoinCondition(sjCond, sjLeft, sjRight)
+    val parsed = parseSelfJoinCondition(sjCond, sjLeft, selfJoin.right)
     if (parsed.isEmpty) return None
-    // parseSelfJoinCondition has validated column correspondence and equi-key uniqueness.
     val (equiPairs, neqPairs) = parsed.get
 
     val sjLeftEquiAttrs: Seq[Attribute] = equiPairs.map(_._1)
@@ -326,26 +251,23 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
     val selfJoinOutputSet = selfJoinSide.outputSet
     val sjEquiExprIds: Set[ExprId] =
       equiPairs.flatMap { case (l, r) => Seq(l.exprId, r.exprId) }.toSet
-    // wrapper Project may reproject equi-keys under fresh alias exprIds; include those.
-    val wrapperEquiExprIds: Set[ExprId] = selfJoinProjectOpt.toSeq.flatMap {
-      p =>
-        p.projectList.flatMap {
-          case a: Attribute if sjEquiExprIds.contains(a.exprId) => Some(a.exprId)
-          case al @ Alias(a: Attribute, _) if sjEquiExprIds.contains(a.exprId) => Some(al.exprId)
-          case _ => None
-        }
+    // A wrapper Project may reproject equi-keys under fresh alias exprIds; include those.
+    val wrapperEquiExprIds: Set[ExprId] = selfJoinProjectOpt.toSeq.flatMap { p =>
+      p.projectList.flatMap {
+        case a: Attribute if sjEquiExprIds.contains(a.exprId) => Some(a.exprId)
+        case al @ Alias(a: Attribute, _) if sjEquiExprIds.contains(a.exprId) => Some(al.exprId)
+        case _ => None
+      }
     }.toSet
     val allEquiExprIds = sjEquiExprIds ++ wrapperEquiExprIds
 
-    // Outer join condition may reference only equi-key attrs from the self-join side.
+    // The outer join condition and any top-level Project may reference only equi-key attrs from the
+    // self-join side (the neq column does not survive the rewrite).
     val outerCondRefs = outerCond.references.filter(selfJoinOutputSet.contains)
     if (!outerCondRefs.forall(a => allEquiExprIds.contains(a.exprId))) return None
-
-    // Top-level subquery Project may reference only equi-key attrs from the self-join side.
-    val projectOk = projectListOpt.forall {
-      pl =>
-        val refs = pl.flatMap(_.references).filter(selfJoinOutputSet.contains)
-        refs.forall(a => allEquiExprIds.contains(a.exprId))
+    val projectOk = projectListOpt.forall { pl =>
+      val refs = pl.flatMap(_.references).filter(selfJoinOutputSet.contains)
+      refs.forall(a => allEquiExprIds.contains(a.exprId))
     }
     if (!projectOk) return None
 
@@ -359,29 +281,17 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
             case None => return None
           }
         case None if projectListOpt.isEmpty =>
-          // Fail-closed: with neither a wrapper Project around the self-join nor a top-level
-          // subquery Project, the outer join currently exposes every self-join column, and
-          // replacing the self-join with `Project(equiKeys, filtered)` would shrink the outer
-          // join's right-hand output arity. RewritePredicateSubquery's positional zip
-          // (`values.zip(sub.output).map(EqualTo.tupled)`) would then bind semi predicates to
-          // the wrong attributes -- silently dropping components of a tuple IN. A
-          // top-level Project (`projectListOpt`) is what would let the arity be preserved
-          // by the top-level rewrite loop; without one, refuse to rewrite.
+          // Fail closed: with no wrapper and no top-level Project, `Project(equiKeys, filtered)`
+          // shrinks the outer join's arity and RewritePredicateSubquery's positional zip misbinds.
           return None
         case None =>
-          // No wrapper Project but there IS a top-level subquery Project: shrinking the outer
-          // join's self-join-side output is safe because the top-level Project is rewritten
-          // consistently via `outputRemap` below and the top-level rewrite loop ensures
-          // subquery output arity matches what the enclosing InSubquery expects.
-          // Outer references may point at sjRight equi-attributes; remap them to sjLeft
+          // Top-level Project preserves arity via `outputRemap`; remap sjRight equi-refs to sjLeft
           // (same output position in a valid self-join).
           val newP = Project(sjLeftEquiAttrs, filtered)
-          val remap: Map[ExprId, Attribute] =
-            equiPairs.map { case (l, r) => r.exprId -> l }.toMap
+          val remap: Map[ExprId, Attribute] = equiPairs.map { case (l, r) => r.exprId -> l }.toMap
           (newP, remap)
       }
 
-    // Rewrite outer join condition to use new wrapper output attributes.
     val newOuterCond = outerCond.transformUp {
       case a: Attribute if outputRemap.contains(a.exprId) => outputRemap(a.exprId)
     }
@@ -392,19 +302,13 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
       outerJoin.copy(left = newSelfJoinSide, condition = Some(newOuterCond))
     }
 
-    // Rewrite top-level Project references.
-    val result = projectListOpt match {
+    projectListOpt match {
       case Some(pl) =>
         val remapped = pl.map(ne => remapNamedExpressionAttributes(ne, outputRemap))
         if (remapped.exists(_.isEmpty)) return None
-        Project(remapped.flatten, newOuterJoin)
-      case None => newOuterJoin
+        Some(Project(remapped.flatten, newOuterJoin))
+      case None => Some(newOuterJoin)
     }
-
-    logDebug(
-      s"Pattern A2 - equiKeys=[${sjLeftEquiAttrs.map(_.name).mkString(",")}]" +
-        s", neqCol=${sjLeftNeqAttr.name}")
-    Some(result)
   }
 
   private def tryExtractSelfJoin(plan: LogicalPlan): Option[Join] = {
@@ -413,9 +317,10 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
       case j: Join if j.joinType == Inner && j.condition.isDefined => j
       case _ => return None
     }
+    // A hinted self-join is not an extraction candidate; see `rewriteDirectSelfJoin`.
+    if (!join.hint.isEmpty) return None
     if (!isSameBaseRelation(join.left, join.right)) return None
-    val parsed = parseSelfJoinCondition(join.condition.get, join.left, join.right)
-    if (parsed.isEmpty) return None
+    if (parseSelfJoinCondition(join.condition.get, join.left, join.right).isEmpty) return None
     Some(join)
   }
 
@@ -437,11 +342,9 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   }
 
   /**
-   * Parse a join condition into equi-pairs and inequality-pairs. Accepts only:
-   *   - `EqualTo(attr, attr)` where the two attrs come from opposite sides,
-   *   - `Not(EqualTo(attr, attr))` -- same side rule,
-   *   - `IsNotNull(attr)` where the attr is one of the join columns.
-   * Anything else in the condition disqualifies the whole rewrite (fail-closed).
+   * Parse a join condition into equi-pairs and inequality-pairs. Accepts only `EqualTo(attr, attr)`
+   * and `Not(EqualTo(attr, attr))` across opposite sides, and `IsNotNull(attr)` on a join column;
+   * anything else fails the whole rewrite closed.
    */
   private def parseSelfJoinCondition(
       condition: Expression,
@@ -471,9 +374,8 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
         (l, r)
     }
 
-    // Only IsNotNull predicates on join columns are safe to drop -- they're redundant with
-    // the join semantics or auto-added by InferFiltersFromConstraints. IsNotNull on other
-    // columns changes semantics if we drop it; bail out.
+    // Only IsNotNull on a join column is safe to drop -- redundant with the join or auto-added by
+    // InferFiltersFromConstraints. IsNotNull on any other column changes semantics; bail out.
     val joinAttrIds: Set[ExprId] =
       (equiPairs ++ neqPairs).flatMap { case (l, r) => Seq(l.exprId, r.exprId) }.toSet
     val isNotNullOnJoinCols = predicates.count {
@@ -483,7 +385,6 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
 
     val totalMatched = equiPairs.size + neqPairs.size + isNotNullOnJoinCols
     if (totalMatched != predicates.size) return None
-
     if (equiPairs.isEmpty || neqPairs.isEmpty) return None
 
     // Only rewrite the single-inequality case. Multiple inequality conjuncts cannot be represented
@@ -545,29 +446,10 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   }
 
   /**
-   * Types whose SQL comparison equality (`=` / `<>`) is provably identical to grouping / DISTINCT
-   * equality (and hashing). The rewrite turns `<>` into COUNT(DISTINCT) and `=` into GROUP BY, so
-   * it must never be applied to a type where those two notions of equality can diverge. This is a
-   * conservative positive allowlist: it admits only the types where the equivalence is well
-   * established and fails closed on everything else, including any new type a future version might
-   * add.
-   *
-   * Deliberately rejected:
-   *   - Float / Double: this rewrite relies on comparison equality (`=` / `<>`) and
-   *     grouping/DISTINCT equality having exactly the same contract. Signed zero and NaN are the
-   *     representative edge cases that make that contract non-trivial for floating point, and
-   *     whether the two paths agree rests on normalization details (e.g. NormalizeFloatingNumbers).
-   *     Rather than depend on that, floats fail closed. Complex types are rejected wholesale below,
-   *     which also covers floats nested inside a struct/array/map.
-   *   - Complex types (Array / Struct / Map) and UDTs / Variant: their equality-vs-grouping
-   *     equivalence is harder to prove and can itself embed floats.
-   *   - Char / Varchar: CHAR / VARCHAR have dedicated declared-type semantics and are
-   *     conservatively kept outside this rewrite. Table columns may reach the optimizer as
-   *     annotated StringType, so the caller ([[isSafeComparisonGroupingAttribute]]) recovers their
-   *     declared type from metadata first; this branch is the single rejection point for both that
-   *     path and first-class CHAR/VARCHAR types.
-   *   - Non-binary collated strings: comparison and grouping can route through different collation
-   *     code paths, so only byte-wise `supportsBinaryEquality` strings are admitted.
+   * Positive allowlist of types where comparison equality (`=`/`<>`) provably coincides with
+   * grouping/distinct equality, so a key can move into GROUP BY / COUNT(DISTINCT). Float/Double
+   * (NaN, signed zero), CHAR/VARCHAR (declared-type/padding), non-binary collated strings, complex
+   * types, UDTs / Variant and unknown types fail closed.
    */
   private def isSafeComparisonGroupingType(dt: DataType): Boolean = dt match {
     case ByteType | ShortType | IntegerType | LongType => true
@@ -576,61 +458,19 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
     case DateType => true
     case TimestampType | TimestampNTZType => true
     case BinaryType => true
-
     case _: CharType | _: VarcharType => false
     case st: StringType if st.supportsBinaryEquality => true
-
     case _ => false
   }
 
   /**
-   * True iff `plan` produces the same row bag on every evaluation.
-   *
-   * This is the primary safety guard for the rewrite, which folds two occurrences of the same
-   * subtree into one aggregate -- sound only when both occurrences produce identical row bags. We
-   * check it at TWO levels:
-   *   - candidate level: the enclosing subquery, before descending into the self-join. Catches
-   *     nondeterminism that lives above the self-join rather than on either side -- e.g. a Pattern
-   *     A2 outer join whose condition is `d.k = sj.k AND rand() < 0.5`. Without this,
-   *     `isSameBaseRelation(sjLeft, sjRight)` could pass (both sides look deterministic) while the
-   *     enclosing plan still contains `Rand`.
-   *   - relation level: [[isSameBaseRelation]] additionally requires the two sides to be
-   *     structurally identical.
-   *
-   * Attribute-level `plan.deterministic` alone is NOT sufficient. Catalyst's
-   * `Expression.deterministic` only checks explicit `Nondeterministic` annotation; several
-   * operators produce a runtime-nondeterministic row bag even though every expression they contain
-   * is `deterministic == true`:
-   *   - `Aggregate` with `First` / `Last` / `collect_list` / `min_by` / `max_by` (tie order),
-   *   - `Window` with `row_number()` / `rank()` over a non-total order,
-   *   - `Limit` / `LocalLimit` / `Sample` / `Offset` (row-bag operator-level nondeterminism),
-   *   - streaming sources.
-   *
-   * This rule collapses two evaluations of the same subtree into one aggregate; repeatability must
-   * be provable, not assumed. That is why both the operator check and the expression check below
-   * are WHITELISTS rather than blacklists -- unknown operators and unknown expression types default
-   * to reject.
-   *
-   * Expression support is allowlisted, not blacklisted. `plan.deterministic` relies on each
-   * expression's reported `deterministic` contract; that is necessary but insufficient for unknown
-   * expression types whose repeatability has not been established -- a builtin that carries hidden
-   * state yet reports `deterministic == true` would otherwise be trusted silently. For a rewrite
-   * that folds two evaluations of a subtree into one aggregate we prefer to miss an optimization
-   * than to misapply one, so new expression types are added to [[isRepeatableExpression]] only
-   * after their repeatability has been established. `plan.deterministic` is kept as a cheap
-   * fast-reject, but the expression allowlist is what actually proves repeatability.
-   *
-   * `plan.subqueriesAll.isEmpty` additionally fail-closes on any embedded expression subquery
-   * (scalar / IN / EXISTS). `plan.exists` in `isRowBagRepeatable` walks only the operator tree and
-   * does not descend into expression subqueries, and `plan.deterministic` does not prove a nested
-   * subquery is row-bag repeatable (e.g. an uncorrelated `LIMIT 1` without `ORDER BY`). Rejecting
-   * any embedded subquery keeps the repeatability proof confined to the operator whitelist below.
+   * Primary safety guard: the rewrite folds two occurrences of one subtree into a single aggregate,
+   * so a plan qualifies only when its operators, leaves and expressions are all allowlisted as
+   * repeatable. `plan.deterministic` alone is insufficient -- Aggregate(First), Window row_number
+   * over a non-total order and Limit/Sample are row-bag nondeterministic yet report deterministic.
+   * Embedded expression subqueries also fail closed.
    */
   private def isRepeatablePlan(plan: LogicalPlan): Boolean = {
-    // The operator/source whitelist is checked before the expression whitelist so that a plan whose
-    // operator is itself unknown -- e.g. Aggregate (carries AggregateExpression) or Window (carries
-    // WindowExpression / SortOrder) -- is attributed to isRowBagRepeatable rather than being masked
-    // by the fact that those operators also carry non-allowlisted expressions.
     plan.deterministic &&
     !plan.isStreaming &&
     plan.subqueriesAll.isEmpty &&
@@ -639,92 +479,58 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   }
 
   /**
-   * Operator whitelist for `isRepeatablePlan`. A plan is row-bag repeatable only when every node is
-   * known to produce a repeatable output row bag from repeatable children. Unknown operators and
-   * unknown leaf sources fail closed.
+   * Operator/leaf allowlist for repeatable row bags; everything unknown fails closed. Kept narrow:
+   * the target shape needs only a Parquet scan optionally wrapped in Project / Filter /
+   * SubqueryAlias plus the self-join. Row ordering is irrelevant to the row-bag contract.
    *
-   * Kept intentionally narrow -- the target workload (Q95-shape self-join in a subquery) only needs
-   * a Parquet relation scan optionally wrapped in Project / Filter / SubqueryAlias plus the
-   * self-join itself. Range and LocalRelation are also trusted deterministic leaves. Adding an
-   * operator here requires proving that its output row values and multiplicities are repeatable.
-   * Pure row ordering is irrelevant to the row-bag contract, but operators not needed by the
-   * target shape remain fail-closed until explicitly reviewed.
-   *
-   * Arbitrary `LeafNode`s are intentionally not trusted. For example, `LogicalRDD` may wrap an
-   * arbitrary RDD lineage whose runtime behavior is invisible to Catalyst's `plan.deterministic`;
-   * `InMemoryRelation`, `DataSourceV2Relation` and custom leaves are likewise rejected until
-   * proven. Streaming sources reach here as `LeafNode`s but are already filtered upstream by
-   * `plan.isStreaming` in [[isRepeatablePlan]].
-   *
-   * `LogicalRelation` is trusted only when its underlying relation is a `HadoopFsRelation` whose
-   * `fileFormat` is EXACTLY `ParquetFileFormat` (`getClass == classOf[ParquetFileFormat]`, not
-   * `isInstanceOf`). `HadoopFsRelation.fileFormat` can be any `FileFormat`, including custom
-   * formats whose scan is not provably a repeatable row bag; `ParquetFileFormat` is also non-final,
-   * so a third-party subclass could override its scan. The target workload only needs stock
-   * Parquet, so every other `FileFormat` -- subclasses of `ParquetFileFormat` included -- and every
-   * non-`HadoopFsRelation` fail closed.
-   *
-   * This helper checks operators and leaf sources only; expression-type repeatability is a separate
-   * concern handled by [[hasRepeatableExpressions]], and both are joined in [[isRepeatablePlan]].
+   * The narrowness is deliberate, not a correctness requirement, but it stays intentionally
+   * conservative: the exact-`ParquetFileFormat` leaf check admits only stock Parquet scans. Other
+   * file formats (ORC, JSON, CSV) reach the same FileSourceScan but remain rejected until each is
+   * separately validated, and likewise for inverting the allowlist into a leaf blocklist. This
+   * keeps the rule fail-closed on any leaf not proven repeatable.
    */
   private def isRowBagRepeatable(plan: LogicalPlan): Boolean = !plan.exists {
-    // TreeNode exposes `exists` but not `forall`, so invert: a whitelisted operator maps to `false`
-    // ("does not break repeatability") and everything else to `true`; negating the whole `exists`
-    // then means "every operator is whitelisted".
+    // Whitelisted operator => false ("does not break repeatability"); negating `exists` then means
+    // "every operator is whitelisted".
     case _: Project => false
     case _: Filter => false
     case _: SubqueryAlias => false
-    // Join is included because our target pattern IS a Join; both children get recursed into.
     case _: Join => false
-    // Explicitly trusted leaves.
     case _: Range => false
     case _: LocalRelation => false
     case relation: LogicalRelation =>
+      // Trust a Parquet scan only: exact `ParquetFileFormat` (getClass, not isInstanceOf, since it
+      // is non-final); any other FileFormat is not provably repeatable.
       relation.relation match {
         case h: HadoopFsRelation if h.fileFormat.getClass == classOf[ParquetFileFormat] => false
         case _ => true
       }
-    // Everything else -- Aggregate, Window, Limit, Sample, Offset, Distinct, Union, Except,
-    // Intersect, Sort, Expand, Generate, and opaque leaf sources -- is conservatively
-    // unsupported and fails closed. (Row ordering itself is irrelevant to the row-bag contract;
-    // these are rejected because their row values/multiplicities are not proven repeatable, or
-    // simply because the target shape does not need them.)
     case _ => true
   }
 
-  /**
-   * Expression-type check for [[isRepeatablePlan]], kept separate from the operator whitelist in
-   * [[isRowBagRepeatable]] so the two safety layers read independently. A plan passes only when
-   * every expression carried by every operator node is repeatable per [[isRepeatableExpression]]; a
-   * whitelisted operator holding an unknown expression -- e.g. `Project(Abs(v))` -- fails closed.
-   */
   private def hasRepeatableExpressions(plan: LogicalPlan): Boolean = {
     !plan.exists(node => node.expressions.exists(expr => !isRepeatableExpression(expr)))
   }
 
   /**
-   * Expression repeatability is allowlisted, consistently with the operator whitelist in
-   * [[isRowBagRepeatable]]. Only expression types whose result is determined entirely by repeatable
-   * children are accepted; unknown expression types fail closed. This rule folds two evaluations of
-   * the same subtree into one, so missing an optimization is preferable to assuming repeatability
-   * for an expression whose runtime behavior has not been proven.
-   *
-   * The whole tree is checked: an expression is repeatable only when its root type is on the
-   * allowlist AND all of its children are themselves repeatable, so e.g. `Add(v, Abs(w))` is
-   * rejected even though `Add` is allowlisted.
-   *
-   * The initial set covers what TPC-DS Q95 and the tests need: column / literal references, Alias,
-   * Cast, basic arithmetic, boolean connectives, the six comparisons plus null-safe equality, and
-   * null checks. Expressions such as `Abs` / `Coalesce` / `CaseWhen` are intentionally absent -- a
-   * self-join over them is simply not rewritten (a missed optimization, not a correctness bug)
-   * until each is added here after its repeatability has been established. Decimal wrappers such as
-   * `PromotePrecision` / `CheckOverflow` are likewise absent and may fail closed; that is
-   * acceptable and must not be worked around by trusting them just to make an arithmetic variant
-   * fire.
+   * Expression allowlist: repeatable only when the root type is allowlisted and all children are,
+   * so `Add(v, Abs(w))` is rejected. Unknown types fail closed (a missed optimization, not a bug).
+   * Decimal wrappers such as `PromotePrecision` / `CheckOverflow` are absent and may fail closed.
    */
   private def isRepeatableExpression(expr: Expression): Boolean = expr match {
     case _: Attribute | _: Literal =>
       true
+    // A STRING -> TIMESTAMP_LTZ cast (micro or nanosecond precision) is not repeatable: for a
+    // time-only string SparkDateTimeUtils fills the missing date from LocalDate.now(zoneId), which
+    // ComputeCurrentTime does not stabilize on this path, so two scans that straddle midnight can
+    // produce different timestamps while the rewrite folds them into a single evaluation. The NTZ
+    // parse is clock-independent (it returns null for a time-only string), so only the LTZ
+    // directions are rejected. Reject whenever such a conversion appears at any nesting level,
+    // including inside array/map/struct element casts -- e.g. CAST(CAST(ss AS ARRAY<TIMESTAMP>) AS
+    // STRING). Each nested Cast node is itself visited here, so a per-node check catches the inner
+    // conversion. Fail closed.
+    case c: Cast if castHasClockDependentStringToTimestamp(c.child.dataType, c.dataType) =>
+      false
     case _: Alias | _: Cast | _: Add | _: Subtract | _: Multiply | _: Divide | _: Remainder |
         _: And | _: Or | _: Not | _: EqualTo | _: EqualNullSafe | _: LessThan |
         _: LessThanOrEqual | _: GreaterThan | _: GreaterThanOrEqual | _: IsNull | _: IsNotNull =>
@@ -734,9 +540,32 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   }
 
   /**
-   * True iff `left` and `right` are the same plan modulo canonicalization AND each side is a
-   * repeatable plan. See [[isRepeatablePlan]] for the repeatability contract.
+   * True when casting `from` to `to` performs a clock-dependent STRING -> TIMESTAMP_LTZ conversion
+   * (microsecond or nanosecond precision) at any nesting level: directly, or inside matching
+   * array / map / struct element casts. Such a cast supplies a time-only string's missing date from
+   * the runtime clock, so it is not repeatable; see [[isRepeatableExpression]]. The scalar
+   * String-source decision is delegated to [[Cast.needsTimeZone]], which enumerates exactly the
+   * zone-dependent (hence LTZ, hence clock-dependent for a bare time) String conversions and stays
+   * in sync as Spark adds timestamp types; String -> TIMESTAMP_NTZ is clock-independent and absent
+   * there.
    */
+  private def castHasClockDependentStringToTimestamp(from: DataType, to: DataType): Boolean =
+    (from, to) match {
+      case (s: StringType, t) => Cast.needsTimeZone(s, t)
+      case (ArrayType(fromEl, _), ArrayType(toEl, _)) =>
+        castHasClockDependentStringToTimestamp(fromEl, toEl)
+      case (MapType(fromKey, fromVal, _), MapType(toKey, toVal, _)) =>
+        castHasClockDependentStringToTimestamp(fromKey, toKey) ||
+          castHasClockDependentStringToTimestamp(fromVal, toVal)
+      case (StructType(fromFields), StructType(toFields))
+          if fromFields.length == toFields.length =>
+        fromFields.zip(toFields).exists { case (f, t) =>
+          castHasClockDependentStringToTimestamp(f.dataType, t.dataType)
+        }
+      case _ => false
+    }
+
+  /** True iff `left`/`right` are the same plan modulo canonicalization AND each is repeatable. */
   private def isSameBaseRelation(left: LogicalPlan, right: LogicalPlan): Boolean = {
     left.sameResult(right) &&
     isRepeatablePlan(left) && isRepeatablePlan(right)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregate.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types._
 
 /**
  * Rewrites supported uncorrelated IN-subquery inequality self-joins into
- * `GROUP BY + HAVING COUNT(DISTINCT) > 1`, avoiding the self-join cross-product.
+ * `GROUP BY + HAVING MIN(neq) <> MAX(neq)`, avoiding the self-join cross-product.
  *
  * Supports a direct self-join (Pattern A') and a self-join nested under an outer inner join
  * (Pattern A2, where only the self-join child becomes an Aggregate). Unsupported and correlated
@@ -46,7 +46,8 @@ import org.apache.spark.sql.types._
  */
 object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with PredicateHelper {
 
-  private val CountDistinctAliasName = "_rewrite_selfjoin_inequality_cnt_distinct"
+  private val MinNeqAliasName = "_rewrite_selfjoin_inequality_min"
+  private val MaxNeqAliasName = "_rewrite_selfjoin_inequality_max"
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (!conf.getConf(SQLConf.REWRITE_SELF_JOIN_INEQUALITY_TO_AGGREGATE_ENABLED)) {
@@ -69,26 +70,31 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
   // ============================================================================
 
   /**
-   * Build `Filter(cnt > 1, Aggregate(equiKeys, child))` with a `COUNT(DISTINCT neqCol)`.
+   * Build `Filter(min <> max, Aggregate(equiKeys, child))`, taking MIN and MAX over the neq column.
+   * `MIN(neqCol) <> MAX(neqCol)` is true exactly when the group holds two or more distinct non-null
+   * values -- the same test as `COUNT(DISTINCT neqCol) > 1`, but avoids the distinct-dedup
+   * aggregation stages and supports partial aggregation.
    *
    * The `IsNotNull(equiKeys)` filter preserves the equi-join's NULL semantics: `=` never matches a
    * NULL key, but GROUP BY would fold all NULL keys into one group that can leak NULL into a
-   * `NOT IN`. The neq column needs no filter -- `COUNT(DISTINCT)` already ignores NULL.
+   * `NOT IN`. The neq column needs no filter -- MIN/MAX ignore NULL, and a group with fewer than
+   * two non-null values has `min = max` (or both NULL, which makes `<>` NULL), so `<>` is never
+   * true for it and the group is dropped.
    */
-  private def buildAggregateHavingDistinctGt1(
+  private def buildAggregateHavingMultipleDistinct(
       equiKeys: Seq[Attribute],
       neqCol: Attribute,
       child: LogicalPlan): LogicalPlan = {
-    val countExpr = Count(Seq(neqCol)).toAggregateExpression(isDistinct = true)
-    val countAlias = Alias(countExpr, CountDistinctAliasName)()
-    val aggExprs: Seq[NamedExpression] = equiKeys :+ countAlias
+    val minAlias = Alias(Min(neqCol).toAggregateExpression(), MinNeqAliasName)()
+    val maxAlias = Alias(Max(neqCol).toAggregateExpression(), MaxNeqAliasName)()
+    val aggExprs: Seq[NamedExpression] = equiKeys :+ minAlias :+ maxAlias
     val nonNullChild = equiKeys
       .map(a => IsNotNull(a): Expression)
       .reduceOption(And)
       .map(Filter(_, child))
       .getOrElse(child)
     val agg = Aggregate(equiKeys, aggExprs, nonNullChild)
-    Filter(GreaterThan(countAlias.toAttribute, Literal(1L, LongType)), agg)
+    Filter(Not(EqualTo(minAlias.toAttribute, maxAlias.toAttribute)), agg)
   }
 
   /**
@@ -198,7 +204,8 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
 
     val innerLeftEquiAttrs: Seq[Attribute] = equiPairs.map(_._1)
     val innerLeftNeqAttr: Attribute = neqPairs.head._1
-    val filtered = buildAggregateHavingDistinctGt1(innerLeftEquiAttrs, innerLeftNeqAttr, innerLeft)
+    val filtered =
+      buildAggregateHavingMultipleDistinct(innerLeftEquiAttrs, innerLeftNeqAttr, innerLeft)
 
     // Fail closed on a bare-Join subquery: with no wrapper Project, replacing the self-join output
     // with `Project(equiKeys, filtered)` shrinks arity and RewritePredicateSubquery's positional
@@ -271,7 +278,7 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
     }
     if (!projectOk) return None
 
-    val filtered = buildAggregateHavingDistinctGt1(sjLeftEquiAttrs, sjLeftNeqAttr, sjLeft)
+    val filtered = buildAggregateHavingMultipleDistinct(sjLeftEquiAttrs, sjLeftNeqAttr, sjLeft)
 
     val (newSelfJoinSide, outputRemap): (LogicalPlan, Map[ExprId, Attribute]) =
       selfJoinProjectOpt match {
@@ -387,58 +394,45 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
     if (totalMatched != predicates.size) return None
     if (equiPairs.isEmpty || neqPairs.isEmpty) return None
 
-    // Only rewrite the single-inequality case. Multiple inequality conjuncts cannot be represented
-    // by COUNT(DISTINCT) over a single column.
+    // A single inequality only: MIN/MAX over one column cannot represent multiple neqs.
     if (neqPairs.size != 1) return None
 
-    // The rewrite swaps SQL comparison equality for grouping/DISTINCT equality: `<>` becomes
-    // COUNT(DISTINCT neqCol) and `=` becomes GROUP BY equiKey. It is only sound on types where
-    // those two notions of equality coincide, so gate every equi-key and the neq column on a
-    // positive `isSafeComparisonGroupingType` allowlist rather than `RowOrdering.isOrderable`:
-    // orderable only proves an order/hash exists, not that comparison and grouping agree. Fail
-    // closed on anything not proven safe (float -0.0/NaN, complex types, non-binary collations,
-    // and future/unknown types).
-    //
-    // Check BOTH ends of every pair, not just the sjLeft attribute. `isSameBaseRelation` proves
-    // the two sides are canonically equal, but `AttributeReference.canonicalized` rewrites the
-    // reference to drop metadata, so canonical equality does NOT prove the sjRight attribute
-    // carries the same CHAR/VARCHAR metadata that `isSafeComparisonGroupingAttribute` reads. Gate
-    // each side independently rather than assume they match.
-    val keyAttrs =
-      (equiPairs ++ neqPairs).flatMap { case (left, right) => Seq(left, right) }
+    // The rewrite swaps comparison equality (`=`/`<>`) for grouping and MIN/MAX ordering equality,
+    // so gate every equi-key and the neq column -- both ends of each pair, since canonicalization
+    // drops the metadata that `isSafeComparisonGroupingAttribute` reads and the two ends may differ
+    // -- on a positive type allowlist. Fail closed on anything not proven safe.
+    val keyAttrs = (equiPairs ++ neqPairs).flatMap { case (l, r) => Seq(l, r) }
     if (!keyAttrs.forall(isSafeComparisonGroupingAttribute)) return None
 
-    // Canonicalization intentionally erases cosmetic Alias names, so name equality cannot prove
-    // that the two predicate ends refer to the same underlying column. Resolve each end by its own
-    // ExprId against its child output and require matching output ordinals instead.
-    val equiValid = equiPairs.forall {
-      case (l, r) => sameOutputPosition(leftPlan, rightPlan, l, r)
-    }
-    val neqValid = neqPairs.forall {
-      case (l, r) => sameOutputPosition(leftPlan, rightPlan, l, r)
-    }
+    // The rewrite expresses "two or more distinct values" as MIN(neq) <> MAX(neq), so the neq
+    // column must be orderable. The allowlist above already implies this, but assert Spark's own
+    // MIN/MAX input contract (RowOrdering.isOrderable, the same check Min/Max run) explicitly, so
+    // the requirement is visible at the rewrite site.
+    if (!RowOrdering.isOrderable(neqPairs.head._1.dataType)) return None
+
+    // Resolve each predicate end by ExprId and require matching output ordinals, not name equality
+    // (canonicalization erases cosmetic Alias names).
+    val equiValid =
+      equiPairs.forall { case (l, r) => sameOutputPosition(leftPlan, rightPlan, l, r) }
+    val neqValid = neqPairs.forall { case (l, r) => sameOutputPosition(leftPlan, rightPlan, l, r) }
     if (!equiValid || !neqValid) return None
 
-    // Equi-key output positions must be distinct across pairs. Keep the same positional identity
-    // here so swapped or duplicate aliases cannot make two different underlying columns look equal.
+    // Equi-key output positions must be distinct, so swapped/duplicate aliases cannot collide.
     val leftEquiOrdinals = equiPairs.map { case (l, _) => outputOrdinal(leftPlan, l) }
     if (leftEquiOrdinals.exists(_ < 0)) return None
     if (leftEquiOrdinals.distinct.size != leftEquiOrdinals.size) return None
 
-    // Defensive: reject when the neq column overlaps an equi-key column
-    // (e.g. `t1.k = t2.k AND t1.k <> t2.k`).
+    // Reject when the neq column overlaps an equi-key column (e.g. `t1.k = t2.k AND t1.k <> t2.k`).
     val neqLeftOrdinal = outputOrdinal(leftPlan, neqPairs.head._1)
     if (neqLeftOrdinal < 0 || leftEquiOrdinals.contains(neqLeftOrdinal)) return None
     Some((equiPairs, neqPairs))
   }
 
   /**
-   * Attribute-aware gate applied to the equi keys and the neq column. A CHAR/VARCHAR column reaches
-   * the optimizer as StringType with its declared type recorded in the attribute metadata
-   * (CharVarcharUtils stamps it when the relation output is built), so checking `attr.dataType`
-   * alone would let it through the StringType branch of [[isSafeComparisonGroupingType]]. Recover
-   * the declared raw type from the metadata (falling back to `dataType` when there is no marker)
-   * and run it through the datatype allowlist, so CHAR/VARCHAR fail closed there in every config.
+   * Type gate applied to each equi-key and the neq column. CHAR/VARCHAR reach the optimizer as
+   * StringType with the declared type recorded in the attribute metadata, so recover the raw type
+   * from metadata (falling back to `dataType`) before running the datatype allowlist -- otherwise
+   * they would slip through the StringType branch.
    */
   private def isSafeComparisonGroupingAttribute(attr: Attribute): Boolean = {
     val rawType = CharVarcharUtils.getRawType(attr.metadata).getOrElse(attr.dataType)
@@ -447,7 +441,7 @@ object RewriteSelfJoinInequalityToAggregate extends Rule[LogicalPlan] with Predi
 
   /**
    * Positive allowlist of types where comparison equality (`=`/`<>`) provably coincides with
-   * grouping/distinct equality, so a key can move into GROUP BY / COUNT(DISTINCT). Float/Double
+   * grouping and MIN/MAX ordering equality, so a key can move into GROUP BY / MIN-MAX. Float/Double
    * (NaN, signed zero), CHAR/VARCHAR (declared-type/padding), non-binary collated strings, complex
    * types, UDTs / Variant and unknown types fail closed.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -58,6 +58,14 @@ class SparkOptimizer(
   override def preCBORules: Seq[Rule[LogicalPlan]] =
     Seq(OptimizeMetadataOnlyDeleteFromTable)
 
+  // Runs inside the operator optimization batch (before RewritePredicateSubquery), so the rule can
+  // observe the uncorrelated InSubquery shape while the self-join multiplicity is still
+  // unobservable. Placed here rather than in Catalyst's Optimizer because its repeatability guard
+  // depends on file-source semantics (LogicalRelation / HadoopFsRelation / ParquetFileFormat) that
+  // live in sql/core.
+  override def extendedOperatorOptimizationRules: Seq[Rule[LogicalPlan]] =
+    super.extendedOperatorOptimizationRules :+ RewriteSelfJoinInequalityToAggregate
+
   override def defaultBatches: Seq[Batch] = flattenBatches(Seq(
     preOptimizationBatches,
     super.defaultBatches,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregateSuite.scala
@@ -1,0 +1,1037 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+/**
+ * Correctness tests for [[RewriteSelfJoinInequalityToAggregate]].
+ *
+ * Positive A' / A2 cases assert both result equivalence and that the rewrite actually fired.
+ *
+ * `assert(!ruleFired(plan))` on its own only proves the rewrite did not happen -- not that it was
+ * the guard under test that stopped it. A fixture whose two self-join sides are not structurally
+ * identical is rejected by `isSameBaseRelation` before any predicate is even parsed, and such a
+ * test passes while covering nothing. So six important rejection paths -- the predicate parser, the
+ * single-inequality requirement, output-position identity, the nondeterminism guard, the
+ * leaf-source allowlist (LogicalRDD vs Parquet), and the expression-type allowlist (`abs(v)` vs
+ * `v + 1`) -- are tested as single-variable pairs: the same fixture and the same query shape, one
+ * control query that must fire and one variant that changes only the feature under test and must
+ * not. A firing control does not pin the rejection to a particular line, but it does rule out an
+ * unrelated fixture mismatch as the reason its partner was rejected. The row-bag whitelist
+ * (Aggregate, Window) stays a plain negative: dropping the operator would change the query shape
+ * rather than one feature.
+ *
+ * Self-joined fixtures are real tables, not temp views over VALUES. Spark deduplicates a self-join
+ * over a [[org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation]] via `newInstance()`,
+ * which refreshes one side's ExprIds without inserting a rename-only Project, so both sides stay
+ * structurally identical. A temp view over VALUES cannot, and Spark renames one side with a Project
+ * instead, which would make `isSameBaseRelation` false for every self-join below. `range()` needs
+ * no such treatment -- Range is a MultiInstanceRelation already.
+ */
+class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSparkSession {
+
+  private val rewriteConf = SQLConf.REWRITE_SELF_JOIN_INEQUALITY_TO_AGGREGATE_ENABLED.key
+
+  /** Signature alias produced by the rewrite; presence => rule definitely fired. */
+  private val CountDistinctAlias = "_rewrite_selfjoin_inequality_cnt_distinct"
+
+  private def ruleFired(plan: LogicalPlan): Boolean =
+    plan.exists {
+      p =>
+        p.expressions.exists(_.exists {
+          case a: Alias if a.name == CountDistinctAlias => true
+          case _ => false
+        })
+    }
+
+  private def assertRuleFired(sql: String): Unit = {
+    withSQLConf(rewriteConf -> "true") {
+      val plan = spark.sql(sql).queryExecution.optimizedPlan
+      assert(ruleFired(plan), s"self-join inequality rewrite should fire:\n$plan")
+    }
+  }
+
+  private def assertRuleNotFired(sql: String): Unit = {
+    withSQLConf(rewriteConf -> "true") {
+      val plan = spark.sql(sql).queryExecution.optimizedPlan
+      assert(!ruleFired(plan), s"self-join inequality rewrite must not fire:\n$plan")
+    }
+  }
+
+  /**
+   * A real table, so that a self-join of it dedups into two structurally identical sides. See the
+   * class comment for why a temp view over VALUES cannot be used for a self-joined fixture.
+   */
+  private def createTable(name: String, schema: String, values: String): Unit = {
+    spark.sql(s"DROP TABLE IF EXISTS $name")
+    spark.sql(s"CREATE TABLE $name($schema) USING parquet")
+    spark.sql(s"INSERT INTO $name SELECT * FROM VALUES $values")
+  }
+
+  /** Run `sql` twice, first with rewrite ON then OFF, and return the two result row sets. */
+  private def runBoth(sql: String): (Set[Row], Set[Row]) = {
+    var on: Set[Row] = null
+    var off: Set[Row] = null
+    withSQLConf(rewriteConf -> "true") {
+      on = spark.sql(sql).collect().toSet
+    }
+    withSQLConf(rewriteConf -> "false") {
+      off = spark.sql(sql).collect().toSet
+    }
+    (on, off)
+  }
+
+  private def setupTable(): Unit = {
+    // k=1: distinct v={10,20}      -> matches (has 2 non-null distinct)
+    // k=2: distinct v={30}         -> no match (only 1)
+    // k=3: distinct v={40,50,60}   -> matches
+    // k=4: v={70, NULL}            -> no match (only 1 non-null)
+    // k=5: v={NULL, NULL}          -> no match (0 non-null)
+    // k=6: v={80, 90, NULL}        -> matches
+    // k=7: v={100,100}             -> no match: duplicate-only. Proves DISTINCT is required;
+    //                                a plain COUNT(v) > 1 would wrongly match this group.
+    createTable(
+      "T",
+      "k INT, v INT",
+      """  (1, 10), (1, 10), (1, 20),
+        |  (2, 30),
+        |  (3, 40), (3, 50), (3, 60),
+        |  (4, 70), (4, CAST(NULL AS INT)),
+        |  (5, CAST(NULL AS INT)), (5, CAST(NULL AS INT)),
+        |  (6, 80), (6, 90), (6, CAST(NULL AS INT)),
+        |  (7, 100), (7, 100)""".stripMargin
+    )
+  }
+
+  // ==================== Positive: rewrite fires and is semantically equivalent ===============
+
+  test("Pattern A': direct InSubquery self-join is rewritten") {
+    setupTable()
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+
+    assertRuleFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"rewrite ON $on != OFF $off")
+    assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+  }
+
+  test("Pattern A2: nested self-join is rewritten") {
+    setupTable()
+    spark.sql(
+      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+        |  (1), (3), (6) AS D(k)""".stripMargin)
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT d.k
+        |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
+        |             ON s1.k = s2.k AND s1.v <> s2.v) sj
+        |  WHERE d.k = sj.k)""".stripMargin
+
+    assertRuleFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"Pattern A2 rewrite ON $on != OFF $off")
+    assert(on == Set(Row(1), Row(3), Row(6)))
+  }
+
+  test("Pattern A2: self-join on the LEFT of the outer join is rewritten") {
+    // Mirror of the Pattern A2 test above. There the self-join is the RIGHT child of the outer join
+    // (`selfJoinOnRight = true`); here it is the LEFT child (`selfJoinOnRight = false`). The rule
+    // has an explicit branch for each side, so both are covered.
+    setupTable()
+    spark.sql(
+      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+        |  (1), (3), (6) AS D(k)""".stripMargin)
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT d.k
+        |  FROM (SELECT s1.k FROM T s1 JOIN T s2
+        |        ON s1.k = s2.k AND s1.v <> s2.v) sj, D d
+        |  WHERE sj.k = d.k)""".stripMargin
+
+    assertRuleFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"Pattern A2 (self-join on left) rewrite ON $on != OFF $off")
+    assert(on == Set(Row(1), Row(3), Row(6)))
+  }
+
+  test("Pattern A2: nondeterminism in the outer join condition must not be rewritten") {
+    // Both self-join sides are still repeatable here, so the per-side `isSameBaseRelation` check
+    // would pass; the `rand()` conjunct lives on the outer join ABOVE the self-join. Only the
+    // candidate-level `isRepeatablePlan` walk over the whole subquery catches it, so the rule must
+    // fail closed. This is the case the candidate-level guard exists for.
+    setupTable()
+    spark.sql(
+      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+        |  (1), (3), (6) AS D(k)""".stripMargin)
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT d.k
+        |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
+        |             ON s1.k = s2.k AND s1.v <> s2.v) sj
+        |  WHERE d.k = sj.k AND rand() < 0.5)""".stripMargin
+
+    assertRuleNotFired(sql)
+  }
+
+  test("Pattern A': multi-equi tuple IN with sjRight key remap is rewritten") {
+    // Exercises the multi-equi-key path: two equi keys (k1, k2) drive the GROUP BY, and the tuple
+    // IN projects `s1.k1, s2.k2` -- so the second output column comes from the RIGHT self-join side
+    // and must be remapped to its sjLeft counterpart by `canonicalizeWrapper`. This one case covers
+    // multiple equi keys, tuple IN output arity, the two injected IsNotNull(equiKey) filters, and
+    // the sjRight-attribute remap at once.
+    createTable(
+      "TM",
+      "k1 INT, k2 INT, v INT",
+      """  (1, 1, 10), (1, 1, 20),
+        |  (1, 2, 30), (1, 2, 30),
+        |  (2, 1, 40), (2, 1, 50),
+        |  (CAST(NULL AS INT), 1, 60), (CAST(NULL AS INT), 1, 70),
+        |  (3, CAST(NULL AS INT), 80), (3, CAST(NULL AS INT), 90)""".stripMargin)
+    val sql =
+      """SELECT k1, k2 FROM TM outer_t WHERE (k1, k2) IN (
+        |  SELECT s1.k1, s2.k2 FROM TM s1 JOIN TM s2
+        |    ON s1.k1 = s2.k1 AND s1.k2 = s2.k2 AND s1.v <> s2.v)""".stripMargin
+
+    assertRuleFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"multi-equi tuple IN rewrite ON $on != OFF $off")
+    // (1,1): distinct v={10,20} -> matches; (1,2): v={30} -> no; (2,1): v={40,50} -> matches;
+    // (NULL,1) and (3,NULL): NULL equi key filtered out by the injected IsNotNull. -> {(1,1),(2,1)}
+    assert(on == Set(Row(1, 1), Row(2, 1)), s"expected {(1,1),(2,1)}, got $on")
+  }
+
+  test("NULL / 3VL on inequality column is preserved") {
+    setupTable()
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+
+    assertRuleFired(sql)
+    val (on, off) = runBoth(sql)
+    // k=4 (v={70,NULL}) and k=5 (v={NULL,NULL}) do not satisfy plain SQL <>.
+    assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+    assert(off == on, s"NULL/3VL semantics diverge between rewrite ON and OFF: $on vs $off")
+  }
+
+  test("NULL equi-key is filtered before aggregation for NOT IN") {
+    createTable(
+      "TN",
+      "k INT, v INT",
+      """  (CAST(NULL AS INT), 10),
+        |  (CAST(NULL AS INT), 20),
+        |  (1, 10), (1, 20),
+        |  (2, 30)""".stripMargin
+    )
+    spark.sql(
+      """CREATE OR REPLACE TEMP VIEW OuterKeys AS SELECT * FROM VALUES
+        |  (1), (2), (3) AS OuterKeys(k)""".stripMargin)
+    val sql =
+      """SELECT k FROM OuterKeys o WHERE k NOT IN (
+        |  SELECT s1.k FROM TN s1 JOIN TN s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+
+    assertRuleFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"NULL equi-key NOT IN semantics diverge: ON=$on OFF=$off")
+    assert(on == Set(Row(2), Row(3)), s"expected {2,3}, got $on")
+  }
+
+  test("Swapped aliases must not be treated as the same self-join columns") {
+    // The guard under test is `sameOutputPosition`. Both queries alias the same two base columns
+    // to the names `k` and `v` on both sides, so a rule that compares attribute names would fire
+    // on both; only the output ordinal tells them apart. The control fires, which is what makes
+    // the negative case evidence that the ordinal check -- not a structural mismatch -- rejected
+    // the swapped one.
+    createTable("AliasBase", "a INT, b INT", "  (1, 10), (1, 20), (2, 30)")
+
+    val alignedSql =
+      """SELECT a FROM AliasBase outer_t WHERE a IN (
+        |  SELECT s1.k
+        |  FROM (SELECT a AS k, b AS v FROM AliasBase) s1
+        |  JOIN (SELECT a AS k, b AS v FROM AliasBase) s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(alignedSql)
+    val (alignedOn, alignedOff) = runBoth(alignedSql)
+    assert(
+      alignedOn == alignedOff,
+      s"aligned-alias control diverges: ON=$alignedOn OFF=$alignedOff")
+    assert(alignedOn == Set(Row(1)), s"aligned-alias control expected {1}, got $alignedOn")
+
+    // s1.k is `a` (output position 0) but s2.k is `b` (output position 1): same name, different
+    // column. Rewriting this would count distinct `b` per `a`, which is a different query.
+    val swappedSql =
+      """SELECT a FROM AliasBase outer_t WHERE a IN (
+        |  SELECT s1.k
+        |  FROM (SELECT a AS k, b AS v FROM AliasBase) s1
+        |  JOIN (SELECT a AS v, b AS k FROM AliasBase) s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(swappedSql)
+    val (on, off) = runBoth(swappedSql)
+    assert(on == off, s"swapped-alias semantics diverge: ON=$on OFF=$off")
+    assert(on.isEmpty, s"swapped-alias baseline should be empty, got $on")
+  }
+
+  test("Two different relations with the same schema must not be treated as a self-join") {
+    // The guard under test is `isSameBaseRelation`: it must reject a join between two DIFFERENT
+    // base tables even when they share a schema and column names. Distinct Parquet tables
+    // canonicalize to distinct `rootPaths`, so `left.canonicalized == right.canonicalized` is
+    // false and the rewrite must not fire. This pins a real correctness boundary, not just a
+    // missed optimization: rewriting `TLeft JOIN TRight` as COUNT(DISTINCT) over TLeft alone would
+    // drop TRight's rows and change the answer, so removing the guard would make ON diverge from
+    // OFF here.
+    createTable("TLeft", "k INT, v INT", "  (1, 10), (1, 10), (2, 30)")
+    createTable("TRight", "k INT, v INT", "  (1, 20), (1, 20), (2, 30)")
+    val sql =
+      """SELECT k FROM TLeft outer_t WHERE k IN (
+        |  SELECT s1.k FROM TLeft s1 JOIN TRight s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"different-relation join semantics diverge: ON=$on OFF=$off")
+    // k=1: TLeft v={10} vs TRight v={20} -> 10<>20 true -> qualifies; k=2: 30<>30 false -> no.
+    assert(on == Set(Row(1)), s"expected {1}, got $on")
+  }
+
+  // ==================== Positive: rewritten plan is structurally the aggregate ================
+  //
+  // Result parity (ON == OFF) proves the two queries return the same rows; it does not prove the
+  // rewrite produced the specific GROUP BY + HAVING COUNT(DISTINCT) > 1 shape rather than, say,
+  // leaving the self-join and happening to agree. These controls compare the rewritten plan against
+  // a hand-written aggregate SQL that spells out the intended shape, INCLUDING two `IS NOT NULL`
+  // filters: on the equi-key (which the rewrite injects to preserve equi-join NULL semantics) and
+  // on the neq column. `v IS NOT NULL` is semantically redundant for COUNT(DISTINCT v), which
+  // already ignores NULL, but the original `s1.v <> s2.v` lets InferFiltersFromConstraints derive
+  // `isnotnull(v)` and push it below the aggregate, so the equivalent SQL must include it to match
+  // the shape the optimizer actually produces. The comparison itself is `compareCanonicalizedPlans`
+  // (see its doc for why canonicalizing first, and disabling checkAnalysis, is required here).
+
+  private def optimizedPlanWith(sql: String, rewrite: Boolean): LogicalPlan =
+    withSQLConf(rewriteConf -> rewrite.toString) {
+      spark.sql(sql).queryExecution.optimizedPlan
+    }
+
+  /**
+   * Assert two optimized plans are structurally equal. Canonicalize first: the rewrite creates
+   * fresh aliases, whose names and exprIds are cosmetic for this structural check, while the
+   * Join-vs-Aggregate shape difference this asserts on survives canonicalization. `checkAnalysis`
+   * is disabled because both plans are already analyzed and optimized, and a canonicalized plan is
+   * not re-analyzable (its HAVING references a zeroed exprId), which the default would reject
+   * before any comparison.
+   */
+  private def compareCanonicalizedPlans(actual: LogicalPlan, expected: LogicalPlan): Unit =
+    comparePlans(actual.canonicalized, expected.canonicalized, checkAnalysis = false)
+
+  test("Pattern A' rewritten plan is structurally the equivalent aggregate") {
+    setupTable()
+    val selfJoinSql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    val aggregateSql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
+        |  GROUP BY k HAVING count(DISTINCT v) > 1)""".stripMargin
+
+    val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
+    val expected = optimizedPlanWith(aggregateSql, rewrite = false)
+    assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
+    assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
+    compareCanonicalizedPlans(actual, expected)
+  }
+
+  test("Pattern A2 rewritten plan is structurally the equivalent aggregate") {
+    setupTable()
+    spark.sql(
+      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+        |  (1), (3), (6) AS D(k)""".stripMargin)
+    val selfJoinSql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT d.k
+        |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
+        |             ON s1.k = s2.k AND s1.v <> s2.v) sj
+        |  WHERE d.k = sj.k)""".stripMargin
+    val aggregateSql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT d.k
+        |  FROM D d, (SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
+        |             GROUP BY k HAVING count(DISTINCT v) > 1) sj
+        |  WHERE d.k = sj.k)""".stripMargin
+
+    val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
+    val expected = optimizedPlanWith(aggregateSql, rewrite = false)
+    assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
+    assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
+    compareCanonicalizedPlans(actual, expected)
+  }
+
+  // ==================== Negative: rewrite must produce equivalent results (or bail) ==========
+
+  test("Plain InnerJoin at top level: results unchanged (rewrite must not touch it)") {
+    setupTable()
+    val sql =
+      """SELECT ws1.k FROM T ws1 JOIN T ws2
+        |ON ws1.k = ws2.k AND ws1.v <> ws2.v""".stripMargin
+    // Row-multiplicity matters here; using count() to catch any drop or dup.
+    var onCount: Long = -1L
+    var offCount: Long = -1L
+    withSQLConf(rewriteConf -> "true") {
+      onCount = spark.sql(sql).count()
+    }
+    withSQLConf(rewriteConf -> "false") {
+      offCount = spark.sql(sql).count()
+    }
+    assert(
+      onCount == offCount,
+      s"plain InnerJoin row-count differs: rewrite=$onCount vs baseline=$offCount")
+    assertRuleNotFired(sql)
+  }
+
+  test("IS DISTINCT FROM is rejected by the self-join condition parser") {
+    setupTable()
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.v IS DISTINCT FROM s2.v)""".stripMargin
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"IS DISTINCT FROM semantics diverge: ON=$on OFF=$off")
+    // Assert the full result, not just contains(4): unlike `<>`, `IS DISTINCT FROM` treats NULL as
+    // a value, so k=4 (v={70,NULL}) qualifies alongside k=1, k=3 and k=6.
+    assert(on == Set(Row(1), Row(3), Row(4), Row(6)), s"expected {1,3,4,6}, got $on")
+    assertRuleNotFired(sql)
+  }
+
+  test("IsNotNull on a non-join column is rejected") {
+    // The guard under test is the predicate parser: it accepts IsNotNull only on a column the
+    // join condition already references, because such a predicate is implied by the equi-key or
+    // the inequality and can be dropped, while IsNotNull(w) filters rows the aggregate would
+    // otherwise count. The control is the same query without that one conjunct.
+    createTable(
+      "T3",
+      "k INT, v INT, w INT",
+      """  (1, 10, 100), (1, 20, 200),
+        |  (2, 30, CAST(NULL AS INT)), (2, 40, CAST(NULL AS INT))""".stripMargin)
+
+    val controlSql =
+      """SELECT k FROM T3 outer_t WHERE k IN (
+        |  SELECT s1.k FROM T3 s1 JOIN T3 s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"T3 control diverges: ON=$controlOn OFF=$controlOff")
+    assert(controlOn == Set(Row(1), Row(2)), s"T3 control expected {1,2}, got $controlOn")
+
+    val sql =
+      """SELECT k FROM T3 outer_t WHERE k IN (
+        |  SELECT s1.k FROM T3 s1 JOIN T3 s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v AND s1.w IS NOT NULL)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"IsNotNull(non-join-col) semantics diverge: ON=$on OFF=$off")
+    assert(on == Set(Row(1)), s"expected {1}, got $on")
+  }
+
+  test("Multiple inequality columns are rejected") {
+    // The guard under test is `neqPairs.size != 1`. Two inequalities need "at least two rows
+    // differing in v AND in w", which no count-distinct over a single column can express. The
+    // control is the same query with only the first inequality.
+    createTable(
+      "T2",
+      "k INT, v INT, w INT",
+      """  (1, 10, 100), (1, 20, 200),
+        |  (2, 30, 300),
+        |  (3, 40, 100), (3, 50, 100)""".stripMargin)
+
+    val controlSql =
+      """SELECT k FROM T2 outer_t WHERE k IN (
+        |  SELECT s1.k FROM T2 s1 JOIN T2 s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"T2 control diverges: ON=$controlOn OFF=$controlOff")
+    assert(controlOn == Set(Row(1), Row(3)), s"T2 control expected {1,3}, got $controlOn")
+
+    val sql =
+      """SELECT k FROM T2 outer_t WHERE k IN (
+        |  SELECT s1.k FROM T2 s1 JOIN T2 s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v AND s1.w <> s2.w)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"multi-column neq semantics diverge: ON=$on OFF=$off")
+    assert(on == Set(Row(1)), s"expected {1}, got $on")
+  }
+
+  test("LeftOuter join is outside existence context: results unchanged") {
+    setupTable()
+    val sql =
+      """SELECT ws1.k FROM T ws1 LEFT OUTER JOIN T ws2
+        |ON ws1.k = ws2.k AND ws1.v <> ws2.v""".stripMargin
+    // Row multiplicity matters here.
+    var onCount: Long = -1L
+    var offCount: Long = -1L
+    withSQLConf(rewriteConf -> "true") {
+      onCount = spark.sql(sql).count()
+    }
+    withSQLConf(rewriteConf -> "false") {
+      offCount = spark.sql(sql).count()
+    }
+    assert(onCount == offCount, s"LeftOuter row-count differs: $onCount vs $offCount")
+    assertRuleNotFired(sql)
+  }
+
+  test("Inequality column overlapping an equi-key is rejected") {
+    setupTable()
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.k <> s2.k)""".stripMargin
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"unsatisfiable predicate diverges: ON=$on OFF=$off")
+    assert(on.isEmpty, s"unsatisfiable predicate should produce empty set, got $on")
+    assertRuleNotFired(sql)
+  }
+
+  test("Config gate: rewrite disabled leaves a valid A' candidate untouched") {
+    setupTable()
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    withSQLConf(rewriteConf -> "false") {
+      val plan = spark.sql(sql).queryExecution.optimizedPlan
+      assert(!ruleFired(plan), s"config off must not fire rewrite:\n$plan")
+      val res = spark.sql(sql).collect().toSet
+      assert(res == Set(Row(1), Row(3), Row(6)), s"config off correctness broken: $res")
+    }
+  }
+
+  // ==================== Correlated subquery: rule must fail-closed ====================
+
+  private def setupOuterT(): Unit = {
+    spark.sql(
+      """CREATE OR REPLACE TEMP VIEW OuterT AS SELECT * FROM VALUES
+        |  (1), (3), (6) AS OuterT(k)""".stripMargin)
+  }
+
+  test("Correlated InSubquery is fail-closed") {
+    setupTable()
+    setupOuterT()
+    val sql =
+      """SELECT o.k FROM OuterT o WHERE o.k IN (
+        |  SELECT s1.k FROM T s1 JOIN T s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v
+        |  WHERE s2.k = o.k)""".stripMargin
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"correlated IN parity: ON=$on OFF=$off")
+    assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+    assertRuleNotFired(sql)
+  }
+
+  // ==================== Repeatability whitelist: unknown operators fail-closed ==============
+
+  test("Aggregate (first) inside subquery breaks row-bag repeatability: rule bails out") {
+    // FIRST() is order-dependent and its aggregate result is not row-bag repeatable across
+    // two evaluations, yet Catalyst's Expression.deterministic returns true. The whitelist
+    // in `isRowBagRepeatable` must reject any Aggregate node inside the subquery plan.
+    // range(...) avoids ConvertToLocalRelation folding the Aggregate away.
+    val sql =
+      """SELECT k FROM (SELECT CAST(id AS INT) AS k, CAST(id AS INT) AS v FROM range(100)) t
+        |WHERE k IN (
+        |  SELECT s1.k FROM (
+        |      SELECT CAST(id % 10 AS INT) AS k, first(CAST(id AS INT)) AS v
+        |      FROM range(200) GROUP BY id % 10
+        |    ) s1
+        |  JOIN (
+        |      SELECT CAST(id % 10 AS INT) AS k, first(CAST(id AS INT)) AS v
+        |      FROM range(200) GROUP BY id % 10
+        |    ) s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(sql)
+  }
+
+  test("Window (row_number) inside subquery breaks row-bag repeatability: rule bails out") {
+    // ROW_NUMBER over non-total order breaks ties nondeterministically. Whitelist rejects
+    // any Window node inside the subquery plan.
+    val sql =
+      """SELECT k FROM (SELECT CAST(id AS INT) AS k, CAST(id AS INT) AS v FROM range(100)) t
+        |WHERE k IN (
+        |  SELECT s1.k FROM (
+        |      SELECT k, ROW_NUMBER() OVER (PARTITION BY k ORDER BY grp) AS v
+        |      FROM (SELECT CAST(id % 10 AS INT) AS k, CAST(id % 3 AS INT) AS grp FROM range(200))
+        |    ) s1
+        |  JOIN (
+        |      SELECT k, ROW_NUMBER() OVER (PARTITION BY k ORDER BY grp) AS v
+        |      FROM (SELECT CAST(id % 10 AS INT) AS k, CAST(id % 3 AS INT) AS grp FROM range(200))
+        |    ) s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(sql)
+  }
+
+  test("Nondeterministic self-join input is rejected") {
+    // The guard under test is `plan.deterministic` inside `isRepeatablePlan`. Both sides use the
+    // same explicit seed, so the two subplans do have the same canonical shape and the rejection
+    // cannot come from `isSameBaseRelation`. The control replaces `rand(41) < 0.5` with a
+    // deterministic filter and nothing else, proving this Range/Filter/Project shape does reach
+    // the rewrite.
+    val controlSql =
+      """SELECT k FROM (SELECT CAST(id AS INT) AS k, CAST(id AS INT) AS v FROM range(100)) t
+        |WHERE k IN (
+        |  SELECT s1.k FROM (
+        |      SELECT CAST(id % 10 AS INT) AS k, CAST(id AS INT) AS v
+        |      FROM range(1000) WHERE id % 2 = 0
+        |    ) s1
+        |  JOIN (
+        |      SELECT CAST(id % 10 AS INT) AS k, CAST(id AS INT) AS v
+        |      FROM range(1000) WHERE id % 2 = 0
+        |    ) s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"range control diverges: ON=$controlOn OFF=$controlOff")
+    assert(
+      controlOn == Set(Row(0), Row(2), Row(4), Row(6), Row(8)),
+      s"range control expected the even keys, got $controlOn")
+
+    val sql =
+      """SELECT k FROM (SELECT CAST(id AS INT) AS k, CAST(id AS INT) AS v FROM range(100)) t
+        |WHERE k IN (
+        |  SELECT s1.k FROM (
+        |      SELECT CAST(id % 10 AS INT) AS k, CAST(id AS INT) AS v
+        |      FROM range(1000) WHERE rand(41) < 0.5
+        |    ) s1
+        |  JOIN (
+        |      SELECT CAST(id % 10 AS INT) AS k, CAST(id AS INT) AS v
+        |      FROM range(1000) WHERE rand(41) < 0.5
+        |    ) s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(sql)
+  }
+
+  test("LogicalRDD leaf is not a trusted repeatable source: rule bails out") {
+    // The guard under test is the leaf allowlist in `isRowBagRepeatable`: a Parquet
+    // `LogicalRelation` is trusted, but a `LogicalRDD` (createDataFrame over an RDD) wraps an
+    // arbitrary RDD lineage whose runtime row bag Catalyst cannot prove repeatable, so it must
+    // fail closed even though `plan.deterministic` is true. Both fixtures are MultiInstanceRelation
+    // leaves, so each self-join dedups into two structurally identical sides without a rename-only
+    // Project -- the rejection therefore comes from the leaf allowlist, not `isSameBaseRelation`.
+    // The Parquet control uses the same schema, data and query shape and fires, which is what makes
+    // the LogicalRDD negative evidence that the leaf allowlist -- not a structural mismatch --
+    // rejected it.
+    createTable("RddCtl", "k INT, v INT", "  (1, 10), (1, 20), (2, 30)")
+    val controlSql =
+      """SELECT k FROM RddCtl outer_t WHERE k IN (
+        |  SELECT s1.k FROM RddCtl s1 JOIN RddCtl s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"Parquet control diverges: ON=$controlOn OFF=$controlOff")
+    assert(controlOn == Set(Row(1)), s"Parquet control expected {1}, got $controlOn")
+
+    val schema = StructType(Seq(StructField("k", IntegerType), StructField("v", IntegerType)))
+    val rows = spark.sparkContext.parallelize(Seq(Row(1, 10), Row(1, 20), Row(2, 30)))
+    spark.createDataFrame(rows, schema).createOrReplaceTempView("RddT")
+    val sql =
+      """SELECT k FROM RddT outer_t WHERE k IN (
+        |  SELECT s1.k FROM RddT s1 JOIN RddT s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"LogicalRDD semantics diverge: ON=$on OFF=$off")
+    assert(on == Set(Row(1)), s"expected {1}, got $on")
+  }
+
+  test("Non-allowlisted deterministic expression (Abs) fails closed") {
+    // The guard under test is the expression allowlist in `isRepeatableExpression`: it trusts
+    // expression TYPES, not merely `deterministic`. Abs is deterministic, but is intentionally not
+    // yet part of the expression allowlist; until its repeatability contract is explicitly admitted
+    // there, a self-join whose side projects abs(v) fails closed -- a missed optimization, not a
+    // correctness bug. This test verifies that an unknown-but-deterministic expression is not
+    // silently let through by `plan.deterministic`.
+    //
+    // Control and negative are a single-variable pair: both project one derived column and differ
+    // ONLY in its expression. The control uses `v + 1` (Add over Attribute + Literal, all
+    // allowlisted) and fires; wrapping the same column in abs() -- the sole change -- makes it not
+    // fire, so the rejection is attributable to the expression allowlist rather than a structural
+    // mismatch. `+ 1` (not `+ 0`) is used so the Add survives arithmetic simplification and the
+    // control genuinely exercises a compound allowlisted expression. v is INT here, so the Add is a
+    // plain `Add(v, 1)` with no decimal PromotePrecision / CheckOverflow wrappers.
+    setupTable()
+
+    val controlSql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k
+        |  FROM (SELECT k, v + 1 AS x FROM T) s1
+        |  JOIN (SELECT k, v + 1 AS x FROM T) s2
+        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"Add control diverges: ON=$controlOn OFF=$controlOff")
+    // v+1 is injective over the (non-null) v values, so distinctness per k is unchanged: {1,3,6}.
+    assert(
+      controlOn == Set(Row(1), Row(3), Row(6)),
+      s"Add control expected {1,3,6}, got $controlOn")
+
+    val sql =
+      """SELECT k FROM T outer_t WHERE k IN (
+        |  SELECT s1.k
+        |  FROM (SELECT k, abs(v) AS x FROM T) s1
+        |  JOIN (SELECT k, abs(v) AS x FROM T) s2
+        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"Abs-projected self-join semantics diverge: ON=$on OFF=$off")
+  }
+
+  // ==================== Data-type safety: comparison vs grouping/DISTINCT equality ============
+  //
+  // The rewrite turns `<>` into COUNT(DISTINCT) and `=` into GROUP BY, so it is only sound on
+  // types where SQL comparison equality coincides with grouping/DISTINCT equality.
+  // `parseSelfJoinCondition` gates BOTH the neq column and every equi-key through
+  // `isSafeComparisonGroupingType` (a positive allowlist, not `RowOrdering.isOrderable`). These
+  // tests pin the boundary for the risky types.
+
+  test("Float/Double neq column is rejected (comparison-vs-DISTINCT contract, defensive)") {
+    // The guard under test is `isSafeComparisonGroupingType` on the NEQ column. Control and
+    // negative differ only in which column feeds the inequality: `vi` (Int, allowlisted) fires,
+    // `vd` (Double) does not. Double fails closed defensively: the rewrite depends on comparison
+    // equality and grouping/DISTINCT equality agreeing, and for floating point that agreement on
+    // signed zero and NaN rests on normalization details (NormalizeFloatingNumbers) that need not
+    // match across Spark versions or native backends. On current Spark, comparison semantics and
+    // aggregation normalization are aligned for these cases, so the OFF baseline of the negative
+    // query is {1}; the rule does not fire, so ON matches it. The test pins fail-closed behavior,
+    // not a divergence in current Spark.
+    createTable(
+      "TFloat",
+      "k INT, vi INT, vd DOUBLE",
+      """  (1, 10, 1.0), (1, 20, 2.0),
+        |  (2, 30, 0.0), (2, 30, -0.0),
+        |  (3, 40, CAST('NaN' AS DOUBLE)), (3, 50, CAST('NaN' AS DOUBLE))""".stripMargin)
+
+    val controlSql =
+      """SELECT k FROM TFloat outer_t WHERE k IN (
+        |  SELECT s1.k FROM TFloat s1 JOIN TFloat s2
+        |    ON s1.k = s2.k AND s1.vi <> s2.vi)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"Int-neq control diverges: ON=$controlOn OFF=$controlOff")
+    assert(controlOn == Set(Row(1), Row(3)), s"Int-neq control expected {1,3}, got $controlOn")
+
+    val sql =
+      """SELECT k FROM TFloat outer_t WHERE k IN (
+        |  SELECT s1.k FROM TFloat s1 JOIN TFloat s2
+        |    ON s1.k = s2.k AND s1.vd <> s2.vd)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"Double-neq semantics diverge: ON=$on OFF=$off")
+    // k=1 matches (1.0 <> 2.0); k=2 does not (0.0 = -0.0); k=3 does not (Spark NaN = NaN).
+    assert(on == Set(Row(1)), s"Double-neq baseline expected {1}, got $on")
+  }
+
+  test("Float/Double equi-key is rejected (defensive fail-closed)") {
+    // The guard under test is `isSafeComparisonGroupingType` on the EQUI key. Current Spark aligns
+    // floating-point comparison semantics with grouping normalization here, but the rule does not
+    // depend on that implementation contract, so it fails closed. Control and negative differ only
+    // in the equi-key column: `ki` (Int) fires, `kd` (Double) does not.
+    createTable(
+      "TFloatKey",
+      "kd DOUBLE, ki INT, v INT",
+      """  (1.0, 1, 10), (1.0, 1, 20),
+        |  (2.0, 2, 30),
+        |  (0.0, 3, 40), (-0.0, 3, 50)""".stripMargin)
+
+    val controlSql =
+      """SELECT ki FROM TFloatKey outer_t WHERE ki IN (
+        |  SELECT s1.ki FROM TFloatKey s1 JOIN TFloatKey s2
+        |    ON s1.ki = s2.ki AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"Int-key control diverges: ON=$controlOn OFF=$controlOff")
+    assert(controlOn == Set(Row(1), Row(3)), s"Int-key control expected {1,3}, got $controlOn")
+
+    val sql =
+      """SELECT kd FROM TFloatKey outer_t WHERE kd IN (
+        |  SELECT s1.kd FROM TFloatKey s1 JOIN TFloatKey s2
+        |    ON s1.kd = s2.kd AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(sql)
+    val (on, off) = runBoth(sql)
+    assert(on == off, s"Double-key semantics diverge: ON=$on OFF=$off")
+  }
+
+  test("Complex-type neq column (array/struct) is rejected wholesale") {
+    // The guard under test is the wholesale rejection of complex types by
+    // `isSafeComparisonGroupingType`, which also covers any Float/Double nested inside them.
+    // Control (`v` Int) fires; the ARRAY<DOUBLE> and STRUCT<..DOUBLE> variants -- identical query
+    // shape, only the neq column changed -- do not.
+    createTable(
+      "TCplx",
+      "k INT, v INT, a ARRAY<DOUBLE>, s STRUCT<x: INT, y: DOUBLE>",
+      """  (1, 10, ARRAY(1.0), NAMED_STRUCT('x', 1, 'y', 1.0)),
+        |  (1, 20, ARRAY(2.0), NAMED_STRUCT('x', 2, 'y', 2.0)),
+        |  (2, 30, ARRAY(1.0), NAMED_STRUCT('x', 1, 'y', 1.0))""".stripMargin)
+
+    val controlSql =
+      """SELECT k FROM TCplx outer_t WHERE k IN (
+        |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(controlSql)
+    val (controlOn, controlOff) = runBoth(controlSql)
+    assert(controlOn == controlOff, s"Int-neq control diverges: ON=$controlOn OFF=$controlOff")
+    assert(controlOn == Set(Row(1)), s"Int-neq control expected {1}, got $controlOn")
+
+    val arraySql =
+      """SELECT k FROM TCplx outer_t WHERE k IN (
+        |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
+        |    ON s1.k = s2.k AND s1.a <> s2.a)""".stripMargin
+    assertRuleNotFired(arraySql)
+    val (arrayOn, arrayOff) = runBoth(arraySql)
+    assert(arrayOn == arrayOff, s"array-neq semantics diverge: ON=$arrayOn OFF=$arrayOff")
+
+    val structSql =
+      """SELECT k FROM TCplx outer_t WHERE k IN (
+        |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
+        |    ON s1.k = s2.k AND s1.s <> s2.s)""".stripMargin
+    assertRuleNotFired(structSql)
+    val (structOn, structOff) = runBoth(structSql)
+    assert(structOn == structOff, s"struct-neq semantics diverge: ON=$structOn OFF=$structOff")
+  }
+
+  test("String neq/equi key: default (UTF8_BINARY) fires, non-binary collation fails closed") {
+    // The guard under test is the StringType branch of `isSafeComparisonGroupingType`: only
+    // `supportsBinaryEquality` (byte-wise) strings are admitted, because a non-binary collation
+    // (Spark 4.0+) routes comparison and grouping through different code paths. The control uses a
+    // default-collation table for BOTH the equi key and the neq column and fires -- proving plain
+    // strings are not rejected wholesale.
+    //
+    // The two negatives collate exactly ONE column each, so each pins the rejection to a specific
+    // gate: a UTF8_LCASE NEQ column exercises the neq-side check, a UTF8_LCASE EQUI key exercises
+    // the equi-side check. Collating both at once would leave it ambiguous which gate fired and
+    // stay green if either were deleted -- mirroring the split Float neq / Float equi coverage.
+    createTable(
+      "TStrBin",
+      "k STRING, v STRING",
+      """  ('a', 'x'), ('a', 'y'),
+        |  ('b', 'z')""".stripMargin)
+    val binSql =
+      """SELECT k FROM TStrBin outer_t WHERE k IN (
+        |  SELECT s1.k FROM TStrBin s1 JOIN TStrBin s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(binSql)
+    val (binOn, binOff) = runBoth(binSql)
+    assert(binOn == binOff, s"binary-string control diverges: ON=$binOn OFF=$binOff")
+    assert(binOn == Set(Row("a")), s"binary-string control expected {a}, got $binOn")
+
+    // Negative 1: only the NEQ column is non-binary collated -> neq-side type gate rejects.
+    createTable(
+      "TStrCiNeq",
+      "k STRING, v STRING COLLATE UTF8_LCASE",
+      """  ('a', 'x'), ('a', 'y'),
+        |  ('b', 'z')""".stripMargin)
+    val ciNeqSql =
+      """SELECT k FROM TStrCiNeq outer_t WHERE k IN (
+        |  SELECT s1.k FROM TStrCiNeq s1 JOIN TStrCiNeq s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(ciNeqSql)
+    val (neqOn, neqOff) = runBoth(ciNeqSql)
+    assert(neqOn == neqOff, s"collated-neq semantics diverge: ON=$neqOn OFF=$neqOff")
+
+    // Negative 2: only the EQUI key is non-binary collated -> equi-side type gate rejects.
+    createTable(
+      "TStrCiEqui",
+      "k STRING COLLATE UTF8_LCASE, v STRING",
+      """  ('a', 'x'), ('a', 'y'),
+        |  ('b', 'z')""".stripMargin)
+    val ciEquiSql =
+      """SELECT k FROM TStrCiEqui outer_t WHERE k IN (
+        |  SELECT s1.k FROM TStrCiEqui s1 JOIN TStrCiEqui s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleNotFired(ciEquiSql)
+    val (equiOn, equiOff) = runBoth(ciEquiSql)
+    assert(equiOn == equiOff, s"collated-equi semantics diverge: ON=$equiOn OFF=$equiOff")
+  }
+
+  test("CHAR/VARCHAR join keys are rejected via declared-type metadata") {
+    // The guard under test is isSafeComparisonGroupingAttribute: CHAR/VARCHAR table columns reach
+    // the optimizer as annotated StringType (CharVarcharUtils records the declared type in the
+    // attribute metadata), so a dataType-only check would admit them through the StringType branch.
+    // The rule recovers the declared raw type from the metadata and fails closed. Control: a plain
+    // STRING table -- identical query shape and data -- fires, proving strings are not rejected
+    // wholesale; the CHAR(5) and VARCHAR(5) variants, differing only in the declared column type,
+    // do not. Both the equi key `k` and the neq column `v` are CHAR/VARCHAR, so both gate paths are
+    // pinned.
+    createTable(
+      "TStr",
+      "k STRING, v STRING",
+      """  ('a', 'x'), ('a', 'y'),
+        |  ('b', 'z')""".stripMargin)
+    val stringSql =
+      """SELECT k FROM TStr outer_t WHERE k IN (
+        |  SELECT s1.k FROM TStr s1 JOIN TStr s2
+        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    assertRuleFired(stringSql)
+    val (strOn, strOff) = runBoth(stringSql)
+    assert(strOn == strOff, s"string control diverges: ON=$strOn OFF=$strOff")
+    assert(strOn == Set(Row("a")), s"string control expected {a}, got $strOn")
+
+    Seq("CHAR(5)", "VARCHAR(5)").foreach { keyType =>
+      createTable(
+        "TCharVarchar",
+        s"k $keyType, v $keyType",
+        """  ('a', 'x'), ('a', 'y'),
+          |  ('b', 'z')""".stripMargin)
+      val sql =
+        """SELECT k FROM TCharVarchar outer_t WHERE k IN (
+          |  SELECT s1.k FROM TCharVarchar s1 JOIN TCharVarchar s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"$keyType not-fired query diverges: ON=$on OFF=$off")
+    }
+  }
+
+  test("ANSI: rewrite preserves observable error behavior (throw-or-succeed parity)") {
+    // The guard under test is not a rejection but a parity property: the expression allowlist
+    // admits Cast, which can throw under ANSI. The rewrite evaluates the projected `CAST(s AS INT)`
+    // once per row inside the Aggregate, while the baseline self-join evaluates it per row on each
+    // side -- the same set of rows either way -- so a malformed value must make BOTH forms behave
+    // the same. k=2 holds a non-numeric 's'.
+    //
+    // Parity is checked as observable behavior, not just "an exception happened": both succeed with
+    // equal rows, or both throw with the same error class. A one-sided throw is a blocker.
+    createTable(
+      "TAnsi",
+      "k INT, s STRING",
+      """  (1, '10'), (1, '20'),
+        |  (2, '30'), (2, 'xyz')""".stripMargin)
+    val sql =
+      """SELECT k FROM TAnsi outer_t WHERE k IN (
+        |  SELECT s1.k
+        |  FROM (SELECT k, CAST(s AS INT) AS x FROM TAnsi) s1
+        |  JOIN (SELECT k, CAST(s AS INT) AS x FROM TAnsi) s2
+        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+
+    Seq("false", "true").foreach { ansi =>
+      withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+        // The rule still fires at plan level regardless of ANSI (the cast throws only at runtime).
+        assertRuleFired(sql)
+        val on = runOutcome(sql, rewrite = true)
+        val off = runOutcome(sql, rewrite = false)
+        (on, off) match {
+          case (Right(onRows), Right(offRows)) =>
+            assert(onRows == offRows,
+              s"ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
+          case (Left(onErr), Left(offErr)) =>
+            assert(onErr == offErr,
+              s"ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
+          case _ =>
+            fail(s"ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+        }
+      }
+    }
+  }
+
+  test("ANSI: Remainder neq column preserves error behavior; Divide is type-gated") {
+    // Cast is not the only allowlisted expression that can throw under ANSI. This pins the two
+    // arithmetic ops the review asked about:
+    //   - Remainder (`%`) on INT operands stays INT, an allowlisted type, so the rule fires. It can
+    //     raise DIVIDE_BY_ZERO under ANSI, so it exercises the throw-parity property directly, not
+    //     resting it on the Cast test alone: the rewrite evaluates `v % w` once per row inside
+    //     the Aggregate and the baseline self-join evaluates it per row on each side -- the same
+    //     rows -- so a `% 0` must make BOTH forms behave identically.
+    //   - Divide (`/`) is admitted by the expression allowlist (`isRepeatableExpression` trusts it
+    //     wherever it appears in the scanned plan), but a Divide-derived NEQ KEY is stopped one
+    //     layer later by the type guard: `/` always widens INT operands to a Double result, which
+    //     `isSafeComparisonGroupingType` rejects, so a `v / w` neq column never fires. There is
+    //     thus no runtime Divide path to check for parity; the type gate stops it first. (Decimal
+    //     operands would keep a Decimal result but wrap the Divide in CheckOverflow, which the
+    //     expression allowlist rejects, so a Decimal `/` neq key has no firing path.) The two
+    //     layers are independent: allowlisting Divide as repeatable is not the same as admitting a
+    //     Divide result as a safe comparison/grouping key.
+    // Row (2, 30, 0) forces `30 % 0`, which throws under ANSI and yields NULL otherwise.
+    createTable(
+      "TAnsiDiv",
+      "k INT, v INT, w INT",
+      """  (1, 10, 3), (1, 20, 7),
+        |  (2, 30, 0), (2, 40, 4)""".stripMargin)
+
+    // Divide: Double result -> rejected by the data-type allowlist regardless of ANSI.
+    val divSql =
+      """SELECT k FROM TAnsiDiv outer_t WHERE k IN (
+        |  SELECT s1.k
+        |  FROM (SELECT k, v / w AS x FROM TAnsiDiv) s1
+        |  JOIN (SELECT k, v / w AS x FROM TAnsiDiv) s2
+        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+    assertRuleNotFired(divSql)
+
+    // Remainder: INT result -> fires; assert throw-or-succeed parity under ANSI off and on.
+    val remSql =
+      """SELECT k FROM TAnsiDiv outer_t WHERE k IN (
+        |  SELECT s1.k
+        |  FROM (SELECT k, v % w AS x FROM TAnsiDiv) s1
+        |  JOIN (SELECT k, v % w AS x FROM TAnsiDiv) s2
+        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+    Seq("false", "true").foreach { ansi =>
+      withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+        // The rule fires at plan level regardless of ANSI (the remainder throws only at runtime).
+        assertRuleFired(remSql)
+        val on = runOutcome(remSql, rewrite = true)
+        val off = runOutcome(remSql, rewrite = false)
+        (on, off) match {
+          case (Right(onRows), Right(offRows)) =>
+            assert(onRows == offRows,
+              s"Remainder ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
+            // Positive signal (ANSI off): the remainders are defined, so the rewrite must return
+            // the real membership. k=1: 10%3=1, 20%7=6 -> {1,6} matches; k=2: 30%0=NULL, 40%4=0
+            // -> {0} no match. Result is exactly {1}.
+            if (ansi == "false") {
+              assert(onRows == Set(Row(1)), s"Remainder ANSI=false expected {1}, got $onRows")
+            }
+          case (Left(onErr), Left(offErr)) =>
+            assert(onErr == offErr,
+              s"Remainder ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
+          case _ =>
+            fail(s"Remainder ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+        }
+      }
+    }
+  }
+
+  /**
+   * Run `sql` with the rewrite on/off and capture observable behavior: `Right(rows)` on success or
+   * `Left(errorClass)` if execution throws. Used to assert the rewrite does not change whether, or
+   * with what error, a query fails (e.g. under ANSI).
+   */
+  private def runOutcome(sql: String, rewrite: Boolean): Either[String, Set[Row]] = {
+    withSQLConf(rewriteConf -> rewrite.toString) {
+      try {
+        Right(spark.sql(sql).collect().toSet)
+      } catch {
+        case e: SparkThrowable => Left(Option(e.getCondition).getOrElse(e.getClass.getName))
+        case e: Throwable => Left(e.getClass.getName)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregateSuite.scala
@@ -18,10 +18,10 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.expressions.{Alias, InSubquery, ListQuery, Not}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, EqualTo, InSubquery, ListQuery, Not}
 import org.apache.spark.sql.catalyst.optimizer.ReorderJoin
 import org.apache.spark.sql.catalyst.plans.Inner
-import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -55,8 +55,9 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
 
   private val rewriteConf = SQLConf.REWRITE_SELF_JOIN_INEQUALITY_TO_AGGREGATE_ENABLED.key
 
-  /** Signature alias produced by the rewrite; presence => rule definitely fired. */
-  private val CountDistinctAlias = "_rewrite_selfjoin_inequality_cnt_distinct"
+  /** Signature aliases produced by the rewrite; presence of both => rule definitely fired. */
+  private val MinNeqAlias = "_rewrite_selfjoin_inequality_min"
+  private val MaxNeqAlias = "_rewrite_selfjoin_inequality_max"
 
   // Descends into subqueries: `QueryPlan.exists` does not, and the rewrite's signature alias lives
   // inside the IN-subquery when the rule runs on an analyzed (not-yet-rewritten) plan.
@@ -68,8 +69,9 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
       }) => ()
     }.isDefined
 
+  /** Require BOTH aliases: a rewrite that emitted MIN but dropped MAX is still a bug. */
   private def ruleFired(plan: LogicalPlan): Boolean =
-    hasAlias(plan, CountDistinctAlias)
+    hasAlias(plan, MinNeqAlias) && hasAlias(plan, MaxNeqAlias)
 
   private def assertRuleFired(sql: String): Unit = {
     withSQLConf(rewriteConf -> "true") {
@@ -137,8 +139,8 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
     // k=4: v={70, NULL}            -> no match (only 1 non-null)
     // k=5: v={NULL, NULL}          -> no match (0 non-null)
     // k=6: v={80, 90, NULL}        -> matches
-    // k=7: v={100,100}             -> no match: duplicate-only. Proves DISTINCT is required;
-    //                                a plain COUNT(v) > 1 would wrongly match this group.
+    // k=7: v={100,100}             -> no match: duplicate-only, min(v)==max(v)==100 so min<>max is
+    //                                false. A plain COUNT(v) > 1 would wrongly match this group.
     createTable(
       "T",
       "k INT, v INT",
@@ -433,7 +435,7 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
       // base tables even when they share a schema and column names. Distinct Parquet tables
       // canonicalize to distinct `rootPaths`, so `left.canonicalized == right.canonicalized` is
       // false and the rewrite must not fire. This pins a real correctness boundary, not just a
-      // missed optimization: rewriting `TLeft JOIN TRight` as COUNT(DISTINCT) over TLeft alone
+      // missed optimization: rewriting `TLeft JOIN TRight` as MIN(v) <> MAX(v) over TLeft alone
       // would drop TRight's rows and change the answer, so removing the guard would make ON diverge
       // from OFF here.
       createTable("TLeft", "k INT, v INT", "  (1, 10), (1, 10), (2, 30)")
@@ -452,32 +454,44 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
 
   // ==================== Positive: rewritten plan is structurally the aggregate ================
   //
-  // Result parity (ON == OFF) proves the two queries return the same rows; it does not prove the
-  // rewrite produced the specific GROUP BY + HAVING COUNT(DISTINCT) > 1 shape rather than, say,
-  // leaving the self-join and happening to agree. These controls compare the rewritten plan against
-  // a hand-written aggregate SQL that spells out the intended shape, INCLUDING two `IS NOT NULL`
-  // filters: on the equi-key (which the rewrite injects to preserve equi-join NULL semantics) and
-  // on the neq column. `v IS NOT NULL` is semantically redundant for COUNT(DISTINCT v), which
-  // already ignores NULL, but the original `s1.v <> s2.v` lets InferFiltersFromConstraints derive
-  // `isnotnull(v)` and push it below the aggregate, so the equivalent SQL must include it to match
-  // the shape the optimizer actually produces. The comparison itself is `compareCanonicalizedPlans`
-  // (see its doc for why canonicalizing first, and disabling checkAnalysis, is required here).
+  // Result parity (ON == OFF) does not prove the rewrite produced the GROUP BY + HAVING
+  // MIN(v) <> MAX(v) shape rather than leaving the self-join and happening to agree. These controls
+  // assert that shape directly. A full canonicalized-plan comparison against hand-written aggregate
+  // SQL would be wrong here: InferFiltersFromConstraints adds isnotnull(min)/isnotnull(max) to a
+  // hand-written HAVING but not to the rule's own filter (created in a later batch), so it would
+  // fail on redundant null predicates -- and matching it by hardening the rule would be the wrong
+  // fix.
 
   private def optimizedPlanWith(sql: String, rewrite: Boolean): LogicalPlan =
     withSQLConf(rewriteConf -> rewrite.toString) {
       spark.sql(sql).queryExecution.optimizedPlan
     }
 
-  /**
-   * Assert two optimized plans are structurally equal. Canonicalize first: the rewrite creates
-   * fresh aliases, whose names and exprIds are cosmetic for this structural check, while the
-   * Join-vs-Aggregate shape difference this asserts on survives canonicalization. `checkAnalysis`
-   * is disabled because both plans are already analyzed and optimized, and a canonicalized plan is
-   * not re-analyzable (its HAVING references a zeroed exprId), which the default would reject
-   * before any comparison.
-   */
-  private def compareCanonicalizedPlans(actual: LogicalPlan, expected: LogicalPlan): Unit =
-    comparePlans(actual.canonicalized, expected.canonicalized, checkAnalysis = false)
+  // The rewrite shape: an Aggregate emitting both signature aliases, with a Filter on top whose
+  // condition includes Not(EqualTo(min, max)). Match the two operands by ExprId (Catalyst attribute
+  // identity), not by name -- the rule itself never trusts names -- so a same-named attribute from
+  // elsewhere cannot satisfy it. `exists` on the condition, not exact match, because
+  // InferFiltersFromConstraints may fold redundant isnotnull(min/max) into the same Filter.
+  private def assertMinMaxRewriteShape(plan: LogicalPlan): Unit = {
+    val found = plan.collectFirstWithSubqueries {
+      case Filter(cond, agg: Aggregate)
+          if {
+            // Key by alias name so the shape requires exactly one MIN alias AND one MAX alias: two
+            // same-named aliases collapse to a single map key and fail the keySet check, which a
+            // bare `size == 2` on exprIds would not catch.
+            val signatureAttrs = agg.aggregateExpressions.collect {
+              case a: Alias if a.name == MinNeqAlias || a.name == MaxNeqAlias =>
+                a.name -> a.toAttribute
+            }.toMap
+            signatureAttrs.keySet == Set(MinNeqAlias, MaxNeqAlias) && cond.exists {
+              case Not(EqualTo(l: Attribute, r: Attribute)) =>
+                Set(l.exprId, r.exprId) == signatureAttrs.values.map(_.exprId).toSet
+              case _ => false
+            }
+          } => ()
+    }
+    assert(found.isDefined, s"expected a MIN(v) <> MAX(v) aggregate rewrite shape:\n$plan")
+  }
 
   test("Pattern A' rewritten plan is structurally the equivalent aggregate") {
     withTable("T") {
@@ -486,16 +500,10 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
         """SELECT k FROM T outer_t WHERE k IN (
           |  SELECT s1.k FROM T s1 JOIN T s2
           |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-      val aggregateSql =
-        """SELECT k FROM T outer_t WHERE k IN (
-          |  SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
-          |  GROUP BY k HAVING count(DISTINCT v) > 1)""".stripMargin
 
       val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
-      val expected = optimizedPlanWith(aggregateSql, rewrite = false)
       assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
-      assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
-      compareCanonicalizedPlans(actual, expected)
+      assertMinMaxRewriteShape(actual)
     }
   }
 
@@ -512,18 +520,10 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
             |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
             |             ON s1.k = s2.k AND s1.v <> s2.v) sj
             |  WHERE d.k = sj.k)""".stripMargin
-        val aggregateSql =
-          """SELECT k FROM T outer_t WHERE k IN (
-            |  SELECT d.k
-            |  FROM D d, (SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
-            |             GROUP BY k HAVING count(DISTINCT v) > 1) sj
-            |  WHERE d.k = sj.k)""".stripMargin
 
         val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
-        val expected = optimizedPlanWith(aggregateSql, rewrite = false)
         assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
-        assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
-        compareCanonicalizedPlans(actual, expected)
+        assertMinMaxRewriteShape(actual)
       }
     }
   }
@@ -673,8 +673,8 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   test("Multiple inequality columns are rejected") {
     withTable("T2") {
       // The guard under test is `neqPairs.size != 1`. Two inequalities need "at least two rows
-      // differing in v AND in w", which no count-distinct over a single column can express. The
-      // control is the same query with only the first inequality.
+      // differing in v AND in w", which no MIN/MAX over a single column can express. The control is
+      // the same query with only the first inequality.
       createTable(
         "T2",
         "k INT, v INT, w INT",
@@ -976,20 +976,20 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
     }
   }
 
-  // ==================== Data-type safety: comparison vs grouping/DISTINCT equality ============
+  // ==================== Data-type safety: comparison vs grouping/MIN-MAX equality =============
   //
-  // The rewrite turns `<>` into COUNT(DISTINCT) and `=` into GROUP BY, so it is only sound on
-  // types where SQL comparison equality coincides with grouping/DISTINCT equality.
+  // The rewrite turns `<>` into MIN(v) <> MAX(v) and `=` into GROUP BY, so it is only sound on
+  // types where SQL comparison equality coincides with grouping/MIN-MAX ordering equality.
   // `parseSelfJoinCondition` gates BOTH the neq column and every equi-key through
   // `isSafeComparisonGroupingType` (a positive allowlist, not `RowOrdering.isOrderable`). These
   // tests pin the boundary for the risky types.
 
-  test("Float/Double neq column is rejected (comparison-vs-DISTINCT contract, defensive)") {
+  test("Float/Double neq column is rejected (comparison-vs-MIN-MAX contract, defensive)") {
     withTable("TFloat") {
       // The guard under test is `isSafeComparisonGroupingType` on the NEQ column. Control and
       // negative differ only in which column feeds the inequality: `vi` (Int, allowlisted) fires,
       // `vd` (Double) does not. Double fails closed defensively: the rewrite depends on comparison
-      // equality and grouping/DISTINCT equality agreeing, and for floating point that
+      // equality and grouping/MIN-MAX ordering equality agreeing, and for floating point that
       // agreement on signed zero and NaN rests on normalization details (NormalizeFloatingNumbers)
       // that need not match across Spark versions or native backends. On current Spark, comparison
       // semantics and aggregation normalization are aligned for these cases, so the OFF baseline of

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RewriteSelfJoinInequalityToAggregateSuite.scala
@@ -18,8 +18,10 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.expressions.Alias
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.expressions.{Alias, InSubquery, ListQuery, Not}
+import org.apache.spark.sql.catalyst.optimizer.ReorderJoin
+import org.apache.spark.sql.catalyst.plans.Inner
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -56,14 +58,18 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   /** Signature alias produced by the rewrite; presence => rule definitely fired. */
   private val CountDistinctAlias = "_rewrite_selfjoin_inequality_cnt_distinct"
 
+  // Descends into subqueries: `QueryPlan.exists` does not, and the rewrite's signature alias lives
+  // inside the IN-subquery when the rule runs on an analyzed (not-yet-rewritten) plan.
+  private def hasAlias(plan: LogicalPlan, name: String): Boolean =
+    plan.collectFirstWithSubqueries {
+      case p if p.expressions.exists(_.exists {
+        case a: Alias if a.name == name => true
+        case _ => false
+      }) => ()
+    }.isDefined
+
   private def ruleFired(plan: LogicalPlan): Boolean =
-    plan.exists {
-      p =>
-        p.expressions.exists(_.exists {
-          case a: Alias if a.name == CountDistinctAlias => true
-          case _ => false
-        })
-    }
+    hasAlias(plan, CountDistinctAlias)
 
   private def assertRuleFired(sql: String): Unit = {
     withSQLConf(rewriteConf -> "true") {
@@ -80,6 +86,21 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   }
 
   /**
+   * Optimize just the IN-subquery plan (rewrite left at its default-off) and return the result, so
+   * a test can prove what shape the subquery reaches the rule as -- e.g. a bare Join with no
+   * wrapper Project -- before asserting the rule declines it. Without this, `assertRuleNotFired`
+   * alone can pass merely because the fixture never produced the shape the guard means to reject.
+   */
+  private def optimizedInSubqueryPlan(sql: String): LogicalPlan = {
+    val analyzed = spark.sql(sql).queryExecution.analyzed
+    val subqueries = analyzed.subqueriesAll
+    assert(
+      subqueries.length == 1,
+      s"expected exactly one subquery in analyzed plan, got ${subqueries.length}:\n$analyzed")
+    spark.sessionState.optimizer.execute(subqueries.head)
+  }
+
+  /**
    * A real table, so that a self-join of it dedups into two structurally identical sides. See the
    * class comment for why a temp view over VALUES cannot be used for a self-joined fixture.
    */
@@ -89,17 +110,24 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
     spark.sql(s"INSERT INTO $name SELECT * FROM VALUES $values")
   }
 
-  /** Run `sql` twice, first with rewrite ON then OFF, and return the two result row sets. */
+  /**
+   * Run `sql` twice, first with rewrite ON then OFF. The rewrite must not change the outer query's
+   * row multiplicity, so assert ON and OFF agree as MULTISETS (a `.toSet` here would hide a
+   * duplicated or dropped row) before handing callers the row sets their fixed-value assertions
+   * compare against. `QueryTest.sameRows` is Spark's own multiset comparison (order-insensitive,
+   * duplicate-sensitive) and formats the offending rows on mismatch.
+   */
   private def runBoth(sql: String): (Set[Row], Set[Row]) = {
-    var on: Set[Row] = null
-    var off: Set[Row] = null
-    withSQLConf(rewriteConf -> "true") {
-      on = spark.sql(sql).collect().toSet
+    val on = withSQLConf(rewriteConf -> "true") {
+      spark.sql(sql).collect().toSeq
     }
-    withSQLConf(rewriteConf -> "false") {
-      off = spark.sql(sql).collect().toSet
+    val off = withSQLConf(rewriteConf -> "false") {
+      spark.sql(sql).collect().toSeq
     }
-    (on, off)
+    QueryTest.sameRows(on, off).foreach { error =>
+      fail(s"rewrite changed row multiplicity between ON and OFF:\n$error")
+    }
+    (on.toSet, off.toSet)
   }
 
   private def setupTable(): Unit = {
@@ -127,194 +155,299 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   // ==================== Positive: rewrite fires and is semantically equivalent ===============
 
   test("Pattern A': direct InSubquery self-join is rewritten") {
-    setupTable()
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
 
-    assertRuleFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"rewrite ON $on != OFF $off")
-    assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+      assertRuleFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"rewrite ON $on != OFF $off")
+      assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+    }
+  }
+
+  test("InSubquery in a SELECT-list CASE WHEN is rewritten, not only in a WHERE predicate") {
+    withTable("T") {
+      // `apply` rewrites via transformAllExpressionsWithPruning, so an InSubquery anywhere in the
+      // plan is a candidate -- not just a WHERE filter. A Project is a valid host for an InSubquery
+      // (see ValidateSubqueryExpression), so pin that the rewrite fires when the same uncorrelated
+      // self-join subquery sits inside a projected CASE WHEN. Moving it out of WHERE is the only
+      // change from the Pattern A' control above.
+      setupTable()
+      val subquery =
+        """SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v""".stripMargin
+      val sql =
+        s"""SELECT k, CASE WHEN k IN ($subquery) THEN 1 ELSE 0 END AS flag
+           |FROM T outer_t""".stripMargin
+
+      assertRuleFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"SELECT-list InSubquery rewrite ON $on != OFF $off")
+    }
+  }
+
+  test("Rewrite is idempotent: a second application on the rewritten plan is a no-op") {
+    withTable("T") {
+      // After the rewrite the outer `k IN (...)` is still an InSubquery, now over the aggregate, so
+      // the rule revisits it on any later pass. Applying the rule to its own output must change
+      // nothing: the aggregate no longer matches the self-join shape, so the second pass returns
+      // the plan unchanged.
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      withSQLConf(rewriteConf -> "true") {
+        val analyzed = spark.sql(sql).queryExecution.analyzed
+        val once = RewriteSelfJoinInequalityToAggregate(analyzed)
+        assert(ruleFired(once), s"precondition: first pass should fire:\n$once")
+        val twice = RewriteSelfJoinInequalityToAggregate(once)
+        assert(twice == once, s"rule is not idempotent:\n$once\n-- second pass -->\n$twice")
+      }
+    }
   }
 
   test("Pattern A2: nested self-join is rewritten") {
-    setupTable()
-    spark.sql(
-      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
-        |  (1), (3), (6) AS D(k)""".stripMargin)
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT d.k
-        |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
-        |             ON s1.k = s2.k AND s1.v <> s2.v) sj
-        |  WHERE d.k = sj.k)""".stripMargin
+    withTable("T") {
+      withTempView("D") {
+        setupTable()
+        spark.sql(
+          """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+            |  (1), (3), (6) AS D(k)""".stripMargin)
+        val sql =
+          """SELECT k FROM T outer_t WHERE k IN (
+            |  SELECT d.k
+            |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
+            |             ON s1.k = s2.k AND s1.v <> s2.v) sj
+            |  WHERE d.k = sj.k)""".stripMargin
 
-    assertRuleFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"Pattern A2 rewrite ON $on != OFF $off")
-    assert(on == Set(Row(1), Row(3), Row(6)))
+        assertRuleFired(sql)
+        val (on, off) = runBoth(sql)
+        assert(on == off, s"Pattern A2 rewrite ON $on != OFF $off")
+        assert(on == Set(Row(1), Row(3), Row(6)))
+      }
+    }
   }
 
   test("Pattern A2: self-join on the LEFT of the outer join is rewritten") {
-    // Mirror of the Pattern A2 test above. There the self-join is the RIGHT child of the outer join
-    // (`selfJoinOnRight = true`); here it is the LEFT child (`selfJoinOnRight = false`). The rule
-    // has an explicit branch for each side, so both are covered.
-    setupTable()
-    spark.sql(
-      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
-        |  (1), (3), (6) AS D(k)""".stripMargin)
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT d.k
-        |  FROM (SELECT s1.k FROM T s1 JOIN T s2
-        |        ON s1.k = s2.k AND s1.v <> s2.v) sj, D d
-        |  WHERE sj.k = d.k)""".stripMargin
+    withTable("T") {
+      withTempView("D") {
+        // Mirror of the Pattern A2 test above. There the self-join is the RIGHT child of the outer
+        // join (`selfJoinOnRight = true`); here it is the LEFT child (`selfJoinOnRight = false`).
+        // The rule has an explicit branch for each side, so both are covered.
+        setupTable()
+        spark.sql(
+          """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+            |  (1), (3), (6) AS D(k)""".stripMargin)
+        val sql =
+          """SELECT k FROM T outer_t WHERE k IN (
+            |  SELECT d.k
+            |  FROM (SELECT s1.k FROM T s1 JOIN T s2
+            |        ON s1.k = s2.k AND s1.v <> s2.v) sj, D d
+            |  WHERE sj.k = d.k)""".stripMargin
 
-    assertRuleFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"Pattern A2 (self-join on left) rewrite ON $on != OFF $off")
-    assert(on == Set(Row(1), Row(3), Row(6)))
+        assertRuleFired(sql)
+        val (on, off) = runBoth(sql)
+        assert(on == off, s"Pattern A2 (self-join on left) rewrite ON $on != OFF $off")
+        assert(on == Set(Row(1), Row(3), Row(6)))
+      }
+    }
   }
 
   test("Pattern A2: nondeterminism in the outer join condition must not be rewritten") {
-    // Both self-join sides are still repeatable here, so the per-side `isSameBaseRelation` check
-    // would pass; the `rand()` conjunct lives on the outer join ABOVE the self-join. Only the
-    // candidate-level `isRepeatablePlan` walk over the whole subquery catches it, so the rule must
-    // fail closed. This is the case the candidate-level guard exists for.
-    setupTable()
-    spark.sql(
-      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
-        |  (1), (3), (6) AS D(k)""".stripMargin)
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT d.k
-        |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
-        |             ON s1.k = s2.k AND s1.v <> s2.v) sj
-        |  WHERE d.k = sj.k AND rand() < 0.5)""".stripMargin
+    withTable("T") {
+      withTempView("D") {
+        // Both self-join sides are still repeatable here, so the per-side `isSameBaseRelation`
+        // check would pass; the `rand()` conjunct lives on the outer join ABOVE the self-join. Only
+        // the candidate-level `isRepeatablePlan` walk over the whole subquery catches it, so the
+        // rule must fail closed. This is the case the candidate-level guard exists for.
+        setupTable()
+        spark.sql(
+          """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+            |  (1), (3), (6) AS D(k)""".stripMargin)
+        val sql =
+          """SELECT k FROM T outer_t WHERE k IN (
+            |  SELECT d.k
+            |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
+            |             ON s1.k = s2.k AND s1.v <> s2.v) sj
+            |  WHERE d.k = sj.k AND rand() < 0.5)""".stripMargin
 
-    assertRuleNotFired(sql)
+        assertRuleNotFired(sql)
+      }
+    }
+  }
+
+  test("Clock-dependent STRING -> TIMESTAMP cast in the subquery is fail-closed") {
+    withTable("TTs") {
+      // A time-only STRING cast to TIMESTAMP takes its missing date from the runtime clock
+      // (LocalDate.now), so two self-join scans that straddle midnight can disagree while the
+      // rewrite folds them into one evaluation. The neq column here is derived by such a cast, so
+      // the rewrite must not fire. Isolate the cast as the sole cause with a same-shape control
+      // whose derived neq column uses a benign INT -> BIGINT cast (which does fire), and cover the
+      // nested form CAST(CAST(t AS ARRAY<TIMESTAMP>) AS STRING) where the timestamp conversion
+      // hides inside an array element cast and the final column type is STRING.
+      createTable(
+        "TTs",
+        "k INT, v INT, t STRING",
+        """  (1, 10, '01:00:00'), (1, 20, '02:00:00'),
+          |  (2, 30, '03:00:00')""".stripMargin)
+
+      def wrapped(neqExpr: String): String =
+        s"""SELECT k FROM TTs outer_t WHERE k IN (
+           |  SELECT s1.k FROM
+           |    (SELECT k, $neqExpr AS nc FROM TTs) s1
+           |    JOIN (SELECT k, $neqExpr AS nc FROM TTs) s2
+           |    ON s1.k = s2.k AND s1.nc <> s2.nc)""".stripMargin
+
+      // Same wrapper shape with a repeatable cast fires, proving the shape itself is supported.
+      assertRuleFired(wrapped("CAST(v AS BIGINT)"))
+
+      // Direct and array-nested STRING -> TIMESTAMP casts are both fail-closed.
+      assertRuleNotFired(wrapped("CAST(t AS TIMESTAMP)"))
+      assertRuleNotFired(wrapped("CAST(CAST(ARRAY(t) AS ARRAY<TIMESTAMP>) AS STRING)"))
+
+      // STRING -> TIMESTAMP_NTZ stays supported: it does not consult the session time zone and a
+      // time-only string parses to NULL deterministically rather than borrowing the runtime date,
+      // so the guard only rejects the clock-dependent LTZ conversion, not all string-to-timestamp.
+      assertRuleFired(wrapped("CAST(t AS TIMESTAMP_NTZ)"))
+    }
   }
 
   test("Pattern A': multi-equi tuple IN with sjRight key remap is rewritten") {
-    // Exercises the multi-equi-key path: two equi keys (k1, k2) drive the GROUP BY, and the tuple
-    // IN projects `s1.k1, s2.k2` -- so the second output column comes from the RIGHT self-join side
-    // and must be remapped to its sjLeft counterpart by `canonicalizeWrapper`. This one case covers
-    // multiple equi keys, tuple IN output arity, the two injected IsNotNull(equiKey) filters, and
-    // the sjRight-attribute remap at once.
-    createTable(
-      "TM",
-      "k1 INT, k2 INT, v INT",
-      """  (1, 1, 10), (1, 1, 20),
-        |  (1, 2, 30), (1, 2, 30),
-        |  (2, 1, 40), (2, 1, 50),
-        |  (CAST(NULL AS INT), 1, 60), (CAST(NULL AS INT), 1, 70),
-        |  (3, CAST(NULL AS INT), 80), (3, CAST(NULL AS INT), 90)""".stripMargin)
-    val sql =
-      """SELECT k1, k2 FROM TM outer_t WHERE (k1, k2) IN (
-        |  SELECT s1.k1, s2.k2 FROM TM s1 JOIN TM s2
-        |    ON s1.k1 = s2.k1 AND s1.k2 = s2.k2 AND s1.v <> s2.v)""".stripMargin
+    withTable("TM") {
+      // Exercises the multi-equi-key path: two equi keys (k1, k2) drive the GROUP BY, and the tuple
+      // IN projects `s1.k1, s2.k2` -- so the second output column comes from the RIGHT self-join
+      // side and must be remapped to its sjLeft counterpart by `canonicalizeWrapper`. This one case
+      // covers multiple equi keys, tuple IN output arity, the two injected IsNotNull(equiKey)
+      // filters, and the sjRight-attribute remap at once.
+      createTable(
+        "TM",
+        "k1 INT, k2 INT, v INT",
+        """  (1, 1, 10), (1, 1, 20),
+          |  (1, 2, 30), (1, 2, 30),
+          |  (2, 1, 40), (2, 1, 50),
+          |  (CAST(NULL AS INT), 1, 60), (CAST(NULL AS INT), 1, 70),
+          |  (3, CAST(NULL AS INT), 80), (3, CAST(NULL AS INT), 90)""".stripMargin)
+      val sql =
+        """SELECT k1, k2 FROM TM outer_t WHERE (k1, k2) IN (
+          |  SELECT s1.k1, s2.k2 FROM TM s1 JOIN TM s2
+          |    ON s1.k1 = s2.k1 AND s1.k2 = s2.k2 AND s1.v <> s2.v)""".stripMargin
 
-    assertRuleFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"multi-equi tuple IN rewrite ON $on != OFF $off")
-    // (1,1): distinct v={10,20} -> matches; (1,2): v={30} -> no; (2,1): v={40,50} -> matches;
-    // (NULL,1) and (3,NULL): NULL equi key filtered out by the injected IsNotNull. -> {(1,1),(2,1)}
-    assert(on == Set(Row(1, 1), Row(2, 1)), s"expected {(1,1),(2,1)}, got $on")
+      assertRuleFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"multi-equi tuple IN rewrite ON $on != OFF $off")
+      // (1,1): distinct v={10,20} -> matches; (1,2): v={30} -> no; (2,1): v={40,50} -> matches;
+      // (NULL,1) and (3,NULL): NULL equi key filtered out by the injected IsNotNull. ->
+      // {(1,1),(2,1)}
+      assert(on == Set(Row(1, 1), Row(2, 1)), s"expected {(1,1),(2,1)}, got $on")
+    }
   }
 
   test("NULL / 3VL on inequality column is preserved") {
-    setupTable()
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
 
-    assertRuleFired(sql)
-    val (on, off) = runBoth(sql)
-    // k=4 (v={70,NULL}) and k=5 (v={NULL,NULL}) do not satisfy plain SQL <>.
-    assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
-    assert(off == on, s"NULL/3VL semantics diverge between rewrite ON and OFF: $on vs $off")
+      assertRuleFired(sql)
+      val (on, off) = runBoth(sql)
+      // k=4 (v={70,NULL}) and k=5 (v={NULL,NULL}) do not satisfy plain SQL <>.
+      assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+      assert(off == on, s"NULL/3VL semantics diverge between rewrite ON and OFF: $on vs $off")
+    }
   }
 
   test("NULL equi-key is filtered before aggregation for NOT IN") {
-    createTable(
-      "TN",
-      "k INT, v INT",
-      """  (CAST(NULL AS INT), 10),
-        |  (CAST(NULL AS INT), 20),
-        |  (1, 10), (1, 20),
-        |  (2, 30)""".stripMargin
-    )
-    spark.sql(
-      """CREATE OR REPLACE TEMP VIEW OuterKeys AS SELECT * FROM VALUES
-        |  (1), (2), (3) AS OuterKeys(k)""".stripMargin)
-    val sql =
-      """SELECT k FROM OuterKeys o WHERE k NOT IN (
-        |  SELECT s1.k FROM TN s1 JOIN TN s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+    withTable("TN") {
+      withTempView("OuterKeys") {
+        createTable(
+          "TN",
+          "k INT, v INT",
+          """  (CAST(NULL AS INT), 10),
+            |  (CAST(NULL AS INT), 20),
+            |  (1, 10), (1, 20),
+            |  (2, 30)""".stripMargin
+        )
+        spark.sql(
+          """CREATE OR REPLACE TEMP VIEW OuterKeys AS SELECT * FROM VALUES
+            |  (1), (2), (3) AS OuterKeys(k)""".stripMargin)
+        val sql =
+          """SELECT k FROM OuterKeys o WHERE k NOT IN (
+            |  SELECT s1.k FROM TN s1 JOIN TN s2
+            |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
 
-    assertRuleFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"NULL equi-key NOT IN semantics diverge: ON=$on OFF=$off")
-    assert(on == Set(Row(2), Row(3)), s"expected {2,3}, got $on")
+        assertRuleFired(sql)
+        val (on, off) = runBoth(sql)
+        assert(on == off, s"NULL equi-key NOT IN semantics diverge: ON=$on OFF=$off")
+        assert(on == Set(Row(2), Row(3)), s"expected {2,3}, got $on")
+      }
+    }
   }
 
   test("Swapped aliases must not be treated as the same self-join columns") {
-    // The guard under test is `sameOutputPosition`. Both queries alias the same two base columns
-    // to the names `k` and `v` on both sides, so a rule that compares attribute names would fire
-    // on both; only the output ordinal tells them apart. The control fires, which is what makes
-    // the negative case evidence that the ordinal check -- not a structural mismatch -- rejected
-    // the swapped one.
-    createTable("AliasBase", "a INT, b INT", "  (1, 10), (1, 20), (2, 30)")
+    withTable("AliasBase") {
+      // The guard under test is `sameOutputPosition`. Both queries alias the same two base columns
+      // to the names `k` and `v` on both sides, so a rule that compares attribute names would fire
+      // on both; only the output ordinal tells them apart. The control fires, which is what makes
+      // the negative case evidence that the ordinal check -- not a structural mismatch -- rejected
+      // the swapped one.
+      createTable("AliasBase", "a INT, b INT", "  (1, 10), (1, 20), (2, 30)")
 
-    val alignedSql =
-      """SELECT a FROM AliasBase outer_t WHERE a IN (
-        |  SELECT s1.k
-        |  FROM (SELECT a AS k, b AS v FROM AliasBase) s1
-        |  JOIN (SELECT a AS k, b AS v FROM AliasBase) s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(alignedSql)
-    val (alignedOn, alignedOff) = runBoth(alignedSql)
-    assert(
-      alignedOn == alignedOff,
-      s"aligned-alias control diverges: ON=$alignedOn OFF=$alignedOff")
-    assert(alignedOn == Set(Row(1)), s"aligned-alias control expected {1}, got $alignedOn")
+      val alignedSql =
+        """SELECT a FROM AliasBase outer_t WHERE a IN (
+          |  SELECT s1.k
+          |  FROM (SELECT a AS k, b AS v FROM AliasBase) s1
+          |  JOIN (SELECT a AS k, b AS v FROM AliasBase) s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(alignedSql)
+      val (alignedOn, alignedOff) = runBoth(alignedSql)
+      assert(
+        alignedOn == alignedOff,
+        s"aligned-alias control diverges: ON=$alignedOn OFF=$alignedOff")
+      assert(alignedOn == Set(Row(1)), s"aligned-alias control expected {1}, got $alignedOn")
 
-    // s1.k is `a` (output position 0) but s2.k is `b` (output position 1): same name, different
-    // column. Rewriting this would count distinct `b` per `a`, which is a different query.
-    val swappedSql =
-      """SELECT a FROM AliasBase outer_t WHERE a IN (
-        |  SELECT s1.k
-        |  FROM (SELECT a AS k, b AS v FROM AliasBase) s1
-        |  JOIN (SELECT a AS v, b AS k FROM AliasBase) s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleNotFired(swappedSql)
-    val (on, off) = runBoth(swappedSql)
-    assert(on == off, s"swapped-alias semantics diverge: ON=$on OFF=$off")
-    assert(on.isEmpty, s"swapped-alias baseline should be empty, got $on")
+      // s1.k is `a` (output position 0) but s2.k is `b` (output position 1): same name, different
+      // column. Rewriting this would count distinct `b` per `a`, which is a different query.
+      val swappedSql =
+        """SELECT a FROM AliasBase outer_t WHERE a IN (
+          |  SELECT s1.k
+          |  FROM (SELECT a AS k, b AS v FROM AliasBase) s1
+          |  JOIN (SELECT a AS v, b AS k FROM AliasBase) s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(swappedSql)
+      val (on, off) = runBoth(swappedSql)
+      assert(on == off, s"swapped-alias semantics diverge: ON=$on OFF=$off")
+      assert(on.isEmpty, s"swapped-alias baseline should be empty, got $on")
+    }
   }
 
   test("Two different relations with the same schema must not be treated as a self-join") {
-    // The guard under test is `isSameBaseRelation`: it must reject a join between two DIFFERENT
-    // base tables even when they share a schema and column names. Distinct Parquet tables
-    // canonicalize to distinct `rootPaths`, so `left.canonicalized == right.canonicalized` is
-    // false and the rewrite must not fire. This pins a real correctness boundary, not just a
-    // missed optimization: rewriting `TLeft JOIN TRight` as COUNT(DISTINCT) over TLeft alone would
-    // drop TRight's rows and change the answer, so removing the guard would make ON diverge from
-    // OFF here.
-    createTable("TLeft", "k INT, v INT", "  (1, 10), (1, 10), (2, 30)")
-    createTable("TRight", "k INT, v INT", "  (1, 20), (1, 20), (2, 30)")
-    val sql =
-      """SELECT k FROM TLeft outer_t WHERE k IN (
-        |  SELECT s1.k FROM TLeft s1 JOIN TRight s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"different-relation join semantics diverge: ON=$on OFF=$off")
-    // k=1: TLeft v={10} vs TRight v={20} -> 10<>20 true -> qualifies; k=2: 30<>30 false -> no.
-    assert(on == Set(Row(1)), s"expected {1}, got $on")
+    withTable("TLeft", "TRight") {
+      // The guard under test is `isSameBaseRelation`: it must reject a join between two DIFFERENT
+      // base tables even when they share a schema and column names. Distinct Parquet tables
+      // canonicalize to distinct `rootPaths`, so `left.canonicalized == right.canonicalized` is
+      // false and the rewrite must not fire. This pins a real correctness boundary, not just a
+      // missed optimization: rewriting `TLeft JOIN TRight` as COUNT(DISTINCT) over TLeft alone
+      // would drop TRight's rows and change the answer, so removing the guard would make ON diverge
+      // from OFF here.
+      createTable("TLeft", "k INT, v INT", "  (1, 10), (1, 10), (2, 30)")
+      createTable("TRight", "k INT, v INT", "  (1, 20), (1, 20), (2, 30)")
+      val sql =
+        """SELECT k FROM TLeft outer_t WHERE k IN (
+          |  SELECT s1.k FROM TLeft s1 JOIN TRight s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"different-relation join semantics diverge: ON=$on OFF=$off")
+      // k=1: TLeft v={10} vs TRight v={20} -> 10<>20 true -> qualifies; k=2: 30<>30 false -> no.
+      assert(on == Set(Row(1)), s"expected {1}, got $on")
+    }
   }
 
   // ==================== Positive: rewritten plan is structurally the aggregate ================
@@ -347,185 +480,299 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
     comparePlans(actual.canonicalized, expected.canonicalized, checkAnalysis = false)
 
   test("Pattern A' rewritten plan is structurally the equivalent aggregate") {
-    setupTable()
-    val selfJoinSql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    val aggregateSql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
-        |  GROUP BY k HAVING count(DISTINCT v) > 1)""".stripMargin
+    withTable("T") {
+      setupTable()
+      val selfJoinSql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      val aggregateSql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
+          |  GROUP BY k HAVING count(DISTINCT v) > 1)""".stripMargin
 
-    val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
-    val expected = optimizedPlanWith(aggregateSql, rewrite = false)
-    assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
-    assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
-    compareCanonicalizedPlans(actual, expected)
+      val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
+      val expected = optimizedPlanWith(aggregateSql, rewrite = false)
+      assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
+      assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
+      compareCanonicalizedPlans(actual, expected)
+    }
   }
 
   test("Pattern A2 rewritten plan is structurally the equivalent aggregate") {
-    setupTable()
-    spark.sql(
-      """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
-        |  (1), (3), (6) AS D(k)""".stripMargin)
-    val selfJoinSql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT d.k
-        |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
-        |             ON s1.k = s2.k AND s1.v <> s2.v) sj
-        |  WHERE d.k = sj.k)""".stripMargin
-    val aggregateSql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT d.k
-        |  FROM D d, (SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
-        |             GROUP BY k HAVING count(DISTINCT v) > 1) sj
-        |  WHERE d.k = sj.k)""".stripMargin
+    withTable("T") {
+      withTempView("D") {
+        setupTable()
+        spark.sql(
+          """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+            |  (1), (3), (6) AS D(k)""".stripMargin)
+        val selfJoinSql =
+          """SELECT k FROM T outer_t WHERE k IN (
+            |  SELECT d.k
+            |  FROM D d, (SELECT s1.k FROM T s1 JOIN T s2
+            |             ON s1.k = s2.k AND s1.v <> s2.v) sj
+            |  WHERE d.k = sj.k)""".stripMargin
+        val aggregateSql =
+          """SELECT k FROM T outer_t WHERE k IN (
+            |  SELECT d.k
+            |  FROM D d, (SELECT k FROM T WHERE k IS NOT NULL AND v IS NOT NULL
+            |             GROUP BY k HAVING count(DISTINCT v) > 1) sj
+            |  WHERE d.k = sj.k)""".stripMargin
 
-    val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
-    val expected = optimizedPlanWith(aggregateSql, rewrite = false)
-    assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
-    assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
-    compareCanonicalizedPlans(actual, expected)
+        val actual = optimizedPlanWith(selfJoinSql, rewrite = true)
+        val expected = optimizedPlanWith(aggregateSql, rewrite = false)
+        assert(ruleFired(actual), s"precondition: rewrite should fire:\n$actual")
+        assert(!ruleFired(expected), s"precondition: expected plan is the hand-written aggregate")
+        compareCanonicalizedPlans(actual, expected)
+      }
+    }
   }
 
   // ==================== Negative: rewrite must produce equivalent results (or bail) ==========
 
   test("Plain InnerJoin at top level: results unchanged (rewrite must not touch it)") {
-    setupTable()
-    val sql =
-      """SELECT ws1.k FROM T ws1 JOIN T ws2
-        |ON ws1.k = ws2.k AND ws1.v <> ws2.v""".stripMargin
-    // Row-multiplicity matters here; using count() to catch any drop or dup.
-    var onCount: Long = -1L
-    var offCount: Long = -1L
-    withSQLConf(rewriteConf -> "true") {
-      onCount = spark.sql(sql).count()
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT ws1.k FROM T ws1 JOIN T ws2
+          |ON ws1.k = ws2.k AND ws1.v <> ws2.v""".stripMargin
+      // Row-multiplicity matters here; using count() to catch any drop or dup.
+      var onCount: Long = -1L
+      var offCount: Long = -1L
+      withSQLConf(rewriteConf -> "true") {
+        onCount = spark.sql(sql).count()
+      }
+      withSQLConf(rewriteConf -> "false") {
+        offCount = spark.sql(sql).count()
+      }
+      assert(
+        onCount == offCount,
+        s"plain InnerJoin row-count differs: rewrite=$onCount vs baseline=$offCount")
+      assertRuleNotFired(sql)
     }
-    withSQLConf(rewriteConf -> "false") {
-      offCount = spark.sql(sql).count()
+  }
+
+  test("Bare-Join subquery (no wrapper Project) fails closed: Pattern A' arity guard") {
+    withTable("T") {
+      // The guard under test is the `projectListOpt match { case None => None }` bail in
+      // `rewriteDirectSelfJoin`. With no wrapper Project the self-join output is `left ++ right`;
+      // replacing it with `Project(equiKeys, aggregate)` would shrink the arity that
+      // RewritePredicateSubquery later positionally zips against, misbinding the semi predicates. A
+      // `SELECT *` over the self-join whose tuple IN references every output column lets
+      // RemoveNoopOperators strip the identity Project, so the subquery reaches the rule as a bare
+      // Join -- proven below before asserting the rule declines it.
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE (k, v, k, v) IN (
+          |  SELECT * FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      optimizedInSubqueryPlan(sql) match {
+        case _: Join =>
+        case other => fail(s"expected a bare Join subquery, got:\n$other")
+      }
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"bare-Join A' arity guard semantics diverge: ON=$on OFF=$off")
     }
-    assert(
-      onCount == offCount,
-      s"plain InnerJoin row-count differs: rewrite=$onCount vs baseline=$offCount")
-    assertRuleNotFired(sql)
+  }
+
+  test("Bare-Join nested self-join (no Project anywhere) fails closed: Pattern A2 arity guard") {
+    withTable("T") {
+      withTempView("D") {
+        // The guard under test is the `case None if projectListOpt.isEmpty => return None` bail in
+        // `rewriteNestedSelfJoin`: with no wrapper Project and no top-level Project, changing the
+        // self-join output arity would misbind the positional semi-predicate zip. `SELECT *` plus a
+        // tuple IN over every column lets RemoveNoopOperators expose the bare nested self-join.
+        // ReorderJoin is excluded (a valid config) so the bare nested self-join deterministically
+        // reaches this rule rather than being reshaped away; the shape is then asserted so the test
+        // fails loudly if it stops reaching the guard. The two sides use renaming subqueries (ka/va
+        // vs kb/vb) so `SELECT *` yields distinct names -- a plain `T s1 JOIN T s2` would emit two
+        // columns named `k` and fail analysis; the renames are children of the self-join, so the
+        // identity `SELECT *` is still stripped.
+        setupTable()
+        spark.sql(
+          """CREATE OR REPLACE TEMP VIEW D AS SELECT * FROM VALUES
+            |  (1), (3), (6) AS D(k)""".stripMargin)
+        val sql =
+          """SELECT k FROM T outer_t WHERE (k, v, k, k, v) IN (
+            |  SELECT * FROM D d JOIN (
+            |    SELECT * FROM (SELECT k AS ka, v AS va FROM T) s1
+            |    JOIN (SELECT k AS kb, v AS vb FROM T) s2
+            |      ON s1.ka = s2.kb AND s1.va <> s2.vb) sj
+            |  ON d.k = sj.ka)""".stripMargin
+        withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ReorderJoin.ruleName) {
+          // A child that is a `sameResult` Inner Join carrying an inequality is exactly the
+          // self-join rewriteNestedSelfJoin extracts; asserting it proves execution reaches the
+          // arity guard.
+          def isTargetSelfJoin(p: LogicalPlan): Boolean = p match {
+            case j: Join if j.joinType == Inner =>
+              j.left.sameResult(j.right) &&
+                j.condition.exists(_.exists { case _: Not => true; case _ => false })
+            case _ => false
+          }
+          optimizedInSubqueryPlan(sql) match {
+            case j: Join if isTargetSelfJoin(j.left) || isTargetSelfJoin(j.right) =>
+            case other => fail(s"expected a bare nested self-join child, got:\n$other")
+          }
+          assertRuleNotFired(sql)
+          val (on, off) = runBoth(sql)
+          assert(on == off, s"bare-Join A2 arity guard semantics diverge: ON=$on OFF=$off")
+        }
+      }
+    }
   }
 
   test("IS DISTINCT FROM is rejected by the self-join condition parser") {
-    setupTable()
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.v IS DISTINCT FROM s2.v)""".stripMargin
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"IS DISTINCT FROM semantics diverge: ON=$on OFF=$off")
-    // Assert the full result, not just contains(4): unlike `<>`, `IS DISTINCT FROM` treats NULL as
-    // a value, so k=4 (v={70,NULL}) qualifies alongside k=1, k=3 and k=6.
-    assert(on == Set(Row(1), Row(3), Row(4), Row(6)), s"expected {1,3,4,6}, got $on")
-    assertRuleNotFired(sql)
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v IS DISTINCT FROM s2.v)""".stripMargin
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"IS DISTINCT FROM semantics diverge: ON=$on OFF=$off")
+      // Assert the full result, not just contains(4): unlike `<>`, `IS DISTINCT FROM` treats NULL
+      // as a value, so k=4 (v={70,NULL}) qualifies alongside k=1, k=3 and k=6.
+      assert(on == Set(Row(1), Row(3), Row(4), Row(6)), s"expected {1,3,4,6}, got $on")
+      assertRuleNotFired(sql)
+    }
   }
 
   test("IsNotNull on a non-join column is rejected") {
-    // The guard under test is the predicate parser: it accepts IsNotNull only on a column the
-    // join condition already references, because such a predicate is implied by the equi-key or
-    // the inequality and can be dropped, while IsNotNull(w) filters rows the aggregate would
-    // otherwise count. The control is the same query without that one conjunct.
-    createTable(
-      "T3",
-      "k INT, v INT, w INT",
-      """  (1, 10, 100), (1, 20, 200),
-        |  (2, 30, CAST(NULL AS INT)), (2, 40, CAST(NULL AS INT))""".stripMargin)
+    withTable("T3") {
+      // The guard under test is the predicate parser: it accepts IsNotNull only on a column the
+      // join condition already references, because such a predicate is implied by the equi-key or
+      // the inequality and can be dropped, while IsNotNull(w) filters rows the aggregate would
+      // otherwise count. The control is the same query without that one conjunct.
+      createTable(
+        "T3",
+        "k INT, v INT, w INT",
+        """  (1, 10, 100), (1, 20, 200),
+          |  (2, 30, CAST(NULL AS INT)), (2, 40, CAST(NULL AS INT))""".stripMargin)
 
-    val controlSql =
-      """SELECT k FROM T3 outer_t WHERE k IN (
-        |  SELECT s1.k FROM T3 s1 JOIN T3 s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"T3 control diverges: ON=$controlOn OFF=$controlOff")
-    assert(controlOn == Set(Row(1), Row(2)), s"T3 control expected {1,2}, got $controlOn")
+      val controlSql =
+        """SELECT k FROM T3 outer_t WHERE k IN (
+          |  SELECT s1.k FROM T3 s1 JOIN T3 s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(controlSql)
+      val (controlOn, controlOff) = runBoth(controlSql)
+      assert(controlOn == controlOff, s"T3 control diverges: ON=$controlOn OFF=$controlOff")
+      assert(controlOn == Set(Row(1), Row(2)), s"T3 control expected {1,2}, got $controlOn")
 
-    val sql =
-      """SELECT k FROM T3 outer_t WHERE k IN (
-        |  SELECT s1.k FROM T3 s1 JOIN T3 s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v AND s1.w IS NOT NULL)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"IsNotNull(non-join-col) semantics diverge: ON=$on OFF=$off")
-    assert(on == Set(Row(1)), s"expected {1}, got $on")
+      val sql =
+        """SELECT k FROM T3 outer_t WHERE k IN (
+          |  SELECT s1.k FROM T3 s1 JOIN T3 s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v AND s1.w IS NOT NULL)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"IsNotNull(non-join-col) semantics diverge: ON=$on OFF=$off")
+      assert(on == Set(Row(1)), s"expected {1}, got $on")
+    }
   }
 
   test("Multiple inequality columns are rejected") {
-    // The guard under test is `neqPairs.size != 1`. Two inequalities need "at least two rows
-    // differing in v AND in w", which no count-distinct over a single column can express. The
-    // control is the same query with only the first inequality.
-    createTable(
-      "T2",
-      "k INT, v INT, w INT",
-      """  (1, 10, 100), (1, 20, 200),
-        |  (2, 30, 300),
-        |  (3, 40, 100), (3, 50, 100)""".stripMargin)
+    withTable("T2") {
+      // The guard under test is `neqPairs.size != 1`. Two inequalities need "at least two rows
+      // differing in v AND in w", which no count-distinct over a single column can express. The
+      // control is the same query with only the first inequality.
+      createTable(
+        "T2",
+        "k INT, v INT, w INT",
+        """  (1, 10, 100), (1, 20, 200),
+          |  (2, 30, 300),
+          |  (3, 40, 100), (3, 50, 100)""".stripMargin)
 
-    val controlSql =
-      """SELECT k FROM T2 outer_t WHERE k IN (
-        |  SELECT s1.k FROM T2 s1 JOIN T2 s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"T2 control diverges: ON=$controlOn OFF=$controlOff")
-    assert(controlOn == Set(Row(1), Row(3)), s"T2 control expected {1,3}, got $controlOn")
+      val controlSql =
+        """SELECT k FROM T2 outer_t WHERE k IN (
+          |  SELECT s1.k FROM T2 s1 JOIN T2 s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(controlSql)
+      val (controlOn, controlOff) = runBoth(controlSql)
+      assert(controlOn == controlOff, s"T2 control diverges: ON=$controlOn OFF=$controlOff")
+      assert(controlOn == Set(Row(1), Row(3)), s"T2 control expected {1,3}, got $controlOn")
 
-    val sql =
-      """SELECT k FROM T2 outer_t WHERE k IN (
-        |  SELECT s1.k FROM T2 s1 JOIN T2 s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v AND s1.w <> s2.w)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"multi-column neq semantics diverge: ON=$on OFF=$off")
-    assert(on == Set(Row(1)), s"expected {1}, got $on")
+      val sql =
+        """SELECT k FROM T2 outer_t WHERE k IN (
+          |  SELECT s1.k FROM T2 s1 JOIN T2 s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v AND s1.w <> s2.w)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"multi-column neq semantics diverge: ON=$on OFF=$off")
+      assert(on == Set(Row(1)), s"expected {1}, got $on")
+    }
   }
 
   test("LeftOuter join is outside existence context: results unchanged") {
-    setupTable()
-    val sql =
-      """SELECT ws1.k FROM T ws1 LEFT OUTER JOIN T ws2
-        |ON ws1.k = ws2.k AND ws1.v <> ws2.v""".stripMargin
-    // Row multiplicity matters here.
-    var onCount: Long = -1L
-    var offCount: Long = -1L
-    withSQLConf(rewriteConf -> "true") {
-      onCount = spark.sql(sql).count()
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT ws1.k FROM T ws1 LEFT OUTER JOIN T ws2
+          |ON ws1.k = ws2.k AND ws1.v <> ws2.v""".stripMargin
+      // Row multiplicity matters here.
+      var onCount: Long = -1L
+      var offCount: Long = -1L
+      withSQLConf(rewriteConf -> "true") {
+        onCount = spark.sql(sql).count()
+      }
+      withSQLConf(rewriteConf -> "false") {
+        offCount = spark.sql(sql).count()
+      }
+      assert(onCount == offCount, s"LeftOuter row-count differs: $onCount vs $offCount")
+      assertRuleNotFired(sql)
     }
-    withSQLConf(rewriteConf -> "false") {
-      offCount = spark.sql(sql).count()
+  }
+
+  test("Join hint on the self-join is fail-closed") {
+    withTable("T") {
+      // The guard under test is `hint != JoinHint.NONE`. The rewrite deletes the self-join, so a
+      // hint on it is a directive about a join that would vanish; fail closed instead. Control (no
+      // hint) fires; the same query with a BROADCAST hint on the inner self-join -- the only change
+      // -- must not fire. A hint never changes rows, so results are identical either way.
+      setupTable()
+      val controlSql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(controlSql)
+
+      val hintedSql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT /*+ BROADCAST(s2) */ s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(hintedSql)
+      val (on, off) = runBoth(hintedSql)
+      assert(on == off, s"hinted self-join semantics diverge: ON=$on OFF=$off")
+      assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
     }
-    assert(onCount == offCount, s"LeftOuter row-count differs: $onCount vs $offCount")
-    assertRuleNotFired(sql)
   }
 
   test("Inequality column overlapping an equi-key is rejected") {
-    setupTable()
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.k <> s2.k)""".stripMargin
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"unsatisfiable predicate diverges: ON=$on OFF=$off")
-    assert(on.isEmpty, s"unsatisfiable predicate should produce empty set, got $on")
-    assertRuleNotFired(sql)
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.k <> s2.k)""".stripMargin
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"unsatisfiable predicate diverges: ON=$on OFF=$off")
+      assert(on.isEmpty, s"unsatisfiable predicate should produce empty set, got $on")
+      assertRuleNotFired(sql)
+    }
   }
 
   test("Config gate: rewrite disabled leaves a valid A' candidate untouched") {
-    setupTable()
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    withSQLConf(rewriteConf -> "false") {
-      val plan = spark.sql(sql).queryExecution.optimizedPlan
-      assert(!ruleFired(plan), s"config off must not fire rewrite:\n$plan")
-      val res = spark.sql(sql).collect().toSet
-      assert(res == Set(Row(1), Row(3), Row(6)), s"config off correctness broken: $res")
+    withTable("T") {
+      setupTable()
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k FROM T s1 JOIN T s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      withSQLConf(rewriteConf -> "false") {
+        val plan = spark.sql(sql).queryExecution.optimizedPlan
+        assert(!ruleFired(plan), s"config off must not fire rewrite:\n$plan")
+        val res = spark.sql(sql).collect().toSet
+        assert(res == Set(Row(1), Row(3), Row(6)), s"config off correctness broken: $res")
+      }
     }
   }
 
@@ -538,17 +785,33 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   }
 
   test("Correlated InSubquery is fail-closed") {
-    setupTable()
-    setupOuterT()
-    val sql =
-      """SELECT o.k FROM OuterT o WHERE o.k IN (
-        |  SELECT s1.k FROM T s1 JOIN T s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v
-        |  WHERE s2.k = o.k)""".stripMargin
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"correlated IN parity: ON=$on OFF=$off")
-    assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
-    assertRuleNotFired(sql)
+    withTable("T") {
+      withTempView("OuterT") {
+        setupTable()
+        setupOuterT()
+        val sql =
+          """SELECT o.k FROM OuterT o WHERE o.k IN (
+            |  SELECT s1.k FROM T s1 JOIN T s2
+            |    ON s1.k = s2.k AND s1.v <> s2.v
+            |  WHERE s2.k = o.k)""".stripMargin
+        // Precondition: the InSubquery is genuinely correlated -- its ListQuery carries outer
+        // references -- so the not-fired result exercises the `lq.children.isEmpty` fail-closed
+        // guard in `apply`, not an unrelated shape mismatch that would leave this test vacuous.
+        val analyzed = spark.sql(sql).queryExecution.analyzed
+        var sawCorrelated = false
+        analyzed.foreach { node =>
+          node.expressions.foreach(_.foreach {
+            case InSubquery(_, lq: ListQuery) => sawCorrelated ||= lq.children.nonEmpty
+            case _ =>
+          })
+        }
+        assert(sawCorrelated, s"expected a correlated InSubquery in analyzed plan:\n$analyzed")
+        val (on, off) = runBoth(sql)
+        assert(on == off, s"correlated IN parity: ON=$on OFF=$off")
+        assert(on == Set(Row(1), Row(3), Row(6)), s"expected {1,3,6}, got $on")
+        assertRuleNotFired(sql)
+      }
+    }
   }
 
   // ==================== Repeatability whitelist: unknown operators fail-closed ==============
@@ -632,78 +895,85 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   }
 
   test("LogicalRDD leaf is not a trusted repeatable source: rule bails out") {
-    // The guard under test is the leaf allowlist in `isRowBagRepeatable`: a Parquet
-    // `LogicalRelation` is trusted, but a `LogicalRDD` (createDataFrame over an RDD) wraps an
-    // arbitrary RDD lineage whose runtime row bag Catalyst cannot prove repeatable, so it must
-    // fail closed even though `plan.deterministic` is true. Both fixtures are MultiInstanceRelation
-    // leaves, so each self-join dedups into two structurally identical sides without a rename-only
-    // Project -- the rejection therefore comes from the leaf allowlist, not `isSameBaseRelation`.
-    // The Parquet control uses the same schema, data and query shape and fires, which is what makes
-    // the LogicalRDD negative evidence that the leaf allowlist -- not a structural mismatch --
-    // rejected it.
-    createTable("RddCtl", "k INT, v INT", "  (1, 10), (1, 20), (2, 30)")
-    val controlSql =
-      """SELECT k FROM RddCtl outer_t WHERE k IN (
-        |  SELECT s1.k FROM RddCtl s1 JOIN RddCtl s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"Parquet control diverges: ON=$controlOn OFF=$controlOff")
-    assert(controlOn == Set(Row(1)), s"Parquet control expected {1}, got $controlOn")
+    withTable("RddCtl") {
+      withTempView("RddT") {
+        // The guard under test is the leaf allowlist in `isRowBagRepeatable`: a Parquet
+        // `LogicalRelation` is trusted, but a `LogicalRDD` (createDataFrame over an RDD) wraps an
+        // arbitrary RDD lineage whose runtime row bag Catalyst cannot prove repeatable, so it must
+        // fail closed even though `plan.deterministic` is true. Both fixtures are
+        // MultiInstanceRelation leaves, so each self-join dedups into two structurally identical
+        // sides without a rename-only Project -- the rejection therefore comes from the leaf
+        // allowlist, not `isSameBaseRelation`. The Parquet control uses the same schema, data and
+        // query shape and fires, which is what makes the LogicalRDD negative evidence that the leaf
+        // allowlist -- not a structural mismatch -- rejected it.
+        createTable("RddCtl", "k INT, v INT", "  (1, 10), (1, 20), (2, 30)")
+        val controlSql =
+          """SELECT k FROM RddCtl outer_t WHERE k IN (
+            |  SELECT s1.k FROM RddCtl s1 JOIN RddCtl s2
+            |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+        assertRuleFired(controlSql)
+        val (controlOn, controlOff) = runBoth(controlSql)
+        assert(controlOn == controlOff, s"Parquet control diverges: ON=$controlOn OFF=$controlOff")
+        assert(controlOn == Set(Row(1)), s"Parquet control expected {1}, got $controlOn")
 
-    val schema = StructType(Seq(StructField("k", IntegerType), StructField("v", IntegerType)))
-    val rows = spark.sparkContext.parallelize(Seq(Row(1, 10), Row(1, 20), Row(2, 30)))
-    spark.createDataFrame(rows, schema).createOrReplaceTempView("RddT")
-    val sql =
-      """SELECT k FROM RddT outer_t WHERE k IN (
-        |  SELECT s1.k FROM RddT s1 JOIN RddT s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"LogicalRDD semantics diverge: ON=$on OFF=$off")
-    assert(on == Set(Row(1)), s"expected {1}, got $on")
+        val schema = StructType(Seq(StructField("k", IntegerType), StructField("v", IntegerType)))
+        val rows = spark.sparkContext.parallelize(Seq(Row(1, 10), Row(1, 20), Row(2, 30)))
+        spark.createDataFrame(rows, schema).createOrReplaceTempView("RddT")
+        val sql =
+          """SELECT k FROM RddT outer_t WHERE k IN (
+            |  SELECT s1.k FROM RddT s1 JOIN RddT s2
+            |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+        assertRuleNotFired(sql)
+        val (on, off) = runBoth(sql)
+        assert(on == off, s"LogicalRDD semantics diverge: ON=$on OFF=$off")
+        assert(on == Set(Row(1)), s"expected {1}, got $on")
+      }
+    }
   }
 
   test("Non-allowlisted deterministic expression (Abs) fails closed") {
-    // The guard under test is the expression allowlist in `isRepeatableExpression`: it trusts
-    // expression TYPES, not merely `deterministic`. Abs is deterministic, but is intentionally not
-    // yet part of the expression allowlist; until its repeatability contract is explicitly admitted
-    // there, a self-join whose side projects abs(v) fails closed -- a missed optimization, not a
-    // correctness bug. This test verifies that an unknown-but-deterministic expression is not
-    // silently let through by `plan.deterministic`.
-    //
-    // Control and negative are a single-variable pair: both project one derived column and differ
-    // ONLY in its expression. The control uses `v + 1` (Add over Attribute + Literal, all
-    // allowlisted) and fires; wrapping the same column in abs() -- the sole change -- makes it not
-    // fire, so the rejection is attributable to the expression allowlist rather than a structural
-    // mismatch. `+ 1` (not `+ 0`) is used so the Add survives arithmetic simplification and the
-    // control genuinely exercises a compound allowlisted expression. v is INT here, so the Add is a
-    // plain `Add(v, 1)` with no decimal PromotePrecision / CheckOverflow wrappers.
-    setupTable()
+    withTable("T") {
+      // The guard under test is the expression allowlist in `isRepeatableExpression`: it trusts
+      // expression TYPES, not merely `deterministic`. Abs is deterministic, but is intentionally
+      // not yet part of the expression allowlist; until its repeatability contract is explicitly
+      // admitted there, a self-join whose side projects abs(v) fails closed -- a missed
+      // optimization, not a correctness bug. This test verifies that an unknown-but-deterministic
+      // expression is not silently let through by `plan.deterministic`.
+      //
+      // Control and negative are a single-variable pair: both project one derived column and differ
+      // ONLY in its expression. The control uses `v + 1` (Add over Attribute + Literal, all
+      // allowlisted) and fires; wrapping the same column in abs() -- the sole change -- makes it
+      // not fire, so the rejection is attributable to the expression allowlist rather than a
+      // structural mismatch. `+ 1` (not `+ 0`) is used so the Add survives arithmetic
+      // simplification and the control genuinely exercises a compound allowlisted expression. v is
+      // INT here, so the Add is a plain `Add(v, 1)` with no decimal PromotePrecision /
+      // CheckOverflow wrappers.
+      setupTable()
 
-    val controlSql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k
-        |  FROM (SELECT k, v + 1 AS x FROM T) s1
-        |  JOIN (SELECT k, v + 1 AS x FROM T) s2
-        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"Add control diverges: ON=$controlOn OFF=$controlOff")
-    // v+1 is injective over the (non-null) v values, so distinctness per k is unchanged: {1,3,6}.
-    assert(
-      controlOn == Set(Row(1), Row(3), Row(6)),
-      s"Add control expected {1,3,6}, got $controlOn")
+      val controlSql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k
+          |  FROM (SELECT k, v + 1 AS x FROM T) s1
+          |  JOIN (SELECT k, v + 1 AS x FROM T) s2
+          |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+      assertRuleFired(controlSql)
+      val (controlOn, controlOff) = runBoth(controlSql)
+      assert(controlOn == controlOff, s"Add control diverges: ON=$controlOn OFF=$controlOff")
+      // v+1 is injective over the (non-null) v values, so distinctness per k is unchanged: {1,3,6}.
+      assert(
+        controlOn == Set(Row(1), Row(3), Row(6)),
+        s"Add control expected {1,3,6}, got $controlOn")
 
-    val sql =
-      """SELECT k FROM T outer_t WHERE k IN (
-        |  SELECT s1.k
-        |  FROM (SELECT k, abs(v) AS x FROM T) s1
-        |  JOIN (SELECT k, abs(v) AS x FROM T) s2
-        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"Abs-projected self-join semantics diverge: ON=$on OFF=$off")
+      val sql =
+        """SELECT k FROM T outer_t WHERE k IN (
+          |  SELECT s1.k
+          |  FROM (SELECT k, abs(v) AS x FROM T) s1
+          |  JOIN (SELECT k, abs(v) AS x FROM T) s2
+          |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"Abs-projected self-join semantics diverge: ON=$on OFF=$off")
+    }
   }
 
   // ==================== Data-type safety: comparison vs grouping/DISTINCT equality ============
@@ -715,305 +985,385 @@ class RewriteSelfJoinInequalityToAggregateSuite extends QueryTest with SharedSpa
   // tests pin the boundary for the risky types.
 
   test("Float/Double neq column is rejected (comparison-vs-DISTINCT contract, defensive)") {
-    // The guard under test is `isSafeComparisonGroupingType` on the NEQ column. Control and
-    // negative differ only in which column feeds the inequality: `vi` (Int, allowlisted) fires,
-    // `vd` (Double) does not. Double fails closed defensively: the rewrite depends on comparison
-    // equality and grouping/DISTINCT equality agreeing, and for floating point that agreement on
-    // signed zero and NaN rests on normalization details (NormalizeFloatingNumbers) that need not
-    // match across Spark versions or native backends. On current Spark, comparison semantics and
-    // aggregation normalization are aligned for these cases, so the OFF baseline of the negative
-    // query is {1}; the rule does not fire, so ON matches it. The test pins fail-closed behavior,
-    // not a divergence in current Spark.
-    createTable(
-      "TFloat",
-      "k INT, vi INT, vd DOUBLE",
-      """  (1, 10, 1.0), (1, 20, 2.0),
-        |  (2, 30, 0.0), (2, 30, -0.0),
-        |  (3, 40, CAST('NaN' AS DOUBLE)), (3, 50, CAST('NaN' AS DOUBLE))""".stripMargin)
+    withTable("TFloat") {
+      // The guard under test is `isSafeComparisonGroupingType` on the NEQ column. Control and
+      // negative differ only in which column feeds the inequality: `vi` (Int, allowlisted) fires,
+      // `vd` (Double) does not. Double fails closed defensively: the rewrite depends on comparison
+      // equality and grouping/DISTINCT equality agreeing, and for floating point that
+      // agreement on signed zero and NaN rests on normalization details (NormalizeFloatingNumbers)
+      // that need not match across Spark versions or native backends. On current Spark, comparison
+      // semantics and aggregation normalization are aligned for these cases, so the OFF baseline of
+      // the negative query is {1}; the rule does not fire, so ON matches it. The test pins
+      // fail-closed behavior, not a divergence in current Spark.
+      createTable(
+        "TFloat",
+        "k INT, vi INT, vd DOUBLE",
+        """  (1, 10, 1.0), (1, 20, 2.0),
+          |  (2, 30, 0.0), (2, 30, -0.0),
+          |  (3, 40, CAST('NaN' AS DOUBLE)), (3, 50, CAST('NaN' AS DOUBLE))""".stripMargin)
 
-    val controlSql =
-      """SELECT k FROM TFloat outer_t WHERE k IN (
-        |  SELECT s1.k FROM TFloat s1 JOIN TFloat s2
-        |    ON s1.k = s2.k AND s1.vi <> s2.vi)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"Int-neq control diverges: ON=$controlOn OFF=$controlOff")
-    assert(controlOn == Set(Row(1), Row(3)), s"Int-neq control expected {1,3}, got $controlOn")
+      val controlSql =
+        """SELECT k FROM TFloat outer_t WHERE k IN (
+          |  SELECT s1.k FROM TFloat s1 JOIN TFloat s2
+          |    ON s1.k = s2.k AND s1.vi <> s2.vi)""".stripMargin
+      assertRuleFired(controlSql)
+      val (controlOn, controlOff) = runBoth(controlSql)
+      assert(controlOn == controlOff, s"Int-neq control diverges: ON=$controlOn OFF=$controlOff")
+      assert(controlOn == Set(Row(1), Row(3)), s"Int-neq control expected {1,3}, got $controlOn")
 
-    val sql =
-      """SELECT k FROM TFloat outer_t WHERE k IN (
-        |  SELECT s1.k FROM TFloat s1 JOIN TFloat s2
-        |    ON s1.k = s2.k AND s1.vd <> s2.vd)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"Double-neq semantics diverge: ON=$on OFF=$off")
-    // k=1 matches (1.0 <> 2.0); k=2 does not (0.0 = -0.0); k=3 does not (Spark NaN = NaN).
-    assert(on == Set(Row(1)), s"Double-neq baseline expected {1}, got $on")
+      val sql =
+        """SELECT k FROM TFloat outer_t WHERE k IN (
+          |  SELECT s1.k FROM TFloat s1 JOIN TFloat s2
+          |    ON s1.k = s2.k AND s1.vd <> s2.vd)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"Double-neq semantics diverge: ON=$on OFF=$off")
+      // k=1 matches (1.0 <> 2.0); k=2 does not (0.0 = -0.0); k=3 does not (Spark NaN = NaN).
+      assert(on == Set(Row(1)), s"Double-neq baseline expected {1}, got $on")
+    }
   }
 
   test("Float/Double equi-key is rejected (defensive fail-closed)") {
-    // The guard under test is `isSafeComparisonGroupingType` on the EQUI key. Current Spark aligns
-    // floating-point comparison semantics with grouping normalization here, but the rule does not
-    // depend on that implementation contract, so it fails closed. Control and negative differ only
-    // in the equi-key column: `ki` (Int) fires, `kd` (Double) does not.
-    createTable(
-      "TFloatKey",
-      "kd DOUBLE, ki INT, v INT",
-      """  (1.0, 1, 10), (1.0, 1, 20),
-        |  (2.0, 2, 30),
-        |  (0.0, 3, 40), (-0.0, 3, 50)""".stripMargin)
+    withTable("TFloatKey") {
+      // The guard under test is `isSafeComparisonGroupingType` on the EQUI key. Current Spark
+      // aligns floating-point comparison semantics with grouping normalization here, but the rule
+      // does not depend on that implementation contract, so it fails closed. Control and negative
+      // differ only in the equi-key column: `ki` (Int) fires, `kd` (Double) does not.
+      createTable(
+        "TFloatKey",
+        "kd DOUBLE, ki INT, v INT",
+        """  (1.0, 1, 10), (1.0, 1, 20),
+          |  (2.0, 2, 30),
+          |  (0.0, 3, 40), (-0.0, 3, 50)""".stripMargin)
 
-    val controlSql =
-      """SELECT ki FROM TFloatKey outer_t WHERE ki IN (
-        |  SELECT s1.ki FROM TFloatKey s1 JOIN TFloatKey s2
-        |    ON s1.ki = s2.ki AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"Int-key control diverges: ON=$controlOn OFF=$controlOff")
-    assert(controlOn == Set(Row(1), Row(3)), s"Int-key control expected {1,3}, got $controlOn")
+      val controlSql =
+        """SELECT ki FROM TFloatKey outer_t WHERE ki IN (
+          |  SELECT s1.ki FROM TFloatKey s1 JOIN TFloatKey s2
+          |    ON s1.ki = s2.ki AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(controlSql)
+      val (controlOn, controlOff) = runBoth(controlSql)
+      assert(controlOn == controlOff, s"Int-key control diverges: ON=$controlOn OFF=$controlOff")
+      assert(controlOn == Set(Row(1), Row(3)), s"Int-key control expected {1,3}, got $controlOn")
 
-    val sql =
-      """SELECT kd FROM TFloatKey outer_t WHERE kd IN (
-        |  SELECT s1.kd FROM TFloatKey s1 JOIN TFloatKey s2
-        |    ON s1.kd = s2.kd AND s1.v <> s2.v)""".stripMargin
-    assertRuleNotFired(sql)
-    val (on, off) = runBoth(sql)
-    assert(on == off, s"Double-key semantics diverge: ON=$on OFF=$off")
+      val sql =
+        """SELECT kd FROM TFloatKey outer_t WHERE kd IN (
+          |  SELECT s1.kd FROM TFloatKey s1 JOIN TFloatKey s2
+          |    ON s1.kd = s2.kd AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(sql)
+      val (on, off) = runBoth(sql)
+      assert(on == off, s"Double-key semantics diverge: ON=$on OFF=$off")
+    }
   }
 
   test("Complex-type neq column (array/struct) is rejected wholesale") {
-    // The guard under test is the wholesale rejection of complex types by
-    // `isSafeComparisonGroupingType`, which also covers any Float/Double nested inside them.
-    // Control (`v` Int) fires; the ARRAY<DOUBLE> and STRUCT<..DOUBLE> variants -- identical query
-    // shape, only the neq column changed -- do not.
-    createTable(
-      "TCplx",
-      "k INT, v INT, a ARRAY<DOUBLE>, s STRUCT<x: INT, y: DOUBLE>",
-      """  (1, 10, ARRAY(1.0), NAMED_STRUCT('x', 1, 'y', 1.0)),
-        |  (1, 20, ARRAY(2.0), NAMED_STRUCT('x', 2, 'y', 2.0)),
-        |  (2, 30, ARRAY(1.0), NAMED_STRUCT('x', 1, 'y', 1.0))""".stripMargin)
+    withTable("TCplx") {
+      // The guard under test is the wholesale rejection of complex types by
+      // `isSafeComparisonGroupingType`, which also covers any Float/Double nested inside them.
+      // Control (`v` Int) fires; the ARRAY<DOUBLE> and STRUCT<..DOUBLE> variants -- identical query
+      // shape, only the neq column changed -- do not.
+      createTable(
+        "TCplx",
+        "k INT, v INT, a ARRAY<DOUBLE>, s STRUCT<x: INT, y: DOUBLE>",
+        """  (1, 10, ARRAY(1.0), NAMED_STRUCT('x', 1, 'y', 1.0)),
+          |  (1, 20, ARRAY(2.0), NAMED_STRUCT('x', 2, 'y', 2.0)),
+          |  (2, 30, ARRAY(1.0), NAMED_STRUCT('x', 1, 'y', 1.0))""".stripMargin)
 
-    val controlSql =
-      """SELECT k FROM TCplx outer_t WHERE k IN (
-        |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(controlSql)
-    val (controlOn, controlOff) = runBoth(controlSql)
-    assert(controlOn == controlOff, s"Int-neq control diverges: ON=$controlOn OFF=$controlOff")
-    assert(controlOn == Set(Row(1)), s"Int-neq control expected {1}, got $controlOn")
+      val controlSql =
+        """SELECT k FROM TCplx outer_t WHERE k IN (
+          |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(controlSql)
+      val (controlOn, controlOff) = runBoth(controlSql)
+      assert(controlOn == controlOff, s"Int-neq control diverges: ON=$controlOn OFF=$controlOff")
+      assert(controlOn == Set(Row(1)), s"Int-neq control expected {1}, got $controlOn")
 
-    val arraySql =
-      """SELECT k FROM TCplx outer_t WHERE k IN (
-        |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
-        |    ON s1.k = s2.k AND s1.a <> s2.a)""".stripMargin
-    assertRuleNotFired(arraySql)
-    val (arrayOn, arrayOff) = runBoth(arraySql)
-    assert(arrayOn == arrayOff, s"array-neq semantics diverge: ON=$arrayOn OFF=$arrayOff")
+      val arraySql =
+        """SELECT k FROM TCplx outer_t WHERE k IN (
+          |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
+          |    ON s1.k = s2.k AND s1.a <> s2.a)""".stripMargin
+      assertRuleNotFired(arraySql)
+      val (arrayOn, arrayOff) = runBoth(arraySql)
+      assert(arrayOn == arrayOff, s"array-neq semantics diverge: ON=$arrayOn OFF=$arrayOff")
 
-    val structSql =
-      """SELECT k FROM TCplx outer_t WHERE k IN (
-        |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
-        |    ON s1.k = s2.k AND s1.s <> s2.s)""".stripMargin
-    assertRuleNotFired(structSql)
-    val (structOn, structOff) = runBoth(structSql)
-    assert(structOn == structOff, s"struct-neq semantics diverge: ON=$structOn OFF=$structOff")
+      val structSql =
+        """SELECT k FROM TCplx outer_t WHERE k IN (
+          |  SELECT s1.k FROM TCplx s1 JOIN TCplx s2
+          |    ON s1.k = s2.k AND s1.s <> s2.s)""".stripMargin
+      assertRuleNotFired(structSql)
+      val (structOn, structOff) = runBoth(structSql)
+      assert(structOn == structOff, s"struct-neq semantics diverge: ON=$structOn OFF=$structOff")
+    }
   }
 
   test("String neq/equi key: default (UTF8_BINARY) fires, non-binary collation fails closed") {
-    // The guard under test is the StringType branch of `isSafeComparisonGroupingType`: only
-    // `supportsBinaryEquality` (byte-wise) strings are admitted, because a non-binary collation
-    // (Spark 4.0+) routes comparison and grouping through different code paths. The control uses a
-    // default-collation table for BOTH the equi key and the neq column and fires -- proving plain
-    // strings are not rejected wholesale.
-    //
-    // The two negatives collate exactly ONE column each, so each pins the rejection to a specific
-    // gate: a UTF8_LCASE NEQ column exercises the neq-side check, a UTF8_LCASE EQUI key exercises
-    // the equi-side check. Collating both at once would leave it ambiguous which gate fired and
-    // stay green if either were deleted -- mirroring the split Float neq / Float equi coverage.
-    createTable(
-      "TStrBin",
-      "k STRING, v STRING",
-      """  ('a', 'x'), ('a', 'y'),
-        |  ('b', 'z')""".stripMargin)
-    val binSql =
-      """SELECT k FROM TStrBin outer_t WHERE k IN (
-        |  SELECT s1.k FROM TStrBin s1 JOIN TStrBin s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(binSql)
-    val (binOn, binOff) = runBoth(binSql)
-    assert(binOn == binOff, s"binary-string control diverges: ON=$binOn OFF=$binOff")
-    assert(binOn == Set(Row("a")), s"binary-string control expected {a}, got $binOn")
+    withTable("TStrBin", "TStrCiNeq", "TStrCiEqui") {
+      // The guard under test is the StringType branch of `isSafeComparisonGroupingType`: only
+      // `supportsBinaryEquality` (byte-wise) strings are admitted, because a non-binary collation
+      // (Spark 4.0+) routes comparison and grouping through different code paths. The control uses
+      // a default-collation table for BOTH the equi key and the neq column and fires -- proving
+      // plain strings are not rejected wholesale.
+      //
+      // The two negatives collate exactly ONE column each, so each pins the rejection to a specific
+      // gate: a UTF8_LCASE NEQ column exercises the neq-side check, a UTF8_LCASE EQUI key exercises
+      // the equi-side check. Collating both at once would leave it ambiguous which gate fired and
+      // stay green if either were deleted -- mirroring the split Float neq / Float equi coverage.
+      createTable(
+        "TStrBin",
+        "k STRING, v STRING",
+        """  ('a', 'x'), ('a', 'y'),
+          |  ('b', 'z')""".stripMargin)
+      val binSql =
+        """SELECT k FROM TStrBin outer_t WHERE k IN (
+          |  SELECT s1.k FROM TStrBin s1 JOIN TStrBin s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleFired(binSql)
+      val (binOn, binOff) = runBoth(binSql)
+      assert(binOn == binOff, s"binary-string control diverges: ON=$binOn OFF=$binOff")
+      assert(binOn == Set(Row("a")), s"binary-string control expected {a}, got $binOn")
 
-    // Negative 1: only the NEQ column is non-binary collated -> neq-side type gate rejects.
-    createTable(
-      "TStrCiNeq",
-      "k STRING, v STRING COLLATE UTF8_LCASE",
-      """  ('a', 'x'), ('a', 'y'),
-        |  ('b', 'z')""".stripMargin)
-    val ciNeqSql =
-      """SELECT k FROM TStrCiNeq outer_t WHERE k IN (
-        |  SELECT s1.k FROM TStrCiNeq s1 JOIN TStrCiNeq s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleNotFired(ciNeqSql)
-    val (neqOn, neqOff) = runBoth(ciNeqSql)
-    assert(neqOn == neqOff, s"collated-neq semantics diverge: ON=$neqOn OFF=$neqOff")
+      // Negative 1: only the NEQ column is non-binary collated -> neq-side type gate rejects.
+      createTable(
+        "TStrCiNeq",
+        "k STRING, v STRING COLLATE UTF8_LCASE",
+        """  ('a', 'x'), ('a', 'y'),
+          |  ('b', 'z')""".stripMargin)
+      val ciNeqSql =
+        """SELECT k FROM TStrCiNeq outer_t WHERE k IN (
+          |  SELECT s1.k FROM TStrCiNeq s1 JOIN TStrCiNeq s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(ciNeqSql)
+      val (neqOn, neqOff) = runBoth(ciNeqSql)
+      assert(neqOn == neqOff, s"collated-neq semantics diverge: ON=$neqOn OFF=$neqOff")
 
-    // Negative 2: only the EQUI key is non-binary collated -> equi-side type gate rejects.
-    createTable(
-      "TStrCiEqui",
-      "k STRING COLLATE UTF8_LCASE, v STRING",
-      """  ('a', 'x'), ('a', 'y'),
-        |  ('b', 'z')""".stripMargin)
-    val ciEquiSql =
-      """SELECT k FROM TStrCiEqui outer_t WHERE k IN (
-        |  SELECT s1.k FROM TStrCiEqui s1 JOIN TStrCiEqui s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleNotFired(ciEquiSql)
-    val (equiOn, equiOff) = runBoth(ciEquiSql)
-    assert(equiOn == equiOff, s"collated-equi semantics diverge: ON=$equiOn OFF=$equiOff")
+      // Negative 2: only the EQUI key is non-binary collated -> equi-side type gate rejects.
+      createTable(
+        "TStrCiEqui",
+        "k STRING COLLATE UTF8_LCASE, v STRING",
+        """  ('a', 'x'), ('a', 'y'),
+          |  ('b', 'z')""".stripMargin)
+      val ciEquiSql =
+        """SELECT k FROM TStrCiEqui outer_t WHERE k IN (
+          |  SELECT s1.k FROM TStrCiEqui s1 JOIN TStrCiEqui s2
+          |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+      assertRuleNotFired(ciEquiSql)
+      val (equiOn, equiOff) = runBoth(ciEquiSql)
+      assert(equiOn == equiOff, s"collated-equi semantics diverge: ON=$equiOn OFF=$equiOff")
+    }
   }
 
   test("CHAR/VARCHAR join keys are rejected via declared-type metadata") {
-    // The guard under test is isSafeComparisonGroupingAttribute: CHAR/VARCHAR table columns reach
-    // the optimizer as annotated StringType (CharVarcharUtils records the declared type in the
-    // attribute metadata), so a dataType-only check would admit them through the StringType branch.
-    // The rule recovers the declared raw type from the metadata and fails closed. Control: a plain
-    // STRING table -- identical query shape and data -- fires, proving strings are not rejected
-    // wholesale; the CHAR(5) and VARCHAR(5) variants, differing only in the declared column type,
-    // do not. Both the equi key `k` and the neq column `v` are CHAR/VARCHAR, so both gate paths are
-    // pinned.
-    createTable(
-      "TStr",
-      "k STRING, v STRING",
-      """  ('a', 'x'), ('a', 'y'),
-        |  ('b', 'z')""".stripMargin)
-    val stringSql =
-      """SELECT k FROM TStr outer_t WHERE k IN (
-        |  SELECT s1.k FROM TStr s1 JOIN TStr s2
-        |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-    assertRuleFired(stringSql)
-    val (strOn, strOff) = runBoth(stringSql)
-    assert(strOn == strOff, s"string control diverges: ON=$strOn OFF=$strOff")
-    assert(strOn == Set(Row("a")), s"string control expected {a}, got $strOn")
-
-    Seq("CHAR(5)", "VARCHAR(5)").foreach { keyType =>
+    withTable("TStr", "TCharVarchar") {
+      // The guard under test is isSafeComparisonGroupingAttribute: CHAR/VARCHAR table columns reach
+      // the optimizer as annotated StringType (CharVarcharUtils records the declared type in the
+      // attribute metadata), so a dataType-only check would admit them through the StringType
+      // branch. The rule recovers the declared raw type from the metadata and fails closed.
+      // Control: a plain STRING table -- identical query shape and data -- fires, proving strings
+      // are not rejected wholesale; the CHAR(5) and VARCHAR(5) variants, differing only in the
+      // declared column type, do not. Both the equi key `k` and the neq column `v` are
+      // CHAR/VARCHAR, so both gate paths are pinned.
       createTable(
-        "TCharVarchar",
-        s"k $keyType, v $keyType",
+        "TStr",
+        "k STRING, v STRING",
         """  ('a', 'x'), ('a', 'y'),
           |  ('b', 'z')""".stripMargin)
-      val sql =
-        """SELECT k FROM TCharVarchar outer_t WHERE k IN (
-          |  SELECT s1.k FROM TCharVarchar s1 JOIN TCharVarchar s2
+      val stringSql =
+        """SELECT k FROM TStr outer_t WHERE k IN (
+          |  SELECT s1.k FROM TStr s1 JOIN TStr s2
           |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
-      assertRuleNotFired(sql)
-      val (on, off) = runBoth(sql)
-      assert(on == off, s"$keyType not-fired query diverges: ON=$on OFF=$off")
+      assertRuleFired(stringSql)
+      val (strOn, strOff) = runBoth(stringSql)
+      assert(strOn == strOff, s"string control diverges: ON=$strOn OFF=$strOff")
+      assert(strOn == Set(Row("a")), s"string control expected {a}, got $strOn")
+
+      Seq("CHAR(5)", "VARCHAR(5)").foreach { keyType =>
+        createTable(
+          "TCharVarchar",
+          s"k $keyType, v $keyType",
+          """  ('a', 'x'), ('a', 'y'),
+            |  ('b', 'z')""".stripMargin)
+        val sql =
+          """SELECT k FROM TCharVarchar outer_t WHERE k IN (
+            |  SELECT s1.k FROM TCharVarchar s1 JOIN TCharVarchar s2
+            |    ON s1.k = s2.k AND s1.v <> s2.v)""".stripMargin
+        assertRuleNotFired(sql)
+        val (on, off) = runBoth(sql)
+        assert(on == off, s"$keyType not-fired query diverges: ON=$on OFF=$off")
+      }
     }
   }
 
   test("ANSI: rewrite preserves observable error behavior (throw-or-succeed parity)") {
-    // The guard under test is not a rejection but a parity property: the expression allowlist
-    // admits Cast, which can throw under ANSI. The rewrite evaluates the projected `CAST(s AS INT)`
-    // once per row inside the Aggregate, while the baseline self-join evaluates it per row on each
-    // side -- the same set of rows either way -- so a malformed value must make BOTH forms behave
-    // the same. k=2 holds a non-numeric 's'.
-    //
-    // Parity is checked as observable behavior, not just "an exception happened": both succeed with
-    // equal rows, or both throw with the same error class. A one-sided throw is a blocker.
-    createTable(
-      "TAnsi",
-      "k INT, s STRING",
-      """  (1, '10'), (1, '20'),
-        |  (2, '30'), (2, 'xyz')""".stripMargin)
-    val sql =
-      """SELECT k FROM TAnsi outer_t WHERE k IN (
-        |  SELECT s1.k
-        |  FROM (SELECT k, CAST(s AS INT) AS x FROM TAnsi) s1
-        |  JOIN (SELECT k, CAST(s AS INT) AS x FROM TAnsi) s2
-        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+    withTable("TAnsi") {
+      // The guard under test is not a rejection but a parity property: the expression allowlist
+      // admits Cast, which can throw under ANSI. The rewrite evaluates the projected `CAST(s AS
+      // INT)` once per row inside the Aggregate, while the baseline self-join evaluates it per row
+      // on each side -- the same set of rows either way -- so a malformed value must make BOTH
+      // forms behave the same. k=2 holds a non-numeric 's'.
+      //
+      // Parity is checked as observable behavior, not just "an exception happened": both succeed
+      // with equal rows, or both throw with the same error class. A one-sided throw is a blocker.
+      createTable(
+        "TAnsi",
+        "k INT, s STRING",
+        """  (1, '10'), (1, '20'),
+          |  (2, '30'), (2, 'xyz')""".stripMargin)
+      val sql =
+        """SELECT k FROM TAnsi outer_t WHERE k IN (
+          |  SELECT s1.k
+          |  FROM (SELECT k, CAST(s AS INT) AS x FROM TAnsi) s1
+          |  JOIN (SELECT k, CAST(s AS INT) AS x FROM TAnsi) s2
+          |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
 
-    Seq("false", "true").foreach { ansi =>
-      withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
-        // The rule still fires at plan level regardless of ANSI (the cast throws only at runtime).
-        assertRuleFired(sql)
-        val on = runOutcome(sql, rewrite = true)
-        val off = runOutcome(sql, rewrite = false)
-        (on, off) match {
-          case (Right(onRows), Right(offRows)) =>
-            assert(onRows == offRows,
-              s"ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
-          case (Left(onErr), Left(offErr)) =>
-            assert(onErr == offErr,
-              s"ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
-          case _ =>
-            fail(s"ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+      Seq("false", "true").foreach { ansi =>
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+          // The rule still fires at plan level regardless of ANSI (the cast throws only at
+          // runtime).
+          assertRuleFired(sql)
+          val on = runOutcome(sql, rewrite = true)
+          val off = runOutcome(sql, rewrite = false)
+          (on, off) match {
+            case (Right(onRows), Right(offRows)) =>
+              assert(onRows == offRows,
+                s"ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
+              // Concrete positive signal under ANSI off: the cast is defined (yields NULL, does not
+              // throw) for every surviving row, so the rewrite must return the real membership {1},
+              // not merely agree with OFF.
+              if (ansi == "false") {
+                assert(onRows == Set(Row(1)), s"ANSI=false expected {1}, got $onRows")
+              }
+            case (Left(onErr), Left(offErr)) =>
+              assert(onErr == offErr,
+                s"ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
+              if (ansi == "true") {
+                assert(onErr == "CAST_INVALID_INPUT",
+                  s"ANSI=true expected CAST_INVALID_INPUT, got $onErr")
+              }
+            case _ =>
+              fail(s"ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+          }
         }
       }
     }
   }
 
   test("ANSI: Remainder neq column preserves error behavior; Divide is type-gated") {
-    // Cast is not the only allowlisted expression that can throw under ANSI. This pins the two
-    // arithmetic ops the review asked about:
-    //   - Remainder (`%`) on INT operands stays INT, an allowlisted type, so the rule fires. It can
-    //     raise DIVIDE_BY_ZERO under ANSI, so it exercises the throw-parity property directly, not
-    //     resting it on the Cast test alone: the rewrite evaluates `v % w` once per row inside
-    //     the Aggregate and the baseline self-join evaluates it per row on each side -- the same
-    //     rows -- so a `% 0` must make BOTH forms behave identically.
-    //   - Divide (`/`) is admitted by the expression allowlist (`isRepeatableExpression` trusts it
-    //     wherever it appears in the scanned plan), but a Divide-derived NEQ KEY is stopped one
-    //     layer later by the type guard: `/` always widens INT operands to a Double result, which
-    //     `isSafeComparisonGroupingType` rejects, so a `v / w` neq column never fires. There is
-    //     thus no runtime Divide path to check for parity; the type gate stops it first. (Decimal
-    //     operands would keep a Decimal result but wrap the Divide in CheckOverflow, which the
-    //     expression allowlist rejects, so a Decimal `/` neq key has no firing path.) The two
-    //     layers are independent: allowlisting Divide as repeatable is not the same as admitting a
-    //     Divide result as a safe comparison/grouping key.
-    // Row (2, 30, 0) forces `30 % 0`, which throws under ANSI and yields NULL otherwise.
-    createTable(
-      "TAnsiDiv",
-      "k INT, v INT, w INT",
-      """  (1, 10, 3), (1, 20, 7),
-        |  (2, 30, 0), (2, 40, 4)""".stripMargin)
+    withTable("TAnsiDiv") {
+      // Cast is not the only allowlisted expression that can throw under ANSI. This pins the two
+      // arithmetic ops the review asked about:
+      //   - Remainder (`%`) on INT operands stays INT, an allowlisted type, so the rule fires. It
+      // can raise DIVIDE_BY_ZERO under ANSI, so it exercises the throw-parity property directly,
+      // not resting it on the Cast test alone: the rewrite evaluates `v % w` once per row inside
+      // the Aggregate and the baseline self-join evaluates it per row on each side -- the same rows
+      // -- so a `% 0` must make BOTH forms behave identically.
+      //   - Divide (`/`) is admitted by the expression allowlist (`isRepeatableExpression` trusts
+      // it wherever it appears in the scanned plan), but a Divide-derived NEQ KEY is stopped one
+      // layer later by the type guard: `/` always widens INT operands to a Double result, which
+      // `isSafeComparisonGroupingType` rejects, so a `v / w` neq column never fires. There is thus
+      // no runtime Divide path to check for parity; the type gate stops it first. (Decimal operands
+      // would keep a Decimal result but wrap the Divide in CheckOverflow, which the expression
+      // allowlist rejects, so a Decimal `/` neq key has no firing path.) The two layers are
+      // independent: allowlisting Divide as repeatable is not the same as admitting a Divide result
+      // as a safe comparison/grouping key. Row (2, 30, 0) forces `30 % 0`, which throws under ANSI
+      // and yields NULL otherwise.
+      createTable(
+        "TAnsiDiv",
+        "k INT, v INT, w INT",
+        """  (1, 10, 3), (1, 20, 7),
+          |  (2, 30, 0), (2, 40, 4)""".stripMargin)
 
-    // Divide: Double result -> rejected by the data-type allowlist regardless of ANSI.
-    val divSql =
-      """SELECT k FROM TAnsiDiv outer_t WHERE k IN (
-        |  SELECT s1.k
-        |  FROM (SELECT k, v / w AS x FROM TAnsiDiv) s1
-        |  JOIN (SELECT k, v / w AS x FROM TAnsiDiv) s2
-        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
-    assertRuleNotFired(divSql)
+      // Divide: Double result -> rejected by the data-type allowlist regardless of ANSI.
+      val divSql =
+        """SELECT k FROM TAnsiDiv outer_t WHERE k IN (
+          |  SELECT s1.k
+          |  FROM (SELECT k, v / w AS x FROM TAnsiDiv) s1
+          |  JOIN (SELECT k, v / w AS x FROM TAnsiDiv) s2
+          |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+      assertRuleNotFired(divSql)
 
-    // Remainder: INT result -> fires; assert throw-or-succeed parity under ANSI off and on.
-    val remSql =
-      """SELECT k FROM TAnsiDiv outer_t WHERE k IN (
-        |  SELECT s1.k
-        |  FROM (SELECT k, v % w AS x FROM TAnsiDiv) s1
-        |  JOIN (SELECT k, v % w AS x FROM TAnsiDiv) s2
-        |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
-    Seq("false", "true").foreach { ansi =>
-      withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
-        // The rule fires at plan level regardless of ANSI (the remainder throws only at runtime).
-        assertRuleFired(remSql)
-        val on = runOutcome(remSql, rewrite = true)
-        val off = runOutcome(remSql, rewrite = false)
-        (on, off) match {
-          case (Right(onRows), Right(offRows)) =>
-            assert(onRows == offRows,
-              s"Remainder ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
-            // Positive signal (ANSI off): the remainders are defined, so the rewrite must return
-            // the real membership. k=1: 10%3=1, 20%7=6 -> {1,6} matches; k=2: 30%0=NULL, 40%4=0
-            // -> {0} no match. Result is exactly {1}.
-            if (ansi == "false") {
-              assert(onRows == Set(Row(1)), s"Remainder ANSI=false expected {1}, got $onRows")
-            }
-          case (Left(onErr), Left(offErr)) =>
-            assert(onErr == offErr,
-              s"Remainder ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
-          case _ =>
-            fail(s"Remainder ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+      // Remainder: INT result -> fires; assert throw-or-succeed parity under ANSI off and on.
+      val remSql =
+        """SELECT k FROM TAnsiDiv outer_t WHERE k IN (
+          |  SELECT s1.k
+          |  FROM (SELECT k, v % w AS x FROM TAnsiDiv) s1
+          |  JOIN (SELECT k, v % w AS x FROM TAnsiDiv) s2
+          |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+      Seq("false", "true").foreach { ansi =>
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+          // The rule fires at plan level regardless of ANSI (the remainder throws only at runtime).
+          assertRuleFired(remSql)
+          val on = runOutcome(remSql, rewrite = true)
+          val off = runOutcome(remSql, rewrite = false)
+          (on, off) match {
+            case (Right(onRows), Right(offRows)) =>
+              assert(onRows == offRows,
+                s"Remainder ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
+              // Positive signal (ANSI off): the remainders are defined, so the rewrite must return
+              // the real membership. k=1: 10%3=1, 20%7=6 -> {1,6} matches; k=2: 30%0=NULL, 40%4=0
+              // -> {0} no match. Result is exactly {1}.
+              if (ansi == "false") {
+                assert(onRows == Set(Row(1)), s"Remainder ANSI=false expected {1}, got $onRows")
+              }
+            case (Left(onErr), Left(offErr)) =>
+              assert(onErr == offErr,
+                s"Remainder ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
+              if (ansi == "true") {
+                assert(onErr == "REMAINDER_BY_ZERO",
+                  s"Remainder ANSI=true expected REMAINDER_BY_ZERO, got $onErr")
+              }
+            case _ =>
+              fail(s"Remainder ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+          }
+        }
+      }
+    }
+  }
+
+  test("ANSI: NULL equi-key row with a throwing neq expression preserves error parity") {
+    withTable("TAnsiNull") {
+      // The rewrite excludes NULL equi keys with an injected `IsNotNull(k)` Filter, whereas the
+      // baseline self-join excludes them only through `s1.k = s2.k`. These are different mechanisms
+      // that the optimizer may place differently relative to the throwing `CAST(s AS INT)`, so this
+      // pins that the injected filter does not change WHETHER the cast throws: both forms must
+      // throw with the same error class, or both succeed with equal rows. The NULL-key row carries
+      // the bad value 'bad', so it is exactly the row the injected filter could drop before the
+      // cast runs.
+      createTable(
+        "TAnsiNull",
+        "k INT, s STRING",
+        """  (CAST(NULL AS INT), 'bad'),
+          |  (1, '10'), (1, '20')""".stripMargin)
+      val sql =
+        """SELECT k FROM TAnsiNull outer_t WHERE k IN (
+          |  SELECT s1.k
+          |  FROM (SELECT k, CAST(s AS INT) AS x FROM TAnsiNull) s1
+          |  JOIN (SELECT k, CAST(s AS INT) AS x FROM TAnsiNull) s2
+          |    ON s1.k = s2.k AND s1.x <> s2.x)""".stripMargin
+
+      Seq("false", "true").foreach { ansi =>
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+          assertRuleFired(sql)
+          val on = runOutcome(sql, rewrite = true)
+          val off = runOutcome(sql, rewrite = false)
+          (on, off) match {
+            case (Right(onRows), Right(offRows)) =>
+              assert(onRows == offRows,
+                s"ANSI=$ansi both succeeded but diverged: ON=$onRows OFF=$offRows")
+              // Concrete positive signal under ANSI off: the cast is defined (yields NULL, does not
+              // throw) for every surviving row, so the rewrite must return the real membership {1},
+              // not merely agree with OFF.
+              if (ansi == "false") {
+                assert(onRows == Set(Row(1)), s"ANSI=false expected {1}, got $onRows")
+              }
+            case (Left(onErr), Left(offErr)) =>
+              assert(onErr == offErr,
+                s"ANSI=$ansi both threw but different error: ON=$onErr OFF=$offErr")
+              if (ansi == "true") {
+                assert(onErr == "CAST_INVALID_INPUT",
+                  s"ANSI=true expected CAST_INVALID_INPUT, got $onErr")
+              }
+            case _ =>
+              fail(s"ANSI=$ansi one-sided error behavior: ON=$on OFF=$off")
+          }
         }
       }
     }


### PR DESCRIPTION
This PR implements SPARK-41416 and supersedes the previous implementation attempt in #38951.

## What changes were proposed in this pull request?

Add an opt-in optimizer rule, `RewriteSelfJoinInequalityToAggregate`, that rewrites supported inequality self-joins inside uncorrelated `IN` subqueries into:

```sql
GROUP BY equi_keys
HAVING MIN(inequality_col) <> MAX(inequality_col)
```

over a single copy of the relation, eliminating the self-join pair expansion for patterns such as TPC-DS Q95.

For the supported inequality-column types, `MIN(v) <> MAX(v)` is equivalent to "the group contains at least two distinct non-null values", i.e. `COUNT(DISTINCT v) > 1`, while avoiding the distinct-dedup aggregation stages and using ordinary decomposable MIN/MAX aggregates.

The rule targets two `InSubquery` shapes:

* Pattern A': the subquery's top-level `InnerJoin` is a direct self-join.
* Pattern A2: the subquery contains an outer `InnerJoin` with a self-join child; only the self-join child is replaced while the outer join is preserved.

The rule runs in `extendedOperatorOptimizationRules`, before `RewritePredicateSubquery` converts the predicate subquery into a semi/anti/existence join, so it operates on the uncorrelated `InSubquery` representation.

The rewrite is deliberately fail-closed. It only fires when:

* both self-join sides are proven to represent the same repeatable relation;
* the relevant operators, expressions, and leaf source are considered repeatable;
* the equi keys and the inequality column pass separate type allowlists.

The two allowlists differ because the two roles rely on different type properties. The equi keys move into `GROUP BY`, so `=` must coincide with grouping equality; a collated string is allowed only under binary equality. The inequality column moves into `MIN`/`MAX`, which compare by ordering, so a collated string is allowed only under binary ordering (`supportsBinaryOrdering`, not the weaker binary equality), ensuring that values tied by the ordering are also equal under `=` (and therefore not distinct under `<>`).

The leaf-source repeatability check trusts only a small allowlist: the stock Parquet file source (`ParquetFileFormat`, matched by exact class), `Range`, and `LocalRelation`. Other file formats (ORC/CSV/JSON), DataSourceV2 relations, cached tables, and `LogicalRDD` are conservatively excluded, so the rewrite is a no-op on them even when the shape matches.

Floating-point types, complex types, non-binary collated strings, CHAR/VARCHAR, and any cast whose Cast.needsTimeZone is true (every cast from VARIANT regardless of target, plus the clock-dependent String/Date/Time/Timestamp conversions) are conservatively rejected.


Correlated `InSubquery` expressions are left unchanged because the ExprId remapping performed by this rule does not rewrite correlated predicates.

The rewrite also inserts `IsNotNull` filters on the equi keys before aggregation. This preserves the original equi-join's SQL three-valued NULL semantics: a normal `=` join does not match NULL keys, whereas `GROUP BY` would otherwise form a NULL group that could leak NULL into the subquery result and change `IN` / `NOT IN` behavior.

The rule is controlled by:

```text
spark.sql.optimizer.rewriteSelfJoinInequalityToAggregate.enabled
```

It is `internal()` and disabled by default.

## Why are the changes needed?

An inequality self-join inside an existence-style subquery, such as TPC-DS Q95, may generate a quadratic number of candidate row pairs for each repeated equi key, even though the query only needs to determine whether at least two distinct inequality-column values exist.

For a key with `n` matching rows, the self-join may examine up to `O(n^2)` candidate pairs.

The equivalent condition can instead be evaluated using:

```sql
GROUP BY equi_key
HAVING MIN(inequality_col) <> MAX(inequality_col)
```

which scans one copy of the relation and avoids the self-join pair expansion.

The benefit therefore depends strongly on the per-key multiplicity: higher multiplicity increases the amount of work removed by the rewrite.

### Lifecycle / promotion criteria

This rewrite remains experimental and disabled by default because it does not yet have a reliable profitability model.

Table size or broadcastability alone is not sufficient to predict whether the rewrite is profitable. To isolate this, I swept input size against per-key multiplicity, forcing the rule-off physical plan to stay fixed within each row (`BroadcastHashJoin` for the ~100 MB row, `SortMergeJoin` for the ~1 GB row, which does not broadcast). The rule was toggled on the same build (warm-up 2 + median of 5, rule-on / rule-off results verified identical per cell). Each cell reports runtime reduction (on vs off) and speedup:

| Rewrite-off plan | m=1 | m=3 | m=5 | m=7 | m=10 |
| :--------------- | :--: | :--: | :--: | :--: | :--: |
| ~10 MB, BroadcastHashJoin | ~0% / 1.0x | ~56% / 2.3x | ~56% / 2.3x | ~51% / 2.0x | ~62% / 2.6x |
| ~100 MB, BroadcastHashJoin | ~65% / 2.9x | ~60% / 2.5x | ~74% / 3.9x | ~84% / 6.3x | ~87% / 7.7x |
| ~1 GB, SortMergeJoin | −27% / 0.8x | ~33% / 1.5x | ~55% / 2.2x | ~65% / 2.5x | ~66% / 2.9x |

Within each row the input size and join strategy are fixed; only the per-key multiplicity `m` varies. Profitability is clearly sensitive to `m`, with the cleanest trend in the `~1 GB` row. This shows that table size or broadcastability alone is not a sufficient cost signal: broadcast avoids the build-side shuffle but does not remove the self-join's `O(sum m^2)` candidate-pair expansion.

The `~10 MB` row is small enough that both sides sit near a fixed per-query overhead floor, so its numbers are noisy (non-monotonic) and should be read only as "no regression at small size" rather than as a precise speedup.

The `~1 GB` row also shows the regression case: at `m=1` there is no multiplicity-driven pair expansion to eliminate, so the aggregation/shuffle overhead outweighs the work removed by the rewrite. This is exactly why the rule must remain an opt-in rather than being gated on size.

Variable-width `STRING`/`BINARY` inequality columns can shift the break-even multiplicity higher. To check whether this is a real pessimization, I ran a separate inequality-column type probe (INT vs STRING vs BINARY) on the same build, toggling only the flag. In this probe, their variable-width MIN/MAX buffers caused the rule-on plan to use `SortAggregateExec` (with additional Sorts) instead of hash aggregation. In the `~1 GB`, forced-`SortMergeJoin` case (speedup = rule-off / rule-on):

| neq type | m=1 | m=3 | m=5 |
| :------- | :--: | :--: | :--: |
| `INT`    | 0.8x | 1.5x | 1.9x |
| `STRING` | 0.6x | 0.9x | 1.2x |
| `BINARY` | 0.8x | 1.1x | 1.5x |

The `SortAggregate` cost keeps `STRING`/`BINARY` a lower win tier than `INT` and pushes their break-even higher: `STRING` crosses 1x by `m=5` and `BINARY` by `m=3`, but neither is categorically unprofitable. This is a further reason the profitability decision is left to the opt-in flag rather than the type gate, which admits `STRING`/`BINARY` on correctness grounds alone.

The rule may be considered for promotion to default-on once the optimizer has a sufficiently reliable cost signal for this distribution-sensitive behavior, for example statistics that can estimate expected per-key pair expansion or an equivalent reduction factor, and that signal is validated across both broadcastable and non-broadcastable cases without introducing material regressions.

Until such a signal exists, the rule remains an explicit opt-in rather than using table size or broadcastability alone as a profitability gate.

If no sufficiently reliable profitability signal can be derived from statistics available to the optimizer and the rule remains too workload-specific to justify its maintenance cost, the experimental rule can be removed.

## Does this PR introduce any user-facing change?

No.

The rule is internal and disabled by default. Existing behavior is unchanged unless the configuration is explicitly enabled:

```text
spark.sql.optimizer.rewriteSelfJoinInequalityToAggregate.enabled=true
```

When enabled, the rewrite is only applied to supported shapes that satisfy the rule's correctness guards. Unsupported cases are left unchanged.

## How was this patch tested?

Added `RewriteSelfJoinInequalityToAggregateSuite` covering:

* positive rewrites for Pattern A' and Pattern A2;
* a Q95-shaped query whose two `IN` subqueries exercise Pattern A' and Pattern A2 together;
* Pattern A2 with the self-join on either side of the outer join;
* multi-equi-key tuple `IN` and right-side key remapping;
* the `InSubquery` in a SELECT-list `CASE WHEN`, not only a WHERE predicate;
* rule idempotence (re-applying the rule on its output is a no-op);
* the expected `Aggregate + Filter(MIN <> MAX)` rewrite shape;
* configuration gating;
* NULL / three-valued logic preservation for both equi keys and inequality columns;
* `NOT IN` NULL semantics;
* relation identity and repeatability guards;
* correlated subqueries;
* swapped aliases and output-position identity;
* different relations with identical schemas;
* `LIMIT` (row-bag operator whitelist), nondeterministic expressions, and `LogicalRDD` sources;
* unsupported deterministic expressions;
* `IS DISTINCT FROM`;
* multiple inequality columns;
* a bare-`Join` subquery (no wrapper Project) for both Pattern A' and Pattern A2 arity guards;
* a LEFT OUTER self-join inside the `IN` subquery (unsupported join type);
* join hints on both the direct and nested self-join;
* floating-point types for both equi keys and inequality columns, and complex
  inequality-column types;
* non-binary string collations (equi key and inequality column gated separately);
* CHAR / VARCHAR metadata handling;
* clock-dependent STRING-to-TIMESTAMP casts, including nested array/map/struct
  casts, and `VARIANT` casts to scalar or nested LTZ-containing targets;
* STRING-to-TIMESTAMP_NTZ as a repeatable control;
* ANSI runtime error-behavior parity (`CAST` and `Remainder`).

The targeted tests were run with:

```bash
build/sbt 'sql/testOnly org.apache.spark.sql.execution.RewriteSelfJoinInequalityToAggregateSuite'
build/sbt 'sql/scalastyle'
```

### TPC-DS Q95 benchmark

I also ran an end-to-end TPC-DS Q95 benchmark comparing the rule disabled (baseline self-join) and enabled, using the same Spark build for both runs. The rule was toggled only through the configuration flag, and the query results were verified to be identical.

One warm-up run per configuration was discarded, and the median of 5 measured runs was compared.

Enabling the rule reduced Q95 runtime by roughly 84%, corresponding to about a 6.2x speedup.

Environment:

* Vanilla Apache Spark JVM execution
* No Gluten / Velox
* Intel machine, `local[16]`
* TPC-DS SF300
* Median of 5 measured runs

## Was this patch authored or co-authored using generative AI tooling?

Yes. Claude Code (Opus 4.8) was used during development.

