### PR TITLE
[SPARK-59212][K8S][INFRA] Pin the Minikube container runtime to `docker` in K8s CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1428,6 +1428,10 @@ jobs:
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           kubernetes-version: "1.37.0"
+          # Minikube 1.39.0 changed the default container runtime to containerd. The image
+          # builds below go through `minikube docker-env`, which needs a real Docker daemon
+          # in the node, so pin the runtime rather than inherit the default.
+          container-runtime: docker
           # GitHub Actions limit 4C/16G, limit to 2C/6G for better resource statistic
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           cpus: 2
@@ -1522,6 +1526,10 @@ jobs:
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           kubernetes-version: "1.36.0"
+          # Minikube 1.39.0 changed the default container runtime to containerd. The image
+          # builds below go through `minikube docker-env`, which needs a real Docker daemon
+          # in the node, so pin the runtime rather than inherit the default.
+          container-runtime: docker
           cpus: 2
           memory: 6144m
       - name: Print K8S pods and nodes info


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pass `container-runtime: docker` to both `medyagh/setup-minikube` steps in
`.github/workflows/build_and_test.yml` -- the `k8s-integration-tests` job and the
`oidc-e2e` job -- so the Minikube node's container runtime is chosen explicitly instead of
inherited from the Minikube default.

### Why are the changes needed?

The K8s integration test job currently fails for every PR, during image construction.

[Minikube 1.39.0](https://github.com/kubernetes/minikube/releases/tag/v1.39.0) changed the
default container runtime from Docker to containerd
([kubernetes/minikube#23562](https://github.com/kubernetes/minikube/pull/23562)). Both jobs
pin `setup-minikube` by SHA but leave `minikube-version` at the action's default of
`latest`, so CI picked up 1.39.0 as soon as it was released and the node now comes up on
containerd:

```
* minikube v1.39.0 on Ubuntu 24.04
* Automatically selected the docker driver.
* Preparing Kubernetes v1.37.0 on containerd 2.3.4 ...
    Container Runtime Version:  containerd://2.3.4
```

Both jobs then build images through `eval $(minikube docker-env)`, which now points at
containerd's Docker shim rather than a real Docker daemon:

```
! Using the docker-env command with the containerd runtime is a highly experimental
  feature, please provide feedback or contribute to make it better
```

That shim does not implement enough of the Docker API for buildx. Because the pointed-at
endpoint is not a usable Docker daemon, buildx falls back to the `docker-container` driver,
and bootstrapping BuildKit inside it fails:

```
#0 building with "default" instance using docker-container driver
#1 [internal] booting buildkit
#1 pulling image moby/buildkit:buildx-stable-1 2.7s done
#1 ERROR: failed to inspect pulled image moby/buildkit:buildx-stable-1: Error response from daemon: 404 page not found
ERROR: failed to build: failed to inspect pulled image moby/buildkit:buildx-stable-1: Error response from daemon: 404 page not found
[error] (kubernetes-integration-tests / dockerImgs) java.lang.IllegalStateException: Process ... exited with code 1
```

Minikube 1.38.1 still defaults to the Docker runtime and passes; 1.39.0 fails consistently.

`container-runtime: docker` is the fix rather than pinning `minikube-version`, because it
addresses the cause and does not freeze CI on an aging Minikube. The Docker runtime remains
fully supported in 1.39.0 -- that release ships cri-dockerd v0.4.3 and includes a
cri-dockerd fix specifically for Kubernetes v1.36+
([kubernetes/minikube#22921](https://github.com/kubernetes/minikube/pull/22921)) -- so
`docker` stays a valid choice for the Kubernetes versions these two jobs use (1.37.0 and
1.36.0). Runners are x86_64, which cri-dockerd supports.

Fixing only `k8s-integration-tests` would leave `oidc-e2e` broken, since it builds its
image the same way; both steps are updated.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

By CI in this PR. This change touches only `.github`, which `dev/is-changed.py` maps to the
`root` module, so both `k8s-integration-tests` and `oidc-e2e` run here and exercise the
image build path that was failing.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
