### PR TITLE
[WIP][PS] Do not widen float32 to float64 in NumPy ufunc results

### DIFF
--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -474,6 +474,50 @@ def _check_operand_types(op_name: str, inputs: Tuple[Any, ...]) -> None:
             )
 
 
+def _numpy_output_dtypes(ufunc: Callable, inputs: Tuple[Any, ...], count: int) -> Tuple[Any, ...]:
+    # The dtypes NumPy itself produces for these operands, asked of NumPy directly rather
+    # than by reimplementing its promotion rules: float32 with an int8 or a Python scalar
+    # stays float32, while float32 with an int64 widens to float64. Always returns one entry
+    # per output, None where NumPy cannot answer for these operands.
+    unknown = (None,) * count
+    if not any(str(getattr(inp, "dtype", "")) in ("float32", "Float32") for inp in inputs):
+        # Only a float32 operand can lose precision below, so skip the probe entirely.
+        return unknown
+    probes = []
+    for inp in inputs:
+        dtype = getattr(inp, "dtype", None)
+        if dtype is None:
+            # A scalar, which NumPy promotes weakly; pass it through as itself.
+            probes.append(inp)
+        else:
+            probes.append(np.ones(1, dtype=getattr(dtype, "numpy_dtype", dtype)))
+    try:
+        with np.errstate(all="ignore"):
+            outputs = ufunc(*probes)
+    except Exception:
+        # NumPy cannot evaluate every dtype reaching here (a decimal column arrives as
+        # object), and a ufunc that rejects these operands has to keep raising from the
+        # call itself rather than from this probe.
+        return unknown
+    dtypes = (
+        tuple(output.dtype for output in outputs)
+        if isinstance(outputs, tuple)
+        else (outputs.dtype,)
+    )
+    return dtypes if len(dtypes) == count else unknown
+
+
+def _restore_float32_output(output: SeriesOrIndex, expected: Any) -> SeriesOrIndex:
+    # Spark's functions return a double for a float input, so a float32 column comes back
+    # as float64 where NumPy keeps single precision. Besides the dtype, that lets values
+    # outside the float32 range through: NumPy overflows exp(90) to infinity and underflows
+    # square(1e-23) to zero, while the double result keeps both finite and non-zero.
+    dtype = str(output.dtype)
+    if expected == np.float32 and dtype in ("float64", "Float64"):
+        return output.astype("Float32" if dtype == "Float64" else "float32")
+    return output
+
+
 # Copied from pandas.
 # See also https://docs.scipy.org/doc/numpy/reference/arrays.classes.html#standard-array-subclasses
 def maybe_dispatch_ufunc_to_dunder_op(
@@ -562,7 +606,11 @@ def maybe_dispatch_ufunc_to_spark_func(
         # that column_op unwraps to a Column -- no literal wrapping needed. Build one
         # Series per output and return them as a 2-tuple (see the mapping's docstring).
         first_func, second_func = multi_output_np_spark_mappings[op_name]
-        return column_op(first_func)(*inputs), column_op(second_func)(*inputs)
+        first_dtype, second_dtype = _numpy_output_dtypes(ufunc, inputs, 2)
+        return (
+            _restore_float32_output(column_op(first_func)(*inputs), first_dtype),
+            _restore_float32_output(column_op(second_func)(*inputs), second_dtype),
+        )
 
     if (
         method == "__call__"
@@ -578,7 +626,9 @@ def maybe_dispatch_ufunc_to_spark_func(
             args = [F.lit(inp) for inp in args]
             return np_spark_map_func(*args)
 
-        return column_op(convert_arguments)(*inputs)
+        return _restore_float32_output(
+            column_op(convert_arguments)(*inputs), _numpy_output_dtypes(ufunc, inputs, 1)[0]
+        )
     else:
         return NotImplemented
 

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -274,6 +274,75 @@ class NumPyCompatTestsMixin:
                 self.assert_eq(np_func(psdf.a), np_func(pdf.a), almost=True)
 
     @_skip_if_numpy_differs
+    def test_np_float32_output_dtypes(self):
+        # NumPy keeps single precision for a float32 input, while Spark's functions return a
+        # double. Only a strict assert_eq compares dtypes -- almost=True checks values and
+        # null positions alone -- so the assertions below are deliberately not approximate.
+        pdf = pd.DataFrame(
+            {
+                "a": np.array([0.25, 1.5, 8.0, 64.0], dtype="float32"),
+                "b": np.array([0.5, 2.0, 3.0, -1.5], dtype="float32"),
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        # Rounding the double result back to float32 returns exactly what NumPy computes for
+        # these: they either only move the exponent or are correctly rounded in both widths.
+        for np_func in (np.absolute, np.fabs, np.rint, np.sqrt, np.square, np.trunc):
+            with self.subTest(ufunc=np_func.__name__):
+                self.assert_eq(np_func(psdf.a), np_func(pdf.a))
+        for np_func in (np.copysign, np.fmax, np.fmin, np.fmod, np.hypot):
+            with self.subTest(ufunc=np_func.__name__):
+                self.assert_eq(np_func(psdf.a, psdf.b), np_func(pdf.a, pdf.b))
+
+        # A transcendental computed in double and rounded once can land a single bit away
+        # from NumPy's single-precision loop, so its values are compared approximately; the
+        # dtype is what this test is for and is still checked exactly.
+        for np_func in (np.cbrt, np.cos, np.exp, np.log, np.tanh):
+            with self.subTest(ufunc=np_func.__name__):
+                self.assert_eq(np_func(psdf.a), np_func(pdf.a), almost=True)
+                self.assertEqual(np_func(psdf.a).dtype, np_func(pdf.a).dtype)
+
+        # Multi-output ufuncs restore each output on its own: frexp's exponent is an int32
+        # either way, and only its mantissa follows the input's precision.
+        for np_func in (np.frexp, np.modf):
+            with self.subTest(ufunc=np_func.__name__):
+                ps_first, ps_second = np_func(psdf.a)
+                pd_first, pd_second = np_func(pdf.a)
+                self.assert_eq(ps_first, pd_first)
+                self.assert_eq(ps_second, pd_second)
+
+        # A nullable Float32 keeps the extension dtype rather than widening to Float64.
+        pser = pd.Series(pd.array([0.25, None, 8.0], dtype="Float32"))
+        psser = ps.from_pandas(pser)
+        self.assert_eq(np.sqrt(psser), np.sqrt(pser))
+
+        # NumPy's own promotion decides the result, so it is what the restore follows: an
+        # int8 operand or a Python scalar keeps float32, while an int64 widens to float64.
+        pdf = pd.DataFrame(
+            {
+                "a": np.array([0.25, 8.0], dtype="float32"),
+                "narrow": np.array([2, 3], dtype="int8"),
+                "wide": np.array([2, 3], dtype="int64"),
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.fmod(psdf.a, psdf.narrow), np.fmod(pdf.a, pdf.narrow))
+        self.assert_eq(np.fmod(psdf.a, psdf.wide), np.fmod(pdf.a, pdf.wide))
+        self.assert_eq(np.fmod(psdf.a, 2), np.fmod(pdf.a, 2))
+
+    def test_np_float32_range(self):
+        # Restoring the dtype also restores float32's range. NumPy overflows to infinity
+        # past ~3.4e38 and underflows to zero below the smallest subnormal, where a double
+        # result stays finite and non-zero and so disagrees with pandas on both.
+        pdf = pd.DataFrame({"a": np.array([80.0, 88.0, 90.0, 100.0, 200.0], dtype="float32")})
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.isinf(np.exp(psdf.a).to_pandas()), np.isinf(np.exp(pdf.a)))
+
+        pdf = pd.DataFrame({"a": np.array([1e-20, 1e-23, 1e-30], dtype="float32")})
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(np.square(psdf.a), np.square(pdf.a))
+
     def test_np_reciprocal_integer(self):
         # np.reciprocal on an integer column does integer division (truncated
         # toward zero): 1 -> 1, -1 -> -1, and every other magnitude -> 0. The


### PR DESCRIPTION
**WIP, opened for a scope discussion rather than for merge.** The change works, but the divergence it fixes is wider than what it covers. See the last section.

### What changes were proposed in this pull request?

Restore NumPy's output dtype when a pandas-on-Spark ufunc receives a float32 column. The dispatch asks NumPy which dtype it would return for the operand dtypes, rather than reimplementing NumPy's promotion rules, and casts back when Spark widened the result.

### Why are the changes needed?

Spark's math functions return a double for a float input, so a ufunc on a float32 column returns float64 where pandas returns float32, losing float32's range with it: `np.exp(np.float32(90))` gives `1.22e39` here and `inf` in pandas. This is long-standing rather than new, since the previous `pandas_udf` entries declared `DoubleType` and widened identically, and it affects 40 mapping entries including `sqrt`, which has no cast at all.

### Does this PR introduce _any_ user-facing change?

Yes. A ufunc on a float32 column returns float32 instead of float64, and values outside the float32 range now overflow to infinity and underflow to zero as they do in pandas.

### How was this patch tested?

New `test_np_float32_output_dtypes` and `test_np_float32_range` in `NumPyCompatTestsMixin`, which fail without the change; their float32 assertions are strict rather than `almost=True`, since only a strict comparison checks dtype.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)

### Open question on scope

float32 is not the only divergence. Sweeping every input dtype, the output dtype also differs for narrow integer and boolean inputs, for `reciprocal`/`sign`/`square`/`trunc` on integers, for `ceil`/`floor`, and for decimal columns. Binary ufuncs across dtype pairs are not swept yet.

The narrow-integer case is worth deciding with this PR, since the range argument above applies to int16 too; the rest look like separate tickets. Which scope would you prefer:

1. Restore NumPy's float output dtype wherever Spark can represent it, so float32 plus int16/Int8/Int16/boolean. One condition on top of this PR.
2. The float32 case only, as this PR stands.
3. Treat double output as intended and document it instead.

int8 and boolean inputs make NumPy return float16, which Spark has no type for, so exact parity is not reachable there.
