### PR TITLE
[SPARK-59148][PYTHON][CONNECT][TEST][4.0] Skip test_nested_dataframes in the Spark Connect compatibility test

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import os
 import unittest
 
 from pyspark.sql.tests.streaming.test_streaming_foreach_batch import StreamingTestsForeachBatchMixin
@@ -33,6 +34,11 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
     def test_streaming_foreach_batch_graceful_stop(self):
         super().test_streaming_foreach_batch_graceful_stop()
 
+    @unittest.skipIf(
+        os.environ.get("SPARK_SKIP_CONNECT_COMPAT_TESTS") == "1",
+        "SPARK-44462: a newer server runs foreachBatch on the cloned session, so batch_updates "
+        "is not visible from the client session.",
+    )
     def test_nested_dataframes(self):
         def curried_function(df):
             def inner(batch_df, batch_id):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip `StreamingForeachBatchParityTests.test_nested_dataframes` when `SPARK_SKIP_CONNECT_COMPAT_TESTS` is set.

### Why are the changes needed?

The Spark Connect compatibility jobs run this branch's `pyspark-connect` tests against a server built from `master`. The `pyspark-connect-old-client` job in `build_and_test.yml` and `build_python_connect40.yml` both clone `branch-4.0` for the client side.

https://github.com/apache/spark/pull/55410 (SPARK-44462) changes the server so the DataFrame handed to `foreachBatch` is bound to the session `StreamExecution` clones for the query, which is what classic `foreachBatch` already does. `test_nested_dataframes` creates a temp view from the batch DataFrame and reads it back through the client session, so against that server it fails:

```
File ".../connect/streaming/test_parity_foreach_batch.py", line 49, in test_nested_dataframes
    collected = self.spark.sql("select * from batch_updates").collect()
pyspark.errors.exceptions.connect.AnalysisException: [TABLE_OR_VIEW_NOT_FOUND] The table or view `batch_updates` cannot be found.
```

Failing run: https://github.com/LuciferYang/spark/actions/runs/33346837991/job/99354964415

The assertion holds for a 4.0 server, so the guard is scoped to the compatibility jobs and this branch's own CI keeps running the test. SPARK-52077 skipped `ArrowUDTFParityTests` the same way.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

`test_nested_dataframes` still runs with `SPARK_SKIP_CONNECT_COMPAT_TESTS` unset and is skipped with it set to `1`. This branch's CI cannot exercise the case the guard is for, since it runs against a 4.0 server; the `pyspark-connect-old-client` job on https://github.com/apache/spark/pull/55410 is what verifies it, once this lands.

Pass GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
