### PR TITLE
[SPARK-59172][CORE] Use isEmpty/nonEmpty instead of size comparisons in core

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -559,7 +559,7 @@ private[spark] class ExecutorAllocationManager(
       updates: Map[Int, ExecutorAllocationManager.TargetNumUpdates],
       now: Long): Int = {
     // Only call cluster manager if target has changed.
-    if (updates.size > 0) {
+    if (updates.nonEmpty) {
       val requestAcknowledged = try {
         logDebug("requesting updates: " + updates)
         testing ||

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorResourcesAmounts.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorResourcesAmounts.scala
@@ -184,7 +184,7 @@ private[spark] class ExecutorResourcesAmounts(
             }
           }
 
-          if (taskAmount == 0 && allocatedAddressesMap.size > 0) {
+          if (taskAmount == 0 && allocatedAddressesMap.nonEmpty) {
             allocatedAddresses.put(rName, allocatedAddressesMap.toMap)
           } else {
             return None

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -202,7 +202,7 @@ private[spark] class HighlyCompressedMapStatus private (
   extends MapStatus with Externalizable {
 
   // loc could be null when the default constructor is called during deserialization
-  require(loc == null || avgSize > 0 || hugeBlockSizes.size > 0
+  require(loc == null || avgSize > 0 || hugeBlockSizes.nonEmpty
     || numNonEmptyBlocks == 0 || _mapTaskId > 0,
     "Average size can only be zero for map stages that produced no output")
 

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -200,7 +200,7 @@ class ExternalAppendOnlyMap[K, V, C](
         currentMap = null
       }
       isSpilled
-    } else if (currentMap.size > 0) {
+    } else if (currentMap.nonEmpty) {
       spill(currentMap)
       currentMap = new SizeTrackingAppendOnlyMap[K, C]
       true

--- a/core/src/test/scala/org/apache/spark/DistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DistributedSuite.scala
@@ -248,7 +248,7 @@ class DistributedSuite extends SparkFunSuite with Matchers with LocalSparkContex
     // ensure only a subset of partitions were cached
     val rddBlocks = sc.env.blockManager.master.getMatchingBlockIds(_.isRDD,
       askStorageEndpoints = true)
-    assert(rddBlocks.size > 0, "no RDD blocks found")
+    assert(rddBlocks.nonEmpty, "no RDD blocks found")
     assert(rddBlocks.size < numPartitions, s"too many RDD blocks found, expected <$numPartitions")
   }
 

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -39,7 +39,7 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
   test("internal accumulators in TaskContext") {
     val taskContext = TaskContext.empty()
     val accumUpdates = taskContext.taskMetrics.accumulators()
-    assert(accumUpdates.size > 0)
+    assert(accumUpdates.nonEmpty)
     val testAccum = taskContext.taskMetrics.testAccum.get
     assert(accumUpdates.exists(_.id == testAccum.id))
   }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1124,7 +1124,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
       tracker.registerMapOutput(0, 0, MapStatus(BlockManagerId("exec-1", "hostA", 1000),
         Array(2L), 0))
       tracker.removeOutputsOnHost("hostA")
-      assert(tracker.shuffleStatuses(0).mapIdToMapIndex.filter(_._2 == 0).size == 0)
+      assert(tracker.shuffleStatuses(0).mapIdToMapIndex.filter(_._2 == 0).isEmpty)
     } finally {
       tracker.stop()
       rpcEnv.shutdown()
@@ -1141,7 +1141,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
       tracker.registerMapOutput(0, 0, MapStatus(BlockManagerId("exec-1", "hostA", 1000),
         Array(2L), 0))
       tracker.unregisterMapOutput(0, 0, BlockManagerId("exec-1", "hostA", 1000))
-      assert(tracker.shuffleStatuses(0).mapIdToMapIndex.filter(_._2 == 0).size == 0)
+      assert(tracker.shuffleStatuses(0).mapIdToMapIndex.filter(_._2 == 0).isEmpty)
     } finally {
       tracker.stop()
       rpcEnv.shutdown()

--- a/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
@@ -223,7 +223,7 @@ trait SparkTestSuite
     } else {
       Seq(LogManager.getRootLogger)
     }
-    if (loggers.size == 0) {
+    if (loggers.isEmpty) {
       throw new SparkException(s"Cannot get any logger to add the appender")
     }
     val restoreLevels = loggers.map(_.getLevel)

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -492,7 +492,7 @@ class StandaloneDynamicAllocationSuite
 
     eventually(timeout(10.seconds), interval(100.millis)) {
       val afterList = getApplications().head.executors.keys.toSet
-      assert(beforeList.intersect(afterList).size == 0)
+      assert(beforeList.intersect(afterList).isEmpty)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
@@ -43,7 +43,7 @@ class RDDCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
         val shuffled = keyed.reduceByKey(_ + _)
         val keysOnly = shuffled.keys
         keysOnly.count()
-        assert(getAllFiles.size > 0)
+        assert(getAllFiles.nonEmpty)
         keysOnly.cleanShuffleDependencies(true)
         val resultingFiles = getAllFiles
         assert(resultingFiles === Set())

--- a/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
@@ -75,11 +75,11 @@ object FakeTask {
       priority: Int,
       rpId: Int,
       prefLocs: Seq[TaskLocation]*): TaskSet = {
-    if (prefLocs.size != 0 && prefLocs.size != numTasks) {
+    if (prefLocs.nonEmpty && prefLocs.size != numTasks) {
       throw new IllegalArgumentException("Wrong number of task locations")
     }
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
-      new FakeTask(stageId, i, if (prefLocs.size != 0) prefLocs(i) else Nil)
+      new FakeTask(stageId, i, if (prefLocs.nonEmpty) prefLocs(i) else Nil)
     }
     new TaskSet(tasks, stageId, stageAttemptId, priority = priority, null, rpId, None)
   }
@@ -98,7 +98,7 @@ object FakeTask {
       stageAttemptId: Int,
       priority: Int,
       prefLocs: Seq[TaskLocation]*): TaskSet = {
-    if (prefLocs.size != 0 && prefLocs.size != numTasks) {
+    if (prefLocs.nonEmpty && prefLocs.size != numTasks) {
       throw new IllegalArgumentException("Wrong number of task locations")
     }
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
@@ -131,11 +131,11 @@ object FakeTask {
       priority: Int,
       rpId: Int,
       prefLocs: Seq[TaskLocation]*): TaskSet = {
-    if (prefLocs.size != 0 && prefLocs.size != numTasks) {
+    if (prefLocs.nonEmpty && prefLocs.size != numTasks) {
       throw new IllegalArgumentException("Wrong number of task locations")
     }
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
-      new FakeTask(stageId, i, if (prefLocs.size != 0) prefLocs(i) else Nil, isBarrier = true)
+      new FakeTask(stageId, i, if (prefLocs.nonEmpty) prefLocs(i) else Nil, isBarrier = true)
     }
     new TaskSet(tasks, stageId, stageAttemptId, priority = priority, null, rpId, None)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
@@ -206,7 +206,7 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
 
     // Prepare information needed for replay
     val applications = fileSystem.listStatus(logDirPath)
-    assert(applications != null && applications.size > 0)
+    assert(applications != null && applications.nonEmpty)
     val eventLog = applications.sortBy(_.getModificationTime).last
     assert(!eventLog.isDirectory)
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2164,7 +2164,7 @@ class TaskSetManagerSuite
     // if the time threshold has not been exceeded, no speculative run should be triggered
     clock.advance(1000*60*60)
     assert(!manager.checkSpeculatableTasks(0))
-    assert(sched.speculativeTasks.size == 0)
+    assert(sched.speculativeTasks.isEmpty)
 
     // Now the task should have been running for 60 minutes and 1 second
     clock.advance(1000)
@@ -2177,7 +2177,7 @@ class TaskSetManagerSuite
     } else {
       // If the feature flag is turned off, or the stage contains too many tasks
       assert(!manager.checkSpeculatableTasks(0))
-      assert(sched.speculativeTasks.size == 0)
+      assert(sched.speculativeTasks.isEmpty)
     }
   }
 
@@ -2353,7 +2353,7 @@ class TaskSetManagerSuite
     }
     clock.advance(1000*60*60)
     assert(!manager.checkSpeculatableTasks(0))
-    assert(sched.speculativeTasks.size == 0)
+    assert(sched.speculativeTasks.isEmpty)
     // Now the task should have been running for 60 minutes and 1 second
     clock.advance(1000)
     assert(manager.checkSpeculatableTasks(0))
@@ -2459,7 +2459,7 @@ class TaskSetManagerSuite
     clock.advance(1000)
     manager.checkSpeculatableTasks(sched.MIN_TIME_TO_SPECULATION)
     // The task is not considered as speculative task due to minimum threshold interval of 3s
-    assert(sched.speculativeTasks.size == 0)
+    assert(sched.speculativeTasks.isEmpty)
     clock.advance(2000)
     manager.checkSpeculatableTasks(sched.MIN_TIME_TO_SPECULATION)
     // After 3s have elapsed now the task is marked as speculative task

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -322,7 +322,7 @@ abstract class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter 
 
       val execs = KVUtils.viewToSeq(store.view(classOf[ExecutorStageSummaryWrapper]).index("stage")
         .first(key(stages.head)).last(key(stages.head)))
-      assert(execs.size > 0)
+      assert(execs.nonEmpty)
       execs.foreach { exec =>
         assert(exec.info.memoryBytesSpilled === s1Tasks.size * value / 2)
       }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -762,7 +762,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     assert(master.getLocations("a1").size > 0, "master was not told about a1")
 
     master.removeExecutor(store.blockManagerId.executorId)
-    assert(master.getLocations("a1").size == 0, "a1 was not removed from master")
+    assert(master.getLocations("a1").isEmpty, "a1 was not removed from master")
 
     val reregister = !master.driverHeartbeatEndPoint.askSync[Boolean](
       BlockManagerHeartbeat(store.blockManagerId))
@@ -794,7 +794,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     assert(master.getLocations("a1").size > 0, "master was not told about a1")
 
     master.removeExecutor(store.blockManagerId.executorId)
-    assert(master.getLocations("a1").size == 0, "a1 was not removed from master")
+    assert(master.getLocations("a1").isEmpty, "a1 was not removed from master")
 
     store.putSingle("a2", a2, StorageLevel.MEMORY_ONLY)
     store.waitForAsyncReregister()

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -521,8 +521,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     assert(store.getSingleAndReleaseLock("a3").isDefined, "a3 was not in store")
 
     // Checking whether master knows about the blocks or not
-    assert(master.getLocations("a1").size > 0, "master was not told about a1")
-    assert(master.getLocations("a2").size > 0, "master was not told about a2")
+    assert(master.getLocations("a1").nonEmpty, "master was not told about a1")
+    assert(master.getLocations("a2").nonEmpty, "master was not told about a2")
     assert(master.getLocations("a3").size === 0, "master was told about a3")
 
     // Drop a1 and a2 from memory; this should be reported back to the master
@@ -570,8 +570,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     assert(store.getSingleAndReleaseLock("a3-to-remove").isDefined, "a3 was not in store")
 
     // Checking whether master knows about the blocks or not
-    assert(master.getLocations("a1-to-remove").size > 0, "master was not told about a1")
-    assert(master.getLocations("a2-to-remove").size > 0, "master was not told about a2")
+    assert(master.getLocations("a1-to-remove").nonEmpty, "master was not told about a1")
+    assert(master.getLocations("a2-to-remove").nonEmpty, "master was not told about a2")
     assert(master.getLocations("a3-to-remove").size === 0, "master was told about a3")
 
     // Remove a1 and a2 and a3. Should be no-op for a3.
@@ -728,7 +728,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
       removedFromMemory: Boolean,
       removedFromDisk: Boolean): Unit = {
     def assertSizeReported(captor: ArgumentCaptor[Long], expectRemoved: Boolean): Unit = {
-      assert(captor.getAllValues().size() >= 1)
+      assert(!captor.getAllValues().isEmpty)
       if (expectRemoved) {
         assert(captor.getValue() > 0)
       } else {
@@ -759,7 +759,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     store.putSingle("a1", a1, StorageLevel.MEMORY_ONLY)
 
     assert(store.getSingleAndReleaseLock("a1").isDefined, "a1 was not in store")
-    assert(master.getLocations("a1").size > 0, "master was not told about a1")
+    assert(master.getLocations("a1").nonEmpty, "master was not told about a1")
 
     master.removeExecutor(store.blockManagerId.executorId)
     assert(master.getLocations("a1").isEmpty, "a1 was not removed from master")
@@ -791,7 +791,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     )
 
     store.putSingle("a1", a1, StorageLevel.MEMORY_ONLY)
-    assert(master.getLocations("a1").size > 0, "master was not told about a1")
+    assert(master.getLocations("a1").nonEmpty, "master was not told about a1")
 
     master.removeExecutor(store.blockManagerId.executorId)
     assert(master.getLocations("a1").isEmpty, "a1 was not removed from master")
@@ -799,8 +799,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     store.putSingle("a2", a2, StorageLevel.MEMORY_ONLY)
     store.waitForAsyncReregister()
 
-    assert(master.getLocations("a1").size > 0, "a1 was not reregistered with master")
-    assert(master.getLocations("a2").size > 0, "master was not told about a2")
+    assert(master.getLocations("a1").nonEmpty, "a1 was not reregistered with master")
+    assert(master.getLocations("a2").nonEmpty, "master was not told about a2")
   }
 
   test("reregistration doesn't dead lock") {

--- a/core/src/test/scala/org/apache/spark/util/NextIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/NextIteratorSuite.scala
@@ -74,7 +74,7 @@ class NextIteratorSuite extends SparkFunSuite with Matchers {
     var closeCalled = 0
 
     override def getNext(): Int = {
-      if (ints.size == 0) {
+      if (ints.isEmpty) {
         finished = true
         0
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This replaces size-vs-zero comparisons with the direct emptiness / non-emptiness predicates in the `core` module (main and test):
- **Emptiness**: `x.size == 0` -> `x.isEmpty`.
- **Non-emptiness**: `x.size > 0` / `x.size != 0` / `x.size >= 1` -> `x.nonEmpty` for Scala collections, and `!x.isEmpty` for Java collections (e.g. a Mockito `ArgumentCaptor.getAllValues()` list).

Main: `ExecutorAllocationManager`, `ExecutorResourcesAmounts`, `MapStatus`, `ExternalAppendOnlyMap`. Test: `MapOutputTrackerSuite`, `SparkTestSuite`, `StandaloneDynamicAllocationSuite`, `TaskSetManagerSuite`, `BlockManagerSuite`, `NextIteratorSuite`, `DistributedSuite`, `InternalAccumulatorSuite`, `RDDCleanerSuite`, `FakeTask`, `ReplayListenerSuite`, `AppStatusListenerSuite`.

Deliberately left unchanged, because they are **not** collection-emptiness checks:
- `ManagedBuffer` byte counts (`BlockManager`, `ShuffleBlockFetcherIterator`) and other byte-length checks (`DirectByteBufferOutputStream` in `PythonRunner`, a `ChunkedByteBuffer` block, `ChunkedByteBufferOutputStream`) -- `size` is a byte count and these types have no `isEmpty`.
- `hadoopConf.size()` -- Hadoop `Configuration` exposes `size()` but not `isEmpty()`.
- On the `MapStatus` `require`, `avgSize > 0` (a numeric average size) is left as-is; only the adjacent `hugeBlockSizes` check is converted.

### Why are the changes needed?

`isEmpty` / `nonEmpty` state the intent directly and are the idioms used elsewhere in these files. Behavior is unchanged: for every converted receiver (Scala collections and `java.util` collections), the predicate is exactly equivalent to the original comparison.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. This is a behavior-preserving refactor; the `core` module (main + test) compiles cleanly. Counterpart of SPARK-59149 (SQL) and SPARK-59173 (MLlib).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
