### PR TITLE
[SPARK-59118][SQL][4.x] Warn when doAs is enabled but not enforced

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -23,12 +23,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.hadoop.hive.common.ServerUtils
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
+import org.apache.hive.service.auth.HiveAuthFactory.AuthTypes
 import org.apache.hive.service.cli.thrift.{ThriftBinaryCLIService, ThriftHttpCLIService}
 import org.apache.hive.service.server.HiveServer2
 
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.LogKeys.CONFIG
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql.{SparkSession, SQLContext}
 import org.apache.spark.sql.hive.HiveUtils
@@ -105,6 +107,28 @@ object HiveThriftServer2 extends Logging {
     }
   }
 
+  // Sessions are impersonated for metastore calls, but queries run as the service identity
+  // (SPARK-5159), so storage ACLs are checked against the wrong principal. Auth types that never
+  // establish a user identity have nothing to impersonate, so they are exempt.
+  private[thriftserver] def warnIfIneffectiveDoAs(hiveConf: HiveConf): Unit = {
+    val authType = hiveConf.getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION)
+    val unverifiedAuthTypes = Seq(AuthTypes.NONE, AuthTypes.NOSASL).map(_.getAuthName)
+    // Constant on the left: authType is null when explicitly set empty, and this must not NPE.
+    val authVerifiesUser = !unverifiedAuthTypes.exists(_.equalsIgnoreCase(authType))
+    if (authVerifiesUser && hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_ENABLE_DOAS)) {
+      logWarning(log"${MDC(CONFIG, ConfVars.HIVE_SERVER2_ENABLE_DOAS.varname)} is set to true, " +
+        log"but the Spark Thrift Server impersonates the connecting user only for Hive " +
+        log"metastore calls: queries and the storage access they perform still run as the " +
+        log"server's own service identity, so storage permissions are checked against the " +
+        log"service principal rather than the connecting user (SPARK-5159). That can expose " +
+        log"data the connecting user is not authorized to read. Setting it to false silences " +
+        log"this, but note that it stops impersonating metastore calls too, so it is not a " +
+        log"no-op (and unsetting it does not help -- Hive's own default is true). Spark 5.0 " +
+        log"is expected to refuse to start on this configuration; set " +
+        log"spark.sql.hive.thriftServer.allowIneffectiveDoAs=true there to keep it running.")
+    }
+  }
+
   def main(args: Array[String]): Unit = {
     // If the arguments contains "-h" or "--help", print out the usage and exit.
     if (args.contains("-h") || args.contains("--help")) {
@@ -154,6 +178,7 @@ private[hive] class HiveThriftServer2(sparkSession: SparkSession)
   private val started = new AtomicBoolean(false)
 
   override def init(hiveConf: HiveConf): Unit = {
+    HiveThriftServer2.warnIfIneffectiveDoAs(hiveConf)
     val sparkSqlCliService = new SparkSQLCLIService(this, sparkSession)
     setSuperField(this, "cliService", sparkSqlCliService)
     addService(sparkSqlCliService)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2DoAsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2DoAsSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
+import org.apache.hive.service.auth.HiveAuthFactory.AuthTypes
+import org.apache.logging.log4j.Level
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * Tests for the SPARK-59118 startup warning: `hive.server2.enable.doAs` is accepted but
+ * impersonation does not reach query execution. Spark 5.0 refuses to start instead.
+ */
+class HiveThriftServer2DoAsSuite extends SparkFunSuite {
+
+  private def hiveConf(authType: String, doAs: Boolean): HiveConf = {
+    val conf = new HiveConf()
+    conf.setVar(ConfVars.HIVE_SERVER2_AUTHENTICATION, authType)
+    conf.setBoolVar(ConfVars.HIVE_SERVER2_ENABLE_DOAS, doAs)
+    conf
+  }
+
+  /** Warnings naming the doAs conf, emitted while checking `conf`. */
+  private def doAsWarnings(conf: HiveConf): Seq[String] = {
+    val appender = new LogAppender("doAs impersonation warning")
+    val canary = "doAs-appender-canary"
+    withLogAppender(appender, level = Some(Level.WARN)) {
+      HiveThriftServer2.warnIfIneffectiveDoAs(conf)
+      logWarning(canary)
+    }
+    val messages = appender.loggingEvents
+      .filter(_.getLevel == Level.WARN)
+      .map(_.getMessage.getFormattedMessage)
+    // Without this, a broken appender would make every "does not warn" case pass vacuously.
+    assert(messages.exists(_.contains(canary)), "log appender captured nothing")
+    messages.filter(_.contains(ConfVars.HIVE_SERVER2_ENABLE_DOAS.varname)).toSeq
+  }
+
+  // The auth types that establish a user identity worth impersonating.
+  private val verifyingAuthTypes =
+    AuthTypes.values().filterNot(Set(AuthTypes.NONE, AuthTypes.NOSASL)).map(_.getAuthName)
+
+  test("SPARK-5159 / SPARK-59118 warn when doAs is enabled but not enforced") {
+    val warnings = doAsWarnings(hiveConf("KERBEROS", doAs = true))
+    assert(warnings.length == 1)
+    assert(warnings.head.contains("SPARK-5159"))
+  }
+
+  test("SPARK-59118 warn for every auth type that verifies the user") {
+    // Guards against a new AuthTypes value silently landing on the quiet side.
+    assert(verifyingAuthTypes.nonEmpty)
+    verifyingAuthTypes.foreach { authType =>
+      assert(doAsWarnings(hiveConf(authType, doAs = true)).length == 1, s"no warning: $authType")
+    }
+  }
+
+  test("SPARK-59118 does not warn when auth type establishes no user identity") {
+    Seq("NONE", "NOSASL", "none", "noSasl").foreach { authType =>
+      assert(doAsWarnings(hiveConf(authType, doAs = true)).isEmpty, s"warned: $authType")
+    }
+  }
+
+  test("SPARK-59118 does not warn when doAs is disabled") {
+    verifyingAuthTypes.foreach { authType =>
+      assert(doAsWarnings(hiveConf(authType, doAs = false)).isEmpty, s"warned: $authType")
+    }
+  }
+
+  test("SPARK-59118 does not warn on an untouched Hive config") {
+    // Hive defaults doAs to true and auth to NONE, so a stock config must stay quiet.
+    assert(doAsWarnings(new HiveConf()).isEmpty)
+  }
+
+  test("SPARK-59118 an unrecognized auth type warns") {
+    assert(doAsWarnings(hiveConf("NOT_AN_AUTH_TYPE", doAs = true)).length == 1)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a softer follow on of https://github.com/apache/spark/pull/58414 for 4.X branch which warns when doAs is enabled but not enforced. We should log rather than fail a previously running job.

### Why are the changes needed?

People might expect doAs to run as a different user, which is not supported.

### Does this PR introduce _any_ user-facing change?

Explicit error unless config flag is disabled.

### How was this patch tested?

New unit test.

### Was this patch authored or co-authored using generative AI tooling?
Yes, claude 