### PR TITLE
[SPARK-58837][CONNECT] Use per-module Python loggers

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1280,6 +1280,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_connect_column",
         "pyspark.sql.tests.connect.test_connect_creation",
         "pyspark.sql.tests.connect.test_connect_readwriter",
+        "pyspark.sql.tests.connect.test_connect_logging",
         "pyspark.sql.tests.connect.test_connect_retry",
         "pyspark.sql.tests.connect.test_connect_session",
         "pyspark.sql.tests.connect.test_connect_local_server",

--- a/python/docs/source/development/logger.rst
+++ b/python/docs/source/development/logger.rst
@@ -167,3 +167,44 @@ This approach aligns with the standard Python logging practices.
     file_logger.warning(f"User {user} takes an {action}", user=user, action=action)
 
 The log messages will be saved in `application.log` in the same JSON format.
+
+Spark Connect Client Logging
+============================
+
+The Spark Connect Python client logs through one logger per module, all rooted at
+``pyspark.sql.connect``. Every Connect log record is emitted through a single handler on that
+root logger, in the same JSON format described above.
+
+============================================  ==========================================
+Logger                                        Covers
+============================================  ==========================================
+``pyspark.sql.connect``                       Root of the hierarchy, sets the default level
+``pyspark.sql.connect.client.core``           RPC requests and responses, Arrow batches, plan compression
+``pyspark.sql.connect.client.retries``        Retries and backoff, including gRPC ``UNAVAILABLE``
+``pyspark.sql.connect.client.reattach``       Reattachable execution streams
+``pyspark.sql.connect.client.artifact``       Artifact uploads
+``pyspark.sql.connect.dataframe``             DataFrame operations
+``pyspark.sql.connect.plan``                  Logical plan construction and cached relation cleanup
+``pyspark.sql.connect.session``               Session lifecycle
+============================================  ==========================================
+
+Connect logging is disabled by default. Setting the ``SPARK_CONNECT_LOG_LEVEL`` environment
+variable enables the whole hierarchy at that level:
+
+.. code-block:: bash
+
+    export SPARK_CONNECT_LOG_LEVEL=debug
+
+``DEBUG`` on the whole hierarchy is verbose, because ``client.core`` dumps every request and
+response. To follow one area instead, set the level on that logger with the standard Python
+logging module. For example, to watch the client retry against an unresponsive server without
+the rest of the output:
+
+.. code-block:: python
+
+    import logging
+
+    logging.getLogger("pyspark.sql.connect.client.retries").setLevel(logging.DEBUG)
+
+Levels are read when a message is logged, so this takes effect at any point, including after the
+session has been created.

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -33,7 +33,9 @@ import grpc
 import pyspark.sql.connect.proto as proto
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
 from pyspark.errors import PySparkRuntimeError, PySparkValueError
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
+
+logger = getLogger(__name__)
 
 JAR_PREFIX: str = "jars"
 PYFILE_PREFIX: str = "pyfiles"

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -96,7 +96,7 @@ from pyspark.sql.connect.expressions import (
     LiteralExpression,
     PythonUDF,
 )
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
 from pyspark.sql.connect.observation import Observation
 from pyspark.sql.connect.plan import (
     CommonInlineUserDefinedDataSource,
@@ -125,6 +125,8 @@ if TYPE_CHECKING:
     from pyspark.sql.connect.session import SparkSession
     from pyspark.sql.datasource import DataSource
 
+
+logger = getLogger(__name__)
 
 PYSPARK_ROOT = os.path.dirname(pyspark.__file__)
 _OPERATION_ID_METADATA_KEY = "spark-connect-operation-id"

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -29,8 +29,10 @@ import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
 from pyspark.errors import PySparkRuntimeError
 from pyspark.sql.connect.client.retries import RetryException, Retrying
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
 from pyspark.util import disable_gc
+
+logger = getLogger(__name__)
 
 
 class ExecutePlanResponseReattachableIterator(Generator):

--- a/python/pyspark/sql/connect/client/retries.py
+++ b/python/pyspark/sql/connect/client/retries.py
@@ -27,7 +27,9 @@ from google.rpc import error_details_pb2
 from grpc_status import rpc_status
 
 from pyspark.errors import PySparkRuntimeError
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
+
+logger = getLogger(__name__)
 
 """
 This module contains retry system. The system is designed to be

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -71,7 +71,7 @@ from pyspark.sql.connect.expressions import (
 )
 from pyspark.sql.connect.functions import builtin as F
 from pyspark.sql.connect.group import GroupedData
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
 from pyspark.sql.connect.merge import MergeIntoWriter
 from pyspark.sql.connect.readwriter import DataFrameWriter, DataFrameWriterV2
 from pyspark.sql.connect.streaming.readwriter import DataStreamWriter
@@ -109,6 +109,9 @@ if TYPE_CHECKING:
     from pyspark.sql.metrics import ExecutionInfo
     from pyspark.sql.pandas._typing import DataFrameLike as PandasDataFrameLike
     from pyspark.sql.plot import PySparkPlotAccessor
+
+
+logger = getLogger(__name__)
 
 
 class DataFrame(ParentDataFrame):

--- a/python/pyspark/sql/connect/logging.py
+++ b/python/pyspark/sql/connect/logging.py
@@ -20,9 +20,57 @@ import logging
 import os
 from typing import Optional
 
-from pyspark.logger import PySparkLogger
+from pyspark.logger.logger import JSONFormatter
 
-__all__ = ["configureLogging", "getLogLevel"]
+__all__ = ["configureLogging", "getLogger", "getLogLevel"]
+
+# Root of the Spark Connect logger hierarchy. It owns the handler that all Connect loggers
+# write through, and its level is the default for every logger below it.
+_CONNECT_LOGGER_NAME = "pyspark.sql.connect"
+
+# Above CRITICAL, so nothing is emitted. Used instead of `Logger.disabled` because `disabled`
+# is only honored on the logger a message is logged on, which would leave child loggers
+# inheriting the standard library root logger's WARNING instead of staying silent.
+_LOG_LEVEL_OFF = logging.CRITICAL + 1
+
+_handler: Optional[logging.Handler] = None
+
+
+def getLogger(name: Optional[str] = None) -> logging.Logger:
+    """
+    Return a logger in the Spark Connect logger hierarchy, creating it if necessary.
+
+    Spark Connect logs through one logger per module, all rooted at ``pyspark.sql.connect``,
+    so a single area can be turned on without enabling the rest:
+
+    .. code-block:: python
+
+        import logging
+
+        logging.getLogger("pyspark.sql.connect.client.retries").setLevel(logging.DEBUG)
+
+    The available loggers are ``pyspark.sql.connect`` and, below it, ``client.core``,
+    ``client.retries``, ``client.reattach``, ``client.artifact``, ``dataframe``, ``plan``,
+    and ``session``.
+
+    Parameters
+    ----------
+    name : str, optional
+        Name of the logger, either relative to ``pyspark.sql.connect`` or fully qualified.
+        When omitted, the root Spark Connect logger is returned.
+
+    .. versionadded:: 4.4.0
+    """
+    if not name or name == _CONNECT_LOGGER_NAME:
+        qualified_name = _CONNECT_LOGGER_NAME
+    elif name.startswith(_CONNECT_LOGGER_NAME + "."):
+        qualified_name = name
+    else:
+        qualified_name = f"{_CONNECT_LOGGER_NAME}.{name}"
+
+    # Deliberately a plain logger rather than PySparkLogger, which attaches a handler to every
+    # instance it creates. Records propagate to the handler on the root Connect logger instead.
+    return logging.getLogger(qualified_name)
 
 
 def configureLogging(level: Optional[str] = None) -> logging.Logger:
@@ -32,25 +80,38 @@ def configureLogging(level: Optional[str] = None) -> logging.Logger:
     the SPARK_CONNECT_LOG_LEVEL environment variable.
     When both are absent, logging is disabled.
 
+    The level applies to the root Spark Connect logger, and therefore to every Connect logger
+    that does not have a level of its own. See :func:`getLogger` for enabling a single logger.
+
     .. versionadded:: 4.0.0
+
+    .. versionchanged:: 4.4.0
+        Repeated calls no longer attach an additional handler, and a level set on the root
+        Spark Connect logger before PySpark is imported is no longer overwritten.
     """
-    logger = PySparkLogger.getLogger(__name__)
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(fmt="%(asctime)s %(process)d %(levelname)s %(funcName)s %(message)s")
-    )
-    logger.addHandler(handler)
+    global _handler
+
+    logger = logging.getLogger(_CONNECT_LOGGER_NAME)
+
+    if _handler is None:
+        _handler = logging.StreamHandler()
+        _handler.setFormatter(JSONFormatter())
+    if _handler not in logger.handlers:
+        logger.addHandler(_handler)
+
+    if level is None:
+        level = os.environ.get("SPARK_CONNECT_LOG_LEVEL")
 
     if level is not None:
         logger.setLevel(level.upper())
-    elif "SPARK_CONNECT_LOG_LEVEL" in os.environ:
-        logger.setLevel(os.environ["SPARK_CONNECT_LOG_LEVEL"].upper())
-    else:
-        logger.disabled = True
+        logger.disabled = False
+    elif logger.level == logging.NOTSET:
+        logger.setLevel(_LOG_LEVEL_OFF)
     return logger
 
 
-# Instantiate the logger based on the environment configuration.
+# Instantiate the root Spark Connect logger based on the environment configuration. Kept as a
+# module-level name for backwards compatibility, new code should use getLogger(__name__).
 logger = configureLogging()
 
 
@@ -63,6 +124,6 @@ def getLogLevel() -> Optional[int]:
     .. versionadded:: 3.5.0
     """
 
-    if not logger.disabled:
+    if not logger.disabled and logger.level < _LOG_LEVEL_OFF:
         return logger.level
     return None

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -50,7 +50,7 @@ from pyspark.serializers import CloudPickleSerializer
 from pyspark.sql.column import Column
 from pyspark.sql.connect.conversion import storage_level_to_proto
 from pyspark.sql.connect.expressions import Expression, SubqueryExpression
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
 from pyspark.sql.connect.proto import base_pb2 as spark_dot_connect_dot_base__pb2
 from pyspark.sql.connect.types import UnparsedDataType, pyspark_types_to_proto_types
 from pyspark.sql.types import DataType, StructType
@@ -61,6 +61,9 @@ if TYPE_CHECKING:
     from pyspark.sql.connect.observation import Observation
     from pyspark.sql.connect.session import SparkSession
     from pyspark.sql.connect.udf import UserDefinedFunction
+
+
+logger = getLogger(__name__)
 
 
 class LogicalPlan:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -61,7 +61,7 @@ from pyspark.sql.connect.client import DefaultChannelBuilder, SparkConnectClient
 from pyspark.sql.connect.conf import RuntimeConf
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.functions import builtin as F
-from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.logging import getLogger
 from pyspark.sql.connect.plan import (
     SQL,
     CachedRelation,
@@ -112,6 +112,9 @@ if TYPE_CHECKING:
     from pyspark.sql.connect.tvf import TableValuedFunction
     from pyspark.sql.connect.udf import UDFRegistration
     from pyspark.sql.connect.udtf import UDTFRegistration
+
+
+logger = getLogger(__name__)
 
 
 class SparkSession:

--- a/python/pyspark/sql/tests/connect/test_connect_logging.py
+++ b/python/pyspark/sql/tests/connect/test_connect_logging.py
@@ -1,0 +1,175 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import contextlib
+import io
+import logging
+import os
+import unittest
+from unittest import mock
+
+from pyspark.testing.connectutils import (
+    connect_requirement_message,
+    should_test_connect,
+)
+
+if should_test_connect:
+    from pyspark.sql.connect import logging as connect_logging
+
+CONNECT_ROOT = "pyspark.sql.connect"
+
+MODULE_LOGGERS = [
+    "pyspark.sql.connect.client.core",
+    "pyspark.sql.connect.client.retries",
+    "pyspark.sql.connect.client.reattach",
+    "pyspark.sql.connect.client.artifact",
+    "pyspark.sql.connect.dataframe",
+    "pyspark.sql.connect.plan",
+    "pyspark.sql.connect.session",
+]
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class ConnectLoggingTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = {}
+        for logger in [logging.getLogger()] + [
+            logging.getLogger(name) for name in [CONNECT_ROOT] + MODULE_LOGGERS
+        ]:
+            self._saved[logger.name] = (logger.level, logger.disabled, list(logger.handlers))
+
+        # Detach the handler owned by the module so that enabling a level in a test does not
+        # write to stderr. configureLogging reattaches it, which test_single_handler relies on.
+        logging.getLogger(CONNECT_ROOT).removeHandler(connect_logging._handler)
+
+    def tearDown(self):
+        for name, (level, disabled, handlers) in self._saved.items():
+            logger = logging.getLogger(name)
+            logger.setLevel(level)
+            logger.disabled = disabled
+            logger.handlers[:] = handlers
+        logging.Logger.manager._clear_cache()
+
+    @contextlib.contextmanager
+    def env_log_level(self, value=None):
+        env = {} if value is None else {"SPARK_CONNECT_LOG_LEVEL": value}
+        with mock.patch.dict(os.environ, env, clear=True):
+            yield
+
+    @contextlib.contextmanager
+    def capture(self, *names):
+        buffer = io.StringIO()
+        handler = logging.StreamHandler(buffer)
+        handler.setLevel(logging.NOTSET)
+        loggers = [logging.getLogger(name) for name in names]
+        for logger in loggers:
+            logger.addHandler(handler)
+        # Keep captured records off stderr, in case a preceding configureLogging reattached it.
+        logging.getLogger(CONNECT_ROOT).removeHandler(connect_logging._handler)
+        try:
+            yield buffer
+        finally:
+            for logger in loggers:
+                logger.removeHandler(handler)
+
+    def configure_default(self):
+        """Reconfigure as if PySpark were freshly imported with no logging configured."""
+        for name in [CONNECT_ROOT] + MODULE_LOGGERS:
+            logging.getLogger(name).setLevel(logging.NOTSET)
+        logging.Logger.manager._clear_cache()
+        with self.env_log_level():
+            connect_logging.configureLogging()
+
+    def test_get_logger_resolves_names(self):
+        self.assertEqual(connect_logging.getLogger().name, CONNECT_ROOT)
+        self.assertEqual(
+            connect_logging.getLogger("client.retries").name,
+            "pyspark.sql.connect.client.retries",
+        )
+        self.assertEqual(
+            connect_logging.getLogger("pyspark.sql.connect.client.retries").name,
+            "pyspark.sql.connect.client.retries",
+        )
+
+    def test_default_is_silent(self):
+        self.configure_default()
+        for name in MODULE_LOGGERS:
+            logger = logging.getLogger(name)
+            self.assertGreater(logger.getEffectiveLevel(), logging.CRITICAL, name)
+            self.assertFalse(logger.isEnabledFor(logging.WARNING), name)
+
+    def test_no_warning_leak_to_root(self):
+        # A disabled parent does not silence its children, so the off switch has to be a level.
+        # Without it, children would inherit the standard library root logger's WARNING.
+        self.configure_default()
+        with self.capture(CONNECT_ROOT, "") as buffer:
+            logging.getLogger("pyspark.sql.connect.client.retries").warning("leaked")
+        self.assertEqual(buffer.getvalue(), "")
+
+    def test_single_handler(self):
+        for _ in range(3):
+            with self.env_log_level():
+                connect_logging.configureLogging()
+        handlers = logging.getLogger(CONNECT_ROOT).handlers
+        self.assertEqual(handlers.count(connect_logging._handler), 1)
+
+    def test_env_var_sets_root_level(self):
+        with self.env_log_level("debug"):
+            connect_logging.configureLogging()
+        self.assertEqual(logging.getLogger(CONNECT_ROOT).level, logging.DEBUG)
+        for name in MODULE_LOGGERS:
+            self.assertTrue(logging.getLogger(name).isEnabledFor(logging.DEBUG), name)
+
+    def test_configure_logging_argument_re_enables(self):
+        self.configure_default()
+        self.assertIsNone(connect_logging.getLogLevel())
+
+        with self.env_log_level():
+            connect_logging.configureLogging("warn")
+        self.assertEqual(connect_logging.getLogLevel(), logging.WARNING)
+
+    def test_child_enabled_independently(self):
+        self.configure_default()
+        logging.getLogger("pyspark.sql.connect.client.retries").setLevel(logging.DEBUG)
+
+        with self.capture(CONNECT_ROOT) as buffer:
+            logging.getLogger("pyspark.sql.connect.client.retries").debug("retry detail")
+            logging.getLogger("pyspark.sql.connect.client.core").debug("proto dump")
+
+        self.assertIn("retry detail", buffer.getvalue())
+        self.assertNotIn("proto dump", buffer.getvalue())
+
+    def test_get_log_level(self):
+        self.configure_default()
+        self.assertIsNone(connect_logging.getLogLevel())
+
+        with self.env_log_level("debug"):
+            connect_logging.configureLogging()
+        self.assertEqual(connect_logging.getLogLevel(), logging.DEBUG)
+
+    def test_user_set_root_level_survives_configure(self):
+        # A level set before PySpark is imported must not be overwritten by the default.
+        logging.getLogger(CONNECT_ROOT).setLevel(logging.INFO)
+        with self.env_log_level():
+            connect_logging.configureLogging()
+        self.assertEqual(logging.getLogger(CONNECT_ROOT).level, logging.INFO)
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is an attempt at [SPARK-58837](https://issues.apache.org/jira/projects/SPARK/issues/SPARK-58837?filter=reportedbyme). We introduce per-module Python loggers for the Spark Connect Python client, so that logging levels can be controlled on a per-module basis.

For example, a client can now do:

```py
  import logging
  logging.getLogger("pyspark.sql.connect.client.retries").setLevel(logging.DEBUG)
```

to log retries.


Other changes:

- Fix issue in `configureLogger` which would add new handlers every time it is called. We now only create a handler once.
- Fix issue where logs would be emitted twice, by `PySparkLogger` and by the handler added by `configureLogger`

### Why are the changes needed?

Currently, the Python Connect client logs everything using the `pyspark.sql.connect.logging` root logger, which is gated on the `SPARK_CONNECT_LOG_LEVEL` environment variable, so we cannot control logging on a fine-grained fashion.

For example, when trying to connect to a Connect server that does not respond, the client will silently retry and backoff, which can be confusing to users. Enabling logging of gRPC UNAVAILABLE retries would be useful, but is only possible by setting `SPARK_CONNECT_LOG_LEVEL=DEBUG`, which then produces way too much log volume.

### Does this PR introduce _any_ user-facing change?

- Users can now control logging levels on a per-module level.
- Logs are not duplicated anymore.


### How was this patch tested?

Unit tests


### Was this patch authored or co-authored using generative AI tooling?

`Generated-by:  codex-cli 0.147.0`