### PR TITLE
[SPARK-59019][SQL][4.2] Make RewriteWithExpression non-excludable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -301,6 +301,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
   def nonExcludableRules: Seq[String] =
     Seq(
       FinishAnalysis.ruleName,
+      // ReplaceExpressions (in FinishAnalysis) turns Between/NullIf into the Unevaluable
+      // With expression; excluding this rule leaks it into codegen and fails with INTERNAL_ERROR.
+      RewriteWithExpression.ruleName,
       RewriteDistinctAggregates.ruleName,
       ReplaceDeduplicateWithAggregate.ruleName,
       ReplaceIntersectWithSemiJoin.ruleName,

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.expressions.{CodegenObjectFactoryMode, GenericRow, Hex}
 import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Partial}
-import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, NestedColumnAliasingSuite}
+import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, NestedColumnAliasingSuite, RewriteWithExpression}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{LocalLimit, Project, RepartitionByExpression, Sort}
 import org.apache.spark.sql.connector.catalog.CatalogManager
@@ -5116,6 +5116,20 @@ class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
       sql("SELECT col1 + rand() FROM VALUES(1) GROUP BY 1")
       sql("SELECT rand() FROM VALUES(1) GROUP BY ALL")
       sql("SELECT col1 - rand() FROM VALUES(1) GROUP BY ALL")
+    }
+  }
+
+  test("SPARK-59019: BETWEEN succeeds when RewriteWithExpression is in excludedRules") {
+    // RewriteWithExpression is non-excludable, so adding it to excludedRules has no effect.
+    // Before the fix, this threw INTERNAL_ERROR because With nodes reached codegen.
+    withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+      RewriteWithExpression.ruleName) {
+      checkAnswer(
+        sql("SELECT x BETWEEN 1 AND 2 AS in_range FROM (VALUES (1)) AS t(x)"),
+        Row(true))
+      checkAnswer(
+        sql("SELECT x BETWEEN 1 AND 2 AS in_range FROM (VALUES (3)) AS t(x)"),
+        Row(false))
     }
   }
 }


### PR DESCRIPTION
Backport of #58323 to branch-4.2.

### What changes were proposed in this pull request?

Same as #58323 - add `RewriteWithExpression` to `nonExcludableRules`.

### Why are the changes needed?

The bug exists since SPARK-45760 introduced `RewriteWithExpression` in 4.0.0. `Between` uses `With(input)` and `RewriteWithExpression` is not in `nonExcludableRules` on branch-4.2.

### Does this PR introduce _any_ user-facing change?

Same as #58323.

### How was this patch tested?

Same regression test as #58323.

### Was this patch authored or co-authored using generative AI tooling?

No.