### PR TITLE
[SPARK-59250][SQL] Translate an empty runtime IN filter to AlwaysFalse in DSv2 runtime filtering

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -848,6 +848,10 @@ abstract class InMemoryBaseTable(
     }
 
     override def filter(filters: Array[Filter]): Unit = {
+      if (filters.exists(_.isInstanceOf[AlwaysFalse])) {
+        this.data = Seq.empty
+        return
+      }
       if (partitioning.length == 1 && identityPartitionReferences.length == 1) {
         val ref = identityPartitionReferences.head
         filters.foreach {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
@@ -24,7 +24,7 @@ import org.scalatest.Assertions.assert
 import org.apache.spark.sql.connector.catalog.constraints.Constraint
 import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, NamedReference, SortOrder, Transform}
-import org.apache.spark.sql.connector.expressions.filter.{And, Predicate}
+import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, And, Predicate}
 import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsRuntimeV2Filtering}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsOverwriteV2, WriteBuilder, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
@@ -81,6 +81,10 @@ class InMemoryTableWithV2Filter(
     }
 
     override def filter(filters: Array[Predicate]): Unit = {
+      if (filters.exists(_.isInstanceOf[AlwaysFalse])) {
+        data = Seq.empty
+        return
+      }
       if (partitioning.length == 1 && identityPartitionReferences.length == 1) {
         val ref = identityPartitionReferences.head
         filters.foreach {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, Depend
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
-import org.apache.spark.sql.connector.expressions.filter.{And => V2And, Not => V2Not, Or => V2Or, Predicate}
+import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, And => V2And, Not => V2Not, Or => V2Or, Predicate}
 import org.apache.spark.sql.connector.read.LocalScan
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream, SupportsRealTimeMode}
 import org.apache.spark.sql.connector.write.{V1Write, Write}
@@ -975,6 +975,8 @@ private[sql] object DataSourceV2Strategy extends Logging {
     case TrueLiteral => None
     case in: InSubqueryExec if in.isResultUnavailable =>
       None
+    case in: InSubqueryExec if in.values().exists(_.isEmpty) =>
+      Some(new AlwaysFalse())
     case in @ InSubqueryExec(PushableColumnAndNestedColumn(name), _, _, _, _, _) =>
       val values = in.values().getOrElse {
         throw SparkException.internalError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -2659,29 +2659,14 @@ class DynamicPartitionPruningV1SuiteAEOn extends DynamicPartitionPruningV1Suite
 }
 
 abstract class DynamicPartitionPruningV2Suite extends DynamicPartitionPruningDataSourceSuiteBase {
+  import testImplicits._
+
   override protected def runAnalyzeColumnCommands: Boolean = false
 
   override protected def initState(): Unit = {
     spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryTableCatalog].getName)
     spark.conf.set("spark.sql.defaultCatalog", "testcat")
   }
-}
-
-class DynamicPartitionPruningV2SuiteAEOff extends DynamicPartitionPruningV2Suite
-  with DisableAdaptiveExecutionSuite
-
-class DynamicPartitionPruningV2SuiteAEOn extends DynamicPartitionPruningV2Suite
-  with EnableAdaptiveExecutionSuite
-
-abstract class DynamicPartitionPruningV2FilterSuite
-    extends DynamicPartitionPruningV2Suite {
-
-  override protected def initState(): Unit = {
-    super.initState()
-    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryTableWithV2FilterCatalog].getName)
-  }
-
-  import testImplicits._
 
   private def collectFactScan(df: DataFrame): BatchScanExec = {
     val scans = collectWithSubqueries(df.queryExecution.executedPlan) {
@@ -2743,6 +2728,21 @@ abstract class DynamicPartitionPruningV2FilterSuite
             s"got ${scan.filteredPartitions.flatten.size} of ${scan.inputPartitions.size}")
       }
     }
+  }
+}
+
+class DynamicPartitionPruningV2SuiteAEOff extends DynamicPartitionPruningV2Suite
+  with DisableAdaptiveExecutionSuite
+
+class DynamicPartitionPruningV2SuiteAEOn extends DynamicPartitionPruningV2Suite
+  with EnableAdaptiveExecutionSuite
+
+abstract class DynamicPartitionPruningV2FilterSuite
+    extends DynamicPartitionPruningV2Suite {
+
+  override protected def initState(): Unit = {
+    super.initState()
+    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryTableWithV2FilterCatalog].getName)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -2680,6 +2680,70 @@ abstract class DynamicPartitionPruningV2FilterSuite
     super.initState()
     spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryTableWithV2FilterCatalog].getName)
   }
+
+  import testImplicits._
+
+  private def collectFactScan(df: DataFrame): BatchScanExec = {
+    val scans = collectWithSubqueries(df.queryExecution.executedPlan) {
+      case b: BatchScanExec if b.runtimeFilters.nonEmpty => b
+    }
+    assert(scans.size == 1, s"expected exactly 1 scan with runtime filters, got:\n$scans")
+    scans.head
+  }
+
+  test("SPARK-59250: DPP prunes all DSv2 partitions when the runtime IN filter is empty",
+    DisableAdaptiveExecution("an empty build side collapses the join under AQE")) {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      // no dim rows match, so the runtime filter degenerates into store_id IN ()
+      val df = sql(
+        """
+          |SELECT f.date_id, f.store_id FROM fact_sk f
+          |JOIN dim_store s ON f.store_id = s.store_id AND s.country = 'XX'
+        """.stripMargin)
+
+      checkPartitionPruningPredicate(df, withSubquery = true, withBroadcast = false)
+      checkAnswer(df, Nil)
+
+      val scan = collectFactScan(df)
+      assert(scan.filteredPartitions.flatten.isEmpty,
+        s"expected all partitions pruned by the empty runtime filter, " +
+          s"got ${scan.filteredPartitions.flatten.size} of ${scan.inputPartitions.size}")
+    }
+  }
+
+  test("SPARK-59250: DPP prunes all DSv2 partitions when the runtime IN filter " +
+    "on a cast key is empty",
+    DisableAdaptiveExecution("an empty build side collapses the join under AQE")) {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      withTable("dim_big") {
+        Seq[(Long, String)]((1L, "NL"), (2L, "NL"), (3L, "DE"), (4L, "US"), (5L, "US"))
+          .toDF("store_id", "country")
+          .write
+          .format(tableFormat)
+          .saveAsTable("dim_big")
+
+        // the BIGINT dim key adds cast(f.store_id as bigint) on the pruning key, and no dim
+        // rows match, so the runtime filter degenerates into cast(store_id) IN ()
+        val df = sql(
+          """
+            |SELECT f.date_id, f.store_id FROM fact_sk f
+            |JOIN dim_big s ON f.store_id = s.store_id AND s.country = 'XX'
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df, withSubquery = true, withBroadcast = false)
+        checkAnswer(df, Nil)
+
+        val scan = collectFactScan(df)
+        assert(scan.filteredPartitions.flatten.isEmpty,
+          s"expected all partitions pruned by the empty runtime filter, " +
+            s"got ${scan.filteredPartitions.flatten.size} of ${scan.inputPartitions.size}")
+      }
+    }
+  }
 }
 
 class DynamicPartitionPruningV2FilterSuiteAEOff


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `DataSourceV2Strategy.translateRuntimeFilterV2`, match an `InSubqueryExec` whose subquery result is empty before the pushable-column check, and translate it to `AlwaysFalse`.

`expr IN ()` is false for every row regardless of `expr`, so the translation is valid even when `expr` itself is untranslatable, e.g. a join key wrapped in a cast inserted by type coercion (`cast(col as bigint) IN dynamicpruning#x`).

The test connector scans `InMemoryTableWithV2Filter` and `InMemoryBaseTable.InMemoryBatchScan` are updated to honor `AlwaysFalse` by pruning all partitions.

### Why are the changes needed?

When the build side of a DPP join produces no rows, the runtime filter degenerates to `key IN ()`. Today this is either emitted as a zero-value `IN` predicate that connectors cannot interpret meaningfully (Spark's own `InMemoryTableWithV2Filter` ignores it: its `filter()` requires `children().length > 1`), or, when the key is wrapped in a cast, dropped entirely with "Can't translate ... unsupported expression". Either way the scan reads every partition to produce zero output rows.

Translating to `AlwaysFalse` prunes everything and makes the connector contract explicit: connectors receive a well-defined predicate instead of a degenerate IN.

### Does this PR introduce _any_ user-facing change?

No correctness change. DSv2 scans receiving an empty runtime IN filter can now prune all partitions instead of reading everything.

### How was this patch tested?

New tests in `DynamicPartitionPruningV2Suite` covering a bare pruning key and a cast-wrapped pruning key; both assert `filteredPartitions` is empty. The tests run through V1 `Filter`, V2 `Predicate`, and Catalyst runtime filtering. Previously all 25 partitions were read.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5
