### PR TITLE
[SPARK-59229][CORE] Identify Apache Spark in the User-Agent for Ivy dependency resolution

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -34,13 +34,38 @@ import org.apache.ivy.plugins.matcher.GlobPatternMatcher
 import org.apache.ivy.plugins.repository.file.FileRepository
 import org.apache.ivy.plugins.resolver.{ChainResolver, FileSystemResolver, IBiblioResolver}
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkBuildInfo, SparkException}
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.util.ArrayImplicits._
 
 /** Provides utility functions to be used inside SparkSubmit. */
 private[spark] object MavenUtils extends Logging {
   val JAR_IVY_SETTING_PATH_KEY: String = "spark.jars.ivySettings"
+
+  /** System property Ivy reads to determine the HTTP User-Agent. */
+  private[util] val USER_AGENT_PROPERTY = "http.agent"
+
+  /**
+   * User-Agent identifying Spark to remote artifact repositories, in the form
+   * `product RWS comment` per RFC 9110 Section 10.1.5, e.g.
+   * `Apache-Spark/4.0.0 (Apache-Ivy/2.5.3)`. Repository operators use this to attribute traffic
+   * and to identify the tool and version behind it.
+   */
+  private[util] lazy val sparkUserAgent: String =
+    s"Apache-Spark/${SparkBuildInfo.spark_version} (Apache-Ivy/${Ivy.getIvyVersion})"
+
+  /**
+   * Set the `http.agent` system property so Ivy identifies itself as Spark when fetching from
+   * remote repositories. Set once and left in place: Ivy's HttpClient-backed handler captures the
+   * User-Agent when its singleton is class-initialized, so restoring the previous value afterwards
+   * would have no effect on requests and would race with concurrent resolution. An explicitly
+   * configured value always wins, so an operator can still override with `-Dhttp.agent=...`.
+   */
+  private def setUserAgentIfAbsent(): Unit = {
+    if (System.getProperty(USER_AGENT_PROPERTY) == null) {
+      System.setProperty(USER_AGENT_PROPERTY, sparkUserAgent)
+    }
+  }
 
   // Exposed for testing
   // var printStream = SparkSubmit.printStream
@@ -277,6 +302,7 @@ private[spark] object MavenUtils extends Logging {
       remoteRepos: Option[String],
       ivyPath: Option[String],
       useLocalM2AsCache: Boolean = true)(implicit printStream: PrintStream): IvySettings = {
+    setUserAgentIfAbsent()
     val ivySettings: IvySettings = new IvySettings
     processIvyPathArg(ivySettings, ivyPath)
 
@@ -310,6 +336,7 @@ private[spark] object MavenUtils extends Logging {
    */
   def loadIvySettings(settingsFile: String, remoteRepos: Option[String], ivyPath: Option[String])(
       implicit printStream: PrintStream): IvySettings = {
+    setUserAgentIfAbsent()
     val uri = new URI(settingsFile)
     val file = Option(uri.getScheme).getOrElse("file") match {
       case "file" => new File(uri.getPath)

--- a/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala
@@ -25,12 +25,14 @@ import java.nio.file.{Files, Paths}
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
+import org.apache.ivy.Ivy
 import org.apache.ivy.core.module.descriptor.MDArtifact
 import org.apache.ivy.core.settings.IvySettings
 import org.apache.ivy.plugins.resolver.{AbstractResolver, ChainResolver, FileSystemResolver, IBiblioResolver}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
+import org.apache.spark.SparkBuildInfo
 import org.apache.spark.util.MavenUtils.MavenCoordinate
 
 class MavenUtilsSuite
@@ -38,6 +40,8 @@ class MavenUtilsSuite
     with BeforeAndAfterEach {
 
   private var tempIvyPath: String = _
+
+  private var originalUserAgent: Option[String] = None
 
   private val noOpOutputStream = new OutputStream {
     def write(b: Int) = {}
@@ -57,10 +61,18 @@ class MavenUtilsSuite
 
   override def beforeEach(): Unit = {
     super.beforeEach()
+    // `buildIvySettings` and `loadIvySettings` set this global property as a side effect;
+    // save and clear it so each test is isolated and the value does not leak to other suites.
+    originalUserAgent = Option(System.getProperty(MavenUtils.USER_AGENT_PROPERTY))
+    System.clearProperty(MavenUtils.USER_AGENT_PROPERTY)
     tempIvyPath = SparkFileUtils.createTempDir(namePrefix = "ivy").getAbsolutePath()
   }
 
   override def afterEach(): Unit = {
+    originalUserAgent match {
+      case Some(userAgent) => System.setProperty(MavenUtils.USER_AGENT_PROPERTY, userAgent)
+      case None => System.clearProperty(MavenUtils.USER_AGENT_PROPERTY)
+    }
     SparkFileUtils.deleteRecursively(new File(tempIvyPath))
     super.afterEach()
   }
@@ -308,5 +320,42 @@ class MavenUtilsSuite
       assert(!jarPath.exists(_.indexOf("mydep") >= 0), "should not find pom dependency." +
         s" Resolved jars are: $jarPath")
     }
+  }
+
+  test("SPARK-59229: user agent identifies Spark and the underlying Ivy version") {
+    val userAgent = MavenUtils.sparkUserAgent
+    // `product RWS comment` per RFC 9110 Section 10.1.5.
+    assert(userAgent.matches("""^Apache-Spark/\S+ \(Apache-Ivy/\S+\)$"""),
+      s"User agent [$userAgent] does not match the RFC 9110 product/comment form")
+    assert(userAgent === s"Apache-Spark/${SparkBuildInfo.spark_version} " +
+      s"(Apache-Ivy/${Ivy.getIvyVersion})")
+  }
+
+  test("SPARK-59229: buildIvySettings sets the user agent when it is unset") {
+    assert(System.getProperty(MavenUtils.USER_AGENT_PROPERTY) === null)
+    MavenUtils.buildIvySettings(None, Some(tempIvyPath))
+    assert(System.getProperty(MavenUtils.USER_AGENT_PROPERTY) === MavenUtils.sparkUserAgent)
+  }
+
+  test("SPARK-59229: loadIvySettings sets the user agent when it is unset") {
+    val settingsText =
+      s"""
+         |<ivysettings>
+         |  <caches defaultCacheDir="$tempIvyPath/cache"/>
+         |</ivysettings>
+         |""".stripMargin
+    val settingsFile = Paths.get(tempIvyPath, "ivysettings.xml")
+    Files.write(settingsFile, settingsText.getBytes(StandardCharsets.UTF_8))
+
+    assert(System.getProperty(MavenUtils.USER_AGENT_PROPERTY) === null)
+    MavenUtils.loadIvySettings(settingsFile.toString, None, Some(tempIvyPath))
+    assert(System.getProperty(MavenUtils.USER_AGENT_PROPERTY) === MavenUtils.sparkUserAgent)
+  }
+
+  test("SPARK-59229: an explicitly configured user agent is not overwritten") {
+    val configuredUserAgent = "AcmeCorp/1.0"
+    System.setProperty(MavenUtils.USER_AGENT_PROPERTY, configuredUserAgent)
+    MavenUtils.buildIvySettings(None, Some(tempIvyPath))
+    assert(System.getProperty(MavenUtils.USER_AGENT_PROPERTY) === configuredUserAgent)
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -963,6 +963,12 @@ Apart from these, the following properties are also available, and may be useful
     will be searched for in the local maven repo, then maven central and finally any additional remote
     repositories given by the command-line option <code>--repositories</code>. For more details, see
     <a href="submitting-applications.html#advanced-dependency-management">Advanced Dependency Management</a>.
+    <p/>
+    When fetching these artifacts, Spark identifies itself to remote repositories with a
+    <code>User-Agent</code> of the form
+    <code>Apache-Spark/&lt;spark-version&gt; (Apache-Ivy/&lt;ivy-version&gt;)</code>, by setting the
+    <code>http.agent</code> system property if it is not already set. Set
+    <code>-Dhttp.agent=...</code> to override it.
   </td>
   <td>1.5.0</td>
 </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the `http.agent` system property in `MavenUtils` so that Ivy identifies itself as Spark when resolving `--packages` / `spark.jars.packages` coordinates from remote repositories.

Requests now carry:

```
Apache-Spark/4.0.0 (Apache-Ivy/2.5.3)
```

instead of Ivy's default `Apache Ivy/2.5.3`.

The format follows RFC 9110 Section 10.1.5 (`product *( RWS ( product / comment ) )`) — a product token carrying Spark's identity and version, plus a comment carrying the underlying resolution engine, so operator tooling that already matches on the Ivy version keeps working.

Details:

- `http.agent` is Ivy's own designed override point — `AbstractURLHandler.getUserAgent()` returns `System.getProperty("http.agent", "Apache Ivy/" + Ivy.getIvyVersion())`, and both `BasicURLHandler` and `HttpClientHandler` inherit it. No new Ivy API or custom handler is required.
- The property is set **once, if absent**, rather than set-and-restored around the download. `URLHandlerRegistry.getHttp()` returns `HttpClientHandler.DELETE_ON_EXIT_INSTANCE` when httpclient is on the classpath (it is — httpclient 4.5.14 ships in the distribution), and that singleton bakes the User-Agent in at class-initialization time via `HttpClients.custom().setUserAgent(...)`. A save/set/restore wrapper would therefore have no effect on requests and would race between concurrent resolutions.
- `buildIvySettings()` / `loadIvySettings()` are the insertion points: all three call paths (`Artifact.scala`, `IsolatedClientLoader.scala`, `DependencyUtils.scala`) go through one of them before `resolveMavenCoordinates()`, and neither touches HTTP itself. In `loadIvySettings()` it is the first statement, ahead of `ivySettings.load(file)`, because `XmlSettingsParser` is the one reachable path that can trigger `HttpClientHandler`'s static init (when the settings XML carries `httpRequestMethod`).
- `SparkBuildInfo.spark_version` is used rather than `org.apache.spark.SPARK_VERSION`, which lives in `core` and is not available from `common/utils`.

### Why are the changes needed?

Repository operators rely on the User-Agent to attribute traffic and to reach the responsible party when a client misbehaves. A bare `Apache Ivy/2.5.3` is un-attributable: it could be Spark, Ant, sbt, or a hand-rolled Ivy client. Operators cannot tell which tool to talk to, cannot distinguish an old Spark with poor caching behavior from a current one, and have no signal to route a conversation about excessive consumption.

This matters in practice because Spark clusters without a repository-manager proxy generate a burst of resolution traffic at every job launch, so Spark is a meaningful share of this traffic on public repositories.

### Does this PR introduce _any_ user-facing change?

Yes, in two respects, both additive:

1. Requests Spark makes to remote artifact repositories during dependency resolution now carry `User-Agent: Apache-Spark/<version> (Apache-Ivy/<version>)` instead of `Apache Ivy/<version>`. No resolution behavior changes.
2. Setting `-Dhttp.agent=...` explicitly continues to win — the property is only set when unset — and this is now documented under `spark.jars.packages` in `docs/configuration.md`.

Note that `http.agent` is a JVM-global property affecting any `HttpURLConnection`, not only Ivy. In practice the Spark-adjacent HTTP clients (Hadoop, AWS SDK, Kubernetes client) use their own stacks and set their own User-Agent, so the blast radius is small, and labelling stray JDK-level requests from a Spark driver as Spark is accurate anyway. The set-only-if-absent guard is the mitigation.

### How was this patch tested?

New tests in `MavenUtilsSuite`:

- the User-Agent matches the RFC 9110 `product RWS comment` form, and is composed from the real `SparkBuildInfo.spark_version` and `Ivy.getIvyVersion` rather than a hardcoded literal;
- `buildIvySettings` sets the property when it is unset;
- `loadIvySettings` sets it too;
- an explicitly configured value is not overwritten.

The suite's `beforeEach`/`afterEach` were extended to save, clear, and restore `http.agent`, so the new global side effect cannot leak between tests or into other suites in the same JVM.

```
./build/mvn -pl common/utils -am test
```
→ 101 tests succeeded, 0 failed (`MavenUtilsSuite`: `tests="17" failures="0" errors="0"`).

`./dev/scalastyle` → passed.

Additionally, verified on the wire rather than only by inspection, since the `HttpClientHandler` class-init timing is the part worth confirming empirically. A local HTTP server was pointed at as the repository and the request headers logged:

```
CONFIGURED_AGENT=Apache-Spark/5.0.0-SNAPSHOT (Apache-Ivy/2.5.3)
OBSERVED_USER_AGENT=Apache-Spark/5.0.0-SNAPSHOT (Apache-Ivy/2.5.3)
```

and with the override in place:

```
CONFIGURED_AGENT=AcmeCorp/1.0
OBSERVED_USER_AGENT=AcmeCorp/1.0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
