### PR TITLE
[SPARK-58944][INFRA][FOLLOWUP] Handle manually completed cherry-picks

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -779,6 +779,7 @@ def _do_cherry_pick(pr_num, merge_hash, pick_ref):
 
     git.run("git fetch %s %s:%s" % (PUSH_REMOTE_NAME, pick_ref, pick_branch_name))
     git.run("git checkout %s" % pick_branch_name)
+    pick_head = git.run("git rev-parse HEAD").strip()
 
     try:
         git.run(
@@ -796,18 +797,21 @@ def _do_cherry_pick(pr_num, merge_hash, pick_ref):
         continue_maybe(msg, True)
         msg = "Okay, please fix any conflicts and 'git add' conflicting files... Finished?"
         continue_maybe(msg, True)
-        # Important to use `scissors` and `--edit` otherwise git will strip lines starting with `#`
-        # when calling `--continue`. See: https://github.com/apache/spark/pull/58214
-        git.run(
-            [
-                "git",
-                "-c",
-                "commit.cleanup=scissors",
-                "cherry-pick",
-                "--continue",
-                "--edit",
-            ]
-        )
+        if git.run("git rev-parse HEAD").strip() == pick_head:
+            # Important to use `scissors` and `--edit` otherwise git will strip lines starting
+            # with `#` when calling `--continue`. See: https://github.com/apache/spark/pull/58214
+            git.run(
+                [
+                    "git",
+                    "-c",
+                    "commit.cleanup=scissors",
+                    "cherry-pick",
+                    "--continue",
+                    "--edit",
+                ]
+            )
+        else:
+            print("Cherry-pick already completed manually; continuing with the backport.")
 
     continue_maybe(
         "Pick complete (local ref %s). Push to %s?" % (pick_branch_name, PUSH_REMOTE_NAME)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Record the target branch's HEAD before starting a cherry-pick. After a conflict is resolved,
continue the cherry-pick in the merge script only when HEAD is unchanged. If the committer already
completed the cherry-pick manually, proceed with the backport instead of invoking
`git cherry-pick --continue` a second time.

### Why are the changes needed?

Git tells committers resolving a cherry-pick conflict to run `git cherry-pick --continue`. If they
follow that instruction before returning to the merge script, the script currently tries to
continue the already-completed cherry-pick and fails with `no cherry-pick or revert in progress`.

### Does this PR introduce _any_ user-facing change?

Yes, for Spark committers using `dev/merge_spark_pr.py`. The script now accepts an already-completed
manual conflict resolution. This only changes unreleased committer tooling.

### How was this patch tested?

Ran `git diff --check`.

Ran `dev/merge_spark_pr.py --dry-run 58404`, selected `branch-4.2`, reproduced the cherry-pick
conflict, resolved it, and manually ran `git cherry-pick --continue`. The script detected the new
HEAD, skipped its second `--continue`, reached the dry-run push, restored the original branch, and
exited successfully without external changes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
