### PR TITLE
[SPARK-59128][BUILD] Upgrade mariadb-java-client from 3.5.7 to 3.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
       --enable-native-access=ALL-UNNAMED
       -XX:+EnableDynamicAgentLoading
     </extraJavaTestArgs>
-    <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
+    <mariadb.java.client.version>3.5.10</mariadb.java.client.version>
     <mysql.connector.version>9.6.0</mysql.connector.version>
     <postgresql.version>42.7.13</postgresql.version>
     <db2.jcc.version>12.1.4.0</db2.jcc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `org.mariadb.jdbc:mariadb-java-client` from 3.5.7 to 3.5.10.

### Why are the changes needed?

3.5.9 fixes three CVEs that affect 3.5.0 through 3.5.8:

- [CVE-2026-55856](https://github.com/advisories/GHSA-g9jj-cgmh-9f38): the initial handshake writes a `mysql_clear_password` response after checking only that SSL is enabled, so a MITM presenting a self-signed certificate gets the password before the certificate fingerprint is checked.
- [CVE-2026-55857](https://github.com/advisories/GHSA-qxvw-fvwx-5cp7): cleartext transmission of sensitive information and insufficiently protected credentials.
- [CVE-2026-55858](https://github.com/advisories/GHSA-xvr9-35cr-46v9): inappropriate encoding for output context.

3.5.10 fixes more issues of the same kind: CONJ-1342 (`socketFactory` can load arbitrary bytecode through a `jar:` URL, which is RCE when the JDBC URL is attacker controlled), CONJ-1332 (a rogue server can cause a pre-auth OOM with a multipart packet) and CONJ-1326 (unsafe escaping in `enquoteLiteral()`).

Release notes: [3.5.8](https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.5.8), [3.5.9](https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.5.9), [3.5.10](https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.5.10).

### Does this PR introduce _any_ user-facing change?

No. The driver is a test-scoped dependency of `sql/core` and `connector/docker-integration-tests`, so it is not on a published classpath and does not appear in `dev/deps/spark-deps-*`.

### How was this patch tested?

`build/sbt "sql/testOnly *MariaDBConnectionProviderSuite *ConnectionProviderSuite"` passes (16 tests). Those suites load `org.mariadb.jdbc.Driver` and run the secure connection provider against it, which is where Spark touches the driver outside the Docker integration tests. The Docker integration tests were not run locally.

The CVE-2026-55856 fix only takes effect when TLS is enabled and an untrusted certificate was accepted under `sslMode=verify-full` or `verify-ca`, so it does not change how the MariaDB and MySQL integration tests connect.

Pass GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
