### PR TITLE
[SPARK-59151][SQL] Add a VariantBuilder.canonicalize primitive for Variant aggregation

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -504,6 +504,15 @@ public class VariantBuilder {
   }
 
   private void appendVariantImpl(byte[] value, byte[] metadata, int pos) {
+    appendVariantImpl(value, metadata, pos, /* needNormalization */ false);
+  }
+
+  // Shared re-emit walk for `appendVariant` and `canonicalize`. Object/array structure is rebuilt
+  // identically in both modes. When `needNormalization` is true, scalar values are canonicalized as
+  // they are re-emitted (see `appendCanonicalizedScalar`); otherwise they are copied byte-for-byte,
+  // which is the behavior `appendVariant` and its callers rely on.
+  private void appendVariantImpl(
+      byte[] value, byte[] metadata, int pos, boolean needNormalization) {
     checkIndex(pos, value.length);
     int basicType = value[pos] & BASIC_TYPE_MASK;
     switch (basicType) {
@@ -518,7 +527,7 @@ public class VariantBuilder {
             String key = getMetadataKey(metadata, id);
             int newId = addKey(key);
             fields.add(new FieldEntry(key, newId, writePos - start));
-            appendVariantImpl(value, metadata, elementPos);
+            appendVariantImpl(value, metadata, elementPos, needNormalization);
           }
           finishWritingObject(start, fields);
           return null;
@@ -532,16 +541,329 @@ public class VariantBuilder {
             int offset = readUnsigned(value, offsetStart + offsetSize * i, offsetSize);
             int elementPos = dataStart + offset;
             offsets.add(writePos - start);
-            appendVariantImpl(value, metadata, elementPos);
+            appendVariantImpl(value, metadata, elementPos, needNormalization);
           }
           finishWritingArray(start, offsets);
           return null;
         });
         break;
       default:
+        if (needNormalization) {
+          appendCanonicalizedScalar(value, pos);
+        } else {
+          shallowAppendVariantImpl(value, pos);
+        }
+        break;
+    }
+  }
+
+  // Canonicalize and append a single scalar value: integers re-emitted at the smallest int width,
+  // integer-valued decimals promoted to the integer encoding, decimal trailing zeros stripped,
+  // -0.0 mapped to +0.0, and short strings short-encoded -- so e.g. `1.0`, `1`, and a wide-encoded
+  // `1` all produce byte-equal output. The scalar normalization rules that the read-side check
+  // (`isValueCanonical`) must mirror are factored into shared helpers so the two cannot drift.
+  private void appendCanonicalizedScalar(byte[] value, int pos) {
+    switch (VariantUtil.getType(value, pos)) {
+      case LONG:
+        appendLong(VariantUtil.getLong(value, pos));
+        break;
+      case DECIMAL: {
+        BigDecimal bd = VariantUtil.getDecimal(value, pos);
+        if (decimalPromotesToLong(bd)) {
+          appendLong(bd.longValue());
+        } else {
+          // Fractional, or too large for a long: emit as a decimal (negative scale coerced to 0).
+          appendDecimal(canonicalDecimalForm(bd));
+        }
+        break;
+      }
+      case FLOAT:
+        appendFloat(canonicalizeFloat(VariantUtil.getFloat(value, pos)));
+        break;
+      case DOUBLE:
+        appendDouble(canonicalizeDouble(VariantUtil.getDouble(value, pos)));
+        break;
+      case STRING:
+        appendString(VariantUtil.getString(value, pos));
+        break;
+      default:
         shallowAppendVariantImpl(value, pos);
         break;
     }
+  }
+
+  // Return a canonical Variant.
+  // Two Variants are semantically equal iff their canonical forms are byte-equal,
+  // so canonicalizing lets the byte-equality machinery (hash aggregate bucketing,
+  // hash partitioning) group and compare Variants by value rather than by
+  // their incidental physical encoding.
+  //
+  // The metadata dictionary is rebuilt with its keys sorted by (the same order
+  // finishWritingObject} already uses for object fields, so the two stay
+  // consistent) and unused entries stripped, with field ids remapped to the sorted positions.
+  public static Variant canonicalize(Variant v) {
+    // Fast path: a top-level (pos == 0) input that is already canonical is returned unchanged. A
+    // sub-variant (pos != 0) is a view into a parent's shared value/metadata, so it always takes
+    // the slow path, which reads the element at v.pos and rebuilds a standalone canonical Variant.
+    if (v.pos == 0 && isCanonical(v.value, v.metadata)) {
+      return v;
+    }
+    VariantBuilder builder = new VariantBuilder(/* allowDuplicateKeys */ false);
+    builder.buildCanonicalized(v.value, v.metadata, v.pos);
+    return builder.result();
+  }
+
+  // Populate this freshly constructed builder so that `result()` produces the canonical Variant
+  // equivalent of the element at `pos` within `(value, metadata)` (`pos` is non-zero for a
+  // sub-variant that shares a parent's arrays). First collect every object key the element
+  // references, sort them, and pre-populate the dictionary so ids equal sorted positions. Then
+  // reuse `appendVariantImpl` in normalization mode to re-emit the value: since the dictionary is
+  // already populated in sorted order, its `addKey` calls return those sorted ids without adding,
+  // so the structure is canonical and unreferenced keys (never collected) are stripped, while
+  // scalar values are canonicalized as they are re-emitted (see `appendCanonicalizedScalar`).
+  private void buildCanonicalized(byte[] value, byte[] metadata, int pos) {
+    ArrayList<String> keys = new ArrayList<>();
+    collectAllObjectKeys(value, metadata, pos, keys);
+    // Sort by UTF-8-encoded bytes -- the same order finishWritingObject sorts object fields and
+    // getFieldByKey binary-searches -- so dictionary ids match field order and fields come out
+    // with strictly ascending ids.
+    keys.sort((a, b) -> compareKeys(encodeKey(a), encodeKey(b)));
+    keys = new ArrayList<>(new LinkedHashSet<>(keys));
+    for (String key : keys) {
+      addKey(key);
+    }
+    appendVariantImpl(value, metadata, pos, /* needNormalization */ true);
+  }
+
+  // Recursively collect every object key referenced under `pos` into `keys`, walking objects and
+  // arrays (scalars carry no keys). A key that no field references is never collected, so it is
+  // absent from the rebuilt dictionary -- that is how canonicalization strips unused entries.
+  private void collectAllObjectKeys(
+      byte[] value, byte[] metadata, int pos, ArrayList<String> keys) {
+    checkIndex(pos, value.length);
+    int basicType = value[pos] & BASIC_TYPE_MASK;
+    switch (basicType) {
+      case OBJECT:
+        handleObject(value, pos, (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+          for (int i = 0; i < size; ++i) {
+            int id = readUnsigned(value, idStart + idSize * i, idSize);
+            int offset = readUnsigned(value, offsetStart + offsetSize * i, offsetSize);
+            int elementPos = dataStart + offset;
+            keys.add(getMetadataKey(metadata, id));
+            collectAllObjectKeys(value, metadata, elementPos, keys);
+          }
+          return null;
+        });
+        break;
+      case ARRAY:
+        handleArray(value, pos, (size, offsetSize, offsetStart, dataStart) -> {
+          for (int i = 0; i < size; ++i) {
+            int offset = readUnsigned(value, offsetStart + offsetSize * i, offsetSize);
+            int elementPos = dataStart + offset;
+            collectAllObjectKeys(value, metadata, elementPos, keys);
+          }
+          return null;
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Return true iff `(value, metadata)` is ALREADY in the exact byte form that `buildCanonicalized`
+  // would produce -- i.e. calling `canonicalize` on it is a no-op. Intended as a read-side fast
+  // path so already-canonical Variants skip the allocation-heavy rebuild (dictionary sort +
+  // re-serialize).
+  //
+  // Checked here:
+  //   - metadata dictionary: keys sorted + deduped, minimal offset width, no unused keys;
+  //   - objects/arrays: field ids ascending, offsets exact-cumulative, id/offset widths minimal;
+  //   - scalars:
+  //     - minimal int width
+  //     - decimal integer-promoted, trailing-zero-free, minimal width
+  //     - float/double the exact bytes appendFloat/appendDouble emit
+  //     - string short-encoded when it fits.
+  public static boolean isCanonical(byte[] value, byte[] metadata) {
+    checkIndex(0, metadata.length);
+    // Metadata offset width must be the minimal width `result()` would pick.
+    int metaOffsetSize = ((metadata[0] >> 6) & 0x3) + 1;
+    int numKeys = readUnsigned(metadata, 1, metaOffsetSize);
+    // Keys must be strictly ascending by UTF-8 bytes -- the order buildCanonicalized sorts the
+    // dictionary in, and the order finishWritingObject / getFieldByKey use for object fields.
+    if (numKeys > 1) {
+      byte[] prevKey = encodeKey(getMetadataKey(metadata, 0));
+      for (int id = 1; id < numKeys; ++id) {
+        byte[] key = encodeKey(getMetadataKey(metadata, id));
+        if (compareKeys(prevKey, key) >= 0) {
+          return false;
+        }
+        prevKey = key;
+      }
+    }
+    // result() writes header = VERSION | ((offsetSize - 1) << 6): version low nibble, sorted /
+    // reserved bits 0, offset width (from max(total string size, numKeys)) in the top two bits.
+    // Require exactly that byte, so an otherwise-canonical Variant with a set sorted-strings bit
+    // (or a foreign version) is rebuilt rather than wrongly accepted as canonical.
+    int lastOffset = readUnsigned(metadata, 1 + (numKeys + 1) * metaOffsetSize, metaOffsetSize);
+    long maxSize = Math.max(lastOffset, numKeys);
+    if ((metadata[0] & 0xFF) != (VERSION | ((minIntWidth(maxSize) - 1) << 6))) {
+      return false;
+    }
+    // Walk the value: verify object/array structure is minimal and record which dictionary ids it
+    // references. A canonical Variant references every id in [0, numKeys) with no unused keys.
+    boolean[] referenced = new boolean[numKeys];
+    if (!isValueCanonical(value, metadata, 0, referenced)) {
+      return false;
+    }
+    for (int id = 0; id < numKeys; ++id) {
+      if (!referenced[id]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Value-traversal half of `isCanonical`. Returns false on the first non-canonical node.
+  private static boolean isValueCanonical(
+      byte[] value, byte[] metadata, int pos, boolean[] referenced) {
+    switch (VariantUtil.getType(value, pos)) {
+      case OBJECT:
+        return handleObject(value, pos,
+            (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+          // Field ids strictly ascending: with a sorted dictionary, canon emits fields in key
+          // order, and key order == id order. This also rejects duplicate keys (equal ids).
+          int prevId = -1;
+          int dataSize = 0;
+          for (int i = 0; i < size; ++i) {
+            int id = readUnsigned(value, idStart + idSize * i, idSize);
+            if (id <= prevId || id >= referenced.length) {
+              return false;
+            }
+            prevId = id;
+            referenced[id] = true;
+            // Offsets must be the exact running data size (no gaps or padding).
+            int offset = readUnsigned(value, offsetStart + offsetSize * i, offsetSize);
+            if (offset != dataSize) {
+              return false;
+            }
+            int elementPos = dataStart + offset;
+            if (!isValueCanonical(value, metadata, elementPos, referenced)) {
+              return false;
+            }
+            dataSize += VariantUtil.valueSize(value, elementPos);
+          }
+          int lastOffset = readUnsigned(value, offsetStart + offsetSize * size, offsetSize);
+          if (lastOffset != dataSize) {
+            return false;
+          }
+          int maxId = size == 0 ? 0 : prevId;
+          return idSize == minIntWidth(maxId) && offsetSize == minIntWidth(dataSize);
+        });
+      case ARRAY:
+        return handleArray(value, pos, (size, offsetSize, offsetStart, dataStart) -> {
+          int dataSize = 0;
+          for (int i = 0; i < size; ++i) {
+            int offset = readUnsigned(value, offsetStart + offsetSize * i, offsetSize);
+            if (offset != dataSize) {
+              return false;
+            }
+            int elementPos = dataStart + offset;
+            if (!isValueCanonical(value, metadata, elementPos, referenced)) {
+              return false;
+            }
+            dataSize += VariantUtil.valueSize(value, elementPos);
+          }
+          int lastOffset = readUnsigned(value, offsetStart + offsetSize * size, offsetSize);
+          if (lastOffset != dataSize) {
+            return false;
+          }
+          return offsetSize == minIntWidth(dataSize);
+        });
+      case LONG:
+        // Must use the smallest int width `appendLong` would pick.
+        return VariantUtil.getTypeInfo(value, pos)
+            == canonicalLongTypeInfo(VariantUtil.getLong(value, pos));
+      case DECIMAL: {
+        BigDecimal onDisk = VariantUtil.getDecimalWithOriginalScale(value, pos);
+        BigDecimal stripped = onDisk.stripTrailingZeros();
+        // A decimal that promotes to a long is stored as the wrong type -> not canonical.
+        if (decimalPromotesToLong(stripped)) {
+          return false;
+        }
+        BigDecimal canonForm = canonicalDecimalForm(stripped);
+        return onDisk.scale() == canonForm.scale()
+            && VariantUtil.getTypeInfo(value, pos) == canonicalDecimalTypeInfo(canonForm);
+      }
+      case FLOAT: {
+        // Canonical iff the stored 4 bytes are exactly what `appendFloat` would write.
+        int rawBits = (int) VariantUtil.readLong(value, pos + 1, 4);
+        float f = Float.intBitsToFloat(rawBits);
+        return rawBits == Float.floatToIntBits(canonicalizeFloat(f));
+      }
+      case DOUBLE: {
+        // Same as FLOAT, over 8 bytes.
+        long rawBits = VariantUtil.readLong(value, pos + 1, 8);
+        double d = Double.longBitsToDouble(rawBits);
+        return rawBits == Double.doubleToLongBits(canonicalizeDouble(d));
+      }
+      case STRING:
+        // A short string is always canonical (its length <= MAX_SHORT_STR_SIZE by construction). A
+        // LONG_STR is canonical only when its length exceeds the short-string cap.
+        if ((value[pos] & BASIC_TYPE_MASK) == SHORT_STR) {
+          return true;
+        }
+        return readUnsigned(value, pos + 1, U32_SIZE) > MAX_SHORT_STR_SIZE;
+      default:
+        return true;
+    }
+  }
+
+  // Smallest unsigned integer byte width that can hold `value`.
+  private static int minIntWidth(long value) {
+    if (value <= U8_MAX) return 1;
+    if (value <= U16_MAX) return 2;
+    if (value <= U24_MAX) return 3;
+    return 4;
+  }
+
+  // Smallest long type width that can hold `l`.
+  private static int canonicalLongTypeInfo(long l) {
+    if (l == (byte) l) return INT1;
+    if (l == (short) l) return INT2;
+    if (l == (int) l) return INT4;
+    return INT8;
+  }
+
+  // Smallest decimal type width that can hold `d`.
+  private static int canonicalDecimalTypeInfo(BigDecimal d) {
+    if (d.scale() <= MAX_DECIMAL4_PRECISION && d.precision() <= MAX_DECIMAL4_PRECISION) {
+      return DECIMAL4;
+    } else if (d.scale() <= MAX_DECIMAL8_PRECISION && d.precision() <= MAX_DECIMAL8_PRECISION) {
+      return DECIMAL8;
+    } else {
+      return DECIMAL16;
+    }
+  }
+
+  // -0.0 canonicalizes to +0.0.
+  private static float canonicalizeFloat(float f) {
+    return f == 0.0f ? 0.0f : f;
+  }
+
+  private static double canonicalizeDouble(double d) {
+    return d == 0.0d ? 0.0d : d;
+  }
+
+  // True iff a stripped decimal is a whole number that fits in a long.
+  private static boolean decimalPromotesToLong(BigDecimal stripped) {
+    return stripped.scale() <= 0
+        && stripped.compareTo(LONG_MIN_AS_DECIMAL) >= 0
+        && stripped.compareTo(LONG_MAX_AS_DECIMAL) <= 0;
+  }
+
+  // The decimal canon emits for a non-promoted value.
+  private static BigDecimal canonicalDecimalForm(BigDecimal stripped) {
+    return stripped.scale() < 0 ? stripped.setScale(0) : stripped;
   }
 
   private void appendWithDeletionImpl(

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -599,7 +599,7 @@ public class VariantBuilder {
   // their incidental physical encoding.
   //
   // The metadata dictionary is rebuilt with its keys sorted by (the same order
-  // finishWritingObject} already uses for object fields, so the two stay
+  // finishWritingObject already uses for object fields, so the two stay
   // consistent) and unused entries stripped, with field ids remapped to the sorted positions.
   public static Variant canonicalize(Variant v) {
     // Fast path: a top-level (pos == 0) input that is already canonical is returned unchanged. A
@@ -613,20 +613,9 @@ public class VariantBuilder {
     return builder.result();
   }
 
-  // Populate this freshly constructed builder so that `result()` produces the canonical Variant
-  // equivalent of the element at `pos` within `(value, metadata)` (`pos` is non-zero for a
-  // sub-variant that shares a parent's arrays). First collect every object key the element
-  // references, sort them, and pre-populate the dictionary so ids equal sorted positions. Then
-  // reuse `appendVariantImpl` in normalization mode to re-emit the value: since the dictionary is
-  // already populated in sorted order, its `addKey` calls return those sorted ids without adding,
-  // so the structure is canonical and unreferenced keys (never collected) are stripped, while
-  // scalar values are canonicalized as they are re-emitted (see `appendCanonicalizedScalar`).
   private void buildCanonicalized(byte[] value, byte[] metadata, int pos) {
     ArrayList<String> keys = new ArrayList<>();
     collectAllObjectKeys(value, metadata, pos, keys);
-    // Sort by UTF-8-encoded bytes -- the same order finishWritingObject sorts object fields and
-    // getFieldByKey binary-searches -- so dictionary ids match field order and fields come out
-    // with strictly ascending ids.
     keys.sort((a, b) -> compareKeys(encodeKey(a), encodeKey(b)));
     keys = new ArrayList<>(new LinkedHashSet<>(keys));
     for (String key : keys) {
@@ -635,9 +624,6 @@ public class VariantBuilder {
     appendVariantImpl(value, metadata, pos, /* needNormalization */ true);
   }
 
-  // Recursively collect every object key referenced under `pos` into `keys`, walking objects and
-  // arrays (scalars carry no keys). A key that no field references is never collected, so it is
-  // absent from the rebuilt dictionary -- that is how canonicalization strips unused entries.
   private void collectAllObjectKeys(
       byte[] value, byte[] metadata, int pos, ArrayList<String> keys) {
     checkIndex(pos, value.length);
@@ -685,11 +671,8 @@ public class VariantBuilder {
   //     - string short-encoded when it fits.
   public static boolean isCanonical(byte[] value, byte[] metadata) {
     checkIndex(0, metadata.length);
-    // Metadata offset width must be the minimal width `result()` would pick.
     int metaOffsetSize = ((metadata[0] >> 6) & 0x3) + 1;
     int numKeys = readUnsigned(metadata, 1, metaOffsetSize);
-    // Keys must be strictly ascending by UTF-8 bytes -- the order buildCanonicalized sorts the
-    // dictionary in, and the order finishWritingObject / getFieldByKey use for object fields.
     if (numKeys > 1) {
       byte[] prevKey = encodeKey(getMetadataKey(metadata, 0));
       for (int id = 1; id < numKeys; ++id) {
@@ -700,17 +683,11 @@ public class VariantBuilder {
         prevKey = key;
       }
     }
-    // result() writes header = VERSION | ((offsetSize - 1) << 6): version low nibble, sorted /
-    // reserved bits 0, offset width (from max(total string size, numKeys)) in the top two bits.
-    // Require exactly that byte, so an otherwise-canonical Variant with a set sorted-strings bit
-    // (or a foreign version) is rebuilt rather than wrongly accepted as canonical.
     int lastOffset = readUnsigned(metadata, 1 + (numKeys + 1) * metaOffsetSize, metaOffsetSize);
     long maxSize = Math.max(lastOffset, numKeys);
     if ((metadata[0] & 0xFF) != (VERSION | ((minIntWidth(maxSize) - 1) << 6))) {
       return false;
     }
-    // Walk the value: verify object/array structure is minimal and record which dictionary ids it
-    // references. A canonical Variant references every id in [0, numKeys) with no unused keys.
     boolean[] referenced = new boolean[numKeys];
     if (!isValueCanonical(value, metadata, 0, referenced)) {
       return false;

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -156,6 +156,11 @@ public class VariantUtil {
   public static final int MAX_DECIMAL8_PRECISION = 18;
   public static final int MAX_DECIMAL16_PRECISION = 38;
 
+  // Long.MIN_VALUE / Long.MAX_VALUE as BigDecimals, hoisted so the decimal-to-long range check
+  // (VariantBuilder.decimalPromotesToLong) does not rebuild them on every call.
+  static final BigDecimal LONG_MIN_AS_DECIMAL = BigDecimal.valueOf(Long.MIN_VALUE);
+  static final BigDecimal LONG_MAX_AS_DECIMAL = BigDecimal.valueOf(Long.MAX_VALUE);
+
   // Write the least significant `numBytes` bytes in `value` into `bytes[pos, pos + numBytes)` in
   // little endian.
   public static void writeLong(byte[] bytes, int pos, long value, int numBytes) {

--- a/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
+++ b/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
@@ -25,18 +25,17 @@ import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
  * Direct unit tests for `VariantBuilder.canonicalize`.
  *
  * The canonical form is the contract that `canonicalize(a)` and `canonicalize(b)` are byte-equal
- * iff `a` and `b` are semantically equal. This suite grows as the feature is built up. It currently
- * covers structural canonicalization (metadata dictionary key order, unused-key stripping, object
- * field-id remapping) and value normalization for integers, decimals, float/double, and strings
+ * iff `a` and `b` are semantically equal. It currently covers structural canonicalization
+ * (metadata dictionary key order, unused-key stripping, object field-id remapping)
+ * and value normalization for integers, decimals, float/double, and strings
  * (integer width, integer-promotion, trailing-zero strip, -0.0 -> +0.0, canonical NaN, short-string
  * encoding). The `isCanonical` read-side predicate is complete and checked against `canonicalize`
- * by a soundness oracle over a mixed corpus; the fast-path wiring comes next.
+ * by a soundness oracle over a mixed corpus.
  */
 class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsuite
 
   private def parse(json: String): Variant =
-    // allowDuplicateKeys = false
-    VariantBuilder.parseJson(json, false)
+    VariantBuilder.parseJson(json, /*allowDuplicateKeys = */ false)
 
   private def canon(v: Variant): Variant = VariantBuilder.canonicalize(v)
 
@@ -59,9 +58,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("object key order does not affect the canonical form") {
-    // The same object written with its keys in different order must canonicalize to equal bytes:
-    // the rebuilt dictionary is sorted and the field ids remapped, so the incoming key order (which
-    // drives the metadata dictionary order) is normalized away.
     val a = canon(parse("""{"a":1,"b":2}"""))
     val b = canon(parse("""{"b":2,"a":1}"""))
     assert(bytesEqual(a, b), "objects equal up to key order must canonicalize to equal bytes")
@@ -74,21 +70,16 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("canonical form is independent of the incoming metadata dictionary order") {
-    // Two encodings of the same value whose dictionaries are populated in different orders (driven
-    // by the outer key order) must collapse to identical bytes once the dictionary is rebuilt
-    // sorted.
     val a = canon(parse("""{"m":{"a":1},"a":{"b":2}}"""))
     val b = canon(parse("""{"a":{"b":2},"m":{"a":1}}"""))
     assert(bytesEqual(a, b), "canonical metadata must not depend on incoming dictionary order")
   }
 
   test("object key order inside array elements is normalized, array element order is preserved") {
-    // Canonicalization descends into array elements, so per-element object key order is normalized.
     val a = canon(parse("""[{"a":1,"b":2},{"c":3}]"""))
     val b = canon(parse("""[{"b":2,"a":1},{"c":3}]"""))
     assert(bytesEqual(a, b), "object key order within array elements must be normalized")
 
-    // But array element ORDER is semantic and must never be reordered.
     val c = canon(parse("""[1,2]"""))
     val d = canon(parse("""[2,1]"""))
     assert(!bytesEqual(c, d), "array element order is significant and must be preserved")
@@ -121,7 +112,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- Value normalization: DECIMAL -----
 
   test("integer-valued decimal canonicalizes to the integer encoding") {
-    // Sanity: 1.0 and 1 differ before canon, so this genuinely exercises decimal -> long promotion.
     assert(!bytesEqual(parse("1.0"), parse("1")), "1.0 and 1 should differ before canon")
     assert(bytesEqual(canon(parse("1.0")), canon(parse("1"))), "1.0 must canonicalize to 1")
     assert(bytesEqual(canon(parse("1.000")), canon(parse("1"))), "1.000 must canonicalize to 1")
@@ -146,9 +136,7 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("integer decimal too large for a long is not promoted (stays a decimal)") {
-    // 10^20 exceeds Long range; the fits-long check must reject promotion, else longValue() would
-    // silently wrap. Confirm it parses as a decimal and canonicalizes to a decimal, value intact.
-    val big = "100000000000000000000" // 10^20, 21 digits -> stored as DECIMAL (too big for a long)
+    val big = "100000000000000000000"
     assert(VariantUtil.getType(parse(big).getValue, 0) == VariantUtil.Type.DECIMAL,
       "sanity: 10^20 should parse as a DECIMAL")
     val canonBig = canon(parse(big))
@@ -161,9 +149,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- Value normalization: integer width -----
 
   test("non-minimal integer width is reduced to the smallest") {
-    // parse_json and appendLong always emit minimal-width ints, so hand-build an INT8-encoded 1
-    // (a wide 8-byte encoding of the value 1) to exercise width reduction. Reuse a parsed scalar's
-    // empty-dictionary metadata so only the value bytes are crafted.
     val int8Header =
       ((VariantUtil.INT8 << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
     val int8One =
@@ -182,9 +167,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("non-canonical NaN canonicalizes to the canonical NaN") {
-    // appendDouble uses doubleToLongBits, which collapses NaN, so a non-canonical NaN can't be
-    // produced via the builder -- hand-craft the value bytes (DOUBLE header + a NaN whose mantissa
-    // differs from the canonical 0x7ff8000000000000). Reuse a parsed scalar's empty metadata.
     val doubleHeader =
       ((VariantUtil.DOUBLE << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
     val bytes = java.nio.ByteBuffer.allocate(9).order(java.nio.ByteOrder.LITTLE_ENDIAN)
@@ -198,8 +180,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- Value normalization: string encoding -----
 
   test("a short string stored as long_str is re-encoded as a short string") {
-    // parse_json / appendString always short-encode short strings, so hand-craft a LONG_STR-encoded
-    // "hi" (a short string wastefully stored as long) to exercise the re-encoding.
     val longStrHeader =
       ((VariantUtil.LONG_STR << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
     val text = "hi".getBytes(java.nio.charset.StandardCharsets.UTF_8)
@@ -214,26 +194,18 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- isCanonical: metadata dictionary -----
 
   test("isCanonical accepts a sorted metadata dictionary and rejects an unsorted one") {
-    // parse_json builds the dictionary in key-encounter order, so an object whose keys are already
-    // ascending is canonical, while one written out of order is not (canon would re-sort it).
     assert(isCanon(parse("""{"a":1,"b":2}""")), "ascending dictionary is canonical")
     assert(!isCanon(parse("""{"b":2,"a":1}""")), "descending dictionary is not canonical")
-    // Encounter order z, a, m is not sorted.
     assert(!isCanon(parse("""{"z":1,"a":2,"m":3}""")), "unsorted dictionary is not canonical")
-    // canon re-sorts the dictionary, so its output is accepted.
     assert(isCanon(canon(parse("""{"b":2,"a":1}"""))), "canon output has a sorted dictionary")
   }
 
   test("isCanonical accepts an empty dictionary") {
-    // Scalars and scalar-only arrays carry an empty dictionary (trivially sorted and minimal).
     assert(isCanon(parse("1")), "a scalar's empty dictionary is canonical")
     assert(isCanon(parse("[1,2,3]")), "an array of scalars has an empty dictionary")
   }
 
   test("isCanonical rejects a non-minimal metadata offset width") {
-    // parse_json always uses the minimal offset width, so hand-craft a one-key dictionary that
-    // wastes 2 bytes per offset where 1 byte fits. Reuse the parsed header byte for VERSION (its
-    // offset-size bits are 0), then set the offset-size bits to select a 2-byte width.
     val emptyMeta = parse("1").getMetadata
     val version = emptyMeta(0)
     val header2 = (version | (1 << 6)).toByte // offset width = 2 bytes
@@ -253,8 +225,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- isCanonical: object / array structure -----
 
   test("isCanonical rejects a dictionary with an unused key") {
-    // A dictionary entry no field references is stripped by canon (parse_json never emits one),
-    // so build a value with an unused key directly: the referenced-key check must reject it.
     val b = new VariantBuilder(false)
     b.addKey("unused")
     b.appendLong(1)
@@ -264,7 +234,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("isCanonical accepts already-canonical nested objects and arrays") {
-    // Encounter order is ascending here, so parse_json already produces the canonical structure.
     assert(isCanon(parse("""{"a":{"b":1}}""")), "a canonical nested object is accepted")
     assert(isCanon(parse("""{"a":[1,2,3]}""")), "a canonical object-of-array is accepted")
     assert(isCanon(parse("[1,2]")), "a scalar array is accepted")
@@ -273,7 +242,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("isCanonical accepts canonicalize's output for nested structures") {
-    // A structural mini-oracle: whatever canon emits must pass the structure + dictionary checks.
     val inputs = Seq(
       """{"b":2,"a":1}""",
       """{"z":{"b":1,"a":2},"m":3}""",
@@ -285,9 +253,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("isCanonical rejects a non-minimal array offset width") {
-    // parse_json always uses the minimal offset width, so hand-craft an array [1] that wastes 2
-    // bytes per offset where 1 byte fits. The value data is a single INT1(1) (2 bytes), so the
-    // canonical offset width is 1.
     val elem = parse("1").getValue // INT1(1), a 2-byte canonical scalar, reused as the element
     val arrayHeader = ((0 << (VariantUtil.BASIC_TYPE_BITS + 2)) |
       ((2 - 1) << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.ARRAY).toByte // 2-byte offset width
@@ -359,8 +324,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- NaN and pass-through type coverage -----
 
   test("canonicalize and isCanonical handle a non-canonical float NaN") {
-    // appendFloat uses floatToIntBits, which collapses NaN, so hand-craft a FLOAT with a
-    // non-canonical NaN bit pattern (mantissa differs from the canonical 0x7fc00000).
     val floatHeader =
       ((VariantUtil.FLOAT << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
     val bytes = java.nio.ByteBuffer.allocate(1 + 4).order(java.nio.ByteOrder.LITTLE_ENDIAN)
@@ -375,8 +338,6 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("canonicalize passes through date, timestamp, binary, and uuid unchanged") {
-    // These types have no canonicalization rules (parse_json cannot produce them), so canonicalize
-    // is a no-op and isCanonical accepts them as stored. Build one of each directly.
     def build(f: VariantBuilder => Unit): Variant = {
       val b = new VariantBuilder(false)
       f(b)
@@ -451,15 +412,12 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   // ----- canonicalize: sub-variant (pos != 0) -----
 
   test("canonicalize treats a sub-variant (pos != 0) as a standalone value") {
-    // getFieldByKey returns a pos != 0 view sharing the parent's value/metadata arrays.
-    // Canonicalizing it must produce the standalone canonical form of that element -- equal to
-    // canonicalizing the same object on its own, and independent of the parent's dictionary/order.
     val parent = parse("""{"outer":{"b":2,"a":1},"z":3}""")
     val sub = parent.getFieldByKey("outer") // the object {"b":2,"a":1} as a pos != 0 view
     assert(sub.getType == VariantUtil.Type.OBJECT, "sanity: sub is the nested object")
     assert(bytesEqual(canon(sub), canon(parse("""{"a":1,"b":2}"""))),
       "a sub-variant canonicalizes to the standalone canonical form of that element")
-    // And it must NOT canonicalize the whole parent root instead.
+    // It must NOT canonicalize the whole parent root instead.
     assert(!bytesEqual(canon(sub), canon(parent)),
       "canonicalizing a sub-variant must not canonicalize the whole parent")
     // A doubly-nested array-element sub-variant works too.

--- a/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
+++ b/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.types.variant
+
+import java.util.Arrays
+
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+
+/**
+ * Direct unit tests for `VariantBuilder.canonicalize`.
+ *
+ * The canonical form is the contract that `canonicalize(a)` and `canonicalize(b)` are byte-equal
+ * iff `a` and `b` are semantically equal. This suite grows as the feature is built up. It currently
+ * covers structural canonicalization (metadata dictionary key order, unused-key stripping, object
+ * field-id remapping) and value normalization for integers, decimals, float/double, and strings
+ * (integer width, integer-promotion, trailing-zero strip, -0.0 -> +0.0, canonical NaN, short-string
+ * encoding). The `isCanonical` read-side predicate is complete and checked against `canonicalize`
+ * by a soundness oracle over a mixed corpus; the fast-path wiring comes next.
+ */
+class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsuite
+
+  private def parse(json: String): Variant =
+    // allowDuplicateKeys = false
+    VariantBuilder.parseJson(json, false)
+
+  private def canon(v: Variant): Variant = VariantBuilder.canonicalize(v)
+
+  private def bytesEqual(a: Variant, b: Variant): Boolean =
+    Arrays.equals(a.getValue, b.getValue) && Arrays.equals(a.getMetadata, b.getMetadata)
+
+  private def isCanon(v: Variant): Boolean =
+    VariantBuilder.isCanonical(v.getValue, v.getMetadata)
+
+  private def buildDouble(d: Double): Variant = {
+    val b = new VariantBuilder(false)
+    b.appendDouble(d)
+    b.result()
+  }
+
+  private def buildFloat(f: Float): Variant = {
+    val b = new VariantBuilder(false)
+    b.appendFloat(f)
+    b.result()
+  }
+
+  test("object key order does not affect the canonical form") {
+    // The same object written with its keys in different order must canonicalize to equal bytes:
+    // the rebuilt dictionary is sorted and the field ids remapped, so the incoming key order (which
+    // drives the metadata dictionary order) is normalized away.
+    val a = canon(parse("""{"a":1,"b":2}"""))
+    val b = canon(parse("""{"b":2,"a":1}"""))
+    assert(bytesEqual(a, b), "objects equal up to key order must canonicalize to equal bytes")
+  }
+
+  test("nested object key order does not affect the canonical form") {
+    val a = canon(parse("""{"outer":{"a":1,"b":2},"z":3}"""))
+    val b = canon(parse("""{"z":3,"outer":{"b":2,"a":1}}"""))
+    assert(bytesEqual(a, b), "nested object key order must be normalized recursively")
+  }
+
+  test("canonical form is independent of the incoming metadata dictionary order") {
+    // Two encodings of the same value whose dictionaries are populated in different orders (driven
+    // by the outer key order) must collapse to identical bytes once the dictionary is rebuilt
+    // sorted.
+    val a = canon(parse("""{"m":{"a":1},"a":{"b":2}}"""))
+    val b = canon(parse("""{"a":{"b":2},"m":{"a":1}}"""))
+    assert(bytesEqual(a, b), "canonical metadata must not depend on incoming dictionary order")
+  }
+
+  test("object key order inside array elements is normalized, array element order is preserved") {
+    // Canonicalization descends into array elements, so per-element object key order is normalized.
+    val a = canon(parse("""[{"a":1,"b":2},{"c":3}]"""))
+    val b = canon(parse("""[{"b":2,"a":1},{"c":3}]"""))
+    assert(bytesEqual(a, b), "object key order within array elements must be normalized")
+
+    // But array element ORDER is semantic and must never be reordered.
+    val c = canon(parse("""[1,2]"""))
+    val d = canon(parse("""[2,1]"""))
+    assert(!bytesEqual(c, d), "array element order is significant and must be preserved")
+  }
+
+  test("canonicalize is idempotent") {
+    val inputs = Seq(
+      """{"b":2,"a":1}""",
+      """{"a":1,"b":2}""",
+      """{"outer":{"z":1,"a":2},"m":[1,2,3]}""",
+      "[1,2,3]",
+      "\"hello\"",
+      "true",
+      "null",
+      "1",
+      "{}",
+      "[]")
+    for (json <- inputs) {
+      val once = canon(parse(json))
+      val twice = canon(once)
+      assert(bytesEqual(once, twice), s"canonicalize must be idempotent for input $json")
+    }
+  }
+
+  test("empty object and empty array canonicalize without error") {
+    assert(bytesEqual(canon(parse("{}")), canon(parse("{}"))))
+    assert(bytesEqual(canon(parse("[]")), canon(parse("[]"))))
+  }
+
+  // ----- Value normalization: DECIMAL -----
+
+  test("integer-valued decimal canonicalizes to the integer encoding") {
+    // Sanity: 1.0 and 1 differ before canon, so this genuinely exercises decimal -> long promotion.
+    assert(!bytesEqual(parse("1.0"), parse("1")), "1.0 and 1 should differ before canon")
+    assert(bytesEqual(canon(parse("1.0")), canon(parse("1"))), "1.0 must canonicalize to 1")
+    assert(bytesEqual(canon(parse("1.000")), canon(parse("1"))), "1.000 must canonicalize to 1")
+  }
+
+  test("decimal trailing zeros are stripped") {
+    assert(!bytesEqual(parse("1.50"), parse("1.5")), "1.50 and 1.5 should differ before canon")
+    assert(bytesEqual(canon(parse("1.50")), canon(parse("1.5"))), "1.50 must canonicalize to 1.5")
+    assert(bytesEqual(canon(parse("1.500")), canon(parse("1.5"))), "1.500 must canonicalize to 1.5")
+  }
+
+  test("decimal normalization applies inside nested objects and arrays") {
+    assert(bytesEqual(canon(parse("""{"a":1.0}""")), canon(parse("""{"a":1}"""))))
+    assert(bytesEqual(
+      canon(parse("""{"a":[1.0, 2.50]}""")),
+      canon(parse("""{"a":[1, 2.5]}"""))))
+  }
+
+  test("non-integer decimal is not promoted to an integer") {
+    assert(!bytesEqual(canon(parse("1.5")), canon(parse("1"))), "1.5 must not collapse to 1")
+    assert(!bytesEqual(canon(parse("1.5")), canon(parse("2"))), "1.5 must not collapse to 2")
+  }
+
+  test("integer decimal too large for a long is not promoted (stays a decimal)") {
+    // 10^20 exceeds Long range; the fits-long check must reject promotion, else longValue() would
+    // silently wrap. Confirm it parses as a decimal and canonicalizes to a decimal, value intact.
+    val big = "100000000000000000000" // 10^20, 21 digits -> stored as DECIMAL (too big for a long)
+    assert(VariantUtil.getType(parse(big).getValue, 0) == VariantUtil.Type.DECIMAL,
+      "sanity: 10^20 should parse as a DECIMAL")
+    val canonBig = canon(parse(big))
+    assert(VariantUtil.getType(canonBig.getValue, 0) == VariantUtil.Type.DECIMAL,
+      "10^20 must remain a DECIMAL, not be wrapped into a long")
+    val actual = VariantUtil.getDecimal(canonBig.getValue, 0)
+    assert(actual.compareTo(new java.math.BigDecimal(big)) == 0, "10^20 value must be preserved")
+  }
+
+  // ----- Value normalization: integer width -----
+
+  test("non-minimal integer width is reduced to the smallest") {
+    // parse_json and appendLong always emit minimal-width ints, so hand-build an INT8-encoded 1
+    // (a wide 8-byte encoding of the value 1) to exercise width reduction. Reuse a parsed scalar's
+    // empty-dictionary metadata so only the value bytes are crafted.
+    val int8Header =
+      ((VariantUtil.INT8 << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val int8One =
+      new Variant(Array[Byte](int8Header, 1, 0, 0, 0, 0, 0, 0, 0), parse("1").getMetadata)
+    assert(!bytesEqual(int8One, parse("1")), "sanity: INT8(1) and INT1(1) differ before canon")
+    assert(bytesEqual(canon(int8One), canon(parse("1"))), "INT8(1) must reduce to INT1(1)")
+  }
+
+  // ----- Value normalization: float / double -----
+
+  test("negative zero canonicalizes to positive zero") {
+    assert(!bytesEqual(buildDouble(-0.0d), buildDouble(0.0d)), "sanity: -0.0d and +0.0d differ")
+    assert(bytesEqual(canon(buildDouble(-0.0d)), canon(buildDouble(0.0d))), "double -0.0 -> +0.0")
+    assert(!bytesEqual(buildFloat(-0.0f), buildFloat(0.0f)), "sanity: -0.0f and +0.0f differ")
+    assert(bytesEqual(canon(buildFloat(-0.0f)), canon(buildFloat(0.0f))), "float -0.0 -> +0.0")
+  }
+
+  test("non-canonical NaN canonicalizes to the canonical NaN") {
+    // appendDouble uses doubleToLongBits, which collapses NaN, so a non-canonical NaN can't be
+    // produced via the builder -- hand-craft the value bytes (DOUBLE header + a NaN whose mantissa
+    // differs from the canonical 0x7ff8000000000000). Reuse a parsed scalar's empty metadata.
+    val doubleHeader =
+      ((VariantUtil.DOUBLE << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val bytes = java.nio.ByteBuffer.allocate(9).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(doubleHeader).putLong(0x7ff8000000000001L).array()
+    val nonCanonicalNaN = new Variant(bytes, parse("1").getMetadata)
+    assert(!bytesEqual(nonCanonicalNaN, buildDouble(Double.NaN)), "sanity: NaN encodings differ")
+    assert(bytesEqual(canon(nonCanonicalNaN), canon(buildDouble(Double.NaN))),
+      "all NaN bit patterns must canonicalize to the same bytes")
+  }
+
+  // ----- Value normalization: string encoding -----
+
+  test("a short string stored as long_str is re-encoded as a short string") {
+    // parse_json / appendString always short-encode short strings, so hand-craft a LONG_STR-encoded
+    // "hi" (a short string wastefully stored as long) to exercise the re-encoding.
+    val longStrHeader =
+      ((VariantUtil.LONG_STR << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val text = "hi".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val bytes = java.nio.ByteBuffer.allocate(1 + 4 + text.length)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(longStrHeader).putInt(text.length).put(text).array()
+    val longEncoded = new Variant(bytes, parse("1").getMetadata)
+    assert(!bytesEqual(longEncoded, parse("\"hi\"")), "sanity: long_str and short_str 'hi' differ")
+    assert(bytesEqual(canon(longEncoded), parse("\"hi\"")), "long_str 'hi' -> short_str")
+  }
+
+  // ----- isCanonical: metadata dictionary -----
+
+  test("isCanonical accepts a sorted metadata dictionary and rejects an unsorted one") {
+    // parse_json builds the dictionary in key-encounter order, so an object whose keys are already
+    // ascending is canonical, while one written out of order is not (canon would re-sort it).
+    assert(isCanon(parse("""{"a":1,"b":2}""")), "ascending dictionary is canonical")
+    assert(!isCanon(parse("""{"b":2,"a":1}""")), "descending dictionary is not canonical")
+    // Encounter order z, a, m is not sorted.
+    assert(!isCanon(parse("""{"z":1,"a":2,"m":3}""")), "unsorted dictionary is not canonical")
+    // canon re-sorts the dictionary, so its output is accepted.
+    assert(isCanon(canon(parse("""{"b":2,"a":1}"""))), "canon output has a sorted dictionary")
+  }
+
+  test("isCanonical accepts an empty dictionary") {
+    // Scalars and scalar-only arrays carry an empty dictionary (trivially sorted and minimal).
+    assert(isCanon(parse("1")), "a scalar's empty dictionary is canonical")
+    assert(isCanon(parse("[1,2,3]")), "an array of scalars has an empty dictionary")
+  }
+
+  test("isCanonical rejects a non-minimal metadata offset width") {
+    // parse_json always uses the minimal offset width, so hand-craft a one-key dictionary that
+    // wastes 2 bytes per offset where 1 byte fits. Reuse the parsed header byte for VERSION (its
+    // offset-size bits are 0), then set the offset-size bits to select a 2-byte width.
+    val emptyMeta = parse("1").getMetadata
+    val version = emptyMeta(0)
+    val header2 = (version | (1 << 6)).toByte // offset width = 2 bytes
+    val meta = java.nio.ByteBuffer.allocate(1 + 2 + 2 + 2 + 1)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(header2)
+      .put(1.toByte).put(0.toByte) // numKeys = 1
+      .put(0.toByte).put(0.toByte) // offset[0] = 0
+      .put(1.toByte).put(0.toByte) // offset[1] = 1 (one key byte)
+      .put('a'.toByte) // key "a"
+      .array()
+    // isCanonical inspects only the metadata at this step, so any value bytes suffice.
+    assert(!VariantBuilder.isCanonical(parse("1").getValue, meta),
+      "a 2-byte offset width where 1 byte fits is not canonical")
+  }
+
+  // ----- isCanonical: object / array structure -----
+
+  test("isCanonical rejects a dictionary with an unused key") {
+    // A dictionary entry no field references is stripped by canon (parse_json never emits one),
+    // so build a value with an unused key directly: the referenced-key check must reject it.
+    val b = new VariantBuilder(false)
+    b.addKey("unused")
+    b.appendLong(1)
+    val withUnusedKey = b.result()
+    assert(!VariantBuilder.isCanonical(withUnusedKey.getValue, withUnusedKey.getMetadata),
+      "a dictionary with an unreferenced key is not canonical")
+  }
+
+  test("isCanonical accepts already-canonical nested objects and arrays") {
+    // Encounter order is ascending here, so parse_json already produces the canonical structure.
+    assert(isCanon(parse("""{"a":{"b":1}}""")), "a canonical nested object is accepted")
+    assert(isCanon(parse("""{"a":[1,2,3]}""")), "a canonical object-of-array is accepted")
+    assert(isCanon(parse("[1,2]")), "a scalar array is accepted")
+    assert(isCanon(parse("{}")), "an empty object is accepted")
+    assert(isCanon(parse("[]")), "an empty array is accepted")
+  }
+
+  test("isCanonical accepts canonicalize's output for nested structures") {
+    // A structural mini-oracle: whatever canon emits must pass the structure + dictionary checks.
+    val inputs = Seq(
+      """{"b":2,"a":1}""",
+      """{"z":{"b":1,"a":2},"m":3}""",
+      "[1,2,3]",
+      """{"a":[{"y":1,"x":2}],"b":{"d":4,"c":5}}""")
+    for (json <- inputs) {
+      assert(isCanon(canon(parse(json))), s"canon output must be structurally canonical: $json")
+    }
+  }
+
+  test("isCanonical rejects a non-minimal array offset width") {
+    // parse_json always uses the minimal offset width, so hand-craft an array [1] that wastes 2
+    // bytes per offset where 1 byte fits. The value data is a single INT1(1) (2 bytes), so the
+    // canonical offset width is 1.
+    val elem = parse("1").getValue // INT1(1), a 2-byte canonical scalar, reused as the element
+    val arrayHeader = ((0 << (VariantUtil.BASIC_TYPE_BITS + 2)) |
+      ((2 - 1) << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.ARRAY).toByte // 2-byte offset width
+    val arr = java.nio.ByteBuffer.allocate(1 + 1 + 2 + 2 + elem.length)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(arrayHeader)
+      .put(1.toByte) // size = 1
+      .put(0.toByte).put(0.toByte) // offset[0] = 0
+      .put(elem.length.toByte).put(0.toByte) // offset[1] = data size
+      .put(elem) // element: INT1(1)
+      .array()
+    val nonMinimalArray = new Variant(arr, parse("1").getMetadata)
+    assert(isCanon(parse("[1]")), "sanity: a minimal-width array is canonical")
+    assert(!VariantBuilder.isCanonical(nonMinimalArray.getValue, nonMinimalArray.getMetadata),
+      "an array with a 2-byte offset width where 1 byte fits is not canonical")
+  }
+
+  // ----- isCanonical: scalar values -----
+
+  test("isCanonical rejects a non-minimally-encoded integer") {
+    val int8Header =
+      ((VariantUtil.INT8 << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val int8One =
+      new Variant(Array[Byte](int8Header, 1, 0, 0, 0, 0, 0, 0, 0), parse("1").getMetadata)
+    assert(!VariantBuilder.isCanonical(int8One.getValue, int8One.getMetadata),
+      "INT8(1) is not minimal-width")
+    assert(isCanon(parse("1")), "INT1(1) is canonical")
+  }
+
+  test("isCanonical rejects integer-valued and trailing-zero decimals") {
+    assert(!isCanon(parse("1.0")), "1.0 canonicalizes to the integer 1")
+    assert(!isCanon(parse("1.50")), "1.50 has a trailing zero")
+    assert(isCanon(parse("1.5")), "1.5 is a minimal fractional decimal")
+  }
+
+  test("isCanonical rejects -0.0 and non-canonical NaN") {
+    assert(!isCanon(buildFloat(-0.0f)), "float -0.0 is not canonical")
+    assert(!isCanon(buildDouble(-0.0d)), "double -0.0 is not canonical")
+    assert(isCanon(buildFloat(0.0f)), "float +0.0 is canonical")
+    assert(isCanon(buildDouble(1.5d)), "an ordinary double is canonical")
+    assert(isCanon(buildDouble(Double.NaN)), "the canonical double NaN is canonical")
+
+    // Hand-craft a double NaN whose mantissa differs from the canonical 0x7ff8000000000000.
+    val doubleHeader =
+      ((VariantUtil.DOUBLE << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val nanBytes = java.nio.ByteBuffer.allocate(9).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(doubleHeader).putLong(0x7ff8000000000001L).array()
+    val nonCanonicalNaN = new Variant(nanBytes, parse("1").getMetadata)
+    assert(!VariantBuilder.isCanonical(nonCanonicalNaN.getValue, nonCanonicalNaN.getMetadata),
+      "a non-canonical NaN bit pattern is not canonical")
+  }
+
+  test("isCanonical rejects a short string stored as long_str") {
+    val longStrHeader =
+      ((VariantUtil.LONG_STR << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val text = "hi".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val bytes = java.nio.ByteBuffer.allocate(1 + 4 + text.length)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(longStrHeader).putInt(text.length).put(text).array()
+    val longEncoded = new Variant(bytes, parse("1").getMetadata)
+    assert(!VariantBuilder.isCanonical(longEncoded.getValue, longEncoded.getMetadata),
+      "a short string stored as long_str is not canonical")
+    assert(isCanon(parse("\"hi\"")), "a short-encoded string is canonical")
+    // A genuinely long string (> MAX_SHORT_STR_SIZE bytes) is canonical as long_str.
+    val bigString = "\"" + ("x" * 70) + "\""
+    assert(isCanon(parse(bigString)), "a >63-byte string is canonical as long_str")
+  }
+
+  // ----- NaN and pass-through type coverage -----
+
+  test("canonicalize and isCanonical handle a non-canonical float NaN") {
+    // appendFloat uses floatToIntBits, which collapses NaN, so hand-craft a FLOAT with a
+    // non-canonical NaN bit pattern (mantissa differs from the canonical 0x7fc00000).
+    val floatHeader =
+      ((VariantUtil.FLOAT << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val bytes = java.nio.ByteBuffer.allocate(1 + 4).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .put(floatHeader).putInt(0x7fc00001).array()
+    val nonCanonicalNaN = new Variant(bytes, parse("1").getMetadata)
+    assert(!bytesEqual(nonCanonicalNaN, buildFloat(Float.NaN)), "sanity: NaN encodings differ")
+    assert(!VariantBuilder.isCanonical(nonCanonicalNaN.getValue, nonCanonicalNaN.getMetadata),
+      "a non-canonical float NaN is not canonical")
+    assert(bytesEqual(canon(nonCanonicalNaN), canon(buildFloat(Float.NaN))),
+      "all float NaN bit patterns canonicalize to the same bytes")
+    assert(isCanon(buildFloat(Float.NaN)), "the canonical float NaN is canonical")
+  }
+
+  test("canonicalize passes through date, timestamp, binary, and uuid unchanged") {
+    // These types have no canonicalization rules (parse_json cannot produce them), so canonicalize
+    // is a no-op and isCanonical accepts them as stored. Build one of each directly.
+    def build(f: VariantBuilder => Unit): Variant = {
+      val b = new VariantBuilder(false)
+      f(b)
+      b.result()
+    }
+    val samples = Seq(
+      build(_.appendDate(19000)),
+      build(_.appendTimestamp(1234567890123L)),
+      build(_.appendTimestampNtz(1234567890123L)),
+      build(_.appendBinary(Array[Byte](1, 2, 3, 4))),
+      build(_.appendUuid(new java.util.UUID(1L, 2L))))
+    for (v <- samples) {
+      assert(bytesEqual(v, canon(v)), "a pass-through scalar must be unchanged by canonicalize")
+      assert(isCanon(v), "a pass-through scalar must be recognized as canonical")
+    }
+  }
+
+  // ----- isCanonical soundness oracle -----
+
+  test("isCanonical soundness oracle: a true result guarantees canonicalize is a no-op") {
+    // The crown-jewel invariant. For every sample:
+    //   (soundness) isCanonical(v) == true  =>  canonicalize(v) is byte-identical to v. A false
+    //     positive would let a non-canonical Variant through and silently split hash-agg buckets.
+    //   (quality)   canonicalize(v) is always recognized as canonical (fast path engages).
+    val parsed = Seq(
+      "0", "1", "-1", "127", "128", "-128", "100000",
+      "1.0", "1.5", "1.50", "1.000", "0.0",
+      "100000000000000000000", "-100000000000000000000",
+      "true", "false", "null",
+      "\"\"", "\"hi\"", "\"" + ("x" * 70) + "\"",
+      "{}", "[]", "[1,2,3]", "[3,2,1]", "[1,[2,[3]]]",
+      """{"a":1,"b":2}""", """{"b":2,"a":1}""", """{"a":1.0,"b":1.50}""",
+      """{"z":{"b":1,"a":2},"m":[1,2,3]}""",
+      """{"a":[{"y":1,"x":2}],"b":{"d":4,"c":5}}""").map(parse)
+
+    // Hand-crafted non-canonical encodings that parse_json never produces.
+    val emptyMeta = parse("1").getMetadata
+    def prim(t: Int): Byte = ((t << VariantUtil.BASIC_TYPE_BITS) | VariantUtil.PRIMITIVE).toByte
+    val int8One = new Variant(
+      Array[Byte](prim(VariantUtil.INT8), 1, 0, 0, 0, 0, 0, 0, 0), emptyMeta)
+    val nonCanonicalNaN = new Variant(
+      java.nio.ByteBuffer.allocate(9).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        .put(prim(VariantUtil.DOUBLE)).putLong(0x7ff8000000000001L).array(), emptyMeta)
+    val nonCanonicalFloatNaN = new Variant(
+      java.nio.ByteBuffer.allocate(5).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        .put(prim(VariantUtil.FLOAT)).putInt(0x7fc00001).array(), emptyMeta)
+    val hi = "hi".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val longStrHi = new Variant(
+      java.nio.ByteBuffer.allocate(1 + 4 + hi.length).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        .put(prim(VariantUtil.LONG_STR)).putInt(hi.length).put(hi).array(), emptyMeta)
+    val unusedKey = {
+      val b = new VariantBuilder(false)
+      b.addKey("unused")
+      b.appendLong(1)
+      b.result()
+    }
+    val handCrafted =
+      Seq(int8One, buildFloat(-0.0f), buildDouble(-0.0d), nonCanonicalNaN, nonCanonicalFloatNaN,
+        longStrHi, unusedKey)
+
+    for (v <- parsed ++ handCrafted) {
+      val c = canon(v)
+      if (VariantBuilder.isCanonical(v.getValue, v.getMetadata)) {
+        assert(bytesEqual(v, c),
+          "SOUNDNESS VIOLATION: isCanonical was true but canonicalize changed the bytes")
+      }
+      assert(VariantBuilder.isCanonical(c.getValue, c.getMetadata),
+        "canonicalize output must be recognized as canonical (fast path must engage)")
+    }
+  }
+
+  // ----- canonicalize: sub-variant (pos != 0) -----
+
+  test("canonicalize treats a sub-variant (pos != 0) as a standalone value") {
+    // getFieldByKey returns a pos != 0 view sharing the parent's value/metadata arrays.
+    // Canonicalizing it must produce the standalone canonical form of that element -- equal to
+    // canonicalizing the same object on its own, and independent of the parent's dictionary/order.
+    val parent = parse("""{"outer":{"b":2,"a":1},"z":3}""")
+    val sub = parent.getFieldByKey("outer") // the object {"b":2,"a":1} as a pos != 0 view
+    assert(sub.getType == VariantUtil.Type.OBJECT, "sanity: sub is the nested object")
+    assert(bytesEqual(canon(sub), canon(parse("""{"a":1,"b":2}"""))),
+      "a sub-variant canonicalizes to the standalone canonical form of that element")
+    // And it must NOT canonicalize the whole parent root instead.
+    assert(!bytesEqual(canon(sub), canon(parent)),
+      "canonicalizing a sub-variant must not canonicalize the whole parent")
+    // A doubly-nested array-element sub-variant works too.
+    val elem = parse("""{"arr":[{"y":2,"x":1}]}""").getFieldByKey("arr").getElementAtIndex(0)
+    assert(bytesEqual(canon(elem), canon(parse("""{"x":1,"y":2}"""))),
+      "a nested array-element sub-variant canonicalizes standalone")
+  }
+
+  // ----- non-ASCII (UTF-8 vs UTF-16) key ordering -----
+
+  test("object key ordering uses UTF-8 byte order, not Java String (UTF-16) order") {
+    // U+E000 is a single UTF-16 code unit (0xE000); U+1F600 is a surrogate pair (0xD83D 0xDE00).
+    // Java String (UTF-16) order puts high surrogate 0xD83D before 0xE000 (k2 < k1), whereas
+    // UTF-8 / code-point order has U+E000 < U+1F600 (k1 < k2). canonicalize must sort by UTF-8
+    // (the order finishWritingObject emits fields and getFieldByKey binary-searches) so field ids
+    // come out ascending and isCanonical accepts the result; a UTF-16 sort would break both.
+    val k1 = "\uE000"
+    val k2 = "\uD83D\uDE00"
+    val a = canon(parse(s"""{"$k1":1,"$k2":2}"""))
+    val b = canon(parse(s"""{"$k2":2,"$k1":1}"""))
+    assert(bytesEqual(a, b), "canonical form must not depend on incoming non-ASCII key order")
+    assert(isCanon(a), "canon output with non-ASCII keys must be recognized as canonical")
+    // Fields must stay retrievable, i.e. laid out in the UTF-8 order getFieldByKey binary-searches.
+    assert(bytesEqual(canon(a.getFieldByKey(k1)), canon(parse("1"))), "k1 -> 1")
+    assert(bytesEqual(canon(a.getFieldByKey(k2)), canon(parse("2"))), "k2 -> 2")
+  }
+
+  test("isCanonical uses UTF-8, not UTF-16, order for non-ASCII dictionary keys") {
+    val k1 = "\uE000" // U+E000
+    val k2 = "\uD83D\uDE00" // U+1F600 (surrogate pair)
+    // [k1, k2] is ascending in UTF-8 (U+E000 < U+1F600), so it is canonical.
+    assert(isCanon(parse(s"""{"$k1":1,"$k2":2}""")), "UTF-8-ascending non-ASCII dictionary")
+    // [k2, k1] is ascending in UTF-16 (0xD83D < 0xE000) but DESCENDING in UTF-8. A UTF-16 check
+    // would wrongly accept it; the UTF-8 check must reject it (canon re-sorts it to [k1, k2]).
+    assert(!isCanon(parse(s"""{"$k2":2,"$k1":1}""")),
+      "dictionary ordered by UTF-16 rather than UTF-8 must be rejected")
+  }
+}

--- a/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
+++ b/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
@@ -35,7 +35,7 @@ import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsuite
 
   private def parse(json: String): Variant =
-    VariantBuilder.parseJson(json, /*allowDuplicateKeys = */ false)
+    VariantBuilder.parseJson(json, /* allowDuplicateKeys = */ false)
 
   private def canon(v: Variant): Variant = VariantBuilder.canonicalize(v)
 
@@ -434,8 +434,8 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
     // UTF-8 / code-point order has U+E000 < U+1F600 (k1 < k2). canonicalize must sort by UTF-8
     // (the order finishWritingObject emits fields and getFieldByKey binary-searches) so field ids
     // come out ascending and isCanonical accepts the result; a UTF-16 sort would break both.
-    val k1 = "\uE000"
-    val k2 = "\uD83D\uDE00"
+    val k1 = new String(Character.toChars(0xE000))
+    val k2 = new String(Character.toChars(0x1F600))
     val a = canon(parse(s"""{"$k1":1,"$k2":2}"""))
     val b = canon(parse(s"""{"$k2":2,"$k1":1}"""))
     assert(bytesEqual(a, b), "canonical form must not depend on incoming non-ASCII key order")
@@ -446,8 +446,8 @@ class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsui
   }
 
   test("isCanonical uses UTF-8, not UTF-16, order for non-ASCII dictionary keys") {
-    val k1 = "\uE000" // U+E000
-    val k2 = "\uD83D\uDE00" // U+1F600 (surrogate pair)
+    val k1 = new String(Character.toChars(0xE000))
+    val k2 = new String(Character.toChars(0x1F600))
     // [k1, k2] is ascending in UTF-8 (U+E000 < U+1F600), so it is canonical.
     assert(isCanon(parse(s"""{"$k1":1,"$k2":2}""")), "UTF-8-ascending non-ASCII dictionary")
     // [k2, k1] is ascending in UTF-16 (0xD83D < 0xE000) but DESCENDING in UTF-8. A UTF-16 check

--- a/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
+++ b/common/variant/src/test/scala/org/apache/spark/types/variant/VariantCanonicalizeSuite.scala
@@ -35,7 +35,9 @@ import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 class VariantCanonicalizeSuite extends AnyFunSuite { // scalastyle:ignore funsuite
 
   private def parse(json: String): Variant =
-    VariantBuilder.parseJson(json, /* allowDuplicateKeys = */ false)
+    VariantBuilder.parseJson(
+      json,
+      /* allowDuplicateKeys = */ false)
 
   private def canon(v: Variant): Variant = VariantBuilder.canonicalize(v)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This adds a canonicalization primitive to `VariantBuilder` (in `common/variant`).

- **`public static Variant canonicalize(Variant v)`** returns a byte-canonical `Variant`, so two semantically-equal Variants produce byte-identical `value`/`metadata`. It:
  - rebuilds the metadata dictionary sorted by UTF-8 key bytes, deduped, with unreferenced keys stripped and field ids remapped;
  - normalizes scalars: smallest integer width, integer-valued decimals promoted to the integer encoding, decimal trailing zeros stripped, `-0.0` -> `+0.0`, non-canonical `NaN` collapsed to the canonical bit pattern, short strings encoded as `SHORT_STR`. Types with no canonical rule (null/boolean/date/timestamp/timestamp_ntz/binary/uuid) pass through unchanged.
  - A top-level (`pos == 0`) value that is already canonical is returned unchanged (fast path, below); a sub-variant (`pos != 0`, a view into a parent's shared arrays) is rebuilt into its standalone canonical form.

- **`public static boolean isCanonical(byte[] value, byte[] metadata)`** is the read-side predicate whose `true` result guarantees `canonicalize` is a no-op. It is used as the fast path inside `canonicalize`.

- `VariantUtil` gains `Long.MIN_VALUE`/`Long.MAX_VALUE` `BigDecimal` constants used by the decimal-to-long promotion check (hoisted out of the per-call path).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Hash-based grouping and comparison (GROUP BY / DISTINCT / equi-join) bucket by byte-equality, but two semantically-equal Variants can have different byte representations: 
- {"a": 1, "b": 2} vs {"b": 2, "a": 1}
- different incoming object-key order
- different metadata dictionary order
- non-minimal integer/decimal encodings
- `-0.0` vs `+0.0`
- non-canonical `NaN` bit patterns
- short string stored as `LONG_STR`.
Without a canonical form, such values hash and compare unequal and land in different buckets, so grouping/deduplication on Variant would produce wrong results. `canonicalize` maps semantically-equal Variants to identical bytes, which is the building block for supporting Variant in aggregation/join keys. This PR introduces only the primitive and its tests. The expression and analyzer changes that use it will follow in subsequent PRs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests are introduced in VariantCanonicalizeSuite in this PR to cover all of the new code

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-By: Claude Opus 4.8