### PR TITLE
[SPARK-59202][ML][TESTS] Enable save/load round-trip tests in Java ML tree suites

### DIFF
--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,11 +30,12 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 public class JavaDecisionTreeClassifierSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -62,18 +65,15 @@ public class JavaDecisionTreeClassifierSuite extends SharedSparkSession {
     model.depth();
     model.toDebugString();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = new File(tempDir, "model").getPath();
     try {
-      model3.save(sc.sc(), path);
+      model.save(path);
       DecisionTreeClassificationModel sameModel =
-        DecisionTreeClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+        DecisionTreeClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,11 +30,12 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 public class JavaGBTClassifierSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -67,17 +70,14 @@ public class JavaGBTClassifierSuite extends SharedSparkSession {
     model.trees();
     model.treeWeights();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = new File(tempDir, "model").getPath();
     try {
-      model3.save(sc.sc(), path);
-      GBTClassificationModel sameModel = GBTClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+      model.save(path);
+      GBTClassificationModel sameModel = GBTClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,11 +32,12 @@ import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 public class JavaRandomForestClassifierSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -86,18 +89,15 @@ public class JavaRandomForestClassifierSuite extends SharedSparkSession {
     model.treeWeights();
     Vector importances = model.featureImportances();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = new File(tempDir, "model").getPath();
     try {
-      model3.save(sc.sc(), path);
+      model.save(path);
       RandomForestClassificationModel sameModel =
-          RandomForestClassificationModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model3, sameModel);
+          RandomForestClassificationModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,12 +31,13 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 
 public class JavaDecisionTreeRegressorSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -64,17 +67,14 @@ public class JavaDecisionTreeRegressorSuite extends SharedSparkSession {
     model.depth();
     model.toDebugString();
 
-    /*
-    // TODO: Add test once save/load are implemented.   SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = new File(tempDir, "model").getPath();
     try {
-      model2.save(sc.sc(), path);
-      DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      DecisionTreeRegressionModel sameModel = DecisionTreeRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,12 +31,13 @@ import org.apache.spark.ml.feature.LabeledPoint;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 
 public class JavaGBTRegressorSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -68,17 +71,14 @@ public class JavaGBTRegressorSuite extends SharedSparkSession {
     model.trees();
     model.treeWeights();
 
-    /*
-    // TODO: Add test once save/load are implemented.  SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = new File(tempDir, "model").getPath();
     try {
-      model2.save(sc.sc(), path);
-      GBTRegressionModel sameModel = GBTRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      GBTRegressionModel sameModel = GBTRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.regression;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,12 +33,13 @@ import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.tree.impl.TreeTests;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.util.Utils;
 
 
 public class JavaRandomForestRegressorSuite extends SharedSparkSession {
 
   @Test
-  public void runDT() {
+  public void runDT() throws IOException {
     int nPoints = 20;
     double A = 2.0;
     double B = -1.5;
@@ -88,17 +91,14 @@ public class JavaRandomForestRegressorSuite extends SharedSparkSession {
     model.treeWeights();
     Vector importances = model.featureImportances();
 
-    /*
-    // TODO: Add test once save/load are implemented.   SPARK-6725
     File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
-    String path = tempDir.toURI().toString();
+    String path = new File(tempDir, "model").getPath();
     try {
-      model2.save(sc.sc(), path);
-      RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(sc.sc(), path);
-      TreeTests.checkEqual(model2, sameModel);
+      model.save(path);
+      RandomForestRegressionModel sameModel = RandomForestRegressionModel.load(path);
+      TreeTests.checkEqual(model, sameModel);
     } finally {
       Utils.deleteRecursively(tempDir);
     }
-    */
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Six Java ML tree test suites -- `JavaDecisionTreeClassifierSuite`, `JavaGBTClassifierSuite`, `JavaRandomForestClassifierSuite`, `JavaDecisionTreeRegressorSuite`, `JavaGBTRegressorSuite`, `JavaRandomForestRegressorSuite` -- carried commented-out save/load round-trip tests with a `// TODO: Add test once save/load are implemented.  SPARK-6725` marker.

Save/load has long shipped (`MLWritable` / `MLReadable`). This enables those tests. The commented code was obsolete -- it used the old `save(SparkContext, path)` / `load(SparkContext, path)` mllib API and referenced stale variable names (`model2` / `model3`) -- so each block is rewritten to the current API:

```java
File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
String path = new File(tempDir, "model").getPath();
try {
  model.save(path);
  <Model> sameModel = <Model>.load(path);
  TreeTests.checkEqual(model, sameModel);
} finally {
  Utils.deleteRecursively(tempDir);
}
```

### Why are the changes needed?

The blocks were dead (obsolete API and wrong variable names) rather than merely disabled. Enabling them adds Java-facing save/load round-trip coverage for the tree models, matching what the Scala suites already provide via `DefaultReadWriteTest`.

### Does this PR introduce _any_ user-facing change?

No. Test-only.

### How was this patch tested?

Ran the six enabled Java suites locally; all pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
