### PR TITLE
[SPARK-58968][SQL][4.2] Fix SPJ allowKeysSubsetOfPartitionKeys correctness for non-join operators

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -380,15 +380,17 @@ case class CoalescedHashPartitioning(from: HashPartitioning, partitions: Seq[Coa
  *   unique partition keys, or (2) `GroupPartitionsExec` coalesces partitions with duplicate keys.
  *
  * == Distribution Satisfaction and Grouping ==
- * Besides the default `satisfies()`, `KeyedPartitioning` exposes two additional methods used by
- * `EnsureRequirements` to handle grouped and non-grouped KPs separately:
+ * Besides the default `satisfies()`, `KeyedPartitioning` answers two more questions. They differ in
+ * what they let happen to the data before the distribution counts as met.
  *
- * - `nonGroupedSatisfies()`: called on non-grouped KPs to check as-is satisfaction (without
- *   inserting `GroupPartitionsExec`).
- * - `groupedSatisfies()`: called on non-grouped KPs to check whether inserting
- *   `GroupPartitionsExec` would satisfy the distribution. When it returns true, the distribution
- *   is NOT yet satisfied -- `EnsureRequirements` will insert `GroupPartitionsExec` to coalesce
- *   duplicate partition keys.
+ * - `nonGroupedSatisfies()`: is the distribution met by the partitioning as it stands, with no node
+ *   inserted? It is the default `Partitioning` implementation, so for a `ClusteredDistribution` it
+ *   is always false.
+ * - `groupedSatisfies()`: do the partition keys match what the distribution asks for? Duplicate
+ *   keys are ignored, so this asks about the key expressions alone. `satisfies()` is this plus
+ *   `isGrouped`, and nothing more. `EnsureRequirements` asks it directly, of grouped and
+ *   non-grouped partitionings alike, because a `GroupPartitionsExec` may be needed either way: to
+ *   coalesce duplicate partition keys, or to project them down to the operation keys.
  *
  * For `OrderedDistribution`, `GroupPartitionsExec` must also sort the partition keys to meet the
  * ordering requirement.
@@ -499,6 +501,26 @@ case class KeyedPartitioning(
     KeyedPartitioning.projectKeys(partitionKeys, keyDataTypes, positions)
 
   /**
+   * The number of partitions a `GroupPartitionsExec` projecting these keys to `positions` would
+   * leave, which is the number of distinct projected keys. `positions` must be distinct and in
+   * range, as it must be for `projectKeys`.
+   *
+   * A projection that keeps every position is the identity on the key values, so it needs no
+   * projected rows at all. The rest allocate a row per partition and hash it with an uncached
+   * `hashCode`, which makes this the expensive question to ask of a partitioning. A caller asking
+   * it for several position sets should memoize on the set.
+   */
+  def numPartitionsProjectedOn(positions: Seq[Int]): Int = {
+    if (positions.length < expressions.length) {
+      projectKeys(positions)._2.distinct.size
+    } else if (isGrouped) {
+      numPartitions
+    } else {
+      partitionKeys.distinct.size
+    }
+  }
+
+  /**
    * Reduces this partitioning's partition keys by applying the given reducers.
    * Returns the reduced keys and their data types.
    */
@@ -510,8 +532,10 @@ case class KeyedPartitioning(
     nonGroupedSatisfies(required) || (isGrouped && groupedSatisfies(required))
   }
 
-  def nonGroupedSatisfies(required: Distribution): Boolean = super.satisfies0(required)
+  /** The first of the two questions the class doc lists. */
+  private def nonGroupedSatisfies(required: Distribution): Boolean = super.satisfies0(required)
 
+  /** The second of the two questions the class doc lists. */
   def groupedSatisfies(required: Distribution): Boolean = {
     required match {
       case c @ ClusteredDistribution(requiredClustering, requireAllClusterKeys, _) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -41,9 +41,12 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * storage-partitioned joins to align partitions from different sides of the join.
  *
  * @param child The child plan providing bucketed/partitioned input
- * @param joinKeyPositions Optional projection to select a subset of the partitioning key
- *                         for join compatibility (e.g., when join keys are a subset of
- *                         partition keys)
+ * @param joinKeyPositions Optional projection selecting a subset of the partitioning key positions,
+ *                         so that partitions sharing the projected key are coalesced. Used whenever
+ *                         the operation's keys are a subset of the partition keys, either the join
+ *                         keys of a storage-partitioned join or the `PARTITION BY` and grouping
+ *                         keys of a single-child operator. The name is historical, the projection
+ *                         is not join-specific.
  * @param expectedPartitionKeys Optional sequence of expected partition key values and their
  *                              split counts
  * @param reducers Optional reducers to apply to partition keys for grouping compatibility

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.exchange
 
 import scala.annotation.tailrec
+import scala.collection.immutable.BitSet
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -53,6 +54,15 @@ case class EnsureRequirements(
     requiredDistribution: Option[Distribution] = None)
   extends Rule[SparkPlan] {
 
+  /**
+   * How a [[KeyedPartitioning]] can satisfy a required distribution. A `Left` satisfies it as it
+   * is. A `Right` satisfies it after a [[GroupPartitionsExec]] that projects its partition keys to
+   * the given partition expression positions, and carries `None` positions when the node only has
+   * to coalesce duplicate partition keys. See `splitKeyedPartitionings`.
+   */
+  private type KeyedResolution =
+    Either[KeyedPartitioning, (KeyedPartitioning, Option[Seq[Int]])]
+
   private def ensureDistributionAndOrdering(
       parent: Option[SparkPlan],
       originalChildren: Seq[SparkPlan],
@@ -61,87 +71,83 @@ case class EnsureRequirements(
       shuffleOrigin: ShuffleOrigin): Seq[SparkPlan] = {
     assert(requiredChildDistributions.length == originalChildren.length)
     assert(requiredChildOrderings.length == originalChildren.length)
-    // Ensure that the operator's children satisfy their output distribution requirements.
-    var children = originalChildren.zip(requiredChildDistributions).map {
-      case (child, distribution) =>
-        // Split child's partitioning into categories
-        val (other, grouped, nonGrouped) = splitKeyedPartitionings(child.outputPartitioning)
-
-        // If non-KeyedPartitioning already satisfies, no changes needed
-        if (other.exists(_.satisfies(distribution))) {
-          child
-        } else {
-          // Check KeyedPartitioning satisfaction conditions
-          val groupedSatisfies = grouped.find(_.satisfies(distribution))
-          val nonGroupedSatisfiesAsIs = nonGrouped.exists(_.nonGroupedSatisfies(distribution))
-          val nonGroupedSatisfiesWhenGrouped = nonGrouped.find(_.groupedSatisfies(distribution))
-
-          // Check if any KeyedPartitioning satisfies the distribution
-          if (groupedSatisfies.isDefined || nonGroupedSatisfiesAsIs
-              || nonGroupedSatisfiesWhenGrouped.isDefined) {
-            distribution match {
-              case o: OrderedDistribution =>
-                // OrderedDistribution requires grouped KeyedPartitioning with sorted keys
-                // according to the distribution's ordering.
-                // Find any KeyedPartitioning that satisfies via groupedSatisfies.
-                val satisfyingKeyedPartitioning =
-                  groupedSatisfies.orElse(nonGroupedSatisfiesWhenGrouped).get
-                val attrs = satisfyingKeyedPartitioning.expressions.flatMap(_.collectLeaves())
-                  .map(_.asInstanceOf[Attribute])
-                val keyRowOrdering = RowOrdering.create(o.ordering, attrs)
-                val keyOrdering = keyRowOrdering.on((t: InternalRowComparableWrapper) => t.row)
-                if (satisfyingKeyedPartitioning.partitionKeys.sliding(2).forall {
-                  case Seq(k1, k2) => keyOrdering.lteq(k1, k2)
-                }) {
-                  child
-                } else {
-                  // Use distributePartitions to spread splits across expected partitions
-                  val sortedGroupedKeys = satisfyingKeyedPartitioning.partitionKeys
-                    .groupBy(identity).view.mapValues(_.size)
-                    .toSeq.sortBy(_._1)(keyOrdering)
-                  GroupPartitionsExec(child,
-                    expectedPartitionKeys = Some(sortedGroupedKeys),
-                    distributePartitions = true
-                  )
-                }
-
-              case _ if groupedSatisfies.isDefined =>
-                // Grouped KeyedPartitioning already satisfies
-                child
-
-              case _ if nonGroupedSatisfiesAsIs =>
-                // Non-grouped KeyedPartitioning satisfies without grouping
-                child
-
-              case _ =>
-                // Non-grouped KeyedPartitioning satisfies only after grouping
-                GroupPartitionsExec(child)
-            }
-          } else {
-            // No partitioning satisfies - need broadcast or shuffle
-            val numPartitions = distribution.requiredNumPartitions
-              .getOrElse(conf.numShufflePartitions)
-            distribution match {
-              case BroadcastDistribution(mode) =>
-                BroadcastExchangeExec(mode, child)
-              case _: StatefulOpClusteredDistribution =>
-                ShuffleExchangeExec(
-                  distribution.createPartitioning(numPartitions), child,
-                  REQUIRED_BY_STATEFUL_OPERATOR)
-              case _ =>
-                ShuffleExchangeExec(
-                  distribution.createPartitioning(numPartitions), child, shuffleOrigin)
-            }
-          }
-        }
-    }
-
     // Get the indexes of children which have specified distribution requirements and need to be
     // co-partitioned.
     val childrenIndexes = requiredChildDistributions.zipWithIndex.filter {
       case (_: ClusteredDistribution, _) => true
       case _ => false
     }.map(_._2)
+    // A co-partitioning operator gets its projected-key `GroupPartitionsExec` from the multi-child
+    // block below, not from here. See `clusterKeyPositions`.
+    val isCoPartitioned = childrenIndexes.length > 1
+    // Ensure that the operator's children satisfy their output distribution requirements.
+    var children = originalChildren.zip(requiredChildDistributions).map {
+      case (child, distribution) =>
+        // Ask what the child's partitioning still needs to satisfy the distribution
+        val (otherSatisfies, keyed) =
+          splitKeyedPartitionings(child.outputPartitioning, distribution, isCoPartitioned)
+
+        // If a non-KeyedPartitioning already satisfies, no changes needed
+        if (otherSatisfies) {
+          child
+        } else {
+          keyed match {
+            case Some(resolution) =>
+              (distribution, resolution) match {
+                case (o: OrderedDistribution, _) =>
+                  // OrderedDistribution requires grouped KeyedPartitioning with sorted keys
+                  // according to the distribution's ordering.
+                  val satisfyingKeyedPartitioning = resolution.fold(identity, _._1)
+                  // The single-column invariant in KeyedPartitioning.supportsExpressions guarantees
+                  // one attribute per partition expression.
+                  val attrs = satisfyingKeyedPartitioning.expressions.flatMap(_.references)
+                  val keyRowOrdering = RowOrdering.create(o.ordering, attrs)
+                  val keyOrdering = keyRowOrdering.on((t: InternalRowComparableWrapper) => t.row)
+                  val keys = satisfyingKeyedPartitioning.partitionKeys
+                  // An empty zip is vacuously sorted, which is the answer for a single key.
+                  if (keys.zip(keys.drop(1)).forall { case (k1, k2) => keyOrdering.lteq(k1, k2) }) {
+                    child
+                  } else {
+                    // Use distributePartitions to spread splits across expected partitions
+                    val sortedGroupedKeys = keys
+                      .groupBy(identity).view.mapValues(_.size)
+                      .toSeq.sortBy(_._1)(keyOrdering)
+                    GroupPartitionsExec(child,
+                      expectedPartitionKeys = Some(sortedGroupedKeys),
+                      distributePartitions = true
+                    )
+                  }
+
+                // A KeyedPartitioning satisfies the distribution and a node would change nothing
+                case (_, scala.Left(_)) =>
+                  child
+
+                // A KeyedPartitioning satisfies the distribution only after a GroupPartitionsExec:
+                // to coalesce duplicate partition keys, to project the partition keys down to the
+                // operation keys, or both. The positions to project to come from whichever member
+                // of the child's partitioning leaves the most partitions.
+                case (_, scala.Right((_, positions))) =>
+                  GroupPartitionsExec(child, joinKeyPositions = positions)
+              }
+
+            case None =>
+              // No partitioning satisfies - need broadcast or shuffle
+              val numPartitions = distribution.requiredNumPartitions
+                .getOrElse(conf.numShufflePartitions)
+              distribution match {
+                case BroadcastDistribution(mode) =>
+                  BroadcastExchangeExec(mode, child)
+                case _: StatefulOpClusteredDistribution =>
+                  ShuffleExchangeExec(
+                    distribution.createPartitioning(numPartitions), child,
+                    REQUIRED_BY_STATEFUL_OPERATOR)
+                case _ =>
+                  ShuffleExchangeExec(
+                    distribution.createPartitioning(numPartitions), child, shuffleOrigin)
+              }
+          }
+        }
+    }
 
     // Special case: if all sides of the join are single partition and it's physical size less than
     // or equal spark.sql.maxSinglePartitionBytes.
@@ -859,42 +865,256 @@ case class EnsureRequirements(
   }
 
   /**
-   * Splits a partitioning into three categories:
-   * 1. Non-KeyedPartitioning (HashPartitioning, RangePartitioning, etc.)
-   * 2. Grouped KeyedPartitioning (isGrouped = true)
-   * 3. Non-grouped KeyedPartitioning (isGrouped = false)
+   * The positions of `kp`'s partition expressions that are operation keys of `distribution`, and so
+   * have to survive a projection. All of them when nothing needs projecting.
+   *
+   * Under `v2BucketingAllowKeysSubsetOfPartitionKeys` a [[KeyedPartitioning]] may be grouped on
+   * more keys than the operation requires, in which case partitions sharing an operation key are
+   * still separate. A partition expression is an operation key in two ways:
+   *
+   *  - one of its *references* is a cluster key. This is the form `groupedSatisfies` and
+   *    `KeyedShuffleSpec.keyPositions` both use, where a `bucket(4, a)` transform covers the
+   *    cluster key `a`.
+   *  - the expression *itself* is a cluster key. This is what keeps a position whose expression is
+   *    clustered on while its references are not, as for a `years(ts)` under a clustering that
+   *    names `years(ts)` rather than `ts`.
+   *
+   * Returns every position for a co-partitioned operator. There the multi-child block owns the
+   * projection, a storage-partitioned join through `checkKeyGroupCompatible` and anything else
+   * through `withJoinKeyPositions`. Projecting here as well would leave that block deriving
+   * positions from an already projected partitioning and applying them to the unprojected partition
+   * expressions.
+   *
+   * An empty result means no partition expression covers an operation key, so there is nothing to
+   * project onto. That is the answer for a member that cannot satisfy `distribution`, which is why
+   * the caller only asks for members that can. It also happens for a member that can. One whose
+   * expressions have no references at all makes every `groupedSatisfies` branch vacuously true, and
+   * nothing at `KeyedPartitioning` construction rejects that. The caller skips such a member rather
+   * than project it to no position, which would collapse every partition into one.
+   *
+   * Keeping a position is only sound because `groupedSatisfies`' subset branch also requires
+   * `expressions.forall(_.collectLeaves().size == 1)`. A kept expression is then a function of a
+   * single cluster key, so coalescing on the projected keys cannot put rows that share an operation
+   * key on different partitions.
+   */
+  private def clusterKeyPositions(
+      kp: KeyedPartitioning,
+      distribution: Distribution,
+      isCoPartitioned: Boolean): BitSet = distribution match {
+    case c: ClusteredDistribution if !isCoPartitioned =>
+      kp.expressions.zipWithIndex.collect {
+        case (e, i) if c.clustering.exists(_.semanticEquals(e)) ||
+            e.references.exists(ref => c.clustering.exists(_.semanticEquals(ref))) => i
+      }.to(BitSet)
+    case _ => kp.expressions.indices.to(BitSet)
+  }
+
+  /**
+   * Splits a partitioning into the two questions the caller acts on, in this order:
+   *
+   * 1. does one of its non-[[KeyedPartitioning]] members (HashPartitioning, RangePartitioning,
+   *    etc.) already satisfy `distribution`, in which case the child needs nothing
+   * 2. and if not, how can a [[KeyedPartitioning]] member satisfy it. As it is (`Left`), or after a
+   *    [[GroupPartitionsExec]] projecting to the given partition expression positions (`Right`,
+   *    with `None` positions when the node only has to coalesce duplicate partition keys), or not
+   *    at all (`None`)
+   *
+   * The order matters for more than tidiness. The first question touches no partition key, the
+   * second projects them. And a `Left` is not the same answer as a satisfying non-keyed member,
+   * because the `OrderedDistribution` arm has to look at the keys of the partitioning it gets.
+   *
+   * At most one `KeyedPartitioning` comes back, because the caller acts on a single one. Whichever
+   * it takes, the child then satisfies the distribution and the rest of its partitioning is
+   * irrelevant. A partitioning that satisfies the distribution can still come back as a `Right`,
+   * because `satisfies` over-claims under `v2BucketingAllowKeysSubsetOfPartitionKeys`.
+   *
+   * That is the point of classifying by what still has to happen to the data rather than by how the
+   * partitioning was built. An already grouped `KeyedPartitioning` can still need a
+   * `GroupPartitionsExec`, because `v2BucketingAllowKeysSubsetOfPartitionKeys` lets it be grouped
+   * on more keys than the operation requires, and `isGrouped` only tells whether the *full*
+   * partition keys are unique. Keeping both reasons in one answer leaves the caller a single
+   * `ClusteredDistribution` arm that inserts the node, and one place that decides the projection.
    *
    * @param partitioning The partitioning to split
-   * @return A tuple of (other, grouped, nonGrouped) where:
-   *         - other: Option containing non-KeyedPartitioning(s)
-   *         - grouped: Seq of grouped KeyedPartitionings
-   *         - nonGrouped: Seq of non-grouped KeyedPartitionings
+   * @param distribution The distribution to satisfy
+   * @param isCoPartitioned Whether the parent operator co-partitions more than one child, in which
+   *                        case the projection is not done here (see `clusterKeyPositions`)
    */
-  private def splitKeyedPartitionings(partitioning: Partitioning) = {
-    val otherPartitionings = ArrayBuffer.empty[Partitioning]
-    val groupedKeyedPartitionings = ArrayBuffer.empty[KeyedPartitioning]
-    val nonGroupedKeyedPartitionings = ArrayBuffer.empty[KeyedPartitioning]
+  private def splitKeyedPartitionings(
+      partitioning: Partitioning,
+      distribution: Distribution,
+      isCoPartitioned: Boolean): (Boolean, Option[KeyedResolution]) = {
+    // `PartitioningCollection.flatten` is not on this branch, so the recursion stays local.
+    def flatten(p: Partitioning): Seq[Partitioning] = p match {
+      case PartitioningCollection(partitionings) => partitionings.flatMap(flatten)
+      case other => other +: Nil
+    }
+    val flattened = flatten(partitioning)
 
-    def split(p: Partitioning): Unit = p match {
-      case c: PartitioningCollection => c.partitionings.foreach(split)
-      case k: KeyedPartitioning =>
-        if (k.isGrouped) {
-          groupedKeyedPartitionings += k
-        } else {
-          nonGroupedKeyedPartitionings += k
+    if (flattened.exists(p => !p.isInstanceOf[KeyedPartitioning] && p.satisfies(distribution))) {
+      (true, None)
+    } else {
+      val keyed = flattened.collect { case k: KeyedPartitioning => k }
+      (false, resolveKeyedPartitioning(keyed, distribution, isCoPartitioned))
+    }
+  }
+
+  /**
+   * How one of `keyedPartitionings` can satisfy `distribution`, or `None` when none of them can.
+   * See `splitKeyedPartitionings`, which is the only caller.
+   */
+  private def resolveKeyedPartitioning(
+      keyedPartitionings: Seq[KeyedPartitioning],
+      distribution: Distribution,
+      isCoPartitioned: Boolean): Option[KeyedResolution] = {
+    // `KeyedPartitioning.numPartitionsProjectedOn` allocates a row per input partition and hashes
+    // it with an uncached `hashCode`, so the answer is memoized. It is free for a position set that
+    // keeps every position, which is the common shape on the default config, where nothing narrows
+    // the positions and the node is inserted only to coalesce duplicate keys.
+    //
+    // The position set is the whole memo key. The projection reads each key value at
+    // `KeyedPartitioning.keyDataTypes`, the types the keys were built with, and every member of a
+    // child's partitioning shares the same keys, so the same position set projects to the same
+    // count whichever member is asked. Reading the values at the *expressions'* types would not
+    // have that property, and would not even be sound. A reducer can rewrite the keys onto another
+    // key space while a member keeps reporting the expressions it was built from.
+    val projectedNumPartitions = mutable.Map.empty[BitSet, Int]
+    def numPartitionsAfter(kp: KeyedPartitioning, positions: BitSet): Int =
+      projectedNumPartitions.getOrElseUpdate(
+        positions, kp.numPartitionsProjectedOn(positions.toSeq))
+
+    // Which members can satisfy the distribution at all, and which of their partition expression
+    // positions are operation keys. Nothing here touches a partition key.
+    //
+    // Both questions are asked, because neither implies the other. `satisfies` is the strict one,
+    // and it also enforces `requiredNumPartitions`. `groupedSatisfies` ignores the count and asks
+    // about the key expressions alone, so it also admits a member a `GroupPartitionsExec` still has
+    // to coalesce. A non-grouped member always needs that node, since `satisfies0` gates a
+    // `ClusteredDistribution` on `isGrouped`.
+    //
+    // The two overlap on the key matching, and asking the strict one first keeps that to a single
+    // matching for every member that is admitted.
+    //
+    // The positions are only computed for a member that can satisfy. For one that cannot, no
+    // position would be covered, and an empty set means something else there (see
+    // `clusterKeyPositions`).
+    val admitted = keyedPartitionings.flatMap { k =>
+      val satisfies = k.satisfies(distribution)
+      if (satisfies || k.groupedSatisfies(distribution)) {
+        val positions = clusterKeyPositions(k, distribution, isCoPartitioned)
+        // A member covering no position is skipped rather than projected onto nothing, which would
+        // collapse every partition into one. See `clusterKeyPositions`.
+        Option.when(positions.nonEmpty || k.expressions.isEmpty)((k, satisfies, positions))
+      } else {
+        None
+      }
+    }
+
+    // A node is pointless when a member satisfies and nothing is left for the node to do, which
+    // holds in two ways. Either the projection drops no position, so `satisfies` is not the
+    // over-claim this fix is about. That is also the only shape `UnspecifiedDistribution` and
+    // `AllTuples` ever reach, the two `nonGroupedSatisfies` covers, because `clusterKeyPositions`
+    // returns every position for them. Or a position is dropped but the projection merges nothing,
+    // so every operation key already lives on a single partition. Keeping the member is then better
+    // than projecting. Both describe the same number of partitions, and only the member still names
+    // the dropped keys, which lets a downstream operator co-partition on them too.
+    //
+    // `numPartitions` is the count to compare against in the second case. There the distribution is
+    // a `ClusteredDistribution`, so `satisfies` went through `isGrouped && groupedSatisfies`, and a
+    // grouped partitioning has distinct keys, leaving the node nothing to coalesce.
+    //
+    // The first form is asked of every member before the second, because answering it costs no key
+    // work at all. A member that narrows would otherwise pay a projection that a later
+    // full-coverage member makes pointless.
+    val satisfiedAsIs = admitted
+      .find { case (k, satisfies, positions) =>
+        satisfies && positions.size == k.expressions.length
+      }
+      .orElse(admitted.find { case (k, satisfies, positions) =>
+        satisfies && numPartitionsAfter(k, positions) == k.numPartitions
+      })
+      .map(_._1)
+
+    if (satisfiedAsIs.isDefined) {
+      // A member that needs no node settles the child, whatever the candidates would have offered.
+      // `Left` and `Right` are qualified throughout, because `catalyst.expressions` has its own.
+      satisfiedAsIs.map(scala.Left(_))
+    } else {
+      // Every admitted member needs a node, and every one of them satisfies the distribution once
+      // it has one, so what is left is which one to build it from. They are the candidates, keyed
+      // by the positions the node would project them to.
+      //
+      // One entry per distinct position set is enough, and the first member wins. The same set
+      // projects to the same keys whichever member applies it, because `PartitioningCollection`
+      // guarantees its members share the `partitionKeys` reference and their arity, so position `i`
+      // addresses the same key column in all of them.
+      //
+      // `GroupPartitionsExec` re-derives the member independently, with a `collectFirst` over its
+      // child's partitioning, so the member recorded here and the one used at execution agree only
+      // because of that same guarantee, `PartitioningCollection.checkKeyedPartitioningInvariant`
+      // and the value-equality interning in `fromPartitionings` behind it. Relaxing the invariant
+      // means changing both places together, not just this one. What the members may still differ
+      // in is their `expressionDataTypes`, which nothing enforces. That does not reach the keys,
+      // because both sides read them at `KeyedPartitioning.keyDataTypes` instead.
+      //
+      // The order is the child's, so when two sets leave the same number of partitions, the one
+      // from the member the child reports first wins. That tie is the only thing the order decides,
+      // and either winner satisfies the distribution. The two project to different keys though, so
+      // the choice is visible in the plan.
+      val candidates = admitted.map { case (k, _, positions) => k -> positions }.distinctBy(_._2)
+
+      // A required partition count comes first, because a node derives its count from the keys it
+      // is handed rather than from the operator. It filters the candidates rather than vetoing the
+      // winner. One that would land on the required count must not lose to one that cannot honour
+      // it and send the whole child to a shuffle instead.
+      //
+      // A member with fewer partitions than the count is refused without projecting anything, since
+      // a projection merges partitions and never splits them.
+      val eligible = distribution.requiredNumPartitions match {
+        case Some(n) => candidates.filter { case (k, ps) =>
+          k.numPartitions >= n && numPartitionsAfter(k, ps) == n
         }
-      case o => otherPartitionings += o
+        case None => candidates
+      }
+      if (eligible.isEmpty) {
+        // Either no member was admitted at all, or no projection leaves the required count. Both
+        // send the caller to a shuffle, which can honour it.
+        None
+      } else {
+        // Among the rest the choice is plan quality. Take the projection leaving the most
+        // partitions.
+        //
+        // A position set contained in another one is dropped without ranking it. Projecting to
+        // fewer positions can merge partitions but never split them, so a contained set can never
+        // leave more partitions than the set containing it, and can only tie. Dropping it therefore
+        // costs no parallelism, and on a tie it settles the choice toward the wider set, which
+        // still names the keys the narrower one would have dropped.
+        //
+        // It saves projections too, though only for the members that do not satisfy. The loop above
+        // already counted every narrowing set of a satisfying member, to decide whether that member
+        // needed a node at all. Either way the projection is the expensive step here, since
+        // `KeyedPartitioning.projectKeys` allocates a row per input partition and
+        // `InternalRowComparableWrapper.hashCode` is uncached, and the containment test is not.
+        // That test is quadratic in the number of *distinct position sets*, not in the number of
+        // members, both are small, and each pair is an int compare that rejects most of them, then
+        // a word compare on a `BitSet`. Nothing in it touches a partition key.
+        val maximal = eligible.filter { case (_, positions) =>
+          !eligible.exists { case (_, o) => o.size > positions.size && positions.subsetOf(o) }
+        }
+        // With one candidate left there is nothing to rank, and no count is needed either. That is
+        // the ordinary shape on the default config, so it is worth not projecting for it.
+        val (kp, positions) =
+          if (maximal.size == 1) maximal.head
+          else maximal.maxBy { case (k, ps) => numPartitionsAfter(k, ps) }
+
+        // Satisfied after a node, whether that node has to coalesce duplicate partition keys,
+        // project down to the operation keys, or both. A `kp` that satisfies lands here too when
+        // the projection does merge partitions, which is exactly where `satisfies` over-claims:
+        // rows sharing an operation key are spread over partitions it reports as clustered.
+        Some(scala.Right(
+          (kp, Option.when(positions.size < kp.expressions.length)(positions.toSeq))))
+      }
     }
-
-    split(partitioning)
-
-    val other = otherPartitionings.length match {
-      case 0 => None
-      case 1 => Some(otherPartitionings.head)
-      case _ => Some(PartitioningCollection(otherPartitionings.toSeq))
-    }
-
-    (other, groupedKeyedPartitionings.toSeq, nonGroupedKeyedPartitionings.toSeq)
   }
 
   def apply(plan: SparkPlan): SparkPlan = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -4437,4 +4437,220 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
       }
     }
   }
+
+  test("SPARK-58968: a window over reduced partition keys coalesces partitions") {
+    // The window keyed on `a.ts` is a subset of the partition keys, so it needs a node that
+    // projects the keys to position 0 and merges the partitions that share the projected key.
+    // Here the two rows do share a `ts` but sit on separate partitions of the join's (year,
+    // bucket) grouping, so without the projection the result is wrong.
+    //
+    // The join reduces the identity side onto the year key space, which leaves keys the left
+    // partitioning's expressions no longer describe, `IntegerType` years under `identity(ts)`.
+    // Reading them at the expression's type threw at planning until SPARK-59120 made every reader
+    // take its types from the keys.
+    val cols = Array(
+      Column.create("id", IntegerType),
+      Column.create("ts", TimestampType),
+      Column.create("v", IntegerType))
+    withTable("t_identity", "t_years") {
+      createTable("t_identity", cols, Array(identity("ts"), bucket(4, "id")))
+      createTable("t_years", cols, Array(years("ts"), bucket(4, "id")))
+      Seq("t_identity", "t_years").foreach { t =>
+        sql(s"INSERT INTO testcat.ns.$t VALUES " +
+          s"(1, cast('2020-01-01' as timestamp), 10), (2, cast('2020-01-01' as timestamp), 20)")
+      }
+
+      val query =
+        """SELECT /*+ MERGE(a, b) */ a.id, b.v,
+          |  SUM(b.v) OVER (PARTITION BY a.ts) AS s
+          |FROM testcat.ns.t_identity a JOIN testcat.ns.t_years b
+          |ON a.ts = b.ts AND a.id = b.id
+          |""".stripMargin
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
+          SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+        val df = sql(query)
+        val plan = df.queryExecution.executedPlan
+        assert(collectAllShuffles(plan).isEmpty, "should not contain any shuffle")
+        assert(plan.outputPartitioning.numPartitions == 1,
+          "projecting to the year column merges the two partitions that share a ts")
+        checkAnswer(df, Seq(Row(1, 10, 30), Row(2, 20, 30)))
+      }
+    }
+  }
+
+  test("SPARK-58968: no GroupPartitionsExec when a join collection member needs none") {
+    // An inner join reports `PartitioningCollection(left, right)`, and unlike a projection it does
+    // not enumerate the mixed combinations, so the two members are all there is. A window keyed on
+    // a.k1 with b.k2 and b.k3 therefore sees one member covering position 0 only (a.k1 is the
+    // cluster key, a.k2 and a.k3 are not) and one covering positions 1 and 2.
+    //
+    // Every partition holds a distinct k1, so rows sharing (k1, k2, k3) share a partition and the
+    // left member satisfies the window's distribution as it is. Projecting the right member to
+    // (k2, k3) would merge the two partitions holding (9, 9) instead, for nothing. The member that
+    // needs no node has to win even though the other one covers more operation keys.
+    val cols = Array(
+      Column.create("k1", IntegerType),
+      Column.create("k2", IntegerType),
+      Column.create("k3", IntegerType),
+      Column.create("v", IntegerType))
+    val partitions = Array(identity("k1"), identity("k2"), identity("k3"))
+    withTable("t1", "t2") {
+      createTable("t1", cols, partitions)
+      createTable("t2", cols, partitions)
+      Seq("t1", "t2").foreach { t =>
+        sql(s"INSERT INTO testcat.ns.$t VALUES (1, 9, 9, 10), (2, 9, 9, 20), " +
+          s"(3, 8, 8, 30), (4, 7, 7, 40)")
+      }
+
+      // Selecting every key column keeps a pruning `ProjectExec` out of the plan. One would rebuild
+      // the collection as the cross-product of the per-position alternatives, which does contain a
+      // member covering all three positions, and the question would not arise.
+      val query =
+        """SELECT /*+ MERGE(a, b) */ a.k1, a.k2, a.k3, a.v, b.k1, b.k2, b.k3, b.v,
+          |  SUM(b.v) OVER (PARTITION BY a.k1, b.k2, b.k3) AS s
+          |FROM testcat.ns.t1 a JOIN testcat.ns.t2 b
+          |ON a.k1 = b.k1 AND a.k2 = b.k2 AND a.k3 = b.k3
+          |""".stripMargin
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+        val df = sql(query)
+        val plan = df.queryExecution.executedPlan
+        assert(collectAllShuffles(plan).isEmpty, "should not contain any shuffle")
+        assert(collectAllGroupPartitions(plan).isEmpty,
+          "the join's left member satisfies the window's distribution as it is")
+        assert(plan.outputPartitioning.numPartitions == 4,
+          "coalescing on (k2, k3) would leave 3 partitions and merge nothing that had to merge")
+        checkAnswer(df, Seq(
+          Row(1, 9, 9, 10, 1, 9, 9, 10, 10),
+          Row(2, 9, 9, 20, 2, 9, 9, 20, 20),
+          Row(3, 8, 8, 30, 3, 8, 8, 30, 30),
+          Row(4, 7, 7, 40, 4, 7, 7, 40, 40)))
+      }
+    }
+  }
+
+  test("SPARK-58968: window top-k over PARTITION BY subset of partition keys coalesces " +
+      "partitions") {
+    // items is partitioned by (id, name). A top-k window that ranks by PARTITION BY id (a subset of
+    // the partition keys) must coalesce the (1,'aa') and (1,'bb') partitions before ranking so that
+    // id=1 is ranked across both rows and yields a single row. Otherwise each partition is ranked
+    // independently and id=1 surfaces twice.
+    //
+    // The second spec repeats the key, so the required clustering carries a duplicate. The
+    // projection is decided per partition expression, so a duplicate in the clustering cannot
+    // change it - that case does not fail on its own, it only pins that the duplicate is harmless.
+    val items_partitions = Array(identity("id"), identity("name"))
+    createTable(items, itemsColumns, items_partitions)
+    sql(s"INSERT INTO testcat.ns.$items VALUES " +
+      s"(1, 'aa', 10.0, cast('2020-01-01' as timestamp)), " +
+      s"(1, 'bb', 20.0, cast('2020-01-01' as timestamp)), " +
+      s"(2, 'cc', 30.0, cast('2020-01-01' as timestamp))")
+
+    val expected = Seq(Row(1L, "bb", 20.0f), Row(2L, "cc", 30.0f))
+
+    Seq("id", "id, id").foreach { partitionSpec =>
+      val query =
+        s"""SELECT id, name, price FROM (
+           |  SELECT id, name, price,
+           |    ROW_NUMBER() OVER (PARTITION BY $partitionSpec ORDER BY price DESC) rn
+           |  FROM testcat.ns.$items
+           |) t WHERE rn = 1
+           |""".stripMargin
+
+      // Result correctness does not depend on AQE: EnsureRequirements also runs in AQE's
+      // queryStagePreparationRules and likewise skips the GroupPartitionsExec, ranking id=1
+      // per-partition. Verify the wrong result under the default (AQE on) configuration.
+      withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+        checkAnswer(sql(query), expected)
+      }
+
+      // The plan-shape assertion needs a static, fully-planned tree, so disable AQE here.
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+        val groupPartitions = collectAllGroupPartitions(sql(query).queryExecution.executedPlan)
+        // The node has to project down to [id], not only coalesce: `name` is a partition key the
+        // window does not group by, so coalescing on (id, name) would merge nothing.
+        assert(groupPartitions.map(_.joinKeyPositions) == Seq(Some(Seq(0))),
+          s"PARTITION BY $partitionSpec: GroupPartitionsExec expected to project to the subset " +
+            "key [id] and coalesce the partitions sharing it")
+      }
+    }
+  }
+
+  test("SPARK-58968: non-grouped KeyedPartitioning with PARTITION BY subset of partition keys " +
+      "coalesces partitions") {
+    // `numRowsPerSplit = 1`, so the two rows sharing (1, 'aa') produce two splits for that key and
+    // the scan reports a non-grouped KeyedPartitioning([id, name]). A plain window (no
+    // WindowGroupLimit above it) is the only operator requiring ClusteredDistribution([id]) here,
+    // so the GroupPartitionsExec inserted for it must both coalesce the duplicate (1, 'aa') splits
+    // and project down to [id]. Coalescing alone leaves id=1 on two partitions.
+    val items_partitions = Array(identity("id"), identity("name"))
+    createTable(items, itemsColumns, items_partitions)
+    sql(s"INSERT INTO testcat.ns.$items VALUES " +
+      s"(1, 'aa', 10.0, cast('2020-01-01' as timestamp)), " +
+      s"(1, 'aa', 15.0, cast('2020-01-01' as timestamp)), " +
+      s"(1, 'bb', 20.0, cast('2020-01-01' as timestamp)), " +
+      s"(2, 'cc', 30.0, cast('2020-01-01' as timestamp))")
+
+    val query =
+      s"""SELECT id, name, price, SUM(price) OVER (PARTITION BY id) AS s
+         |FROM testcat.ns.$items
+         |""".stripMargin
+    val expected = Seq(
+      Row(1L, "aa", 10.0f, 45.0), Row(1L, "aa", 15.0f, 45.0), Row(1L, "bb", 20.0f, 45.0),
+      Row(2L, "cc", 30.0f, 30.0))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      checkAnswer(sql(query), expected)
+    }
+
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val groupPartitions =
+        collectAllGroupPartitions(sql(query).queryExecution.executedPlan)
+      assert(groupPartitions.map(_.joinKeyPositions) == Seq(Some(Seq(0))),
+        "the GroupPartitionsExec must project to the operation key [id], not only coalesce the " +
+          "duplicate (id, name) splits")
+    }
+  }
+
+  test("SPARK-58968: no GroupPartitionsExec when projecting to the operation keys coalesces " +
+      "nothing") {
+    // Every id has exactly one name, so projecting KeyedPartitioning([id, name]) down to [id]
+    // leaves the same number of partitions. Every id already lives on a single partition, so the
+    // partitioning satisfies ClusteredDistribution([id]) as it is. Inserting a GroupPartitionsExec
+    // would only add a CoalescedRDD layer and narrow the reported partitioning to [id].
+    val items_partitions = Array(identity("id"), identity("name"))
+    createTable(items, itemsColumns, items_partitions)
+    sql(s"INSERT INTO testcat.ns.$items VALUES " +
+      s"(1, 'aa', 10.0, cast('2020-01-01' as timestamp)), " +
+      s"(2, 'bb', 20.0, cast('2020-01-01' as timestamp)), " +
+      s"(3, 'cc', 30.0, cast('2020-01-01' as timestamp))")
+
+    val query =
+      s"""SELECT id, name, price, SUM(price) OVER (PARTITION BY id) AS s
+         |FROM testcat.ns.$items
+         |""".stripMargin
+    val expected = Seq(
+      Row(1L, "aa", 10.0f, 10.0), Row(2L, "bb", 20.0f, 20.0), Row(3L, "cc", 30.0f, 30.0))
+
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val df = sql(query)
+      checkAnswer(df, expected)
+      val plan = df.queryExecution.executedPlan
+      assert(collectAllGroupPartitions(plan).isEmpty,
+        "projecting to [id] coalesces nothing, so no GroupPartitionsExec is needed")
+      assert(collectAllShuffles(plan).isEmpty, "no shuffle either")
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -40,10 +40,16 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class EnsureRequirementsSuite extends SharedSparkSession {
-  private val exprA = Literal(1)
-  private val exprB = Literal(2)
-  private val exprC = Literal(3)
-  private val exprD = Literal(4)
+  // Attributes rather than this branch's `Literal`s, because the new tests below match partition
+  // expressions against cluster keys. SPARK-57038 made the same change on `master`.
+  private val exprA = AttributeReference("a", IntegerType)()
+  private val exprB = AttributeReference("b", IntegerType)()
+  private val exprC = AttributeReference("c", IntegerType)()
+  private val exprD = AttributeReference("d", IntegerType)()
+  // Filler attributes, only ever used to mean "not a cluster key".
+  private val exprX = AttributeReference("x", IntegerType)()
+  private val exprY = AttributeReference("y", IntegerType)()
+  private val exprZ = AttributeReference("z", IntegerType)()
 
   private val EnsureRequirements = new EnsureRequirements()
 
@@ -1399,6 +1405,413 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       requiredChildOrdering = Seq(Seq.empty)
     )
 
+  test("SPARK-58968: a grouped KeyedPartitioning must still honour requiredNumPartitions") {
+    val exprKey = AttributeReference("k", IntegerType)()
+    // A grouped KeyedPartitioning with three distinct keys and three partitions.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning =
+        KeyedPartitioning(Seq(exprKey), Seq(InternalRow(1), InternalRow(2), InternalRow(3))))
+    // `requiredNumPartitions` is a hard requirement - `Partitioning.satisfies` refuses to satisfy a
+    // distribution whose partition count differs, and neither `keysSatisfy` nor
+    // `nonGroupedSatisfies` checks it on its own. A stateful streaming operator asks for this shape
+    // through `StatefulOperatorPartitioning.getCompatibleDistribution`.
+    val parent = parentRequiring(
+      child,
+      ClusteredDistribution(Seq(exprKey), requiredNumPartitions = Some(5)))
+
+    val newChild = EnsureRequirements.apply(parent).children.head
+    assert(newChild.isInstanceOf[ShuffleExchangeExec],
+      s"expected a shuffle to reach 5 partitions, got ${newChild.getClass.getSimpleName}")
+    assert(newChild.outputPartitioning.numPartitions == 5)
+  }
+
+  test("SPARK-58968: a KeyedPartitioning with no partition expressions is kept as it is") {
+    // No in-tree producer builds one. The scan gates on `supportsExpressions`, and the projecting
+    // and grouping nodes derive their expressions from an existing partitioning. But the guard
+    // that keeps such a member is what stops it from falling to the shuffle branch, where
+    // `UnspecifiedDistribution.createPartitioning` throws outright.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq.empty, Seq(InternalRow(), InternalRow())))
+    val parent = parentRequiring(child, UnspecifiedDistribution)
+
+    assert(EnsureRequirements.apply(parent).children.head eq child)
+  }
+
+  test("SPARK-58968: a partitioning that covers no operation key is shuffled, not projected") {
+    val exprKey = AttributeReference("k", IntegerType)()
+    // Nothing at `KeyedPartitioning` construction requires a partition expression to reference a
+    // column. A DSv2 scan cannot report one that does not, because `supportsExpressions` refuses
+    // it, but no other producer is held to that, so a reference-free expression is possible here.
+    //
+    // Such a partitioning has no attributes to check against the operation keys, which makes
+    // `keysSatisfy` vacuously true, and it covers no position to project onto. Projecting to
+    // no position at all would put every row on a single partition, so the child has to be
+    // shuffled.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning =
+        KeyedPartitioning(Seq(Literal(1)), Seq(InternalRow(1), InternalRow(2), InternalRow(3))))
+    val parent = parentRequiring(child, ClusteredDistribution(Seq(exprKey)))
+
+    val newChild = EnsureRequirements.apply(parent).children.head
+    assert(newChild.isInstanceOf[ShuffleExchangeExec],
+      s"expected a shuffle, got ${newChild.getClass.getSimpleName}")
+    assert(groupPartitionsNodes(newChild).isEmpty)
+  }
+
+  test("SPARK-58968: no GroupPartitionsExec when a cluster key is the partition expression " +
+      "itself") {
+    val exprId = AttributeReference("id", IntegerType)()
+    val exprTs = AttributeReference("ts", IntegerType)()
+    val transform = years(exprTs)
+    // Partitioned by (id, years(ts)) with two partitions sharing id = 1, so projecting to [id]
+    // would merge them.
+    val keys = Seq(InternalRow(1, 1), InternalRow(1, 2), InternalRow(2, 3))
+
+    // Both cluster keys are covered, `id` at the reference level and `years(ts)` at the expression
+    // level. The partitioning is exactly the clustering, so no projection is needed. Deriving the
+    // positions from `KeyedShuffleSpec.keyPositions` alone would look up `years(ts)` by its
+    // *reference* `ts`, which is not a cluster key, drop it, and coalesce for nothing. And under
+    // `requireAllClusterKeys` the resulting `KeyedPartitioning([id])` would not even satisfy the
+    // distribution the node was inserted for.
+    Seq(true, false).foreach { requireAllClusterKeys =>
+      val child = new DummySparkPlanWithBatchScanChild(
+        outputPartitioning = KeyedPartitioning(Seq(exprId, transform), keys))
+      val parent = parentRequiring(
+        child,
+        ClusteredDistribution(Seq(exprId, transform), requireAllClusterKeys))
+
+      withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+        val newChild = EnsureRequirements.apply(parent).children.head
+        // Note: do not interpolate the plan into an assertion message here. `BatchScanExec`'s table
+        // is null in this fixture, so rendering the tree throws, and `assert`'s clue is by-value.
+        assert(groupPartitionsNodes(newChild).isEmpty,
+          s"requireAllClusterKeys=$requireAllClusterKeys: the partitioning already satisfies")
+        assert(newChild.outputPartitioning.numPartitions == 3)
+      }
+    }
+  }
+
+  test("SPARK-58968: a transform position is kept when its reference is a cluster key") {
+    // `clusterKeyPositions` keeps a position two ways. The other tests all keep plain attributes,
+    // which the expression-level test matches on its own, so this is the one that turns on the
+    // reference-level test: `bucket(4, a)` is not a cluster key, its reference `a` is.
+    //
+    // It is also the shape the soundness argument is about. `keysSatisfy`'s subset branch requires
+    // every expression to have a single reference, so a kept expression is a function of one
+    // cluster key, and coalescing on the projected keys cannot separate rows sharing that key.
+    //
+    // Two of the three buckets carry the same value, so projecting to position 0 merges them,
+    // which is what keeps this out of the needs-no-node case.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(
+        Seq(bucket(4, exprA), exprB),
+        Seq(InternalRow(1, 10), InternalRow(1, 20), InternalRow(2, 30))))
+    val parent = parentRequiring(child, ClusteredDistribution(Seq(exprA)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      val gpes = groupPartitionsNodes(newChild)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(0))),
+        "expected a node projecting to the bucket position, whose reference is the cluster key")
+      assert(gpes.map(_.groupedPartitions.size) == Seq(2))
+    }
+  }
+
+  test("SPARK-58968: a non-grouped KeyedPartitioning may still group when the resulting count " +
+      "matches requiredNumPartitions") {
+    val exprKey = AttributeReference("k", IntegerType)()
+    // Three partitions and two distinct keys, so a plain (non-projecting) GroupPartitionsExec
+    // produces two, which is exactly what the distribution asks for. The requirement has to be
+    // checked against the count the node would produce, not against the count the partitioning has
+    // now. Refusing to group here would cost a shuffle for nothing.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning =
+        KeyedPartitioning(Seq(exprKey), Seq(InternalRow(1), InternalRow(1), InternalRow(2))))
+    val parent = parentRequiring(
+      child,
+      ClusteredDistribution(Seq(exprKey), requiredNumPartitions = Some(2)))
+
+    val newChild = EnsureRequirements.apply(parent).children.head
+    assert(groupPartitionsNodes(newChild).size == 1,
+      s"expected a GroupPartitionsExec, got ${newChild.getClass.getSimpleName}")
+    assert(newChild.collect { case s: ShuffleExchangeExec => s }.isEmpty, "no shuffle needed")
+    assert(newChild.outputPartitioning.numPartitions == 2)
+  }
+
+  test("SPARK-58968: a single-partition KeyedPartitioning under OrderedDistribution") {
+    val exprKey = AttributeReference("k", IntegerType)()
+    // One partition, so `partitionKeys.sliding(2)` yields a single window of size one. A
+    // `case Seq(k1, k2)` lambda cannot match it and throws `MatchError` at planning time. A v2
+    // table whose rows all share one partition value reports exactly this -
+    // `DataSourceV2ScanExecBase` has no single-partition short-circuit.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq(exprKey), Seq(InternalRow(1))))
+    val parent = parentRequiring(child, OrderedDistribution(Seq(SortOrder(exprKey, Ascending))))
+
+    withSQLConf(SQLConf.V2_BUCKETING_SORTING_ENABLED.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      assert(groupPartitionsNodes(newChild).isEmpty,
+        "a single partition is trivially sorted, so no node is needed")
+      assert(newChild.outputPartitioning.numPartitions == 1)
+    }
+  }
+
+  test("SPARK-58968: a projection whose resulting count matches requiredNumPartitions still " +
+      "groups") {
+    val exprN = AttributeReference("n", IntegerType)()
+    val exprI = AttributeReference("i", IntegerType)()
+    // Three partitions on (n, i), and projecting to the operation key [i] leaves two, which is
+    // what the distribution asks for. It mirrors the test below, where the projected count misses
+    // the requirement and we shuffle. Here it matches and the node is the right answer.
+    val keys = Seq(InternalRow(1, 1), InternalRow(2, 1), InternalRow(3, 2))
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq(exprN, exprI), keys))
+    val parent = parentRequiring(
+      child,
+      ClusteredDistribution(Seq(exprI), requiredNumPartitions = Some(2)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      assert(groupPartitionsNodes(newChild).map(_.joinKeyPositions) ==
+        Seq(Some(Seq(1))), "expected a node projecting to the operation key [i]")
+      assert(newChild.collect { case s: ShuffleExchangeExec => s }.isEmpty, "no shuffle needed")
+      assert(newChild.outputPartitioning.numPartitions == 2)
+    }
+  }
+
+  test("SPARK-58968: requiredNumPartitions is honoured with allowKeysSubsetOfPartitionKeys off") {
+    val exprKey = AttributeReference("k", IntegerType)()
+    // Three partitions, two distinct keys, so a coalescing node would leave two - one short of the
+    // requirement. `master` inserted that node and left the plan with the wrong partition count;
+    // this path does not depend on the subset config, which is left at its default here.
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning =
+        KeyedPartitioning(Seq(exprKey), Seq(InternalRow(1), InternalRow(1), InternalRow(2))))
+    val parent = parentRequiring(
+      child,
+      ClusteredDistribution(Seq(exprKey), requiredNumPartitions = Some(3)))
+
+    val newChild = EnsureRequirements.apply(parent).children.head
+    assert(newChild.isInstanceOf[ShuffleExchangeExec],
+      s"expected a shuffle, got ${newChild.getClass.getSimpleName}")
+    assert(newChild.outputPartitioning.numPartitions == 3)
+  }
+
+  test("SPARK-58968: a projection that would break requiredNumPartitions falls back to a shuffle") {
+    val exprN = AttributeReference("n", IntegerType)()
+    val exprI = AttributeReference("i", IntegerType)()
+    // Partitioned by (n, i) with three partitions. Projecting to the operation key [i] leaves two.
+    val keys = Seq(InternalRow(1, 1), InternalRow(2, 1), InternalRow(3, 2))
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq(exprN, exprI), keys))
+    // The partitioning matches `requiredNumPartitions` as it stands, but it needs a projection to
+    // satisfy the clustering, and a `GroupPartitionsExec` derives its count from the keys it is
+    // given, so it would produce two partitions and break the requirement the check just passed.
+    // A shuffle is the only thing that gets both right.
+    val parent = parentRequiring(
+      child,
+      ClusteredDistribution(Seq(exprI), requiredNumPartitions = Some(3)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      assert(newChild.isInstanceOf[ShuffleExchangeExec],
+        s"expected a shuffle, got ${newChild.getClass.getSimpleName}")
+      assert(newChild.outputPartitioning.numPartitions == 3)
+    }
+  }
+
+  test("SPARK-58968: cogroup on a non-leading subset of the partition keys projects to that key") {
+    val nL = AttributeReference("nL", IntegerType)()
+    val iL = AttributeReference("iL", IntegerType)()
+    val nR = AttributeReference("nR", IntegerType)()
+    val iR = AttributeReference("iR", IntegerType)()
+    // Partition keys are (n, i). Projecting to position 1 (= i, the cogroup key) leaves [1, 2],
+    // projecting to position 0 (= n) would leave [1, 2, 3].
+    val keys = Seq(InternalRow(1, 1), InternalRow(2, 1), InternalRow(3, 2))
+
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq(nL, iL), keys))
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq(nR, iR), keys))
+
+    val pythonUdf = PythonUDF("pyUDF", null,
+      StructType(Seq(StructField("value", IntegerType))),
+      Seq.empty,
+      PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
+      true)
+
+    // FlatMapCoGroupsInPandasExec requires ClusteredDistribution on both children but is not a
+    // ShuffledJoin, so the projection must come from the multi-child co-partitioning block, not
+    // from an inline GroupPartitionsExec. Otherwise the positions get applied twice and the
+    // second application indexes into the unprojected partition expressions.
+    val cogroup = FlatMapCoGroupsInPandasExec(
+      Seq(iL), Seq(iR), pythonUdf,
+      AttributeReference("value", IntegerType)() :: Nil, left, right)
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true") {
+      val result = EnsureRequirements.apply(cogroup)
+      val gpes = groupPartitionsNodes(result)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(1)), Some(Seq(1))),
+        "both sides must be grouped on the cogroup key i, which is at position 1")
+      assert(gpes.map(_.groupedPartitions.size) == Seq(2, 2))
+      assert(result.children.map(_.outputPartitioning).forall {
+        case k: KeyedPartitioning => k.expressions == Seq(iL) || k.expressions == Seq(iR)
+        case _ => false
+      }, "the reported partitioning must be on the cogroup key")
+    }
+  }
+
+  test("SPARK-58968: a required count filters the candidates, it does not veto the winner") {
+    // Projecting to [a] leaves 2 partitions, to [a, b] leaves 3, and the distribution asks for 2.
+    // So only the narrower set can honour the count, and it is the one the containment prune would
+    // drop and the ranking would lose. Testing the count on the winner instead, or pruning before
+    // filtering, sends the whole child to a shuffle.
+    val keys = Seq(
+      InternalRow(1, 1, 1), InternalRow(1, 2, 2), InternalRow(2, 2, 3), InternalRow(2, 2, 4))
+    val onlyA = KeyedPartitioning(Seq(exprA, exprX, exprY), keys).copy(isGrouped = false)
+    val aAndB = onlyA.copy(expressions = Seq(exprA, exprB, exprY))
+
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection(Seq(onlyA, aAndB)))
+    val parent = parentRequiring(
+      child,
+      ClusteredDistribution(Seq(exprA, exprB), requiredNumPartitions = Some(2)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      assert(newChild.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "the candidate that honours the required count must not lose to the one that cannot")
+      val gpes = groupPartitionsNodes(newChild)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(0))))
+      assert(gpes.map(_.groupedPartitions.size) == Seq(2))
+    }
+  }
+
+  test("SPARK-58968: a contained position set never wins, not even on a tie") {
+    // The third key column is constant, so projecting to [a] and to [a, b] both leave 3 partitions.
+    // `{0}` is contained in `{0, 1}` and is dropped for that reason alone, which settles the tie
+    // toward the wider set, the one that still names `b`. Ranking by count alone would take
+    // whichever the child reports first.
+    val keys = Seq(InternalRow(1, 1, 7), InternalRow(2, 2, 7), InternalRow(3, 3, 7))
+    val onlyA = KeyedPartitioning(Seq(exprA, exprX, exprY), keys).copy(isGrouped = false)
+    val aAndB = onlyA.copy(expressions = Seq(exprA, exprB, exprY))
+
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection(Seq(onlyA, aAndB)))
+    val parent = parentRequiring(child, ClusteredDistribution(Seq(exprA, exprB)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      val gpes = groupPartitionsNodes(newChild)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(0, 1))),
+        "the containing set must win the tie, so that the projection still names b")
+      assert(gpes.map(_.groupedPartitions.size) == Seq(3))
+    }
+  }
+
+  test("SPARK-58968: a narrower projection wins when it leaves more partitions") {
+    // The first key column has 4 distinct values, the second and third 3 between them. So the
+    // member covering position 0 alone leaves more partitions than the one covering positions 1 and
+    // 2, and neither position set contains the other, so coverage would pick the wrong one.
+    val keys = Seq(
+      InternalRow(1, 9, 9), InternalRow(2, 9, 9), InternalRow(3, 8, 8), InternalRow(4, 7, 7))
+    // `isGrouped = false` keeps both members out of the needs-no-node case, so both are candidates
+    // and the ranking decides. The wider one comes first, so taking the widest gives positions
+    // [1, 2] and 3 partitions instead.
+    val onlyB = KeyedPartitioning(Seq(exprX, exprB, exprC), keys).copy(isGrouped = false)
+    val onlyA = onlyB.copy(expressions = Seq(exprA, exprY, exprZ))
+
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection(Seq(onlyB, onlyA)))
+    val parent = parentRequiring(child, ClusteredDistribution(Seq(exprA, exprB, exprC)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      val gpes = groupPartitionsNodes(newChild)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(0))),
+        "the projection leaving the most partitions must win over the one covering more keys")
+      assert(gpes.map(_.groupedPartitions.size) == Seq(4))
+    }
+  }
+
+  test("SPARK-58968: the candidate covering the most operation keys wins") {
+    // Partition keys are (a, <second key column>, y). Projecting to the first position alone
+    // leaves 2 partitions, projecting to the first two leaves 3.
+    val keys = Seq(
+      InternalRow(1, 1, 1), InternalRow(1, 1, 2), InternalRow(1, 2, 3), InternalRow(2, 2, 4))
+    // Two members of one collection name the second key column differently. `x` is not a cluster
+    // key and `b` is, so they disagree on how many operation keys they cover, one against two.
+    // Only the wider one keeps partitions that share an `a` but differ in `b` apart, which is why
+    // the widest coverage is picked rather than the first member. `copy` keeps the `partitionKeys`
+    // reference `PartitioningCollection` requires its members to share.
+    val onlyA = KeyedPartitioning(Seq(exprA, exprX, exprY), keys)
+    val aAndB = onlyA.copy(expressions = Seq(exprA, exprB, exprY))
+
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection(Seq(onlyA, aAndB)))
+    val parent = parentRequiring(child, ClusteredDistribution(Seq(exprA, exprB)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      val gpes = groupPartitionsNodes(newChild)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(0, 1))),
+        "the projection must come from the member covering both operation keys")
+      assert(gpes.map(_.groupedPartitions.size) == Seq(3))
+    }
+  }
+
+  test("SPARK-58968: the candidate whose projection leaves the most partitions wins") {
+    // The first key column has 2 distinct values, the second 3. Both members below cover one
+    // operation key, so the coverage prefilter keeps both and the projected counts decide.
+    val keys = Seq(
+      InternalRow(1, 5, 1), InternalRow(1, 6, 2), InternalRow(2, 7, 3), InternalRow(2, 7, 4))
+    // The member leaving fewer partitions comes first, so taking the first, or the fewest, gives
+    // position 0 and 2 partitions instead.
+    val onlyA = KeyedPartitioning(Seq(exprA, exprY, exprZ), keys)
+    val onlyB = onlyA.copy(expressions = Seq(exprX, exprB, exprZ))
+
+    val child = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection(Seq(onlyA, onlyB)))
+    val parent = parentRequiring(child, ClusteredDistribution(Seq(exprA, exprB)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val newChild = EnsureRequirements.apply(parent).children.head
+      val gpes = groupPartitionsNodes(newChild)
+      assert(gpes.map(_.joinKeyPositions) == Seq(Some(Seq(1))),
+        "the projection must come from the member leaving the most partitions")
+      assert(gpes.map(_.groupedPartitions.size) == Seq(3))
+    }
+  }
+
+  test("SPARK-58968: equally covering candidates follow the child's own order") {
+    // Projecting to either of the first two key columns leaves 2 partitions, so the two members
+    // below cover one operation key each and their projections are equally good. Nothing ranks
+    // them. The choice is still visible in the plan, because they project to different keys, so it
+    // follows the order the child reports its partitionings in.
+    val keys = Seq(
+      InternalRow(1, 5, 1), InternalRow(1, 6, 2), InternalRow(2, 5, 3), InternalRow(2, 6, 4))
+    val onlyA = KeyedPartitioning(Seq(exprA, exprY, exprZ), keys)
+    val onlyB = onlyA.copy(expressions = Seq(exprX, exprB, exprZ))
+
+    Seq(Seq(onlyA, onlyB) -> Seq(0), Seq(onlyB, onlyA) -> Seq(1)).foreach {
+      case (members, expectedPositions) =>
+        val child = new DummySparkPlanWithBatchScanChild(
+          outputPartitioning = PartitioningCollection(members))
+        val parent = parentRequiring(child, ClusteredDistribution(Seq(exprA, exprB)))
+
+        withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+          val newChild = EnsureRequirements.apply(parent).children.head
+          val gpes = groupPartitionsNodes(newChild)
+          assert(gpes.map(_.joinKeyPositions) == Seq(Some(expectedPositions)),
+            s"the first of the two equally covering members must win, expected " +
+              s"$expectedPositions")
+          assert(gpes.map(_.groupedPartitions.size) == Seq(2))
+        }
+    }
+  }
+
   test("SPARK-56549: tryEnableSortedMerge traversal continues through plain unary nodes") {
     withSQLConf(SQLConf.V2_BUCKETING_PRESERVE_ORDERING_ON_COALESCE_ENABLED.key -> "true") {
       val exprKey = AttributeReference("k", IntegerType)()
@@ -1500,6 +1913,16 @@ class EnsureRequirementsSuite extends SharedSparkSession {
 
   private def anyGpeEnabled(plan: SparkPlan): Boolean =
     plan.collectFirst { case gpe: GroupPartitionsExec if gpe.enableSortedMerge => true }.isDefined
+
+  /** A parent that requires `distribution` of its single `child` and no ordering. */
+  private def parentRequiring(child: SparkPlan, distribution: Distribution): DummySparkPlan =
+    DummySparkPlan(
+      children = Seq(child),
+      requiredChildDistribution = Seq(distribution),
+      requiredChildOrdering = Seq(Seq.empty))
+
+  private def groupPartitionsNodes(plan: SparkPlan): Seq[GroupPartitionsExec] =
+    plan.collect { case g: GroupPartitionsExec => g }
 }
 
 private case class DummyLeafSafeForKWayMerge(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This builds on two changes that are now on master.

#58351 (SPARK-59057) renamed `KeyedPartitioning.isNarrowed` to `isCollapsed` and split `groupedSatisfies` into `keysSatisfy` and `mayGroupToSatisfy`. Two things here follow from that. The classification asks whether a member can satisfy the distribution once a `GroupPartitionsExec` is allowed, which is `keysSatisfy` for a grouped member and `mayGroupToSatisfy` for a non-grouped one, since only the second may coalesce duplicate keys and only it needs the collapse permission. That composition is a new `KeyedPartitioning.keysMaySatisfy`, which keeps `keysSatisfy` private. And the tests that build a `KeyedPartitioning` state `isCollapsed` explicitly, because that parameter lost its default.

#58420 (SPARK-59120) made every reader of a `KeyedPartitioning`'s partition keys take its types from `keyDataTypes`, the schema the keys were written under, rather than from the partition expressions. This PR projects those keys on more paths, so it needs that fix underneath it. Without it, projecting the keys of a partitioning whose keys a reducer rewrote throws `ClassCastException` at planning.

This is an alternative to #58245, which fixes the same JIRA by adding the projection to one of the two branches below.

`EnsureRequirements` split a child's `KeyedPartitioning`s by `isGrouped` and then had two branches that each had to insert a `GroupPartitionsExec`. This PR classifies by what still has to happen to the data instead.

- `splitKeyedPartitionings` now takes the required distribution and answers two questions, in this order. Whether a non-`KeyedPartitioning` member already satisfies it, and if not, how a `KeyedPartitioning` member can. As it is, or after a `GroupPartitionsExec` projecting to the partition expression positions returned with it, with `None` positions when the node only has to coalesce duplicate partition keys. At most one partitioning comes back, because the caller acts on a single one of them. The order is deliberate, since the keyed half is the one that projects partition keys, so it only runs when no plain member is enough.
- A new `clusterKeyPositions` helper derives those positions from the required clustering, and a new `KeyedPartitioning.numPartitionsProjectedOn` answers how many partitions a projection onto them would leave.
- The four-way match collapses to three cases, because the two arms that each had to insert a `GroupPartitionsExec` become one. It now matches on the distribution and the resolution together, since two of the three arms are decided by the resolution rather than by the distribution. The `OrderedDistribution` arm keeps its own insertion, as on `master`.

`clusterKeyPositions` keeps a partition expression when it is one of the operation keys. `keysSatisfy` recognises that at the *reference* level, where a `bucket(4, a)` transform covers the cluster key `a`, and also at the *expression* level, where the cluster key is the partition expression itself. Both are honoured here, which is why the positions are derived from the clustering rather than taken from `KeyedShuffleSpec.keyPositions`. That answers only the first, which is the right question for a storage-partitioned join but would drop a partition expression that is itself an operation key. The expression-level test is what keeps a position whose expression is clustered on while its references are not. No production path builds such a clustering today. `V2ExpressionUtils.toCatalystTransformOpt` maps `IdentityTransform` to the resolved attribute itself, so the reference-level test matches the same position anyway, and `DistributionAndOrderingUtils.prepareQuery` maps `resolveTransformExpression` over a write's clustering, so a `TransformExpression` does not survive into one. The test builds the shape by hand, with a table partitioned by `(id, years(ts))` and clustered on those same two expressions. The check is here because `keysSatisfy` already accepts that shape, so deriving the positions any other way would make the two disagree.

A member whose expressions cover no operation key at all is skipped rather than projected to no position, which would put every partition into one. Only a partitioning whose expressions have no references can get there. A DSv2 scan cannot report one, because `supportsExpressions` refuses it, but nothing rejects it at `KeyedPartitioning` construction.

A partitioning that satisfies the distribution is kept as it is when nothing is left for a node to do, which holds in two ways. Either the projection drops no position, so `satisfies` is not the over-claim this fix is about. Or a position is dropped but the projection merges nothing, so every operation key already lives on a single partition. Keeping the partitioning is then better than projecting, because `KeyedPartitioning([id, name])` and `KeyedPartitioning([id])` describe the same number of partitions and only the first lets a downstream operator co-partition on `name` too. This is where the collapse gives the single insertion point a new way to be wrong, namely inserting a node that merges nothing, which cannot happen on `master`, where a grouped partitioning got no node at all.

That question is asked of every member of the child's partitioning, not just of the one a node would be built from, because a child can report a whole `PartitioningCollection` and its members can disagree about which positions are operation keys. An inner join is where they do. Its `outputPartitioning` is the two sides' partitionings, and unlike `AliasAwareOutputExpression` it does not enumerate the mixed combinations, so a window keyed on one side's first key column and the other side's remaining ones sees one member covering position 0 and one covering the rest. The first needs no node, the second would coalesce for nothing.

Among the members that do need a node, the one whose projection leaves the most partitions is used, and that answer is exact rather than a heuristic. Only the position sets not contained in another one have to be projected. Projecting to fewer positions can merge partitions but never split them, so a contained set can never leave more partitions than the set containing it, and can only tie. Dropping it therefore costs no parallelism, and on a tie it settles the choice toward the wider set, which still names the keys the narrower one would have dropped. In the ordinary case one set contains all the others and a single projection settles it, and only sets that genuinely disagree, neither containing the other, each cost one. That matters because the projection is the expensive step here, since `KeyedPartitioning.projectKeys` allocates a row per input partition and `InternalRowComparableWrapper.hashCode` is uncached. So the count is memoized per position set as well, a set covering every position needs no projection at all, being the identity on the key values, and a single surviving candidate with no required count needs none either, which is the shape the default config produces. Keeping one member per position set costs nothing either, because `PartitioningCollection` guarantees its members share the `partitionKeys` reference and their arity, so position `i` addresses the same key column in all of them.

`Distribution.requiredNumPartitions` needs care, because a `GroupPartitionsExec` derives its number of partitions from the partition keys it is handed rather than from the operator. The requirement is therefore checked against the count such a node *would* produce, not against the count the partitioning happens to have now, and it filters the candidates rather than vetoing the winner. One that would land on the required number must not lose the ranking to one that cannot honour it and send the whole child to a shuffle instead. As-is satisfaction goes through `satisfies`, which enforces the count on its own.

For an operator that co-partitions more than one child no projection is done here, because that belongs to the multi-child block below, which a storage-partitioned join reaches through `checkKeyGroupCompatible` and anything else through `withJoinKeyPositions`. Projecting inline as well would leave that block deriving positions from an already projected partitioning and applying them to the unprojected keys.

`KeyedPartitioning.satisfies` is not touched, so nothing outside `EnsureRequirements` changes behaviour. It does still answer `true` for a partitioning that needs a projection first, which means `ValidateRequirements` cannot catch a missing `GroupPartitionsExec`. Giving that check the strict test directly, without changing what `satisfies` answers, is a follow-up we are working on.

The `OrderedDistribution` arm also loses a `MatchError`. It tested that the partition keys are sorted with `partitionKeys.sliding(2)`, which yields one short window for a single-key partitioning, and `case Seq(k1, k2)` cannot match it, so planning threw. A v2 table whose rows all share one partition value reports such a partitioning, since `DataSourceV2ScanExecBase` has no single-partition short-circuit, and with `v2BucketingAllowSorting` on, a global sort on the partition key reaches this branch. The test is now a zip of the keys with their successors, which is vacuously true for one key. Pre-existing, but the branch is rewritten here anyway.

Two scaladocs are corrected as well. `KeyedPartitioning` taught `isGrouped` as the axis this PR replaces. `GroupPartitionsExec.joinKeyPositions` described its projection as being "for join compatibility", and it now carries the projection for a single-child operator too.

#### Backport to `branch-4.2`

Everything above is #58262's description, unchanged. This is what differs on this branch.

**`keysMaySatisfy` is not added, and `EnsureRequirements` asks `groupedSatisfies` directly.** #58351 split `groupedSatisfies` into `keysSatisfy`, the key matching, and `mayGroupToSatisfy`, that matching plus permission to coalesce a collapsed partitioning, and `keysMaySatisfy` composes the two. Neither the split nor the permission is on this branch: `isCollapsed` and its gate arrive in 4.3.0 with SPARK-46367, and this branch's `groupedSatisfies` is exactly what `master` calls `keysSatisfy`. So `keysMaySatisfy`'s two arms coincide here. The class doc describes the two questions this branch has rather than `master`'s four.

**Four smaller deviations.**

- `nonGroupedSatisfies` becomes private, as on `master`: the rewrite removes its last caller outside the class.
- `splitKeyedPartitionings` keeps a local recursion instead of `PartitioningCollection.flatten`, which is not on this branch.
- The shared `exprA` .. `exprD` fixtures in `EnsureRequirementsSuite` become attributes, where this branch has `Literal`s, because the new tests match partition expressions against cluster keys. SPARK-57038 made the same change on `master`, and its absence here is also why this branch's planner reads the partition expressions through `collectLeaves()` where `master` reads `references`.
- The config is spelled `V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS` here, the `JOIN_` was dropped from the name later. Read `v2BucketingAllowKeysSubsetOfPartitionKeys` above as that.

**Two of the 24 tests are not carried over**, because the shapes they cover do not exist on this branch:

- `SPARK-58968: keysMaySatisfy asks the collapse gate of a non-grouped partitioning only`, in `ProjectedOrderingAndPartitioningSuite`. It contrasts `keysMaySatisfy` with `mayGroupToSatisfy` under the collapse gate, and none of the three is here, so that suite is untouched.
- `SPARK-58968: window top-k over union output partitioning coalesces partitions`. `UnionExec` does not merge `KeyedPartitioning`s on this branch, so the union reports no keyed partitioning for the window to see and no `GroupPartitionsExec` is inserted.

The two `SPARK-46367` test tidy-ups do not apply either, since those tests are not on this branch.

**The measurements below are `master`'s.** On this branch, 22 tests and **14 of them fail on the base** at `773f49a0456`: the three window tests, the transform position, the `MatchError`, four of the six `requiredNumPartitions` tests, and all five multi-member ones. `SPARK-58968: a partitioning that covers no operation key is shuffled, not projected` passes on this branch's base, where it failed on `master`; it stays as a guard on the skip path. Ran `DistributionSuite` and `ShuffleSpecSuite` with 20 tests, and `KeyGroupedPartitioningSuite`, `EnsureRequirementsSuite`, `ValidateRequirementsSuite`, `ProjectedOrderingAndPartitioningSuite`, `GroupPartitionsExecSuite` and `PlannerSuite` with 263. `dev/lint-scala` is clean.

**Nothing goes below this branch.** `GroupPartitionsExec.scala` does not exist on `branch-4.1`, so 4.1 and lower are unaffected.


### Why are the changes needed?

With `v2BucketingAllowKeysSubsetOfPartitionKeys` enabled, `KeyedPartitioning.keysSatisfy` only requires that some operation key overlaps the partition attributes. A partitioning grouped on `(id, name)` therefore reports that it satisfies `ClusteredDistribution([id])` while rows sharing an `id` still sit on separate partitions. A storage-partitioned join projects the keys down to the operation keys in `checkKeyGroupCompatible`, and for a non-join operator nothing did.

`isGrouped` is the wrong thing to classify on, because it only says the *full* partition keys are unique and says nothing about whether the *projected* keys are. A `GroupPartitionsExec` is needed either to coalesce duplicate partition keys, or to project down to the operation keys, or both, and splitting by provenance put those two reasons in different branches. Both branches returned wrong results.

1. A grouped partitioning over a superset of the operation keys got no node at all, so a top-k window over `PARTITION BY id` on an `(id, name)`-partitioned table surfaced `id=1` twice, once per `(1,'aa')` and `(1,'bb')` partition.
2. A non-grouped partitioning over a superset got a node without a projection, so it coalesced by the full partition keys and left the operation key split. Any source reporting more than one split per partition value hits this. `SUM(price) OVER (PARTITION BY id)` over the same table with two splits for `(1,'aa')` returned 25.0 and 20.0 instead of 45.0.

Both reach back to 4.2.0, where `GroupPartitionsExec` and this classification were introduced.

A reduced storage-partitioned join reaches the same wrong result through a third shape. Joining an `identity(ts)`-partitioned table to a `years(ts)`-partitioned one under `v2BucketingAllowCompatibleTransforms` leaves both sides grouped on `(year, bucket)`, so two rows sharing a `ts` in different buckets sit on separate partitions. `SUM(v) OVER (PARTITION BY ts)` then returns 10 and 20 on `master` where the answer is 30 and 30, and the projection this PR inserts is what merges the two partitions. Before #58420 that same query threw `ClassCastException` at planning once the keys were read, so the wrong answer only became observable when that fix landed.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes a data correctness issue. With `v2BucketingAllowKeysSubsetOfPartitionKeys` enabled, a single-child operator whose keys are a subset of the partition keys now produces correct results, namely a window `PARTITION BY` and the single-pass aggregate shapes (`FlatMapGroupsInBatchExec`, `ArrowAggregatePythonExec`, `MapGroupsExec`). A two-phase SQL aggregate was already correct, because its partial `HashAggregate` is a `PartitioningPreservingUnaryExecNode`, so it narrows `KP([id, name])` to `KP([id])` before the final aggregate sees it. A cogroup is unaffected either way, because the projection there is left to the multi-child block, exactly as before.

Two further changes are not gated on that config.

The `requiredNumPartitions` rule applies whether `allowKeysSubsetOfPartitionKeys` is on or off, since a scan still needs `spark.sql.sources.v2.bucketing.enabled` to report a `KeyedPartitioning` at all, and `master` has no count check on the grouping path. A non-grouped `KeyedPartitioning` with 3 partitions and 2 distinct keys under `ClusteredDistribution([k], requiredNumPartitions = Some(3))` got a `GroupPartitionsExec` with 2 partitions on `master` and now gets a shuffle with 3. I could not find a query where such a distribution meets a `KeyedPartitioning` today, so this is robustness rather than a reachable wrong result. Only `StatefulOperatorPartitioning` and `AQEUtils` ever set the requirement. The `AQEUtils` one fires only over a `HashPartitioning` child. `StatefulOperatorPartitioning` sets it through a plain `ClusteredDistribution` when `spark.sql.streaming.statefulOperator.useStrictDistribution` is off, and a streaming scan never reports a `KeyedPartitioning`, because `MicroBatchScanExec`, `ContinuousScanExec` and `RealTimeStreamScanExec` all leave `keyGroupedPartitioning` at `None`. The initial-state child of `flatMapGroupsWithState` and `transformWithState` is a batch plan though, so it can be a scan that does. That operator co-partitions its two children, so the shape is the multi-child block's to decide either way, and what changes here is only that a candidate which cannot honour the count no longer wins the resolution. The requirement is part of the `ClusteredDistribution` contract though, the two could meet more widely as this area grows, and honouring it costs nothing where nobody asks for a count, so it seemed the wrong thing to keep ignoring.

The `MatchError` fix is gated on `v2BucketingAllowSorting` instead, which is also off by default.

`explain` gains one label where the new projection happens. A `GroupPartitionsExec` inserted for a single-child operator now carries `joinKeyPositions`, so the node prints `JoinKeyPositions: [...]` where it printed nothing before. The name is historical, and the scaladoc now says the projection is not join-specific. This needs `allowKeysSubsetOfPartitionKeys` on, so no golden file moves.

### How was this patch tested?

Added regression tests in `KeyGroupedPartitioningSuite`:

- window top-k over `PARTITION BY` a subset of the partition keys, for both `PARTITION BY id` and the duplicated `PARTITION BY id, id`
- window top-k over union output partitioning
- a plain window over a subset of the partition keys on a non-grouped `KeyedPartitioning`, asserting the inserted node projects to the operation key rather than only coalescing
- no `GroupPartitionsExec` and no shuffle when projecting to the operation keys merges nothing
- a window over an inner join's two-member `PartitioningCollection`, keyed on the left side's first key column and the right side's remaining two, asserting no node is inserted because the left member needs none, even though the right one covers more operation keys
- a window over a join that reduced one side's keys onto the other side's key space, asserting the two rows sharing a `ts` end up on one partition

and in `EnsureRequirementsSuite`:

- a `FlatMapCoGroupsInPandasExec` over `(n, i)`-partitioned children grouped on `i`, asserting both sides are grouped on `i` and not on `n`
- a grouped `KeyedPartitioning` whose count differs from `requiredNumPartitions`, asserting the count is still honoured with a shuffle
- an `(n, i)`-partitioned `KeyedPartitioning` whose count matches `requiredNumPartitions` but which needs a projection, asserting it falls back to a shuffle rather than to a node that would break the count it just passed
- a projecting `KeyedPartitioning` whose *post-projection* count matches `requiredNumPartitions`, asserting it still groups on the operation key with no shuffle
- a non-grouped `KeyedPartitioning` whose *post-grouping* count matches `requiredNumPartitions`, asserting it still groups without a shuffle
- the same count rule with `allowKeysSubsetOfPartitionKeys` left at its default, asserting the shuffle
- an `(id, years(ts))`-partitioned `KeyedPartitioning` clustered on those same two expressions, with and without `requireAllClusterKeys`, asserting no node is inserted when a cluster key is the partition expression itself
- a `(bucket(4, a), b)`-partitioned `KeyedPartitioning` clustered on `a` alone, asserting the node projects to the bucket position. This is the one test where the reference-level match decides a kept position, and it is the shape the single-reference soundness argument is about. `master` inserts no node at all here, so the partitions sharing a bucket stay apart.
- a single-partition `KeyedPartitioning` under `OrderedDistribution`, asserting planning no longer throws a `MatchError`
- a `KeyedPartitioning` with no partition expressions, asserting it is still kept as it is, since without that guard it reaches the shuffle branch, where `UnspecifiedDistribution.createPartitioning` throws
- a `KeyedPartitioning` whose expressions reference no column, asserting the child is shuffled rather than projected to no position at all
- a `PartitioningCollection` whose two members cover a different number of operation keys, asserting the wider one supplies the projection
- two members whose position sets are nested and whose projections leave the same number of partitions, asserting the containing set still wins, so the projection keeps naming the key the other would have dropped
- two members whose position sets are nested, where only the narrower one's projection lands on `requiredNumPartitions`, asserting it is used rather than pruned and lost to the wider one
- two members whose position sets are not nested and where the narrower one leaves more partitions, asserting the narrower projection wins over the wider coverage
- two members covering one position each whose projections leave different numbers of partitions, asserting the one leaving the most supplies the projection
- two members covering one position each whose projections leave the same number of partitions, asserting the one the child reports first wins, in both collection orders

and in `ProjectedOrderingAndPartitioningSuite` a grouped and collapsed `KeyedPartitioning`, asserting `keysMaySatisfy` accepts it where `mayGroupToSatisfy` refuses it, because a grouped partitioning has no duplicate keys left for a node to coalesce.

Seventeen of the twenty-four fail without the production change in this commit, measured on `master`. Those are the four window tests, the reference-free expressions, the transform position, the `MatchError`, four of the six `requiredNumPartitions` tests, all five multi-member ones and the `keysMaySatisfy` one, which does not even compile there. The other seven pass already and guard this PR's own insertion decision. Removing the condition each one covers makes it fail, with one exception worth naming. `the candidate covering the most operation keys wins` survives the removal of either the containment prune or the ranking, because either mechanism alone picks the same winner, so it earns its place by documenting the shape rather than by pinning a single condition. The join test is one of the seven. The base leaves that plan alone too, and it is here because an earlier revision of this PR inserted a node there. Removing the `isCoPartitioned` guard also fails two pre-existing SPJ tests.

`DistributionSuite` and `ShuffleSpecSuite` pass with 29 tests, and `KeyGroupedPartitioningSuite`, `EnsureRequirementsSuite`, `ProjectedOrderingAndPartitioningSuite`, `GroupPartitionsExecSuite` and `PlannerSuite` pass with 295.

The window `PARTITION BY` tests come from #58245.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

Co-authored-by: Xiduo You <ulyssesyou@apache.org>

