### PR TITLE
[MINOR][INFRA][DOCS] Merge conflicting specification of PySpark Python version in `docs` job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1073,8 +1073,8 @@ jobs:
     env:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
-      PYSPARK_DRIVER_PYTHON: python3.9
-      PYSPARK_PYTHON: python3.9
+      PYSPARK_DRIVER_PYTHON: python3.12
+      PYSPARK_PYTHON: python3.12
       GITHUB_PREV_SHA: ${{ github.event.before }}
     container:
       image: ${{ needs.precondition.outputs.image_docs_url_link }}
@@ -1145,8 +1145,6 @@ jobs:
           if [ `./dev/is-changed.py -m $pyspark_modules` = false ]; then export SKIP_PYTHONDOC=1; fi
           if [ `./dev/is-changed.py -m sparkr` = false ]; then export SKIP_RDOC=1; fi
         fi
-        export PYSPARK_DRIVER_PYTHON=python3.12
-        export PYSPARK_PYTHON=python3.12
         # Print the values of environment variables `SKIP_ERRORDOC`, `SKIP_SCALADOC`, `SKIP_PYTHONDOC`, `SKIP_RDOC` and `SKIP_SQLDOC`
         echo "SKIP_ERRORDOC: $SKIP_ERRORDOC"
         echo "SKIP_SCALADOC: $SKIP_SCALADOC"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Merge the inline shell specification of PySpark Python up into the job-level `env` block. Inline specifies Python 3.12 and overrides the job-level specification of Python 3.9.

### Why are the changes needed?

I believe the conflict of 3.9 vs. 3.12 on the same job is an unintentional oversight from #54310.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI ran the affected `docs` job [successfully](https://github.com/nchammas/spark/actions/runs/33769150677/job/100696029564#step:12:33).

### Was this patch authored or co-authored using generative AI tooling?

No.