### PR TITLE
[SPARK-59188][SQL] Make CatalogV2Util.replace recurse through nested collections

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, MapType, Metadata, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, Metadata, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -426,8 +426,9 @@ private[sql] object CatalogV2Util {
             .getOrElse(throw new SparkIllegalArgumentException("_LEGACY_ERROR_TEMP_3226"))
         Some(field.copy(dataType = map.copy(keyType = updated.dataType)))
 
-      case (Seq("key", names @ _*), map @ MapType(keyStruct: StructType, _, _)) =>
-        Some(field.copy(dataType = map.copy(keyType = replace(keyStruct, names, update, ifExists))))
+      case (Seq("key", names @ _*), map: MapType) =>
+        Some(field.copy(dataType = map.copy(keyType =
+          replaceNested(map.keyType, names, update, ifExists))))
 
       case (Seq("value"), map @ MapType(_, mapValueType, isNullable)) =>
         val updated = update(StructField("value", mapValueType, nullable = isNullable))
@@ -436,9 +437,9 @@ private[sql] object CatalogV2Util {
           valueType = updated.dataType,
           valueContainsNull = updated.nullable)))
 
-      case (Seq("value", names @ _*), map @ MapType(_, valueStruct: StructType, _)) =>
+      case (Seq("value", names @ _*), map: MapType) =>
         Some(field.copy(dataType = map.copy(valueType =
-          replace(valueStruct, names, update, ifExists))))
+          replaceNested(map.valueType, names, update, ifExists))))
 
       case (Seq("element"), array @ ArrayType(elementType, isNullable)) =>
         val updated = update(StructField("element", elementType, nullable = isNullable))
@@ -447,9 +448,9 @@ private[sql] object CatalogV2Util {
           elementType = updated.dataType,
           containsNull = updated.nullable)))
 
-      case (Seq("element", names @ _*), array @ ArrayType(elementStruct: StructType, _)) =>
+      case (Seq("element", names @ _*), array: ArrayType) =>
         Some(field.copy(dataType = array.copy(elementType =
-          replace(elementStruct, names, update, ifExists))))
+          replaceNested(array.elementType, names, update, ifExists))))
 
       case (names, dataType) =>
         if (!ifExists) {
@@ -468,6 +469,55 @@ private[sql] object CatalogV2Util {
     }
 
     new StructType(newFields)
+  }
+
+  /**
+   * Applies `update` to the nested field addressed by `fieldNames`, where `dataType` is the type
+   * reached after stepping into a map key/value or an array element. Unlike `replace`, which only
+   * descends into structs, this also recurses through nested maps and arrays, matching the paths
+   * emitted for schema changes computed against nested collection types.
+   */
+  private def replaceNested(
+      dataType: DataType,
+      fieldNames: Seq[String],
+      update: StructField => Option[StructField],
+      ifExists: Boolean): DataType = {
+    (fieldNames, dataType) match {
+      case (names, struct: StructType) =>
+        replace(struct, names, update, ifExists)
+
+      case (Seq("key"), map @ MapType(keyType, _, _)) =>
+        val updated = update(StructField("key", keyType, nullable = false))
+            .getOrElse(throw new SparkIllegalArgumentException("_LEGACY_ERROR_TEMP_3226"))
+        map.copy(keyType = updated.dataType)
+
+      case (Seq("key", names @ _*), map: MapType) =>
+        map.copy(keyType = replaceNested(map.keyType, names, update, ifExists))
+
+      case (Seq("value"), map @ MapType(_, mapValueType, isNullable)) =>
+        val updated = update(StructField("value", mapValueType, nullable = isNullable))
+            .getOrElse(throw new SparkIllegalArgumentException("_LEGACY_ERROR_TEMP_3225"))
+        map.copy(valueType = updated.dataType, valueContainsNull = updated.nullable)
+
+      case (Seq("value", names @ _*), map: MapType) =>
+        map.copy(valueType = replaceNested(map.valueType, names, update, ifExists))
+
+      case (Seq("element"), array @ ArrayType(elementType, isNullable)) =>
+        val updated = update(StructField("element", elementType, nullable = isNullable))
+            .getOrElse(throw new SparkIllegalArgumentException("_LEGACY_ERROR_TEMP_3224"))
+        array.copy(elementType = updated.dataType, containsNull = updated.nullable)
+
+      case (Seq("element", names @ _*), array: ArrayType) =>
+        array.copy(elementType = replaceNested(array.elementType, names, update, ifExists))
+
+      case (names, other) =>
+        if (!ifExists) {
+          throw new SparkIllegalArgumentException(
+            errorClass = "_LEGACY_ERROR_TEMP_3223",
+            messageParameters = Map("name" -> names.head, "dataType" -> other.simpleString))
+        }
+        dataType
+    }
   }
 
   def loadTable(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.{
   AsOfTimestamp, AsOfVersion, TimeTravelSpec, UnresolvedRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.types.{ArrayType, DoubleType, IntegerType, LongType, MapType, StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class CatalogV2UtilSuite extends SparkFunSuite {
@@ -273,6 +273,59 @@ class CatalogV2UtilSuite extends SparkFunSuite {
     val existing = viewWithDependencies(None)
     val rebuilt = CatalogV2Util.viewInfoBuilderFrom(existing).build()
     assert(rebuilt.viewDependencies() === null)
+  }
+
+  test("SPARK-59188: add a column to a struct nested in an array of arrays") {
+    val schema = new StructType()
+      .add("col", ArrayType(ArrayType(new StructType().add("x", IntegerType))))
+    val changed = CatalogV2Util.applySchemaChanges(
+      schema,
+      Seq(TableChange.addColumn(Array("col", "element", "element", "y"), DoubleType)),
+      None,
+      "ALTER TABLE")
+    val expected = new StructType()
+      .add("col", ArrayType(ArrayType(
+        new StructType().add("x", IntegerType).add("y", DoubleType))))
+    assert(changed === expected)
+  }
+
+  test("SPARK-59188: update a column type in a struct nested in a map of arrays") {
+    val schema = new StructType()
+      .add("col", MapType(StringType, ArrayType(new StructType().add("x", IntegerType))))
+    val changed = CatalogV2Util.applySchemaChanges(
+      schema,
+      Seq(TableChange.updateColumnType(Array("col", "value", "element", "x"), LongType)),
+      None,
+      "ALTER TABLE")
+    val expected = new StructType()
+      .add("col", MapType(StringType, ArrayType(new StructType().add("x", LongType))))
+    assert(changed === expected)
+  }
+
+  test("SPARK-59188: update the key type of a map nested in an array") {
+    val schema = new StructType()
+      .add("col", ArrayType(MapType(IntegerType, StringType)))
+    val changed = CatalogV2Util.applySchemaChanges(
+      schema,
+      Seq(TableChange.updateColumnType(Array("col", "element", "key"), LongType)),
+      None,
+      "ALTER TABLE")
+    val expected = new StructType()
+      .add("col", ArrayType(MapType(LongType, StringType)))
+    assert(changed === expected)
+  }
+
+  test("SPARK-59188: an invalid path below a nested collection still fails") {
+    val schema = new StructType()
+      .add("col", ArrayType(ArrayType(IntegerType)))
+    val e = intercept[SparkIllegalArgumentException] {
+      CatalogV2Util.applySchemaChanges(
+        schema,
+        Seq(TableChange.addColumn(Array("col", "element", "missing", "y"), DoubleType)),
+        None,
+        "ALTER TABLE")
+    }
+    assert(e.getMessage.contains("missing"))
   }
 
   private def viewWithDependencies(dependencies: Option[DependencyList]): View = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CatalogV2Util.replace` resolves multi-segment paths through collections with patterns like `case (Seq("element", names @ _*), array @ ArrayType(elementStruct: StructType, _))`, so the traversal only continues when the child of a map key/value or array element is a struct. When the child is another collection, e.g. `ARRAY<ARRAY<STRUCT<...>>>`, the path falls through to the catch-all and throws `_LEGACY_ERROR_TEMP_3223`.

This PR relaxes the three multi-segment cases to accept any `MapType`/`ArrayType` child and moves the descent into a new `replaceNested` helper that recurses through nested maps, arrays and structs. Terminal `key`/`value`/`element` segments behave exactly as in the existing single-segment cases, structs delegate back to `replace`, and an unresolvable segment still raises `_LEGACY_ERROR_TEMP_3223` (or is a no-op with `ifExists`).

### Why are the changes needed?

`ResolveSchemaEvolution.computeSchemaChanges` recurses through collections unconditionally and emits paths such as `AddColumn(["col", "element", "element", "y"])` for `col ARRAY<ARRAY<STRUCT<x: INT>>>`, but `CatalogV2Util.applySchemaChanges` cannot apply them:

```
IllegalArgumentException: Cannot find field: element in array<struct<x:int>>
```

so schema evolution fails on any change nested below two levels of collections. The change emitter and the change applier now agree on which paths are valid.

### Does this PR introduce _any_ user-facing change?

Yes: schema changes addressing fields nested in collections of collections (e.g. adding a column to a struct inside an array of arrays, or changing the type of a map key inside an array) now apply instead of throwing. Previously valid paths behave as before.

### How was this patch tested?

New tests in `CatalogV2UtilSuite`: adding a column to a struct in an array of arrays, updating a column type in a struct in a map of arrays, updating a map key type nested in an array, and an invalid nested path still failing.

```
build/sbt "catalyst/testOnly org.apache.spark.sql.connector.catalog.CatalogV2UtilSuite"
```

