### PR TITLE
[SPARK-59121][SQL][4.2] Fix wrong results when a storage-partitioned join reduces the partition keys of both sides

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpression.scala
@@ -24,18 +24,46 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.DataType
 
 /**
+ * The identity of a partition transform function. It holds the two values
+ * [[TransformExpression]] compares in `isSameFunction`, and it carries no exprIds, so an
+ * expression can hold one in a plain field and expression equality still answers the same after
+ * canonicalization.
+ *
+ * @param canonicalName the transform function's canonical name
+ * @param numBucketsOpt the number of buckets if the transform is `bucket`. Unset otherwise.
+ */
+case class TransformFunctionId(canonicalName: String, numBucketsOpt: Option[Int])
+
+/**
  * Represents a partition transform expression, for instance, `bucket`, `days`, `years`, etc.
  *
  * @param function the transform function itself. Spark will use it to decide whether two
  *                 partition transform expressions are compatible.
  * @param numBucketsOpt the number of buckets if the transform is `bucket`. Unset otherwise.
+ * @param reducedWith the transform this one's partition keys were reduced together with, if they
+ *                    were. A storage-partitioned join can reduce both sides' keys onto a common
+ *                    key space, and when both sides reduce that space is a third one that neither
+ *                    transform describes. The keys become `r1(f1(x))` = `r2(f2(x))`, so this
+ *                    expression computes neither their values nor their data type. Set, it says
+ *                    exactly that, and names the other half of the pairing that produced the space,
+ *                    which is the only thing that tells two such key spaces apart. See
+ *                    `KeyedShuffleSpec.reducersBothWays`, which is the only producer.
  */
 case class TransformExpression(
     function: BoundFunction,
     children: Seq[Expression],
-    numBucketsOpt: Option[Int] = None) extends Expression {
+    numBucketsOpt: Option[Int] = None,
+    reducedWith: Option[TransformFunctionId] = None) extends Expression {
 
   override def nullable: Boolean = true
+
+  /** Drops the trailing `reducedWith` when it is unset, so the ordinary form is unchanged. */
+  override protected def stringArgs: Iterator[Any] =
+    if (reducedWith.isEmpty) super.stringArgs.take(productArity - 1) else super.stringArgs
+
+  /** The identity of this expression's transform function. */
+  lazy val functionId: TransformFunctionId =
+    TransformFunctionId(function.canonicalName(), numBucketsOpt)
 
   /**
    * Whether this [[TransformExpression]] has the same semantics as `other`.
@@ -46,16 +74,13 @@ case class TransformExpression(
    * be triggered, by comparing partition transforms from both sides of the join and checking
    * whether they are compatible.
    *
+   * It compares the transforms only. A caller that compares partition keys has to consult
+   * `reducedWith` as well, since a reduced key space is not the one its transform names.
+   *
    * @param other the transform expression to compare to
    * @return true if this and `other` has the same semantics w.r.t to transform, false otherwise.
    */
-  def isSameFunction(other: TransformExpression): Boolean = other match {
-    case TransformExpression(otherFunction, _, otherNumBucketsOpt) =>
-      function.canonicalName() == otherFunction.canonicalName() &&
-        numBucketsOpt == otherNumBucketsOpt
-    case _ =>
-      false
-  }
+  def isSameFunction(other: TransformExpression): Boolean = functionId == other.functionId
 
   /**
    * Whether this [[TransformExpression]]'s function is compatible with the `other`
@@ -122,27 +147,69 @@ case class TransformExpression(
     Option(res)
   }
 
+  /**
+   * The unordered pair of transforms whose reduce produced this expression's keys, which is what
+   * identifies the key space they landed in. Reducing is symmetric, so the two sides of one reduce
+   * carry the same pair.
+   */
+  private def reducedKeySpace: Option[Set[TransformFunctionId]] =
+    reducedWith.map(partner => Set(functionId, partner))
+
+  /**
+   * Whether this and `other` describe the same reduced key space, i.e. whether the same pair of
+   * transforms was reduced together to produce both.
+   *
+   * Two reduces that happen to land on the same space through different pairings are not
+   * recognised as one. For instance `bucket(12)` with `bucket(8)` and `bucket(12)` with
+   * `bucket(20)` both reduce onto `id % 4`. The [[Reducer]] API does not name the space it reduces
+   * onto, so the pairing is all there is to compare.
+   */
+  def hasSameReducedKeys(other: TransformExpression): Boolean =
+    reducedWith.isDefined && reducedKeySpace == other.reducedKeySpace
+
+  /** Records that this expression's keys were reduced together with `other`'s. */
+  def reducedTogetherWith(other: TransformExpression): TransformExpression =
+    copy(reducedWith = Some(other.functionId))
+
   override def dataType: DataType = function.resultType()
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
     copy(children = newChildren)
 
-  private lazy val resolvedFunction: Option[Expression] = this match {
-    case TransformExpression(scalarFunc: ScalarFunction[_], arguments, Some(numBuckets)) =>
-      Some(V2ExpressionUtils.resolveScalarFunction(scalarFunc,
-        Seq(Literal(numBuckets)) ++ arguments))
-    case TransformExpression(scalarFunc: ScalarFunction[_], arguments, None) =>
+  /**
+   * The scalar function call this transform stands for, with the bucket count prepended as a
+   * literal argument. `None` when the bound function is not a [[ScalarFunction]], and also when a
+   * join reduced this expression's keys, since then the call no longer computes them. Evaluating it
+   * to place a row would send the row to a partition it does not belong to. That second arm is a
+   * local gate. No caller reaches it today, because every consumer of a reduced partitioning
+   * refuses it first, and the write path never sees one.
+   */
+  lazy val resolvedFunction: Option[Expression] = function match {
+    case scalarFunc: ScalarFunction[_] if reducedWith.isEmpty =>
+      val arguments = numBucketsOpt.fold(children)(n => Literal(n) +: children)
       Some(V2ExpressionUtils.resolveScalarFunction(scalarFunc, arguments))
     case _ => None
   }
 
-  override def eval(input: InternalRow): Any = {
-    resolvedFunction match {
-      case Some(fn) => fn.eval(input)
-      case None => throw QueryExecutionErrors.cannotEvaluateExpressionError(this)
-    }
+  override def eval(input: InternalRow): Any = resolvedFunction match {
+    case Some(fn) => fn.eval(input)
+    case None => throw QueryExecutionErrors.cannotEvaluateExpressionError(this)
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
     throw QueryExecutionErrors.cannotGenerateCodeForExpressionError(this)
+}
+
+object TransformExpression {
+  /**
+   * Whether `e` is a partition expression whose keys a join reduced onto a key space that no
+   * transform describes, so that `e` no longer computes them. False after a one-side reduce, where
+   * the expression reported is the target transform and describes the reduced keys exactly. False
+   * for anything that is not a [[TransformExpression]], an attribute in particular, since a reduce
+   * always leaves a transform behind.
+   */
+  def hasReducedKeys(e: Expression): Boolean = e match {
+    case t: TransformExpression => t.reducedWith.isDefined
+    case _ => false
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -446,46 +446,49 @@ case class KeyedPartitioning(
    * The types the `partitionKeys` rows were built with. Anything reading those rows should take its
    * types from here. It is a driver-side value, since `partitionKeys` is `@transient`.
    *
-   * They are the `expressionDataTypes` unless a reducer has rewritten the keys. With
-   * `v2BucketingAllowCompatibleTransforms` a storage-partitioned join reduces one or both sides'
-   * keys onto a common key space, while the partitioning keeps reporting the expressions it was
-   * built from. Joining an `identity(ts)`-partitioned table to a `years(ts)`-partitioned one leaves
-   * `IntegerType` year values under a `TimestampType`-declared expression. With no key at all the
-   * expressions are all there is, and there is no row to read or to place.
+   * They differ from the `expressionDataTypes` in two cases. A join that reduced both sides' keys
+   * onto a key space no transform names leaves a marked expression whose type can be anything, see
+   * `expressionsDescribeKeys`. A one-side reduce keeps them equal, because the expression the
+   * partitioning then reports is the target transform and `EnsureRequirements` refuses a reducer
+   * whose result type disagrees with it. `KeyedShuffleSpec.createPartitioning` is the other case.
+   * It puts the other child's expressions over these keys with no reducer in sight, so a struct
+   * field can be named differently on the two sides. With no key at all the expressions are all
+   * there is, and there is no row to read or to place.
+   *
+   * The two cases can meet, and then the fallback is not truthful. A marked partitioning can end up
+   * with no key, for instance when `v2BucketingPartitionFilterEnabled` intersects two sides that
+   * hold disjoint keys, and it then reports the un-reduced transform's type while the other leg of
+   * the same pairing reports the reducer's. `EnsureRequirements`' reduced-types check compares the
+   * two and fails a query whose result is empty. The same query fails on a `ClassCastException`
+   * without this marker, so nothing regresses. SPARK-59176 tracks the fix, which needs the
+   * reducer's result type recorded where the key is missing.
    *
    * `ShuffleExchangeExec` is the one reader that stays on `expressionDataTypes`. It evaluates the
    * expressions to place the other child's rows, and it runs on executors, where this value is not
-   * available. `expressionsDescribeKeyShape` is what keeps that site sound.
+   * available. `expressionsDescribeKeys` is what keeps that site sound.
    *
-   * Only the first key's types are read, and nothing enforces that the rest match. Reduced keys
-   * also break three readers in ways no choice of types can fix, and SPARK-59121 covers all three:
-   *
-   *  - `EnsureRequirements`' `OrderedDistribution` arm orders these rows by the partition
-   *    attributes.
-   *  - the `UnionExec` key merge concatenates several children's keys.
-   *  - `KeyedShuffleSpec.reducers` binds its reducer to the partition expression, then reads a
-   *    stored key with it.
+   * Only the first key's types are read, and nothing enforces that the rest match.
    */
   @transient lazy val keyDataTypes: Seq[DataType] =
     partitionKeys.headOption.map(_.dataTypes).getOrElse(expressionDataTypes)
-
-  /**
-   * Whether the `partitionKeys` rows still read the same at `expressionDataTypes`, which is what
-   * `ShuffleExchangeExec` declares them at.
-   *
-   * Shapes rather than plain equality, the test `HashJoin` applies to its join key types.
-   * `KeyedShuffleSpec.createPartitioning` puts the other child's expressions over these keys, so a
-   * struct field name can differ here with no reducer involved.
-   */
-  @transient lazy val expressionsDescribeKeyShape: Boolean =
-    keyDataTypes.corresponds(expressionDataTypes)(
-      DataType.equalsStructurally(_, _, ignoreNullability = true))
 
   /** Driver-side, like the `keyDataTypes` it comes from. */
   @transient lazy val keyRowOrdering =
     RowOrdering.createNaturalAscendingOrdering(keyDataTypes)
 
   @transient lazy val keyOrdering = keyRowOrdering.on((t: InternalRowComparableWrapper) => t.row)
+
+  /**
+   * Whether the partition expressions still describe the `partitionKeys`, i.e. whether evaluating
+   * them on a row produces the key the row belongs under.
+   *
+   * They stop describing the keys when a join reduces both sides onto a common key space. The keys
+   * become `r1(f1(x))` = `r2(f2(x))`, which is a third space no transform names, so the reduce
+   * marks the expressions instead (`TransformExpression.reducedWith`). Reducing one side only keeps
+   * them truthful, because the other side's transform describes the reduced keys exactly and
+   * `KeyedShuffleSpec.reducersBothWays` reports that one.
+   */
+  def expressionsDescribeKeys: Boolean = !expressions.exists(TransformExpression.hasReducedKeys)
 
   def toGrouped: KeyedPartitioning = {
     val groupedPartitionKeys = partitionKeys.distinct.sorted(keyOrdering)
@@ -558,7 +561,12 @@ case class KeyedPartitioning(
         }
 
       case o @ OrderedDistribution(_) if SQLConf.get.v2BucketingAllowSorting =>
-        o.areAllClusterKeysMatched(expressions)
+        // `EnsureRequirements` orders the key rows by the attributes the expressions are over, and
+        // nothing makes a reducer order-preserving, so that ordering says nothing about reduced
+        // keys. This is the local gate. A reduced position always carries a transform and an
+        // `ORDER BY` cannot name one, so the match below already refuses every case a query can
+        // reach. Do not read the first clause as redundant.
+        expressionsDescribeKeys && o.areAllClusterKeysMatched(expressions)
 
       case _ =>
         false
@@ -1005,10 +1013,15 @@ case class CoalescedHashShuffleSpec(
  * When a key-grouped partitioning is reduced onto another partitioning's key space, the original
  * partition expressions no longer describe the reduced keys (their data type and their value are
  * those of the target key space). This pair carries both the reducer and the expression the
- * reduced keys correspond to, so the output partitioning can report a type-correct expression.
+ * reduced keys correspond to, so the output partitioning can report an expression that either
+ * describes the keys or says that it does not.
  *
  * @param reducer reducer that maps this side's partition key values onto the other side's key space
- * @param reducedExpression expression whose data type matches the reduced keys. Stored as-is from
+ * @param reducedExpression the expression the reduced keys correspond to. When only this side
+ *                          reduces, that is the other side's transform and its data type matches
+ *                          the reduced keys. When both sides reduce, no transform describes the
+ *                          keys, and this is this side's own expression marked with the pairing
+ *                          that reduced it (`TransformExpression.reducedWith`). Stored as-is from
  *                          the expression pair that produced the reducer; the only structural
  *                          consumer, `GroupPartitionsExec`, re-targets it at each reported
  *                          `KeyedPartitioning`'s own key attribute in `outputPartitioning` and
@@ -1112,24 +1125,40 @@ case class KeyedShuffleSpec(
     }
   }
 
-  private def isExpressionCompatible(left: Expression, right: Expression): Boolean =
-    (left, right) match {
-      case (_: LeafExpression, _: LeafExpression) => true
-      case (left: TransformExpression, right: TransformExpression) =>
-        if (SQLConf.get.v2BucketingPushPartValuesEnabled &&
-          !SQLConf.get.v2BucketingPartiallyClusteredDistributionEnabled &&
-          SQLConf.get.v2BucketingAllowCompatibleTransforms) {
-          left.isCompatible(right)
-        } else {
-          left.isSameFunction(right)
-        }
-      case (_: AttributeReference, _: TransformExpression) |
-           (_: TransformExpression, _: AttributeReference) =>
-        SQLConf.get.v2BucketingPushPartValuesEnabled &&
-          !SQLConf.get.v2BucketingPartiallyClusteredDistributionEnabled &&
-          SQLConf.get.v2BucketingAllowCompatibleTransforms
-      case _ => false
+  private def isExpressionCompatible(left: Expression, right: Expression): Boolean = {
+    if (TransformExpression.hasReducedKeys(left) || TransformExpression.hasReducedKeys(right)) {
+      // Reduced keys are in a key space that neither transform names, so comparing the transforms
+      // says nothing about whether the two sides are laid out the same way. The pair that was
+      // reduced together is laid out the same way, since its two sides came out of one reduce onto
+      // one key space. Anything else has to shuffle. That includes a pair that reduced onto the
+      // same space through a different pairing, which nothing here can tell apart, and an identity
+      // side, which holds raw values.
+      (left, right) match {
+        case (l: TransformExpression, r: TransformExpression) => l.hasSameReducedKeys(r)
+        case _ => false
+      }
+    } else {
+      (left, right) match {
+        case (_: LeafExpression, _: LeafExpression) => true
+        case (left: TransformExpression, right: TransformExpression) =>
+          if (canReduceKeys) left.isCompatible(right) else left.isSameFunction(right)
+        case (_: AttributeReference, _: TransformExpression) |
+             (_: TransformExpression, _: AttributeReference) => canReduceKeys
+        case _ => false
+      }
     }
+  }
+
+  /**
+   * Whether a join may reduce one or both sides' partition keys onto a common key space, which is
+   * what lets two different transforms be compatible in the first place.
+   */
+  private def canReduceKeys: Boolean = {
+    val conf = SQLConf.get
+    conf.v2BucketingPushPartValuesEnabled &&
+      !conf.v2BucketingPartiallyClusteredDistributionEnabled &&
+      conf.v2BucketingAllowCompatibleTransforms
+  }
 
   /**
    * Compute the reducers for both sides of a join between this shuffle spec and `other`, in a
@@ -1153,6 +1182,14 @@ case class KeyedShuffleSpec(
       : (Option[Seq[Option[KeyReducer]]], Option[Seq[Option[KeyReducer]]]) = {
     val results: Seq[(Option[KeyReducer], Option[KeyReducer])] =
       partitioning.expressions.zip(other.partitioning.expressions).map {
+      // Keys an earlier join already reduced live in a key space that neither expression
+      // describes, so a reducer derived from those expressions would be applied to values it was
+      // not built for. `areKeysCompatible` admits only the pair that was reduced together, and
+      // that pair is already in one key space, so there is nothing left to reduce.
+      case (e1, e2)
+          if TransformExpression.hasReducedKeys(e1) || TransformExpression.hasReducedKeys(e2) =>
+        (None, None)
+
       case (e1: TransformExpression, e2: TransformExpression) =>
         val thisReducer = e1.reducers(e2)
         val otherReducer = e2.reducers(e1)
@@ -1169,10 +1206,10 @@ case class KeyedShuffleSpec(
             KeyReducer(reducer, e2)
           } else {
             // Both sides reduce: the reduced keys are r1(f1(x)) = r2(f2(x)), which no single
-            // transform describes. Keep reporting the original expression; its type can differ
-            // from the reduced keys, which a downstream shuffle or grouping can then fail on with
-            // a ClassCastException. Known gap, tracked in SPARK-59121.
-            KeyReducer(reducer, e1)
+            // transform describes. Report `e1` and mark it with the pairing that produced that key
+            // space, so that whatever needs the keys' values or their type refuses it, while the
+            // partitionings that share the space are still recognised.
+            KeyReducer(reducer, e1.reducedTogetherWith(e2))
           }
         }
 
@@ -1182,7 +1219,7 @@ case class KeyedShuffleSpec(
             KeyReducer(reducer, e1)
           } else {
             // Both sides reduce; symmetric to the both-sides case above.
-            KeyReducer(reducer, e2)
+            KeyReducer(reducer, e2.reducedTogetherWith(e1))
           }
         }
 
@@ -1216,12 +1253,9 @@ case class KeyedShuffleSpec(
       partitioning.expressions.forall { e =>
         e.isInstanceOf[AttributeReference] || e.isInstanceOf[TransformExpression]
       } &&
-      // A reducer leaves keys that the expressions no longer describe, and `ShuffleExchangeExec`
-      // would then compare the two at different types as it builds the shuffle's key map. Matching
-      // shapes are only a proxy for that. `bucket(12)` and `bucket(8)` reducing onto `bucket(4)`
-      // keep the type, pass here, and still misroute rows. SPARK-59045 and SPARK-59121 add the real
-      // test.
-      partitioning.expressionsDescribeKeyShape
+      // Shuffling another child onto these keys evaluates the partition expressions per row to
+      // decide where each row goes, and reduced keys are not what those expressions compute.
+      partitioning.expressionsDescribeKeys
 
   override def createPartitioning(clustering: Seq[Expression]): Partitioning = {
     assert(clustering.size == distribution.clustering.size,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
@@ -19,16 +19,25 @@ package org.apache.spark.sql.catalyst
 
 import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{Attribute, DirectShufflePartitionID}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, DirectShufflePartitionID, Expression, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.physical._
+import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
 
 class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
   private val passThrough_a_10 = ShufflePartitionIdPassThrough(DirectShufflePartitionID($"a"), 10)
   private val passThrough_b_10 = ShufflePartitionIdPassThrough(DirectShufflePartitionID($"b"), 10)
   private val passThrough_c_10 = ShufflePartitionIdPassThrough(DirectShufflePartitionID($"c"), 10)
+
+  /** A bound function with a stable canonical name, enough to build a `TransformExpression`. */
+  private object TestBucketFunction extends ScalarFunction[Int] {
+    override def inputTypes(): Array[DataType] = Array(IntegerType)
+    override def resultType(): DataType = IntegerType
+    override def name(): String = "bucket"
+    override def canonicalName(): String = "test.bucket"
+  }
   protected def checkCompatible(
       left: ShuffleSpec,
       right: ShuffleSpec,
@@ -425,22 +434,41 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
     assert(!RangeShuffleSpec(10, distribution).canCreatePartitioning)
   }
 
-  test("SPARK-59120: canCreatePartitioning: KeyedShuffleSpec requires the declared key shape") {
-    // A partitioning whose keys were built with types the expressions no longer declare, which is
-    // what a reducer leaves behind.
-    def spec(builtWith: Attribute, declared: Attribute, key: InternalRow): KeyedShuffleSpec =
+  test("SPARK-59121: canCreatePartitioning: KeyedShuffleSpec refuses reduced keys") {
+    // A `bucket(12, a)` partitioning whose keys a join reduced together with a `bucket(8, a)` one.
+    // The keys are `a % 4`, which is not what evaluating `bucket(12, a)` on a row produces, so the
+    // other child cannot be shuffled onto them. This replaces SPARK-59120's data-type proxy,
+    // which both bucket transforms pass, since the reduced keys keep their `IntegerType`.
+    val a = $"a".int
+    val bucket12 = TransformExpression(TestBucketFunction, Seq(a), Some(12))
+    val bucket8 = TransformExpression(TestBucketFunction, Seq(a), Some(8))
+    // `builtWith` types the key row, `declared` is what the partitioning reports, so the two can be
+    // made to disagree the way `createPartitioning` does.
+    def divergingSpec(
+        builtWith: Expression,
+        declared: Expression,
+        key: InternalRow): KeyedShuffleSpec =
       KeyedShuffleSpec(
         KeyedPartitioning(Seq(builtWith), Seq(key)).copy(expressions = Seq(declared)),
-        ClusteredDistribution(Seq(declared)))
+        ClusteredDistribution(declared.references.toSeq))
+    def spec(expression: Expression): KeyedShuffleSpec =
+      divergingSpec(expression, expression, InternalRow(1))
 
     withSQLConf(SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true") {
-      assert(!spec($"a".int, $"a".timestamp, InternalRow(2020)).canCreatePartitioning,
-        "`IntegerType` keys cannot be looked up by evaluating a `TimestampType` expression")
+      assert(spec(bucket12).canCreatePartitioning,
+        "keys the expression describes can be evaluated per row")
+      assert(!spec(bucket12.reducedTogetherWith(bucket8)).canCreatePartitioning,
+        "reduced keys cannot")
 
-      // The two sides can name a struct field differently with no reducer involved, see
-      // `expressionsDescribeKeyShape`.
-      def struct(field: String): Attribute = $"a".struct(new StructType().add(field, IntegerType))
-      assert(spec(struct("a"), struct("b"), InternalRow(InternalRow(1))).canCreatePartitioning,
+      // The gate no longer looks at data types, which SPARK-59120's proxy did. That proxy had to
+      // compare struct keys by shape, because `createPartitioning` puts the other child's
+      // expressions over these keys and the two sides can name a field differently. This builds
+      // that divergence, with the key row at `struct<f>` and the partitioning declaring
+      // `struct<g>`.
+      def struct(field: String): Attribute =
+        $"a".struct(new StructType().add(field, IntegerType))
+      assert(divergingSpec(struct("f"), struct("g"), InternalRow(InternalRow(1)))
+        .canCreatePartitioning,
         "a key row reads the same either way, so the field names must not matter")
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -18,12 +18,11 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, ResolveTimeZone, TypeCoercion}
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, SortOrder, TransformExpression, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.expressions.{Expression, SortOrder, TransformExpression}
 import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, RebalancePartitions, RepartitionByExpression, Sort}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.connector.catalog.FunctionCatalog
-import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
 import org.apache.spark.sql.connector.distributions._
 import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -96,10 +95,7 @@ object DistributionAndOrderingUtils {
   }
 
   private def resolveTransformExpression(expr: Expression): Expression = expr.transform {
-    case TransformExpression(scalarFunc: ScalarFunction[_], arguments, Some(numBuckets)) =>
-      V2ExpressionUtils.resolveScalarFunction(scalarFunc, Seq(Literal(numBuckets)) ++ arguments)
-    case TransformExpression(scalarFunc: ScalarFunction[_], arguments, None) =>
-      V2ExpressionUtils.resolveScalarFunction(scalarFunc, arguments)
+    case t: TransformExpression => t.resolvedFunction.getOrElse(t)
   }
 
   private def typeCoercionRules: List[Rule[LogicalPlan]] = if (conf.ansiEnabled) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -37,9 +37,10 @@ import org.apache.spark.sql.execution.{
   RDDScanExec,
   SimpleMode,
   SortExec,
-  SparkPlan}
+  SparkPlan,
+  UnionExec}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation, GroupPartitionsExec}
-import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike}
+import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike, ValidateRequirements}
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.functions.{col, max}
 import org.apache.spark.sql.internal.SQLConf
@@ -296,6 +297,69 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
          |ORDER BY id, purchase_price, sale_price $extraColList
          |""".stripMargin)
   }
+
+  /**
+   * Creates a table partitioned by `bucket(numBuckets, id)` and holding the ids 0 until `numIds`.
+   * Joining two such tables reduces both sides onto the greatest common divisor of their bucket
+   * counts, unless that divisor is a side's own bucket count, in which case only the other side
+   * reduces. `numIds` has to exceed the smaller of the two bucket counts for a reduce to happen at
+   * all. Below that both sides report one key per id, so they are co-partitioned as they stand
+   * and the join has nothing to reduce.
+   */
+  private def createBucketedIdTable(name: String, numBuckets: Int, numIds: Int = 12): Unit = {
+    val bucketedColumns = Array(
+      Column.create("id", LongType),
+      Column.create("data", StringType))
+    createTable(name, bucketedColumns, Array(bucket(numBuckets, "id")))
+    sql(s"INSERT INTO testcat.ns.$name VALUES " +
+      (0 until numIds).map(i => s"($i, 'v$i')").mkString(", "))
+  }
+
+  /** Creates a `bucket<n>` table for each of the given bucket counts. */
+  private def createBucketedIdTables(bucketCounts: Int*): Unit =
+    bucketCounts.foreach(n => createBucketedIdTable(s"bucket$n", n))
+
+  /** Joins `bucket12`, `bucket8` and `bucket<third>` on `id`, in that order. */
+  private def threeWayBucketJoinDF(third: Int): DataFrame =
+    sql("SELECT b12.id FROM testcat.ns.bucket12 b12 " +
+      "JOIN testcat.ns.bucket8 b8 ON b12.id = b8.id " +
+      s"JOIN testcat.ns.bucket$third b ON b12.id = b.id")
+
+  /**
+   * Creates `days1` and `days2` partitioned by `days(ts)` and `years1` and `years2` by `years(ts)`,
+   * all over `(id, ts)`, with the `toYears`-reducing `days` and `years` functions registered.
+   * `leg1Values` goes into `days1` and `years1`, `leg2Values` into `days2` and `years2`.
+   */
+  private def withReducedTsJoinLegs(leg1Values: String, leg2Values: String)(body: => Unit): Unit = {
+    withFunction(
+      UnboundDaysFunctionWithToYearsReducerWithLongResult,
+      UnboundYearsFunctionWithToYearsReducerWithLongResult) {
+      val tsColumns = Array(
+        Column.create("id", LongType),
+        Column.create("ts", TimestampType))
+      Seq(("days1", leg1Values, days("ts")), ("days2", leg2Values, days("ts")),
+        ("years1", leg1Values, years("ts")), ("years2", leg2Values, years("ts"))).foreach {
+        case (table, values, partition) =>
+          createTable(table, tsColumns, Array(partition))
+          sql(s"INSERT INTO testcat.ns.$table VALUES $values")
+      }
+
+      body
+    }
+  }
+
+  /**
+   * Joins `days1` to `years1` and `days2` to `years2`, each reducing both of its sides onto the
+   * year key space, then joins the two reduced legs to each other.
+   */
+  private val reducedTsLegJoin =
+    """
+      |SELECT l.ts FROM
+      |  (SELECT d.ts FROM testcat.ns.days1 d JOIN testcat.ns.years1 y ON y.ts = d.ts) l
+      |  JOIN
+      |  (SELECT y.ts FROM testcat.ns.days2 d JOIN testcat.ns.years2 y ON y.ts = d.ts) r
+      |  ON l.ts = r.ts
+      |""".stripMargin
 
   private def testWithCustomersAndOrders(
       customers_partitions: Array[Transform],
@@ -700,6 +764,143 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
     }
     assert(mixedKeyGroupPartitions(a1, dt1, o1).canonicalized ==
       mixedKeyGroupPartitions(a2, dt2, o2).canonicalized)
+  }
+
+  test("SPARK-59121: two sides reduced together are not reduced a second time") {
+    val both = "(0, cast('2020-01-01' as timestamp)), (1, cast('2021-01-03' as timestamp))"
+    val one = "(1, cast('2021-01-03' as timestamp))"
+    withReducedTsJoinLegs(both, one) {
+      // Both inner joins reduce onto the year key space, and the two legs hold different key sets,
+      // so the outer join takes the path that pushes the common keys down and computes reducers.
+      // The two legs are the same pairing, so they are compatible and there is nothing left to
+      // reduce. Deriving a reducer from their expressions again would apply `toYears` to keys
+      // that already hold years.
+      withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+        checkAnswer(sql(reducedTsLegJoin), Seq(Row(Timestamp.valueOf("2021-01-03 00:00:00"))))
+      }
+    }
+  }
+
+  test("SPARK-59121: a join does not reduce already reduced partition keys") {
+    createBucketedIdTables(12, 8, 6)
+
+    // The first join reduces both sides onto `id % 4` (the greatest common divisor of 12 and 8), so
+    // `bucket(12, id)` no longer describes its keys. The second join must not derive a `bucket(6)`
+    // reducer from that expression and apply it to keys that are already reduced. It has to
+    // shuffle instead. `(id % 4) % 6` is `id % 4`, so the reduce would leave the left keys alone
+    // while the right side moves to `id % 6`.
+    withSQLConf(
+      SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+      SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      val df = threeWayBucketJoinDF(6)
+
+      checkAnswer(df, (0 until 12).map(i => Row(i.toLong)))
+      assert(collectShuffles(stripAQEPlan(df.queryExecution.executedPlan)).size == 2,
+        "the second join cannot join on reduced keys, so both its sides are shuffled")
+    }
+  }
+
+  test("SPARK-59121: a union does not merge an already reduced partitioning") {
+    createBucketedIdTables(12, 8)
+
+    // The union's children report the same `bucket(12, id)` expressions, but the join side's keys
+    // were reduced to `id % 4` and its expressions no longer describe them. Merging the two into
+    // one partitioning would claim `bucket(12, id)` for the concatenated keys, and the aggregate
+    // above would then group a key of the reduced side with an unrelated key of the other side.
+    withSQLConf(
+      SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+      SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      val df = sql("SELECT id, count(*) AS c FROM (" +
+        "SELECT b12.id FROM testcat.ns.bucket12 b12 JOIN testcat.ns.bucket8 b8 ON b12.id = b8.id " +
+        "UNION ALL SELECT id FROM testcat.ns.bucket12) GROUP BY id")
+
+      checkAnswer(df, (0 until 12).map(i => Row(i.toLong, 2L)))
+      val unions = collect(stripAQEPlan(df.queryExecution.executedPlan)) { case u: UnionExec => u }
+      assert(unions.size == 1)
+      assert(!unions.head.outputPartitioning.isInstanceOf[physical.KeyedPartitioning],
+        "the union must not claim a key-grouped partitioning it cannot describe")
+    }
+  }
+
+  test("SPARK-59121: another side is not shuffled onto reduced keys") {
+    createBucketedIdTables(12, 8, 2)
+
+    // The first join reduces both sides onto `id % 4`, and that partitioning has more partitions
+    // than `bucket(2, id)`, so it is the one `EnsureRequirements` would pick to shuffle the third
+    // table onto. It must not. Shuffling evaluates the reported `bucket(12, id)` per row, which
+    // does not produce the reduced keys the partitions are laid out by.
+    withSQLConf(
+      SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+      SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+      SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      val df = threeWayBucketJoinDF(2)
+
+      checkAnswer(df, (0 until 12).map(i => Row(i.toLong)))
+      // The reduced side is the one that gets shuffled, onto `bucket(2, id)`. Nothing is shuffled
+      // onto the reduced keys, which is what the assertion below states directly.
+      val shuffles = collectShuffles(stripAQEPlan(df.queryExecution.executedPlan))
+      assert(shuffles.size == 1)
+      assert(shuffles.forall(_.outputPartitioning match {
+        case kp: physical.KeyedPartitioning => kp.expressionsDescribeKeys
+        case _ => true
+      }))
+    }
+  }
+
+  test("SPARK-59121: two reduced partitionings are not compatible by their transforms") {
+    // 24 ids, so that each leg's two sides really report different key sets and the join reduces
+    // them. With 12 ids `bucket(18, id)` is the identity and the leg would be co-partitioned as it
+    // stands, with nothing reduced and nothing to tell apart.
+    Seq("left12" -> 12, "left8" -> 8, "right12" -> 12, "right18" -> 18).foreach {
+      case (name, buckets) => createBucketedIdTable(name, buckets, numIds = 24)
+    }
+
+    // The two legs reduce onto two different key spaces: `bucket(12) JOIN bucket(8)` onto `id % 4`
+    // and `bucket(12) JOIN bucket(18)` onto `id % 6`. Both legs keep reporting `bucket(12, id)`, so
+    // comparing the transforms says the two sides are co-partitioned when they are not, and an id
+    // sits in a different partition on each side. Only the pairing tells the two spaces apart, and
+    // marking the keys without it is not enough.
+    withSQLConf(
+      SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+      SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      val df = sql(
+        """
+          |SELECT l.id FROM
+          |  (SELECT l12.id FROM testcat.ns.left12 l12
+          |    JOIN testcat.ns.left8 l8 ON l12.id = l8.id) l
+          |  JOIN
+          |  (SELECT r12.id FROM testcat.ns.right12 r12
+          |    JOIN testcat.ns.right18 r18 ON r12.id = r18.id) r
+          |  ON l.id = r.id
+          |""".stripMargin)
+
+      checkAnswer(df, (0 until 24).map(i => Row(i.toLong)))
+    }
+  }
+
+  test("SPARK-59121: two sides reduced onto the same keys still join without a shuffle") {
+    val values = "(0, cast('2020-01-01' as timestamp)), (1, cast('2021-01-03' as timestamp))"
+    withReducedTsJoinLegs(values, values) {
+      // Each inner join reduces both of its sides onto the year key space, and the projections keep
+      // one reduced partitioning per side. Refusing to compare reduced keys must not go so far as
+      // to refuse these two. They came out of the same pairing, so they carry the same keys and
+      // the outer join is co-partitioned as well.
+      withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+        val df = sql(reducedTsLegJoin)
+
+        checkAnswer(df, Seq(
+          Row(Timestamp.valueOf("2020-01-01 00:00:00")),
+          Row(Timestamp.valueOf("2021-01-03 00:00:00"))))
+        val plan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(collectShuffles(plan).isEmpty, "should not add shuffle for any of the three joins")
+      }
+    }
   }
 
   test("partitioned join: join with two partition keys and matching & sorted partitions") {
@@ -3974,6 +4175,18 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
           assert(shuffles.isEmpty, "should not add shuffle for both sides of the join")
           val groupPartitions = collectGroupPartitions(df.queryExecution.executedPlan)
           assert(groupPartitions.forall(_.outputPartitioning.numPartitions == 2))
+
+          // SPARK-59121: neither side's transform describes its keys any more, since both were
+          // reduced onto one year space. They were reduced together, so they must still be
+          // co-partitioned, and refusing to compare reduced keys must not go so far as to break
+          // this. Validate the join subtree rather than the whole plan, because
+          // `ValidateRequirements` walks children and a query stage is a leaf, so validating an
+          // AQE plan checks nothing.
+          val joins = collect(stripAQEPlan(df.queryExecution.executedPlan)) {
+            case smj: SortMergeJoinExec => smj
+          }
+          assert(joins.size == 1)
+          assert(ValidateRequirements.validate(joins.head))
 
           checkAnswer(df, Seq(Row(0, 1), Row(1, 1)))
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -19,8 +19,9 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, Partitioning, PartitioningCollection, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder, TransformExpression}
+import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
+import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, BucketReducer}
 import org.apache.spark.sql.execution.{DummySparkPlan, LeafExecNode, SafeForKWayMerge}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -34,6 +35,36 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
 
   private def row(a: Int): InternalRow = InternalRow.fromSeq(Seq(a))
   private def row(a: Int, b: Int): InternalRow = InternalRow.fromSeq(Seq(a, b))
+
+  test("SPARK-59121: a node with no reducers keeps the child's reduced key marker") {
+    // This node re-reports the child's expressions, projected to `joinKeyPositions`. A reduce that
+    // happened below it has to survive that, or a further join above reads the reported transform
+    // as if it still described the keys.
+    val reducedExpr = TransformExpression(BucketFunction, Seq(exprA), Some(12))
+      .reducedTogetherWith(TransformExpression(BucketFunction, Seq(exprA), Some(8)))
+    val child = DummySparkPlan(outputPartitioning =
+      KeyedPartitioning(Seq(reducedExpr, exprB), Seq(row(1, 10), row(2, 20), row(1, 30))))
+    val gpe = GroupPartitionsExec(child, joinKeyPositions = Some(Seq(0)))
+
+    assert(gpe.reducers.isEmpty, "test setup: this node reduces nothing itself")
+    gpe.outputPartitioning match {
+      case kp: KeyedPartitioning =>
+        assert(kp.expressions === Seq(reducedExpr), "the projection keeps the marked expression")
+        assert(!kp.expressionsDescribeKeys)
+      case other => fail(s"Expected KeyedPartitioning, got $other")
+    }
+
+    // Same for a node that reduces the other position. The position it does not reduce passes
+    // through, marker and all.
+    val reducingGpe = GroupPartitionsExec(child, reducers = Some(Seq(None, Some(
+      KeyReducer(BucketReducer(2), TransformExpression(BucketFunction, Seq(exprB), Some(2)))))))
+    reducingGpe.outputPartitioning match {
+      case kp: KeyedPartitioning =>
+        assert(kp.expressions.head === reducedExpr, "the unreduced position keeps its marker")
+        assert(!kp.expressionsDescribeKeys)
+      case other => fail(s"Expected KeyedPartitioning, got $other")
+    }
+  }
 
   test("SPARK-56241: non-coalescing passes through child ordering unchanged") {
     // Each partition has a distinct key — no coalescing happens.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This builds on #58335, which makes a reduced key-grouped partitioning report a transform that describes its keys for the two reducer shapes where one exists. When both sides of the join reduce there is none. The keys become `r1(f1(x))` = `r2(f2(x))`, a third key space that neither side's transform names. `bucket(12, id)` joined to `bucket(8, id)` is the flagship example. `BucketFunction.reducer` hands both sides `BucketReducer(4)`, the keys become `id % 4`, and both sides keep reporting the transforms they were built from. That is the gap #58335 names and leaves open, and this PR closes it by saying so rather than by inventing an expression.

`TransformExpression` gains a fourth field, `reducedWith: Option[TransformFunctionId]`, which names the transform this one's keys were reduced together with. `KeyedShuffleSpec.reducersBothWays` is the only producer. In its both-sides-reduce branch it now reports `e1.reducedTogetherWith(e2)` instead of the bare `e1`. The marker holds no `Expression`, only a canonical name and a bucket count, so it is safe in a field canonicalization does not descend into.

Putting it on the expression rather than on `KeyedPartitioning` is what keeps the change small. Every site that derives a partitioning already carries the expressions along. `AliasAwareOutputExpression` projects them, `GroupPartitionsExec.outputPartitioning` re-reports them, and `TransformExpression.withReference` re-targets them, so the marker is inherited, and dropped with the position it belongs to, without a line of new plumbing. `GroupPartitionsExec` needed no change at all.

Four sites then refuse to reason about such keys, and a fifth refusal falls out of expression equality:

- `KeyedShuffleSpec.isExpressionCompatible` does not compare marked keys by transform. Two of them are compatible when the same pair was reduced together, which is the pair the join produced. Anything else has to shuffle.
- `KeyedShuffleSpec.canCreatePartitioning` does not shuffle another child onto marked keys, because that evaluates the reported expressions per row.
- `KeyedShuffleSpec.reducersBothWays` does not reduce marked keys a second time.
- `keysSatisfy` does not let marked keys satisfy an `OrderedDistribution`. An ordering is a claim about the key *values*, and nothing makes a reducer order-preserving. This one is a local guard. A marked position always carries a transform, and a SQL `ORDER BY` cannot name one.
- `UnionExec.comparePartitioning` compares the children's expressions with `semanticEquals`, so a marked child no longer merges with an unmarked sibling reporting the same transform. No change was needed there.

Clustering is the one thing a marked partitioning still satisfies, and that is sound. The keys remain a function of the same attributes, which is all `ClusteredDistribution` asks.

Two things promised in the review of SPARK-59120 (#58420) are now delivered, since the marker answers the question they approximated: `KeyedPartitioning.expressionsDescribeKeyShape` and its use in `canCreatePartitioning` are replaced by `expressionsDescribeKeys`, and the three-reader list in the `keyDataTypes` scaladoc is gone.

Keeping the type check as a second conjunct was considered and dropped. It is not sufficient, since `bucket(12)` and `bucket(8)` reducing onto `bucket(4)` keep their `IntegerType` and pass it. It is not necessary either. After a one-side reduce the reported expression is the target transform, and `EnsureRequirements` already refuses a reducer whose `resultType()` disagrees with the other side's key types, which are that transform's, with `STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES`. So the keys and the expressions agree at every reachable one-side reduce, and a both-sides reduce is marked. The unit test that pinned the type proxy is replaced by one that pins the marker, and it keeps the proxy's struct case. A partitioning whose key row was built at `struct<f>` while it declares `struct<g>`, which is what `createPartitioning` produces, is still accepted. Re-adding any type comparison to the gate fails that assertion.

Two smaller things came with it. `TransformExpression.resolvedFunction` refuses a marked expression, so `eval` throws on one instead of computing the un-reduced transform and misrouting the row. That is a local gate rather than a live check, because every consumer of a reduced partitioning refuses it first and the write path never sees one. It also replaces the copy of the rule that prepends the bucket count as a literal argument in `DistributionAndOrderingUtils`, and both copies had to be touched here anyway, since the extractor grew a field.

The `keyDataTypes` scaladoc also records where its no-key fallback stops being truthful. A marked partitioning can end up with no key, for instance when `v2BucketingPartitionFilterEnabled` intersects two sides that hold disjoint keys, and it then reports the un-reduced transform's type while the other leg of the same pairing reports the reducer's. SPARK-59176 tracks that, with the repro and two ways to fix it. The same query fails on a `ClassCastException` without this marker, so nothing regresses here.

### Why are the changes needed?

Four failures, each one a test here, all measured on this PR's base. All of them need `spark.sql.sources.v2.bucketing.allowCompatibleTransforms.enabled`, which is off by default, since that is what admits a reducer at all.

1. Two reduces onto different key spaces look co-partitioned. Four tables holding ids 0 until 24, bucketed by 12 and 8 on one side and by 12 and 18 on the other. The first pair reduces onto `id % 4`, the second onto `id % 6`, and both keep reporting `bucket(12, id)`. Joining the two returns **8 of 24 rows** with no shuffle. This is also what the pairing in the marker is for. Marking the keys without recording which pair produced them fixes everything else here and still returns those 8 rows.
2. Reducing keys twice. Three tables bucketed by 12, 8 and 6: the first join reduces onto `id % 4`, then the second derives a `bucket(6)` reducer from the reported `bucket(12, id)` and applies it to keys that are already reduced. `(id % 4) % 6` leaves the left keys alone while the right side moves to `id % 6`, so the query loses rows with no shuffle.
3. Reducing keys twice, the other way. Two `days`/`years` joins that each reduce both sides onto one year space, then joined to each other with different key sets on the two legs. The outer join derives reducers again and planning throws `ClassCastException: Long cannot be cast to Integer`.
4. Merging a reduced partitioning in a union. `(bucket12 JOIN bucket8) UNION ALL bucket12` reports `bucket(12, id)` on both sides of the union, so the two are merged although the join side's keys are `id % 4`. A `GROUP BY id` above it returns each id twice.

The fifth refusal, `canCreatePartitioning`, guards a hazard the first one opens up. Once a marked partitioning is no longer compatible with anything but its own pairing, `EnsureRequirements` takes the one-side-shuffle path instead, and there it would happily shuffle the other child onto the reduced keys, which places rows by evaluating `bucket(12, id)` against partitions laid out by `id % 4`. Measured with tables bucketed by 12, 8 and 2 and `v2BucketingShuffleEnabled`, with the clause removed the query returns **8 of 12 rows**.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes the wrong results and the crash above. A query that used to reach one of them now shuffles instead, so its plan changes.

It also refuses two plans that happen to be correct today, In both cases nothing can tell the two apart from the outside.

The first is a second join onto an already reduced space. `bucket(12) JOIN bucket(8)` lands on `id % 4`. Meeting a `bucket(4, id)` or `bucket(2, id)` table, `BucketReducer` would compose correctly, since those counts divide 4. Meeting a `bucket(6, id)` table it would not, and that is failure 2 above. The `Reducer` API cannot say which of the two it is, so both now shuffle: `bucket12 JOIN bucket8 JOIN bucket4` goes from 0 shuffles to 2, with the same rows. This only arises where both sides reduced, i.e. where `gcd(a, b) < min(a, b)`. A chain in which one bucket count divides the other takes the one-side path and is unaffected.

The second is two reduces that land on the same space through different pairings, e.g. `bucket(12)` with `bucket(8)` and `bucket(12)` with `bucket(20)`, both of which give `id % 4`. They are treated as different spaces and the join shuffles.

Both cost a shuffle, not a wrong answer. A follow-up can give them back by letting a `ReducibleFunction` name the transform it reduces onto, which makes this whole shape disappear rather than be refused.

Queries whose keys were not reduced on both sides are unaffected, and a join of two sides that were reduced together keeps its plan.

### How was this patch tested?

Ten new tests. Six query tests in `KeyGroupedPartitioningSuite`, and one each in `TransformExpressionSuite`, `ShuffleSpecSuite`, `GroupPartitionsExecSuite` and `ProjectedOrderingAndPartitioningSuite`. One existing test changed, see below.

Four of the six query tests fail on the base commit with wrong rows or a crash, listed as failures 1 to 4 above. A fifth, `another side is not shuffled onto reduced keys`, returns the right rows there with no shuffle. This PR costs it one shuffle, and it is what pins the `canCreatePartitioning` clause. Each refusal was ablated, and each ablation fails exactly the tests written for it:

- `canCreatePartitioning`'s clause removed: `another side is not shuffled onto reduced keys` returns 8 of 12 rows.
- the same-pairing allowance in `isExpressionCompatible` made unconditional, i.e. the refusal taken too far. `two sides reduced onto the same keys still join without a shuffle` fails, and so does the existing `SPARK-56164: Reducers with different result types to original keys`.
- the pairing thrown away, so that any two marked keys count as one space. `two reduced partitionings are not compatible by their transforms` returns 8 of 24 rows. That is the ablation the test exists for, and it is why the marker records the pair rather than a bit.
- the `reducersBothWays` guard removed. `two sides reduced together are not reduced a second time` throws the `ClassCastException`. No other test in the suite reaches that guard, and instrumenting it to throw on entry showed every one of them misses it. That is why the test is built the way it is, with different key sets on the two legs so that the join computes reducers at all.

`SPARK-56164` is the existing test for the both-sides-reduce shape, and it gained one assertion, that the join's own requirements still validate, i.e. that the two sides which were reduced together are still co-partitioned. That is the no-regression half of this change, and it belongs on the test that already describes the shape rather than in a copy of it.

The four unit tests cover what a query test states only indirectly. They are the pairing relation itself, the `canCreatePartitioning` refusal, that a node which reduces nothing (or reduces another position) inherits the marker from its child, and that a projection drops the marker with the position it belongs to. The last two hold by construction under this representation, which is exactly why they are worth keeping, since an earlier design of this fix carried the marker on `KeyedPartitioning` and got both wrong.

Green: `ShuffleSpecSuite`, `DistributionSuite`, `TransformExpressionSuite`, `KeyGroupedPartitioningSuite`, `GroupPartitionsExecSuite`, `EnsureRequirementsSuite`, `ProjectedOrderingAndPartitioningSuite`, `ValidateRequirementsSuite`, `WriteDistributionAndOrderingSuite`, `PlannerSuite`, `UnionSuite`, `DataSourceV2Suite`, 488 tests in all. `dev/lint-scala` is clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

#### Backport to branch-4.2

The production change is the same. Four tailorings, all because the surrounding code arrived after this branch:

- The `PartitioningCollection` invariant paragraph is left out. `checkKeyedPartitioningInvariant` came with SPARK-59057, so there is no invariant list here to document.
- `V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS` is the name the config still has on this branch.
- The unit test for `hasSameReducedKeys` is left out. `TransformExpressionSuite` does not exist here, because SPARK-58769 was never backported. The relation stays covered end to end by `two reduced partitionings are not compatible by their transforms`.
- The projection test is left out. It needs `DummyLeafExecWithPartitioning`, which came with SPARK-46367.

Run against the branch tip, four of the six new query tests fail. `a union does not merge an already reduced partitioning` passes here rather than failing, because this branch's `UnionExec` does not merge key-grouped partitionings at all. The test is kept, so the refusal stays covered if that ever lands here.

Green here: `ShuffleSpecSuite`, `DistributionSuite`, `KeyGroupedPartitioningSuite`, `GroupPartitionsExecSuite`, `EnsureRequirementsSuite`, `ProjectedOrderingAndPartitioningSuite`, `ValidateRequirementsSuite`, `WriteDistributionAndOrderingSuite`, 312 tests in all. `dev/lint-scala` is clean.
