### PR TITLE
[SPARK-57417][SQL][PYTHON][FOLLOWUP] Fix the `variant_delete` version to 4.3.0

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -23063,7 +23063,7 @@ def variant_delete(v: "ColumnOrName", *paths: Union[Column, str]) -> Column:
     Multiple paths are applied left to right. Returns NULL if `v` is NULL; NULL paths are
     skipped.
 
-    .. versionadded:: 5.0.0
+    .. versionadded:: 4.3.0
 
     Parameters
     ----------

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -14453,7 +14453,7 @@ object functions {
    *   additional JSONPath arguments, applied after `path` in order. A column that evaluates to a
    *   string.
    * @group variant_funcs
-   * @since 5.0.0
+   * @since 4.3.0
    * @return
    *   Returns a column that evaluates to a variant.
    */
@@ -14474,7 +14474,7 @@ object functions {
    * @param paths
    *   additional JSONPath strings, applied after `path` in order. A string. Must be a constant.
    * @group variant_funcs
-   * @since 5.0.0
+   * @since 4.3.0
    * @return
    *   Returns a column that evaluates to a variant.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -882,7 +882,7 @@ object TryVariantGetExpressionBuilder extends VariantGetExpressionBuilderBase(fa
       > SELECT _FUNC_(NULL, '$.a');
        NULL
   """,
-  since = "5.0.0",
+  since = "4.3.0",
   group = "variant_funcs"
 )
 // scalastyle:on line.size.limit


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the version metadata of the `variant_delete` expression, which was incorrectly recorded as `5.0.0` instead of `4.3.0`.

Four places are corrected:

| File | Item |
| --- | --- |
| `sql/catalyst/.../variant/variantExpressions.scala` | `VariantDelete`'s `@ExpressionDescription(since = ...)` |
| `sql/api/.../functions.scala` | `@since` of `variant_delete(Column, Column, Column*)` |
| `sql/api/.../functions.scala` | `@since` of `variant_delete(Column, String, String*)` |
| `python/pyspark/sql/functions/builtin.py` | `.. versionadded::` |

`python/pyspark/sql/connect/functions/builtin.py` needs no change since it reuses the classic docstring via `variant_delete.__doc__ = pysparkfuncs.variant_delete.__doc__`.

### Why are the changes needed?

`variant_delete` was added by [SPARK-57417](https://issues.apache.org/jira/browse/SPARK-57417) (77d302a1d5a, 2026-06-17) and backported to `branch-4.3` as 38e2143defa, so it first ships in Apache Spark 4.3.0, not 5.0.0. The commit is already contained in the [v4.3.0-rc1](https://github.com/apache/spark/releases/tag/v4.3.0-rc1) tag (2026-08-31).
- https://github.com/apache/spark/pull/56471

The wrong version misleads users about the minimum Spark version required to use this function, and it is surfaced publicly through the SQL built-in function documentation, the Scala API Scaladoc, and the PySpark API docs.

### Does this PR introduce _any_ user-facing change?

No behavior change. This only corrects the documented availability version of `variant_delete` from `5.0.0` to `4.3.0`. Since `variant_delete` has not been released yet, this is a correction within unreleased branches only.

### How was this patch tested?

Documentation metadata change only, no logic is touched. Existing tests for `variant_delete` (`VariantExpressionSuite`, `VariantSuite`, `PlanGenerationTestSuite`, and the PySpark doctests) continue to cover the function.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5