### PR TITLE
[SPARK-59181][NETWORK] Use system default trust managers in SSLFactory when truststore is missing

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/ssl/SSLFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/ssl/SSLFactory.java
@@ -338,32 +338,11 @@ public class SSLFactory {
     return engine;
   }
 
-  private static TrustManager[] credulousTrustStoreManagers() {
-    return new TrustManager[]{new X509TrustManager() {
-      @Override
-      public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
-        throws CertificateException {
-      }
-
-      @Override
-      public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
-        throws CertificateException {
-      }
-
-      @Override
-      public X509Certificate[] getAcceptedIssuers() {
-        return null;
-      }
-    }};
-  }
-
   private static TrustManager[] trustStoreManagers(
       File trustStore, String trustStorePassword,
       boolean trustStoreReloadingEnabled, int trustStoreReloadIntervalMs)
           throws IOException, GeneralSecurityException {
-    if (trustStore == null || !trustStore.exists()) {
-      return credulousTrustStoreManagers();
-    } else {
+    if (trustStore != null && trustStore.exists()) {
       if (trustStoreReloadingEnabled) {
         ReloadingX509TrustManager reloading = new ReloadingX509TrustManager(
           KeyStore.getDefaultType(), trustStore, trustStorePassword, trustStoreReloadIntervalMs);
@@ -372,6 +351,12 @@ public class SSLFactory {
       } else {
         return defaultTrustManagers(trustStore, trustStorePassword);
       }
+    } else {
+      // Use the system default TrustManager instead of a "trust-all" implementation
+      TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+        TrustManagerFactory.getDefaultAlgorithm());
+      tmf.init((KeyStore) null);
+      return tmf.getTrustManagers();
     }
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/ssl/SSLFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ssl/SSLFactorySuite.java
@@ -101,4 +101,14 @@ public class SSLFactorySuite {
       factory.createSSLEngine(true, ByteBufAllocator.DEFAULT);
     });
   }
+
+  @Test
+  public void testBuildWithoutTrustStoreUsesSystemDefault() throws Exception {
+    // Should not throw exception and should not use credulous managers
+    SSLFactory factory = new SSLFactory.Builder()
+      .requestedProtocol("TLSv1.3")
+      .keyStore(new File(SslSampleConfigs.keyStorePath), "password")
+      .build();
+    assertNotNull(factory.createSSLEngine(true, ByteBufAllocator.DEFAULT));
+  }
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -634,6 +634,8 @@ replaced with one of the above namespaces.
     <td>
       Path to the trust store file. The path can be absolute or relative to the directory in which
       the process is started.
+      <br />
+      If not provided, the JVM default trust store is used. <strong>Note:</strong> Starting in Spark 4.0, the insecure "trust-all" fallback behavior when a trust store is missing has been removed. Deployments relying on self-signed or internal-CA certificates must explicitly configure a trust store or add their CA to the JVM default trust store to prevent RPC connections from failing.
     </td>
     <td>ui,standalone,historyServer,rpc</td>
   </tr>


### PR DESCRIPTION
*(Replacing stale PR #56089 because GitHub blocked reopening it after branch updates)*

### What changes were proposed in this pull request?
Refactored `SSLFactory.java` to replace the insecure `credulousTrustStoreManagers` fallback with the JVM's default `TrustManagerFactory`. When a truststore is not explicitly provided, the system now correctly utilizes the standard system trust managers instead of blindly trusting all certificates. 

### Why are the changes needed?
The previous implementation defaulted to a "trust-all" behavior if a truststore was missing or misconfigured. This silent security failure left internal Spark networking (RPC, Shuffle) vulnerable to Man-in-the-Middle (MITM) attacks. Aligning with standard Java security practices ensures robust certificate validation is maintained by default. 

### Does this PR introduce _any_ user-facing change?
Yes. Operators relying on self-signed or internal-CA certificates without explicitly configuring a truststore will now see RPC TLS connections fail. They must either explicitly configure a truststore (`spark.ssl.trustStore`) or add their internal CA to the JVM's default trust store.

### How was this patch tested?
Added a new unit test case `testBuildWithoutTrustStoreUsesSystemDefault` in `SSLFactorySuite.java` to verify successful engine initialization without a specific truststore. Verified all existing tests in `SSLFactorySuite` pass as expected. 

### Was this patch authored or co-authored using generative AI tooling?
No.