### PR TITLE
[SPARK-57900][K8S][TESTS] Add OIDC credential propagation E2E tests on Minikube with moto

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1545,9 +1545,10 @@ jobs:
             -t oidc-e2e-test \
             build
           # The job class (OidcS3ReadWriteJob) lives in this module's jar, which is not
-          # part of the assembly. Bake it into /opt/spark/jars so it is on the driver
-          # classpath (a local:// application resource is copied to work-dir, which is
-          # not on the classpath -- see SPARK-43540).
+          # part of the assembly and is not copied into the image by docker-image-tool.sh
+          # (it only copies examples/jars). SparkSubmit already puts a local:// primary
+          # resource on the driver classpath, so this is not a classpath gap -- the jar
+          # simply has to be present in the container, so bake it into /opt/spark/jars.
           JOB_JAR=$(ls connector/credential-aws-integration-tests/target/scala-*/spark-credential-aws-integration-tests_*.jar | grep -v -- '-tests.jar' | head -1)
           JOB_JAR_NAME=$(basename "$JOB_JAR")
           BUILD_CTX=$(mktemp -d)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -182,6 +182,7 @@ jobs:
               \"docs\" : \"$docs\",
               \"yarn\" : \"$yarn\",
               \"k8s-integration-tests\" : \"$kubernetes\",
+              \"oidc-e2e\" : \"$kubernetes\",
               \"buf\" : \"$buf\",
               \"ui\" : \"$ui\",
               \"transpile\": \"$transpile\",
@@ -541,6 +542,7 @@ jobs:
         fromJson(needs.precondition.outputs.required).sparkr == 'true' ||
         fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true' ||
         fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true' ||
+        fromJson(needs.precondition.outputs.required).oidc-e2e == 'true' ||
         fromJson(needs.precondition.outputs.required).tpcds-1g == 'true')
     name: "Precompile Spark"
     runs-on: ubuntu-latest
@@ -582,7 +584,7 @@ jobs:
       run: |
         ./build/sbt -Phadoop-3 -Pyarn -Pspark-ganglia-lgpl -Phadoop-cloud -Phive \
           -Pkubernetes -Pjvm-profiler -Pkinesis-asl -Pcredential-aws -Phive-thriftserver \
-          -Pdocker-integration-tests -Pkubernetes-integration-tests -Pvolcano \
+          -Pdocker-integration-tests -Pkubernetes-integration-tests -Pvolcano -Poidc-e2e \
           Test/package streaming-kinesis-asl-assembly/assembly connect/assembly assembly/package
     - name: Package compile output
       run: |
@@ -1445,6 +1447,170 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: spark-on-kubernetes-it-log
+          path: "**/target/integration-tests.log"
+
+  oidc-e2e:
+    needs: [precondition, precompile]
+    if: fromJson(needs.precondition.outputs.required).oidc-e2e == 'true'
+    name: Run OIDC E2E integration tests (Minikube + moto)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Bootstrap composite actions
+        uses: actions/checkout@v6
+      - name: Checkout and sync Spark repository
+        uses: ./.github/actions/checkout-and-sync
+        with:
+          ref: ${{ needs.precondition.outputs.head_sha }}
+      - name: Cache SBT and Maven
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/apache-maven-*
+            build/*.jar
+            ~/.sbt
+          key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          restore-keys: |
+            build-${{ runner.os }}-
+      - name: Restore Coursier local repository
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/coursier
+          key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          restore-keys: |
+            coursier-${{ runner.os }}-
+      - name: Free up disk space
+        timeout-minutes: 10
+        continue-on-error: true
+        run: |
+          if [ -f ./dev/free_disk_space ]; then
+            ./dev/free_disk_space
+          fi
+      - name: Install Java ${{ inputs.java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: ${{ inputs.java }}
+      - name: Download precompiled artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: spark-compile-${{ inputs.branch }}-${{ github.run_id }}
+      - name: Extract precompiled artifact
+        run: |
+          zstd -dc compile-artifact.tar.zst | tar -xf -
+          rm compile-artifact.tar.zst
+      - name: Install Python and moto
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y python3-venv
+          # Install moto into an isolated virtualenv. A plain "pip install --user"
+          # leaves the OS-provided packages under /usr/lib/python3/dist-packages on
+          # the import path, and that copy of pyOpenSSL is incompatible with the
+          # cryptography build pulled in transitively, which crashes moto on startup
+          # (AttributeError: module 'lib' has no attribute 'GEN_EMAIL'). A venv gives
+          # moto a clean, self-consistent dependency set.
+          python3 -m venv "${RUNNER_TEMP}/moto-venv"
+          "${RUNNER_TEMP}/moto-venv/bin/pip" install --upgrade pip
+          "${RUNNER_TEMP}/moto-venv/bin/pip" install "moto[server,s3,sts]>=5.0.0"
+          echo "MOTO_PYTHON=${RUNNER_TEMP}/moto-venv/bin/python" >> $GITHUB_ENV
+      - name: Start Minikube
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
+        with:
+          kubernetes-version: "1.36.0"
+          cpus: 2
+          memory: 6144m
+      - name: Print K8S pods and nodes info
+        run: |
+          kubectl get pods -A
+          kubectl describe node
+      - name: Resolve moto host IP reachable from Minikube pods
+        run: |
+          # The host gateway IP as seen from inside Minikube
+          HOST_IP=$(minikube ssh "ip route | grep default | awk '{print \$3}'" | tr -d '[:space:]')
+          echo "MOTO_HOST_IP=${HOST_IP}" >> $GITHUB_ENV
+          echo "Moto reachable from Minikube at: http://${HOST_IP}:5000"
+      - name: Build and load Spark image into Minikube
+        run: |
+          eval $(minikube docker-env)
+          # Build the base Spark Docker image using the precompiled artifact. The
+          # precompile step builds with -Phadoop-cloud, so hadoop-aws and the AWS SDK
+          # (needed for S3A) are included in /opt/spark/jars.
+          ./bin/docker-image-tool.sh \
+            -r docker.io/kubespark \
+            -t oidc-e2e-test \
+            build
+          # The job class (OidcS3ReadWriteJob) lives in this module's jar, which is not
+          # part of the assembly. Bake it into /opt/spark/jars so it is on the driver
+          # classpath (a local:// application resource is copied to work-dir, which is
+          # not on the classpath -- see SPARK-43540).
+          JOB_JAR=$(ls connector/credential-aws-integration-tests/target/scala-*/spark-credential-aws-integration-tests_*.jar | grep -v -- '-tests.jar' | head -1)
+          JOB_JAR_NAME=$(basename "$JOB_JAR")
+          BUILD_CTX=$(mktemp -d)
+          cp "$JOB_JAR" "$BUILD_CTX/"
+          cat > "$BUILD_CTX/Dockerfile" <<EOF
+          FROM docker.io/kubespark/spark:oidc-e2e-test
+          COPY ${JOB_JAR_NAME} /opt/spark/jars/${JOB_JAR_NAME}
+          EOF
+          docker build -t docker.io/kubespark/spark:oidc-e2e-test-job "$BUILD_CTX"
+          rm -rf "$BUILD_CTX"
+          export SPARK_IMAGE="docker.io/kubespark/spark:oidc-e2e-test-job"
+          echo "SPARK_IMAGE=${SPARK_IMAGE}" >> $GITHUB_ENV
+      - name: Run OIDC E2E integration tests
+        run: |
+          # moto must be started in the same step as the test run: GitHub Actions
+          # terminates background processes when a step's shell exits, so a moto
+          # started in a previous step would already be dead here.
+          # Use the isolated venv python so moto runs against a clean, self-consistent
+          # dependency set (avoids the broken OS-provided pyOpenSSL).
+          "${MOTO_PYTHON}" -m moto.server -H 0.0.0.0 -p 5000 > /tmp/moto.log 2>&1 &
+          MOTO_PID=$!
+          trap "kill ${MOTO_PID} 2>/dev/null || true" EXIT
+          # Wait for moto to be ready, and fail loudly (with logs) if it never comes up.
+          ready=false
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:5000/ >/dev/null 2>&1; then
+              ready=true
+              break
+            fi
+            if ! kill -0 ${MOTO_PID} 2>/dev/null; then
+              echo "ERROR: moto server process exited early." >&2
+              cat /tmp/moto.log >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "${ready}" != "true" ]; then
+            echo "ERROR: moto server did not become ready within 30s." >&2
+            cat /tmp/moto.log >&2
+            exit 1
+          fi
+          echo "moto server is ready on 127.0.0.1:5000 (PID ${MOTO_PID})."
+          # Pods inside Minikube reach moto via the host gateway IP; the test
+          # process (on the host) reaches the same moto server on loopback.
+          MOTO_ENDPOINT="http://${MOTO_HOST_IP}:5000"
+          MOTO_CLIENT_ENDPOINT="http://127.0.0.1:5000"
+          # Grant cluster-admin to all service accounts. This is intentionally broad
+          # but scoped to this ephemeral, single-run CI Minikube cluster (destroyed
+          # with the runner). It mirrors kubernetes-integration-tests and spares the
+          # test from provisioning fine-grained RBAC (pod create/exec/log, namespace
+          # management) for the many service accounts Spark-on-K8s uses. Do NOT copy
+          # this into any shared or long-lived cluster; there, create a minimal Role
+          # limited to the test namespace instead.
+          kubectl create clusterrolebinding serviceaccounts-cluster-admin \
+            --clusterrole=cluster-admin --group=system:serviceaccounts || true
+          build/sbt \
+            -Phadoop-3 -Pkubernetes -Pcredential-aws -Poidc-e2e \
+            -Dspark.kubernetes.test.deployMode=minikube \
+            -Dspark.oidc.test.stsEndpoint="${MOTO_ENDPOINT}" \
+            -Dspark.oidc.test.s3Endpoint="${MOTO_ENDPOINT}" \
+            -Dspark.oidc.test.s3ClientEndpoint="${MOTO_CLIENT_ENDPOINT}" \
+            -Dspark.oidc.test.sparkImage="${SPARK_IMAGE}" \
+            "credential-aws-integration-tests/test"
+      - name: Upload OIDC E2E integration tests log files
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: oidc-e2e-it-log
           path: "**/target/integration-tests.log"
 
   ui:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,6 +116,10 @@ jobs:
           if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             yarn=`./dev/is-changed.py -m yarn`
             kubernetes=`./dev/is-changed.py -m kubernetes`
+            # The OIDC E2E job covers connector/credential-aws end to end on K8s, so it
+            # must run when either the Kubernetes support or the credential-aws module
+            # (including its integration-tests module, mapped to credential-aws) changes.
+            oidc_e2e=`./dev/is-changed.py -m kubernetes,credential-aws`
             sparkr=`./dev/is-changed.py -m sparkr`
             tpcds=`./dev/is-changed.py -m sql`
             docker=`./dev/is-changed.py -m docker-integration-tests`
@@ -156,6 +160,7 @@ jobs:
             pandas=false
             yarn=false
             kubernetes=false
+            oidc_e2e=false
             sparkr=false
             tpcds=false
             docker=false
@@ -182,7 +187,7 @@ jobs:
               \"docs\" : \"$docs\",
               \"yarn\" : \"$yarn\",
               \"k8s-integration-tests\" : \"$kubernetes\",
-              \"oidc-e2e\" : \"$kubernetes\",
+              \"oidc-e2e\" : \"$oidc_e2e\",
               \"buf\" : \"$buf\",
               \"ui\" : \"$ui\",
               \"transpile\": \"$transpile\",
@@ -1511,7 +1516,7 @@ jobs:
           # moto a clean, self-consistent dependency set.
           python3 -m venv "${RUNNER_TEMP}/moto-venv"
           "${RUNNER_TEMP}/moto-venv/bin/pip" install --upgrade pip
-          "${RUNNER_TEMP}/moto-venv/bin/pip" install "moto[server,s3,sts]>=5.0.0"
+          "${RUNNER_TEMP}/moto-venv/bin/pip" install "moto[server,s3,sts]>=5.0.0,<6.0.0"
           echo "MOTO_PYTHON=${RUNNER_TEMP}/moto-venv/bin/python" >> $GITHUB_ENV
       - name: Start Minikube
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -45,5 +45,6 @@ jobs:
           "tpcds-1g": "true",
           "docker-integration-tests": "true",
           "k8s-integration-tests": "true",
+          "oidc-e2e": "true",
           "lint" : "true"
         }

--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -52,6 +52,7 @@ jobs:
           "docker-integration-tests": "true",
           "yarn": "true",
           "k8s-integration-tests": "true",
+          "oidc-e2e": "true",
           "buf": "true",
           "ui": "true"
         }

--- a/.github/workflows/build_java25.yml
+++ b/.github/workflows/build_java25.yml
@@ -52,6 +52,7 @@ jobs:
           "docker-integration-tests": "true",
           "yarn": "true",
           "k8s-integration-tests": "true",
+          "oidc-e2e": "true",
           "buf": "true",
           "ui": "true"
         }

--- a/connector/credential-aws-integration-tests/README.md
+++ b/connector/credential-aws-integration-tests/README.md
@@ -1,0 +1,195 @@
+---
+layout: global
+title: Spark OIDC AWS Credential Propagation Integration Tests
+---
+
+# Running the OIDC E2E Integration Tests
+
+These tests verify the end-to-end OIDC credential propagation flow on a real Kubernetes cluster:
+
+```
+Projected SA Token -> FileTokenIngestor -> AwsStsCredentialProvider -> moto STS -> moto S3 (via S3A)
+```
+
+[moto](https://github.com/getmoto/moto) is an Apache 2.0-licensed Python library that emulates
+AWS services (S3 and STS) locally.  It runs as a lightweight HTTP server alongside Minikube.
+
+## Prerequisites
+
+- **Minikube** >= 1.38.0. The GitHub Actions workflow runs the tests with 2 CPUs and
+  6 GB memory, which is sufficient. Locally, 4 CPUs gives more headroom for the driver
+  and (dynamically allocated) executor pods:
+  ```
+  minikube start --cpus 4 --memory 6144
+  ```
+- **Python 3** with moto installed:
+  ```
+  pip install "moto[server,s3,sts]>=5.0.0"
+  ```
+- **Docker** available (for building the Spark image into Minikube's daemon).
+
+## Quickstart
+
+The simplest way to run the tests is the wrapper script:
+
+```
+connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
+```
+
+This script:
+1. Verifies prerequisites (minikube running, moto installed).
+2. Starts the moto server (`python3 -m moto.server`) on port 5000, listening on all interfaces.
+3. Detects the host IP as seen from inside Minikube pods.
+4. Builds Spark and the Docker image with `-Phadoop-cloud` (so the image has
+   hadoop-aws and the AWS SDK for S3A) and bakes the job jar (`OidcS3ReadWriteJob`)
+   into `/opt/spark/jars` so it is on the driver classpath.
+5. Runs the integration tests via Maven.
+6. Stops moto on exit.
+
+## Script Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--spark-tgz <path>` | (none) | Pre-built Spark distribution tgz. When omitted, tests run against the current source tree. |
+| `--image-tag <tag>` | (generated) | Use a pre-built Spark image with this tag. |
+| `--image-repo <repo>` | `docker.io/kubespark` | Docker image repository. |
+| `--spark-image <image>` | (derived) | Full image name (overrides `--image-repo` + `--image-tag`). |
+| `--deploy-mode <mode>` | `minikube` | Kubernetes backend: `minikube`, `docker-desktop`, `rancher-desktop`, `cloud`. |
+| `--namespace <ns>` | (auto-generated) | Kubernetes namespace. Created if absent; deleted on exit. |
+| `--service-account <sa>` | `default` | Kubernetes service account. |
+| `--moto-port <port>` | `5000` | Port for the moto server. |
+| `--role-arn <arn>` | `arn:aws:iam::123456789012:role/oidc-e2e-test-role` | IAM role ARN for `AssumeRoleWithWebIdentity` (moto accepts any well-formed ARN). |
+| `--s3-bucket <bucket>` | `oidc-e2e-test-bucket` | S3 bucket name created in moto. |
+| `--token-file <path>` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | OIDC token file path inside the driver pod. |
+| `--skip-build` | false | Skip building Spark and the Docker image. |
+| `--java-version <ver>` | `17` | Java version for the build. |
+| `--hadoop-profile <prof>` | `hadoop-3` | Hadoop Maven profile. |
+
+## Running with a Pre-built Image
+
+If you already have a Spark image built (e.g. from a previous run):
+
+```
+connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh \
+  --image-tag my-tag \
+  --skip-build
+```
+
+> **Warning:** `--skip-build` reuses an existing Spark image and does **not**
+> rebuild it. If you have changed `connector/credential-aws` (or any Spark
+> source) since the image was built, the tests will silently run against the
+> **stale image** and may produce misleading results. Always run without
+> `--skip-build` after modifying code, or rebuild the image explicitly.
+>
+> Unlike `kubernetes-integration-tests`, this module does not bind image
+> building to the sbt `test` task, so image freshness is the caller's
+> responsibility. In CI (GitHub Actions) this is a non-issue: each run builds
+> the image from scratch on a fresh runner before the tests execute.
+
+## Running Tests Directly
+
+If you prefer to manage moto and the image yourself, you can run the tests directly via Maven.
+
+> **Note:** the image passed via `spark.oidc.test.sparkImage` must be built with
+> `-Phadoop-cloud` (so it contains hadoop-aws and the AWS SDK for S3A) and must have
+> the module jar (`OidcS3ReadWriteJob`) baked into `/opt/spark/jars`. The
+> `dev-run-integration-tests.sh` script does this for you.
+
+```bash
+# 1. Start moto server (in a separate terminal or background)
+python3 -m moto.server -H 0.0.0.0 -p 5000 &
+
+# 2. Determine the host IP reachable from Minikube pods
+HOST_IP=$(minikube ssh "ip route | grep default | awk '{print \$3}'" | tr -d '[:space:]')
+MOTO_ENDPOINT="http://${HOST_IP}:5000"
+
+# 3. Run the tests. Pods reach moto via the host gateway IP, while the test process
+#    on the host reaches it on loopback (s3ClientEndpoint).
+build/mvn integration-test -am \
+  -pl connector/credential-aws-integration-tests \
+  -Phadoop-3 -Pkubernetes -Pcredential-aws -Poidc-e2e \
+  -Dspark.kubernetes.test.deployMode=minikube \
+  -Dspark.oidc.test.stsEndpoint="${MOTO_ENDPOINT}" \
+  -Dspark.oidc.test.s3Endpoint="${MOTO_ENDPOINT}" \
+  -Dspark.oidc.test.s3ClientEndpoint="http://127.0.0.1:5000" \
+  -Dspark.oidc.test.sparkImage="docker.io/kubespark/spark:my-tag"
+```
+
+Or with sbt:
+
+```bash
+build/sbt \
+  -Phadoop-3 -Pkubernetes -Pcredential-aws -Poidc-e2e \
+  -Dspark.kubernetes.test.deployMode=minikube \
+  -Dspark.oidc.test.stsEndpoint="${MOTO_ENDPOINT}" \
+  -Dspark.oidc.test.s3Endpoint="${MOTO_ENDPOINT}" \
+  -Dspark.oidc.test.s3ClientEndpoint="http://127.0.0.1:5000" \
+  -Dspark.oidc.test.sparkImage="docker.io/kubespark/spark:my-tag" \
+  'credential-aws-integration-tests/test'
+```
+
+## Available Maven / System Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `spark.kubernetes.test.deployMode` | `minikube` | Kubernetes backend. |
+| `spark.kubernetes.test.master` | (auto) | Kubernetes API server URL. |
+| `spark.kubernetes.test.imageRepo` | `docker.io/kubespark` | Docker image repository. |
+| `spark.kubernetes.test.imageTag` | `N/A` | Docker image tag. |
+| `spark.kubernetes.test.namespace` | (auto-generated) | Kubernetes namespace for the tests. |
+| `spark.kubernetes.test.serviceAccountName` | `default` | Kubernetes service account. |
+| `spark.oidc.test.stsEndpoint` | `http://localhost:5000` | moto STS endpoint as seen from Minikube pods (host gateway IP). |
+| `spark.oidc.test.s3Endpoint` | `http://localhost:5000` | moto S3 endpoint as seen from Minikube pods (host gateway IP). |
+| `spark.oidc.test.s3ClientEndpoint` | `http://127.0.0.1:5000` | moto S3 endpoint as seen from the test JVM on the host (loopback). |
+| `spark.oidc.test.roleArn` | `arn:aws:iam::123456789012:role/oidc-e2e-test-role` | IAM role ARN. |
+| `spark.oidc.test.tokenFile` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | OIDC token file path inside pods. |
+| `spark.oidc.test.s3Bucket` | `oidc-e2e-test-bucket` | S3 bucket name in moto. |
+| `spark.oidc.test.sparkImage` | (derived from repo+tag) | Full Spark Docker image name. |
+| `test.include.tags` | (none) | Comma-separated ScalaTest tags to include. |
+| `test.exclude.tags` | (none) | Comma-separated ScalaTest tags to exclude. |
+
+## Test Cases
+
+| Test | Status | Description |
+|---|---|---|
+| Basic S3 read/write | Implemented | Projected SA token -> moto STS -> S3A write/read on Minikube |
+| Mid-job token rotation | Implemented | The identity token file (supplied by an init container into an emptyDir) is rewritten mid-job; the driver re-reads it on renewal and S3 access continues across the rotation |
+| Late-registering executor | Implemented | With dynamic allocation, an executor registered after credential acquisition receives credentials (via the SparkAppConfig registration response) and writes to S3 |
+
+## Architecture
+
+```
++-------------------------------------------------------+
+|  GitHub Actions runner / developer machine            |
+|                                                       |
+|   moto_server :5000  (S3 + STS emulator)              |
+|                                                       |
+|  +-------------------------------------------------+  |
+|  |  Minikube                                       |  |
+|  |                                                 |  |
+|  |  +----------------+     +--------------------+  |  |
+|  |  | Driver Pod     |     | Executor Pod(s)    |  |  |
+|  |  |                |     |                    |  |  |
+|  |  | FileToken      |     | SparkOidc          |  |  |
+|  |  | Ingestor       |     | AwsCredentials     |  |  |
+|  |  |      |         |     | Provider           |  |  |
+|  |  |      v         | RPC |  reads creds       |  |  |
+|  |  | AwsSts         |---->|  from store        |  |  |
+|  |  | Credential     |     |      |             |  |  |
+|  |  | Provider       |     |      v             |  |  |
+|  |  |      |         |     |  S3A --> moto S3   |  |  |
+|  |  |      v         |     |                    |  |  |
+|  |  |  moto STS      |     |                    |  |  |
+|  |  +----------------+     +--------------------+  |  |
+|  +-------------------------------------------------+  |
++-------------------------------------------------------+
+```
+
+> **Note:** the `RPC` arrow above is a simplification. Credentials actually reach
+> executors by three complementary paths: (1) the `SparkAppConfig` registration
+> response, so a newly-registered executor has credentials immediately (exercised by
+> the late-registering-executor test); (2) the `UpdateUserCredentials` RPC broadcast on
+> each renewal (exercised by the token-rotation test); and (3) the `TaskDescription`,
+> which carries the current credentials to guarantee availability before a task runs.
+> The raw identity token never leaves the driver -- only the delegated, short-lived
+> service credentials are propagated.

--- a/connector/credential-aws-integration-tests/README.md
+++ b/connector/credential-aws-integration-tests/README.md
@@ -131,7 +131,6 @@ build/sbt \
 | Property | Default | Description |
 |---|---|---|
 | `spark.kubernetes.test.deployMode` | `minikube` | Kubernetes backend. |
-| `spark.kubernetes.test.master` | (auto) | Kubernetes API server URL. |
 | `spark.kubernetes.test.imageRepo` | `docker.io/kubespark` | Docker image repository. |
 | `spark.kubernetes.test.imageTag` | `N/A` | Docker image tag. |
 | `spark.kubernetes.test.namespace` | (auto-generated) | Kubernetes namespace for the tests. |

--- a/connector/credential-aws-integration-tests/README.md
+++ b/connector/credential-aws-integration-tests/README.md
@@ -24,7 +24,7 @@ AWS services (S3 and STS) locally.  It runs as a lightweight HTTP server alongsi
   ```
 - **Python 3** with moto installed:
   ```
-  pip install "moto[server,s3,sts]>=5.0.0"
+  pip install "moto[server,s3,sts]>=5.0.0,<6.0.0"
   ```
 - **Docker** available (for building the Spark image into Minikube's daemon).
 
@@ -50,7 +50,6 @@ This script:
 
 | Option | Default | Description |
 |---|---|---|
-| `--spark-tgz <path>` | (none) | Pre-built Spark distribution tgz. When omitted, tests run against the current source tree. |
 | `--image-tag <tag>` | (generated) | Use a pre-built Spark image with this tag. |
 | `--image-repo <repo>` | `docker.io/kubespark` | Docker image repository. |
 | `--spark-image <image>` | (derived) | Full image name (overrides `--image-repo` + `--image-tag`). |
@@ -62,7 +61,6 @@ This script:
 | `--s3-bucket <bucket>` | `oidc-e2e-test-bucket` | S3 bucket name created in moto. |
 | `--token-file <path>` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | OIDC token file path inside the driver pod. |
 | `--skip-build` | false | Skip building Spark and the Docker image. |
-| `--java-version <ver>` | `17` | Java version for the build. |
 | `--hadoop-profile <prof>` | `hadoop-3` | Hadoop Maven profile. |
 
 ## Running with a Pre-built Image

--- a/connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
+++ b/connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
@@ -20,7 +20,7 @@
 #
 # Prerequisites:
 #   - Minikube running  (minikube start --cpus 4 --memory 6144)
-#   - Python 3 + moto installed  (pip install "moto[server,s3,sts]>=5.0.0")
+#   - Python 3 + moto installed  (pip install "moto[server,s3,sts]>=5.0.0,<6.0.0")
 #   - Docker available and pointing at Minikube's daemon (eval $(minikube docker-env))
 #
 # Usage (run from anywhere; the script resolves the repository root from its own
@@ -28,8 +28,6 @@
 #   connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh [options]
 #
 # Options:
-#   --spark-tgz <path>        Path to a pre-built Spark tgz distribution.
-#                             When omitted, tests run against the current source tree.
 #   --image-tag <tag>         Use a pre-built Spark image with this tag instead of building one.
 #   --image-repo <repo>       Docker image repository (default: docker.io/kubespark).
 #   --spark-image <image>     Full image name (overrides --image-repo + --image-tag).
@@ -43,7 +41,6 @@
 #   --token-file <path>       Path to the OIDC token file inside the driver pod
 #                             (default: /var/run/secrets/kubernetes.io/serviceaccount/token).
 #   --skip-build              Skip rebuilding Spark and the Docker image.
-#   --java-version <ver>      Java version to build with (default: 17).
 #   --hadoop-profile <prof>   Hadoop Maven profile (default: hadoop-3).
 
 set -e
@@ -57,7 +54,6 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 IMAGE_REPO="docker.io/kubespark"
 IMAGE_TAG=""
 SPARK_IMAGE=""
-SPARK_TGZ=""
 DEPLOY_MODE="minikube"
 NAMESPACE=""
 SERVICE_ACCOUNT="default"
@@ -66,7 +62,6 @@ ROLE_ARN="arn:aws:iam::123456789012:role/oidc-e2e-test-role"
 S3_BUCKET="oidc-e2e-test-bucket"
 TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
 SKIP_BUILD=false
-JAVA_VERSION="17"
 HADOOP_PROFILE="hadoop-3"
 
 MOTO_PID=""
@@ -76,7 +71,6 @@ MOTO_PID=""
 # ---------------------------------------------------------------------------
 while (( "$#" )); do
   case "$1" in
-    --spark-tgz)       SPARK_TGZ="$2";        shift 2 ;;
     --image-tag)       IMAGE_TAG="$2";         shift 2 ;;
     --image-repo)      IMAGE_REPO="$2";        shift 2 ;;
     --spark-image)     SPARK_IMAGE="$2";       shift 2 ;;
@@ -88,7 +82,6 @@ while (( "$#" )); do
     --s3-bucket)       S3_BUCKET="$2";         shift 2 ;;
     --token-file)      TOKEN_FILE="$2";        shift 2 ;;
     --skip-build)      SKIP_BUILD=true;        shift   ;;
-    --java-version)    JAVA_VERSION="$2";      shift 2 ;;
     --hadoop-profile)  HADOOP_PROFILE="$2";    shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -111,12 +104,12 @@ check_prereqs() {
   log "Checking prerequisites..."
 
   if ! command -v python3 &>/dev/null; then
-    echo "ERROR: python3 not found. Install Python 3 and run: pip install 'moto[server,s3,sts]>=5.0.0'" >&2
+    echo "ERROR: python3 not found. Install Python 3 and run: pip install 'moto[server,s3,sts]>=5.0.0,<6.0.0'" >&2
     exit 1
   fi
 
   if ! python3 -c "import moto" &>/dev/null; then
-    echo "ERROR: moto not found. Run: pip install 'moto[server,s3,sts]>=5.0.0'" >&2
+    echo "ERROR: moto not found. Run: pip install 'moto[server,s3,sts]>=5.0.0,<6.0.0'" >&2
     exit 1
   fi
 
@@ -259,9 +252,6 @@ run_tests() {
   fi
   if [[ -n "${SERVICE_ACCOUNT}" ]]; then
     mvn_args+=("-Dspark.kubernetes.test.serviceAccountName=${SERVICE_ACCOUNT}")
-  fi
-  if [[ -n "${SPARK_TGZ}" ]]; then
-    mvn_args+=("-Dspark.kubernetes.test.sparkTgz=${SPARK_TGZ}")
   fi
 
   build/mvn "${mvn_args[@]}"

--- a/connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
+++ b/connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper script for running the OIDC E2E integration tests locally.
+# Mirrors the interface of resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
+#
+# Prerequisites:
+#   - Minikube running  (minikube start --cpus 4 --memory 6144)
+#   - Python 3 + moto installed  (pip install "moto[server,s3,sts]>=5.0.0")
+#   - Docker available and pointing at Minikube's daemon (eval $(minikube docker-env))
+#
+# Usage (run from anywhere; the script resolves the repository root from its own
+# location and builds from there):
+#   connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh [options]
+#
+# Options:
+#   --spark-tgz <path>        Path to a pre-built Spark tgz distribution.
+#                             When omitted, tests run against the current source tree.
+#   --image-tag <tag>         Use a pre-built Spark image with this tag instead of building one.
+#   --image-repo <repo>       Docker image repository (default: docker.io/kubespark).
+#   --spark-image <image>     Full image name (overrides --image-repo + --image-tag).
+#   --deploy-mode <mode>      Kubernetes backend: minikube (default), docker-desktop, rancher-desktop, cloud.
+#   --namespace <ns>          Kubernetes namespace (created if absent; deleted on exit unless pre-existing).
+#   --service-account <sa>    Kubernetes service account (default: default).
+#   --moto-port <port>        Port for the moto server (default: 5000).
+#   --role-arn <arn>          IAM role ARN for AssumeRoleWithWebIdentity
+#                             (default: arn:aws:iam::123456789012:role/oidc-e2e-test-role).
+#   --s3-bucket <bucket>      S3 bucket name in moto (default: oidc-e2e-test-bucket).
+#   --token-file <path>       Path to the OIDC token file inside the driver pod
+#                             (default: /var/run/secrets/kubernetes.io/serviceaccount/token).
+#   --skip-build              Skip rebuilding Spark and the Docker image.
+#   --java-version <ver>      Java version to build with (default: 17).
+#   --hadoop-profile <prof>   Hadoop Maven profile (default: hadoop-3).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+IMAGE_REPO="docker.io/kubespark"
+IMAGE_TAG=""
+SPARK_IMAGE=""
+SPARK_TGZ=""
+DEPLOY_MODE="minikube"
+NAMESPACE=""
+SERVICE_ACCOUNT="default"
+MOTO_PORT="5000"
+ROLE_ARN="arn:aws:iam::123456789012:role/oidc-e2e-test-role"
+S3_BUCKET="oidc-e2e-test-bucket"
+TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+SKIP_BUILD=false
+JAVA_VERSION="17"
+HADOOP_PROFILE="hadoop-3"
+
+MOTO_PID=""
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while (( "$#" )); do
+  case "$1" in
+    --spark-tgz)       SPARK_TGZ="$2";        shift 2 ;;
+    --image-tag)       IMAGE_TAG="$2";         shift 2 ;;
+    --image-repo)      IMAGE_REPO="$2";        shift 2 ;;
+    --spark-image)     SPARK_IMAGE="$2";       shift 2 ;;
+    --deploy-mode)     DEPLOY_MODE="$2";       shift 2 ;;
+    --namespace)       NAMESPACE="$2";         shift 2 ;;
+    --service-account) SERVICE_ACCOUNT="$2";   shift 2 ;;
+    --moto-port)       MOTO_PORT="$2";         shift 2 ;;
+    --role-arn)        ROLE_ARN="$2";          shift 2 ;;
+    --s3-bucket)       S3_BUCKET="$2";         shift 2 ;;
+    --token-file)      TOKEN_FILE="$2";        shift 2 ;;
+    --skip-build)      SKIP_BUILD=true;        shift   ;;
+    --java-version)    JAVA_VERSION="$2";      shift 2 ;;
+    --hadoop-profile)  HADOOP_PROFILE="$2";    shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() { echo "[dev-run-integration-tests] $*"; }
+
+cleanup() {
+  if [[ -n "${MOTO_PID}" ]]; then
+    log "Stopping moto server (PID ${MOTO_PID})..."
+    kill "${MOTO_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+check_prereqs() {
+  log "Checking prerequisites..."
+
+  if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 not found. Install Python 3 and run: pip install 'moto[server,s3,sts]>=5.0.0'" >&2
+    exit 1
+  fi
+
+  if ! python3 -c "import moto" &>/dev/null; then
+    echo "ERROR: moto not found. Run: pip install 'moto[server,s3,sts]>=5.0.0'" >&2
+    exit 1
+  fi
+
+  if [[ "${DEPLOY_MODE}" == "minikube" ]]; then
+    if ! command -v minikube &>/dev/null; then
+      echo "ERROR: minikube not found. Install minikube and run: minikube start --cpus 4 --memory 6144" >&2
+      exit 1
+    fi
+    if ! minikube status --format='{{.Host}}' 2>/dev/null | grep -q "Running"; then
+      echo "ERROR: minikube is not running. Run: minikube start --cpus 4 --memory 6144" >&2
+      exit 1
+    fi
+  fi
+}
+
+start_moto() {
+  log "Starting moto server on port ${MOTO_PORT}..."
+  # Listen on all interfaces so Minikube pods can reach the host
+  python3 -m moto.server -H 0.0.0.0 -p "${MOTO_PORT}" &
+  MOTO_PID=$!
+  # Wait for moto to be ready
+  local attempts=0
+  until curl -sf "http://localhost:${MOTO_PORT}/" &>/dev/null; do
+    attempts=$((attempts + 1))
+    if [[ ${attempts} -ge 30 ]]; then
+      echo "ERROR: moto server did not start within 30 seconds." >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  log "moto server is ready (PID ${MOTO_PID})."
+}
+
+resolve_moto_host() {
+  # Determine the IP address of the host as seen from inside Minikube pods.
+  # For minikube, this is the default gateway inside the VM.
+  if [[ "${DEPLOY_MODE}" == "minikube" ]]; then
+    MOTO_HOST=$(minikube ssh "ip route | grep default | awk '{print \$3}'" 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "${MOTO_HOST}" ]]; then
+      log "WARNING: Could not detect Minikube gateway IP; falling back to localhost."
+      MOTO_HOST="localhost"
+    fi
+  else
+    MOTO_HOST="localhost"
+  fi
+  MOTO_ENDPOINT="http://${MOTO_HOST}:${MOTO_PORT}"
+  log "moto endpoint reachable from pods: ${MOTO_ENDPOINT}"
+  # The test process runs on the host and reaches moto on loopback, which
+  # generally differs from the pod-facing gateway IP above.
+  MOTO_CLIENT_ENDPOINT="http://127.0.0.1:${MOTO_PORT}"
+  log "moto endpoint reachable from host (test process): ${MOTO_CLIENT_ENDPOINT}"
+}
+
+build_spark_image() {
+  if [[ "${SKIP_BUILD}" == "true" ]]; then
+    log "Skipping build (--skip-build)."
+    return
+  fi
+
+  log "Building Spark and Docker image..."
+
+  cd "${REPO_ROOT}"
+
+  if [[ "${DEPLOY_MODE}" == "minikube" ]]; then
+    eval "$(minikube docker-env)"
+  fi
+
+  # Build the modules. -Phadoop-cloud pulls in hadoop-aws and the AWS SDK so the
+  # image has S3A support; -Poidc-e2e builds this module (which contains the job).
+  build/sbt \
+    "-P${HADOOP_PROFILE}" -Phadoop-cloud -Pkubernetes -Pcredential-aws -Poidc-e2e \
+    package
+
+  # Generate an image tag from timestamp if not provided
+  if [[ -z "${IMAGE_TAG}" ]]; then
+    IMAGE_TAG="oidc-e2e-$(date +%Y%m%d%H%M%S)"
+  fi
+
+  # Build the base Spark Docker image (includes hadoop-aws/AWS SDK via -Phadoop-cloud).
+  ./bin/docker-image-tool.sh \
+    -r "${IMAGE_REPO}" \
+    -t "${IMAGE_TAG}" \
+    build
+
+  # Bake the job jar (OidcS3ReadWriteJob) into /opt/spark/jars so it is on the driver
+  # classpath. A local:// application resource is copied to work-dir, which is not on
+  # the classpath (SPARK-43540), so the job must be baked into the image instead.
+  local job_jar
+  job_jar=$(ls connector/credential-aws-integration-tests/target/scala-*/spark-credential-aws-integration-tests_*.jar \
+    | grep -v -- '-tests.jar' | head -1)
+  local job_jar_name
+  job_jar_name=$(basename "${job_jar}")
+  local build_ctx
+  build_ctx=$(mktemp -d)
+  cp "${job_jar}" "${build_ctx}/"
+  cat > "${build_ctx}/Dockerfile" <<EOF
+FROM ${IMAGE_REPO}/spark:${IMAGE_TAG}
+COPY ${job_jar_name} /opt/spark/jars/${job_jar_name}
+EOF
+  docker build -t "${IMAGE_REPO}/spark:${IMAGE_TAG}-job" "${build_ctx}"
+  rm -rf "${build_ctx}"
+
+  SPARK_IMAGE="${IMAGE_REPO}/spark:${IMAGE_TAG}-job"
+  log "Built Spark image with job jar: ${SPARK_IMAGE}"
+}
+
+run_tests() {
+  log "Running OIDC E2E integration tests..."
+
+  cd "${REPO_ROOT}"
+
+  local mvn_args=(
+    integration-test
+    -am
+    -pl "connector/credential-aws-integration-tests"
+    "-P${HADOOP_PROFILE}"
+    -Pkubernetes
+    -Pcredential-aws
+    -Poidc-e2e
+    "-Dspark.kubernetes.test.deployMode=${DEPLOY_MODE}"
+    "-Dspark.oidc.test.stsEndpoint=${MOTO_ENDPOINT}"
+    "-Dspark.oidc.test.s3Endpoint=${MOTO_ENDPOINT}"
+    "-Dspark.oidc.test.s3ClientEndpoint=${MOTO_CLIENT_ENDPOINT}"
+    "-Dspark.oidc.test.roleArn=${ROLE_ARN}"
+    "-Dspark.oidc.test.s3Bucket=${S3_BUCKET}"
+    "-Dspark.oidc.test.tokenFile=${TOKEN_FILE}"
+  )
+
+  if [[ -n "${SPARK_IMAGE}" ]]; then
+    mvn_args+=("-Dspark.oidc.test.sparkImage=${SPARK_IMAGE}")
+  fi
+  if [[ -n "${IMAGE_REPO}" ]]; then
+    mvn_args+=("-Dspark.kubernetes.test.imageRepo=${IMAGE_REPO}")
+  fi
+  if [[ -n "${IMAGE_TAG}" ]]; then
+    mvn_args+=("-Dspark.kubernetes.test.imageTag=${IMAGE_TAG}")
+  fi
+  if [[ -n "${NAMESPACE}" ]]; then
+    mvn_args+=("-Dspark.kubernetes.test.namespace=${NAMESPACE}")
+  fi
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    mvn_args+=("-Dspark.kubernetes.test.serviceAccountName=${SERVICE_ACCOUNT}")
+  fi
+  if [[ -n "${SPARK_TGZ}" ]]; then
+    mvn_args+=("-Dspark.kubernetes.test.sparkTgz=${SPARK_TGZ}")
+  fi
+
+  build/mvn "${mvn_args[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+check_prereqs
+start_moto
+resolve_moto_host
+build_spark_image
+run_tests
+
+log "OIDC E2E integration tests completed successfully."

--- a/connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
+++ b/connector/credential-aws-integration-tests/dev/dev-run-integration-tests.sh
@@ -166,6 +166,15 @@ resolve_moto_host() {
 build_spark_image() {
   if [[ "${SKIP_BUILD}" == "true" ]]; then
     log "Skipping build (--skip-build)."
+    # The build path tags the runnable image (with the job jar baked in) as
+    # "<repo>/spark:<tag>-job". When skipping the build, derive the same name from
+    # --image-tag so the tests use the job-jar image rather than falling back to the
+    # plain "<repo>/spark:<tag>" (which lacks the job classes and fails with
+    # ClassNotFoundException). An explicit --spark-image still wins.
+    if [[ -z "${SPARK_IMAGE}" && -n "${IMAGE_TAG}" ]]; then
+      SPARK_IMAGE="${IMAGE_REPO}/spark:${IMAGE_TAG}-job"
+      log "Using pre-built job image: ${SPARK_IMAGE}"
+    fi
     return
   fi
 
@@ -194,9 +203,13 @@ build_spark_image() {
     -t "${IMAGE_TAG}" \
     build
 
-  # Bake the job jar (OidcS3ReadWriteJob) into /opt/spark/jars so it is on the driver
-  # classpath. A local:// application resource is copied to work-dir, which is not on
-  # the classpath (SPARK-43540), so the job must be baked into the image instead.
+  # Bake the job jar (OidcS3ReadWriteJob) into the image so its classes are available to
+  # the driver. SparkSubmit already puts a local:// primary resource on the driver
+  # classpath (and into spark.jars for executors), so the reason for baking it in is not
+  # a classpath gap -- it is that docker-image-tool.sh only copies examples/jars into the
+  # image, so this module's jar would otherwise be absent from the container entirely.
+  # We install it under /opt/spark/jars (already on the classpath) to keep the local://
+  # reference simple.
   local job_jar
   job_jar=$(ls connector/credential-aws-integration-tests/target/scala-*/spark-credential-aws-integration-tests_*.jar \
     | grep -v -- '-tests.jar' | head -1)

--- a/connector/credential-aws-integration-tests/pom.xml
+++ b/connector/credential-aws-integration-tests/pom.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.13</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-credential-aws-integration-tests_2.13</artifactId>
+  <properties>
+    <sbt.project.name>credential-aws-integration-tests</sbt.project.name>
+
+    <!-- Integration Test Configuration Properties -->
+    <!-- Kubernetes cluster settings (reuse kubernetes-integration-tests conventions) -->
+    <spark.kubernetes.test.deployMode>minikube</spark.kubernetes.test.deployMode>
+    <spark.kubernetes.test.imageRepo>docker.io/kubespark</spark.kubernetes.test.imageRepo>
+    <spark.kubernetes.test.imageTag>N/A</spark.kubernetes.test.imageTag>
+    <spark.kubernetes.test.master></spark.kubernetes.test.master>
+    <spark.kubernetes.test.namespace></spark.kubernetes.test.namespace>
+    <spark.kubernetes.test.serviceAccountName></spark.kubernetes.test.serviceAccountName>
+
+    <!-- OIDC E2E specific settings -->
+    <!-- moto server endpoint (http://host-gateway:5000 when running inside Minikube) -->
+    <spark.oidc.test.stsEndpoint>http://localhost:5000</spark.oidc.test.stsEndpoint>
+    <!-- S3 endpoint exposed by moto -->
+    <spark.oidc.test.s3Endpoint>http://localhost:5000</spark.oidc.test.s3Endpoint>
+    <!-- S3 endpoint used by the test process on the host (loopback), which may differ
+         from the pod-facing endpoint above when running on Minikube -->
+    <spark.oidc.test.s3ClientEndpoint>http://127.0.0.1:5000</spark.oidc.test.s3ClientEndpoint>
+    <!-- IAM role ARN to assume (moto accepts any well-formed ARN) -->
+    <spark.oidc.test.roleArn>arn:aws:iam::123456789012:role/oidc-e2e-test-role</spark.oidc.test.roleArn>
+    <!-- Path to the Projected SA token file inside the driver pod -->
+    <spark.oidc.test.tokenFile>/var/run/secrets/kubernetes.io/serviceaccount/token</spark.oidc.test.tokenFile>
+    <!-- S3 bucket name to create/use in moto -->
+    <spark.oidc.test.s3Bucket>oidc-e2e-test-bucket</spark.oidc.test.s3Bucket>
+    <!-- Spark image (must include credential-aws jar); defaults to the standard test image -->
+    <spark.oidc.test.sparkImage></spark.oidc.test.sparkImage>
+
+    <test.exclude.tags></test.exclude.tags>
+    <test.include.tags></test.include.tags>
+  </properties>
+  <packaging>jar</packaging>
+  <name>Spark OIDC AWS Credential Propagation Integration Tests</name>
+  <description>
+    End-to-end integration tests for OIDC credential propagation with the AWS reference
+    provider (AwsStsCredentialProvider / SparkOidcAwsCredentialsProvider) running on
+    Minikube with moto as the S3 + STS backend.
+  </description>
+  <url>https://spark.apache.org/</url>
+
+  <dependencies>
+    <!-- Spark core (provided; supplied by the cluster) -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Spark core test-jar: SparkFunSuite and test utilities -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Spark Kubernetes support: provides the fabric8 kubernetes-client HTTP client
+         implementation (resolved at runtime via ServiceLoader). Required even though
+         no classes are imported directly: without it the client aborts at runtime with
+         NoClassDefFoundError for the HTTP client factory. -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-kubernetes_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- credential-aws module under test -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-credential-aws_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- AWS SDK v2 (for pre-creating S3 buckets / verifying results via moto) -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>bundle</artifactId>
+      <version>${aws.java.sdk.v2.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Kubernetes client (fabric8) for pod/namespace management -->
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- spark-tags (required even if unused, to avoid test-exclusion errors) -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- ScalaTest -->
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+
+    <plugins>
+      <!-- Skip unit-test phase; tests run in integration-test phase only -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+
+      <!-- Run ScalaTest in the integration-test phase -->
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>${scalatest-maven-plugin.version}</version>
+        <configuration>
+          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+          <junitxml>.</junitxml>
+          <filereports>SparkTestSuite.txt</filereports>
+          <argLine>-ea -Xmx2g</argLine>
+          <stderr/>
+          <systemProperties>
+            <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
+            <java.awt.headless>true</java.awt.headless>
+            <!-- Spark home used by the test to locate bin/spark-submit. Inherited from
+                 the parent pom (${session.executionRootDirectory}); mirrors the
+                 -Dspark.test.home that SparkBuild sets for the sbt test run, so the
+                 test resolves spark-submit identically under both Maven and sbt. -->
+            <spark.test.home>${spark.test.home}</spark.test.home>
+            <!-- Kubernetes cluster -->
+            <spark.kubernetes.test.deployMode>${spark.kubernetes.test.deployMode}</spark.kubernetes.test.deployMode>
+            <spark.kubernetes.test.master>${spark.kubernetes.test.master}</spark.kubernetes.test.master>
+            <spark.kubernetes.test.namespace>${spark.kubernetes.test.namespace}</spark.kubernetes.test.namespace>
+            <spark.kubernetes.test.serviceAccountName>${spark.kubernetes.test.serviceAccountName}</spark.kubernetes.test.serviceAccountName>
+            <spark.kubernetes.test.imageRepo>${spark.kubernetes.test.imageRepo}</spark.kubernetes.test.imageRepo>
+            <spark.kubernetes.test.imageTag>${spark.kubernetes.test.imageTag}</spark.kubernetes.test.imageTag>
+            <!-- OIDC E2E -->
+            <spark.oidc.test.stsEndpoint>${spark.oidc.test.stsEndpoint}</spark.oidc.test.stsEndpoint>
+            <spark.oidc.test.s3Endpoint>${spark.oidc.test.s3Endpoint}</spark.oidc.test.s3Endpoint>
+            <spark.oidc.test.s3ClientEndpoint>${spark.oidc.test.s3ClientEndpoint}</spark.oidc.test.s3ClientEndpoint>
+            <spark.oidc.test.roleArn>${spark.oidc.test.roleArn}</spark.oidc.test.roleArn>
+            <spark.oidc.test.tokenFile>${spark.oidc.test.tokenFile}</spark.oidc.test.tokenFile>
+            <spark.oidc.test.s3Bucket>${spark.oidc.test.s3Bucket}</spark.oidc.test.s3Bucket>
+            <spark.oidc.test.sparkImage>${spark.oidc.test.sparkImage}</spark.oidc.test.sparkImage>
+          </systemProperties>
+          <tagsToExclude>${test.exclude.tags}</tagsToExclude>
+          <tagsToInclude>${test.include.tags}</tagsToInclude>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <phase>none</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/connector/credential-aws-integration-tests/pom.xml
+++ b/connector/credential-aws-integration-tests/pom.xml
@@ -36,7 +36,6 @@
     <spark.kubernetes.test.deployMode>minikube</spark.kubernetes.test.deployMode>
     <spark.kubernetes.test.imageRepo>docker.io/kubespark</spark.kubernetes.test.imageRepo>
     <spark.kubernetes.test.imageTag>N/A</spark.kubernetes.test.imageTag>
-    <spark.kubernetes.test.master></spark.kubernetes.test.master>
     <spark.kubernetes.test.namespace></spark.kubernetes.test.namespace>
     <spark.kubernetes.test.serviceAccountName></spark.kubernetes.test.serviceAccountName>
 
@@ -177,7 +176,6 @@
             <spark.test.home>${spark.test.home}</spark.test.home>
             <!-- Kubernetes cluster -->
             <spark.kubernetes.test.deployMode>${spark.kubernetes.test.deployMode}</spark.kubernetes.test.deployMode>
-            <spark.kubernetes.test.master>${spark.kubernetes.test.master}</spark.kubernetes.test.master>
             <spark.kubernetes.test.namespace>${spark.kubernetes.test.namespace}</spark.kubernetes.test.namespace>
             <spark.kubernetes.test.serviceAccountName>${spark.kubernetes.test.serviceAccountName}</spark.kubernetes.test.serviceAccountName>
             <spark.kubernetes.test.imageRepo>${spark.kubernetes.test.imageRepo}</spark.kubernetes.test.imageRepo>

--- a/connector/credential-aws-integration-tests/src/main/scala/org/apache/spark/security/aws/integrationtest/OidcLateExecutorJob.scala
+++ b/connector/credential-aws-integration-tests/src/main/scala/org/apache/spark/security/aws/integrationtest/OidcLateExecutorJob.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.security.aws.integrationtest
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.internal.Logging
+
+/**
+ * Spark job used by the OIDC credential propagation E2E suite (OidcCredentialE2ESuite)
+ * to verify that a late-registering executor receives credentials.
+ *
+ * With dynamic allocation enabled, the job:
+ *  1. Runs a small first stage so the driver acquires credentials while few (or one)
+ *     executors are active.
+ *  2. Idles long enough for dynamic allocation to release idle executors.
+ *  3. Runs a second, wider stage that forces new executors to be requested and
+ *     registered *after* credentials were already acquired. Each task in that stage
+ *     writes to S3, so a late-registering executor that did not receive credentials
+ *     would fail the job.
+ *
+ * If every task in the second stage succeeds, late-registering executors received
+ * credentials (via the SparkAppConfig response at registration time) without waiting
+ * for the next renewal broadcast.
+ *
+ * Usage:
+ *   spark-submit --class ...OidcLateExecutorJob <jar> <s3a-output-prefix> <idleMillis> <partitions>
+ */
+object OidcLateExecutorJob extends Logging {
+
+  val SUCCESS_MARKER = "OidcLateExecutorJob: SUCCESS"
+
+  def main(args: Array[String]): Unit = {
+    require(args.length >= 3,
+      s"Usage: ${getClass.getName.stripSuffix("$")} " +
+        "<s3a-output-prefix> <idleMillis> <partitions>")
+
+    val outputPrefix = args(0).stripSuffix("/")
+    val idleMillis = args(1).toLong
+    val partitions = args(2).toInt
+
+    val conf = new SparkConf().setAppName("OidcLateExecutorJob")
+    val sc = new SparkContext(conf)
+
+    try {
+      // Stage 1: small warm-up so the driver acquires credentials early.
+      val warm = sc.parallelize(Seq("warm-1", "warm-2"), numSlices = 1)
+      warm.saveAsTextFile(s"$outputPrefix/warmup/")
+      logInfo(s"Warm-up stage complete; wrote $outputPrefix/warmup/")
+
+      // Idle so dynamic allocation scales executors down (idle timeout is set low
+      // by the test via spark.dynamicAllocation.executorIdleTimeout).
+      logInfo(s"Idling for ${idleMillis}ms to let dynamic allocation scale down...")
+      Thread.sleep(idleMillis)
+
+      // Stage 2: wide stage that forces new executors to be requested/registered.
+      // Each partition writes its own object to S3, so any executor lacking
+      // credentials would fail its task (and thus the job).
+      val wide = sc.parallelize(0 until partitions, numSlices = partitions)
+      wide.map { i =>
+        s"late-executor-partition-$i"
+      }.saveAsTextFile(s"$outputPrefix/wide/")
+      logInfo(s"Wide stage complete; wrote $outputPrefix/wide/ with $partitions partitions")
+
+      // scalastyle:off println
+      println(SUCCESS_MARKER)
+      // scalastyle:on println
+      logInfo(SUCCESS_MARKER)
+    } finally {
+      sc.stop()
+    }
+  }
+}

--- a/connector/credential-aws-integration-tests/src/main/scala/org/apache/spark/security/aws/integrationtest/OidcS3ReadWriteJob.scala
+++ b/connector/credential-aws-integration-tests/src/main/scala/org/apache/spark/security/aws/integrationtest/OidcS3ReadWriteJob.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.security.aws.integrationtest
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.internal.Logging
+
+/**
+ * Spark job used by the OIDC credential propagation E2E suite (OidcCredentialE2ESuite)
+ * to verify OIDC credential propagation.
+ *
+ * The job:
+ *  1. Creates a SparkContext (credentials are propagated to executors by the framework).
+ *  2. Creates a small RDD and writes it as text to the S3 path supplied as the first argument.
+ *  3. Reads back the written data and verifies it is non-empty.
+ *  4. Logs a success marker so the test suite can confirm completion via driver pod logs.
+ *
+ * Usage:
+ *   spark-submit --class org.apache.spark.security.aws.integrationtest.OidcS3ReadWriteJob \
+ *     <jar> <s3a-output-path>
+ *
+ * The S3A credentials provider is expected to be set (by the launching suite) to
+ * [[org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider]] via
+ * `spark.hadoop.fs.s3a.aws.credentials.provider`, together with
+ * `spark.security.oidc.enabled=true` on the driver.
+ */
+object OidcS3ReadWriteJob extends Logging {
+
+  val SUCCESS_MARKER = "OidcS3ReadWriteJob: SUCCESS"
+
+  def main(args: Array[String]): Unit = {
+    require(args.length >= 1,
+      s"Usage: ${getClass.getName.stripSuffix("$")} <s3a-output-path>")
+
+    val outputPath = args(0)
+
+    val conf = new SparkConf().setAppName("OidcS3ReadWriteJob")
+    val sc = new SparkContext(conf)
+
+    try {
+      // Write phase: distribute work to executors so that each executor must use
+      // the propagated OIDC-derived S3 credentials.
+      val data = sc.parallelize(Seq("oidc-test-line-1", "oidc-test-line-2"), numSlices = 2)
+      data.saveAsTextFile(outputPath)
+      logInfo(s"Wrote data to $outputPath")
+
+      // Read-back phase: verify the data is readable with the same credentials.
+      val readBack = sc.textFile(outputPath)
+      val count = readBack.count()
+      require(count > 0, s"Expected non-empty output at $outputPath, got $count records")
+      logInfo(s"Read back $count records from $outputPath")
+
+      // Emit the success marker that OidcCredentialE2ESuite looks for in the driver log.
+      // scalastyle:off println
+      println(SUCCESS_MARKER)
+      // scalastyle:on println
+      logInfo(SUCCESS_MARKER)
+    } finally {
+      sc.stop()
+    }
+  }
+}

--- a/connector/credential-aws-integration-tests/src/main/scala/org/apache/spark/security/aws/integrationtest/OidcTokenRotationJob.scala
+++ b/connector/credential-aws-integration-tests/src/main/scala/org/apache/spark/security/aws/integrationtest/OidcTokenRotationJob.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.security.aws.integrationtest
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.internal.Logging
+
+/**
+ * Long-running Spark job used by the OIDC credential propagation E2E suite
+ * (OidcCredentialE2ESuite) to verify mid-job token rotation.
+ *
+ * The job writes to S3 repeatedly over a period of time. While it runs, the test
+ * rotates the identity token file (simulating an externally-rotated token, e.g. a
+ * Kubernetes projected ServiceAccount token). The driver's UserCredentialManager
+ * re-reads the rotated token on its next renewal, exchanges it for fresh credentials
+ * via STS, and propagates them to executors. Because each iteration writes with the
+ * credentials current at that time, continued success across the rotation boundary
+ * demonstrates that the refresh did not interrupt S3 access.
+ *
+ * Usage:
+ *   spark-submit --class ...OidcTokenRotationJob <jar> \
+ *     <s3a-output-prefix> <iterations> <sleepMillis>
+ *
+ * Each iteration i writes a distinct object at {@code <prefix>/iter-<i>/}. The test
+ * verifies that objects for iterations spanning the rotation are all present.
+ */
+object OidcTokenRotationJob extends Logging {
+
+  val SUCCESS_MARKER = "OidcTokenRotationJob: SUCCESS"
+
+  def main(args: Array[String]): Unit = {
+    require(args.length >= 3,
+      s"Usage: ${getClass.getName.stripSuffix("$")} " +
+        "<s3a-output-prefix> <iterations> <sleepMillis>")
+
+    val outputPrefix = args(0).stripSuffix("/")
+    val iterations = args(1).toInt
+    val sleepMillis = args(2).toLong
+
+    val conf = new SparkConf().setAppName("OidcTokenRotationJob")
+    val sc = new SparkContext(conf)
+
+    try {
+      for (i <- 0 until iterations) {
+        val path = s"$outputPrefix/iter-$i/"
+        val data = sc.parallelize(Seq(s"oidc-rotation-line-$i-a", s"oidc-rotation-line-$i-b"),
+          numSlices = 2)
+        data.saveAsTextFile(path)
+        // Read back to force an S3 read with the current credentials as well.
+        val count = sc.textFile(path).count()
+        require(count > 0, s"Expected non-empty output at $path, got $count records")
+        logInfo(s"Iteration $i: wrote and read back $count records at $path")
+        if (i < iterations - 1) {
+          Thread.sleep(sleepMillis)
+        }
+      }
+
+      // scalastyle:off println
+      println(SUCCESS_MARKER)
+      // scalastyle:on println
+      logInfo(SUCCESS_MARKER)
+    } finally {
+      sc.stop()
+    }
+  }
+}

--- a/connector/credential-aws-integration-tests/src/test/resources/log4j2.properties
+++ b/connector/credential-aws-integration-tests/src/test/resources/log4j2.properties
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/integration-tests.log
+rootLogger.level = info
+rootLogger.appenderRef.file.ref = File
+
+appender.file.type = File
+appender.file.name = File
+appender.file.fileName = target/integration-tests.log
+appender.file.append = true
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
+
+# Suppress verbose output from libraries not related to the tests
+logger.jersey.name = com.sun.jersey
+logger.jersey.level = warn
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = warn
+logger.jetty1.name = org.eclipse.jetty
+logger.jetty1.level = warn
+logger.mortbay.name = org.mortbay
+logger.mortbay.level = warn
+logger.jetty2.name = org.sparkproject.jetty
+logger.jetty2.level = warn
+logger.fabric8.name = io.fabric8
+logger.fabric8.level = warn
+logger.aws.name = software.amazon.awssdk
+logger.aws.level = warn

--- a/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
+++ b/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientBuilder}
-import org.scalatest.{BeforeAndAfterAll, Tag}
+import org.scalatest.Tag
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.matchers.should.Matchers
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
 
 /**
  * End-to-end integration test for OIDC credential propagation with the AWS reference provider.
@@ -70,10 +70,8 @@ import org.apache.spark.internal.Logging
  */
 class OidcCredentialE2ESuite
     extends SparkFunSuite
-    with BeforeAndAfterAll
     with Matchers
-    with Eventually
-    with Logging {
+    with Eventually {
 
   import OidcCredentialE2ESuite._
 
@@ -170,11 +168,15 @@ class OidcCredentialE2ESuite
 
   override def afterAll(): Unit = {
     try {
+      // Wrap each teardown step independently so a failure in one (e.g. the namespace
+      // delete) does not skip the others (closing the S3 and Kubernetes clients).
       if (createdNamespace) {
-        kubernetesClient.namespaces().withName(namespace).delete()
+        Utils.tryLogNonFatalError {
+          kubernetesClient.namespaces().withName(namespace).delete()
+        }
       }
-      Option(s3Client).foreach(_.close())
-      Option(kubernetesClient).foreach(_.close())
+      Utils.tryLogNonFatalError(Option(s3Client).foreach(_.close()))
+      Utils.tryLogNonFatalError(Option(kubernetesClient).foreach(_.close()))
     } finally {
       super.afterAll()
     }
@@ -197,7 +199,8 @@ class OidcCredentialE2ESuite
    */
   test("OIDC credential propagation: basic S3 read/write on Minikube", oidcE2eTag) {
     val outputPath = s"s3a://$s3Bucket/e2e-basic-${UUID.randomUUID().toString.take(8)}/"
-    val conf = baseSparkConf(outputPath)
+    // A fixed executor count (this test does not use dynamic allocation).
+    val conf = baseSparkConf().set("spark.executor.instances", "1")
 
     runOidcJobAndVerify(conf, outputPath)
   }
@@ -239,8 +242,10 @@ class OidcCredentialE2ESuite
     val initialToken = makeUnsignedJwt(initialSubject, ttlSeconds = 600)
     val podTemplatePath = writeDriverPodTemplate(initialToken)
 
-    val conf = baseSparkConf(s"$outputPrefix/")
+    val conf = baseSparkConf()
       .set("spark.kubernetes.driver.pod.name", driverPodName)
+      // A fixed executor count (this test does not use dynamic allocation).
+      .set("spark.executor.instances", "1")
       .set("spark.kubernetes.driver.podTemplateFile", podTemplatePath.toString)
       // The identity token now comes from the init-container-populated emptyDir.
       .set("spark.security.oidc.identityToken.file", "/oidc/token")
@@ -309,6 +314,7 @@ class OidcCredentialE2ESuite
         dumpDriverDiagnostics(driverPodName)
         throw e
     } finally {
+      deleteDriverPod(driverPodName)
       Files.deleteIfExists(podTemplatePath)
     }
   }
@@ -335,7 +341,7 @@ class OidcCredentialE2ESuite
     val driverPodName =
       s"oidc-late-${UUID.randomUUID().toString.replaceAll("-", "").take(16)}-driver"
 
-    val conf = baseSparkConf(s"$outputPrefix/")
+    val conf = baseSparkConf()
       .set("spark.kubernetes.driver.pod.name", driverPodName)
       // Dynamic allocation with shuffle tracking (no external shuffle service on K8s).
       .set("spark.dynamicAllocation.enabled", "true")
@@ -412,6 +418,8 @@ class OidcCredentialE2ESuite
       case e: Throwable =>
         dumpDriverDiagnostics(driverPodName)
         throw e
+    } finally {
+      deleteDriverPod(driverPodName)
     }
   }
 
@@ -419,7 +427,7 @@ class OidcCredentialE2ESuite
   // Helpers
   // -------------------------------------------------------------------------
 
-  private def baseSparkConf(outputPath: String): SparkAppConf = {
+  private def baseSparkConf(): SparkAppConf = {
     val masterUrl = if (k8sMaster.nonEmpty) k8sMaster
     else s"k8s://${kubernetesClient.getMasterUrl}"
 
@@ -428,7 +436,6 @@ class OidcCredentialE2ESuite
       .set("spark.kubernetes.namespace", namespace)
       .set("spark.kubernetes.container.image", sparkImage)
       .set("spark.kubernetes.authenticate.driver.serviceAccountName", serviceAccountName)
-      .set("spark.executor.instances", "1")
       .set("spark.executor.cores", "1")
       .set("spark.kubernetes.driver.request.cores", "0.2")
       .set("spark.kubernetes.executor.request.cores", "0.2")
@@ -452,8 +459,6 @@ class OidcCredentialE2ESuite
       // relying on defaulting behaviour and makes the test intent clear.
       .set("spark.hadoop.fs.s3a.aws.credentials.provider",
         "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider")
-      // OidcS3ReadWriteJob parameters
-      .set("spark.oidc.test.outputPath", outputPath)
   }
 
   private def runOidcJobAndVerify(conf: SparkAppConf, outputPath: String): Unit = {
@@ -467,36 +472,40 @@ class OidcCredentialE2ESuite
       appArgs = Array(outputPath))
 
     try {
-      SparkAppLauncher.launch(
-        appArguments,
-        conf,
-        TIMEOUT.value.toSeconds.toInt,
-        resolveSparkHomeDir())
-    } catch {
-      case e: Throwable =>
-        // spark-submit runs with waitAppCompletion=true, so a non-zero exit means
-        // the driver failed. Dump the driver pod's status, events and logs to make
-        // the root cause visible instead of leaving only a bare exit code.
-        dumpDriverDiagnostics(driverPodName)
-        throw e
-    }
-
-    // The submit above blocks until the driver completes successfully, so the
-    // output should already be in moto. Poll briefly to absorb any eventual
-    // consistency, and dump diagnostics if it never shows up.
-    try {
-      Eventually.eventually(VERIFY_TIMEOUT, INTERVAL) {
-        val objects = s3Client.listObjectsV2(
-          ListObjectsV2Request.builder()
-            .bucket(s3Bucket)
-            .prefix(outputPath.stripPrefix(s"s3a://$s3Bucket/"))
-            .build())
-        objects.contents().asScala should not be empty
+      try {
+        SparkAppLauncher.launch(
+          appArguments,
+          conf,
+          TIMEOUT.value.toSeconds.toInt,
+          resolveSparkHomeDir())
+      } catch {
+        case e: Throwable =>
+          // spark-submit runs with waitAppCompletion=true, so a non-zero exit means
+          // the driver failed. Dump the driver pod's status, events and logs to make
+          // the root cause visible instead of leaving only a bare exit code.
+          dumpDriverDiagnostics(driverPodName)
+          throw e
       }
-    } catch {
-      case e: Throwable =>
-        dumpDriverDiagnostics(driverPodName)
-        throw e
+
+      // The submit above blocks until the driver completes successfully, so the
+      // output should already be in moto. Poll briefly to absorb any eventual
+      // consistency, and dump diagnostics if it never shows up.
+      try {
+        Eventually.eventually(VERIFY_TIMEOUT, INTERVAL) {
+          val objects = s3Client.listObjectsV2(
+            ListObjectsV2Request.builder()
+              .bucket(s3Bucket)
+              .prefix(outputPath.stripPrefix(s"s3a://$s3Bucket/"))
+              .build())
+          objects.contents().asScala should not be empty
+        }
+      } catch {
+        case e: Throwable =>
+          dumpDriverDiagnostics(driverPodName)
+          throw e
+      }
+    } finally {
+      deleteDriverPod(driverPodName)
     }
   }
 
@@ -516,6 +525,19 @@ class OidcCredentialE2ESuite
     } catch {
       case t: Throwable =>
         logInfo(s"Failed to collect driver diagnostics for $driverPodName: ${t.getMessage}")
+    }
+  }
+
+  /**
+   * Best-effort deletion of the driver pod after a test. The suite runs several tests
+   * in the same namespace with `waitAppCompletion=false`, so a driver (and its
+   * executors, which Spark deletes via owner references when the driver goes away) left
+   * running from one test would compete for the limited CPU/memory of the CI Minikube
+   * and could destabilize the next test. Called from each test's `finally`.
+   */
+  private def deleteDriverPod(driverPodName: String): Unit = {
+    Utils.tryLogNonFatalError {
+      kubernetesClient.pods().inNamespace(namespace).withName(driverPodName).delete()
     }
   }
 
@@ -616,6 +638,10 @@ class OidcCredentialE2ESuite
    * required because the rotation test later overwrites /oidc/token from inside the
    * driver container (uid 185): if the init container wrote the file as root, the driver
    * would get "Permission denied" and the rotation would silently fail.
+   *
+   * The init container reuses the Spark image (which already ships `sh`, `printf` and
+   * `chmod`) rather than pulling a separate `busybox` image at test time, avoiding an
+   * external Docker Hub dependency (and its rate limits / network flakiness) during CI.
    */
   private def writeDriverPodTemplate(initialToken: String): java.nio.file.Path = {
     val tmp = Files.createTempFile("oidc-driver-pod-template-", ".yaml")
@@ -631,7 +657,7 @@ class OidcCredentialE2ESuite
          |    emptyDir: {}
          |  initContainers:
          |  - name: init-oidc-token
-         |    image: busybox:1.36
+         |    image: $sparkImage
          |    securityContext:
          |      runAsUser: 185
          |      runAsGroup: 0
@@ -694,12 +720,12 @@ class OidcCredentialE2ESuite
   }
 
   private def resolveSparkHomeDir(): java.nio.file.Path = {
-    // Mirror kubernetes-integration-tests: pick the first candidate directory that
-    // actually contains bin/spark-submit. spark.test.home is set to the Spark source
-    // root by SparkBuild for all test projects; unpackSparkDir is used when an
-    // unpacked distribution is provided; user.dir is the last-resort fallback.
+    // Pick the first candidate directory that actually contains bin/spark-submit.
+    // spark.test.home is set to the Spark source root by SparkBuild (sbt) and via the
+    // pom's systemProperties (Maven) for this module; user.dir is the last-resort
+    // fallback. (Unlike kubernetes-integration-tests, this module does not unpack a
+    // distribution, so there is no unpackSparkDir to consult.)
     val candidates = Seq(
-      sys.props.get("spark.kubernetes.test.unpackSparkDir"),
       sys.props.get("spark.test.home"),
       sys.props.get("user.dir"))
       .flatten
@@ -711,8 +737,7 @@ class OidcCredentialE2ESuite
     }.getOrElse {
       throw new IllegalStateException(
         s"Could not find bin/spark-submit under any of: ${candidates.mkString(", ")}. " +
-          "Set -Dspark.test.home or -Dspark.kubernetes.test.unpackSparkDir to a Spark home " +
-          "that contains bin/spark-submit.")
+          "Set -Dspark.test.home to a Spark home that contains bin/spark-submit.")
     }
     Paths.get(resolved)
   }

--- a/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
+++ b/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
@@ -25,6 +25,7 @@ import java.util.{Base64, UUID}
 import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model._
+import io.fabric8.kubernetes.api.model.rbac.{PolicyRuleBuilder, RoleBindingBuilder, RoleBuilder}
 import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientBuilder}
 import org.scalatest.Tag
 import org.scalatest.concurrent.Eventually
@@ -57,7 +58,6 @@ import org.apache.spark.util.Utils
  * }}}
  *
  * System properties (all have defaults; override via Maven `-D` flags or pom.xml properties):
- *  - spark.kubernetes.test.master     - Kubernetes API server URL
  *  - spark.kubernetes.test.imageRepo  - Docker image repository
  *  - spark.kubernetes.test.imageTag   - Docker image tag
  *  - spark.oidc.test.stsEndpoint      - moto STS endpoint as seen from pods (host gateway IP)
@@ -79,8 +79,6 @@ class OidcCredentialE2ESuite
   // Configuration read from system properties (injected by pom.xml)
   // -------------------------------------------------------------------------
 
-  private val k8sMaster: String =
-    prop("spark.kubernetes.test.master", "")
   private val imageRepo: String =
     prop("spark.kubernetes.test.imageRepo", "docker.io/kubespark")
   private val imageTag: String =
@@ -137,11 +135,11 @@ class OidcCredentialE2ESuite
    * Reads a system property, treating an unset property, an empty string, and the
    * literal string "null" as "not configured" (returning `default`). The last two
    * cases matter because pom.xml declares several of these properties with empty
-   * default values (e.g. `<spark.kubernetes.test.master></spark.kubernetes.test.master>`).
+   * default values (e.g. `<spark.kubernetes.test.namespace></spark.kubernetes.test.namespace>`).
    * When Maven's scalatest plugin forwards an empty property it arrives in the JVM as
-   * the string "null", not "", so a plain getOrElse would use "null" verbatim and
-   * produce nonsense like `--master null`. sbt does not set these properties at all,
-   * so this normalization keeps Maven and sbt behaviour identical.
+   * the string "null", not "", so a plain getOrElse would use "null" verbatim. sbt does
+   * not set these properties at all, so this normalization keeps Maven and sbt behaviour
+   * identical.
    */
   private def prop(key: String, default: String): String = {
     sys.props.get(key) match {
@@ -172,7 +170,16 @@ class OidcCredentialE2ESuite
       // delete) does not skip the others (closing the S3 and Kubernetes clients).
       if (createdNamespace) {
         Utils.tryLogNonFatalError {
-          kubernetesClient.namespaces().withName(namespace).delete()
+          val namespaces = kubernetesClient.namespaces()
+          namespaces.withName(namespace).delete()
+          // Wait for the namespace to be fully gone; otherwise an immediate re-run with
+          // a fixed -Dspark.kubernetes.test.namespace could find it still Terminating,
+          // treat it as pre-existing, and fail on submit.
+          val deadline = System.currentTimeMillis() + DELETE_TIMEOUT_MS
+          while (namespaces.withName(namespace).get() != null &&
+              System.currentTimeMillis() < deadline) {
+            Thread.sleep(INTERVAL.value.toMillis)
+          }
         }
       }
       Utils.tryLogNonFatalError(Option(s3Client).foreach(_.close()))
@@ -260,23 +267,18 @@ class OidcCredentialE2ESuite
       mainClass = ROTATION_JOB_MAIN_CLASS,
       appArgs = Array(s"$outputPrefix/", iterations.toString, sleepMillis.toString))
 
-    // Launch the (non-blocking) submit.
-    SparkAppLauncher.launch(
-      appArguments, conf, TIMEOUT.value.toSeconds.toInt, resolveSparkHomeDir())
-
     try {
+      // Launch the (non-blocking) submit. Inside the try so a launch failure still runs
+      // the finally (driver pod + temp pod-template cleanup).
+      SparkAppLauncher.launch(
+        appArguments, conf, TIMEOUT.value.toSeconds.toInt, resolveSparkHomeDir())
+
       // Wait until the driver has acquired the initial credentials and the job has
       // produced output on both sides of the rotation. Rotate after an early iteration
-      // so that several iterations still remain after the rotation.
-      Eventually.eventually(Timeout(Span(3, Minutes)), INTERVAL) {
-        assert(driverPodPhase(driverPodName) != "Failed",
-          s"Driver pod $driverPodName failed before rotation.")
-        val log = driverLog(driverPodName)
-        assert(log.contains("Credential acquisition successful"),
-          "Driver has not acquired initial credentials yet.")
-        assert(log.contains("Iteration 1:"),
-          "Job has not progressed enough to rotate the token safely.")
-      }
+      // so that several iterations still remain after the rotation. Fails fast if the
+      // driver pod enters the terminal Failed phase.
+      awaitDriverLogContains(driverPodName, Timeout(Span(3, Minutes)),
+        "Credential acquisition successful", "Iteration 1:")
 
       // Rotate the token: overwrite /oidc/token in the running driver pod with a token
       // carrying a DIFFERENT principal.
@@ -286,14 +288,10 @@ class OidcCredentialE2ESuite
 
       // Authoritative check that the rotated token was actually consumed: the driver's
       // renewal loop logs the principal it just loaded. Seeing the rotated principal
-      // proves the new token file was re-read and exchanged (not a no-op).
-      Eventually.eventually(Timeout(Span(2, Minutes)), INTERVAL) {
-        assert(driverPodPhase(driverPodName) != "Failed",
-          s"Driver pod $driverPodName failed after rotation.")
-        val log = driverLog(driverPodName)
-        assert(log.contains(s"Loaded identity token for principal $rotatedSubject"),
-          "Driver did not re-read the rotated token (rotated principal not seen in log).")
-      }
+      // proves the new token file was re-read and exchanged (not a no-op). Fails fast on
+      // a terminal Failed phase.
+      awaitDriverLogContains(driverPodName, Timeout(Span(2, Minutes)),
+        s"Loaded identity token for principal $rotatedSubject")
 
       // Wait for the job to finish successfully (fail fast on a terminal Failed phase).
       awaitDriverSucceeded(driverPodName, VERIFY_TIMEOUT)
@@ -367,27 +365,15 @@ class OidcCredentialE2ESuite
         appArguments, conf, TIMEOUT.value.toSeconds.toInt, resolveSparkHomeDir())
 
       // Wait until the warm-up stage completed and the driver has acquired credentials.
-      Eventually.eventually(Timeout(Span(3, Minutes)), INTERVAL) {
-        assert(driverPodPhase(driverPodName) != "Failed",
-          s"Driver pod $driverPodName failed during warm-up.")
-        val log = driverLog(driverPodName)
-        assert(log.contains("Credential acquisition successful"),
-          "Driver has not acquired credentials yet.")
-        assert(log.contains("Warm-up stage complete"),
-          "Warm-up stage has not completed yet.")
-      }
+      // Fails fast if the driver pod enters the terminal Failed phase.
+      awaitDriverLogContains(driverPodName, Timeout(Span(3, Minutes)),
+        "Credential acquisition successful", "Warm-up stage complete")
 
       // After the idle period, the wide stage forces executors to be (re-)requested.
-      // Wait for the job to report success. Using eventually here tolerates the timing
+      // Wait for the job to report success. The generous timeout tolerates the timing
       // variability of dynamic allocation scaling executors down and back up on a
-      // resource-constrained CI runner.
-      Eventually.eventually(TIMEOUT, INTERVAL) {
-        assert(driverPodPhase(driverPodName) != "Failed",
-          s"Driver pod $driverPodName failed before completing.")
-        val log = driverLog(driverPodName)
-        assert(log.contains(OidcLateExecutorJob.SUCCESS_MARKER),
-          "Job did not reach its success marker (wide stage may not have completed).")
-      }
+      // resource-constrained CI runner; a terminal Failed phase still fails fast.
+      awaitDriverLogContains(driverPodName, TIMEOUT, OidcLateExecutorJob.SUCCESS_MARKER)
 
       // Confirm the driver pod finished successfully (fail fast on terminal Failed).
       awaitDriverSucceeded(driverPodName, VERIFY_TIMEOUT)
@@ -428,8 +414,11 @@ class OidcCredentialE2ESuite
   // -------------------------------------------------------------------------
 
   private def baseSparkConf(): SparkAppConf = {
-    val masterUrl = if (k8sMaster.nonEmpty) k8sMaster
-    else s"k8s://${kubernetesClient.getMasterUrl}"
+    // Derive the master from the fabric8 client (which follows the active kubeconfig)
+    // rather than a separate, un-normalized property. This keeps spark-submit and the
+    // fabric8 client (used here for pod/namespace/exec operations) pointed at the same
+    // cluster, and avoids feeding SparkSubmit a raw "https://..." that it would reject.
+    val masterUrl = s"k8s://${kubernetesClient.getMasterUrl}"
 
     new SparkAppConf()
       .set("spark.master", masterUrl)
@@ -480,16 +469,33 @@ class OidcCredentialE2ESuite
           resolveSparkHomeDir())
       } catch {
         case e: Throwable =>
-          // spark-submit runs with waitAppCompletion=true, so a non-zero exit means
-          // the driver failed. Dump the driver pod's status, events and logs to make
-          // the root cause visible instead of leaving only a bare exit code.
+          // A non-zero spark-submit exit means submission itself failed. Note that a
+          // zero exit does NOT imply the driver succeeded: with waitAppCompletion=true
+          // the submission client returns 0 once the driver reaches any terminal phase,
+          // including Failed (LoggingPodStatusWatcherImpl.hasCompleted is true for both
+          // Succeeded and Failed). The driver-phase and success-marker checks below are
+          // what actually assert success. Dump diagnostics either way.
           dumpDriverDiagnostics(driverPodName)
           throw e
       }
 
-      // The submit above blocks until the driver completes successfully, so the
-      // output should already be in moto. Poll briefly to absorb any eventual
-      // consistency, and dump diagnostics if it never shows up.
+      // spark-submit's exit code does not distinguish Succeeded from Failed, so assert
+      // the driver reached Succeeded (fails fast on Failed) and that the job logged its
+      // success marker before verifying S3 output.
+      try {
+        awaitDriverSucceeded(driverPodName, VERIFY_TIMEOUT)
+        assert(driverLog(driverPodName).contains(OidcS3ReadWriteJob.SUCCESS_MARKER),
+          s"Driver pod $driverPodName succeeded but did not log the success marker " +
+            s"'${OidcS3ReadWriteJob.SUCCESS_MARKER}'.")
+      } catch {
+        case e: Throwable =>
+          dumpDriverDiagnostics(driverPodName)
+          throw e
+      }
+
+      // The driver has completed successfully, so the output should already be in moto.
+      // Poll briefly to absorb any eventual consistency, and dump diagnostics if it
+      // never shows up.
       try {
         Eventually.eventually(VERIFY_TIMEOUT, INTERVAL) {
           val objects = s3Client.listObjectsV2(
@@ -537,7 +543,48 @@ class OidcCredentialE2ESuite
    */
   private def deleteDriverPod(driverPodName: String): Unit = {
     Utils.tryLogNonFatalError {
-      kubernetesClient.pods().inNamespace(namespace).withName(driverPodName).delete()
+      val pods = kubernetesClient.pods().inNamespace(namespace)
+      pods.withName(driverPodName).delete()
+      // Wait for the pod to actually disappear (delete() only requests deletion). This
+      // keeps a still-terminating driver/executors from contending with the next test.
+      val deadline = System.currentTimeMillis() + DELETE_TIMEOUT_MS
+      while (pods.withName(driverPodName).get() != null &&
+          System.currentTimeMillis() < deadline) {
+        Thread.sleep(INTERVAL.value.toMillis)
+      }
+    }
+  }
+
+  /**
+   * Waits until the driver log contains all of the given markers, failing fast if the
+   * driver pod reaches the terminal "Failed" phase in the meantime, and failing on
+   * timeout otherwise.
+   *
+   * This is used instead of ScalaTest's `eventually { assert(phase != "Failed"); ... }`
+   * because `eventually` retries on ANY exception it catches -- including the
+   * `assert(phase != "Failed")` failure -- so a dead pod would not fail fast; the block
+   * would just keep retrying until the timeout expired. A hand-rolled poll loop that
+   * throws (via `fail`) on the terminal phase gives the intended fail-fast behavior.
+   */
+  private def awaitDriverLogContains(
+      driverPodName: String, timeout: Timeout, markers: String*): Unit = {
+    val deadline = System.currentTimeMillis() + timeout.value.toMillis
+    var found = false
+    while (!found) {
+      val phase = driverPodPhase(driverPodName)
+      if (phase == "Failed") {
+        fail(s"Driver pod $driverPodName reached terminal phase Failed while waiting " +
+          s"for: ${markers.mkString(", ")}.")
+      }
+      val log = driverLog(driverPodName)
+      if (markers.forall(log.contains)) {
+        found = true
+      } else if (System.currentTimeMillis() > deadline) {
+        fail(s"Timed out waiting for driver log of $driverPodName to contain: " +
+          s"${markers.filterNot(log.contains).mkString(", ")} (last phase: $phase).")
+      } else {
+        Thread.sleep(INTERVAL.value.toMillis)
+      }
     }
   }
 
@@ -764,12 +811,65 @@ class OidcCredentialE2ESuite
           .build()).create()
       createdNamespace = true
     }
+    // Grant RBAC regardless of whether we created the namespace, so the suite also works
+    // when pointed at a pre-existing namespace on an RBAC-enabled cluster.
+    ensureDriverRbac()
+  }
+
+  /**
+   * Grants the driver's ServiceAccount permission to manage executor pods within the
+   * test namespace, via a namespaced Role + RoleBinding (mirroring the "pods: *" rule in
+   * resource-managers/kubernetes/integration-tests/dev/spark-rbac.yaml). Without this,
+   * on an RBAC-enabled cluster the default SA cannot create executor pods and the tests
+   * time out. Scoping this to the test namespace (rather than relying on a cluster-wide
+   * grant) also makes the suite self-sufficient when run locally.
+   *
+   * Idempotent: re-running against a namespace that already carries these objects
+   * (e.g. a fixed, pre-existing namespace) is tolerated -- an already-exists conflict is
+   * ignored.
+   */
+  private def ensureDriverRbac(): Unit = {
+    val roleName = "oidc-e2e-driver-role"
+    val role = new RoleBuilder()
+      .withNewMetadata().withName(roleName).withNamespace(namespace).endMetadata()
+      .withRules(new PolicyRuleBuilder()
+        .withApiGroups("")
+        .withResources("pods", "services", "configmaps", "persistentvolumeclaims")
+        .withVerbs("*")
+        .build())
+      .build()
+    createIgnoringConflict {
+      kubernetesClient.rbac().roles().inNamespace(namespace).resource(role).create()
+    }
+
+    val roleBinding = new RoleBindingBuilder()
+      .withNewMetadata().withName("oidc-e2e-driver-role-binding")
+      .withNamespace(namespace).endMetadata()
+      .withNewRoleRef("rbac.authorization.k8s.io", "Role", roleName)
+      .addNewSubject()
+        .withKind("ServiceAccount").withName(serviceAccountName).withNamespace(namespace)
+        .endSubject()
+      .build()
+    createIgnoringConflict {
+      kubernetesClient.rbac().roleBindings().inNamespace(namespace).resource(roleBinding)
+        .create()
+    }
+  }
+
+  /** Runs a create() call, ignoring a 409 Conflict (resource already exists). */
+  private def createIgnoringConflict(create: => Any): Unit = {
+    try {
+      create
+    } catch {
+      case e: io.fabric8.kubernetes.client.KubernetesClientException if e.getCode == 409 =>
+        logInfo(s"RBAC object already exists; reusing it: ${e.getMessage}")
+    }
   }
 
   /**
    * Ensures the S3 bucket used by the tests exists in moto. RBAC for the driver's
-   * ServiceAccount is granted separately by the CI workflow / dev-run script (via a
-   * ClusterRoleBinding), not here.
+   * ServiceAccount is granted by [[ensureDriverRbac]] when this suite creates the
+   * namespace.
    */
   private def ensureMotoResources(): Unit = {
     // Create S3 bucket in moto if it does not exist
@@ -798,6 +898,9 @@ private[integrationtest] object OidcCredentialE2ESuite {
   // should already be present; only a short poll is needed for eventual consistency.
   val VERIFY_TIMEOUT: Timeout = Timeout(Span(2, Minutes))
   val INTERVAL: Interval = Interval(Span(10, Seconds))
+
+  /** How long to wait for a namespace/pod deletion to complete before giving up. */
+  val DELETE_TIMEOUT_MS: Long = 60000L
 
   /** ScalaTest tag to mark tests that require a running Kubernetes cluster and moto. */
   object oidcE2eTag extends Tag("org.apache.spark.security.aws.integrationtest.OidcE2ETest")

--- a/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
+++ b/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
@@ -1,0 +1,779 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.security.aws.integrationtest
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.time.Instant
+import java.util.{Base64, UUID}
+
+import scala.jdk.CollectionConverters._
+
+import io.fabric8.kubernetes.api.model._
+import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientBuilder}
+import org.scalatest.{BeforeAndAfterAll, Tag}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Minutes, Seconds, Span}
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model._
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.Logging
+
+/**
+ * End-to-end integration test for OIDC credential propagation with the AWS reference provider.
+ *
+ * Prerequisites (handled by the GitHub Actions workflow or dev-run-integration-tests.sh,
+ * or set up manually):
+ *  - Minikube running
+ *  - moto server running, reachable from the test JVM (loopback) and from Minikube pods
+ *    (host gateway IP)
+ *  - A Spark image built with `-Phadoop-cloud` (for S3A) and the module jar baked into
+ *    `/opt/spark/jars` (for the job classes)
+ *
+ * Activate with:
+ * {{{
+ *   mvn -Pkubernetes -Pcredential-aws -Poidc-e2e integration-test \
+ *     -pl connector/credential-aws-integration-tests
+ * }}}
+ *
+ * System properties (all have defaults; override via Maven `-D` flags or pom.xml properties):
+ *  - spark.kubernetes.test.master     - Kubernetes API server URL
+ *  - spark.kubernetes.test.imageRepo  - Docker image repository
+ *  - spark.kubernetes.test.imageTag   - Docker image tag
+ *  - spark.oidc.test.stsEndpoint      - moto STS endpoint as seen from pods (host gateway IP)
+ *  - spark.oidc.test.s3Endpoint       - moto S3 endpoint as seen from pods (host gateway IP)
+ *  - spark.oidc.test.s3ClientEndpoint - moto S3 endpoint as seen from the test JVM (loopback)
+ *  - spark.oidc.test.roleArn          - IAM role ARN for AssumeRoleWithWebIdentity
+ *  - spark.oidc.test.tokenFile        - path to the OIDC token file inside the driver pod
+ *  - spark.oidc.test.s3Bucket         - S3 bucket name to use in moto
+ *  - spark.oidc.test.sparkImage       - full Spark image name (overrides repo+tag)
+ */
+class OidcCredentialE2ESuite
+    extends SparkFunSuite
+    with BeforeAndAfterAll
+    with Matchers
+    with Eventually
+    with Logging {
+
+  import OidcCredentialE2ESuite._
+
+  // -------------------------------------------------------------------------
+  // Configuration read from system properties (injected by pom.xml)
+  // -------------------------------------------------------------------------
+
+  private val k8sMaster: String =
+    prop("spark.kubernetes.test.master", "")
+  private val imageRepo: String =
+    prop("spark.kubernetes.test.imageRepo", "docker.io/kubespark")
+  private val imageTag: String =
+    // Sentinel default mirrors pom.xml and kubernetes-integration-tests: "N/A" means
+    // no concrete image was configured. sparkImage below fails fast on this value
+    // rather than constructing an unpullable "spark:N/A" reference.
+    prop("spark.kubernetes.test.imageTag", "N/A")
+  private val sparkImage: String = {
+    val explicit = prop("spark.oidc.test.sparkImage", "")
+    if (explicit.nonEmpty) {
+      explicit
+    } else {
+      // Fall back to imageRepo/spark:imageTag only when a concrete tag is available.
+      // The pom.xml default for imageTag is the sentinel "N/A" (mirroring
+      // kubernetes-integration-tests), which does not name a real image. Building
+      // "$imageRepo/spark:N/A" here would defer the failure to an opaque
+      // ImagePullBackOff on the driver pod. Fail fast instead with an actionable
+      // message telling the caller how to provide an image.
+      require(imageTag.nonEmpty && imageTag != "N/A",
+        "No Spark test image configured. Set -Dspark.oidc.test.sparkImage to a full " +
+          "image name (e.g. docker.io/kubespark/spark:my-tag), or set " +
+          "-Dspark.kubernetes.test.imageTag (with -Dspark.kubernetes.test.imageRepo) " +
+          "to a tag that has been built and loaded into the cluster. The " +
+          "dev-run-integration-tests.sh script and the CI workflow set this for you.")
+      s"$imageRepo/spark:$imageTag"
+    }
+  }
+  private val namespace: String =
+    prop("spark.kubernetes.test.namespace",
+      s"oidc-e2e-${UUID.randomUUID().toString.take(8)}")
+  private val serviceAccountName: String =
+    prop("spark.kubernetes.test.serviceAccountName", "default")
+
+  private val stsEndpoint: String =
+    prop("spark.oidc.test.stsEndpoint", "http://localhost:5000")
+  private val s3Endpoint: String =
+    prop("spark.oidc.test.s3Endpoint", "http://localhost:5000")
+  // Endpoint used by the test process (running on the host) to talk to moto for
+  // setup/verification. This differs from [[s3Endpoint]]/[[stsEndpoint]], which are
+  // consumed by the Spark driver/executor pods inside Minikube: pods reach moto via the
+  // host gateway IP (e.g. 192.168.49.1), whereas the host itself reaches it on loopback.
+  private val s3ClientEndpoint: String =
+    prop("spark.oidc.test.s3ClientEndpoint", "http://127.0.0.1:5000")
+  private val roleArn: String =
+    prop("spark.oidc.test.roleArn",
+      "arn:aws:iam::123456789012:role/oidc-e2e-test-role")
+  private val tokenFile: String =
+    prop("spark.oidc.test.tokenFile",
+      "/var/run/secrets/kubernetes.io/serviceaccount/token")
+  private val s3Bucket: String =
+    prop("spark.oidc.test.s3Bucket", "oidc-e2e-test-bucket")
+
+  /**
+   * Reads a system property, treating an unset property, an empty string, and the
+   * literal string "null" as "not configured" (returning `default`). The last two
+   * cases matter because pom.xml declares several of these properties with empty
+   * default values (e.g. `<spark.kubernetes.test.master></spark.kubernetes.test.master>`).
+   * When Maven's scalatest plugin forwards an empty property it arrives in the JVM as
+   * the string "null", not "", so a plain getOrElse would use "null" verbatim and
+   * produce nonsense like `--master null`. sbt does not set these properties at all,
+   * so this normalization keeps Maven and sbt behaviour identical.
+   */
+  private def prop(key: String, default: String): String = {
+    sys.props.get(key) match {
+      case Some(v) if v.nonEmpty && v != "null" => v
+      case _ => default
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Infrastructure
+  // -------------------------------------------------------------------------
+
+  private var kubernetesClient: KubernetesClient = _
+  private var s3Client: S3Client = _
+  private var createdNamespace: Boolean = false
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    kubernetesClient = new KubernetesClientBuilder().build()
+    s3Client = buildS3Client()
+    ensureNamespace()
+    ensureMotoResources()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (createdNamespace) {
+        kubernetesClient.namespaces().withName(namespace).delete()
+      }
+      Option(s3Client).foreach(_.close())
+      Option(kubernetesClient).foreach(_.close())
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Test cases
+  // -------------------------------------------------------------------------
+
+  /**
+   * Test 1: Basic OIDC credential propagation flow.
+   *
+   * Scenario:
+   *  1. A Spark job runs on Minikube with spark.security.oidc.enabled=true.
+   *  2. The driver reads the Projected SA token from [[tokenFile]].
+   *  3. AwsStsCredentialProvider calls moto's AssumeRoleWithWebIdentity.
+   *  4. The resulting credentials are propagated to executors.
+   *  5. Executors write a file to S3 (moto) via S3A using the propagated credentials.
+   *  6. The test verifies the file exists in moto S3.
+   */
+  test("OIDC credential propagation: basic S3 read/write on Minikube", oidcE2eTag) {
+    val outputPath = s"s3a://$s3Bucket/e2e-basic-${UUID.randomUUID().toString.take(8)}/"
+    val conf = baseSparkConf(outputPath)
+
+    runOidcJobAndVerify(conf, outputPath)
+  }
+
+  /**
+   * Test 2: Mid-job token rotation triggers credential refresh.
+   *
+   * Scenario:
+   *  1. A long-running Spark job ([[OidcTokenRotationJob]]) starts with an initial
+   *     identity token supplied by an init container into an emptyDir (simulating an
+   *     externally-provided, rotatable token file such as a K8s projected SA token).
+   *  2. Mid-job, the test rewrites the token file in the driver pod (via `kubectl exec`
+   *     equivalent through the fabric8 client) with a token carrying a DIFFERENT
+   *     principal (subject), simulating an external token rotation.
+   *  3. UserCredentialManager re-reads the rotated token on its next (short-interval)
+   *     renewal, exchanges it via STS, and propagates fresh credentials to executors.
+   *  4. The test asserts the driver actually consumed the rotated token by matching the
+   *     new principal in the driver log ("Loaded identity token for principal <rotated>").
+   *     This distinguishes a real rotation from a no-op (the initial credentials would
+   *     otherwise remain valid for moto's long STS TTL, so "all iterations wrote" alone
+   *     would NOT prove the rotated token was used).
+   *  5. The job keeps writing to S3 across the rotation boundary; the test verifies that
+   *     objects for iterations spanning the rotation all exist.
+   */
+  test("OIDC credential propagation: mid-job token rotation triggers refresh", oidcE2eTag) {
+    val outputPrefix = s"s3a://$s3Bucket/e2e-rotation-${UUID.randomUUID().toString.take(8)}"
+    val iterations = 8
+    val sleepMillis = 5000L
+
+    val driverPodName =
+      s"oidc-rot-${UUID.randomUUID().toString.replaceAll("-", "").take(16)}-driver"
+
+    // Use distinct principals for the initial and rotated tokens so we can prove, from
+    // the driver log, that the rotated token was actually read (not a no-op).
+    val initialSubject = s"system:serviceaccount:$namespace:$serviceAccountName"
+    val rotatedSubject = s"system:serviceaccount:$namespace:rotated-oidc-principal"
+
+    // Initial identity token placed by the init container into /oidc/token.
+    val initialToken = makeUnsignedJwt(initialSubject, ttlSeconds = 600)
+    val podTemplatePath = writeDriverPodTemplate(initialToken)
+
+    val conf = baseSparkConf(s"$outputPrefix/")
+      .set("spark.kubernetes.driver.pod.name", driverPodName)
+      .set("spark.kubernetes.driver.podTemplateFile", podTemplatePath.toString)
+      // The identity token now comes from the init-container-populated emptyDir.
+      .set("spark.security.oidc.identityToken.file", "/oidc/token")
+      // Renew frequently so the rotated token is picked up quickly.
+      .set("spark.security.oidc.renewal.minInterval", "3s")
+      .set("spark.security.oidc.renewal.safetyMargin", "590s")
+      // Do not block: the test needs to rotate the token while the job runs.
+      .set("spark.kubernetes.submission.waitAppCompletion", "false")
+
+    val appArguments = SparkAppArguments(
+      mainAppResource = jobJarResource,
+      mainClass = ROTATION_JOB_MAIN_CLASS,
+      appArgs = Array(s"$outputPrefix/", iterations.toString, sleepMillis.toString))
+
+    // Launch the (non-blocking) submit.
+    SparkAppLauncher.launch(
+      appArguments, conf, TIMEOUT.value.toSeconds.toInt, resolveSparkHomeDir())
+
+    try {
+      // Wait until the driver has acquired the initial credentials and the job has
+      // produced output on both sides of the rotation. Rotate after an early iteration
+      // so that several iterations still remain after the rotation.
+      Eventually.eventually(Timeout(Span(3, Minutes)), INTERVAL) {
+        assert(driverPodPhase(driverPodName) != "Failed",
+          s"Driver pod $driverPodName failed before rotation.")
+        val log = driverLog(driverPodName)
+        assert(log.contains("Credential acquisition successful"),
+          "Driver has not acquired initial credentials yet.")
+        assert(log.contains("Iteration 1:"),
+          "Job has not progressed enough to rotate the token safely.")
+      }
+
+      // Rotate the token: overwrite /oidc/token in the running driver pod with a token
+      // carrying a DIFFERENT principal.
+      val rotatedToken = makeUnsignedJwt(rotatedSubject, ttlSeconds = 600)
+      rewriteDriverTokenFile(driverPodName, rotatedToken)
+      logInfo(s"Rotated identity token in driver pod (new principal: $rotatedSubject).")
+
+      // Authoritative check that the rotated token was actually consumed: the driver's
+      // renewal loop logs the principal it just loaded. Seeing the rotated principal
+      // proves the new token file was re-read and exchanged (not a no-op).
+      Eventually.eventually(Timeout(Span(2, Minutes)), INTERVAL) {
+        assert(driverPodPhase(driverPodName) != "Failed",
+          s"Driver pod $driverPodName failed after rotation.")
+        val log = driverLog(driverPodName)
+        assert(log.contains(s"Loaded identity token for principal $rotatedSubject"),
+          "Driver did not re-read the rotated token (rotated principal not seen in log).")
+      }
+
+      // Wait for the job to finish successfully (fail fast on a terminal Failed phase).
+      awaitDriverSucceeded(driverPodName, VERIFY_TIMEOUT)
+
+      // Verify all iterations wrote output (i.e. S3 access continued across rotation).
+      // iterations is small (< 1000), so a single listObjectsV2 page is sufficient.
+      val prefix = s"$outputPrefix/".stripPrefix(s"s3a://$s3Bucket/")
+      val objects = s3Client.listObjectsV2(
+        ListObjectsV2Request.builder().bucket(s3Bucket).prefix(prefix).build())
+      val keys = objects.contents().asScala.map(_.key())
+      for (i <- 0 until iterations) {
+        assert(keys.exists(_.contains(s"iter-$i/")),
+          s"Missing S3 output for iteration $i (rotation may have interrupted access). " +
+            s"Found keys: ${keys.mkString(", ")}")
+      }
+    } catch {
+      case e: Throwable =>
+        dumpDriverDiagnostics(driverPodName)
+        throw e
+    } finally {
+      Files.deleteIfExists(podTemplatePath)
+    }
+  }
+
+  /**
+   * Test 3: Late-registering executor receives credentials.
+   *
+   * Scenario:
+   *  1. A Spark job ([[OidcLateExecutorJob]]) starts with dynamic allocation enabled and
+   *     runs a small warm-up stage so the driver acquires credentials early.
+   *  2. The job idles long enough for dynamic allocation to release idle executors.
+   *  3. A wider second stage forces new executors to be requested and registered *after*
+   *     credentials were already acquired. Each task in that stage writes to S3.
+   *  4. If every task succeeds (verified by the presence of all wide-stage outputs and a
+   *     Succeeded pod phase), the late-registering executors received credentials via the
+   *     SparkAppConfig registration response, without waiting for the next renewal.
+   */
+  test("OIDC credential propagation: late-registering executor receives credentials",
+      oidcE2eTag) {
+    val outputPrefix = s"s3a://$s3Bucket/e2e-late-exec-${UUID.randomUUID().toString.take(8)}"
+    val idleMillis = 30000L
+    val partitions = 4
+
+    val driverPodName =
+      s"oidc-late-${UUID.randomUUID().toString.replaceAll("-", "").take(16)}-driver"
+
+    val conf = baseSparkConf(s"$outputPrefix/")
+      .set("spark.kubernetes.driver.pod.name", driverPodName)
+      // Dynamic allocation with shuffle tracking (no external shuffle service on K8s).
+      .set("spark.dynamicAllocation.enabled", "true")
+      .set("spark.dynamicAllocation.shuffleTracking.enabled", "true")
+      .set("spark.dynamicAllocation.minExecutors", "0")
+      .set("spark.dynamicAllocation.maxExecutors", "3")
+      .set("spark.dynamicAllocation.initialExecutors", "1")
+      // Scale idle executors down quickly so the wide stage must request new ones.
+      .set("spark.dynamicAllocation.executorIdleTimeout", "5s")
+      .set("spark.dynamicAllocation.shuffleTracking.timeout", "5s")
+      // Do not block: the test observes the driver's progress (and late executor
+      // registration) through the pod log while the job runs.
+      .set("spark.kubernetes.submission.waitAppCompletion", "false")
+
+    val appArguments = SparkAppArguments(
+      mainAppResource = jobJarResource,
+      mainClass = LATE_EXECUTOR_JOB_MAIN_CLASS,
+      appArgs = Array(s"$outputPrefix/", idleMillis.toString, partitions.toString))
+
+    try {
+      // Non-blocking submit; observe progress through the driver pod log.
+      SparkAppLauncher.launch(
+        appArguments, conf, TIMEOUT.value.toSeconds.toInt, resolveSparkHomeDir())
+
+      // Wait until the warm-up stage completed and the driver has acquired credentials.
+      Eventually.eventually(Timeout(Span(3, Minutes)), INTERVAL) {
+        assert(driverPodPhase(driverPodName) != "Failed",
+          s"Driver pod $driverPodName failed during warm-up.")
+        val log = driverLog(driverPodName)
+        assert(log.contains("Credential acquisition successful"),
+          "Driver has not acquired credentials yet.")
+        assert(log.contains("Warm-up stage complete"),
+          "Warm-up stage has not completed yet.")
+      }
+
+      // After the idle period, the wide stage forces executors to be (re-)requested.
+      // Wait for the job to report success. Using eventually here tolerates the timing
+      // variability of dynamic allocation scaling executors down and back up on a
+      // resource-constrained CI runner.
+      Eventually.eventually(TIMEOUT, INTERVAL) {
+        assert(driverPodPhase(driverPodName) != "Failed",
+          s"Driver pod $driverPodName failed before completing.")
+        val log = driverLog(driverPodName)
+        assert(log.contains(OidcLateExecutorJob.SUCCESS_MARKER),
+          "Job did not reach its success marker (wide stage may not have completed).")
+      }
+
+      // Confirm the driver pod finished successfully (fail fast on terminal Failed).
+      awaitDriverSucceeded(driverPodName, VERIFY_TIMEOUT)
+
+      // Prove the scenario actually exercised late-registering executors: more than one
+      // distinct executor must have registered over the run. With initialExecutors=1 and
+      // a short idle timeout, a second (or later) distinct executor ID only appears if
+      // dynamic allocation scaled down and then registered a NEW executor for the wide
+      // stage -- i.e. an executor that registered AFTER the initial credential
+      // acquisition. A single long-lived executor would yield only one ID and fail here.
+      val execIds = registeredExecutorIds(driverLog(driverPodName)).distinct
+      assert(execIds.size >= 2,
+        s"Expected more than one distinct executor to register (evidence of a " +
+          s"late-registering executor after scale-down); saw IDs: ${execIds.mkString(", ")}")
+
+      // Every wide-stage partition must have produced output; a late-registering executor
+      // without credentials would have failed its task and the job.
+      val widePrefix = s"$outputPrefix/wide/".stripPrefix(s"s3a://$s3Bucket/")
+      val objects = s3Client.listObjectsV2(
+        ListObjectsV2Request.builder().bucket(s3Bucket).prefix(widePrefix).build())
+      val keys = objects.contents().asScala.map(_.key())
+      // Spark writes part-* files plus a _SUCCESS marker for a successful save.
+      assert(keys.exists(_.contains("_SUCCESS")),
+        s"Wide stage did not complete successfully. Found keys: ${keys.mkString(", ")}")
+      assert(keys.exists(_.contains("part-")),
+        s"Wide stage produced no part files. Found keys: ${keys.mkString(", ")}")
+    } catch {
+      case e: Throwable =>
+        dumpDriverDiagnostics(driverPodName)
+        throw e
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private def baseSparkConf(outputPath: String): SparkAppConf = {
+    val masterUrl = if (k8sMaster.nonEmpty) k8sMaster
+    else s"k8s://${kubernetesClient.getMasterUrl}"
+
+    new SparkAppConf()
+      .set("spark.master", masterUrl)
+      .set("spark.kubernetes.namespace", namespace)
+      .set("spark.kubernetes.container.image", sparkImage)
+      .set("spark.kubernetes.authenticate.driver.serviceAccountName", serviceAccountName)
+      .set("spark.executor.instances", "1")
+      .set("spark.executor.cores", "1")
+      .set("spark.kubernetes.driver.request.cores", "0.2")
+      .set("spark.kubernetes.executor.request.cores", "0.2")
+      // Make spark-submit block until the driver finishes so the test can detect
+      // job failures immediately (instead of only polling S3 and timing out), and
+      // surface driver progress in the submit output.
+      .set("spark.kubernetes.submission.waitAppCompletion", "true")
+      .set("spark.kubernetes.report.interval", "5s")
+      // OIDC credential propagation
+      .set("spark.security.oidc.enabled", "true")
+      .set("spark.security.oidc.identityToken.file", tokenFile)
+      .set("spark.security.oidc.aws.roleArn", roleArn)
+      .set("spark.security.oidc.aws.stsEndpoint", stsEndpoint)
+      .set("spark.security.oidc.aws.region", "us-east-1")
+      // S3A configuration pointing to moto
+      .set("spark.hadoop.fs.s3a.endpoint", s3Endpoint)
+      .set("spark.hadoop.fs.s3a.path.style.access", "true")
+      .set("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
+      // Explicitly select the OIDC credential provider for S3A. The provider is
+      // registered by the credential-aws module; setting it explicitly avoids
+      // relying on defaulting behaviour and makes the test intent clear.
+      .set("spark.hadoop.fs.s3a.aws.credentials.provider",
+        "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider")
+      // OidcS3ReadWriteJob parameters
+      .set("spark.oidc.test.outputPath", outputPath)
+  }
+
+  private def runOidcJobAndVerify(conf: SparkAppConf, outputPath: String): Unit = {
+    val driverPodName =
+      s"oidc-e2e-${UUID.randomUUID().toString.replaceAll("-", "").take(16)}-driver"
+    conf.set("spark.kubernetes.driver.pod.name", driverPodName)
+
+    val appArguments = SparkAppArguments(
+      mainAppResource = jobJarResource,
+      mainClass = OIDC_JOB_MAIN_CLASS,
+      appArgs = Array(outputPath))
+
+    try {
+      SparkAppLauncher.launch(
+        appArguments,
+        conf,
+        TIMEOUT.value.toSeconds.toInt,
+        resolveSparkHomeDir())
+    } catch {
+      case e: Throwable =>
+        // spark-submit runs with waitAppCompletion=true, so a non-zero exit means
+        // the driver failed. Dump the driver pod's status, events and logs to make
+        // the root cause visible instead of leaving only a bare exit code.
+        dumpDriverDiagnostics(driverPodName)
+        throw e
+    }
+
+    // The submit above blocks until the driver completes successfully, so the
+    // output should already be in moto. Poll briefly to absorb any eventual
+    // consistency, and dump diagnostics if it never shows up.
+    try {
+      Eventually.eventually(VERIFY_TIMEOUT, INTERVAL) {
+        val objects = s3Client.listObjectsV2(
+          ListObjectsV2Request.builder()
+            .bucket(s3Bucket)
+            .prefix(outputPath.stripPrefix(s"s3a://$s3Bucket/"))
+            .build())
+        objects.contents().asScala should not be empty
+      }
+    } catch {
+      case e: Throwable =>
+        dumpDriverDiagnostics(driverPodName)
+        throw e
+    }
+  }
+
+  /** Logs the driver pod's phase, describe-style status and container logs, best-effort. */
+  private def dumpDriverDiagnostics(driverPodName: String): Unit = {
+    try {
+      val pod = kubernetesClient.pods().inNamespace(namespace).withName(driverPodName).get()
+      if (pod == null) {
+        logInfo(s"Driver pod $driverPodName not found in namespace $namespace.")
+      } else {
+        logInfo(s"Driver pod $driverPodName phase: ${pod.getStatus.getPhase}")
+        logInfo(s"Driver pod status: ${pod.getStatus}")
+      }
+      val logs = kubernetesClient.pods().inNamespace(namespace)
+        .withName(driverPodName).getLog()
+      logInfo(s"===== Driver pod logs ($driverPodName) =====\n$logs")
+    } catch {
+      case t: Throwable =>
+        logInfo(s"Failed to collect driver diagnostics for $driverPodName: ${t.getMessage}")
+    }
+  }
+
+  /** The application resource (job jar) baked into the image at /opt/spark/jars. */
+  private def jobJarResource: String = {
+    // Derive the Scala binary version at runtime (e.g. "2.13") rather than hard-coding
+    // it, so the jar name stays correct across Scala version bumps. Mirrors
+    // kubernetes-integration-tests' Utils.getExamplesJarName().
+    val scalaBinaryVersion = scala.util.Properties.versionNumberString
+      .split("\\.")
+      .take(2)
+      .mkString(".")
+    s"local:///opt/spark/jars/" +
+      s"spark-credential-aws-integration-tests_$scalaBinaryVersion-${SPARK_VERSION}.jar"
+  }
+
+  /** Returns the current logs of the driver pod (best-effort, empty on error). */
+  private def driverLog(driverPodName: String): String = {
+    try {
+      kubernetesClient.pods().inNamespace(namespace).withName(driverPodName).getLog()
+    } catch {
+      case _: Throwable => ""
+    }
+  }
+
+  /** Returns the driver pod's phase, or "Unknown" if not found. */
+  private def driverPodPhase(driverPodName: String): String = {
+    val pod = kubernetesClient.pods().inNamespace(namespace).withName(driverPodName).get()
+    if (pod == null || pod.getStatus == null) "Unknown" else pod.getStatus.getPhase
+  }
+
+  /**
+   * Waits for the driver pod to reach a terminal phase, failing fast on "Failed"
+   * instead of waiting for the whole timeout. Returns normally when the pod reaches
+   * "Succeeded"; throws immediately on "Failed"; throws on timeout otherwise.
+   */
+  private def awaitDriverSucceeded(driverPodName: String, timeout: Timeout): Unit = {
+    val deadline = System.currentTimeMillis() + timeout.value.toMillis
+    var phase = driverPodPhase(driverPodName)
+    while (phase != "Succeeded") {
+      if (phase == "Failed") {
+        fail(s"Driver pod $driverPodName reached terminal phase Failed.")
+      }
+      if (System.currentTimeMillis() > deadline) {
+        fail(s"Timed out waiting for driver pod $driverPodName to succeed " +
+          s"(last phase: $phase).")
+      }
+      Thread.sleep(INTERVAL.value.toMillis)
+      phase = driverPodPhase(driverPodName)
+    }
+  }
+
+  /**
+   * Parses the distinct executor IDs that registered with the driver, in the order the
+   * "Registered executor ... with ID <id>" lines appear in the driver log. Used by the
+   * late-executor test to prove that more than one executor registered over the run
+   * (i.e. dynamic allocation scaled down and back up), rather than a single long-lived
+   * executor satisfying the assertions trivially.
+   */
+  private def registeredExecutorIds(driverLogText: String): Seq[String] = {
+    val pattern = """Registered executor \S+ \([^)]*\) with ID (\S+?),""".r
+    pattern.findAllMatchIn(driverLogText).map(_.group(1)).toSeq
+  }
+
+  /**
+   * Builds a minimal unsigned JWT (alg:none) with the sub/iss/iat/exp claims that
+   * FileTokenIngestor requires. moto does not verify the signature, and
+   * FileTokenIngestor only Base64-decodes the payload, so an unsigned token is
+   * sufficient for the test.
+   *
+   * The subject is parameterized so the rotation test can use a distinct principal
+   * for the rotated token and then assert (via the driver log) that the driver
+   * actually re-read the rotated token rather than continuing with the initial one.
+   */
+  private def makeUnsignedJwt(subject: String, ttlSeconds: Long): String = {
+    def b64url(bytes: Array[Byte]): String =
+      Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+    val now = Instant.now().getEpochSecond
+    val header = """{"alg":"none","typ":"JWT"}"""
+    // A unique jti value ensures each rotation produces different token content,
+    // so FileTokenIngestor detects the change even if the subject is unchanged.
+    val payload =
+      s"""{"sub":"$subject",""" +
+        s""""iss":"https://kubernetes.default.svc.cluster.local",""" +
+        s""""iat":$now,"exp":${now + ttlSeconds},"jti":"${UUID.randomUUID()}"}"""
+    val h = b64url(header.getBytes(StandardCharsets.UTF_8))
+    val p = b64url(payload.getBytes(StandardCharsets.UTF_8))
+    s"$h.$p."
+  }
+
+  /**
+   * Writes a driver pod template that uses an init container to place the initial
+   * identity token into an emptyDir mounted at /oidc, shared with the driver container.
+   * Returns the path to the generated template file.
+   *
+   * The init container runs as the same user as the Spark driver (uid 185, gid 0 - the
+   * `spark` user in the official image) and makes the token file group-writable. This is
+   * required because the rotation test later overwrites /oidc/token from inside the
+   * driver container (uid 185): if the init container wrote the file as root, the driver
+   * would get "Permission denied" and the rotation would silently fail.
+   */
+  private def writeDriverPodTemplate(initialToken: String): java.nio.file.Path = {
+    val tmp = Files.createTempFile("oidc-driver-pod-template-", ".yaml")
+    // Write the token, then make it group-writable so the driver (uid 185, gid 0) can
+    // overwrite it during the rotation step. Kept as a single value to avoid a long line.
+    val initCmd = s"printf '%s' '$initialToken' > /oidc/token && chmod 0660 /oidc/token"
+    val yaml =
+      s"""apiVersion: v1
+         |kind: Pod
+         |spec:
+         |  volumes:
+         |  - name: oidc-token
+         |    emptyDir: {}
+         |  initContainers:
+         |  - name: init-oidc-token
+         |    image: busybox:1.36
+         |    securityContext:
+         |      runAsUser: 185
+         |      runAsGroup: 0
+         |    command: ["sh", "-c", "$initCmd"]
+         |    volumeMounts:
+         |    - name: oidc-token
+         |      mountPath: /oidc
+         |  containers:
+         |  - name: spark-kubernetes-driver
+         |    volumeMounts:
+         |    - name: oidc-token
+         |      mountPath: /oidc
+         |""".stripMargin
+    Files.write(tmp, yaml.getBytes(StandardCharsets.UTF_8))
+    tmp
+  }
+
+  /**
+   * Overwrites /oidc/token in the running driver pod with a new token, simulating an
+   * external token rotation. Uses the fabric8 client's exec support.
+   *
+   * The token is embedded in a single-quoted shell argument. makeUnsignedJwt produces
+   * only Base64URL characters and '.' separators (no quotes or shell metacharacters),
+   * and this method additionally asserts that invariant before executing, so the token
+   * cannot break out of the single-quoted argument.
+   *
+   * Correctness note: we wait on `ExecWatch.exitCode()` (which completes only when the
+   * remote command has finished), NOT merely on the ExecListener's onClose callback.
+   * onClose fires on WebSocket close and does not guarantee the `printf ... > /oidc/token`
+   * redirection has actually completed on the pod; closing the ExecWatch before then can
+   * even truncate the write. Waiting for the exit code guarantees the file has been
+   * written before this method returns, so the driver's next renewal observes the new
+   * token (this was the root cause of the rotation test intermittently reading the stale
+   * initial token).
+   */
+  private def rewriteDriverTokenFile(driverPodName: String, newToken: String): Unit = {
+    // Defense in depth: the token is interpolated into a single-quoted shell argument
+    // below. makeUnsignedJwt only emits Base64URL characters and '.' separators, but
+    // enforce that invariant here so a future change to token generation cannot silently
+    // introduce a shell-injection vector (e.g. an embedded single quote or ';').
+    require(newToken.matches("[A-Za-z0-9_.-]+"),
+      s"Refusing to write a token containing shell-unsafe characters: '$newToken'. " +
+        "The token must consist only of Base64URL characters and '.' separators.")
+    val exec = kubernetesClient.pods().inNamespace(namespace).withName(driverPodName)
+      .inContainer("spark-kubernetes-driver")
+      .writingOutput(System.out)
+      .writingError(System.err)
+      .exec("sh", "-c", s"printf '%s' '$newToken' > /oidc/token")
+    try {
+      // Block until the remote command actually completes (the write has landed).
+      // exitCode() may complete with null if the exec channel closes without ever
+      // delivering an exit-code message (e.g. the pod is killed mid-exec); guard the
+      // unboxing so that surfaces as a clear assertion failure rather than an NPE.
+      val exitCode = exec.exitCode().get(30, java.util.concurrent.TimeUnit.SECONDS)
+      assert(exitCode != null && exitCode == 0,
+        s"Writing the rotated token to /oidc/token failed with exit code $exitCode.")
+    } finally {
+      exec.close()
+    }
+  }
+
+  private def resolveSparkHomeDir(): java.nio.file.Path = {
+    // Mirror kubernetes-integration-tests: pick the first candidate directory that
+    // actually contains bin/spark-submit. spark.test.home is set to the Spark source
+    // root by SparkBuild for all test projects; unpackSparkDir is used when an
+    // unpacked distribution is provided; user.dir is the last-resort fallback.
+    val candidates = Seq(
+      sys.props.get("spark.kubernetes.test.unpackSparkDir"),
+      sys.props.get("spark.test.home"),
+      sys.props.get("user.dir"))
+      .flatten
+      // Drop unset/empty/"null" values: Maven forwards empty pom properties as the
+      // string "null" (see prop() above), which is not a usable directory.
+      .filter(v => v.nonEmpty && v != "null")
+    val resolved = candidates.find { dir =>
+      new java.io.File(Paths.get(dir).toFile, "bin/spark-submit").exists()
+    }.getOrElse {
+      throw new IllegalStateException(
+        s"Could not find bin/spark-submit under any of: ${candidates.mkString(", ")}. " +
+          "Set -Dspark.test.home or -Dspark.kubernetes.test.unpackSparkDir to a Spark home " +
+          "that contains bin/spark-submit.")
+    }
+    Paths.get(resolved)
+  }
+
+  private def buildS3Client(): S3Client = {
+    // moto accepts any non-empty credentials. Use the host-reachable endpoint
+    // (loopback), which differs from the pod-facing endpoint used in Spark conf.
+    S3Client.builder()
+      .endpointOverride(URI.create(s3ClientEndpoint))
+      .region(Region.US_EAST_1)
+      .credentialsProvider(
+        StaticCredentialsProvider.create(
+          AwsBasicCredentials.create("test", "test")))
+      .forcePathStyle(true)
+      .build()
+  }
+
+  private def ensureNamespace(): Unit = {
+    val existing = kubernetesClient.namespaces().withName(namespace).get()
+    if (existing == null) {
+      kubernetesClient.namespaces().resource(
+        new NamespaceBuilder()
+          .withNewMetadata().withName(namespace).endMetadata()
+          .build()).create()
+      createdNamespace = true
+    }
+  }
+
+  /**
+   * Ensures the S3 bucket used by the tests exists in moto. RBAC for the driver's
+   * ServiceAccount is granted separately by the CI workflow / dev-run script (via a
+   * ClusterRoleBinding), not here.
+   */
+  private def ensureMotoResources(): Unit = {
+    // Create S3 bucket in moto if it does not exist
+    val buckets = s3Client.listBuckets().buckets().asScala.map(_.name())
+    if (!buckets.contains(s3Bucket)) {
+      s3Client.createBucket(CreateBucketRequest.builder().bucket(s3Bucket).build())
+    }
+  }
+}
+
+private[integrationtest] object OidcCredentialE2ESuite {
+
+  val SPARK_VERSION: String = org.apache.spark.SPARK_VERSION
+
+  val OIDC_JOB_MAIN_CLASS: String =
+    "org.apache.spark.security.aws.integrationtest.OidcS3ReadWriteJob"
+
+  val ROTATION_JOB_MAIN_CLASS: String =
+    "org.apache.spark.security.aws.integrationtest.OidcTokenRotationJob"
+
+  val LATE_EXECUTOR_JOB_MAIN_CLASS: String =
+    "org.apache.spark.security.aws.integrationtest.OidcLateExecutorJob"
+
+  val TIMEOUT: Timeout = Timeout(Span(10, Minutes))
+  // After spark-submit returns (it blocks until the driver completes), the output
+  // should already be present; only a short poll is needed for eventual consistency.
+  val VERIFY_TIMEOUT: Timeout = Timeout(Span(2, Minutes))
+  val INTERVAL: Interval = Interval(Span(10, Seconds))
+
+  /** ScalaTest tag to mark tests that require a running Kubernetes cluster and moto. */
+  object oidcE2eTag extends Tag("org.apache.spark.security.aws.integrationtest.OidcE2ETest")
+}

--- a/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/SparkAppLauncher.scala
+++ b/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/SparkAppLauncher.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.security.aws.integrationtest
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Path, Paths}
+import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
+
+/**
+ * Minimal spark-submit driver used by the OIDC E2E tests.
+ *
+ * These helpers are intentionally self-contained (rather than depending on the
+ * `spark-kubernetes-integration-tests` test-jar) so that this module resolves
+ * cleanly under both Maven and sbt. They mirror the small set of helpers of the
+ * same name in `resource-managers/kubernetes/integration-tests`.
+ */
+private[integrationtest] class SparkAppConf {
+
+  private val map = mutable.Map[String, String]()
+
+  def set(key: String, value: String): SparkAppConf = {
+    map.put(key, value)
+    this
+  }
+
+  def get(key: String): String = map.getOrElse(key, "")
+
+  override def toString: String = map.toString
+
+  def toStringArray: Iterable[String] =
+    map.toList.flatMap(t => List("--conf", s"${t._1}=${t._2}"))
+}
+
+private[integrationtest] case class SparkAppArguments(
+    mainAppResource: String,
+    mainClass: String,
+    appArgs: Array[String])
+
+private[integrationtest] object SparkAppLauncher extends Logging {
+
+  def launch(
+      appArguments: SparkAppArguments,
+      appConf: SparkAppConf,
+      timeoutSecs: Int,
+      sparkHomeDir: Path): Unit = {
+    val sparkSubmitExecutable = sparkHomeDir.resolve(Paths.get("bin", "spark-submit"))
+    logInfo(s"Launching a spark app with arguments $appArguments and conf $appConf")
+    val commandLine = mutable.ArrayBuffer(
+      sparkSubmitExecutable.toFile.getAbsolutePath,
+      "--deploy-mode", "cluster",
+      "--class", appArguments.mainClass,
+      "--master", appConf.get("spark.master")) ++
+      appConf.toStringArray :+ appArguments.mainAppResource
+
+    if (appArguments.appArgs.nonEmpty) {
+      commandLine ++= appArguments.appArgs
+    }
+    logInfo(s"Launching a spark app with command line: ${commandLine.mkString(" ")}")
+    ProcessUtils.executeProcess(commandLine.toArray, timeoutSecs)
+  }
+}
+
+private[integrationtest] object ProcessUtils extends Logging {
+  /**
+   * executeProcess is used to run a command and return the output if it
+   * completes within timeout seconds.
+   */
+  def executeProcess(
+      fullCommand: Array[String],
+      timeout: Long,
+      dumpOutput: Boolean = true,
+      dumpErrors: Boolean = true): Seq[String] = {
+    val pb = new ProcessBuilder().command(fullCommand: _*)
+    pb.redirectErrorStream(true)
+    val proc = pb.start()
+    val outputLines = new ArrayBuffer[String]
+    Utils.tryWithResource(proc.getInputStream)(
+      Source.fromInputStream(_, StandardCharsets.UTF_8.name()).getLines().foreach { line =>
+        if (dumpOutput) {
+          logInfo(line)
+        }
+        outputLines += line
+      })
+    assert(proc.waitFor(timeout, TimeUnit.SECONDS),
+      s"Timed out while executing ${fullCommand.mkString(" ")}")
+    assert(proc.exitValue == 0,
+      s"Failed to execute -- ${fullCommand.mkString(" ")} --" +
+        s"${if (dumpErrors) "\n" + outputLines.mkString("\n")}")
+    outputLines.toSeq
+  }
+}

--- a/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/SparkAppLauncher.scala
+++ b/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/SparkAppLauncher.scala
@@ -30,10 +30,11 @@ import org.apache.spark.util.Utils
 /**
  * Minimal spark-submit driver used by the OIDC E2E tests.
  *
- * These helpers are intentionally self-contained (rather than depending on the
- * `spark-kubernetes-integration-tests` test-jar) so that this module resolves
- * cleanly under both Maven and sbt. They mirror the small set of helpers of the
- * same name in `resource-managers/kubernetes/integration-tests`.
+ * These helpers are intentionally self-contained rather than depending on the
+ * `spark-kubernetes-integration-tests` test-jar. Depending on it would force every
+ * build of this module to also activate `-Pkubernetes-integration-tests`, so the small
+ * set of helpers is duplicated here instead. They mirror the equivalents of the same
+ * name in `resource-managers/kubernetes/integration-tests`.
  */
 private[integrationtest] class SparkAppConf {
 

--- a/dev/scalastyle
+++ b/dev/scalastyle
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-SPARK_PROFILES=${1:-"-Pkubernetes -Pyarn -Pspark-ganglia-lgpl -Pkinesis-asl -Pcredential-aws -Phive-thriftserver -Phive -Pvolcano -Pjvm-profiler -Phadoop-cloud -Pdocker-integration-tests -Pkubernetes-integration-tests"}
+SPARK_PROFILES=${1:-"-Pkubernetes -Pyarn -Pspark-ganglia-lgpl -Pkinesis-asl -Pcredential-aws -Poidc-e2e -Phive-thriftserver -Phive -Pvolcano -Pjvm-profiler -Phadoop-cloud -Pdocker-integration-tests -Pkubernetes-integration-tests"}
 
 # NOTE: echo "q" is needed because SBT prompts the user for input on encountering a build file
 # with failure (either resolution or compilation); the "q" makes SBT quit.

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -493,6 +493,7 @@ credential_aws = Module(
     dependencies=[tags, core],
     source_file_regexes=[
         "connector/credential-aws/",
+        "connector/credential-aws-integration-tests/",
     ],
     build_profile_flags=[
         "-Pcredential-aws",

--- a/pom.xml
+++ b/pom.xml
@@ -3526,6 +3526,13 @@
     </profile>
 
     <profile>
+      <id>oidc-e2e</id>
+      <modules>
+        <module>connector/credential-aws-integration-tests</module>
+      </modules>
+    </profile>
+
+    <profile>
       <id>test-java-home</id>
       <activation>
         <property><name>env.JAVA_HOME</name></property>

--- a/pom.xml
+++ b/pom.xml
@@ -3528,6 +3528,10 @@
     <profile>
       <id>oidc-e2e</id>
       <modules>
+        <!-- The integration-tests module depends on the credential-aws module, so
+             include it here too. This lets -Poidc-e2e be used on its own (without also
+             passing -Pcredential-aws) without failing dependency resolution. -->
+        <module>connector/credential-aws</module>
         <module>connector/credential-aws-integration-tests</module>
       </modules>
     </profile>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -73,10 +73,12 @@ object BuildCommons {
 
   val optionallyEnabledProjects@Seq(kubernetes, yarn,
     sparkGangliaLgpl, streamingKinesisAsl, profiler, credentialAws,
-    dockerIntegrationTests, hadoopCloud, kubernetesIntegrationTests) =
+    dockerIntegrationTests, hadoopCloud, kubernetesIntegrationTests,
+    credentialAwsIntegrationTests) =
     Seq("kubernetes", "yarn",
       "ganglia-lgpl", "streaming-kinesis-asl", "profiler", "credential-aws",
-      "docker-integration-tests", "hadoop-cloud", "kubernetes-integration-tests").map(ProjectRef(buildLocation, _))
+      "docker-integration-tests", "hadoop-cloud", "kubernetes-integration-tests",
+      "credential-aws-integration-tests").map(ProjectRef(buildLocation, _))
 
   val assemblyProjects@Seq(networkYarn, streamingKafka010Assembly, streamingKinesisAslAssembly) =
     Seq("network-yarn", "streaming-kafka-0-10-assembly", "streaming-kinesis-asl-assembly")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a new optional integration-test module, `connector/credential-aws-integration-tests`, that validates the end-to-end OIDC credential propagation pipeline on a real Kubernetes cluster (Minikube). This is Sub-task 11 of the OIDC Credential Propagation SPIP ([SPARK-57703](https://issues.apache.org/jira/browse/SPARK-57703)), and it exercises the
whole feature together: projected ServiceAccount token -> `FileTokenIngestor` -> `AwsStsCredentialProvider` -> STS -> S3A read/write, plus mid-job token rotation and late-registering executors.

The tests use [moto](https://github.com/getmoto/moto) (Apache 2.0-licensed) as a lightweight S3 + STS backend. The original SPIP mentioned LocalStack, but both LocalStack and MinIO have moved away from freely usable OSS distributions and are incompatible with the ASF license policy. moto runs as a plain HTTP server (no extra container) and does not
verify the OIDC JWT, keeping the test focused on Spark's credential propagation logic.

**Three scenarios are implemented:**

1. **Basic flow** (`OidcS3ReadWriteJob`): a Spark job on Minikube exchanges the identity token for STS credentials and reads/writes S3 via S3A.
2. **Mid-job token rotation** (`OidcTokenRotationJob`): a long-running job writes to S3 repeatedly while the test rewrites the identity token file in the driver pod. The initial token is supplied by an init container into an emptyDir (an externally-provided, rotatable token file, as the SPIP assumes). The rotated token carries a *different* principal; with a short renewal interval, `UserCredentialManager` re-reads it, re-exchanges it via STS, and propagates fresh credentials. The test asserts the driver logged the rotated principal (proving the new token was actually read, not a no-op) and that S3 output for all iterations spanning the rotation is present.
3. **Late-registering executor** (`OidcLateExecutorJob`): with dynamic allocation and a short idle timeout, a job warms up, idles until executors scale down, then runs a wider stage that forces new executors to register *after* credentials were acquired. The test asserts more than one distinct executor registered over the run (evidence of a genuinely late-registering executor) and that the wide stage produced all outputs — an executor that did not receive credentials via the `SparkAppConfig` registration response would have failed its task.

**Structure and design:**

- The module is gated behind the `-Poidc-e2e` Maven profile (and requires `-Pkubernetes`), so it is skipped by default.
- Jobs that run on the cluster live in `src/main` so they are packaged into the module jar and baked into the Spark image; test classes are not packaged.
- S3A support (hadoop-aws + AWS SDK) is provided by building the image with `-Phadoop-cloud`.
- Image building is handled by an explicit step (`docker-image-tool.sh`) in CI and by `dev-run-integration-tests.sh` locally, rather than being bound to the sbt test task.
- The spark-submit helpers (`SparkAppLauncher`, `SparkAppConf`, `SparkAppArguments`, `ProcessUtils`) are implemented locally instead of depending on the `spark-kubernetes-integration-tests` test-jar, which sbt could not resolve as an inter-project reference. They mirror the equivalents there.
- moto is reached from two vantage points: pods use the host gateway IP (`spark.oidc.test.s3Endpoint` / `stsEndpoint`), while the test process uses loopback (`spark.oidc.test.s3ClientEndpoint`). In CI, moto is installed into an isolated virtualenv
(to avoid the OS-provided urllib3/pyOpenSSL that crashes moto on startup) and started inside the same workflow step that runs the tests.

**New files:**
- `connector/credential-aws-integration-tests/` — module with the test suite (`OidcCredentialE2ESuite`), the three Spark jobs, spark-submit helpers, `pom.xml`, `log4j2.properties`, a local runner script (`dev-run-integration-tests.sh`), and `README.md`.

**Modified files:**
- `pom.xml` (root) — add the `oidc-e2e` profile / module.
- `project/SparkBuild.scala` — register `credentialAwsIntegrationTests`.
- `.github/workflows/build_and_test.yml` — add the `oidc-e2e` job (moto + Minikube).

### Why are the changes needed?
The SPIP calls for an end-to-end test that validates the full credential propagation pipeline in a realistic Kubernetes environment. The prior sub-tasks each cover a slice with unit/integration tests, but nothing exercised the entire flow — token ingestion, STS exchange, RPC + SparkAppConfig propagation, S3A read/write, and mid-job refresh — against a real cluster. This module provides that coverage and guards against regressions in how the pieces fit together.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
This *is* the test. The suite was run on a local Minikube (with moto) under both build tools and all three scenarios passed:

- sbt: `build/sbt -Phadoop-3 -Pkubernetes -Pcredential-aws -Poidc-e2e ... credential-aws-integration-tests/test`
- Maven: `build/mvn integration-test -pl connector/credential-aws-integration-tests -Phadoop-3 -Pkubernetes -Pcredential-aws -Poidc-e2e ...`

The new `oidc-e2e` GitHub Actions job (Minikube + moto) is green. `dev-run-integration-tests.sh` was also verified to build the image, start/stop moto, and run the suite end-to-end.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
