### PR TITLE
[SPARK-59149][SQL] Use isEmpty/nonEmpty instead of size comparisons in the SQL modules

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4448,7 +4448,7 @@ class Analyzer(
           if (windowExpressionToAliasMap.isEmpty && !hasWindowInPlan(child)) {
             throw QueryCompilationErrors.qualifyRequiresWindowFunctionError()
           }
-          if (windowExpressionToAliasMap.size() > 0) {
+          if (!windowExpressionToAliasMap.isEmpty) {
             val projectList =
               windowExpressionToAliasMap.values().asScala.toSeq
             Filter(newCond, Project(newChild.output ++ projectList, newChild))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4445,7 +4445,7 @@ class Analyzer(
               throw QueryCompilationErrors.aggregateInQualifyNotAllowedError(a)
           }
           // Ensure at least one window function in SELECT or QUALIFY condition.
-          if (windowExpressionToAliasMap.size() == 0 && !hasWindowInPlan(child)) {
+          if (windowExpressionToAliasMap.isEmpty && !hasWindowInPlan(child)) {
             throw QueryCompilationErrors.qualifyRequiresWindowFunctionError()
           }
           if (windowExpressionToAliasMap.size() > 0) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -773,7 +773,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
           break;
        """)
 
-    val switchCode = if (caseBranches.size > 0) {
+    val switchCode = if (caseBranches.nonEmpty) {
       code"""
         switch (${valueGen.value}) {
           ${caseBranches.mkString("\n")}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -6165,7 +6165,7 @@ class AstBuilder extends DataTypeAstBuilder
     checkDuplicateClauses(ctx.clusterBySpec(), "CLUSTER BY", ctx)
     checkDuplicateClauses(ctx.locationSpec, "LOCATION", ctx)
 
-    if (ctx.skewSpec.size > 0) {
+    if (!ctx.skewSpec.isEmpty) {
       invalidStatement("CREATE TABLE ... SKEWED BY", ctx)
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -189,11 +189,11 @@ class ExpressionSetSuite extends SparkFunSuite {
 
     assert((initialSet + (aUpper + 1)).size == 1)
     assert((initialSet + (aUpper + 2)).size == 2)
-    assert((initialSet - (aUpper + 1)).size == 0)
+    assert((initialSet - (aUpper + 1)).isEmpty)
     assert((initialSet - (aUpper + 2)).size == 1)
 
     assert((initialSet + (aLower + 1)).size == 1)
-    assert((initialSet - (aLower + 1)).size == 0)
+    assert((initialSet - (aLower + 1)).isEmpty)
 
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -147,7 +147,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val equivalence = new EquivalentExpressions
     equivalence.addExprTree(add)
     // the `two` inside `fallback` should not be added
-    assert(equivalence.getAllExprStates(1).size == 0)
+    assert(equivalence.getAllExprStates(1).isEmpty)
     assert(equivalence.getAllExprStates().count(_.useCount == 1) == 3) // add, two, explode
   }
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
@@ -617,7 +617,7 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
           .sql(s"select * from $tableName")
           .collect()
           .toSeq
-        assert(rows.size > 0)
+        assert(rows.nonEmpty)
         assert(rows.map(_.getLong(1)).sum > 0)
         logInfo(s"Rows in $tableName: $rows")
       }
@@ -660,7 +660,7 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
           .sql(s"select * from $tableName")
           .collect()
           .toSeq
-        assert(rows.size > 0)
+        assert(rows.nonEmpty)
         assert(rows.map(_.getLong(1)).sum > 0)
         logInfo(s"Rows in $tableName: $rows")
       }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -208,7 +208,7 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
    * were created during the session. Called by SessionHolder during session cleanup.
    */
   def close(): Unit = {
-    if (hasCreatedMLDirs.get() || cachedModel.size() > 0) {
+    if (hasCreatedMLDirs.get() || !cachedModel.isEmpty) {
       try {
         clear()
       } catch {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1027,7 +1027,7 @@ class SparkConnectPlanner(
         sortOrder: Seq[SortOrder]): UntypedKeyValueGroupedDataset = {
       val analyzed = session.sessionState.executePlan(logicalPlan).analyzed
 
-      assertPlan(groupingExprs.size() >= 1)
+      assertPlan(!groupingExprs.isEmpty)
       val dummyFunc = TypedScalaUdf(groupingExprs.get(0), None)
       val groupExprs = groupingExprs.asScala.toSeq.drop(1).map(expr => transformExpression(expr))
 
@@ -2670,7 +2670,7 @@ class SparkConnectPlanner(
           // This relies on the assumption that a KVGDS always requires the head to be a Typed UDF.
           // This is the case for datasets created via groupByKey,
           // and also via RelationalGroupedDS#as, as the first is a dummy UDF currently.
-          if rel.getGroupingExpressionsList.size() >= 1 &&
+          if !rel.getGroupingExpressionsList.isEmpty &&
             isTypedScalaUdfExpr(rel.getGroupingExpressionsList.get(0)) =>
         transformKeyValueGroupedAggregate(rel)
       case _ =>

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -496,7 +496,7 @@ class SparkConnectServiceSuite
                 assert(chunk.getArrowBatch.getRowCount == rowCount)
                 assert(chunk.getArrowBatch.getStartOffset == rowStartOffset)
                 assert(chunk.getArrowBatch.getData != null)
-                assert(chunk.getArrowBatch.getData.size() > 0)
+                assert(!chunk.getArrowBatch.getData.isEmpty)
                 assert(
                   chunk.getArrowBatch.getData.size() <= preferredChunkSizeOption.getOrElse(
                     maxChunkSizeOption.get))

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -187,7 +187,7 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
       assert(validated, msg)
     }
     // In the meanwhile, no any end event should be posted
-    assert(listenerInstance.serviceEndEvents.size() == 0)
+    assert(listenerInstance.serviceEndEvents.isEmpty)
 
     // Try to start an already started SparkConnectService
     SparkConnectService.start(sc)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/resources.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/resources.scala
@@ -65,7 +65,7 @@ case class ListFilesCommand(files: Seq[String] = Seq.empty[String]) extends Leaf
   }
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val fileList = sparkSession.sparkContext.listFiles()
-    if (files.size > 0) {
+    if (files.nonEmpty) {
       files.map { f =>
         val uri = Utils.resolveURI(f)
         uri.getScheme match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -889,7 +889,7 @@ object DataSource extends Logging {
   def validateSchema(formatName: String, schema: StructType, conf: SQLConf): Unit = {
     val shouldAllowEmptySchema = conf.getConf(SQLConf.ALLOW_EMPTY_SCHEMAS_FOR_WRITES)
     def hasEmptySchema(schema: StructType): Boolean = {
-      schema.size == 0 || schema.exists {
+      schema.isEmpty || schema.exists {
         case StructField(_, b: StructType, _, _) => hasEmptySchema(b)
         case _ => false
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -98,7 +98,7 @@ object OrcUtils extends Logging {
     try {
       reader = OrcFile.createReader(file, readerOptions)
       val schema = reader.getSchema
-      if (schema.getFieldNames.size == 0) {
+      if (schema.getFieldNames.isEmpty) {
         None
       } else {
         Some(schema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/InferVariantShreddingSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/InferVariantShreddingSchema.scala
@@ -279,7 +279,7 @@ class InferVariantShreddingSchema(val schema: StructType) {
             }
           }
         // If we weren't able to retain any fields, just use VariantType
-        if (newFields.size() > 0) StructType(newFields) else VariantType
+        if (!newFields.isEmpty) StructType(newFields) else VariantType
       case ArrayType(elementType, _) =>
         ArrayType(finalizeSimpleSchema(elementType, minCardinality, maxFields))
       case ByteType | ShortType | IntegerType | LongType =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetPartitionReaderFactory.scala
@@ -139,7 +139,7 @@ case class ParquetPartitionReaderFactory(
           val openedFooter = openFileAndReadFooter(file)
           assert(openedFooter.inputStreamOpt.isEmpty)
 
-          if (openedFooter.footer != null && openedFooter.footer.getBlocks.size > 0) {
+          if (openedFooter.footer != null && !openedFooter.footer.getBlocks.isEmpty) {
             ParquetUtils.createAggInternalRowFromFooter(openedFooter.footer,
               file.urlEncodedPath, dataSchema, partitionSchema, aggregation.get,
               readDataSchema, file.partitionValues,
@@ -185,7 +185,7 @@ case class ParquetPartitionReaderFactory(
           val openedFooter = openFileAndReadFooter(file)
           assert(openedFooter.inputStreamOpt.isEmpty)
 
-          if (openedFooter.footer != null && openedFooter.footer.getBlocks.size > 0) {
+          if (openedFooter.footer != null && !openedFooter.footer.getBlocks.isEmpty) {
             val row = ParquetUtils.createAggInternalRowFromFooter(openedFooter.footer,
               file.urlEncodedPath, dataSchema, partitionSchema, aggregation.get,
               readDataSchema, file.partitionValues,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncLogPurge.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncLogPurge.scala
@@ -95,7 +95,7 @@ trait AsyncLogPurge extends Logging {
   // used for testing
   private[sql] def arePendingAsyncPurge: Boolean = {
     purgeRunning.get() ||
-      asyncPurgeExecutorService.getQueue.size() > 0 ||
+      !asyncPurgeExecutorService.getQueue.isEmpty ||
       asyncPurgeExecutorService.getActiveCount > 0
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
@@ -383,7 +383,7 @@ class AsyncProgressTrackingMicroBatchExecution(
 
   // used for testing
   def areWritesPendingOrInProgress(): Boolean = {
-    asyncWritesExecutorService.getQueue.size() > 0 || asyncWritesExecutorService.getActiveCount > 0
+    !asyncWritesExecutorService.getQueue.isEmpty || asyncWritesExecutorService.getActiveCount > 0
   }
 
   override protected def getTrigger(): TriggerExecutor = validateAndGetTrigger()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -691,7 +691,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     }
 
     if (numberOfVersionsToRetainInMemory <= 0) {
-      if (loadedMaps.size() > 0) loadedMaps.clear()
+      if (!loadedMaps.isEmpty) loadedMaps.clear()
       return
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -225,7 +225,7 @@ class DataFrameJoinSuite extends SharedSparkSession
       spark.range(10e10.toLong)
         .join(spark.range(10e10.toLong), "id")
         .queryExecution.executedPlan
-    assert(plan1.collect { case p: BroadcastHashJoinExec => p }.size == 0)
+    assert(plan1.collect { case p: BroadcastHashJoinExec => p }.isEmpty)
 
     // now with a hint it should be broadcasted
     val plan2 =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -184,7 +184,7 @@ class MetricViewV2CatalogSuite extends SharedSparkSession {
 
       // SQL configs and current catalog/namespace are first-class typed fields on View, no
       // longer encoded into properties for V2 catalogs.
-      assert(info.sqlConfigs().size > 0,
+      assert(!info.sqlConfigs().isEmpty,
         s"Expected at least one captured SQL config; got ${info.sqlConfigs()}")
       assert(info.currentCatalog() ===
         spark.sessionState.catalogManager.currentCatalog.name())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -56,7 +56,7 @@ class OptimizeMetadataOnlyQuerySuite extends SharedSparkSession {
     val localRelations = df.queryExecution.optimizedPlan.collect {
       case l: LocalRelation => l
     }
-    assert(localRelations.size == 0)
+    assert(localRelations.isEmpty)
   }
 
   private def testMetadataOnly(name: String, sqls: String*): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -1353,7 +1353,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
       }.nonEmpty)
 
       val exchanges = collect(planned) { case s: ShuffleExchangeExec => s }
-      assert(exchanges.size == 0)
+      assert(exchanges.isEmpty)
     }
   }
 
@@ -1373,7 +1373,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
       }.nonEmpty)
 
       val exchanges = collect(planned) { case s: ShuffleExchangeExec => s }
-      assert(exchanges.size == 0)
+      assert(exchanges.isEmpty)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ProjectedOrderingAndPartitioningSuite.scala
@@ -50,9 +50,9 @@ class ProjectedOrderingAndPartitioningSuite
               .toSet.subsetOf(Set("x", "y", "z")))
           case 1 =>
             assert(outputOrdering.size == 1)
-            assert(outputOrdering.head.sameOrderExpressions.size == 0)
+            assert(outputOrdering.head.sameOrderExpressions.isEmpty)
           case 0 =>
-            assert(outputOrdering.size == 0)
+            assert(outputOrdering.isEmpty)
         }
       }
     }
@@ -118,7 +118,7 @@ class ProjectedOrderingAndPartitioningSuite
     val outputOrdering = df.queryExecution.optimizedPlan.outputOrdering
     assert(outputOrdering.size == 1)
     assert(outputOrdering.head.sql == "(x + y) ASC NULLS FIRST")
-    assert(outputOrdering.head.sameOrderExpressions.size == 0)
+    assert(outputOrdering.head.sameOrderExpressions.isEmpty)
   }
 
   test("SPARK-42049: Improve AliasAwareOutputExpression - partitioning - multi-references") {
@@ -222,7 +222,7 @@ class ProjectedOrderingAndPartitioningSuite
 
     val df3 = df.selectExpr("id + 2 AS b")
     val outputOrdering3 = df3.queryExecution.optimizedPlan.outputOrdering
-    assert(outputOrdering3.size == 0)
+    assert(outputOrdering3.isEmpty)
   }
 
   test("SPARK-42049: Improve AliasAwareOutputExpression - no alias but still prune expressions") {
@@ -236,7 +236,7 @@ class ProjectedOrderingAndPartitioningSuite
     val outputOrdering = df2.queryExecution.optimizedPlan.outputOrdering
     assert(outputOrdering.size == 1)
     assert(outputOrdering.head.child.asInstanceOf[Attribute].name == "a")
-    assert(outputOrdering.head.sameOrderExpressions.size == 0)
+    assert(outputOrdering.head.sameOrderExpressions.isEmpty)
   }
 
   test("SPARK-46367: KeyedPartitioning expressions are projected through " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -4815,7 +4815,7 @@ class AdaptiveQueryExecSuite
         """.stripMargin
       )
       assert(findTopLevelBroadcastNestedLoopJoin(adaptivePlan).size == 1)
-      assert(findTopLevelUnion(adaptivePlan).size == 0)
+      assert(findTopLevelUnion(adaptivePlan).isEmpty)
     }
 
     withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -61,7 +61,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val arrowRecordBatches = arrowBatches.map(ArrowConverters.loadBatch(_, allocator))
     val rowCount = arrowRecordBatches.map(_.getLength).sum
     assert(rowCount === indexData.count())
-    arrowRecordBatches.foreach(batch => assert(batch.getNodes.size() > 0))
+    arrowRecordBatches.foreach(batch => assert(!batch.getNodes.isEmpty))
     arrowRecordBatches.foreach(_.close())
     allocator.close()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/TruncateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/TruncateTableSuite.scala
@@ -85,7 +85,7 @@ trait TruncateTableSuiteBase extends command.TruncateTableSuiteBase {
           }
           val aclEntries = fs.getAclStatus(tablePath).getEntries()
           if (ignore) {
-            assert(aclEntries.size() == 0)
+            assert(aclEntries.isEmpty)
           } else {
             assert(aclEntries.size() == 4)
             assert(aclEntries.get(0) == customAcl.get(0))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -871,7 +871,7 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       assert(caseSensitiveFilters.isEmpty)
       assert(caseInsensitiveFilters.isDefined)
 
-      assert(caseInsensitiveFilters.get.getLeaves().size() > 0)
+      assert(!caseInsensitiveFilters.get.getLeaves().isEmpty)
       assert(caseInsensitiveFilters.get.getLeaves().size() == expected.getLeaves().size())
       (0 until expected.getLeaves().size()).foreach { index =>
         assert(caseInsensitiveFilters.get.getLeaves().get(index) == expected.getLeaves().get(index))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/planmerging/PlanMergingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/planmerging/PlanMergingSuite.scala
@@ -432,7 +432,7 @@ class PlanMergingSuite extends SharedSparkSession
               "Missing or unexpected ReusedSubqueryExec in the plan")
           } else {
             assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
-            assert(reusedSubqueryIds.size == 0,
+            assert(reusedSubqueryIds.isEmpty,
               "Missing or unexpected ReusedSubqueryExec in the plan")
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2313,7 +2313,7 @@ class JDBCSuite extends SharedSparkSession {
     modifiedParameters += ("customKey" -> "a-value")
     modifiedParameters += ("dbTable" -> "t1")
     testJdbcOptions(new JDBCOptions(modifiedParameters))
-    assert ((modifiedParameters -- parameters.keys).size == 0)
+    assert ((modifiedParameters -- parameters.keys).isEmpty)
   }
 
   test("SPARK-19318: jdbc data source options should be treated case-insensitive.") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -1344,13 +1344,13 @@ abstract class TransformWithStateSuite extends StateStoreMetricsTest
       CheckNewAnswer(("a", -1), ("b", 31)), // State for "a" should timeout and emit -1
       Execute { q =>
         // Filter for idle progress events and then verify the custom metrics for stateful operator
-        val progData = q.recentProgress.filter(prog => prog.stateOperators.size > 0)
+        val progData = q.recentProgress.filter(prog => prog.stateOperators.nonEmpty)
         assert(progData.filter(prog =>
-          prog.stateOperators(0).customMetrics.get("numValueStateVars") > 0).size > 0)
+          prog.stateOperators(0).customMetrics.get("numValueStateVars") > 0).nonEmpty)
         assert(progData.filter(prog =>
-          prog.stateOperators(0).customMetrics.get("numRegisteredTimers") > 0).size > 0)
+          prog.stateOperators(0).customMetrics.get("numRegisteredTimers") > 0).nonEmpty)
         assert(progData.filter(prog =>
-          prog.stateOperators(0).customMetrics.get("numDeletedTimers") > 0).size > 0)
+          prog.stateOperators(0).customMetrics.get("numDeletedTimers") > 0).nonEmpty)
       }
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
@@ -115,12 +115,12 @@ abstract class TransformWithStateTTLTest
           Execute { q =>
             // Filter for idle progress events and then verify the custom metrics
             // for stateful operator
-            val progData = q.recentProgress.filter(prog => prog.stateOperators.size > 0)
+            val progData = q.recentProgress.filter(prog => prog.stateOperators.nonEmpty)
             assert(progData.filter(prog =>
-              prog.stateOperators(0).customMetrics.get(getStateTTLMetricName) > 0).size > 0)
+              prog.stateOperators(0).customMetrics.get(getStateTTLMetricName) > 0).nonEmpty)
             assert(progData.filter(prog =>
               prog.stateOperators(0).customMetrics
-                .get("numValuesRemovedDueToTTLExpiry") > 0).size > 0)
+                .get("numValuesRemovedDueToTTLExpiry") > 0).nonEmpty)
           }
         )
       }

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
@@ -75,7 +75,7 @@ class SqlResourceWithActualMetricsSuite
       + s"/api/v1/applications/${spark.sparkContext.applicationId}/sql").toURL
     val jsonResult = verifyAndGetSqlRestResult(url)
     val executionDatas = JsonMethods.parse(jsonResult).extract[Seq[ExecutionData]]
-    assert(executionDatas.size > 0,
+    assert(executionDatas.nonEmpty,
       s"Expected Query Result Size is higher than 0 but received: ${executionDatas.size}")
     val executionData = executionDatas.head
     verifySqlRestContent(executionData)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -242,7 +242,7 @@ class HadoopTableReader(
     }.toSeq
 
     // Even if we don't use any partitions, we still need an empty RDD
-    if (hivePartitionRDDs.size == 0) {
+    if (hivePartitionRDDs.isEmpty) {
       new EmptyRDD[InternalRow](sparkSession.sparkContext)
     } else {
       new UnionRDD(hivePartitionRDDs(0).context, hivePartitionRDDs)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
@@ -59,7 +59,7 @@ private[hive] object OrcFileOperator extends Logging {
       : Option[Reader] = {
     def isWithNonEmptySchema(path: Path, reader: Reader): Boolean = {
       reader.getObjectInspector match {
-        case oi: StructObjectInspector if oi.getAllStructFieldRefs.size() == 0 =>
+        case oi: StructObjectInspector if oi.getAllStructFieldRefs.isEmpty =>
           logInfo(
             log"ORC file ${MDC(PATH, path)} has empty schema, it probably contains no rows. " +
               log"Trying to read another ORC file to figure out the schema.")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetEncryptionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetEncryptionSuite.scala
@@ -125,7 +125,7 @@ class ParquetEncryptionSuite extends QueryTest with TestHiveSingleton {
    */
   private def verifyParquetEncrypted(parquetDir: String): Unit = {
     val parquetPartitionFiles = getListOfParquetFiles(new File(parquetDir))
-    assert(parquetPartitionFiles.size >= 1)
+    assert(parquetPartitionFiles.nonEmpty)
     parquetPartitionFiles.foreach { parquetFile =>
       val magicString = "PARE"
       val magicStringLength = magicString.length()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This replaces size-vs-zero comparisons with the direct emptiness / non-emptiness predicates across the SQL modules (`catalyst`, `core`, `hive`, `connect`), in both main and test sources:
- **Emptiness**: `x.size == 0` / `x.size() == 0` -> `x.isEmpty`.
- **Non-emptiness**: `x.size > 0` / `x.size >= 1` -> `x.nonEmpty` for Scala collections, and `!x.isEmpty` for Java collections (`java.util.*`, protobuf lists, `ByteString`, etc.), which have no `nonEmpty`.

Touched files span `Analyzer`, `predicates`, `AstBuilder` (catalyst); `DataSource`, `resources`, `InferVariantShreddingSchema`, `ParquetPartitionReaderFactory`, `AsyncLogPurge`, `AsyncProgressTrackingMicroBatchExecution`, `HDFSBackedStateStoreProvider` (core main); `OrcUtils`, `TableReader`, `OrcFileOperator` (hive main); `MLCache`, `SparkConnectPlanner` (connect main); plus the corresponding test suites.

Deliberately left unchanged, because they are **not** collection-emptiness checks:
- `CostBasedJoinReorder` -- `planCost.size` is a numeric `BigInt` field on `case class Cost(card, size)`.
- `SubExprEvaluationRuntimeSuite`, `FetchErrorDetailsHandlerSuite` -- the receivers are Guava caches (`LoadingCache` / `CacheBuilder`), which expose `size()` but not `isEmpty()`.
- On the `AsyncProgressTrackingMicroBatchExecution` line, `getActiveCount > 0` (a thread-pool active-thread count) is left as-is; only the adjacent `getQueue.size()` check is converted.

### Why are the changes needed?

`isEmpty` / `nonEmpty` state the intent directly and are the idioms used elsewhere in these files. They also avoid computing a full `size` only to compare it against zero (for some collections `size` is `O(n)` while `isEmpty` is `O(1)`). Behavior is unchanged: for every converted receiver -- Scala collections, `java.util` collections, `StructType`, and protobuf/`ByteString` types -- the predicate is exactly equivalent to the original comparison.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. This is a behavior-preserving refactor; the `catalyst`, `sql` (core, main + test), `hive`, and `connect` modules compile cleanly.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
