### PR TITLE
[SPARK-59160][SQL]. Move the currentStageID counter to AdaptiveExecutionCont…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -243,8 +243,6 @@ case class AdaptiveSparkPlanExec(
 
   @volatile private var _isFinalPlan = false
 
-  private var currentStageId = 0
-
   /**
    * Return type for `createQueryStages`
    * @param newPlan the new plan with created query stages.
@@ -790,11 +788,12 @@ case class AdaptiveSparkPlanExec(
       case resultStage @ ResultQueryStageExec(_, optimizedPlan, _) =>
         assertStageNotFailed(resultStage)
         if (firstRun) {
-          // There is already an existing ResultQueryStage created in previous `withFinalPlanUpdate`
+          // There is already an existing ResultQueryStage created in previous `withFinalPlanUpdate
           // e.g, when we do `df.collect` multiple times. Here we create a new result stage to
           // execute it again, as the handler function can be different.
-          val newResultStage = ResultQueryStageExec(currentStageId, optimizedPlan, resultHandler)
-          currentStageId += 1
+          val newResultStage = ResultQueryStageExec(context.currentStageId, optimizedPlan,
+            resultHandler)
+          context.incrementStageId
           setLogicalLinkForNewQueryStage(newResultStage, optimizedPlan)
           CreateStageResult(newPlan = newResultStage,
             allChildStagesMaterialized = false,
@@ -942,8 +941,8 @@ case class AdaptiveSparkPlanExec(
       optimizeQueryStage(plan, isFinalStage = true),
       postStageCreationRules(supportsColumnar),
       "AQE Post Stage Creation")
-    val resultStage = ResultQueryStageExec(currentStageId, optimizedRootPlan, resultHandler)
-    currentStageId += 1
+    val resultStage = ResultQueryStageExec(context.currentStageId, optimizedRootPlan, resultHandler)
+    context.incrementStageId
     setLogicalLinkForNewQueryStage(resultStage, plan)
     resultStage
   }
@@ -961,14 +960,14 @@ case class AdaptiveSparkPlanExec(
             throw SparkException.internalError(
               "Custom columnar rules cannot transform shuffle node to something else.")
           }
-          ShuffleQueryStageExec(currentStageId, newPlan, e.canonicalized)
+          ShuffleQueryStageExec(context.currentStageId, newPlan, e.canonicalized)
         } else {
           assert(e.isInstanceOf[BroadcastExchangeLike])
           if (!newPlan.isInstanceOf[BroadcastExchangeLike]) {
             throw SparkException.internalError(
               "Custom columnar rules cannot transform broadcast node to something else.")
           }
-          BroadcastQueryStageExec(currentStageId, newPlan, e.canonicalized)
+          BroadcastQueryStageExec(context.currentStageId, newPlan, e.canonicalized)
         }
       case i: InMemoryTableScanLike =>
         // Apply `queryStageOptimizerRules` so that we can reuse subquery.
@@ -979,9 +978,9 @@ case class AdaptiveSparkPlanExec(
           throw SparkException.internalError(
             "Custom AQE rules cannot transform table scan node to something else.")
         }
-        TableCacheQueryStageExec(currentStageId, newPlan)
+        TableCacheQueryStageExec(context.currentStageId, newPlan)
     }
-    currentStageId += 1
+    context.incrementStageId
     setLogicalLinkForNewQueryStage(queryStage, plan)
     queryStage
   }
@@ -990,8 +989,8 @@ case class AdaptiveSparkPlanExec(
       existing: ExchangeQueryStageExec,
       exchange: Exchange): ExchangeQueryStageExec = {
     context.markSharedStageResult(existing.resultOption, this)
-    val queryStage = existing.newReuseInstance(currentStageId, exchange.output)
-    currentStageId += 1
+    val queryStage = existing.newReuseInstance(context.currentStageId, exchange.output)
+    context.incrementStageId
     setLogicalLinkForNewQueryStage(queryStage, exchange)
     recordStageId(queryStage)
     queryStage
@@ -1319,6 +1318,13 @@ case class AdaptiveExecutionContext(session: SparkSession, qe: QueryExecution) {
   }
 
   val shuffleIds: ConcurrentHashMap[Int, Boolean] = new ConcurrentHashMap[Int, Boolean]()
+
+  private var _currentStageId = 0
+  private[adaptive] def currentStageId: Int = this._currentStageId
+  private[adaptive] def incrementStageId: Unit = {
+    this._currentStageId += 1
+  }
+
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -791,9 +791,8 @@ case class AdaptiveSparkPlanExec(
           // There is already an existing ResultQueryStage created in previous `withFinalPlanUpdate
           // e.g, when we do `df.collect` multiple times. Here we create a new result stage to
           // execute it again, as the handler function can be different.
-          val newResultStage = ResultQueryStageExec(context.currentStageId, optimizedPlan,
+          val newResultStage = ResultQueryStageExec(context.getAndIcrementStageID(), optimizedPlan,
             resultHandler)
-          context.incrementStageId
           setLogicalLinkForNewQueryStage(newResultStage, optimizedPlan)
           CreateStageResult(newPlan = newResultStage,
             allChildStagesMaterialized = false,
@@ -941,8 +940,8 @@ case class AdaptiveSparkPlanExec(
       optimizeQueryStage(plan, isFinalStage = true),
       postStageCreationRules(supportsColumnar),
       "AQE Post Stage Creation")
-    val resultStage = ResultQueryStageExec(context.currentStageId, optimizedRootPlan, resultHandler)
-    context.incrementStageId
+    val resultStage = ResultQueryStageExec(context.getAndIcrementStageID(), optimizedRootPlan,
+      resultHandler)
     setLogicalLinkForNewQueryStage(resultStage, plan)
     resultStage
   }
@@ -960,14 +959,14 @@ case class AdaptiveSparkPlanExec(
             throw SparkException.internalError(
               "Custom columnar rules cannot transform shuffle node to something else.")
           }
-          ShuffleQueryStageExec(context.currentStageId, newPlan, e.canonicalized)
+          ShuffleQueryStageExec(context.getAndIcrementStageID(), newPlan, e.canonicalized)
         } else {
           assert(e.isInstanceOf[BroadcastExchangeLike])
           if (!newPlan.isInstanceOf[BroadcastExchangeLike]) {
             throw SparkException.internalError(
               "Custom columnar rules cannot transform broadcast node to something else.")
           }
-          BroadcastQueryStageExec(context.currentStageId, newPlan, e.canonicalized)
+          BroadcastQueryStageExec(context.getAndIcrementStageID(), newPlan, e.canonicalized)
         }
       case i: InMemoryTableScanLike =>
         // Apply `queryStageOptimizerRules` so that we can reuse subquery.
@@ -978,9 +977,8 @@ case class AdaptiveSparkPlanExec(
           throw SparkException.internalError(
             "Custom AQE rules cannot transform table scan node to something else.")
         }
-        TableCacheQueryStageExec(context.currentStageId, newPlan)
+        TableCacheQueryStageExec(context.getAndIcrementStageID(), newPlan)
     }
-    context.incrementStageId
     setLogicalLinkForNewQueryStage(queryStage, plan)
     queryStage
   }
@@ -989,8 +987,7 @@ case class AdaptiveSparkPlanExec(
       existing: ExchangeQueryStageExec,
       exchange: Exchange): ExchangeQueryStageExec = {
     context.markSharedStageResult(existing.resultOption, this)
-    val queryStage = existing.newReuseInstance(context.currentStageId, exchange.output)
-    context.incrementStageId
+    val queryStage = existing.newReuseInstance(context.getAndIcrementStageID(), exchange.output)
     setLogicalLinkForNewQueryStage(queryStage, exchange)
     recordStageId(queryStage)
     queryStage
@@ -1318,13 +1315,13 @@ case class AdaptiveExecutionContext(session: SparkSession, qe: QueryExecution) {
   }
 
   val shuffleIds: ConcurrentHashMap[Int, Boolean] = new ConcurrentHashMap[Int, Boolean]()
-
   private var _currentStageId = 0
   private[adaptive] def currentStageId: Int = this._currentStageId
-  private[adaptive] def incrementStageId: Unit = {
+  private[adaptive] def getAndIcrementStageID(): Int = {
+    val retVal = this._currentStageId
     this._currentStageId += 1
+    retVal
   }
-
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -1318,7 +1318,7 @@ case class AdaptiveExecutionContext(session: SparkSession, qe: QueryExecution) {
   private val stageIdCounter = new AtomicInteger(0)
 
   private[adaptive] def getAndIncrementStageID: Int = {
-    stageIdCounter.getAndDecrement()
+    stageIdCounter.getAndIncrement()
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.adaptive
 
 import java.util
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, LinkedBlockingQueue}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -791,7 +791,7 @@ case class AdaptiveSparkPlanExec(
           // There is already an existing ResultQueryStage created in previous `withFinalPlanUpdate
           // e.g, when we do `df.collect` multiple times. Here we create a new result stage to
           // execute it again, as the handler function can be different.
-          val newResultStage = ResultQueryStageExec(context.getAndIcrementStageID(), optimizedPlan,
+          val newResultStage = ResultQueryStageExec(context.getAndIncrementStageID, optimizedPlan,
             resultHandler)
           setLogicalLinkForNewQueryStage(newResultStage, optimizedPlan)
           CreateStageResult(newPlan = newResultStage,
@@ -940,7 +940,7 @@ case class AdaptiveSparkPlanExec(
       optimizeQueryStage(plan, isFinalStage = true),
       postStageCreationRules(supportsColumnar),
       "AQE Post Stage Creation")
-    val resultStage = ResultQueryStageExec(context.getAndIcrementStageID(), optimizedRootPlan,
+    val resultStage = ResultQueryStageExec(context.getAndIncrementStageID, optimizedRootPlan,
       resultHandler)
     setLogicalLinkForNewQueryStage(resultStage, plan)
     resultStage
@@ -959,14 +959,14 @@ case class AdaptiveSparkPlanExec(
             throw SparkException.internalError(
               "Custom columnar rules cannot transform shuffle node to something else.")
           }
-          ShuffleQueryStageExec(context.getAndIcrementStageID(), newPlan, e.canonicalized)
+          ShuffleQueryStageExec(context.getAndIncrementStageID, newPlan, e.canonicalized)
         } else {
           assert(e.isInstanceOf[BroadcastExchangeLike])
           if (!newPlan.isInstanceOf[BroadcastExchangeLike]) {
             throw SparkException.internalError(
               "Custom columnar rules cannot transform broadcast node to something else.")
           }
-          BroadcastQueryStageExec(context.getAndIcrementStageID(), newPlan, e.canonicalized)
+          BroadcastQueryStageExec(context.getAndIncrementStageID, newPlan, e.canonicalized)
         }
       case i: InMemoryTableScanLike =>
         // Apply `queryStageOptimizerRules` so that we can reuse subquery.
@@ -977,7 +977,7 @@ case class AdaptiveSparkPlanExec(
           throw SparkException.internalError(
             "Custom AQE rules cannot transform table scan node to something else.")
         }
-        TableCacheQueryStageExec(context.getAndIcrementStageID(), newPlan)
+        TableCacheQueryStageExec(context.getAndIncrementStageID, newPlan)
     }
     setLogicalLinkForNewQueryStage(queryStage, plan)
     queryStage
@@ -987,7 +987,7 @@ case class AdaptiveSparkPlanExec(
       existing: ExchangeQueryStageExec,
       exchange: Exchange): ExchangeQueryStageExec = {
     context.markSharedStageResult(existing.resultOption, this)
-    val queryStage = existing.newReuseInstance(context.getAndIcrementStageID(), exchange.output)
+    val queryStage = existing.newReuseInstance(context.getAndIncrementStageID, exchange.output)
     setLogicalLinkForNewQueryStage(queryStage, exchange)
     recordStageId(queryStage)
     queryStage
@@ -1315,12 +1315,10 @@ case class AdaptiveExecutionContext(session: SparkSession, qe: QueryExecution) {
   }
 
   val shuffleIds: ConcurrentHashMap[Int, Boolean] = new ConcurrentHashMap[Int, Boolean]()
-  private var _currentStageId = 0
-  private[adaptive] def currentStageId: Int = this._currentStageId
-  private[adaptive] def getAndIcrementStageID(): Int = {
-    val retVal = this._currentStageId
-    this._currentStageId += 1
-    retVal
+  private val stageIdCounter = new AtomicInteger(0)
+
+  private[adaptive] def getAndIncrementStageID: Int = {
+    stageIdCounter.getAndDecrement()
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -672,7 +672,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
         """
           |(17) ShuffleQueryStage
           |Output [1]: [max#xL]
-          |Arguments: 0""".stripMargin,
+          |Arguments: 2""".stripMargin,
         """
           |(22) AdaptiveSparkPlan
           |Output [1]: [max(id)#xL]


### PR DESCRIPTION
…ext to avoid clash of stageIDs when sharing the stages
### What changes were proposed in this pull request?
Move the currentStageId counter from AdaptiveSparkPlanExec to AdativeExecutionContext.
 
### Why are the changes needed?
The counter is initialized in the constructor of AdaptiveSparkPlanExec as
private var currentStageId = 0 
but the previous stages encountered in the subplans and cached in stageCache field of AdaptiveExecutionContext are bound to clash with IDs generated in the current AdaptiveSparkPlanExec.
As of now in the stock spark code, those Ids are not used for lookups ( instead its the canonicalized plans which are used), so there are no issues. ( atleast there are no failing tests and possibly no scope of bug).
 
May be to make the code safer for future , the currentStageId should be moved as a var field in AdaptiveExecutionContext , to guarantee uniqueness among all the stages seen within an AdaptiveExecutionContext.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests passing should be sufficient, though will write a dedicated unit test.


### Was this patch authored or co-authored using generative AI tooling?
No