### PR TITLE
[SPARK-59169][CORE] Log a warning when KVStoreProtobufSerializer falls back to JSON SerDe

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
@@ -60,7 +60,7 @@ private[spark] object KVStoreProtobufSerializer extends Logging {
     val serializer = serializerMap.get(klass)
     if (serializer.isEmpty && missedClasses.add(klass)) {
       logWarning(log"No Protobuf SerDe found for class ${MDC(CLASS_NAME, klass.getName)}, " +
-        log"falling back to use the JSON SerDe.")
+        "falling back to use the JSON SerDe.")
     }
     serializer
   }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
@@ -19,9 +19,12 @@ package org.apache.spark.status.protobuf
 
 import java.lang.reflect.ParameterizedType
 import java.util.ServiceLoader
+import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters._
 
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.LogKeys.CLASS_NAME
 import org.apache.spark.status.KVUtils.KVStoreScalaSerializer
 
 private[spark] class KVStoreProtobufSerializer extends KVStoreScalaSerializer {
@@ -39,7 +42,7 @@ private[spark] class KVStoreProtobufSerializer extends KVStoreScalaSerializer {
     }
 }
 
-private[spark] object KVStoreProtobufSerializer {
+private[spark] object KVStoreProtobufSerializer extends Logging {
 
   private[this] lazy val serializerMap: Map[Class[_], ProtobufSerDe[Any]] = {
     def getGenericsType(klass: Class[_]): Class[_] = {
@@ -51,6 +54,14 @@ private[spark] object KVStoreProtobufSerializer {
     }.toMap
   }
 
-  def getSerializer(klass: Class[_]): Option[ProtobufSerDe[Any]] =
-    serializerMap.get(klass)
+  private[this] val missedClasses = ConcurrentHashMap.newKeySet[Class[_]]()
+
+  def getSerializer(klass: Class[_]): Option[ProtobufSerDe[Any]] = {
+    val serializer = serializerMap.get(klass)
+    if (serializer.isEmpty && missedClasses.add(klass)) {
+      logWarning(log"No Protobuf SerDe found for class ${MDC(CLASS_NAME, klass.getName)}, " +
+        log"falling back to use the JSON SerDe.")
+    }
+    serializer
+  }
 }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
@@ -60,7 +60,7 @@ private[spark] object KVStoreProtobufSerializer extends Logging {
     val serializer = serializerMap.get(klass)
     if (serializer.isEmpty && missedClasses.add(klass)) {
       logWarning(log"No Protobuf SerDe found for class ${MDC(CLASS_NAME, klass.getName)}, " +
-        "falling back to use the JSON SerDe.")
+        log"falling back to use the JSON SerDe.")
     }
     serializer
   }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
@@ -23,9 +23,12 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters._
 
+import org.apache.spark.deploy.history.FsHistoryProviderMetadata
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.CLASS_NAME
+import org.apache.spark.status.AppStatusStoreMetadata
 import org.apache.spark.status.KVUtils.KVStoreScalaSerializer
+import org.apache.spark.util.kvstore.{LevelDB, RocksDB}
 
 private[spark] class KVStoreProtobufSerializer extends KVStoreScalaSerializer {
   override def serialize(o: Object): Array[Byte] =
@@ -56,13 +59,21 @@ private[spark] object KVStoreProtobufSerializer extends Logging {
 
   private[this] val missedClasses = ConcurrentHashMap.newKeySet[Class[_]]()
 
+  // KVStore bookkeeping values fall back to the JSON SerDe by design: they are tiny,
+  // written at most once per store open, and gain nothing from Protobuf. Skip warning.
+  private[this] val jsonByDesignClasses: Set[Class[_]] = Set(
+    classOf[AppStatusStoreMetadata],
+    classOf[FsHistoryProviderMetadata],
+    classOf[LevelDB.TypeAliases],
+    classOf[RocksDB.TypeAliases])
+
   private[protobuf] def resetMissedClassesForTesting(): Unit = missedClasses.clear()
 
   def getSerializer(klass: Class[_]): Option[ProtobufSerDe[Any]] = {
     val serializer = serializerMap.get(klass)
-    if (serializer.isEmpty && missedClasses.add(klass)) {
+    if (serializer.isEmpty && !jsonByDesignClasses.contains(klass) && missedClasses.add(klass)) {
       logWarning(log"No Protobuf SerDe found for class ${MDC(CLASS_NAME, klass.getName)}, " +
-        log"falling back to use the JSON SerDe.")
+        log"falling back to the JSON SerDe.")
     }
     serializer
   }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
@@ -23,10 +23,8 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.deploy.history.FsHistoryProviderMetadata
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.CLASS_NAME
-import org.apache.spark.status.AppStatusStoreMetadata
 import org.apache.spark.status.KVUtils.KVStoreScalaSerializer
 import org.apache.spark.util.kvstore.{LevelDB, RocksDB}
 
@@ -59,11 +57,10 @@ private[spark] object KVStoreProtobufSerializer extends Logging {
 
   private[this] val missedClasses = ConcurrentHashMap.newKeySet[Class[_]]()
 
-  // KVStore bookkeeping values fall back to the JSON SerDe by design: they are tiny,
-  // written at most once per store open, and gain nothing from Protobuf. Skip warning.
+  // The KVStore backends' own bookkeeping values fall back to the JSON SerDe by design:
+  // they are internals of the kvstore library, which the ProtobufSerDe SPI does not cover.
+  // Skip warning for them.
   private[this] val jsonByDesignClasses: Set[Class[_]] = Set(
-    classOf[AppStatusStoreMetadata],
-    classOf[FsHistoryProviderMetadata],
     classOf[LevelDB.TypeAliases],
     classOf[RocksDB.TypeAliases])
 

--- a/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializer.scala
@@ -56,6 +56,8 @@ private[spark] object KVStoreProtobufSerializer extends Logging {
 
   private[this] val missedClasses = ConcurrentHashMap.newKeySet[Class[_]]()
 
+  private[protobuf] def resetMissedClassesForTesting(): Unit = missedClasses.clear()
+
   def getSerializer(klass: Class[_]): Option[ProtobufSerDe[Any]] = {
     val serializer = serializerMap.get(klass)
     if (serializer.isEmpty && missedClasses.add(klass)) {

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -22,6 +22,8 @@ import java.util.Date
 import scala.collection.mutable
 import scala.io.Source
 
+import org.apache.logging.log4j.Level
+
 import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
 import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.metrics.ExecutorMetricType
@@ -34,6 +36,20 @@ import org.apache.spark.util.Utils.tryWithResource
 
 class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   private val serializer = new KVStoreProtobufSerializer()
+
+  test("SPARK-59169: log a warning once per class when no ProtobufSerDe is found") {
+    val appender = new LogAppender("KVStoreProtobufSerializer fallback warning")
+    withLogAppender(appender, loggerNames = Seq(classOf[KVStoreProtobufSerializer].getName)) {
+      serializer.serialize(FallbackTestData("a"))
+      serializer.serialize(FallbackTestData("b"))
+    }
+    val warnings = appender.loggingEvents
+      .filter(_.getLevel == Level.WARN)
+      .map(_.getMessage.getFormattedMessage)
+      .filter(_.contains(classOf[FallbackTestData].getName))
+    assert(warnings.size === 1)
+    assert(warnings.head.contains("No Protobuf SerDe found for class"))
+  }
 
   test("All the string fields must be optional to avoid NPE") {
     val protoFile = getWorkspaceFilePath(
@@ -1703,3 +1719,5 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     }
   }
 }
+
+private[protobuf] case class FallbackTestData(value: String)

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -52,6 +52,16 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(warnings.head.contains("No Protobuf SerDe found for class"))
   }
 
+  test("SPARK-59169: no warning for KVStore bookkeeping classes without ProtobufSerDe") {
+    KVStoreProtobufSerializer.resetMissedClassesForTesting()
+    val appender = new LogAppender("KVStoreProtobufSerializer by-design fallback")
+    withLogAppender(appender, loggerNames = Seq(classOf[KVStoreProtobufSerializer].getName)) {
+      serializer.serialize(AppStatusStoreMetadata(1L))
+    }
+    val warnings = appender.loggingEvents.filter(_.getLevel == Level.WARN)
+    assert(warnings.isEmpty)
+  }
+
   test("All the string fields must be optional to avoid NPE") {
     val protoFile = getWorkspaceFilePath(
       "core", "src", "main", "protobuf", "org", "apache", "spark", "status", "protobuf",

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -38,6 +38,7 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   private val serializer = new KVStoreProtobufSerializer()
 
   test("SPARK-59169: log a warning once per class when no ProtobufSerDe is found") {
+    KVStoreProtobufSerializer.resetMissedClassesForTesting()
     val appender = new LogAppender("KVStoreProtobufSerializer fallback warning")
     withLogAppender(appender, loggerNames = Seq(classOf[KVStoreProtobufSerializer].getName)) {
       serializer.serialize(FallbackTestData("a"))

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.status._
 import org.apache.spark.status.api.v1._
 import org.apache.spark.ui.scope.{RDDOperationEdge, RDDOperationNode}
 import org.apache.spark.util.Utils.tryWithResource
+import org.apache.spark.util.kvstore.{LevelDB, RocksDB}
 
 class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   private val serializer = new KVStoreProtobufSerializer()
@@ -56,7 +57,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     KVStoreProtobufSerializer.resetMissedClassesForTesting()
     val appender = new LogAppender("KVStoreProtobufSerializer by-design fallback")
     withLogAppender(appender, loggerNames = Seq(classOf[KVStoreProtobufSerializer].getName)) {
-      serializer.serialize(AppStatusStoreMetadata(1L))
+      assert(KVStoreProtobufSerializer.getSerializer(classOf[RocksDB.TypeAliases]).isEmpty)
+      assert(KVStoreProtobufSerializer.getSerializer(classOf[LevelDB.TypeAliases]).isEmpty)
     }
     val warnings = appender.loggingEvents.filter(_.getLevel == Level.WARN)
     assert(warnings.isEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`KVStoreProtobufSerializer.getSerializer` now logs a warning when no `ProtobufSerDe` is registered for a class and it silently falls back to the JSON SerDe. Each missed class is recorded in a concurrent set so the warning is logged at most once per class, avoiding log flood.

### Why are the changes needed?

The fallback is currently silent, so a missing `ProtobufSerDe` registration (e.g. a new UI store class without a corresponding serializer) is easy to miss and quietly loses the performance benefit of Protobuf serialization. A one-time warning makes the gap visible without flooding the log.

### Does this PR introduce _any_ user-facing change?

No, only a new warning log message.

### How was this patch tested?

New UT in `KVStoreProtobufSerializerSuite` (core) verifies the warning content and the once-per-class dedup via `withLogAppender`. Existing `KVStoreProtobufSerializerSuite` suites in `core` and `sql/core` also pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5
