### PR TITLE
[SPARK-59068][SQL][FOLLOWUP] Validate fully pushed runtime filter attributes

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeFiltering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeFiltering.java
@@ -53,9 +53,9 @@ public interface SupportsRuntimeFiltering extends SupportsRuntimeV2Filtering {
    * Spark tracks runtime-filter eligibility by root attribute. If {@link #filterAttributes()}
    * returns a nested reference, this method may receive a filter on another nested field under
    * the same root. Implementations must inspect each filter and use only filters they can apply.
-   * Nested paths are encoded in a V1 {@link Filter} as unquoted dot-separated names such as
-   * {@code parent.child}. A top-level column whose name contains a dot remains quoted, such as
-   * {@code `parent.child`}.
+   * Nested paths are encoded in a V1 {@link Filter} as dot-separated names, with each path part
+   * quoted as needed, such as {@code parent.`child.with.dot`}. A top-level column whose name
+   * contains a dot remains quoted, such as {@code `parent.child`}.
    * <p>
    * If the scan also implements {@link SupportsReportPartitioning}, it must preserve
    * the originally reported partitioning during runtime filtering. While applying runtime filters,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -207,7 +207,7 @@ case class DataSourceV2ScanRelation(
    */
   lazy val runtimeFilterAttrs: AttributeSet = {
     checkRuntimeFilteringInterfaces()
-    checkFullyPushedFilterAttrs()
+    resolvedFullyPushedRuntimeFilterAttrs
     val filterAttrs = scan match {
       case s: SupportsRuntimeV2Filtering => s.filterAttributes
       case s: SupportsRuntimeCatalystFiltering => s.filterAttributes()
@@ -221,15 +221,19 @@ case class DataSourceV2ScanRelation(
     case _ => Array.empty
   }
 
+  private lazy val resolvedFullyPushedRuntimeFilterAttrs: AttributeSet = {
+    checkFullyPushedFilterAttrs()
+    resolveFilterAttrs(
+      declaredFullyPushedRuntimeFilterAttrs, "fullyPushedFilterAttributes()")
+  }
+
   /**
    * Resolved attributes for which a Catalyst runtime-filtering scan fully evaluates predicates.
    * Empty for a [[SupportsRuntimeV2Filtering]] scan, which keeps its post-scan filters.
    */
   lazy val fullyPushedRuntimeFilterAttrs: AttributeSet = {
     checkRuntimeFilteringInterfaces()
-    checkFullyPushedFilterAttrs()
-    resolveFilterAttrs(
-      declaredFullyPushedRuntimeFilterAttrs, "fullyPushedFilterAttributes()")
+    resolvedFullyPushedRuntimeFilterAttrs
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2CatalystRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2CatalystRuntimeFilterSuite.scala
@@ -198,7 +198,7 @@ class DataSourceV2CatalystRuntimeFilterSuite extends SharedSparkSession {
     }
   }
 
-  test("missing fully pushed filter attribute -> identifies the declaring method") {
+  test("missing fully pushed filter attribute -> rejected through runtime filter attrs") {
     val tbl = s"$catalogName.tbl_missing_fully_pushed_filter_attr"
     withTable(tbl) {
       sql(s"CREATE TABLE $tbl (id INT, part INT) USING $v2Source PARTITIONED BY (part)")
@@ -208,7 +208,7 @@ class DataSourceV2CatalystRuntimeFilterSuite extends SharedSparkSession {
       }.getOrElse(fail("Expected a DataSourceV2ScanRelation"))
       val e = intercept[AnalysisException] {
         scanRelation.copy(scan = new MissingFullyPushedFilterAttributeScan)
-          .fullyPushedRuntimeFilterAttrs
+          .runtimeFilterAttrs
       }
       val scanClass = classOf[MissingFullyPushedFilterAttributeScan].getName
       checkError(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up addresses two comments from the post-merge review of #58370:

- Resolve and cache `fullyPushedFilterAttributes()` when `runtimeFilterAttrs` is accessed, then reuse the cached result from `fullyPushedRuntimeFilterAttrs`. The regression now exercises the primary planning entry point ([review comment](https://github.com/apache/spark/pull/58370#discussion_r3892275062)).
- Clarify that V1 filter names use dot-separated paths with each path part quoted as needed, for example `parent.\`child.with.dot\`` ([review comment](https://github.com/apache/spark/pull/58370#discussion_r3892275058)).

### Why are the changes needed?

The primary planning path checked whether fully-pushed references were top-level but did not resolve them. A missing top-level reference could therefore pass validation when no scalar-subquery filter forced `fullyPushedRuntimeFilterAttrs`, making validation depend on the query shape.

The V1 Javadoc also described nested paths as entirely unquoted even though `FieldReference.toString` quotes individual path parts when needed.

### Does this PR introduce _any_ user-facing change?

Should not if https://github.com/apache/spark/pull/58370 makes it in 4.3, as API is unreleased

### How was this patch tested?

```
build/sbt 'sql/testOnly org.apache.spark.sql.connector.DataSourceV2CatalystRuntimeFilterSuite -- -z "missing fully pushed filter attribute"'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex with GPT-5
