### PR TITLE
[SPARK-57938][DOCS] Print active SKIP_ flags when Ruby doc build script runs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1152,12 +1152,6 @@ jobs:
           if [ `./dev/is-changed.py -m $pyspark_modules` = false ]; then export SKIP_PYTHONDOC=1; fi
           if [ `./dev/is-changed.py -m sparkr` = false ]; then export SKIP_RDOC=1; fi
         fi
-        # Print the values of environment variables `SKIP_ERRORDOC`, `SKIP_SCALADOC`, `SKIP_PYTHONDOC`, `SKIP_RDOC` and `SKIP_SQLDOC`
-        echo "SKIP_ERRORDOC: $SKIP_ERRORDOC"
-        echo "SKIP_SCALADOC: $SKIP_SCALADOC"
-        echo "SKIP_PYTHONDOC: $SKIP_PYTHONDOC"
-        echo "SKIP_RDOC: $SKIP_RDOC"
-        echo "SKIP_SQLDOC: $SKIP_SQLDOC"
         cd docs
         bundle exec jekyll build
     - name: Tar documentation

--- a/docs/_plugins/build_api_docs.rb
+++ b/docs/_plugins/build_api_docs.rb
@@ -33,6 +33,16 @@ def print_header(text)
   puts banner_bar
 end
 
+def print_skip_flags
+  print_header "Skip flags enabled"
+  skip_flags = ENV.select { |name, value| name.start_with?('SKIP_') && value == '1' }.sort
+  if skip_flags.empty?
+    puts "None"
+  else
+    skip_flags.each { |name, value| puts "#{name}" }
+  end
+end
+
 def build_spark_if_necessary
   # If spark has already been compiled on the host, skip here.
   if ENV['SPARK_DOCS_IS_BUILT_ON_HOST'] == '1'
@@ -355,6 +365,8 @@ def build_error_docs
   system("python3 '#{SPARK_PROJECT_ROOT}/docs/_plugins/build-error-docs.py'") \
   || raise("Error doc generation failed")
 end
+
+print_skip_flags
 
 if not (ENV['SKIP_ERRORDOC'] == '1')
   build_error_docs


### PR DESCRIPTION
### What changes were proposed in this pull request?

It's useful to know what skip flags are active when the documentation build runs. Instead of `echo`-ing them in the places where we want to know, the build script now prints them itself when it runs.

Extracted from #57010.

### Why are the changes needed?

Helps troubleshoot builds when we want to know what exactly was supposed to run.

The new method to print flags is naive in that it prints all flags that begin with `SKIP_`, even if they have no special meaning to the script. It's a minor tradeoff that lets us avoid repeating the names of every "real" skip flag.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I ran the doc build locally.

```
$ SKIP_API=1 SKIP_SCALADOC=1 SKIP_PYTHONDOC=1 bundle exec jekyll build
Configuration file: .../spark/docs/_config.yml

**********************
* Skip flags enabled *
**********************
SKIP_API
SKIP_PYTHONDOC
SKIP_SCALADOC

************************
* Building error docs. *
************************
Generated: docs/_generated/error-conditions.html
            Source: .../spark/docs
       Destination: .../spark/docs/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 7.553 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

### Was this patch authored or co-authored using generative AI tooling?

No.
