### PR TITLE
[SPARK-59184][BUILD] Cleanup remaining references to Python 3.10 or earlier

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1073,8 +1073,6 @@ jobs:
     env:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
-      PYSPARK_DRIVER_PYTHON: python3.9
-      PYSPARK_PYTHON: python3.9
       GITHUB_PREV_SHA: ${{ github.event.before }}
     container:
       image: ${{ needs.precondition.outputs.image_docs_url_link }}

--- a/dev/run-tests
+++ b/dev/run-tests
@@ -20,9 +20,9 @@
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
-PYTHON_VERSION_CHECK=$(python3 -c 'import sys; print(sys.version_info < (3, 10, 0))')
+PYTHON_VERSION_CHECK=$(python3 -c 'import sys; print(sys.version_info < (3, 11, 0))')
 if [[ "$PYTHON_VERSION_CHECK" == "True" ]]; then
-  echo "Python versions prior to 3.10 are not supported."
+  echo "Python versions prior to 3.11 are not supported."
   exit -1
 fi
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Update remaining requirements of Python 3.10+ to instead require Python 3.11+.
2. Drop stale environment variables specifying Python 3.9.

### Why are the changes needed?

1. These seem to be an oversight vs. a deliberate choice. Spark requires Python 3.11 or newer. I don't see a reason to allow 3.10 anywhere.
2. The `docs` job overrides the Python 3.9 env vars with Python 3.12 in a [later step][1]. It's confusing to have both specified in the same job when only the latter is what's intended.

[1]: https://github.com/apache/spark/blob/3979ac9f6aad52d4e85edd1d4167a3bb29262b92/.github/workflows/build_and_test.yml#L1146-L1147

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI

### Was this patch authored or co-authored using generative AI tooling?

No.