### PR TITLE
[SPARK-59119][CONNECT][PYTHON] Do not crash on cyclic or out-of-range cause_idx in error details

### DIFF
--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -287,11 +287,18 @@ def _extract_jvm_stacktrace(
                 f"({elem.file_name}:{elem.line_number})"
             )
 
-        # If this error has a cause, format that recursively
-        if error.HasField("cause_idx"):
-            format_stacktrace(errors[error.cause_idx])
-
-    format_stacktrace(errors[root_error_idx])
+    # Follow the cause chain iteratively and stop on an out-of-range or already
+    # visited index, so that malformed error details (e.g. a cyclic cause_idx)
+    # cannot crash the client.
+    visited = set()
+    error_idx = root_error_idx
+    while 0 <= error_idx < len(errors) and error_idx not in visited:
+        visited.add(error_idx)
+        error = errors[error_idx]
+        format_stacktrace(error)
+        if not error.HasField("cause_idx"):
+            break
+        error_idx = error.cause_idx
 
     return "\n".join(lines)
 

--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -169,6 +169,62 @@ class ConnectErrorsTest(unittest.TestCase):
         self.assertIn("Root error message", exception.getMessage())
         self.assertIn("Caused by", exception.getMessage())
 
+    def test_convert_exception_with_malformed_cause_chain(self):
+        """SPARK-59119: a cyclic or out-of-range cause_idx in the error details
+        should not crash the conversion."""
+        from google.rpc.error_details_pb2 import ErrorInfo
+
+        from pyspark.sql.connect.proto import FetchErrorDetailsResponse as pb2
+
+        info = ErrorInfo(
+            reason="org.apache.spark.SparkException",
+            metadata={"classes": '["org.apache.spark.SparkException"]'},
+        )
+
+        def make_resp(root_cause_idx, second_cause_idx=None):
+            root = pb2.Error(
+                message="Root error message",
+                error_type_hierarchy=["org.apache.spark.SparkException"],
+                cause_idx=root_cause_idx,
+            )
+            second = pb2.Error(
+                message="Cause error message",
+                error_type_hierarchy=["java.lang.RuntimeException"],
+            )
+            if second_cause_idx is not None:
+                second.cause_idx = second_cause_idx
+            return pb2(root_error_idx=0, errors=[root, second])
+
+        # Two errors pointing at each other; each one is formatted exactly once.
+        exception = convert_exception(
+            info=info,
+            truncated_message="Root error message",
+            resp=make_resp(1, 0),
+            display_server_stacktrace=True,
+        )
+        self.assertIsInstance(exception, SparkConnectGrpcException)
+        self.assertEqual(exception.getMessage().count("Caused by"), 1)
+
+        # An error listed as its own cause.
+        exception = convert_exception(
+            info=info,
+            truncated_message="Root error message",
+            resp=make_resp(0),
+            display_server_stacktrace=True,
+        )
+        self.assertIsInstance(exception, SparkConnectGrpcException)
+        self.assertEqual(exception.getMessage().count("Caused by"), 0)
+
+        # A cause_idx outside the error list.
+        exception = convert_exception(
+            info=info,
+            truncated_message="Root error message",
+            resp=make_resp(5),
+            display_server_stacktrace=True,
+        )
+        self.assertIsInstance(exception, SparkConnectGrpcException)
+        self.assertIn("Root error message", exception.getMessage())
+
     def test_convert_exception_fallback(self):
         # Mock ErrorInfo with missing class information
         from google.rpc.error_details_pb2 import ErrorInfo


### PR DESCRIPTION
### What changes were proposed in this pull request?

`_extract_jvm_stacktrace` in `pyspark/errors/exceptions/connect.py` follows the `cause_idx` chain from `FetchErrorDetailsResponse` recursively, without validating the index. This PR walks the chain iteratively instead and stops when the next index is out of range or has already been visited, so each error is formatted at most once.

The Scala client has a similar unguarded recursion in `GrpcExceptionConverter.errorsToThrowable`; this PR only covers the Python client.

### Why are the changes needed?

If the error details returned by `FetchErrorDetails` contain a malformed cause chain, the client crashes inside error conversion and the original server error is lost:

- a cyclic `cause_idx` (two errors pointing at each other, or an error listed as its own cause) raises `RecursionError: maximum recursion depth exceeded`
- an out-of-range `cause_idx` raises `IndexError: list index out of range`

Reproducible by calling `convert_exception` with a `FetchErrorDetailsResponse` where `errors[0].cause_idx = 1` and `errors[1].cause_idx = 0`.

### Does this PR introduce _any_ user-facing change?

Only for malformed error details: the client now raises the converted server exception instead of `RecursionError`/`IndexError`. Well-formed cause chains are formatted exactly as before.

### How was this patch tested?

Added `test_convert_exception_with_malformed_cause_chain` to `pyspark.errors.tests.test_connect_errors_conversion` covering the mutual cycle, the self-cycle, and the out-of-range case. All tests in the module pass:

```
python -m pytest python/pyspark/errors/tests/test_connect_errors_conversion.py
13 passed
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
