### PR TITLE
[SPARK-59253][UDF] Fix direct dispatcher interrupt race

### DIFF
--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerDispatcher.scala
@@ -356,6 +356,7 @@ abstract class DirectWorkerDispatcher(
         }
       }
     }
+    interrupted = Thread.interrupted() || interrupted
     interrupted
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Capture and clear an interrupt that races with lifecycle notification in
`DirectWorkerDispatcher.awaitInFlightOperations()`.

The interrupt is checked after leaving the `lifecycleLock.synchronized` block.
`Thread.interrupted()` is evaluated first so the interrupt flag is always
cleared. `close()` restores the interrupt after cleanup completes.

### Why are the changes needed?

`lifecycleLock.wait()` may return normally after notification while an
overlapping interrupt leaves the thread's interrupt flag set. Subsequent
cleanup may then fail with `InterruptedException` before it completes.

### Does this PR introduce _any_ user-facing change?

No. The affected UDF worker functionality is unreleased and experimental.

### How was this patch tested?

The existing regression test passed 40 consecutive runs:

`DirectWorkerDispatcherSuite: interrupted close completes cleanup before restoring the interrupt`

The full `DirectWorkerDispatcherSuite` also passed with all 34 tests successful.

### Was this patch authored or co-authored using generative AI tooling?

Yes.
