### PR TITLE
[SPARK-57130][BUILD][FOLLOWUP] make-distribution.sh copies the generated pyspark.zip into the distribution

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -367,6 +367,7 @@ cp "$SPARK_HOME/README.md" "$DISTDIR"
 cp -r "$SPARK_HOME/bin" "$DISTDIR"
 if command -v git && command -v cpio && git rev-parse --git-dir 2>/dev/null; then
   git ls-files -z "$SPARK_HOME/python" | cpio -0pdm "$DISTDIR"
+  cp "$SPARK_HOME/python/lib/pyspark.zip" "$DISTDIR/python/lib"
 else
   cp -r "$SPARK_HOME/python" "$DISTDIR"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

`make-distribution.sh` copies `python/lib/pyspark.zip` into the distribution, alongside the git-tracked python files.

### Why are the changes needed?

SPARK-57130 (#56186) made `make-distribution.sh` copy only git-tracked files for the `python` folder. `python/lib/pyspark.zip` is generated by the build (assembly module) and gitignored, so it no longer reaches the distribution.

Without it:
- `PythonUtils.sparkPythonPath` adds `$SPARK_HOME/python/lib/pyspark.zip` to `PYTHONPATH`, so `bin/pyspark` and Python applications cannot import pyspark from the tarball unless it is pip-installed.
- PySpark applications in YARN mode fail at `Client.findPySparkArchives()`, which requires the file to exist.

### Does this PR introduce _any_ user-facing change?

No. SPARK-57130 broke some PySpark use cases of the binary distribution, but it is unreleased, so no users are affected.

### How was this patch tested?

Ran `dev/make-distribution.sh` on a fresh worktree before and after SPARK-57130, and compared the resulting `dist/python` trees file by file: they are identical except for `python/lib/pyspark.zip`, which is missing after SPARK-57130. Exercised the patched copy step against the built tree, and `dist/python/lib/pyspark.zip` is restored:

```
$ ls dist/python/lib
PY4J_LICENSE.txt		py4j-0.10.9.9-src.zip		pyspark.zip
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex CLI
