### PR TITLE
[SPARK-59165][SDP] SCD2 Ignore-null support; Introduce version map in `_cdc_metadata`

### DIFF
--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessor.scala
@@ -194,6 +194,9 @@ case class Scd2BatchProcessor(
       colName = AutoCdcReservedNames.cdcMetadataColName,
       col = Scd2BatchProcessor.constructCdcMetadataCol(
         recordStartAt = changeArgs.sequencing,
+        // TODO (SC-XXXXX): actually populate version map according to ignore-null selection and
+        // actual authorship in microbatch.
+        versionMap = F.lit(null),
         sequencingType = resolvedSequencingType
       )
     )
@@ -514,6 +517,9 @@ case class Scd2BatchProcessor(
             colName,
             Scd2BatchProcessor.constructCdcMetadataCol(
               recordStartAt = F.lit(null).cast(resolvedSequencingType),
+              // Decomposition tails are synthetic rows that carry no column-level authorship; they
+              // are instead row wide delete markers. They should always hold a null version map.
+              versionMap = F.lit(null),
               sequencingType = resolvedSequencingType
             )
           )
@@ -922,6 +928,9 @@ case class Scd2BatchProcessor(
           isDecompositionTail,
           Scd2BatchProcessor.constructCdcMetadataCol(
             recordStartAt = endAt,
+            // Tombstone rows carry no column-level authorship; they are instead row wide delete
+            // markers. They should always hold a null version map.
+            versionMap = F.lit(null),
             sequencingType = resolvedSequencingType
           )
         ).otherwise(F.col(c)).as(c, metadata)
@@ -1357,6 +1366,9 @@ object Scd2BatchProcessor {
    */
   private[pipelines] val recordStartAtFieldName: String = "__RECORD_START_AT"
 
+  /** CDC metadata field for the ignore-null version map. */
+  private[pipelines] val versionMapFieldName: String = "__VERSION_MAP"
+
   /**
    * Aux-table only column that holds the microbatch id by which a row was logically
    * deleted (null if the row is still live). Future microbatches must treat any row with a
@@ -1567,6 +1579,10 @@ object Scd2BatchProcessor {
   private def recordStartAtOf(cdcMetadataCol: Column): Column =
     cdcMetadataCol.getField(recordStartAtFieldName)
 
+  /** Project the [[versionMapFieldName]] out of an SCD2 CDC metadata column. */
+  private[autocdc] def versionMapOf(cdcMetadataCol: Column): Column =
+    cdcMetadataCol.getField(versionMapFieldName)
+
   /**
    * The [[Scd2IntervalColumns]] of a row read from either the auxiliary or the target table, in
    * the canonical SCD2 row schema. The columns are unresolved name references, so they read from
@@ -1587,7 +1603,11 @@ object Scd2BatchProcessor {
         // The sequence value of the originating CDC event for this row. Nullable because
         // decomposition tails, which are temporarily and synthetically constructed during
         // reconciliation, have a null record start at.
-        StructField(recordStartAtFieldName, sequencingType, nullable = true)
+        StructField(recordStartAtFieldName, sequencingType, nullable = true),
+        // null  = no authorship info (row predates ignore-null, or is synthetic).
+        // empty = no null-valued leaves to record (all columns were non-null).
+        // non-empty = keys are null-valued leaf column paths with authored/declined flags.
+        StructField(versionMapFieldName, Scd2VersionMap.mapType, nullable = true)
       )
     )
 
@@ -1597,11 +1617,13 @@ object Scd2BatchProcessor {
    */
   private[pipelines] def constructCdcMetadataCol(
       recordStartAt: Column,
+      versionMap: Column,
       sequencingType: DataType
   ): Column = {
     val cdcMetadataFieldsInOrder = cdcMetadataColSchema(sequencingType).fields.map { field =>
       val value = field.name match {
         case `recordStartAtFieldName` => recordStartAt
+        case `versionMapFieldName` => versionMap
         case other =>
           throw SparkException.internalError(
             s"Unable to construct SCD2 CDC metadata column due to unknown `${other}` field."

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessor.scala
@@ -1604,9 +1604,14 @@ object Scd2BatchProcessor {
         // decomposition tails, which are temporarily and synthetically constructed during
         // reconciliation, have a null record start at.
         StructField(recordStartAtFieldName, sequencingType, nullable = true),
-        // null  = no authorship info (row predates ignore-null, or is synthetic).
-        // empty = no null-valued leaves to record (all columns were non-null).
-        // non-empty = keys are null-valued leaf column paths with authored/declined flags.
+        // The version map representing null-authorship for the row. If the version map is null for
+        // a row, that row was ingested with ignore-null off, and all columns are considered
+        // explicitly authored (null or not). If the version map is non-null, the row was ingested
+        // with ignore-null on, and contents of the map comply with the contract defined in
+        // [[Scd2VersionMap]].
+        //
+        // Tombstones and decomposition tails also always hold null version maps because column
+        // authorship is not applicable - they are delete markers.
         StructField(versionMapFieldName, Scd2VersionMap.mapType, nullable = true)
       )
     )

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessor.scala
@@ -194,7 +194,7 @@ case class Scd2BatchProcessor(
       colName = AutoCdcReservedNames.cdcMetadataColName,
       col = Scd2BatchProcessor.constructCdcMetadataCol(
         recordStartAt = changeArgs.sequencing,
-        // TODO (SC-XXXXX): actually populate version map according to ignore-null selection and
+        // TODO (SPARK-59183): actually populate version map according to ignore-null selection and
         // actual authorship in microbatch.
         versionMap = F.lit(null),
         sequencingType = resolvedSequencingType

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2VersionMap.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2VersionMap.scala
@@ -70,7 +70,7 @@ import org.apache.spark.sql.types.{BooleanType, MapType, StringType}
  * after creation, it does not change the set of columns whose null values are considered
  * authored/unauthored. Therefore authorship information encoded by the mutated version map is
  * still invariant, and independent of a changing ignore-null configuration. New rows materialized
- * in the map are still compliant to whatever the ignore-null selection was at ingestion time.
+ * in the map are still compliant with whatever the ignore-null selection was at ingestion time.
  */
 private[pipelines] object Scd2VersionMap {
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2VersionMap.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd2VersionMap.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.autocdc
+
+import org.apache.spark.sql.types.{BooleanType, MapType, StringType}
+
+/**
+ * Per-row column authorship tracker for SCD2 ignore-null semantics.
+ *
+ * Recall in SCD2, every materialized row traces back to an upsert event that created it (and
+ * if the row is closed then also a delete/succession event that closed it, but that's not
+ * relevant here). Every data column in the row is at least partially derived by the
+ * corresponding data column in the upsert event that spawned the row.
+ *
+ * For columns where ignore-null was not applied, the data column in the row is fully derived
+ * (authored) by the corresponding data column in the upsert event. For columns where
+ * ignore-null was applied however, if the data column in the upsert event was null
+ * (unauthored), then we need to look backwards to deduce the corresponding inherited data
+ * column for the row.
+ *
+ * Non-null values in an event are always considered authored, regardless of whether the column
+ * in the event was included in the ignore-null configuration or not. Null values however, as
+ * mentioned above, may or may not be considered authored -- it depends on whether they are
+ * specified for a column that was included in the ignore-null configuration.
+ *
+ * In SCD2 the version map helps us answer per row: for all the columns that received a null
+ * value in the upsert event that created this row, which nulls are considered authored vs
+ * unauthored?
+ *
+ * Concretely, the contract of the version map is as follows.
+ * 1. Every column that received a null in the event but is considered authored (i.e. not part
+ *    of ignore-null selection at ingestion), receives an entry of (column name, true) in the
+ *    version map.
+ * 2. Every column that received a null in the event but is considered unauthored (i.e. part
+ *    of the ignore-null selection at ingestion), receives an entry of (column name, false) in
+ *    the version map.
+ * 3. Every column that was not present in the event, but schema evolved in later with a null
+ *    value, will be treated as unauthored BUT does not yet have any entry in the version map.
+ *    An entry will be added as per (2).
+ *
+ * In a single sentence: if a null column in the SCD2 row is either absent from the version
+ * map or has a false value in the version map, the null is considered unauthored by the
+ * upsert event that spawned this row. Otherwise the null value was explicitly authored by
+ * the row.
+ *
+ * As mentioned above, authorship is dependent on the configured ignore-null selection, which
+ * is free to change between pipeline runs for the same AutoCDC flow. As such, we choose that
+ * the version map strictly reflects authorship as of the ignore-null selection that was active
+ * when the upsert event that produced this row was ingested. This means the authorship
+ * information the version map encoded at creation time is invariant/frozen -- even if the
+ * ignore-null selection changes on a future run, the version map is not rewritten (unless the
+ * table is full refreshed).
+ *
+ * It's worth noting that while contract case (3) materializes new entries in the version map
+ * after creation, it does not change the set of columns whose null values are considered
+ * authored/unauthored. Therefore authorship information encoded by the mutated version map is
+ * still invariant, and independent of a changing ignore-null configuration. New rows materialized
+ * in the map are still compliant to whatever the ignore-null selection was at ingestion time.
+ */
+private[pipelines] object Scd2VersionMap {
+
+  /**
+   * Schema of the version map: `Map(String, Boolean)`.
+   *
+   * Keys are dot-delimited paths to *leaf* columns that received a null value in their
+   * corresponding upsert event (e.g. `"address.city"`, `` "`has space`.city" ``). Paths
+   * must be formatted by [[org.apache.spark.sql.catalyst.util.QuotingUtils.quoted]] to
+   * ensure segments that need quoting are back-tick escaped.
+   *
+   * Values indicate authorship. I.e, `true` => authored-null, `false` => unauthored-null.
+   *
+   * Lack of entry in the map for a null-valued leaf column implies the column was
+   * schema-evolved with an unauthored-null.
+   */
+  def mapType: MapType = MapType(StringType, BooleanType, valueContainsNull = false)
+}

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
@@ -402,6 +402,7 @@ class AutoCdcMergeFlow(
           F.lit(null).cast(sequencingType).as(Scd2BatchProcessor.endAtColName)
         val emptyCdcMetadataCol: Column = Scd2BatchProcessor.constructCdcMetadataCol(
           recordStartAt = F.lit(null),
+          versionMap = F.lit(null),
           sequencingType = sequencingType
         ).as(AutoCdcReservedNames.cdcMetadataColName)
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessorMergeSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessorMergeSuite.scala
@@ -143,56 +143,56 @@ class Scd2BatchProcessorMergeSuite
 
     // A freshly-routed tombstone with no matching aux row is inserted live (no logical-delete
     // marker).
-    val tagged = taggedOf(Row(1, "x", 5L, 5L, Row(5L), true))
+    val tagged = taggedOf(Row(1, "x", 5L, 5L, Row(5L, null), true))
     val affected = canonicalOf()
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 1L)
 
-    checkAnswer(auxTable, Row(1, "x", 5L, 5L, Row(5L), null))
+    checkAnswer(auxTable, Row(1, "x", 5L, 5L, Row(5L, null), null))
   }
 
   test("mergeRowsIntoAuxiliaryTable updates a surviving routed row in place") {
     // An existing hidden no-op upsert at recordStartAt=5 that survives reconciliation.
-    createAuxTable(Row(1, "old", 5L, null, Row(5L), null))
+    createAuxTable(Row(1, "old", 5L, null, Row(5L, null), null))
 
-    val tagged = taggedOf(Row(1, "new", 5L, null, Row(5L), true))
+    val tagged = taggedOf(Row(1, "new", 5L, null, Row(5L, null), true))
     // The affected row survives (still present in the routed set), so it is not logically
     // deleted; only its non-key columns are refreshed.
-    val affected = canonicalOf(Row(1, "old", 5L, null, Row(5L)))
+    val affected = canonicalOf(Row(1, "old", 5L, null, Row(5L, null)))
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 2L)
 
-    checkAnswer(auxTable, Row(1, "new", 5L, null, Row(5L), null))
+    checkAnswer(auxTable, Row(1, "new", 5L, null, Row(5L, null), null))
   }
 
   test("mergeRowsIntoAuxiliaryTable logically deletes an affected row that did not survive") {
     // A tombstone pulled in as affected but absent from this batch's routed set.
-    createAuxTable(Row(1, "gone", 7L, 7L, Row(7L), null))
+    createAuxTable(Row(1, "gone", 7L, 7L, Row(7L, null), null))
 
     // The single tagged row is not routed to the aux table, so the affected aux row has no
     // surviving counterpart and must be logically deleted.
-    val tagged = taggedOf(Row(1, "vis", 10L, null, Row(10L), false))
-    val affected = canonicalOf(Row(1, "gone", 7L, 7L, Row(7L)))
+    val tagged = taggedOf(Row(1, "vis", 10L, null, Row(10L, null), false))
+    val affected = canonicalOf(Row(1, "gone", 7L, 7L, Row(7L, null)))
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 3L)
 
     // Logical, not physical: the row stays but is stamped with this batch's id.
-    checkAnswer(auxTable, Row(1, "gone", 7L, 7L, Row(7L), 3L))
+    checkAnswer(auxTable, Row(1, "gone", 7L, 7L, Row(7L, null), 3L))
   }
 
   test("mergeRowsIntoAuxiliaryTable garbage-collects rows logically deleted by an older batch") {
     createAuxTable(
       // Logically deleted by an older batch (2 != 5) -> physically garbage-collected.
-      Row(1, "gc-old", 7L, 7L, Row(7L), 2L),
+      Row(1, "gc-old", 7L, 7L, Row(7L, null), 2L),
       // Still live (no marker) -> retained.
-      Row(2, "live", 3L, null, Row(3L), null),
+      Row(2, "live", 3L, null, Row(3L, null), null),
       // Logically deleted by the current batch (5 == 5) -> retained for replay-stability.
-      Row(3, "this-batch", 4L, 4L, Row(4L), 5L)
+      Row(3, "this-batch", 4L, 4L, Row(4L, null), 5L)
     )
 
     // One brand-new routed insert keeps the merge source non-empty; none of the seeded rows are
     // in the affected set, so they are all evaluated by the not-matched-by-source GC clause.
-    val tagged = taggedOf(Row(10, "newtomb", 8L, 8L, Row(8L), true))
+    val tagged = taggedOf(Row(10, "newtomb", 8L, 8L, Row(8L, null), true))
     val affected = canonicalOf()
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 5L)
@@ -200,9 +200,9 @@ class Scd2BatchProcessorMergeSuite
     checkAnswer(
       auxTable,
       Seq(
-        Row(2, "live", 3L, null, Row(3L), null),
-        Row(3, "this-batch", 4L, 4L, Row(4L), 5L),
-        Row(10, "newtomb", 8L, 8L, Row(8L), null)
+        Row(2, "live", 3L, null, Row(3L, null), null),
+        Row(3, "this-batch", 4L, 4L, Row(4L, null), 5L),
+        Row(10, "newtomb", 8L, 8L, Row(8L, null), null)
       )
     )
   }
@@ -210,15 +210,15 @@ class Scd2BatchProcessorMergeSuite
   test("mergeRowsIntoAuxiliaryTable is replay-stable: re-running the same batchId is a no-op") {
     createAuxTable(
       // Survives reconciliation -> re-upserted in place.
-      Row(1, "old", 5L, null, Row(5L), null),
+      Row(1, "old", 5L, null, Row(5L, null), null),
       // Affected but does not survive -> logically deleted by this batch.
-      Row(2, "gone", 7L, 7L, Row(7L), null)
+      Row(2, "gone", 7L, 7L, Row(7L, null), null)
     )
 
-    val tagged = taggedOf(Row(1, "new", 5L, null, Row(5L), true))
+    val tagged = taggedOf(Row(1, "new", 5L, null, Row(5L, null), true))
     val affected = canonicalOf(
-      Row(1, "old", 5L, null, Row(5L)),
-      Row(2, "gone", 7L, 7L, Row(7L))
+      Row(1, "old", 5L, null, Row(5L, null)),
+      Row(2, "gone", 7L, 7L, Row(7L, null))
     )
 
     // First application of the batch.
@@ -238,8 +238,8 @@ class Scd2BatchProcessorMergeSuite
     checkAnswer(
       auxTable,
       Seq(
-        Row(1, "new", 5L, null, Row(5L), null),
-        Row(2, "gone", 7L, 7L, Row(7L), 7L)
+        Row(1, "new", 5L, null, Row(5L, null), null),
+        Row(2, "gone", 7L, 7L, Row(7L, null), 7L)
       )
     )
   }
@@ -247,23 +247,23 @@ class Scd2BatchProcessorMergeSuite
   test("mergeRowsIntoAuxiliaryTable applies insert, update, logical-delete, and GC in one merge") {
     createAuxTable(
       // Affected and survives reconciliation -> non-key columns updated in place.
-      Row(1, "old", 5L, null, Row(5L), null),
+      Row(1, "old", 5L, null, Row(5L, null), null),
       // Affected but does not survive -> logically deleted by this batch (stamped with batchId).
-      Row(2, "gone", 7L, 7L, Row(7L), null),
+      Row(2, "gone", 7L, 7L, Row(7L, null), null),
       // Not affected, logically deleted by an older batch (4 != 9) -> physically GC'd.
-      Row(3, "gc", 3L, 3L, Row(3L), 4L)
+      Row(3, "gc", 3L, 3L, Row(3L, null), 4L)
     )
 
     val tagged = taggedOf(
       // Matches key 1 -> update.
-      Row(1, "new", 5L, null, Row(5L), true),
+      Row(1, "new", 5L, null, Row(5L, null), true),
       // New key 4 routed to aux -> insert.
-      Row(4, "ins", 9L, 9L, Row(9L), true)
+      Row(4, "ins", 9L, 9L, Row(9L, null), true)
     )
     // Keys 1 and 2 were pulled in as affected; key 1 survives in the routed set, key 2 does not.
     val affected = canonicalOf(
-      Row(1, "old", 5L, null, Row(5L)),
-      Row(2, "gone", 7L, 7L, Row(7L))
+      Row(1, "old", 5L, null, Row(5L, null)),
+      Row(2, "gone", 7L, 7L, Row(7L, null))
     )
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 9L)
@@ -271,9 +271,9 @@ class Scd2BatchProcessorMergeSuite
     checkAnswer(
       auxTable,
       Seq(
-        Row(1, "new", 5L, null, Row(5L), null),
-        Row(2, "gone", 7L, 7L, Row(7L), 9L),
-        Row(4, "ins", 9L, 9L, Row(9L), null)
+        Row(1, "new", 5L, null, Row(5L, null), null),
+        Row(2, "gone", 7L, 7L, Row(7L, null), 9L),
+        Row(4, "ins", 9L, 9L, Row(9L, null), null)
         // key 3 physically garbage-collected.
       )
     )
@@ -284,21 +284,21 @@ class Scd2BatchProcessorMergeSuite
       defaultAuxIdent,
       defaultAuxTableIdentifier,
       wideAuxSchema,
-      Row(1, "old-name", "active", 10, 5L, null, Row(5L), null)
+      Row(1, "old-name", "active", 10, 5L, null, Row(5L, null), null)
     )
 
     // Every non-key column (name, status, score) differs from the seeded row; the in-place update
     // must refresh all of them, not just the first.
     val tagged = microbatchOf(wideTaggedSchema)(
-      Row(1, "new-name", "inactive", 42, 5L, null, Row(5L), true)
+      Row(1, "new-name", "inactive", 42, 5L, null, Row(5L, null), true)
     )
     val affected = microbatchOf(wideCanonicalSchema)(
-      Row(1, "old-name", "active", 10, 5L, null, Row(5L))
+      Row(1, "old-name", "active", 10, 5L, null, Row(5L, null))
     )
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 1L)
 
-    checkAnswer(auxTable, Row(1, "new-name", "inactive", 42, 5L, null, Row(5L), null))
+    checkAnswer(auxTable, Row(1, "new-name", "inactive", 42, 5L, null, Row(5L, null), null))
   }
 
   test("mergeRowsIntoAuxiliaryTable handles user columns whose names contain a dot") {
@@ -307,12 +307,12 @@ class Scd2BatchProcessorMergeSuite
     // nested-field access and the MERGE would fail to resolve the column.
     createTable(defaultAuxIdent, defaultAuxTableIdentifier, dottedAuxSchema)
 
-    val tagged = microbatchOf(dottedTaggedSchema)(Row(1, "alice", 5L, 5L, Row(5L), true))
+    val tagged = microbatchOf(dottedTaggedSchema)(Row(1, "alice", 5L, 5L, Row(5L, null), true))
     val affected = microbatchOf(dottedCanonicalSchema)()
 
     processor.mergeRowsIntoAuxiliaryTable(tagged, affected, defaultAuxTableIdentifier, batchId = 1L)
 
-    checkAnswer(auxTable, Row(1, "alice", 5L, 5L, Row(5L), null))
+    checkAnswer(auxTable, Row(1, "alice", 5L, 5L, Row(5L, null), null))
   }
 
   // ===========================================================================================
@@ -322,34 +322,34 @@ class Scd2BatchProcessorMergeSuite
   test("mergeRowsIntoTargetTable inserts a visible upsert absent from the target table") {
     createTargetTable()
 
-    val tagged = taggedOf(Row(1, "v", 5L, null, Row(5L), false))
+    val tagged = taggedOf(Row(1, "v", 5L, null, Row(5L, null), false))
     val affected = canonicalOf()
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
 
-    checkAnswer(targetTable, Row(1, "v", 5L, null, Row(5L)))
+    checkAnswer(targetTable, Row(1, "v", 5L, null, Row(5L, null)))
   }
 
   test("mergeRowsIntoTargetTable updates a visible row matched at the same recordStartAt") {
-    createTargetTable(Row(1, "old", 5L, null, Row(5L)))
+    createTargetTable(Row(1, "old", 5L, null, Row(5L, null)))
 
     // The run head at recordStartAt=5 is now closed at 20 with refreshed data; it matches and
     // updates the existing target row in place.
-    val tagged = taggedOf(Row(1, "new", 5L, 20L, Row(5L), false))
-    val affected = canonicalOf(Row(1, "old", 5L, null, Row(5L)))
+    val tagged = taggedOf(Row(1, "new", 5L, 20L, Row(5L, null), false))
+    val affected = canonicalOf(Row(1, "old", 5L, null, Row(5L, null)))
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
 
-    checkAnswer(targetTable, Row(1, "new", 5L, 20L, Row(5L)))
+    checkAnswer(targetTable, Row(1, "new", 5L, 20L, Row(5L, null)))
   }
 
   test("mergeRowsIntoTargetTable deletes an affected row reconciled away") {
-    createTargetTable(Row(1, "old", 5L, null, Row(5L)))
+    createTargetTable(Row(1, "old", 5L, null, Row(5L, null)))
 
     // The only tagged row routes to the aux table (e.g. closed into a tombstone), so no visible
     // row survives for key 1: the previously-affected target row must be deleted.
-    val tagged = taggedOf(Row(1, "x", 5L, 5L, Row(5L), true))
-    val affected = canonicalOf(Row(1, "old", 5L, null, Row(5L)))
+    val tagged = taggedOf(Row(1, "x", 5L, 5L, Row(5L, null), true))
+    val affected = canonicalOf(Row(1, "old", 5L, null, Row(5L, null)))
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
 
@@ -363,34 +363,34 @@ class Scd2BatchProcessorMergeSuite
     // are filtered by the routing flag; the decomposition tail is filtered because it is not an
     // upsert-representing row.
     val tagged = taggedOf(
-      Row(1, "vis", 5L, null, Row(5L), false),
-      Row(2, "tomb", 7L, 7L, Row(7L), true),
-      Row(3, "tail", null, 9L, Row(null), false),
-      Row(4, "hidden", 5L, null, Row(5L), true)
+      Row(1, "vis", 5L, null, Row(5L, null), false),
+      Row(2, "tomb", 7L, 7L, Row(7L, null), true),
+      Row(3, "tail", null, 9L, Row(null, null), false),
+      Row(4, "hidden", 5L, null, Row(5L, null), true)
     )
     val affected = canonicalOf()
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
 
-    checkAnswer(targetTable, Row(1, "vis", 5L, null, Row(5L)))
+    checkAnswer(targetTable, Row(1, "vis", 5L, null, Row(5L, null)))
   }
 
   test("mergeRowsIntoTargetTable applies insert, update, and delete branches in one merge") {
     createTargetTable(
-      Row(1, "old1", 5L, null, Row(5L)),
-      Row(2, "old2", 8L, null, Row(8L))
+      Row(1, "old1", 5L, null, Row(5L, null)),
+      Row(2, "old2", 8L, null, Row(8L, null))
     )
 
     val tagged = taggedOf(
       // Matches key 1 at recordStartAt=5 -> update.
-      Row(1, "new1", 5L, 30L, Row(5L), false),
+      Row(1, "new1", 5L, 30L, Row(5L, null), false),
       // New key 3 -> insert.
-      Row(3, "ins3", 12L, null, Row(12L), false)
+      Row(3, "ins3", 12L, null, Row(12L, null), false)
       // Key 2 has no surviving visible row -> delete.
     )
     val affected = canonicalOf(
-      Row(1, "old1", 5L, null, Row(5L)),
-      Row(2, "old2", 8L, null, Row(8L))
+      Row(1, "old1", 5L, null, Row(5L, null)),
+      Row(2, "old2", 8L, null, Row(8L, null))
     )
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
@@ -398,8 +398,8 @@ class Scd2BatchProcessorMergeSuite
     checkAnswer(
       targetTable,
       Seq(
-        Row(1, "new1", 5L, 30L, Row(5L)),
-        Row(3, "ins3", 12L, null, Row(12L))
+        Row(1, "new1", 5L, 30L, Row(5L, null)),
+        Row(3, "ins3", 12L, null, Row(12L, null))
       )
     )
   }
@@ -410,31 +410,31 @@ class Scd2BatchProcessorMergeSuite
     // parsed as a nested-field access and the MERGE would fail to resolve the column.
     createTable(defaultTargetIdent, defaultTargetTableIdentifier, dottedCanonicalSchema)
 
-    val tagged = microbatchOf(dottedTaggedSchema)(Row(1, "alice", 5L, null, Row(5L), false))
+    val tagged = microbatchOf(dottedTaggedSchema)(Row(1, "alice", 5L, null, Row(5L, null), false))
     val affected = microbatchOf(dottedCanonicalSchema)()
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
 
-    checkAnswer(targetTable, Row(1, "alice", 5L, null, Row(5L)))
+    checkAnswer(targetTable, Row(1, "alice", 5L, null, Row(5L, null)))
   }
 
   test("mergeRowsIntoTargetTable updates every non-key column of a matched row") {
     createTable(defaultTargetIdent, defaultTargetTableIdentifier, wideCanonicalSchema)
     microbatchOf(wideCanonicalSchema)(
-      Row(1, "old-name", "active", 10, 5L, null, Row(5L))
+      Row(1, "old-name", "active", 10, 5L, null, Row(5L, null))
     ).writeTo(defaultTargetTableIdentifier.quotedString).append()
 
     // Every non-key column (name, status, score) differs from the existing row; the in-place
     // update must refresh all of them, exercising the full non-key update assignment map.
     val tagged = microbatchOf(wideTaggedSchema)(
-      Row(1, "new-name", "inactive", 42, 5L, 30L, Row(5L), false)
+      Row(1, "new-name", "inactive", 42, 5L, 30L, Row(5L, null), false)
     )
     val affected = microbatchOf(wideCanonicalSchema)(
-      Row(1, "old-name", "active", 10, 5L, null, Row(5L))
+      Row(1, "old-name", "active", 10, 5L, null, Row(5L, null))
     )
 
     processor.mergeRowsIntoTargetTable(tagged, affected, defaultTargetTableIdentifier)
 
-    checkAnswer(targetTable, Row(1, "new-name", "inactive", 42, 5L, 30L, Row(5L)))
+    checkAnswer(targetTable, Row(1, "new-name", "inactive", 42, 5L, 30L, Row(5L, null)))
   }
 }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessorSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessorSuite.scala
@@ -278,6 +278,18 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
       Scd2BatchProcessor.endAtColName,
       AutoCdcReservedNames.cdcMetadataColName
     ))
+
+    val cdcMetadataSchema =
+      result.schema(AutoCdcReservedNames.cdcMetadataColName).dataType.asInstanceOf[StructType]
+    assert(
+      cdcMetadataSchema.fieldNames.sameElements(
+        Array(Scd2BatchProcessor.recordStartAtFieldName, Scd2BatchProcessor.versionMapFieldName)
+      )
+    )
+
+    val versionMapField = cdcMetadataSchema(Scd2BatchProcessor.versionMapFieldName)
+    assert(versionMapField.dataType == MapType(StringType, BooleanType, valueContainsNull = false))
+    assert(versionMapField.nullable)
   }
 
   test("preprocessMicrobatch returns an empty DataFrame with the full preprocessed schema") {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessorSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2BatchProcessorSuite.scala
@@ -162,9 +162,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // (recordStartAt = null, endAt = 10) takes its endAt as its effective ordering sequence,
     // so the expected per-key window order is 5, tail(10), 15.
     val df = targetTableOf(userSchema)(
-      Row(1, "v15", 15L, null, Row(15L)),
-      Row(1, "tail", null, 10L, Row(null)),
-      Row(1, "v5", 5L, null, Row(5L))
+      Row(1, "v15", 15L, null, Row(15L, null)),
+      Row(1, "tail", null, 10L, Row(null, null)),
+      Row(1, "v5", 5L, null, Row(5L, null))
     )
 
     val withRn = df.withColumn(
@@ -174,9 +174,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = withRn,
       expectedAnswer = Seq(
-        Row(1, "v5", 5L, null, Row(5L), 1),
-        Row(1, "tail", null, 10L, Row(null), 2),
-        Row(1, "v15", 15L, null, Row(15L), 3)
+        Row(1, "v5", 5L, null, Row(5L, null), 1),
+        Row(1, "tail", null, 10L, Row(null, null), 2),
+        Row(1, "v15", 15L, null, Row(15L, null), 3)
       )
     )
   }
@@ -192,12 +192,12 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //   key=2: upsert-representing-first (open variant)   - open upsert vs tombstone.
     //   key=3: upsert-representing-first (closed variant) - closed run head vs tombstone.
     val df = targetTableOf(userSchema)(
-      Row(1, "tomb", 10L, 10L, Row(10L)),
-      Row(1, "tail", null, 10L, Row(null)),
-      Row(2, "tomb", 10L, 10L, Row(10L)),
-      Row(2, "open", 10L, null, Row(10L)),
-      Row(3, "tomb", 10L, 10L, Row(10L)),
-      Row(3, "closed", 10L, 20L, Row(10L))
+      Row(1, "tomb", 10L, 10L, Row(10L, null)),
+      Row(1, "tail", null, 10L, Row(null, null)),
+      Row(2, "tomb", 10L, 10L, Row(10L, null)),
+      Row(2, "open", 10L, null, Row(10L, null)),
+      Row(3, "tomb", 10L, 10L, Row(10L, null)),
+      Row(3, "closed", 10L, 20L, Row(10L, null))
     )
 
     val withRn = df.withColumn(
@@ -207,12 +207,12 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = withRn,
       expectedAnswer = Seq(
-        Row(1, "tail", null, 10L, Row(null), 1),
-        Row(1, "tomb", 10L, 10L, Row(10L), 2),
-        Row(2, "open", 10L, null, Row(10L), 1),
-        Row(2, "tomb", 10L, 10L, Row(10L), 2),
-        Row(3, "closed", 10L, 20L, Row(10L), 1),
-        Row(3, "tomb", 10L, 10L, Row(10L), 2)
+        Row(1, "tail", null, 10L, Row(null, null), 1),
+        Row(1, "tomb", 10L, 10L, Row(10L, null), 2),
+        Row(2, "open", 10L, null, Row(10L, null), 1),
+        Row(2, "tomb", 10L, 10L, Row(10L, null), 2),
+        Row(3, "closed", 10L, 20L, Row(10L, null), 1),
+        Row(3, "tomb", 10L, 10L, Row(10L, null), 2)
       )
     )
   }
@@ -225,12 +225,12 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // by effective recordStartAt - rows from key 2 must not influence row_number positions
     // of rows for key 1, and vice versa.
     val df = targetTableOf(userSchema)(
-      Row(1, "k1-15", 15L, null, Row(15L)),
-      Row(2, "k2-7", 7L, null, Row(7L)),
-      Row(1, "k1-5", 5L, null, Row(5L)),
-      Row(2, "k2-3", 3L, null, Row(3L)),
-      Row(1, "k1-10", 10L, null, Row(10L)),
-      Row(2, "k2-20", 20L, null, Row(20L))
+      Row(1, "k1-15", 15L, null, Row(15L, null)),
+      Row(2, "k2-7", 7L, null, Row(7L, null)),
+      Row(1, "k1-5", 5L, null, Row(5L, null)),
+      Row(2, "k2-3", 3L, null, Row(3L, null)),
+      Row(1, "k1-10", 10L, null, Row(10L, null)),
+      Row(2, "k2-20", 20L, null, Row(20L, null))
     )
 
     val withRn = df.withColumn(
@@ -240,12 +240,12 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = withRn,
       expectedAnswer = Seq(
-        Row(1, "k1-5", 5L, null, Row(5L), 1),
-        Row(1, "k1-10", 10L, null, Row(10L), 2),
-        Row(1, "k1-15", 15L, null, Row(15L), 3),
-        Row(2, "k2-3", 3L, null, Row(3L), 1),
-        Row(2, "k2-7", 7L, null, Row(7L), 2),
-        Row(2, "k2-20", 20L, null, Row(20L), 3)
+        Row(1, "k1-5", 5L, null, Row(5L, null), 1),
+        Row(1, "k1-10", 10L, null, Row(10L, null), 2),
+        Row(1, "k1-15", 15L, null, Row(15L, null), 3),
+        Row(2, "k2-3", 3L, null, Row(3L, null), 1),
+        Row(2, "k2-7", 7L, null, Row(7L, null), 2),
+        Row(2, "k2-20", 20L, null, Row(20L, null), 3)
       )
     )
   }
@@ -343,9 +343,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = processor.preprocessMicrobatch(batch),
       expectedAnswer = Seq(
-        Row(1, 10L, "first-upsert", false, 10L, null, Row(10L)),
-        Row(1, 20L, "second-upsert", false, 20L, null, Row(20L)),
-        Row(1, 30L, null, true, 30L, 30L, Row(30L))
+        Row(1, 10L, "first-upsert", false, 10L, null, Row(10L, null)),
+        Row(1, 20L, "second-upsert", false, 20L, null, Row(20L, null)),
+        Row(1, 30L, null, true, 30L, 30L, Row(30L, null))
       )
     )
   }
@@ -381,8 +381,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = processor.preprocessMicrobatch(batch),
       expectedAnswer = Seq(
-        Row(1, 10L, "alice", false, 10L, null, Row(10L)),
-        Row(1, 10L, "alice", false, 10L, null, Row(10L))
+        Row(1, 10L, "alice", false, 10L, null, Row(10L, null)),
+        Row(1, 10L, "alice", false, 10L, null, Row(10L, null))
       )
     )
   }
@@ -547,7 +547,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     ))
     checkAnswer(
       df = result,
-      expectedAnswer = Row(1, 30, 10L, null, Row(10L))
+      expectedAnswer = Row(1, 30, 10L, null, Row(10L, null))
     )
   }
 
@@ -579,7 +579,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     ))
     checkAnswer(
       df = result,
-      expectedAnswer = Row(1, 30, 10L, 10L, null, Row(10L))
+      expectedAnswer = Row(1, 30, 10L, 10L, null, Row(10L, null))
     )
   }
 
@@ -683,7 +683,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     ))
     checkAnswer(
       df = result,
-      expectedAnswer = Row(1, "u-100", 10L, null, Row(10L))
+      expectedAnswer = Row(1, "u-100", 10L, null, Row(10L, null))
     )
   }
 
@@ -728,8 +728,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 10L, null, Row(10L)),
-        Row(1, null, 20L, 20L, Row(20L))
+        Row(1, "alice", 10L, null, Row(10L, null)),
+        Row(1, null, 20L, 20L, Row(20L, null))
       )
     )
   }
@@ -876,10 +876,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // back to minSeq itself.
     //   - 7  -> sits at the cutoff; included.
     val aux = auxTableOf(userSchema)(
-      Row(1, "v1.3", 3L, null, Row(3L), null),
-      Row(1, "v1.5", 5L, null, Row(5L), null),
-      Row(1, "v1.10", 10L, null, Row(10L), null),
-      Row(2, "v2.7", 7L, null, Row(7L), null)
+      Row(1, "v1.3", 3L, null, Row(3L, null), null),
+      Row(1, "v1.5", 5L, null, Row(5L, null), null),
+      Row(1, "v1.10", 10L, null, Row(10L, null), null),
+      Row(2, "v2.7", 7L, null, Row(7L, null), null)
     )
     val minSeq = minSeqOf(keySchema)(
       Row(1, 10L),
@@ -892,9 +892,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "v1.5", 5L, null, Row(5L)), // sits at key=1's cutoff
-        Row(1, "v1.10", 10L, null, Row(10L)), // after key=1's cutoff
-        Row(2, "v2.7", 7L, null, Row(7L))     // sits at key=2's cutoff, which fell back to minSeq
+        Row(1, "v1.5", 5L, null, Row(5L, null)), // sits at key=1's cutoff
+        Row(1, "v1.10", 10L, null, Row(10L, null)), // after key=1's cutoff
+        Row(2, "v2.7", 7L, null, Row(7L, null)) // key=2's cutoff (fell back to minSeq)
       )
     )
   }
@@ -910,14 +910,14 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val aux = auxTableOf(userSchema)(
       // Tombstone at recordStartAt = 3 (deleted at sequence 3): startAt = endAt = 3.
       // Below the cutoff; dropped.
-      Row(1, null, 3L, 3L, Row(3L), null),
+      Row(1, null, 3L, 3L, Row(3L, null), null),
       // No-op upsert continuation at recordStartAt = 7: startAt inherits its run head's
       // recordStartAt, endAt is null. Sets the cutoff for minSeq=10 (nearest below it).
-      Row(1, "alice", 5L, null, Row(7L), null),
+      Row(1, "alice", 5L, null, Row(7L, null), null),
       // Tombstone at recordStartAt = 12: after the cutoff; included.
-      Row(1, null, 12L, 12L, Row(12L), null),
+      Row(1, null, 12L, 12L, Row(12L, null), null),
       // No-op upsert continuation at recordStartAt = 15: after the cutoff; included.
-      Row(1, "bob", 13L, null, Row(15L), null)
+      Row(1, "bob", 13L, null, Row(15L, null), null)
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
@@ -927,9 +927,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(7L)),
-        Row(1, null, 12L, 12L, Row(12L)),
-        Row(1, "bob", 13L, null, Row(15L))
+        Row(1, "alice", 5L, null, Row(7L, null)),
+        Row(1, null, 12L, 12L, Row(12L, null)),
+        Row(1, "bob", 13L, null, Row(15L, null))
       )
     )
   }
@@ -941,8 +941,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = keySchema.add("value", StringType)
 
     val aux = auxTableOf(userSchema)(
-      Row(1, "alice", 2L, null, Row(8L), null),
-      Row(1, "alice", 2L, null, Row(12L), null)
+      Row(1, "alice", 2L, null, Row(8L, null), null),
+      Row(1, "alice", 2L, null, Row(12L, null), null)
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
@@ -953,9 +953,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
       df = result,
       expectedAnswer = Seq(
         // Row with record start at of 8 sets the cutoff,
-        Row(1, "alice", 2L, null, Row(8L)),
+        Row(1, "alice", 2L, null, Row(8L, null)),
         // Row with record start at of 12 sits after the cutoff.
-        Row(1, "alice", 2L, null, Row(12L))
+        Row(1, "alice", 2L, null, Row(12L, null))
       )
     )
   }
@@ -973,8 +973,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // pull it in as a harmless side effect of the range filter, and this behavior is
     // documented via test.
     val aux = auxTableOf(userSchema)(
-      Row(1, null, 7L, 7L, Row(7L), null),
-      Row(1, null, 12L, 12L, Row(12L), null)
+      Row(1, null, 7L, 7L, Row(7L, null), null),
+      Row(1, null, 12L, 12L, Row(12L, null), null)
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
@@ -985,9 +985,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
       df = result,
       expectedAnswer = Seq(
         // Sets the cutoff.
-        Row(1, null, 7L, 7L, Row(7L)),
+        Row(1, null, 7L, 7L, Row(7L, null)),
         // Sits after the cutoff.
-        Row(1, null, 12L, 12L, Row(12L))
+        Row(1, null, 12L, 12L, Row(12L, null))
       )
     )
   }
@@ -1005,11 +1005,11 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // applies uniformly to the row at the cutoff and to the rows after it.
     val aux = auxTableOf(userSchema)(
       // Cutoff candidate (recordStartAt < minSeq):
-      Row(1, "anchor", 5L, null, Row(5L), currentBatchId), // deleted by current -> kept
+      Row(1, "anchor", 5L, null, Row(5L, null), currentBatchId), // deleted by current -> kept
       // At-or-after minSeq:
-      Row(1, "live", 10L, null, Row(10L), null), // not deleted -> kept
-      Row(1, "retried", 11L, null, Row(11L), currentBatchId), // deleted by current -> kept
-      Row(1, "ignored", 12L, null, Row(12L), differentBatchId)   // deleted by another -> dropped
+      Row(1, "live", 10L, null, Row(10L, null), null), // not deleted -> kept
+      Row(1, "retried", 11L, null, Row(11L, null), currentBatchId), // deleted by current -> kept
+      Row(1, "ignored", 12L, null, Row(12L, null), differentBatchId) // other batch -> dropped
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
@@ -1025,9 +1025,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "anchor", 5L, null, Row(5L)),
-        Row(1, "live", 10L, null, Row(10L)),
-        Row(1, "retried", 11L, null, Row(11L))
+        Row(1, "anchor", 5L, null, Row(5L, null)),
+        Row(1, "live", 10L, null, Row(10L, null)),
+        Row(1, "retried", 11L, null, Row(11L, null))
       )
     )
   }
@@ -1049,8 +1049,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // because row 7 would set the cutoff and then be dropped, leaving nothing at the cutoff
     // at all.
     val aux = auxTableOf(userSchema)(
-      Row(1, "live3", 3L, null, Row(3L), null),
-      Row(1, "stale7", 7L, null, Row(7L), differentBatchId)
+      Row(1, "live3", 3L, null, Row(3L, null), null),
+      Row(1, "stale7", 7L, null, Row(7L, null), differentBatchId)
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
@@ -1065,7 +1065,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
 
     checkAnswer(
       df = result,
-      expectedAnswer = Seq(Row(1, "live3", 3L, null, Row(3L)))
+      expectedAnswer = Seq(Row(1, "live3", 3L, null, Row(3L, null)))
     )
   }
 
@@ -1079,7 +1079,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // drop that aux-only column so the result is union-compatible with target-table rows
     // and preprocessed-microbatch rows downstream, while leaving the (now-shared)
     // `_cdc_metadata` struct schema untouched.
-    val aux = auxTableOf(userSchema)(Row(1, "v", 5L, null, Row(5L), null))
+    val aux = auxTableOf(userSchema)(Row(1, "v", 5L, null, Row(5L, null), null))
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
 
@@ -1095,7 +1095,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val keySchema = new StructType().add("a.b", IntegerType)
     val userSchema = keySchema.add("value", StringType)
 
-    val aux = auxTableOf(userSchema)(Row(1, "v", 5L, null, Row(5L), null))
+    val aux = auxTableOf(userSchema)(Row(1, "v", 5L, null, Row(5L, null), null))
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
 
@@ -1104,7 +1104,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // The lone aux row sets the cutoff (recordStartAt=5 < minSeq=10, no other candidates).
     checkAnswer(
       df = result,
-      expectedAnswer = Seq(Row(1, "v", 5L, null, Row(5L)))
+      expectedAnswer = Seq(Row(1, "v", 5L, null, Row(5L, null)))
     )
   }
 
@@ -1121,9 +1121,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //   (EU, 1): cutoff at 4; nothing follows it, so only the cutoff row is selected.
     //   (US, 2): no aux rows -> contributes nothing.
     val aux = auxTableOf(userSchema)(
-      Row("US", 1, "us1.3", 3L, null, Row(3L), null),
-      Row("US", 1, "us1.10", 10L, null, Row(10L), null),
-      Row("EU", 1, "eu1.4", 4L, null, Row(4L), null)
+      Row("US", 1, "us1.3", 3L, null, Row(3L, null), null),
+      Row("US", 1, "us1.10", 10L, null, Row(10L, null), null),
+      Row("EU", 1, "eu1.4", 4L, null, Row(4L, null), null)
     )
     val minSeq = minSeqOf(keySchema)(
       Row("US", 1, 10L),
@@ -1137,9 +1137,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row("US", 1, "us1.3", 3L, null, Row(3L)),
-        Row("US", 1, "us1.10", 10L, null, Row(10L)),
-        Row("EU", 1, "eu1.4", 4L, null, Row(4L))
+        Row("US", 1, "us1.3", 3L, null, Row(3L, null)),
+        Row("US", 1, "us1.10", 10L, null, Row(10L, null)),
+        Row("EU", 1, "eu1.4", 4L, null, Row(4L, null))
       )
     )
   }
@@ -1165,7 +1165,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = keySchema.add("value", StringType)
 
     // Aux only has rows for key=1. Microbatch only sees key=2.
-    val aux = auxTableOf(userSchema)(Row(1, "v", 5L, null, Row(5L), null))
+    val aux = auxTableOf(userSchema)(Row(1, "v", 5L, null, Row(5L, null), null))
     val minSeq = minSeqOf(keySchema)(Row(2, 10L))
     val target = targetTableOf(userSchema)()
 
@@ -1182,8 +1182,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Aux has rows for keys 1 and 2. Microbatch only mentions key=1, so key=2's aux rows
     // must be dropped (the inner join with minSeq strips them).
     val aux = auxTableOf(userSchema)(
-      Row(1, "v1", 5L, null, Row(5L), null),
-      Row(2, "v2", 7L, null, Row(7L), null)
+      Row(1, "v1", 5L, null, Row(5L, null), null),
+      Row(2, "v2", 7L, null, Row(7L, null), null)
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val target = targetTableOf(userSchema)()
@@ -1192,7 +1192,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
 
     checkAnswer(
       df = result,
-      expectedAnswer = Seq(Row(1, "v1", 5L, null, Row(5L)))
+      expectedAnswer = Seq(Row(1, "v1", 5L, null, Row(5L, null)))
     )
   }
 
@@ -1211,10 +1211,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //   - recordStartAt=10 -> after the cutoff  -> included
     //   - recordStartAt=15 -> after the cutoff  -> included (and is the active row)
     val target = targetTableOf(userSchema)(
-      Row(1, "old", 1L, 5L, Row(1L)),
-      Row(1, "edge", 5L, 10L, Row(5L)),
-      Row(1, "recent", 10L, 15L, Row(10L)),
-      Row(1, "active", 15L, null, Row(15L))
+      Row(1, "old", 1L, 5L, Row(1L, null)),
+      Row(1, "edge", 5L, 10L, Row(5L, null)),
+      Row(1, "recent", 10L, 15L, Row(10L, null)),
+      Row(1, "active", 15L, null, Row(15L, null))
     )
     val minSeq = minSeqOf(keySchema)(Row(1, 10L))
     val aux = auxTableOf(userSchema)()
@@ -1224,9 +1224,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "edge", 5L, 10L, Row(5L)),
-        Row(1, "recent", 10L, 15L, Row(10L)),
-        Row(1, "active", 15L, null, Row(15L))
+        Row(1, "edge", 5L, 10L, Row(5L, null)),
+        Row(1, "recent", 10L, 15L, Row(10L, null)),
+        Row(1, "active", 15L, null, Row(15L, null))
       )
     )
   }
@@ -1238,14 +1238,14 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
 
     // A standalone delete at 40 found nothing live to close, so it survives in the auxiliary
     // table as a tombstone. The upsert at 42 then opened a run in the gap after it.
-    val aux = auxTableOf(userSchema)(Row(1, null, 40L, 40L, Row(40L), null))
-    val target = targetTableOf(userSchema)(Row(1, "target", 42L, null, Row(42L)))
+    val aux = auxTableOf(userSchema)(Row(1, null, 40L, 40L, Row(40L, null), null))
+    val target = targetTableOf(userSchema)(Row(1, "target", 42L, null, Row(42L, null)))
     val minSeq = minSeqOf(keySchema)(Row(1, 50L))
 
     // The target's row at 42 is the cutoff, so the auxiliary tombstone at 40 falls below it.
     checkAnswer(
       df = findAffectedTargetRows(processor, target = target, aux = aux, minSeq = minSeq),
-      expectedAnswer = Seq(Row(1, "target", 42L, null, Row(42L)))
+      expectedAnswer = Seq(Row(1, "target", 42L, null, Row(42L, null)))
     )
     checkAnswer(
       df = findAffectedAuxRows(processor, aux = aux, target = target, minSeq = minSeq),
@@ -1261,15 +1261,15 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // A delete at 41 closed the target's run, leaving no tombstone of its own since the closed
     // row already carries that boundary. A later standalone delete at 42 landed in the gap after
     // it with nothing to close, and so survives in the auxiliary table.
-    val aux = auxTableOf(userSchema)(Row(1, null, 42L, 42L, Row(42L), null))
-    val target = targetTableOf(userSchema)(Row(1, "target", 40L, 41L, Row(40L)))
+    val aux = auxTableOf(userSchema)(Row(1, null, 42L, 42L, Row(42L, null), null))
+    val target = targetTableOf(userSchema)(Row(1, "target", 40L, 41L, Row(40L, null)))
     val minSeq = minSeqOf(keySchema)(Row(1, 50L))
 
     // The tombstone at 42 is the cutoff, so the target's row at 40 falls below it - correctly,
     // since that interval already closed at 41, before anything in the microbatch.
     checkAnswer(
       df = findAffectedAuxRows(processor, aux = aux, target = target, minSeq = minSeq),
-      expectedAnswer = Seq(Row(1, null, 42L, 42L, Row(42L)))
+      expectedAnswer = Seq(Row(1, null, 42L, 42L, Row(42L, null)))
     )
     checkAnswer(
       df = findAffectedTargetRows(processor, target = target, aux = aux, minSeq = minSeq),
@@ -1287,13 +1287,13 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val target = targetTableOf(userSchema)(
       // Key 1: minSeq=10, so the cutoff is recordStartAt=5. "k1.recent" sits at it and
       // "k1.active" follows it; "k1.old" at recordStartAt=1 falls below it.
-      Row(1, "k1.old", 1L, 5L, Row(1L)),
-      Row(1, "k1.recent", 5L, 15L, Row(5L)),
-      Row(1, "k1.active", 15L, null, Row(15L)),
+      Row(1, "k1.old", 1L, 5L, Row(1L, null)),
+      Row(1, "k1.recent", 5L, 15L, Row(5L, null)),
+      Row(1, "k1.active", 15L, null, Row(15L, null)),
       // Key 2: minSeq=20, so the cutoff is recordStartAt=18. Only "k2.active" survives.
-      Row(2, "k2.old", 1L, 10L, Row(1L)),
-      Row(2, "k2.recent", 10L, 18L, Row(10L)),
-      Row(2, "k2.active", 18L, null, Row(18L))
+      Row(2, "k2.old", 1L, 10L, Row(1L, null)),
+      Row(2, "k2.recent", 10L, 18L, Row(10L, null)),
+      Row(2, "k2.active", 18L, null, Row(18L, null))
     )
     val minSeq = minSeqOf(keySchema)(
       Row(1, 10L),
@@ -1306,9 +1306,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "k1.recent", 5L, 15L, Row(5L)),
-        Row(1, "k1.active", 15L, null, Row(15L)),
-        Row(2, "k2.active", 18L, null, Row(18L))
+        Row(1, "k1.recent", 5L, 15L, Row(5L, null)),
+        Row(1, "k1.active", 15L, null, Row(15L, null)),
+        Row(2, "k2.active", 18L, null, Row(18L, null))
       )
     )
   }
@@ -1326,9 +1326,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // (EU, 1)'s cutoff for minSeq=12 is recordStartAt=5, so its older row at
     // recordStartAt=1 falls below it. (US, 2) has no target rows.
     val target = targetTableOf(userSchema)(
-      Row("US", 1, "us1", 1L, null, Row(1L)),
-      Row("EU", 1, "eu1.old", 1L, 5L, Row(1L)),
-      Row("EU", 1, "eu1", 5L, null, Row(5L))
+      Row("US", 1, "us1", 1L, null, Row(1L, null)),
+      Row("EU", 1, "eu1.old", 1L, 5L, Row(1L, null)),
+      Row("EU", 1, "eu1", 5L, null, Row(5L, null))
     )
     val minSeq = minSeqOf(keySchema)(
       Row("US", 1, 10L),
@@ -1342,8 +1342,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row("US", 1, "us1", 1L, null, Row(1L)),
-        Row("EU", 1, "eu1", 5L, null, Row(5L))
+        Row("US", 1, "us1", 1L, null, Row(1L, null)),
+        Row("EU", 1, "eu1", 5L, null, Row(5L, null))
       )
     )
   }
@@ -1369,7 +1369,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = keySchema.add("value", StringType)
 
     // Target only has rows for key=1. Microbatch only sees key=2.
-    val target = targetTableOf(userSchema)(Row(1, "v", 1L, null, Row(1L)))
+    val target = targetTableOf(userSchema)(Row(1, "v", 1L, null, Row(1L, null)))
     val minSeq = minSeqOf(keySchema)(Row(2, 10L))
     val aux = auxTableOf(userSchema)()
 
@@ -1393,9 +1393,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //   - "tomb":  startAt == endAt, so it is excluded by the strict `<` closed check
     //   - "last":  closed, but is the last row in its window partition (no successor)
     val df = targetTableOf(userSchema)(
-      Row(1, "open", 100, 5L, null, Row(5L)),
-      Row(1, "tomb", 200, 10L, 10L, Row(10L)),
-      Row(1, "last", 300, 15L, 25L, Row(15L))
+      Row(1, "open", 100, 5L, null, Row(5L, null)),
+      Row(1, "tomb", 200, 10L, 10L, Row(10L, null)),
+      Row(1, "last", 300, 15L, 25L, Row(15L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1403,9 +1403,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "open", 100, 5L, null, Row(5L)),
-        Row(1, "tomb", 200, 10L, 10L, Row(10L)),
-        Row(1, "last", 300, 15L, 25L, Row(15L))
+        Row(1, "open", 100, 5L, null, Row(5L, null)),
+        Row(1, "tomb", 200, 10L, 10L, Row(10L, null)),
+        Row(1, "last", 300, 15L, 25L, Row(15L, null))
       )
     )
   }
@@ -1422,8 +1422,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // than 10. Here the successor lands at exactly 10, which means it doesn't actually
     // bisect the closed row and therefore shouldn't decompose it.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 42, 5L, 10L, Row(5L)),
-      Row(1, "bob", 99, 10L, null, Row(10L))
+      Row(1, "alice", 42, 5L, 10L, Row(5L, null)),
+      Row(1, "bob", 99, 10L, null, Row(10L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1431,8 +1431,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 42, 5L, 10L, Row(5L)),
-        Row(1, "bob", 99, 10L, null, Row(10L))
+        Row(1, "alice", 42, 5L, 10L, Row(5L, null)),
+        Row(1, "bob", 99, 10L, null, Row(10L, null))
       )
     )
   }
@@ -1452,8 +1452,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Both head and tail must carry the parent's data columns (value="alice", amount=42)
     // identically.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 42, 5L, 30L, Row(5L)),
-      Row(1, "bob", 99, 15L, null, Row(15L))
+      Row(1, "alice", 42, 5L, 30L, Row(5L, null)),
+      Row(1, "bob", 99, 15L, null, Row(15L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1461,9 +1461,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 42, 5L, null, Row(5L)), // head
-        Row(1, "alice", 42, null, 30L, Row(null)), // tail
-        Row(1, "bob", 99, 15L, null, Row(15L))    // bisecting successor
+        Row(1, "alice", 42, 5L, null, Row(5L, null)), // head
+        Row(1, "alice", 42, null, 30L, Row(null, null)), // tail
+        Row(1, "bob", 99, 15L, null, Row(15L, null))    // bisecting successor
       )
     )
   }
@@ -1480,16 +1480,16 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // own row kind (the bisection check looks only at recordStartAt < parent.endAt).
     val df = targetTableOf(userSchema)(
       // Key 1: bisected by an open upsert.
-      Row(1, "alice", 1, 5L, 50L, Row(5L)),
-      Row(1, "bob", 2, 10L, null, Row(10L)),
+      Row(1, "alice", 1, 5L, 50L, Row(5L, null)),
+      Row(1, "bob", 2, 10L, null, Row(10L, null)),
 
       // Key 2: bisected by a tombstone.
-      Row(2, "carol", 3, 5L, 50L, Row(5L)),
-      Row(2, "dave", 4, 20L, 20L, Row(20L)),
+      Row(2, "carol", 3, 5L, 50L, Row(5L, null)),
+      Row(2, "dave", 4, 20L, 20L, Row(20L, null)),
 
       // Key 3: bisected by another closed non-tombstone.
-      Row(3, "eve", 5, 5L, 50L, Row(5L)),
-      Row(3, "frank", 6, 30L, 40L, Row(30L))
+      Row(3, "eve", 5, 5L, 50L, Row(5L, null)),
+      Row(3, "frank", 6, 30L, 40L, Row(30L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1498,17 +1498,17 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
       df = result,
       expectedAnswer = Seq(
         // Key 1.
-        Row(1, "alice", 1, 5L, null, Row(5L)),
-        Row(1, "alice", 1, null, 50L, Row(null)),
-        Row(1, "bob", 2, 10L, null, Row(10L)),
+        Row(1, "alice", 1, 5L, null, Row(5L, null)),
+        Row(1, "alice", 1, null, 50L, Row(null, null)),
+        Row(1, "bob", 2, 10L, null, Row(10L, null)),
         // Key 2.
-        Row(2, "carol", 3, 5L, null, Row(5L)),
-        Row(2, "carol", 3, null, 50L, Row(null)),
-        Row(2, "dave", 4, 20L, 20L, Row(20L)),
+        Row(2, "carol", 3, 5L, null, Row(5L, null)),
+        Row(2, "carol", 3, null, 50L, Row(null, null)),
+        Row(2, "dave", 4, 20L, 20L, Row(20L, null)),
         // Key 3.
-        Row(3, "eve", 5, 5L, null, Row(5L)),
-        Row(3, "eve", 5, null, 50L, Row(null)),
-        Row(3, "frank", 6, 30L, 40L, Row(30L))
+        Row(3, "eve", 5, 5L, null, Row(5L, null)),
+        Row(3, "eve", 5, null, 50L, Row(null, null)),
+        Row(3, "frank", 6, 30L, 40L, Row(30L, null))
       )
     )
   }
@@ -1524,8 +1524,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // non-chronological order. The window orders rows by effective recordStartAt, so the
     // result must still recognize that [5, 30] is bisected by the row at recordStartAt = 15.
     val df = targetTableOf(userSchema)(
-      Row(1, "bob", 99, 15L, null, Row(15L)), // appears first in input
-      Row(1, "alice", 42, 5L, 30L, Row(5L))    // appears last in input but lower in window
+      Row(1, "bob", 99, 15L, null, Row(15L, null)), // appears first in input
+      Row(1, "alice", 42, 5L, 30L, Row(5L, null))    // appears last in input but lower in window
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1533,9 +1533,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 42, 5L, null, Row(5L)),
-        Row(1, "alice", 42, null, 30L, Row(null)),
-        Row(1, "bob", 99, 15L, null, Row(15L))
+        Row(1, "alice", 42, 5L, null, Row(5L, null)),
+        Row(1, "alice", 42, null, 30L, Row(null, null)),
+        Row(1, "bob", 99, 15L, null, Row(15L, null))
       )
     )
   }
@@ -1552,11 +1552,11 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // bisecting successor must NOT bleed into key 2's partition.
     val df = targetTableOf(userSchema)(
       // Key 1: closed [5, 30] bisected by recordStartAt = 15.
-      Row(1, "alice", 42, 5L, 30L, Row(5L)),
-      Row(1, "bob", 99, 15L, null, Row(15L)),
+      Row(1, "alice", 42, 5L, 30L, Row(5L, null)),
+      Row(1, "bob", 99, 15L, null, Row(15L, null)),
 
       // Key 2: a single closed [5, 30] with no successor in its own partition.
-      Row(2, "carol", 7, 5L, 30L, Row(5L))
+      Row(2, "carol", 7, 5L, 30L, Row(5L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1565,11 +1565,11 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
       df = result,
       expectedAnswer = Seq(
         // Key 1 decomposes.
-        Row(1, "alice", 42, 5L, null, Row(5L)),
-        Row(1, "alice", 42, null, 30L, Row(null)),
-        Row(1, "bob", 99, 15L, null, Row(15L)),
+        Row(1, "alice", 42, 5L, null, Row(5L, null)),
+        Row(1, "alice", 42, null, 30L, Row(null, null)),
+        Row(1, "bob", 99, 15L, null, Row(15L, null)),
         // Key 2 passes through.
-        Row(2, "carol", 7, 5L, 30L, Row(5L))
+        Row(2, "carol", 7, 5L, 30L, Row(5L, null))
       )
     )
   }
@@ -1587,9 +1587,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //   [10, 25] bisected by [15, 20]   -> decomposes
     //   [15, 20] is the last row        -> passes through
     val df = targetTableOf(userSchema)(
-      Row(1, "outer", 1, 5L, 30L, Row(5L)),
-      Row(1, "middle", 2, 10L, 25L, Row(10L)),
-      Row(1, "inner", 3, 15L, 20L, Row(15L))
+      Row(1, "outer", 1, 5L, 30L, Row(5L, null)),
+      Row(1, "middle", 2, 10L, 25L, Row(10L, null)),
+      Row(1, "inner", 3, 15L, 20L, Row(15L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1598,13 +1598,13 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
       df = result,
       expectedAnswer = Seq(
         // outer decomposes.
-        Row(1, "outer", 1, 5L, null, Row(5L)),
-        Row(1, "outer", 1, null, 30L, Row(null)),
+        Row(1, "outer", 1, 5L, null, Row(5L, null)),
+        Row(1, "outer", 1, null, 30L, Row(null, null)),
         // middle decomposes.
-        Row(1, "middle", 2, 10L, null, Row(10L)),
-        Row(1, "middle", 2, null, 25L, Row(null)),
+        Row(1, "middle", 2, 10L, null, Row(10L, null)),
+        Row(1, "middle", 2, null, 25L, Row(null, null)),
         // inner passes through.
-        Row(1, "inner", 3, 15L, 20L, Row(15L))
+        Row(1, "inner", 3, 15L, 20L, Row(15L, null))
       )
     )
   }
@@ -1631,12 +1631,19 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     def commentMetadata(comment: String): Metadata =
       new MetadataBuilder().putString("comment", comment).build()
 
-    val cdcMetadataInnerSchema = new StructType().add(
-      Scd2BatchProcessor.recordStartAtFieldName,
-      LongType,
-      nullable = true,
-      metadata = commentMetadata("inner __RECORD_START_AT")
-    )
+    val cdcMetadataInnerSchema = new StructType()
+      .add(
+        Scd2BatchProcessor.recordStartAtFieldName,
+        LongType,
+        nullable = true,
+        metadata = commentMetadata("inner __RECORD_START_AT")
+      )
+      .add(
+        Scd2BatchProcessor.versionMapFieldName,
+        Scd2VersionMap.mapType,
+        nullable = true,
+        metadata = commentMetadata("inner __VERSION_MAP")
+      )
 
     val schema = new StructType()
       .add("id", IntegerType, nullable = false, metadata = commentMetadata("user key"))
@@ -1653,8 +1660,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
 
     // Closed [5, 30] bisected by recordStartAt = 15.
     val df = microbatchOf(schema)(
-      Row(1, "alice", 5L, 30L, Row(5L)),
-      Row(1, "bob", 15L, null, Row(15L))
+      Row(1, "alice", 5L, 30L, Row(5L, null)),
+      Row(1, "bob", 15L, null, Row(15L, null))
     )
 
     val result = processor.decomposeOutOfOrderRows(df)
@@ -1682,19 +1689,19 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //   closed upsert:       startAt < endAt, recordStartAt non-null
     //   decomposition tail:  startAt and recordStartAt null, endAt non-null
     val df = targetTableOf(userSchema)(
-      Row(1, "tomb", 10L, 10L, Row(10L)),
-      Row(2, "open", 20L, null, Row(20L)),
-      Row(3, "closed", 30L, 40L, Row(30L)),
-      Row(4, "tail", null, 50L, Row(null))
+      Row(1, "tomb", 10L, 10L, Row(10L, null)),
+      Row(2, "open", 20L, null, Row(20L, null)),
+      Row(3, "closed", 30L, 40L, Row(30L, null)),
+      Row(4, "tail", null, 50L, Row(null, null))
     )
 
     checkAnswer(
       df = processor.assertWellFormedRowsPostDecomposition(df, batchId = 0),
       expectedAnswer = Seq(
-        Row(1, "tomb", 10L, 10L, Row(10L)),
-        Row(2, "open", 20L, null, Row(20L)),
-        Row(3, "closed", 30L, 40L, Row(30L)),
-        Row(4, "tail", null, 50L, Row(null))
+        Row(1, "tomb", 10L, 10L, Row(10L, null)),
+        Row(2, "open", 20L, null, Row(20L, null)),
+        Row(3, "closed", 30L, 40L, Row(30L, null)),
+        Row(4, "tail", null, 50L, Row(null, null))
       )
     )
   }
@@ -1707,7 +1714,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // the decomposition-tail kind rejects on startAt non-null, while the tombstone, open
     // upsert, and closed upsert kinds all reject on recordStartAt null.
     val df = targetTableOf(userSchema)(
-      Row(1, "malformed", 5L, 10L, Row(null))
+      Row(1, "malformed", 5L, 10L, Row(null, null))
     )
 
     val wrapper = intercept[SparkException] {
@@ -1727,7 +1734,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = new StructType().add("id", IntegerType).add("value", StringType)
 
     val df = targetTableOf(userSchema)(
-      Row(1, "open", 10L, null, Row(10L))
+      Row(1, "open", 10L, null, Row(10L, null))
     )
 
     val result = processor.assertWellFormedRowsPostDecomposition(df, batchId = 0)
@@ -1744,9 +1751,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Distinct effective recordStartAts within the dataframe, so no redundancies - identity
     // transformation expected.
     val df = targetTableOf(userSchema)(
-      Row(1, "v5", 5L, null, Row(5L)),
-      Row(1, "v10", 10L, null, Row(10L)),
-      Row(1, "v15", 15L, 20L, Row(15L))
+      Row(1, "v5", 5L, null, Row(5L, null)),
+      Row(1, "v10", 10L, null, Row(10L, null)),
+      Row(1, "v15", 15L, 20L, Row(15L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1754,9 +1761,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "v5", 5L, null, Row(5L)),
-        Row(1, "v10", 10L, null, Row(10L)),
-        Row(1, "v15", 15L, 20L, Row(15L))
+        Row(1, "v5", 5L, null, Row(5L, null)),
+        Row(1, "v10", 10L, null, Row(10L, null)),
+        Row(1, "v15", 15L, 20L, Row(15L, null))
       )
     )
   }
@@ -1770,8 +1777,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // survives because the window's tiebreaker among truly-identical rows is intentionally
     // undefined.
     val df = targetTableOf(userSchema)(
-      Row(1, "first", 10L, null, Row(10L)),
-      Row(1, "second", 10L, null, Row(10L))
+      Row(1, "first", 10L, null, Row(10L, null)),
+      Row(1, "second", 10L, null, Row(10L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1790,8 +1797,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // overtakes, leaving it 0-width: it ties with its successor on effective sequence
     // and is dropped. The tombstone (last in partition) survives.
     val df = targetTableOf(userSchema)(
-      Row(1, "open", 10L, null, Row(10L)),
-      Row(1, "tomb", 10L, 10L, Row(10L))
+      Row(1, "open", 10L, null, Row(10L, null)),
+      Row(1, "tomb", 10L, 10L, Row(10L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1799,7 +1806,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "tomb", 10L, 10L, Row(10L))
+        Row(1, "tomb", 10L, 10L, Row(10L, null))
       )
     )
   }
@@ -1814,8 +1821,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // tail encodes is already represented by the coincident event, so the leading tail is
     // dropped. The event survives.
     val df = targetTableOf(userSchema)(
-      Row(1, "tail", null, 30L, Row(null)),
-      Row(1, "event", 30L, null, Row(30L))
+      Row(1, "tail", null, 30L, Row(null, null)),
+      Row(1, "event", 30L, null, Row(30L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1823,7 +1830,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "event", 30L, null, Row(30L))
+        Row(1, "event", 30L, null, Row(30L, null))
       )
     )
   }
@@ -1838,10 +1845,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // successor on effective recordStartAt, so the redundancy filter doesn't fire. Every
     // row survives.
     val df = targetTableOf(userSchema)(
-      Row(1, "open", 10L, null, Row(10L)),
-      Row(1, "next1", 15L, null, Row(15L)),
-      Row(1, "tail", null, 30L, Row(null)),
-      Row(1, "next2", 35L, null, Row(35L))
+      Row(1, "open", 10L, null, Row(10L, null)),
+      Row(1, "next1", 15L, null, Row(15L, null)),
+      Row(1, "tail", null, 30L, Row(null, null)),
+      Row(1, "next2", 35L, null, Row(35L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1849,10 +1856,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "open", 10L, null, Row(10L)),
-        Row(1, "next1", 15L, null, Row(15L)),
-        Row(1, "tail", null, 30L, Row(null)),
-        Row(1, "next2", 35L, null, Row(35L))
+        Row(1, "open", 10L, null, Row(10L, null)),
+        Row(1, "next1", 15L, null, Row(15L, null)),
+        Row(1, "tail", null, 30L, Row(null, null)),
+        Row(1, "next2", 35L, null, Row(35L, null))
       )
     )
   }
@@ -1866,8 +1873,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // see key 2's row as its successor and tie on effective sequence; proper partitioning
     // preserves both.
     val df = targetTableOf(userSchema)(
-      Row(1, "v10", 10L, null, Row(10L)),
-      Row(2, "v10", 10L, null, Row(10L))
+      Row(1, "v10", 10L, null, Row(10L, null)),
+      Row(2, "v10", 10L, null, Row(10L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1875,8 +1882,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "v10", 10L, null, Row(10L)),
-        Row(2, "v10", 10L, null, Row(10L))
+        Row(1, "v10", 10L, null, Row(10L, null)),
+        Row(2, "v10", 10L, null, Row(10L, null))
       )
     )
   }
@@ -1890,10 +1897,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // duplicate plus the distinct event. We don't assert which user-data variant of the
     // duplicate survives.
     val df = targetTableOf(userSchema)(
-      Row(1, "dup1", 5L, null, Row(5L)),
-      Row(1, "dup2", 5L, null, Row(5L)),
-      Row(1, "dup3", 5L, null, Row(5L)),
-      Row(1, "different", 10L, null, Row(10L))
+      Row(1, "dup1", 5L, null, Row(5L, null)),
+      Row(1, "dup2", 5L, null, Row(5L, null)),
+      Row(1, "dup3", 5L, null, Row(5L, null)),
+      Row(1, "different", 10L, null, Row(10L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1920,14 +1927,14 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //          covered).
     //   key=4: two tombstones.
     val df = targetTableOf(userSchema)(
-      Row(1, "openA", 10L, null, Row(10L)),
-      Row(1, "openB", 10L, null, Row(10L)),
-      Row(2, "open", 10L, null, Row(10L)),
-      Row(2, "closed", 10L, 20L, Row(10L)),
-      Row(3, "closedA", 10L, 20L, Row(10L)),
-      Row(3, "closedB", 10L, 20L, Row(10L)),
-      Row(4, "tombA", 10L, 10L, Row(10L)),
-      Row(4, "tombB", 10L, 10L, Row(10L))
+      Row(1, "openA", 10L, null, Row(10L, null)),
+      Row(1, "openB", 10L, null, Row(10L, null)),
+      Row(2, "open", 10L, null, Row(10L, null)),
+      Row(2, "closed", 10L, 20L, Row(10L, null)),
+      Row(3, "closedA", 10L, 20L, Row(10L, null)),
+      Row(3, "closedB", 10L, 20L, Row(10L, null)),
+      Row(4, "tombA", 10L, 10L, Row(10L, null)),
+      Row(4, "tombB", 10L, 10L, Row(10L, null))
     )
 
     val expectedSurvivorsPerKey: Map[Int, Set[String]] = Map(
@@ -1957,9 +1964,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // redundancy filter then drops every row whose successor shares its effective sequence,
     // leaving only the trailing tombstone.
     val df = targetTableOf(userSchema)(
-      Row(1, "tail", null, 10L, Row(null)),
-      Row(1, "open", 10L, null, Row(10L)),
-      Row(1, "tomb", 10L, 10L, Row(10L))
+      Row(1, "tail", null, 10L, Row(null, null)),
+      Row(1, "open", 10L, null, Row(10L, null)),
+      Row(1, "tomb", 10L, 10L, Row(10L, null))
     )
 
     val result = processor.dropRedundantRowsPostDecomposition(df)
@@ -1967,7 +1974,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "tomb", 10L, 10L, Row(10L))
+        Row(1, "tomb", 10L, 10L, Row(10L, null))
       )
     )
   }
@@ -1983,8 +1990,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // values. The first row begins a fresh run with startAt=5. The second row, sharing the
     // tracked value, is a continuation of that run and inherits the run head's startAt.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 10L, null, Row(10L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -1992,8 +1999,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, null, Row(10L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, null, Row(10L, null))
       )
     )
   }
@@ -2009,8 +2016,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // its existing startAt encodes the true global run start and must be preserved -
     // and propagated to the in-window continuation.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 2L, null, Row(5L)),
-      Row(1, "alice", 10L, null, Row(10L))
+      Row(1, "alice", 2L, null, Row(5L, null)),
+      Row(1, "alice", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2018,8 +2025,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 2L, null, Row(5L)),
-        Row(1, "alice", 2L, null, Row(10L))
+        Row(1, "alice", 2L, null, Row(5L, null)),
+        Row(1, "alice", 2L, null, Row(10L, null))
       )
     )
   }
@@ -2033,8 +2040,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // first run at the second event's effective recordStartAt and starts a new run whose
     // startAt is the new event's recordStartAt.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "bob", 10L, null, Row(10L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "bob", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2042,8 +2049,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 10L, Row(5L)),
-        Row(1, "bob", 10L, null, Row(10L))
+        Row(1, "alice", 5L, 10L, Row(5L, null)),
+        Row(1, "bob", 10L, null, Row(10L, null))
       )
     )
   }
@@ -2056,9 +2063,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Three consecutive open upserts all agreeing on the tracked column form one no-op
     // run. Every row in the run must end up with the run head's startAt.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 10L, null, Row(10L)),
-      Row(1, "alice", 15L, null, Row(15L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 10L, null, Row(10L, null)),
+      Row(1, "alice", 15L, null, Row(15L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2066,9 +2073,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, null, Row(10L)),
-        Row(1, "alice", 5L, null, Row(15L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, null, Row(10L, null)),
+        Row(1, "alice", 5L, null, Row(15L, null))
       )
     )
   }
@@ -2087,10 +2094,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     //  - the last `alice` row (the run tail) must close at bob's recordStartAt (20), not stay
     //    open and not close at any interior sequence.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 10L, null, Row(10L)),
-      Row(1, "alice", 15L, null, Row(15L)),
-      Row(1, "bob", 20L, null, Row(20L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 10L, null, Row(10L, null)),
+      Row(1, "alice", 15L, null, Row(15L, null)),
+      Row(1, "bob", 20L, null, Row(20L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2098,10 +2105,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, null, Row(10L)),
-        Row(1, "alice", 5L, 20L, Row(15L)),
-        Row(1, "bob", 20L, null, Row(20L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, null, Row(10L, null)),
+        Row(1, "alice", 5L, 20L, Row(15L, null)),
+        Row(1, "bob", 20L, null, Row(20L, null))
       )
     )
   }
@@ -2118,8 +2125,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // as tracked. With no columnSelection, both `name` and `status` are selected. The
     // two rows agree on `name` but disagree on `status`, so they start distinct runs.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", "active", 5L, null, Row(5L)),
-      Row(1, "alice", "inactive", 10L, null, Row(10L))
+      Row(1, "alice", "active", 5L, null, Row(5L, null)),
+      Row(1, "alice", "inactive", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2127,8 +2134,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", "active", 5L, 10L, Row(5L)),
-        Row(1, "alice", "inactive", 10L, null, Row(10L))
+        Row(1, "alice", "active", 5L, 10L, Row(5L, null)),
+        Row(1, "alice", "inactive", 10L, null, Row(10L, null))
       )
     )
   }
@@ -2161,8 +2168,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, null, Row(10L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, null, Row(10L, null))
       )
     )
   }
@@ -2211,8 +2218,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // `status` is excluded from tracking, so the two rows are tracked-equal on the
     // remaining columns (`name`). They should collapse into a single no-op run.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", "active", 5L, null, Row(5L)),
-      Row(1, "alice", "inactive", 10L, null, Row(10L))
+      Row(1, "alice", "active", 5L, null, Row(5L, null)),
+      Row(1, "alice", "inactive", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2220,8 +2227,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", "active", 5L, null, Row(5L)),
-        Row(1, "alice", "inactive", 5L, null, Row(10L))
+        Row(1, "alice", "active", 5L, null, Row(5L, null)),
+        Row(1, "alice", "inactive", 5L, null, Row(10L, null))
       )
     )
   }
@@ -2245,8 +2252,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // nothing to compare, every consecutive upsert pair collapses into a single run -
     // even when the user-visible data differs on every column.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", "active", 5L, null, Row(5L)),
-      Row(1, "bob", "inactive", 10L, null, Row(10L))
+      Row(1, "alice", "active", 5L, null, Row(5L, null)),
+      Row(1, "bob", "inactive", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2254,8 +2261,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", "active", 5L, null, Row(5L)),
-        Row(1, "bob", "inactive", 5L, null, Row(10L))
+        Row(1, "alice", "active", 5L, null, Row(5L, null)),
+        Row(1, "bob", "inactive", 5L, null, Row(10L, null))
       )
     )
   }
@@ -2269,9 +2276,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // pass through identically. The bracketing upserts close (10) and reopen (15) around
     // the tombstone.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 10L, 10L, Row(10L)),
-      Row(1, "alice", 15L, null, Row(15L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 10L, 10L, Row(10L, null)),
+      Row(1, "alice", 15L, null, Row(15L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2279,9 +2286,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 10L, Row(5L)),
-        Row(1, "alice", 10L, 10L, Row(10L)),
-        Row(1, "alice", 15L, null, Row(15L))
+        Row(1, "alice", 5L, 10L, Row(5L, null)),
+        Row(1, "alice", 10L, 10L, Row(10L, null)),
+        Row(1, "alice", 15L, null, Row(15L, null))
       )
     )
   }
@@ -2295,8 +2302,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // null) is excluded from upsert reconciliation. The tail's startAt must stay null
     // and its endAt must pass through unchanged.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", null, 30L, Row(null))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", null, 30L, Row(null, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2304,8 +2311,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 30L, Row(5L)),
-        Row(1, "alice", null, 30L, Row(null))
+        Row(1, "alice", 5L, 30L, Row(5L, null)),
+        Row(1, "alice", null, 30L, Row(null, null))
       )
     )
   }
@@ -2323,9 +2330,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // opens a new run in between. The bisecting event in turn closes at the tail boundary
     // (30), and the tail passes through unchanged.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "bob", 15L, null, Row(15L)),
-      Row(1, "alice", null, 30L, Row(null))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "bob", 15L, null, Row(15L, null)),
+      Row(1, "alice", null, 30L, Row(null, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2333,9 +2340,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 15L, Row(5L)),
-        Row(1, "bob", 15L, 30L, Row(15L)),
-        Row(1, "alice", null, 30L, Row(null))
+        Row(1, "alice", 5L, 15L, Row(5L, null)),
+        Row(1, "bob", 15L, 30L, Row(15L, null)),
+        Row(1, "alice", null, 30L, Row(null, null))
       )
     )
   }
@@ -2349,8 +2356,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // The closed upsert already ended at 15 - strictly before the next event - so its
     // endAt is left intact.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 15L, Row(5L)),
-      Row(1, "bob", 20L, null, Row(20L))
+      Row(1, "alice", 5L, 15L, Row(5L, null)),
+      Row(1, "bob", 20L, null, Row(20L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2358,8 +2365,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 15L, Row(5L)),
-        Row(1, "bob", 20L, null, Row(20L))
+        Row(1, "alice", 5L, 15L, Row(5L, null)),
+        Row(1, "bob", 20L, null, Row(20L, null))
       )
     )
   }
@@ -2372,8 +2379,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // at recordStartAt=20. The first run head must be closed at 20 because the run ends
     // there.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "bob", 20L, null, Row(20L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "bob", 20L, null, Row(20L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2381,8 +2388,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 20L, Row(5L)),
-        Row(1, "bob", 20L, null, Row(20L))
+        Row(1, "alice", 5L, 20L, Row(5L, null)),
+        Row(1, "bob", 20L, null, Row(20L, null))
       )
     )
   }
@@ -2397,8 +2404,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // the now-redundant tombstone for the next transform to drop based on the
     // shape locked in here.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 20L, Row(5L)),
-      Row(1, "alice", 20L, 20L, Row(20L))
+      Row(1, "alice", 5L, 20L, Row(5L, null)),
+      Row(1, "alice", 20L, 20L, Row(20L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2406,8 +2413,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 20L, Row(5L)),
-        Row(1, "alice", 20L, 20L, Row(20L))
+        Row(1, "alice", 5L, 20L, Row(5L, null)),
+        Row(1, "alice", 20L, 20L, Row(20L, null))
       )
     )
   }
@@ -2420,8 +2427,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Downstream transforms identify decomposition tails by recordStartAt = null, so
     // reconciliation must not synthesize a value into the tail's _cdc_metadata.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", null, 30L, Row(null))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", null, 30L, Row(null, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2438,12 +2445,19 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     def commentMetadata(comment: String): Metadata =
       new MetadataBuilder().putString("comment", comment).build()
 
-    val cdcMetadataInnerSchema = new StructType().add(
-      Scd2BatchProcessor.recordStartAtFieldName,
-      LongType,
-      nullable = true,
-      metadata = commentMetadata("inner __RECORD_START_AT")
-    )
+    val cdcMetadataInnerSchema = new StructType()
+      .add(
+        Scd2BatchProcessor.recordStartAtFieldName,
+        LongType,
+        nullable = true,
+        metadata = commentMetadata("inner __RECORD_START_AT")
+      )
+      .add(
+        Scd2BatchProcessor.versionMapFieldName,
+        Scd2VersionMap.mapType,
+        nullable = true,
+        metadata = commentMetadata("inner __VERSION_MAP")
+      )
 
     val schema = new StructType()
       .add("id", IntegerType, nullable = false, metadata = commentMetadata("user key"))
@@ -2461,9 +2475,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Mix of canonical post-decomposition row shapes so we exercise multiple reconciliation
     // branches under the schema-preservation contract.
     val df = microbatchOf(schema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", null, 30L, Row(null)),
-      Row(1, "alice", 30L, 30L, Row(30L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", null, 30L, Row(null, null)),
+      Row(1, "alice", 30L, 30L, Row(30L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2486,8 +2500,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // or successor. Reconciliation must handle the missing neighbors cleanly and pass the
     // single rows through.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(2, "bob", 10L, 20L, Row(10L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(2, "bob", 10L, 20L, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2495,8 +2509,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(2, "bob", 10L, 20L, Row(10L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(2, "bob", 10L, 20L, Row(10L, null))
       )
     )
   }
@@ -2516,8 +2530,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Only `name` is tracked. Two rows agreeing on name but differing on status are
     // tracked-equal and should collapse into one run.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", "active", 5L, null, Row(5L)),
-      Row(1, "alice", "inactive", 10L, null, Row(10L))
+      Row(1, "alice", "active", 5L, null, Row(5L, null)),
+      Row(1, "alice", "inactive", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2525,8 +2539,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", "active", 5L, null, Row(5L)),
-        Row(1, "alice", "inactive", 5L, null, Row(10L))
+        Row(1, "alice", "active", 5L, null, Row(5L, null)),
+        Row(1, "alice", "inactive", 5L, null, Row(10L, null))
       )
     )
   }
@@ -2550,8 +2564,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // `F.col("user.name")` would be parsed as a nested-field access (struct `user`, field
     // `name`) and fail to resolve.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", "active", 5L, null, Row(5L)),
-      Row(1, "alice", "inactive", 10L, null, Row(10L))
+      Row(1, "alice", "active", 5L, null, Row(5L, null)),
+      Row(1, "alice", "inactive", 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2559,8 +2573,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", "active", 5L, null, Row(5L)),
-        Row(1, "alice", "inactive", 5L, null, Row(10L))
+        Row(1, "alice", "active", 5L, null, Row(5L, null)),
+        Row(1, "alice", "inactive", 5L, null, Row(10L, null))
       )
     )
   }
@@ -2575,7 +2589,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     )
     val userSchema = new StructType().add("id", IntegerType).add("value", StringType)
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L))
+      Row(1, "alice", 5L, null, Row(5L, null))
     )
 
     val ex = intercept[AnalysisException] {
@@ -2589,8 +2603,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = new StructType().add("id", IntegerType).add("name", StringType)
 
     val df = targetTableOf(userSchema)(
-      Row(1, null, 5L, null, Row(5L)),
-      Row(1, null, 10L, null, Row(10L))
+      Row(1, null, 5L, null, Row(5L, null)),
+      Row(1, null, 10L, null, Row(10L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2598,8 +2612,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, null, 5L, null, Row(5L)),
-        Row(1, null, 5L, null, Row(10L))
+        Row(1, null, 5L, null, Row(5L, null)),
+        Row(1, null, 5L, null, Row(10L, null))
       )
     )
   }
@@ -2610,9 +2624,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = new StructType().add("id", IntegerType).add("value", StringType)
 
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 10L, null, Row(10L)),
-      Row(1, "alice", 15L, 15L, Row(15L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 10L, null, Row(10L, null)),
+      Row(1, "alice", 15L, 15L, Row(15L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2620,9 +2634,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, 15L, Row(10L)),
-        Row(1, "alice", 15L, 15L, Row(15L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, 15L, Row(10L, null)),
+        Row(1, "alice", 15L, 15L, Row(15L, null))
       )
     )
   }
@@ -2634,10 +2648,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Two keys, each with a fresh-key run head + tracked-equal continuation. The two
     // partitions must reconcile independently.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 10L, null, Row(10L)),
-      Row(2, "bob", 20L, null, Row(20L)),
-      Row(2, "bob", 25L, null, Row(25L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 10L, null, Row(10L, null)),
+      Row(2, "bob", 20L, null, Row(20L, null)),
+      Row(2, "bob", 25L, null, Row(25L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2645,10 +2659,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, null, Row(10L)),
-        Row(2, "bob", 20L, null, Row(20L)),
-        Row(2, "bob", 20L, null, Row(25L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, null, Row(10L, null)),
+        Row(2, "bob", 20L, null, Row(20L, null)),
+        Row(2, "bob", 20L, null, Row(25L, null))
       )
     )
   }
@@ -2666,8 +2680,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // open" transition, which every other no-op-continuation test leaves as a no-op by
     // starting from an already-open row.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 20L, Row(5L)),
-      Row(1, "alice", 20L, null, Row(20L))
+      Row(1, "alice", 5L, 20L, Row(5L, null)),
+      Row(1, "alice", 20L, null, Row(20L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2675,8 +2689,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L)),
-        Row(1, "alice", 5L, null, Row(20L))
+        Row(1, "alice", 5L, null, Row(5L, null)),
+        Row(1, "alice", 5L, null, Row(20L, null))
       )
     )
   }
@@ -2693,8 +2707,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // at its own recordStartAt. This exercises run-head startAt propagation for a closed
     // upsert, which the other run-head tests only cover with open rows.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 10L, Row(5L)),
-      Row(1, "alice", 15L, null, Row(15L))
+      Row(1, "alice", 5L, 10L, Row(5L, null)),
+      Row(1, "alice", 15L, null, Row(15L, null))
     )
 
     val result = processor.reconcileStartAndEndAt(df)
@@ -2702,8 +2716,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 10L, Row(5L)),
-        Row(1, "alice", 15L, null, Row(15L))
+        Row(1, "alice", 5L, 10L, Row(5L, null)),
+        Row(1, "alice", 15L, null, Row(15L, null))
       )
     )
   }
@@ -2730,8 +2744,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // A closed upsert [10, 15) immediately followed by a tombstone at 15. The upsert's reconciled
     // endAt already encodes the delete boundary, so the standalone tombstone is redundant.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 10L, 15L, Row(10L)),
-      Row(1, "alice", 15L, 15L, Row(15L))
+      Row(1, "alice", 10L, 15L, Row(10L, null)),
+      Row(1, "alice", 15L, 15L, Row(15L, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2739,7 +2753,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 10L, 15L, Row(10L))
+        Row(1, "alice", 10L, 15L, Row(10L, null))
       )
     )
   }
@@ -2753,9 +2767,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // at 15, the event closes at the tail's boundary 20, leaving the [null, 20) tail redundant
     // because the [15, 20) upsert already encodes the boundary.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 10L, 15L, Row(10L)),
-      Row(1, "bob", 15L, 20L, Row(15L)),
-      Row(1, "alice", null, 20L, Row(null))
+      Row(1, "alice", 10L, 15L, Row(10L, null)),
+      Row(1, "bob", 15L, 20L, Row(15L, null)),
+      Row(1, "alice", null, 20L, Row(null, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2763,8 +2777,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 10L, 15L, Row(10L)),
-        Row(1, "bob", 15L, 20L, Row(15L))
+        Row(1, "alice", 10L, 15L, Row(10L, null)),
+        Row(1, "bob", 15L, 20L, Row(15L, null))
       )
     )
   }
@@ -2777,8 +2791,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // The closed upsert ends at 15 but the tombstone is at 20, so the delete boundary is not
     // encoded by the preceding row and the tombstone must survive.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 15L, Row(5L)),
-      Row(1, "alice", 20L, 20L, Row(20L))
+      Row(1, "alice", 5L, 15L, Row(5L, null)),
+      Row(1, "alice", 20L, 20L, Row(20L, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2786,8 +2800,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 15L, Row(5L)),
-        Row(1, "alice", 20L, 20L, Row(20L))
+        Row(1, "alice", 5L, 15L, Row(5L, null)),
+        Row(1, "alice", 20L, 20L, Row(20L, null))
       )
     )
   }
@@ -2800,8 +2814,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // The preceding closed upsert ends at 12, strictly before the tail's boundary 20, so the
     // tail is an unmatched delete boundary that must survive for promotion to a tombstone.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 12L, Row(5L)),
-      Row(1, "alice", null, 20L, Row(null))
+      Row(1, "alice", 5L, 12L, Row(5L, null)),
+      Row(1, "alice", null, 20L, Row(null, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2809,8 +2823,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 12L, Row(5L)),
-        Row(1, "alice", null, 20L, Row(null))
+        Row(1, "alice", 5L, 12L, Row(5L, null)),
+        Row(1, "alice", null, 20L, Row(null, null))
       )
     )
   }
@@ -2823,8 +2837,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // With no predecessor, previousEndAt is null and `null <=> endAt` is false, so a leading
     // tombstone (key 1) and a leading decomposition tail (key 2) both survive.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 15L, 15L, Row(15L)),
-      Row(2, "bob", null, 20L, Row(null))
+      Row(1, "alice", 15L, 15L, Row(15L, null)),
+      Row(2, "bob", null, 20L, Row(null, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2832,8 +2846,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 15L, 15L, Row(15L)),
-        Row(2, "bob", null, 20L, Row(null))
+        Row(1, "alice", 15L, 15L, Row(15L, null)),
+        Row(2, "bob", null, 20L, Row(null, null))
       )
     )
   }
@@ -2847,8 +2861,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // row is delete-encoded, so the `isDeleteEncodedRow` guard must keep both. The overlapping
     // intervals are synthetic here purely to isolate the guard.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 20L, Row(5L)),
-      Row(1, "bob", 10L, 20L, Row(10L))
+      Row(1, "alice", 5L, 20L, Row(5L, null)),
+      Row(1, "bob", 10L, 20L, Row(10L, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2856,8 +2870,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 20L, Row(5L)),
-        Row(1, "bob", 10L, 20L, Row(10L))
+        Row(1, "alice", 5L, 20L, Row(5L, null)),
+        Row(1, "bob", 10L, 20L, Row(10L, null))
       )
     )
   }
@@ -2870,9 +2884,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // key 2: a tombstone at 15 that is the first row in its window (kept) - the key-1 upsert
     // must not be treated as its predecessor.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 10L, 15L, Row(10L)),
-      Row(1, "alice", 15L, 15L, Row(15L)),
-      Row(2, "bob", 15L, 15L, Row(15L))
+      Row(1, "alice", 10L, 15L, Row(10L, null)),
+      Row(1, "alice", 15L, 15L, Row(15L, null)),
+      Row(2, "bob", 15L, 15L, Row(15L, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2880,8 +2894,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 10L, 15L, Row(10L)),
-        Row(2, "bob", 15L, 15L, Row(15L))
+        Row(1, "alice", 10L, 15L, Row(10L, null)),
+        Row(2, "bob", 15L, 15L, Row(15L, null))
       )
     )
   }
@@ -2895,10 +2909,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // redundant tail at 20. Both delete-encoded rows are encoded by their immediate predecessors
     // and drop together in one window pass.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 10L, Row(5L)),
-      Row(1, "alice", 10L, 10L, Row(10L)),
-      Row(1, "bob", 15L, 20L, Row(15L)),
-      Row(1, "alice", null, 20L, Row(null))
+      Row(1, "alice", 5L, 10L, Row(5L, null)),
+      Row(1, "alice", 10L, 10L, Row(10L, null)),
+      Row(1, "bob", 15L, 20L, Row(15L, null)),
+      Row(1, "alice", null, 20L, Row(null, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2906,8 +2920,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 10L, Row(5L)),
-        Row(1, "bob", 15L, 20L, Row(15L))
+        Row(1, "alice", 5L, 10L, Row(5L, null)),
+        Row(1, "bob", 15L, 20L, Row(15L, null))
       )
     )
   }
@@ -2923,9 +2937,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // survive: only a preceding upsert makes a delete boundary redundant. This guards the
     // documented "immediately preceding upsert" invariant against adjacent delete-encoded rows.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 15L, Row(5L)),
-      Row(1, "alice", 15L, 15L, Row(15L)),
-      Row(1, "alice", 15L, 15L, Row(15L))
+      Row(1, "alice", 5L, 15L, Row(5L, null)),
+      Row(1, "alice", 15L, 15L, Row(15L, null)),
+      Row(1, "alice", 15L, 15L, Row(15L, null))
     )
 
     val result = processor.dropLeftoverDeletesPostReconciliation(df)
@@ -2933,8 +2947,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 15L, Row(5L)),
-        Row(1, "alice", 15L, 15L, Row(15L))
+        Row(1, "alice", 5L, 15L, Row(5L, null)),
+        Row(1, "alice", 15L, 15L, Row(15L, null))
       )
     )
   }
@@ -2948,8 +2962,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // The [null, 20) tail becomes a tombstone [20, 20] with recordStartAt = 20; the closed
     // upsert is untouched.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 10L, 20L, Row(10L)),
-      Row(1, "alice", null, 20L, Row(null))
+      Row(1, "alice", 10L, 20L, Row(10L, null)),
+      Row(1, "alice", null, 20L, Row(null, null))
     )
 
     val result = processor.promoteDecompositionTailsToTombstones(df)
@@ -2957,8 +2971,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 10L, 20L, Row(10L)),
-        Row(1, "alice", 20L, 20L, Row(20L))
+        Row(1, "alice", 10L, 20L, Row(10L, null)),
+        Row(1, "alice", 20L, 20L, Row(20L, null))
       )
     )
   }
@@ -2970,9 +2984,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // No decomposition tails present: a tombstone, an open upsert, and a closed upsert must all
     // pass through identically.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 15L, 15L, Row(15L)),
-      Row(2, "bob", 5L, null, Row(5L)),
-      Row(3, "carol", 5L, 15L, Row(5L))
+      Row(1, "alice", 15L, 15L, Row(15L, null)),
+      Row(2, "bob", 5L, null, Row(5L, null)),
+      Row(3, "carol", 5L, 15L, Row(5L, null))
     )
 
     val result = processor.promoteDecompositionTailsToTombstones(df)
@@ -2980,9 +2994,9 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 15L, 15L, Row(15L)),
-        Row(2, "bob", 5L, null, Row(5L)),
-        Row(3, "carol", 5L, 15L, Row(5L))
+        Row(1, "alice", 15L, 15L, Row(15L, null)),
+        Row(2, "bob", 5L, null, Row(5L, null)),
+        Row(3, "carol", 5L, 15L, Row(5L, null))
       )
     )
   }
@@ -2997,7 +3011,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Only the framework columns (startAt and the cdc-metadata recordStartAt) are rewritten to
     // the tail's boundary; the inherited user columns must survive verbatim.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", "active", null, 20L, Row(null))
+      Row(1, "alice", "active", null, 20L, Row(null, null))
     )
 
     val result = processor.promoteDecompositionTailsToTombstones(df)
@@ -3005,7 +3019,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", "active", 20L, 20L, Row(20L))
+        Row(1, "alice", "active", 20L, 20L, Row(20L, null))
       )
     )
   }
@@ -3033,8 +3047,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
 
     // A tail (rewritten) plus a non-tail (passed through) so both projection paths are exercised.
     val df = microbatchOf(schema)(
-      Row(1, "alice", null, 20L, Row(null)),
-      Row(1, "alice", 5L, 20L, Row(5L))
+      Row(1, "alice", null, 20L, Row(null, null)),
+      Row(1, "alice", 5L, 20L, Row(5L, null))
     )
 
     val result = processor.promoteDecompositionTailsToTombstones(df)
@@ -3054,10 +3068,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
 
     // Each key carries a closed upsert plus a decomposition tail; only the tails are rewritten.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, 20L, Row(5L)),
-      Row(1, "alice", null, 20L, Row(null)),
-      Row(2, "bob", 8L, 30L, Row(8L)),
-      Row(2, "bob", null, 30L, Row(null))
+      Row(1, "alice", 5L, 20L, Row(5L, null)),
+      Row(1, "alice", null, 20L, Row(null, null)),
+      Row(2, "bob", 8L, 30L, Row(8L, null)),
+      Row(2, "bob", null, 30L, Row(null, null))
     )
 
     val result = processor.promoteDecompositionTailsToTombstones(df)
@@ -3065,10 +3079,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, 20L, Row(5L)),
-        Row(1, "alice", 20L, 20L, Row(20L)),
-        Row(2, "bob", 8L, 30L, Row(8L)),
-        Row(2, "bob", 30L, 30L, Row(30L))
+        Row(1, "alice", 5L, 20L, Row(5L, null)),
+        Row(1, "alice", 20L, 20L, Row(20L, null)),
+        Row(2, "bob", 8L, 30L, Row(8L, null)),
+        Row(2, "bob", 30L, 30L, Row(30L, null))
       )
     )
   }
@@ -3086,7 +3100,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // and startAt null, endAt=20) is promoted to a tombstone at 20 while the dotted user column
     // survives verbatim.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", null, 20L, Row(null))
+      Row(1, "alice", null, 20L, Row(null, null))
     )
 
     val result = processor.promoteDecompositionTailsToTombstones(df)
@@ -3094,7 +3108,7 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df = result,
       expectedAnswer = Seq(
-        Row(1, "alice", 20L, 20L, Row(20L))
+        Row(1, "alice", 20L, 20L, Row(20L, null))
       )
     )
   }
@@ -3119,13 +3133,13 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // A tombstone (startAt == endAt == recordStartAt) is delete-encoded and must live in the
     // aux table, never the target table.
     val df = targetTableOf(userSchema)(
-      Row(1, "t", 5L, 5L, Row(5L))
+      Row(1, "t", 5L, 5L, Row(5L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "t", 5L, 5L, Row(5L), true)
+        Row(1, "t", 5L, 5L, Row(5L, null), true)
       )
     )
   }
@@ -3138,13 +3152,13 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // upsert-representing row, so it is tagged false. (Tails are promoted/dropped upstream of
     // the merges; this pins that the router itself never claims them for the aux table.)
     val df = targetTableOf(userSchema)(
-      Row(1, "tail", null, 10L, Row(null))
+      Row(1, "tail", null, 10L, Row(null, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "tail", null, 10L, Row(null), false)
+        Row(1, "tail", null, 10L, Row(null, null), false)
       )
     )
   }
@@ -3156,13 +3170,13 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // A single open upsert with no following row in its key window cannot be a hidden no-op
     // continuation - it is the visible tail of its (size-1) run.
     val df = targetTableOf(userSchema)(
-      Row(1, "v", 5L, null, Row(5L))
+      Row(1, "v", 5L, null, Row(5L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "v", 5L, null, Row(5L), false)
+        Row(1, "v", 5L, null, Row(5L, null), false)
       )
     )
   }
@@ -3175,17 +3189,17 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // run head's startAt=5 and open endAt. The first two coalesce into hidden aux rows; only
     // the last (the run tail) stays visible in the target table.
     val df = targetTableOf(userSchema)(
-      Row(1, "a", 5L, null, Row(5L)),
-      Row(1, "a", 5L, null, Row(10L)),
-      Row(1, "a", 5L, null, Row(15L))
+      Row(1, "a", 5L, null, Row(5L, null)),
+      Row(1, "a", 5L, null, Row(10L, null)),
+      Row(1, "a", 5L, null, Row(15L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "a", 5L, null, Row(5L), true),
-        Row(1, "a", 5L, null, Row(10L), true),
-        Row(1, "a", 5L, null, Row(15L), false)
+        Row(1, "a", 5L, null, Row(5L, null), true),
+        Row(1, "a", 5L, null, Row(10L, null), true),
+        Row(1, "a", 5L, null, Row(15L, null), false)
       )
     )
   }
@@ -3197,15 +3211,15 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // A real state change between the two rows (value a -> b) breaks the run, so the earlier
     // closed upsert is a visible run tail rather than a hidden no-op continuation.
     val df = targetTableOf(userSchema)(
-      Row(1, "a", 5L, 10L, Row(5L)),
-      Row(1, "b", 10L, null, Row(10L))
+      Row(1, "a", 5L, 10L, Row(5L, null)),
+      Row(1, "b", 10L, null, Row(10L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "a", 5L, 10L, Row(5L), false),
-        Row(1, "b", 10L, null, Row(10L), false)
+        Row(1, "a", 5L, 10L, Row(5L, null), false),
+        Row(1, "b", 10L, null, Row(10L, null), false)
       )
     )
   }
@@ -3218,15 +3232,15 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // though both rows agree on the tracked `value`, the earlier row cannot be hidden - dropping
     // it would erase the gap from the visible timeline.
     val df = targetTableOf(userSchema)(
-      Row(1, "a", 5L, 8L, Row(5L)),
-      Row(1, "a", 10L, null, Row(10L))
+      Row(1, "a", 5L, 8L, Row(5L, null)),
+      Row(1, "a", 10L, null, Row(10L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "a", 5L, 8L, Row(5L), false),
-        Row(1, "a", 10L, null, Row(10L), false)
+        Row(1, "a", 5L, 8L, Row(5L, null), false),
+        Row(1, "a", 10L, null, Row(10L, null), false)
       )
     )
   }
@@ -3243,15 +3257,15 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // With `value` excluded the effective tracked set is empty, so consecutive gapless upserts
     // are always tracked-equal: the earlier one is hidden even though the user data differs.
     val df = targetTableOf(userSchema)(
-      Row(1, "a", 5L, null, Row(5L)),
-      Row(1, "b", 5L, null, Row(10L))
+      Row(1, "a", 5L, null, Row(5L, null)),
+      Row(1, "b", 5L, null, Row(10L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "a", 5L, null, Row(5L), true),
-        Row(1, "b", 5L, null, Row(10L), false)
+        Row(1, "a", 5L, null, Row(5L, null), true),
+        Row(1, "b", 5L, null, Row(10L, null), false)
       )
     )
   }
@@ -3266,19 +3280,19 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // 2's successor only. A window that leaked across keys would mistag one of these boundary
     // rows.
     val df = targetTableOf(userSchema)(
-      Row(1, "a", 5L, null, Row(5L)),
-      Row(1, "a", 5L, null, Row(10L)),
-      Row(2, "b", 7L, null, Row(7L)),
-      Row(2, "b", 7L, null, Row(20L))
+      Row(1, "a", 5L, null, Row(5L, null)),
+      Row(1, "a", 5L, null, Row(10L, null)),
+      Row(2, "b", 7L, null, Row(7L, null)),
+      Row(2, "b", 7L, null, Row(20L, null))
     )
 
     checkAnswer(
       df = withRouteFlag(processor.identifyAndTagAuxRows(df)),
       expectedAnswer = Seq(
-        Row(1, "a", 5L, null, Row(5L), true),
-        Row(1, "a", 5L, null, Row(10L), false),
-        Row(2, "b", 7L, null, Row(7L), true),
-        Row(2, "b", 7L, null, Row(20L), false)
+        Row(1, "a", 5L, null, Row(5L, null), true),
+        Row(1, "a", 5L, null, Row(10L, null), false),
+        Row(2, "b", 7L, null, Row(7L, null), true),
+        Row(2, "b", 7L, null, Row(20L, null), false)
       )
     )
   }
@@ -3300,8 +3314,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // parse `user.name` as a nested-field access (struct `user`, field `name`) and fail to
     // resolve.
     val df = targetTableOf(userSchema)(
-      Row(1, "alice", 5L, null, Row(5L)),
-      Row(1, "alice", 5L, null, Row(10L))
+      Row(1, "alice", 5L, null, Row(5L, null)),
+      Row(1, "alice", 5L, null, Row(10L, null))
     )
 
     val result = processor.identifyAndTagAuxRows(df)
@@ -3316,8 +3330,8 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
         F.col(Scd2BatchProcessor.shouldRouteToAuxTableColName)
       ),
       expectedAnswer = Seq(
-        Row(1, "alice", 5L, null, Row(5L), true),
-        Row(1, "alice", 5L, null, Row(10L), false)
+        Row(1, "alice", 5L, null, Row(5L, null), true),
+        Row(1, "alice", 5L, null, Row(10L, null), false)
       )
     )
   }
@@ -3330,18 +3344,18 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = new StructType().add("id", IntegerType).add("value", StringType)
 
     val left = targetTableOf(userSchema)(
-      Row(1, "L5", 5L, null, Row(5L)),
-      Row(1, "L9", 9L, null, Row(9L))
+      Row(1, "L5", 5L, null, Row(5L, null)),
+      Row(1, "L9", 9L, null, Row(9L, null))
     )
     // Right matches the left row at recordStartAt=5 only; the left row at 9 has no counterpart.
     val right = targetTableOf(userSchema)(
-      Row(1, "R5", 5L, null, Row(5L))
+      Row(1, "R5", 5L, null, Row(5L, null))
     )
 
     checkAnswer(
       df = processor.antiJoinRowsByRecordStartAtPerKey(left, right),
       expectedAnswer = Seq(
-        Row(1, "L9", 9L, null, Row(9L))
+        Row(1, "L9", 9L, null, Row(9L, null))
       )
     )
   }
@@ -3352,18 +3366,18 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     val userSchema = new StructType().add("id", IntegerType).add("value", StringType)
 
     val left = targetTableOf(userSchema)(
-      Row(1, "a", 5L, null, Row(5L)),
-      Row(2, "b", 5L, null, Row(5L))
+      Row(1, "a", 5L, null, Row(5L, null)),
+      Row(2, "b", 5L, null, Row(5L, null))
     )
     // Only key 1 at recordStartAt=5 matches; key 2 at the same recordStartAt must survive.
     val right = targetTableOf(userSchema)(
-      Row(1, "r", 5L, null, Row(5L))
+      Row(1, "r", 5L, null, Row(5L, null))
     )
 
     checkAnswer(
       df = processor.antiJoinRowsByRecordStartAtPerKey(left, right),
       expectedAnswer = Seq(
-        Row(2, "b", 5L, null, Row(5L))
+        Row(2, "b", 5L, null, Row(5L, null))
       )
     )
   }
@@ -3375,10 +3389,10 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Both sides carry a null recordStartAt for the same key. A null-safe equality treats the
     // two as matching, so the left row is anti-joined away (an ordinary `=` would keep it).
     val left = targetTableOf(userSchema)(
-      Row(1, "tailL", null, 10L, Row(null))
+      Row(1, "tailL", null, 10L, Row(null, null))
     )
     val right = targetTableOf(userSchema)(
-      Row(1, "tailR", null, 20L, Row(null))
+      Row(1, "tailR", null, 20L, Row(null, null))
     )
 
     assert(processor.antiJoinRowsByRecordStartAtPerKey(left, right).collect().isEmpty)
@@ -3394,17 +3408,17 @@ class Scd2BatchProcessorSuite extends QueryTest with SharedSparkSession {
     // Rows share id and recordStartAt but differ on the second key column `grp`. Only the exact
     // composite-key match (1, "g") is removed; (1, "h") survives.
     val left = targetTableOf(userSchema)(
-      Row(1, "g", "a", 5L, null, Row(5L)),
-      Row(1, "h", "b", 5L, null, Row(5L))
+      Row(1, "g", "a", 5L, null, Row(5L, null)),
+      Row(1, "h", "b", 5L, null, Row(5L, null))
     )
     val right = targetTableOf(userSchema)(
-      Row(1, "g", "r", 5L, null, Row(5L))
+      Row(1, "g", "r", 5L, null, Row(5L, null))
     )
 
     checkAnswer(
       df = processor.antiJoinRowsByRecordStartAtPerKey(left, right),
       expectedAnswer = Seq(
-        Row(1, "h", "b", 5L, null, Row(5L))
+        Row(1, "h", "b", 5L, null, Row(5L, null))
       )
     )
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2ForeachBatchHandlerSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/Scd2ForeachBatchHandlerSuite.scala
@@ -52,7 +52,7 @@ class Scd2ForeachBatchHandlerSuite
     .add("seq", LongType)
     .add("is_delete", BooleanType)
 
-  /** The SCD2 cdc-metadata struct carries a single `recordStartAt` field (unlike SCD1's two). */
+  /** SCD2 cdc-metadata struct: `recordStartAt` + `versionMap` (unlike SCD1's two sequences). */
   private val scd2MetadataSchema: StructType = Scd2BatchProcessor.cdcMetadataColSchema(LongType)
 
   /** Canonical SCD2 row schema: persisted user columns + framework start/end + cdc metadata. */
@@ -111,7 +111,8 @@ class Scd2ForeachBatchHandlerSuite
   private def del(id: Int, seq: Long): Row = Row(id, null, seq, true)
 
   /** The cdc-metadata struct value for a given `recordStartAt`. */
-  private def meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def meta(recordStartAt: Long, versionMap: Any = null): Row =
+    Row(recordStartAt, versionMap)
 
   /** A canonical target row `(id, value, startAt, endAt, meta(recordStartAt))`. */
   private def targetRow(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcGraphExecutionTestMixin.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcGraphExecutionTestMixin.scala
@@ -168,7 +168,9 @@ trait AutoCdcGraphExecutionTestMixin extends BeforeAndAfterEach {
     val startAt = Scd2BatchProcessor.startAtColName
     val endAt = Scd2BatchProcessor.endAtColName
     val recordStartAt = Scd2BatchProcessor.recordStartAtFieldName
-    s"$startAt BIGINT, $endAt BIGINT, $col STRUCT<$recordStartAt:BIGINT> NOT NULL"
+    val versionMap = Scd2BatchProcessor.versionMapFieldName
+    s"$startAt BIGINT, $endAt BIGINT, " +
+      s"$col STRUCT<$recordStartAt:BIGINT,$versionMap:MAP<STRING,BOOLEAN>> NOT NULL"
   }
 
   /**

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2AuxiliaryTableDurabilitySuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2AuxiliaryTableDurabilitySuite.scala
@@ -45,7 +45,7 @@ class AutoCdcScd2AuxiliaryTableDurabilitySuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   test("a higher-sequence event in a later pipeline run correctly closes and opens records") {
     spark.sql(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2ColumnEvolutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2ColumnEvolutionSuite.scala
@@ -60,7 +60,7 @@ class AutoCdcScd2ColumnEvolutionSuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   /** An explicit SCD2 `TRACK HISTORY ON (name)` selection, shared across the scenarios below. */
   private val trackName: Option[ColumnSelection] =

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2FullRefreshSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2FullRefreshSuite.scala
@@ -42,7 +42,7 @@ class AutoCdcScd2FullRefreshSuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   /** Create an SCD2 target with user columns `(id, name, version)` plus the framework columns. */
   private def createScd2Target(table: String): Unit = {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2MultiPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2MultiPipelineSuite.scala
@@ -38,7 +38,7 @@ class AutoCdcScd2MultiPipelineSuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   test("two AutoCDC pipelines targeting separate tables maintain independent target and " +
     "auxiliary tables") {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SchemaEvolutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SchemaEvolutionSuite.scala
@@ -64,7 +64,7 @@ class AutoCdcScd2SchemaEvolutionSuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   test("a nullable non-key column merges correctly with mixed NULL and non-NULL values") {
     spark.sql(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SchemaEvolutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SchemaEvolutionSuite.scala
@@ -75,40 +75,71 @@ class AutoCdcScd2SchemaEvolutionSuite
 
   test("legacy SCD2 CDC metadata schema evolves to include the version map") {
     val targetName = s"$catalog.$namespace.target"
+    val auxiliaryName = auxTableNameFor("target")
     val cdcMetadataCol = AutoCdcReservedNames.cdcMetadataColName
     val recordStartAt = Scd2BatchProcessor.recordStartAtFieldName
+    val legacyMetadataDdl =
+      s"${Scd2BatchProcessor.startAtColName} BIGINT, " +
+      s"${Scd2BatchProcessor.endAtColName} BIGINT, " +
+      s"$cdcMetadataCol STRUCT<$recordStartAt:BIGINT> NOT NULL"
     spark.sql(
       s"CREATE TABLE $targetName " +
       s"(id INT NOT NULL, name STRING, version BIGINT NOT NULL, " +
-      s"${Scd2BatchProcessor.startAtColName} BIGINT, " +
-      s"${Scd2BatchProcessor.endAtColName} BIGINT, " +
-      s"$cdcMetadataCol STRUCT<$recordStartAt:BIGINT> NOT NULL)"
+      s"$legacyMetadataDdl)"
+    )
+    // Pre-create the auxiliary table too, so both persisted SCD2 schemas take the upgrade path.
+    spark.sql(
+      s"""CREATE TABLE $auxiliaryName """ +
+      s"""(id INT, name STRING, version BIGINT, $legacyMetadataDdl, """ +
+      s"""${Scd2BatchProcessor.deletedByBatchIdColName} BIGINT) """ +
+      s"""TBLPROPERTIES (""" +
+      s"""'${AutoCdcAuxiliaryTable.scdTypePropertyKey}' = '${ScdType.Type2.label}', """ +
+      s"""'${AutoCdcAuxiliaryTable.keyColumnNamesProperty}' = '["id"]', """ +
+      s"""'${AutoCdcAuxiliaryTable.trackHistoryColumnNamesProperty}' = '["name"]')"""
     )
     spark.sql(
-      s"INSERT INTO $targetName SELECT 1, 'alice', CAST(1 AS BIGINT), " +
+      s"INSERT INTO $targetName SELECT 1, 'alice', CAST(5 AS BIGINT), " +
       s"CAST(1 AS BIGINT), CAST(NULL AS BIGINT), " +
-      s"named_struct('$recordStartAt', CAST(1 AS BIGINT))"
+      s"named_struct('$recordStartAt', CAST(5 AS BIGINT))"
+    )
+    spark.sql(
+      s"INSERT INTO $auxiliaryName SELECT 1, 'alice', CAST(1 AS BIGINT), " +
+      s"CAST(1 AS BIGINT), CAST(NULL AS BIGINT), " +
+      s"named_struct('$recordStartAt', CAST(1 AS BIGINT)), CAST(NULL AS BIGINT)"
     )
 
     val stream = MemoryStream[(Int, String, Long)]
-    stream.addData((2, "bob", 2L))
+    // Reconcile both legacy rows: one event extends their run, and the next closes it.
+    stream.addData((1, "alice", 3L), (1, "alicia", 6L))
     runPipeline(singleAutoCdcFlowPipeline(
       flowName = "auto_cdc_flow",
       target = "target",
       sourceDf = stream.toDF().toDF("id", "name", "version"),
       keys = Seq("id"),
       sequencing = functions.col("version"),
-      scdType = ScdType.Type2))
+      scdType = ScdType.Type2,
+      trackHistorySelection =
+        Option(ColumnSelection.IncludeColumns(Seq(UnqualifiedColumnName("name"))))))
 
     val target = spark.table(targetName)
+    val expectedMetadataSchema = Scd2BatchProcessor.cdcMetadataColSchema(LongType)
     assert(
-      target.schema(cdcMetadataCol).dataType ===
-        Scd2BatchProcessor.cdcMetadataColSchema(LongType).asNullable)
+      target.schema(cdcMetadataCol).dataType === expectedMetadataSchema.asNullable)
+    assert(
+      spark.table(auxiliaryName).schema(cdcMetadataCol).dataType ===
+        expectedMetadataSchema)
     checkAnswer(
       target,
       Seq(
-        Row(1, "alice", 1L, 1L, null, scd2Meta(1L)),
-        Row(2, "bob", 2L, 2L, null, scd2Meta(2L))
+        Row(1, "alice", 5L, 1L, 6L, scd2Meta(5L)),
+        Row(1, "alicia", 6L, 6L, null, scd2Meta(6L))
+      )
+    )
+    checkAnswer(
+      spark.table(auxiliaryName),
+      Seq(
+        Row(1, "alice", 1L, 1L, null, scd2Meta(1L), null),
+        Row(1, "alice", 3L, 1L, null, scd2Meta(3L), null)
       )
     )
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SchemaEvolutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SchemaEvolutionSuite.scala
@@ -23,9 +23,16 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.pipelines.autocdc.{ColumnSelection, ScdType, UnqualifiedColumnName}
+import org.apache.spark.sql.pipelines.autocdc.{
+  AutoCdcReservedNames,
+  ColumnSelection,
+  Scd2BatchProcessor,
+  ScdType,
+  UnqualifiedColumnName
+}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.LongType
 
 /**
  * Tests covering SCD Type 2 AutoCDC's interaction with non-key schema evolution across pipeline
@@ -65,6 +72,46 @@ class AutoCdcScd2SchemaEvolutionSuite
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
   private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
+
+  test("legacy SCD2 CDC metadata schema evolves to include the version map") {
+    val targetName = s"$catalog.$namespace.target"
+    val cdcMetadataCol = AutoCdcReservedNames.cdcMetadataColName
+    val recordStartAt = Scd2BatchProcessor.recordStartAtFieldName
+    spark.sql(
+      s"CREATE TABLE $targetName " +
+      s"(id INT NOT NULL, name STRING, version BIGINT NOT NULL, " +
+      s"${Scd2BatchProcessor.startAtColName} BIGINT, " +
+      s"${Scd2BatchProcessor.endAtColName} BIGINT, " +
+      s"$cdcMetadataCol STRUCT<$recordStartAt:BIGINT> NOT NULL)"
+    )
+    spark.sql(
+      s"INSERT INTO $targetName SELECT 1, 'alice', CAST(1 AS BIGINT), " +
+      s"CAST(1 AS BIGINT), CAST(NULL AS BIGINT), " +
+      s"named_struct('$recordStartAt', CAST(1 AS BIGINT))"
+    )
+
+    val stream = MemoryStream[(Int, String, Long)]
+    stream.addData((2, "bob", 2L))
+    runPipeline(singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target",
+      sourceDf = stream.toDF().toDF("id", "name", "version"),
+      keys = Seq("id"),
+      sequencing = functions.col("version"),
+      scdType = ScdType.Type2))
+
+    val target = spark.table(targetName)
+    assert(
+      target.schema(cdcMetadataCol).dataType ===
+        Scd2BatchProcessor.cdcMetadataColSchema(LongType).asNullable)
+    checkAnswer(
+      target,
+      Seq(
+        Row(1, "alice", 1L, 1L, null, scd2Meta(1L)),
+        Row(2, "bob", 2L, 2L, null, scd2Meta(2L))
+      )
+    )
+  }
 
   test("a nullable non-key column merges correctly with mixed NULL and non-NULL values") {
     spark.sql(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SinglePipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2SinglePipelineSuite.scala
@@ -48,7 +48,7 @@ class AutoCdcScd2SinglePipelineSuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   /**
    * DDL for an SCD2 target table with user columns `(id, name, version)` plus the framework

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2TargetTableDurabilitySuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2TargetTableDurabilitySuite.scala
@@ -61,10 +61,12 @@ class AutoCdcScd2TargetTableDurabilitySuite
   private def insertPreloadedCurrentRecord(
       table: String, colValues: String, sequence: Long): Unit = {
     val recordStartAt = Scd2BatchProcessor.recordStartAtFieldName
+    val versionMap = Scd2BatchProcessor.versionMapFieldName
     spark.sql(
       s"INSERT INTO $table SELECT $colValues, " +
       s"CAST($sequence AS BIGINT), CAST(NULL AS BIGINT), " +
-      s"named_struct('$recordStartAt', CAST($sequence AS BIGINT))"
+      s"named_struct('$recordStartAt', CAST($sequence AS BIGINT), " +
+      s"'$versionMap', CAST(NULL AS MAP<STRING, BOOLEAN>))"
     )
   }
 
@@ -83,10 +85,12 @@ class AutoCdcScd2TargetTableDurabilitySuite
   private def insertPreloadedClosedRecord(
       table: String, colValues: String, startAt: Long, endAt: Long): Unit = {
     val recordStartAt = Scd2BatchProcessor.recordStartAtFieldName
+    val versionMap = Scd2BatchProcessor.versionMapFieldName
     spark.sql(
       s"INSERT INTO $table SELECT $colValues, " +
       s"CAST($startAt AS BIGINT), CAST($endAt AS BIGINT), " +
-      s"named_struct('$recordStartAt', CAST($startAt AS BIGINT))"
+      s"named_struct('$recordStartAt', CAST($startAt AS BIGINT), " +
+      s"'$versionMap', CAST(NULL AS MAP<STRING, BOOLEAN>))"
     )
   }
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2TargetTableDurabilitySuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd2TargetTableDurabilitySuite.scala
@@ -38,7 +38,7 @@ class AutoCdcScd2TargetTableDurabilitySuite
   import testImplicits._
 
   /** The SCD2 target's `_cdc_metadata` struct value for a given recordStartAt. */
-  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt)
+  private def scd2Meta(recordStartAt: Long): Row = Row(recordStartAt, null)
 
   /** Create an SCD2 target with user columns `(id, name, version)` plus the framework columns. */
   private def createScd2Target(table: String): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In order to support ignore-null in SCD2, we need to persist additional metadata per row that tells us which column values were actually authored by the upsert event that created the row, and which columns were unauthored by the same upsert event and instead need to inherit a value from a previous row.

This PR is concerned with simply defining the version map schema/concept, and adding it to the `_cdc_metadata` per row. The version map will not be used yet, but will start materializing in both old and new AutoCDC tables.

API for ignore-null is not exposed yet, so a non-null version map will never be created yet.


### Why are the changes needed?
To support the ignore-null feature for AutoCDC SCD2 (as per the [approved SPIP](https://docs.google.com/document/d/10gtGoUOJvY_XoXpJuJ8LGJWPLMkdpgzseiMcKnjDloo/edit?tab=t.0#heading=h.9g6a5f8v6xig)), we need to introduce a new map data structure to persist column authorship. This is a per-row data structure and holds operational metadata, so it naturally fits in `_cdc_metadata`.


### Does this PR introduce _any_ user-facing change?
Yes. The (nullable) version map field is added to the `_cdc_metadata` column. That means existing AutoCDC target tables that do not contain this subfield will undergo schema evolution on their next pipeline run after this change.

Nested-field schema evolution is supported in SDP as of the previous PR in this stack, and the evolution case is captured via unit tests using the in-memory DSv2 catalog.

### How was this patch tested?
Unit tests.

Many existing unit test assertions on final table contents were updated to account for the (null) version map.

### Was this patch authored or co-authored using generative AI tooling?
Yes, using Claude Opus 4.6.