### PR TITLE
[SPARK-59045][SQL][4.3][FOLLOWUP] Fix the subset join key test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -651,6 +651,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
         "JOIN testcat.ns.t2 ON t1.id = t2.id")
 
     withSQLConf(
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
         SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
         SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
       checkAnswer(df, Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to the `branch-4.3` backport of #58335 (commit 0d253fef083). Sets `spark.sql.sources.v2.bucketing.requireAllClusterKeysForCoPartition` to false in the `SPARK-59045: compatible transforms reduce data type with subset join keys` test, which is what every other subset test in this suite already does on this branch.

### Why are the changes needed?

The backport broke this test on `branch-4.3`:

```
- SPARK-59045: compatible transforms reduce data type with subset join keys *** FAILED ***
  List(Exchange hashpartitioning(id#L, 5), ENSURE_REQUIREMENTS, ...) was not empty
  storage-partitioned join should not shuffle
```

On `master` the test plans without the config because SPARK-58558 relaxed `createKeyedShuffleSpec` from requiring the partition keys to exactly match the join keys to requiring them to cover the join keys. SPARK-58558 is not on this branch, so with the config at its default `createKeyedShuffleSpec` refuses the subset shape, both sides are shuffled, and the no-shuffle assertion fails.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The failing test now passes; ran `KeyGroupedPartitioningSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code.

