### PR TITLE
[SPARK-59162][ML] Replace BLAS calls with while loops in GBT models

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -22,7 +22,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
-import org.apache.spark.ml.linalg.{BLAS, DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
 import org.apache.spark.ml.tree._
@@ -367,8 +367,13 @@ class GBTClassificationModel private[ml](
 
   /** Raw prediction for the positive class. */
   private def margin(features: Vector): Double = {
-    val treePredictions = _trees.map(_.rootNode.predictImpl(features).prediction)
-    BLAS.nativeBLAS.ddot(getNumTrees, treePredictions, 1, _treeWeights, 1)
+    var prediction = 0.0
+    var i = 0
+    while (i < _trees.length) {
+      prediction += _trees(i).rootNode.predictImpl(features).prediction * _treeWeights(i)
+      i += 1
+    }
+    prediction
   }
 
   /** (private[ml]) Convert to a model in the old API */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -22,7 +22,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.{Logging, LogKeys}
-import org.apache.spark.ml.linalg.{BLAS, Vector}
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
 import org.apache.spark.ml.tree.impl.GradientBoostedTrees
@@ -301,8 +301,13 @@ class GBTRegressionModel private[ml](
   override def predict(features: Vector): Double = {
     // TODO: When we add a generic Boosting class, handle transform there?  SPARK-7129
     // Classifies by thresholding sum of weighted tree predictions
-    val treePredictions = _trees.map(_.rootNode.predictImpl(features).prediction)
-    BLAS.nativeBLAS.ddot(getNumTrees, treePredictions, 1, _treeWeights, 1)
+    var prediction = 0.0
+    var i = 0
+    while (i < _trees.length) {
+      prediction += _trees(i).rootNode.predictImpl(features).prediction * _treeWeights(i)
+      i += 1
+    }
+    prediction
   }
 
   @Since("1.4.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the BLAS dot products in `GBTClassificationModel.margin` and
`GBTRegressionModel.predict` with indexed `while` loops that accumulate each tree prediction and
weight directly. Remove the now-unused BLAS imports.

### Why are the changes needed?

The BLAS calls first allocate an array containing every tree prediction and then invoke native BLAS
for a small dot product on every model prediction. Direct accumulation avoids the temporary array
and native-call overhead, reducing prediction overhead and Spark Connect server pressure.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing GBT classifier and regressor suites passed:

```
build/sbt 'mllib/testOnly org.apache.spark.ml.classification.GBTClassifierSuite'
build/sbt 'mllib/testOnly org.apache.spark.ml.regression.GBTRegressorSuite'
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
