### PR TITLE
[SPARK-59201][BUILD] Cross-reference the Hadoop fallback version between pom.xml and IsolatedClientLoader

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -67,6 +67,8 @@ private[hive] object IsolatedClientLoader extends Logging {
           case e: RuntimeException if e.getMessage.contains("hadoop") =>
             // If the error message contains hadoop, it is probably because the hadoop
             // version cannot be resolved.
+            // Keep in sync with the default `hadoop.version` in the root pom.xml, which carries
+            // the reverse reminder to update this value.
             val fallbackVersion = "3.5.0"
             logWarning(log"Failed to resolve Hadoop artifacts for the version " +
               log"${MDC(HADOOP_VERSION, hadoopVersion)}. We will change the hadoop version from " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

`pom.xml`'s `hadoop.version` and `IsolatedClientLoader`'s `fallbackVersion` must be kept in sync (both `3.5.0`). `pom.xml` already carries the reminder `<!-- make sure to update IsolatedClientLoader whenever this version is changed -->`, but the coupling is documented one-way only. This adds the matching reverse comment on the Scala side.

### Why are the changes needed?

Documents the coupling in both directions so a change on either side is caught. A shared constant is not feasible across the Maven/Scala boundary, so a cross-reference comment is the pragmatic option. Comment-only.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A -- comment-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
