### PR TITLE
[SPARK-59147][SQL] Preserve struct nullness when SELECT * EXCEPT drops a nested field

### DIFF
--- a/docs/sql-ref-syntax-qry-star.md
+++ b/docs/sql-ref-syntax-qry-star.md
@@ -51,7 +51,8 @@ except_clause
   * **field_name**
 
     A reference to a field in a column of the set of columns that you can reference.
-    If you exclude all fields from a STRUCT, the result is an empty STRUCT.
+    If you exclude all fields from a STRUCT, the result is an empty STRUCT, even if the STRUCT is NULL.
+    If you exclude only some of the fields, a NULL STRUCT stays NULL.
     Each name must reference a column included in the set of columns that you can reference or their fields.
     Otherwise, Spark SQL raises a UNRESOLVED_COLUMN error. If names overlap or are not unique, Spark raises an EXCEPT_OVERLAPPING_COLUMNS error.
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -760,8 +760,18 @@ case class UnresolvedStarExceptOrReplace(
                   col.toAttribute -> nestedExcept.tail
               }.get
           }
-          Alias(CreateStruct(
-            filterColumns(extractedFields.toImmutableArraySeq, newExcepts)), col.name)()
+          val newStruct = CreateStruct(
+            filterColumns(extractedFields.toImmutableArraySeq, newExcepts))
+          // Dropping a nested field must not change the nullness of the enclosing struct.
+          // CreateStruct is never nullable, so a NULL struct would otherwise be rebuilt as a
+          // non-NULL struct whose remaining fields are NULL. Guard it the same way UpdateFields
+          // does for DropField.
+          val newCol = if (col.nullable) {
+            If(IsNull(col), Literal(null, newStruct.dataType), newStruct)
+          } else {
+            newStruct
+          }
+          Alias(newCol, col.name)()
         // if there are multiple nestedExcepts but one is empty we must have overlapping except
         // columns. throw an error.
         case (_, Some(nestedExcepts)) if nestedExcepts.size > 1 =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -760,13 +760,14 @@ case class UnresolvedStarExceptOrReplace(
                   col.toAttribute -> nestedExcept.tail
               }.get
           }
-          val newStruct = CreateStruct(
-            filterColumns(extractedFields.toImmutableArraySeq, newExcepts))
+          val newFields = filterColumns(extractedFields.toImmutableArraySeq, newExcepts)
+          val newStruct = CreateStruct(newFields)
           // Dropping a nested field must not change the nullness of the enclosing struct.
           // CreateStruct is never nullable, so a NULL struct would otherwise be rebuilt as a
           // non-NULL struct whose remaining fields are NULL. Guard it the same way UpdateFields
-          // does for DropField.
-          val newCol = if (col.nullable) {
+          // does for DropField. Excluding every field is the exception: the result is an empty
+          // struct, which carries nothing from the input, so it is produced unconditionally.
+          val newCol = if (col.nullable && newFields.nonEmpty) {
             If(IsNull(col), Literal(null, newStruct.dataType), newStruct)
           } else {
             newStruct

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1103,7 +1103,7 @@ Project [x#x, y#x]
 table st
 |> drop col.i1
 -- !query analysis
-Project [x#x, named_struct(i2, col#x.i2) AS col#x]
+Project [x#x, if (isnull(col#x)) null else named_struct(i2, col#x.i2) AS col#x]
 +- SubqueryAlias spark_catalog.default.st
    +- Relation spark_catalog.default.st[x#x,col#x] parquet
 
@@ -1112,7 +1112,7 @@ Project [x#x, named_struct(i2, col#x.i2) AS col#x]
 table st
 |> drop col.i1, col.i2
 -- !query analysis
-Project [x#x, named_struct() AS col#x]
+Project [x#x, if (isnull(col#x)) null else named_struct() AS col#x]
 +- SubqueryAlias spark_catalog.default.st
    +- Relation spark_catalog.default.st[x#x,col#x] parquet
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1112,7 +1112,7 @@ Project [x#x, if (isnull(col#x)) null else named_struct(i2, col#x.i2) AS col#x]
 table st
 |> drop col.i1, col.i2
 -- !query analysis
-Project [x#x, if (isnull(col#x)) null else named_struct() AS col#x]
+Project [x#x, named_struct() AS col#x]
 +- SubqueryAlias spark_catalog.default.st
    +- Relation spark_catalog.default.st[x#x,col#x] parquet
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/selectExcept.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/selectExcept.sql.out
@@ -530,3 +530,78 @@ Project [x#x]
          +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
             +- SubqueryAlias T
                +- LocalRelation [c1#x, c2#x, c3#x, c4#x, c5#x]
+
+
+-- !query
+CREATE TEMPORARY VIEW nullable_struct AS SELECT * FROM VALUES
+  (0, CAST(NULL AS STRUCT<a: INT, b: INT, s2: STRUCT<c: INT, d: INT>>)),
+  (1, named_struct("a", 1, "b", 11, "s2", CAST(NULL AS STRUCT<c: INT, d: INT>))),
+  (2, named_struct("a", 2, "b", 22, "s2", named_struct("c", 222, "d", 2222)))
+AS nullable_struct(id, data)
+-- !query analysis
+CreateViewCommand `nullable_struct`, SELECT * FROM VALUES
+  (0, CAST(NULL AS STRUCT<a: INT, b: INT, s2: STRUCT<c: INT, d: INT>>)),
+  (1, named_struct("a", 1, "b", 11, "s2", CAST(NULL AS STRUCT<c: INT, d: INT>))),
+  (2, named_struct("a", 2, "b", 22, "s2", named_struct("c", 222, "d", 2222)))
+AS nullable_struct(id, data), false, false, LocalTempView, UNSUPPORTED, true
+   +- Project [id#x, data#x]
+      +- SubqueryAlias nullable_struct
+         +- LocalRelation [id#x, data#x]
+
+
+-- !query
+SELECT * EXCEPT (data.a) FROM nullable_struct
+-- !query analysis
+Project [id#x, if (isnull(data#x)) null else named_struct(b, data#x.b, s2, data#x.s2) AS data#x]
++- SubqueryAlias nullable_struct
+   +- View (`nullable_struct`, [id#x, data#x])
+      +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+         +- Project [id#x, data#x]
+            +- SubqueryAlias nullable_struct
+               +- LocalRelation [id#x, data#x]
+
+
+-- !query
+SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a) FROM nullable_struct)
+-- !query analysis
+Project [id#x, isnull(data#x) AS (data IS NULL)#x]
++- SubqueryAlias __auto_generated_subquery_name
+   +- Project [id#x, if (isnull(data#x)) null else named_struct(b, data#x.b, s2, data#x.s2) AS data#x]
+      +- SubqueryAlias nullable_struct
+         +- View (`nullable_struct`, [id#x, data#x])
+            +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+               +- Project [id#x, data#x]
+                  +- SubqueryAlias nullable_struct
+                     +- LocalRelation [id#x, data#x]
+
+
+-- !query
+SELECT id, data IS NULL, data.s2 IS NULL FROM (SELECT * EXCEPT (data.s2.c) FROM nullable_struct)
+-- !query analysis
+Project [id#x, isnull(data#x) AS (data IS NULL)#x, isnull(data#x.s2) AS (data.s2 IS NULL)#x]
++- SubqueryAlias __auto_generated_subquery_name
+   +- Project [id#x, if (isnull(data#x)) null else named_struct(a, data#x.a, b, data#x.b, s2, if (isnull(data#x.s2)) null else named_struct(d, data#x.s2.d)) AS data#x]
+      +- SubqueryAlias nullable_struct
+         +- View (`nullable_struct`, [id#x, data#x])
+            +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+               +- Project [id#x, data#x]
+                  +- SubqueryAlias nullable_struct
+                     +- LocalRelation [id#x, data#x]
+
+
+-- !query
+SELECT data.* EXCEPT (s2.c) FROM nullable_struct
+-- !query analysis
+Project [data#x.a AS a#x, data#x.b AS b#x, if (isnull(data#x.s2)) null else named_struct(d, data#x.s2.d) AS s2#x]
++- SubqueryAlias nullable_struct
+   +- View (`nullable_struct`, [id#x, data#x])
+      +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+         +- Project [id#x, data#x]
+            +- SubqueryAlias nullable_struct
+               +- LocalRelation [id#x, data#x]
+
+
+-- !query
+DROP VIEW nullable_struct
+-- !query analysis
+DropTempViewCommand nullable_struct, false

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/selectExcept.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/selectExcept.sql.out
@@ -602,6 +602,44 @@ Project [data#x.a AS a#x, data#x.b AS b#x, if (isnull(data#x.s2)) null else name
 
 
 -- !query
+SELECT * EXCEPT (data.a, data.b, data.s2) FROM nullable_struct
+-- !query analysis
+Project [id#x, named_struct() AS data#x]
++- SubqueryAlias nullable_struct
+   +- View (`nullable_struct`, [id#x, data#x])
+      +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+         +- Project [id#x, data#x]
+            +- SubqueryAlias nullable_struct
+               +- LocalRelation [id#x, data#x]
+
+
+-- !query
+SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a, data.b, data.s2) FROM nullable_struct)
+-- !query analysis
+Project [id#x, isnull(data#x) AS (data IS NULL)#x]
++- SubqueryAlias __auto_generated_subquery_name
+   +- Project [id#x, named_struct() AS data#x]
+      +- SubqueryAlias nullable_struct
+         +- View (`nullable_struct`, [id#x, data#x])
+            +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+               +- Project [id#x, data#x]
+                  +- SubqueryAlias nullable_struct
+                     +- LocalRelation [id#x, data#x]
+
+
+-- !query
+SELECT * EXCEPT (data.s2.c, data.s2.d) FROM nullable_struct
+-- !query analysis
+Project [id#x, if (isnull(data#x)) null else named_struct(a, data#x.a, b, data#x.b, s2, named_struct()) AS data#x]
++- SubqueryAlias nullable_struct
+   +- View (`nullable_struct`, [id#x, data#x])
+      +- Project [cast(id#x as int) AS id#x, cast(data#x as struct<a:int,b:int,s2:struct<c:int,d:int>>) AS data#x]
+         +- Project [id#x, data#x]
+            +- SubqueryAlias nullable_struct
+               +- LocalRelation [id#x, data#x]
+
+
+-- !query
 DROP VIEW nullable_struct
 -- !query analysis
 DropTempViewCommand nullable_struct, false

--- a/sql/core/src/test/resources/sql-tests/inputs/selectExcept.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/selectExcept.sql
@@ -76,3 +76,16 @@ SELECT 1 FROM v1 WHERE 4 IN (*);
 SELECT T.* FROM v1, LATERAL (SELECT  v1.*) AS T(c1, c2, c3, c4, c5);
 SELECT T.* FROM v1, LATERAL (SELECT  COALESCE(v1.*)) AS T(x);
 
+-- EXCEPT a nested field preserves the nullness of the enclosing struct
+CREATE TEMPORARY VIEW nullable_struct AS SELECT * FROM VALUES
+  (0, CAST(NULL AS STRUCT<a: INT, b: INT, s2: STRUCT<c: INT, d: INT>>)),
+  (1, named_struct("a", 1, "b", 11, "s2", CAST(NULL AS STRUCT<c: INT, d: INT>))),
+  (2, named_struct("a", 2, "b", 22, "s2", named_struct("c", 222, "d", 2222)))
+AS nullable_struct(id, data);
+
+SELECT * EXCEPT (data.a) FROM nullable_struct;
+SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a) FROM nullable_struct);
+SELECT id, data IS NULL, data.s2 IS NULL FROM (SELECT * EXCEPT (data.s2.c) FROM nullable_struct);
+SELECT data.* EXCEPT (s2.c) FROM nullable_struct;
+
+DROP VIEW nullable_struct;

--- a/sql/core/src/test/resources/sql-tests/inputs/selectExcept.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/selectExcept.sql
@@ -88,4 +88,9 @@ SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a) FROM nullable_struct);
 SELECT id, data IS NULL, data.s2 IS NULL FROM (SELECT * EXCEPT (data.s2.c) FROM nullable_struct);
 SELECT data.* EXCEPT (s2.c) FROM nullable_struct;
 
+-- EXCEPT every field of a STRUCT yields an empty STRUCT for both NULL and non-NULL inputs
+SELECT * EXCEPT (data.a, data.b, data.s2) FROM nullable_struct;
+SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a, data.b, data.s2) FROM nullable_struct);
+SELECT * EXCEPT (data.s2.c, data.s2.d) FROM nullable_struct;
+
 DROP VIEW nullable_struct;

--- a/sql/core/src/test/resources/sql-tests/results/selectExcept.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/selectExcept.sql.out
@@ -494,3 +494,63 @@ SELECT T.* FROM v1, LATERAL (SELECT  COALESCE(v1.*)) AS T(x)
 struct<x:int>
 -- !query output
 1
+
+
+-- !query
+CREATE TEMPORARY VIEW nullable_struct AS SELECT * FROM VALUES
+  (0, CAST(NULL AS STRUCT<a: INT, b: INT, s2: STRUCT<c: INT, d: INT>>)),
+  (1, named_struct("a", 1, "b", 11, "s2", CAST(NULL AS STRUCT<c: INT, d: INT>))),
+  (2, named_struct("a", 2, "b", 22, "s2", named_struct("c", 222, "d", 2222)))
+AS nullable_struct(id, data)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SELECT * EXCEPT (data.a) FROM nullable_struct
+-- !query schema
+struct<id:int,data:struct<b:int,s2:struct<c:int,d:int>>>
+-- !query output
+0	NULL
+1	{"b":11,"s2":null}
+2	{"b":22,"s2":{"c":222,"d":2222}}
+
+
+-- !query
+SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a) FROM nullable_struct)
+-- !query schema
+struct<id:int,(data IS NULL):boolean>
+-- !query output
+0	true
+1	false
+2	false
+
+
+-- !query
+SELECT id, data IS NULL, data.s2 IS NULL FROM (SELECT * EXCEPT (data.s2.c) FROM nullable_struct)
+-- !query schema
+struct<id:int,(data IS NULL):boolean,(data.s2 IS NULL):boolean>
+-- !query output
+0	true	true
+1	false	true
+2	false	false
+
+
+-- !query
+SELECT data.* EXCEPT (s2.c) FROM nullable_struct
+-- !query schema
+struct<a:int,b:int,s2:struct<d:int>>
+-- !query output
+1	11	NULL
+2	22	{"d":2222}
+NULL	NULL	NULL
+
+
+-- !query
+DROP VIEW nullable_struct
+-- !query schema
+struct<>
+-- !query output
+

--- a/sql/core/src/test/resources/sql-tests/results/selectExcept.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/selectExcept.sql.out
@@ -549,6 +549,36 @@ NULL	NULL	NULL
 
 
 -- !query
+SELECT * EXCEPT (data.a, data.b, data.s2) FROM nullable_struct
+-- !query schema
+struct<id:int,data:struct<>>
+-- !query output
+0	{}
+1	{}
+2	{}
+
+
+-- !query
+SELECT id, data IS NULL FROM (SELECT * EXCEPT (data.a, data.b, data.s2) FROM nullable_struct)
+-- !query schema
+struct<id:int,(data IS NULL):boolean>
+-- !query output
+0	false
+1	false
+2	false
+
+
+-- !query
+SELECT * EXCEPT (data.s2.c, data.s2.d) FROM nullable_struct
+-- !query schema
+struct<id:int,data:struct<a:int,b:int,s2:struct<>>>
+-- !query output
+0	NULL
+1	{"a":1,"b":11,"s2":{}}
+2	{"a":2,"b":22,"s2":{}}
+
+
+-- !query
 DROP VIEW nullable_struct
 -- !query schema
 struct<>


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UnresolvedStarExceptOrReplace.filterColumns` rewrites a struct column when the EXCEPT list
names a nested field: it extracts the retained fields and wraps them back into a
`CreateStruct`. `CreateStruct` resolves to `CreateNamedStruct`, which is never nullable, so
the rebuilt struct is always non-NULL even when the original struct expression evaluated to
NULL.

This PR guards the reconstruction with `If(IsNull(col), Literal(null, dataType), ...)` when
the original column is nullable, the same way `UpdateFields.evalExpr` already does for
`DropField`.

### Why are the changes needed?

Dropping a nested field silently turns a NULL struct into a non-NULL struct whose remaining
fields are NULL. This is a silent correctness bug: nullable structs commonly come from
parsed JSON and from the null-producing side of outer joins, and afterwards `IS NULL`
checks, filters, joins, `COALESCE` and serialized output all behave differently.

```sql
WITH input AS (
  SELECT id,
    CASE
      WHEN id = 0 THEN CAST(NULL AS STRUCT<a: INT, b: INT>)
      ELSE named_struct('a', id, 'b', id + 10)
    END AS s
  FROM VALUES (0), (1) AS t(id)
),
actual AS (
  SELECT * EXCEPT (s.a) FROM input
)
SELECT i.id, i.s IS NULL AS before_except, a.s IS NULL AS after_except, a.s.b
FROM input i JOIN actual a USING (id) ORDER BY id;
```

Before:

```
0  true   false  NULL
1  false  false  11
```

After:

```
0  true   true   NULL
1  false  false  11
```

The same path backs the pipe `|> DROP <col>.<field>` operator, which had the same problem.

### Does this PR introduce _any_ user-facing change?

Yes. `SELECT * EXCEPT (col.field)` (and `|> DROP col.field`) now returns NULL for a row whose
`col` is NULL, instead of a struct of NULL fields. The result type is unchanged. This
corrects wrong results; there is no behavior change for non-nullable structs or for rows
whose struct is not NULL.

### How was this patch tested?

Added cases to `selectExcept.sql` covering a NULL top-level struct, a NULL nested struct, and
struct expansion (`SELECT data.* EXCEPT (s2.c)`), and regenerated the golden files. The new
cases fail on master and pass with the fix. `pipe-operators.sql` analyzer results were
regenerated to reflect the added null guard; its query results are unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
