### PR TITLE
[SPARK-59256][SQL] Choose a ShuffleSpecCollection member by pairing, not by enumeration order

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -318,7 +318,7 @@ trait HashPartitioningLike extends Expression with Partitioning with Unevaluable
 case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
   extends HashPartitioningLike {
 
-  override def createShuffleSpec(distribution: ClusteredDistribution): ShuffleSpec =
+  override def createShuffleSpec(distribution: ClusteredDistribution): HashShuffleSpec =
     HashShuffleSpec(this, distribution)
 
   /**
@@ -364,7 +364,7 @@ case class NullAwareHashPartitioning(expressions: Seq[Expression], numPartitions
     }
   }
 
-  override def createShuffleSpec(distribution: ClusteredDistribution): ShuffleSpec =
+  override def createShuffleSpec(distribution: ClusteredDistribution): NullAwareHashShuffleSpec =
     NullAwareHashShuffleSpec(this, distribution)
 
   override protected def withNewChildrenInternal(
@@ -839,7 +839,7 @@ case class KeyedPartitioning(
     if (isGrouped) keysSatisfy(required) else mayGroupToSatisfy(required)
   }
 
-  override def createShuffleSpec(distribution: ClusteredDistribution): ShuffleSpec = {
+  override def createShuffleSpec(distribution: ClusteredDistribution): KeyedShuffleSpec = {
     val result = KeyedShuffleSpec(this, distribution)
     if (SQLConf.get.v2BucketingAllowKeysSubsetOfPartitionKeys) {
       val joinKeyPositions = result.keyPositions.map(_.nonEmpty).zipWithIndex.filter(_._1).map(_._2)
@@ -860,7 +860,14 @@ case class KeyedPartitioning(
       // rejects them. `project` carries the unknown-keys marker across: only an identity
       // projection reaches here when it is set, the refusal above turns away the narrowing one.
       val projectedPartitioning = project(joinKeyPositions).toGrouped
-      result.copy(partitioning = projectedPartitioning, joinKeyPositions = Some(joinKeyPositions))
+      // Report a projection only where it changed something, so that `joinKeyPositions.isEmpty`
+      // means "this is the child's own layout" (see the `@param`).
+      if (projectedPartitioning == this) {
+        result
+      } else {
+        result.copy(
+          partitioning = projectedPartitioning, joinKeyPositions = Some(joinKeyPositions))
+      }
     } else {
       result
     }
@@ -1290,18 +1297,6 @@ case class BroadcastPartitioning(mode: BroadcastMode) extends Partitioning {
 }
 
 /**
- * This is used in the scenario where an operator has multiple children (e.g., join) and one or more
- * of which have their own requirement regarding whether its data can be considered as
- * co-partitioned from others. This offers APIs for:
- *
- *   - Comparing with specs from other children of the operator and check if they are compatible.
- *      When two specs are compatible, we can say their data are co-partitioned, and Spark will
- *      potentially be able to eliminate shuffle if necessary.
- *   - Creating a partitioning that can be used to re-partition another child, so that to make it
- *      having a compatible partitioning as this node.
- */
-
-/**
  * Represents a partitioning where partition IDs are passed through directly from the
  * DirectShufflePartitionID expression. This partitioning scheme is used when users
  * want to directly control partition placement rather than using hash-based partitioning.
@@ -1344,12 +1339,16 @@ case class ShufflePartitionIdPassThrough(
     copy(expr = newChildren.head.asInstanceOf[DirectShufflePartitionID])
 }
 
-trait ShuffleSpec {
-  /**
-   * Returns the number of partitions of this shuffle spec
-   */
-  def numPartitions: Int
-
+/**
+ * Describes how a child's data is laid out, for the purpose of deciding whether two children are
+ * co-partitioned and, if not, what to shuffle the other one onto.
+ *
+ * A [[LeafShuffleSpec]] is one concrete layout. A [[ShuffleSpecCollection]] stands for a choice
+ * between several. A collection can answer [[isCompatibleWith]], which succeeds when any member
+ * matches. It cannot answer anything that needs one member: which one is right depends on what the
+ * other side matched, and only the caller comparing the two sides can see that.
+ */
+sealed trait ShuffleSpec {
   /**
    * Returns true iff this spec is compatible with the provided shuffle spec.
    *
@@ -1362,9 +1361,27 @@ trait ShuffleSpec {
   def isCompatibleWith(other: ShuffleSpec): Boolean
 
   /**
-   * Whether this shuffle spec can be used to create partitionings for the other children.
+   * Whether this shuffle spec can be used to create partitionings for the other children. A
+   * [[ShuffleSpecCollection]] answers for the whole choice, since the planner asks it of a child's
+   * spec as a whole. Building the partitioning is [[LeafShuffleSpec.createPartitioning]], and that
+   * is always one member's job.
    */
   def canCreatePartitioning: Boolean
+
+  /**
+   * This spec's leaf specs: a [[ShuffleSpecCollection]] yields its members recursively, and a
+   * [[LeafShuffleSpec]] yields itself. A caller that needs one member picks from these. Never
+   * empty, since a collection has at least one member.
+   */
+  def flatten: Seq[LeafShuffleSpec]
+}
+
+/** A [[ShuffleSpec]] describing one layout, as opposed to a choice between several. */
+trait LeafShuffleSpec extends ShuffleSpec {
+  /**
+   * Returns the number of partitions of this shuffle spec
+   */
+  def numPartitions: Int
 
   /**
    * Creates a partitioning that can be used to re-partition the other side with the given
@@ -1375,11 +1392,28 @@ trait ShuffleSpec {
    */
   def createPartitioning(clustering: Seq[Expression]): Partitioning =
     throw SparkUnsupportedOperationException()
+
+  override final def flatten: Seq[LeafShuffleSpec] = Seq(this)
 }
 
-case object SinglePartitionShuffleSpec extends ShuffleSpec {
-  override def isCompatibleWith(other: ShuffleSpec): Boolean = {
-    other.numPartitions == 1
+case object SinglePartitionShuffleSpec extends LeafShuffleSpec {
+  override def isCompatibleWith(other: ShuffleSpec): Boolean = other match {
+    case leaf: LeafShuffleSpec => leaf.numPartitions == 1
+    // `forall`, not the `exists` the other specs use for a collection. They ask whether *some*
+    // member matches them and then plan on that member; this one never names a member, since
+    // `canCreatePartitioning` is false, so the answer has to hold for whichever member the plan
+    // settles on. The counts are projected ones as everywhere here, so a child whose every member
+    // projects to one answers yes even while holding more partitions of its own. Members can only
+    // disagree when the subset config projects them onto different key sets.
+    //
+    // `EnsureRequirements` never reaches this: a spec whose `canCreatePartitioning` is false is
+    // never the best one. The one production caller that can put a collection on the `other` side
+    // is `ValidateRequirements`' `specs.tail.forall(_.isCompatibleWith(specs.head))`, and there the
+    // stricter answer is the safer one. It does leave this direction stricter than the collection's
+    // own `exists`, against the symmetry this trait's doc assumes, but nothing observable follows:
+    // only `KeyedShuffleSpec` can make members disagree on `numPartitions`, and it has no
+    // `SinglePartitionShuffleSpec` case, so that direction is already false.
+    case ShuffleSpecCollection(specs) => specs.forall(isCompatibleWith)
   }
 
   override def canCreatePartitioning: Boolean = false
@@ -1392,7 +1426,7 @@ case object SinglePartitionShuffleSpec extends ShuffleSpec {
 
 case class RangeShuffleSpec(
     numPartitions: Int,
-    distribution: ClusteredDistribution) extends ShuffleSpec {
+    distribution: ClusteredDistribution) extends LeafShuffleSpec {
 
   // `RangePartitioning` is not compatible with any other partitioning since it can't guarantee
   // data are co-partitioned for all the children, as range boundaries are randomly sampled. We
@@ -1429,7 +1463,7 @@ private object HashShuffleSpecCompatibility {
 
 case class HashShuffleSpec(
     partitioning: HashPartitioning,
-    distribution: ClusteredDistribution) extends ShuffleSpec {
+    distribution: ClusteredDistribution) extends LeafShuffleSpec {
 
   /**
    * A sequence where each element is a set of positions of the hash partition key to the cluster
@@ -1515,7 +1549,7 @@ case class HashShuffleSpec(
  */
 case class NullAwareHashShuffleSpec(
     partitioning: NullAwareHashPartitioning,
-    distribution: ClusteredDistribution) extends ShuffleSpec {
+    distribution: ClusteredDistribution) extends LeafShuffleSpec {
 
   lazy val hashKeyPositions: Seq[mutable.BitSet] = {
     val distKeyToPos = mutable.Map.empty[Expression, mutable.BitSet]
@@ -1572,8 +1606,8 @@ case class NullAwareHashShuffleSpec(
 }
 
 case class CoalescedHashShuffleSpec(
-    from: ShuffleSpec,
-    partitions: Seq[CoalescedBoundary]) extends ShuffleSpec {
+    from: LeafShuffleSpec,
+    partitions: Seq[CoalescedBoundary]) extends LeafShuffleSpec {
 
   override def isCompatibleWith(other: ShuffleSpec): Boolean = other match {
     case SinglePartitionShuffleSpec =>
@@ -1643,13 +1677,21 @@ case class IdentityReducer(transform: TransformExpression) extends Reducer[Any, 
  *
  * @param partitioning key grouped partitioning
  * @param distribution distribution
- * @param joinKeyPositions position of join keys among cluster keys.
- *                         This is set if joining on a subset of cluster keys is allowed.
+ * @param joinKeyPositions the positions `partitioning` was projected onto, set only when the
+ *                         projection changed it. `None` therefore means `partitioning` is the one
+ *                         the child reports, and a consumer needs no `GroupPartitionsExec` to
+ *                         produce it. Only `v2BucketingAllowKeysSubsetOfPartitionKeys` projects at
+ *                         all, and it reaches `None` two ways: an identity projection over already
+ *                         grouped and sorted keys rebuilds the same partitioning, and a narrowing
+ *                         one over a marked claim is refused outright. Only the first says the
+ *                         child is grouped on the operation keys; the second leaves a spec that
+ *                         `areKeysCompatible` and `canCreatePartitioning` both turn away. See
+ *                         `KeyedPartitioning.createShuffleSpec`.
  */
 case class KeyedShuffleSpec(
     partitioning: KeyedPartitioning,
     distribution: ClusteredDistribution,
-    joinKeyPositions: Option[Seq[Int]] = None) extends ShuffleSpec {
+    joinKeyPositions: Option[Seq[Int]] = None) extends LeafShuffleSpec {
 
   /**
    * A sequence where each element is a set of positions of the partition expression to the cluster
@@ -1686,7 +1728,7 @@ case class KeyedShuffleSpec(
     //  4. the partition values from both sides are following the same order.
     case otherSpec @ KeyedShuffleSpec(otherPartitioning, otherDistribution, _) =>
       distribution.clustering.length == otherDistribution.clustering.length &&
-        numPartitions == other.numPartitions && areKeysCompatible(otherSpec) &&
+        numPartitions == otherSpec.numPartitions && areKeysCompatible(otherSpec) &&
           partitioning.partitionKeys == otherPartitioning.partitionKeys
     case ShuffleSpecCollection(specs) =>
       specs.exists(isCompatibleWith)
@@ -1914,7 +1956,7 @@ case class KeyedShuffleSpec(
 
 case class ShufflePartitionIdPassThroughSpec(
     partitioning: ShufflePartitionIdPassThrough,
-    distribution: ClusteredDistribution) extends ShuffleSpec {
+    distribution: ClusteredDistribution) extends LeafShuffleSpec {
 
   /**
    * A sequence where each element is a set of positions of the partition key to the cluster
@@ -1957,7 +1999,14 @@ case class ShufflePartitionIdPassThroughSpec(
   override def numPartitions: Int = partitioning.numPartitions
 }
 
+/**
+ * A choice between several layouts, produced by [[PartitioningCollection.createShuffleSpec]].
+ *
+ * `specs` can hold a nested collection, since a [[PartitioningCollection]] can hold a nested one.
+ */
 case class ShuffleSpecCollection(specs: Seq[ShuffleSpec]) extends ShuffleSpec {
+  require(specs.nonEmpty, "expected specs to be non-empty")
+
   override def isCompatibleWith(other: ShuffleSpec): Boolean = {
     specs.exists(_.isCompatibleWith(other))
   }
@@ -1965,16 +2014,5 @@ case class ShuffleSpecCollection(specs: Seq[ShuffleSpec]) extends ShuffleSpec {
   override def canCreatePartitioning: Boolean =
     specs.forall(_.canCreatePartitioning)
 
-  override def createPartitioning(clustering: Seq[Expression]): Partitioning = {
-    // as we only consider # of partitions as the cost now, it doesn't matter which one we choose
-    // since they should all have the same # of partitions.
-    require(specs.map(_.numPartitions).toSet.size == 1, "expected all specs in the collection " +
-      "to have the same number of partitions")
-    specs.head.createPartitioning(clustering)
-  }
-
-  override def numPartitions: Int = {
-    require(specs.nonEmpty, "expected specs to be non-empty")
-    specs.head.numPartitions
-  }
+  override def flatten: Seq[LeafShuffleSpec] = specs.flatMap(_.flatten)
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
@@ -59,7 +59,7 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
   }
 
   protected def checkCreatePartitioning(
-      spec: ShuffleSpec,
+      spec: LeafShuffleSpec,
       dist: ClusteredDistribution,
       expected: Partitioning): Unit = {
     val actual = spec.createPartitioning(dist.clustering)
@@ -506,9 +506,37 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
 
     withSQLConf(SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
       val spec = reduced.createShuffleSpec(ClusteredDistribution(Seq(a)))
-        .asInstanceOf[KeyedShuffleSpec]
       assert(spec.joinKeyPositions === Some(Seq(0)))
       assert(spec.partitioning.partitionKeys.map(_.row.getInt(0)) === Seq(2020, 2021))
+    }
+  }
+
+  test("SPARK-59256: createShuffleSpec reports no projection when it changes nothing") {
+    val a = $"a".int
+    val b = $"b".int
+    val distribution = ClusteredDistribution(Seq(a, b))
+    val sortedKeys = Seq(InternalRow(1, 1), InternalRow(1, 2), InternalRow(2, 1))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      // Every position is a cluster key and the keys are already grouped and sorted, so the
+      // projection and the regrouping both rebuild this partitioning. Reporting positions here
+      // would make a consumer insert a `GroupPartitionsExec` that projects nothing.
+      val unchanged = KeyedPartitioning(Seq(a, b), sortedKeys).createShuffleSpec(distribution)
+      assert(unchanged.joinKeyPositions === None)
+      assert(unchanged.partitioning == KeyedPartitioning(Seq(a, b), sortedKeys))
+
+      // The same positions, but the keys arrive unsorted, so `toGrouped` reorders them. That is a
+      // different partitioning, and the positions say so. This is why the question is not simply
+      // whether every position was kept.
+      val resorted = KeyedPartitioning(Seq(a, b), sortedKeys.reverse)
+        .createShuffleSpec(distribution)
+      assert(resorted.joinKeyPositions === Some(Seq(0, 1)))
+      assert(resorted.partitioning.partitionKeys.map(_.row.getInt(1)) === Seq(1, 2, 1))
+
+      // And a position that is no cluster key is dropped, which has always been reported.
+      val narrowed = KeyedPartitioning(Seq(a, $"z".int), sortedKeys)
+        .createShuffleSpec(ClusteredDistribution(Seq(a)))
+      assert(narrowed.joinKeyPositions === Some(Seq(0)))
     }
   }
 
@@ -781,13 +809,6 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
       SinglePartition
     )
 
-    checkCreatePartitioning(ShuffleSpecCollection(Seq(
-      HashShuffleSpec(HashPartitioning(Seq($"a"), 10), distribution),
-        RangeShuffleSpec(10, distribution))),
-      ClusteredDistribution(Seq($"c", $"d")),
-      HashPartitioning(Seq($"c"), 10)
-    )
-
     // unsupported cases
 
     checkError(
@@ -797,7 +818,7 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
       condition = "UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
       parameters = Map(
         "methodName" -> "createPartitioning$",
-        "className" -> "org.apache.spark.sql.catalyst.plans.physical.ShuffleSpec"))
+        "className" -> "org.apache.spark.sql.catalyst.plans.physical.LeafShuffleSpec"))
   }
 
   test("compatibility: ShufflePartitionIdPassThroughSpec on both sides") {
@@ -874,18 +895,14 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
 
     withSQLConf(SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
       val spec = collection.createShuffleSpec(ClusteredDistribution(Seq(id, t1)))
-        .asInstanceOf[ShuffleSpecCollection]
 
       // The disagreement is kept rather than resolved here. Every member has to stay for
       // `isCompatibleWith`, which answers for any of them, and the collection cannot know which one
-      // the other side matched. `EnsureRequirements` resolves that and asks the member, not the
-      // collection.
-      assert(spec.specs.map(_.numPartitions).toSet === Set(3, 2))
+      // the other side matched. `EnsureRequirements` resolves that and asks the member, so the
+      // collection has no partition count of its own to read.
+      val memberPartitions = spec.flatten.map(_.numPartitions)
+      assert(memberPartitions.toSet === Set(3, 2))
       assert(spec.isCompatibleWith(spec), "every member stays available for matching")
-
-      // So asking the collection for a single answer is the caller's mistake, and it says so.
-      val e = intercept[IllegalArgumentException](spec.createPartitioning(Seq(id, t1)))
-      assert(e.getMessage.contains("expected all specs in the collection to have the same number"))
     }
   }
 
@@ -905,5 +922,48 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
     assert(reducedDataTypes !== Seq(named), "test setup: the reducer names a field to erase")
     assert(reducedKeys.map(_.dataTypes).distinct === Seq(reducedDataTypes),
       "the reported types are the ones the keys hold")
+  }
+
+  test("SPARK-59256: a single-partition side needs every member of a collection to be one") {
+    val id = AttributeReference("id", IntegerType)()
+    val t1 = AttributeReference("t1", IntegerType)()
+    val t2 = AttributeReference("t2", IntegerType)()
+    // Clustering on (id, t1) again. The first member matches `id` only and collapses to one
+    // partition, the second projects onto both positions and keeps three. The members disagree, so
+    // no single answer holds for whichever one the plan settles on.
+    val keys = Seq(InternalRow(1, 1), InternalRow(1, 2), InternalRow(1, 3))
+    val collection = PartitioningCollection.fromPartitionings(Seq(
+      KeyedPartitioning(Seq(id, t2), keys),
+      KeyedPartitioning(Seq(id, t1), keys)))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      val spec = collection.createShuffleSpec(ClusteredDistribution(Seq(id, t1)))
+      val memberPartitions = spec.flatten.map(_.numPartitions)
+      // Ordered, not just as a set: the whole point is that the head is the wrong one to read.
+      assert(memberPartitions === Seq(1, 3))
+
+      // Reading the head's count answers one partition and claims a co-partitioning that does not
+      // hold. Only this direction is asserted: `KeyedShuffleSpec` has no
+      // `SinglePartitionShuffleSpec` case at all, so the reverse is false whatever the member
+      // counts are. That asymmetry is pre-existing and is not what this change is about.
+      assert(!SinglePartitionShuffleSpec.isCompatibleWith(spec))
+    }
+  }
+
+  test("SPARK-59256: an empty collection is rejected at construction, not at the first read") {
+    // `numPartitions` carried this `require` and threw the same way, but only once something asked.
+    // `flatten` would answer `Nil` instead, and the ranking's `max` over it throws a worse message.
+    val e = intercept[IllegalArgumentException](ShuffleSpecCollection(Nil))
+    assert(e.getMessage.contains("expected specs to be non-empty"))
+  }
+
+  test("SPARK-59256: flattening reaches the members of a nested collection") {
+    val distribution = ClusteredDistribution(Seq($"a", $"b"))
+    val buried = HashShuffleSpec(HashPartitioning(Seq($"a"), 10), distribution)
+    val direct = HashShuffleSpec(HashPartitioning(Seq($"b"), 10), distribution)
+    // A `PartitioningCollection` can hold another one, so a spec collection can nest too.
+    val collection = ShuffleSpecCollection(Seq(ShuffleSpecCollection(Seq(buried)), direct))
+
+    assert(collection.flatten === Seq(buried, direct))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -109,10 +109,10 @@ case class GroupPartitionsExec(
                   assert(projectedExpressions.length == exprs.length)
                   projectedExpressions.zip(exprs).map {
                     case (expr, Some(KeyReducer(_, reduced))) =>
-                      // `reduced` was stored from the single spec that `createKeyedShuffleSpec`
-                      // picked (`collectFirst`); re-target it at this `KeyedPartitioning`'s own
-                      // key attribute so that every `KeyedPartitioning` in a collection keeps its
-                      // own.
+                      // `reduced` came from the one member `checkKeyGroupCompatible` paired
+                      // this side on, which need not be the member being rewritten. The keys are
+                      // reduced once, from the shared key rows, so `reduced` describes them
+                      // whichever member this is, and only the key attribute is re-targeted.
                       reduced.withReference(expr.references.head)
                     case (expr, None) => expr
                   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -218,8 +218,9 @@ case class EnsureRequirements(
         } else {
           candidateSpecs
         }
-        // Pick the spec with the best parallelism
-        Some(finalCandidateSpecs.values.maxBy(_.numPartitions))
+        // Pick the spec with the best parallelism. For a collection that is the best any member
+        // offers, since reading one member's count would depend on the enumeration order.
+        Some(finalCandidateSpecs.values.maxBy(_.flatten.map(_.numPartitions).max))
       }
 
       // Check if the following conditions are satisfied:
@@ -256,11 +257,11 @@ case class EnsureRequirements(
         childrenIndexes.filter(i => best.isCompatibleWith(specs(i)))
       }
       lazy val bestMemberOpt = bestSpecOpt.flatMap { best =>
-        val matchedMembers = matchedIndexes.map(i => flattenSpec(specs(i)))
+        val matchedMembers = matchedIndexes.map(i => specs(i).flatten)
         // No member serving every matched child means there is no layout to align them on, so they
         // all take the ordinary shuffle. That needs three or more clustered children, since with
         // two the member that reported the match serves both, and no operator has three today.
-        flattenSpec(best)
+        best.flatten
           .filter(m => matchedMembers.forall(_.exists(m.isCompatibleWith)))
           .maxByOption(_.numPartitions)
       }
@@ -275,7 +276,7 @@ case class EnsureRequirements(
             // own partition expressions -- the chosen best member only says which member of it the
             // two sides agreed on.
             val bestMember = bestMemberOpt.get
-            flattenSpec(specs(idx)).find(bestMember.isCompatibleWith) match {
+            specs(idx).flatten.find(bestMember.isCompatibleWith) match {
               // If `areChildrenCompatible` is false, we can still perform SPJ
               // by shuffling the other side based on join keys (see the else case below).
               // Hence we need to ensure that after this call, the outputPartitioning of the
@@ -523,33 +524,83 @@ case class EnsureRequirements(
     var newLeft = left
     var newRight = right
 
-    val specs = Seq(left, right).zip(requiredChildDistribution).map { case (p, d) =>
-      if (!d.isInstanceOf[ClusteredDistribution]) return None
-      val cd = d.asInstanceOf[ClusteredDistribution]
-      val specOpt = createKeyedShuffleSpec(p.outputPartitioning, cd)
-      if (specOpt.isEmpty) return None
-      specOpt.get
+    def candidatesFor(plan: SparkPlan, required: Distribution): Seq[KeyedShuffleSpec] =
+      required match {
+        case cd: ClusteredDistribution => createKeyedShuffleSpecs(plan.outputPartitioning, cd)
+        case _ => Nil
+      }
+    val leftCandidates = candidatesFor(left, requiredChildDistribution.head)
+    val rightCandidates = candidatesFor(right, requiredChildDistribution(1))
+    if (leftCandidates.isEmpty || rightCandidates.isEmpty) return None
+
+    // A spec carries no `joinKeyPositions` exactly when its partitioning is the child's own member,
+    // so this asks whether `compatibleAsIs` below can hold, i.e. whether the pair needs no
+    // `GroupPartitionsExec` on either side. That is not the last word on the node: the push branch
+    // inserts one whenever it runs, and partially clustered distribution makes it run even for a
+    // pair that is compatible as it stands.
+    def bothUnprojected(l: KeyedShuffleSpec, r: KeyedShuffleSpec): Boolean =
+      l.joinKeyPositions.isEmpty && r.joinKeyPositions.isEmpty
+
+    // How many key groups the pushdown below would leave this pair. `mergeAndDedupPartitions`
+    // keeps one side's keys and drops the other's for the filtered one-sided join types, and there
+    // the dropped side's count says nothing, so rank on the side that survives. The arms that
+    // really merge have no cheap answer, so they take the larger of the two counts. Keep the join
+    // types here in step with `mergeAndDedupPartitions`.
+    val partitionFilter = conf.getConf(SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED)
+    def rank(l: KeyedShuffleSpec, r: KeyedShuffleSpec): Int = joinType match {
+      case LeftOuter | LeftAnti | LeftSingle | ExistenceJoin(_) if partitionFilter =>
+        l.numPartitions
+      case RightOuter if partitionFilter => r.numPartitions
+      case _ => l.numPartitions.max(r.numPartitions)
     }
 
-    val leftSpec = specs.head
-    val rightSpec = specs(1)
+    // Each side may offer several members, and the right one is the one the other side can pair
+    // with, which neither side can tell on its own. So pick the pair rather than a member per side,
+    // and rank the pairs that agree on the keys by the parallelism they offer, the same trade
+    // `ensureDistributionAndOrdering` makes between children when it picks `bestSpecOpt`.
+    //
+    // Two things keep `rank` from being what the join actually gets, both on the merging arms.
+    // `InnerLike` and `LeftSemi` intersect under `v2BucketingPartitionFilterEnabled`, and an
+    // intersection is not monotone in member granularity: members cover different clustering keys
+    // rather than nested ones, so a finer pair can rank above a coarser one and still meet the
+    // other side in fewer groups. And a union does not merely exceed the rank either, because
+    // `reduceKeys` runs between this pick and the merge and collapses distinct keys, so a
+    // `bucket(16)` side reduced onto `bucket(8)` brings 8 keys to a merge its spec ranked at 16.
+    // Ranking on the merged count would match what is delivered, at the cost of merging every
+    // candidate pair, which would also raise `storagePartitionJoinIncompatibleReducedTypesError`
+    // for pairs that are never chosen.
+    //
+    // Ties go to a pair both children report as it stands, to keep the no-grouping-node path. A
+    // projected count never exceeds the physical one, so nothing outranks such a pair, but a coarse
+    // member whose projected count happens to equal it ties, and enumeration order would decide.
+    val agreeingPairs = for {
+      l <- leftCandidates
+      r <- rightCandidates
+      if l.areKeysCompatible(r)
+    } yield (l, r)
+    val bestPair = agreeingPairs.maxByOption { case (l, r) => (rank(l, r), bothUnprojected(l, r)) }
+    // No agreeing pair means no pairing can be planned at all: `isCompatibleWith` and the push
+    // branch's `areKeysCompatible` both fail for every pair, so carrying one to the end would
+    // return `None` after logging a pushdown that does not happen.
+    if (bestPair.isEmpty) return None
+    val (leftSpec, rightSpec) = bestPair.get
     val leftPartitioning = leftSpec.partitioning
     val rightPartitioning = rightSpec.partitioning
 
     // We don't need to alter the existing or add new `GroupPartitionsExec` when the child
     // partitionings are not modified (projected) in specs and left and right side partitionings are
     // compatible with each other.
-    // Left and right `outputPartitioning` is a `PartitioningCollection` or a `KeyedPartitioning`
-    // otherwise `createKeyedShuffleSpec()` would have returned `None`.
-    var isCompatible =
-      left.outputPartitioning.asInstanceOf[Expression].exists(_ == leftPartitioning) &&
-      right.outputPartitioning.asInstanceOf[Expression].exists(_ == rightPartitioning) &&
-      leftSpec.isCompatibleWith(rightSpec)
-    if ((!isCompatible || conf.v2BucketingPartiallyClusteredDistributionEnabled) &&
+    val compatibleAsIs =
+      bothUnprojected(leftSpec, rightSpec) && leftSpec.isCompatibleWith(rightSpec)
+    // Entering the push branch is the same as taking it. The keys agree for this pair by
+    // construction, since `agreeingPairs` filtered on exactly that and an empty result returned
+    // above, so what the branch pushes always applies.
+    val pushCommonValues =
+      (!compatibleAsIs || conf.v2BucketingPartiallyClusteredDistributionEnabled) &&
         (conf.v2BucketingPushPartValuesEnabled ||
-          conf.v2BucketingAllowKeysSubsetOfPartitionKeys)) {
+          conf.v2BucketingAllowKeysSubsetOfPartitionKeys)
+    if (pushCommonValues) {
       logInfo("Pushing common partition values for storage-partitioned join")
-      isCompatible = leftSpec.areKeysCompatible(rightSpec)
 
       // Partition expressions are compatible. Regardless of whether partition values
       // match from both sides of children, we can calculate a superset of partition values and
@@ -566,198 +617,196 @@ case class EnsureRequirements(
       // Following the case 2 above, we don't have to shuffle both sides, but instead can
       // just push the common set of partition values: `[0, 1, 2, 3]` down to the two data
       // sources.
-      if (isCompatible) {
-        val leftPartKeys = leftPartitioning.partitionKeys
-        val rightPartKeys = rightPartitioning.partitionKeys
+      val leftPartKeys = leftPartitioning.partitionKeys
+      val rightPartKeys = rightPartitioning.partitionKeys
 
-        val numLeftPartKeys = MDC(LogKeys.NUM_LEFT_PARTITION_VALUES, leftPartKeys.size)
-        val numRightPartKeys = MDC(LogKeys.NUM_RIGHT_PARTITION_VALUES, rightPartKeys.size)
-        logInfo(
-          log"""
-              |Left side # of partitions: $numLeftPartKeys
-              |Right side # of partitions: $numRightPartKeys
-              |""".stripMargin)
+      val numLeftPartKeys = MDC(LogKeys.NUM_LEFT_PARTITION_VALUES, leftPartKeys.size)
+      val numRightPartKeys = MDC(LogKeys.NUM_RIGHT_PARTITION_VALUES, rightPartKeys.size)
+      logInfo(
+        log"""
+            |Left side # of partitions: $numLeftPartKeys
+            |Right side # of partitions: $numRightPartKeys
+            |""".stripMargin)
 
-        // in case of compatible but not identical partition expressions, we apply 'reduce'
-        // transforms to group one side's partitions as well as the common partition values
-        val (leftReducers, rightReducers) = leftSpec.reducersBothWays(rightSpec)
-        val (leftReducedDataTypes, leftReducedKeys) = leftReducers.fold(
-          (leftPartitioning.keyDataTypes, leftPartitioning.partitionKeys)
-        )(leftPartitioning.reduceKeys)
-        val (rightReducedDataTypes, rightReducedKeys) = rightReducers.fold(
-          (rightPartitioning.keyDataTypes, rightPartitioning.partitionKeys)
-        )(rightPartitioning.reduceKeys)
-        // The reduced types are the types of the key rows the merge below sees. A side with no key
-        // still answers for them while its expressions describe the keys it would have had, and
-        // `keyDataTypes` falls back to those types, erased. After a reduce the expressions no
-        // longer describe them, so the fallback is a type no key of that partitioning would hold,
-        // and comparing it against a real answer fails a co-partitioned query (SPARK-59176). Only
-        // such a side is left out. An empty one that is not marked stays in, which is what keeps
-        // the comparison checking a reducer's result type against the paired transform.
-        val leftTypesDescribeKeys =
-          leftReducedKeys.nonEmpty || leftPartitioning.expressionsDescribeKeys
-        val rightTypesDescribeKeys =
-          rightReducedKeys.nonEmpty || rightPartitioning.expressionsDescribeKeys
-        val reducedDataTypes = if (!leftTypesDescribeKeys) {
-          rightReducedDataTypes
-        } else if (!rightTypesDescribeKeys || leftReducedDataTypes == rightReducedDataTypes) {
-          leftReducedDataTypes
+      // in case of compatible but not identical partition expressions, we apply 'reduce'
+      // transforms to group one side's partitions as well as the common partition values
+      val (leftReducers, rightReducers) = leftSpec.reducersBothWays(rightSpec)
+      val (leftReducedDataTypes, leftReducedKeys) = leftReducers.fold(
+        (leftPartitioning.keyDataTypes, leftPartitioning.partitionKeys)
+      )(leftPartitioning.reduceKeys)
+      val (rightReducedDataTypes, rightReducedKeys) = rightReducers.fold(
+        (rightPartitioning.keyDataTypes, rightPartitioning.partitionKeys)
+      )(rightPartitioning.reduceKeys)
+      // The reduced types are the types of the key rows the merge below sees. A side with no key
+      // still answers for them while its expressions describe the keys it would have had, and
+      // `keyDataTypes` falls back to those types, erased. After a reduce the expressions no
+      // longer describe them, so the fallback is a type no key of that partitioning would hold,
+      // and comparing it against a real answer fails a co-partitioned query (SPARK-59176). Only
+      // such a side is left out. An empty one that is not marked stays in, which is what keeps
+      // the comparison checking a reducer's result type against the paired transform.
+      val leftTypesDescribeKeys =
+        leftReducedKeys.nonEmpty || leftPartitioning.expressionsDescribeKeys
+      val rightTypesDescribeKeys =
+        rightReducedKeys.nonEmpty || rightPartitioning.expressionsDescribeKeys
+      val reducedDataTypes = if (!leftTypesDescribeKeys) {
+        rightReducedDataTypes
+      } else if (!rightTypesDescribeKeys || leftReducedDataTypes == rightReducedDataTypes) {
+        leftReducedDataTypes
+      } else {
+        // The two lists are the erased ones, so a struct in the message prints positional field
+        // names. That is deliberate: the names do not decide where a key belongs, so printing the
+        // connector's own would point a reader at a difference that is not the cause.
+        throw QueryExecutionErrors.storagePartitionJoinIncompatibleReducedTypesError(
+          leftReducers = leftReducers,
+          leftReducedDataTypes = leftReducedDataTypes,
+          rightReducers = rightReducers,
+          rightReducedDataTypes = rightReducedDataTypes)
+      }
+
+      val reducedKeyOrdering = KeyedPartitioning.groupedKeyRowOrdering(reducedDataTypes)
+        .on((t: InternalRowComparableWrapper) => t.row)
+
+      // merge values on both sides
+      var mergedPartitionKeys =
+        mergeAndDedupPartitions(leftReducedKeys, rightReducedKeys, joinType, reducedKeyOrdering)
+          .map((_, 1))
+
+      logInfo(log"After merging, there are " +
+        log"${MDC(LogKeys.NUM_PARTITIONS, mergedPartitionKeys.size)} partitions")
+
+      var replicateLeftSide = false
+      var replicateRightSide = false
+      var applyPartialClustering = false
+
+      // This means we allow partitions that are not clustered on their values,
+      // that is, multiple partitions with the same partition value. In the
+      // following, we calculate how many partitions that each distinct partition
+      // value has, and pushdown the information to scans, so they can adjust their
+      // final input partitions respectively.
+      if (conf.v2BucketingPartiallyClusteredDistributionEnabled) {
+        logInfo("Calculating partially clustered distribution for " +
+            "storage-partitioned join")
+
+        // Similar to `OptimizeSkewedJoin`, we need to check join type and decide
+        // whether partially clustered distribution can be applied. For instance, the
+        // optimization cannot be applied to a left outer join, where the left hand
+        // side is chosen as the side to replicate partitions according to stats.
+        // Otherwise, query result could be incorrect.
+        val canReplicateLeft = ShuffledJoin.canDuplicateLeftSide(joinType)
+        val canReplicateRight = ShuffledJoin.canDuplicateRightSide(joinType)
+
+        if (!canReplicateLeft && !canReplicateRight) {
+          logInfo(log"Skipping partially clustered distribution as it cannot be applied for " +
+            log"join type '${MDC(LogKeys.JOIN_TYPE, joinType)}'")
         } else {
-          // The two lists are the erased ones, so a struct in the message prints positional field
-          // names. That is deliberate: the names do not decide where a key belongs, so printing the
-          // connector's own would point a reader at a difference that is not the cause.
-          throw QueryExecutionErrors.storagePartitionJoinIncompatibleReducedTypesError(
-            leftReducers = leftReducers,
-            leftReducedDataTypes = leftReducedDataTypes,
-            rightReducers = rightReducers,
-            rightReducedDataTypes = rightReducedDataTypes)
-        }
+          // The pre-alignment plan of each side and the grouping this rule inserted over it,
+          // are read once: the statistics and the original partition keys below come from the
+          // plan, the positions projecting them from the grouping.
+          val leftGrouping = innermostGroupPartition(left)
+          val rightGrouping = innermostGroupPartition(right)
+          val unwrappedLeft = leftGrouping.map(_._1.child).getOrElse(left)
+          val unwrappedRight = rightGrouping.map(_._1.child).getOrElse(right)
 
-        val reducedKeyOrdering = KeyedPartitioning.groupedKeyRowOrdering(reducedDataTypes)
-          .on((t: InternalRowComparableWrapper) => t.row)
+          val leftLink = unwrappedLeft.logicalLink
+          val rightLink = unwrappedRight.logicalLink
 
-        // merge values on both sides
-        var mergedPartitionKeys =
-          mergeAndDedupPartitions(leftReducedKeys, rightReducedKeys, joinType, reducedKeyOrdering)
-            .map((_, 1))
-
-        logInfo(log"After merging, there are " +
-          log"${MDC(LogKeys.NUM_PARTITIONS, mergedPartitionKeys.size)} partitions")
-
-        var replicateLeftSide = false
-        var replicateRightSide = false
-        var applyPartialClustering = false
-
-        // This means we allow partitions that are not clustered on their values,
-        // that is, multiple partitions with the same partition value. In the
-        // following, we calculate how many partitions that each distinct partition
-        // value has, and pushdown the information to scans, so they can adjust their
-        // final input partitions respectively.
-        if (conf.v2BucketingPartiallyClusteredDistributionEnabled) {
-          logInfo("Calculating partially clustered distribution for " +
-              "storage-partitioned join")
-
-          // Similar to `OptimizeSkewedJoin`, we need to check join type and decide
-          // whether partially clustered distribution can be applied. For instance, the
-          // optimization cannot be applied to a left outer join, where the left hand
-          // side is chosen as the side to replicate partitions according to stats.
-          // Otherwise, query result could be incorrect.
-          val canReplicateLeft = ShuffledJoin.canDuplicateLeftSide(joinType)
-          val canReplicateRight = ShuffledJoin.canDuplicateRightSide(joinType)
-
-          if (!canReplicateLeft && !canReplicateRight) {
-            logInfo(log"Skipping partially clustered distribution as it cannot be applied for " +
-              log"join type '${MDC(LogKeys.JOIN_TYPE, joinType)}'")
+          replicateLeftSide = if (
+            leftLink.isDefined && rightLink.isDefined &&
+                leftLink.get.stats.sizeInBytes > 1 &&
+                rightLink.get.stats.sizeInBytes > 1) {
+            val leftLinkStatsSizeInBytes = MDC(LogKeys.LEFT_LOGICAL_PLAN_STATS_SIZE_IN_BYTES,
+              leftLink.get.stats.sizeInBytes)
+            val rightLinkStatsSizeInBytes = MDC(LogKeys.RIGHT_LOGICAL_PLAN_STATS_SIZE_IN_BYTES,
+              rightLink.get.stats.sizeInBytes)
+            logInfo(
+              log"""
+                 |Using plan statistics to determine which side of join to fully
+                 |cluster partition values:
+                 |Left side size (in bytes): $leftLinkStatsSizeInBytes
+                 |Right side size (in bytes): $rightLinkStatsSizeInBytes
+                 |""".stripMargin)
+            leftLink.get.stats.sizeInBytes < rightLink.get.stats.sizeInBytes
           } else {
-            // The pre-alignment plan of each side and the grouping this rule inserted over it,
-            // are read once: the statistics and the original partition keys below come from the
-            // plan, the positions projecting them from the grouping.
-            val leftGrouping = innermostGroupPartition(left)
-            val rightGrouping = innermostGroupPartition(right)
-            val unwrappedLeft = leftGrouping.map(_._1.child).getOrElse(left)
-            val unwrappedRight = rightGrouping.map(_._1.child).getOrElse(right)
+            // As a simple heuristic, we pick the side with fewer partitions to apply the
+            // grouping & replication of partitions. The counts read the
+            // pre-alignment plans, for the same reason the statistics do: on a re-run both
+            // aligned reports hold the same number of keys, so comparing them decides nothing.
+            // This also changes a first pass, which compared the aligned report's distinct
+            // keys rather than the splits behind them.
+            logInfo("Using number of partitions to determine which side of join " +
+                "to fully cluster partition values")
+            PartitioningCollection.numKeyedPartitions(unwrappedLeft.outputPartitioning)
+              .getOrElse(leftPartKeys.size) <
+              PartitioningCollection.numKeyedPartitions(unwrappedRight.outputPartitioning)
+              .getOrElse(rightPartKeys.size)
+          }
 
-            val leftLink = unwrappedLeft.logicalLink
-            val rightLink = unwrappedRight.logicalLink
+          replicateRightSide = !replicateLeftSide
 
-            replicateLeftSide = if (
-              leftLink.isDefined && rightLink.isDefined &&
-                  leftLink.get.stats.sizeInBytes > 1 &&
-                  rightLink.get.stats.sizeInBytes > 1) {
-              val leftLinkStatsSizeInBytes = MDC(LogKeys.LEFT_LOGICAL_PLAN_STATS_SIZE_IN_BYTES,
-                leftLink.get.stats.sizeInBytes)
-              val rightLinkStatsSizeInBytes = MDC(LogKeys.RIGHT_LOGICAL_PLAN_STATS_SIZE_IN_BYTES,
-                rightLink.get.stats.sizeInBytes)
-              logInfo(
-                log"""
-                   |Using plan statistics to determine which side of join to fully
-                   |cluster partition values:
-                   |Left side size (in bytes): $leftLinkStatsSizeInBytes
-                   |Right side size (in bytes): $rightLinkStatsSizeInBytes
-                   |""".stripMargin)
-              leftLink.get.stats.sizeInBytes < rightLink.get.stats.sizeInBytes
-            } else {
-              // As a simple heuristic, we pick the side with fewer partitions to apply the
-              // grouping & replication of partitions. The counts read the
-              // pre-alignment plans, for the same reason the statistics do: on a re-run both
-              // aligned reports hold the same number of keys, so comparing them decides nothing.
-              // This also changes a first pass, which compared the aligned report's distinct
-              // keys rather than the splits behind them.
-              logInfo("Using number of partitions to determine which side of join " +
-                  "to fully cluster partition values")
-              PartitioningCollection.numKeyedPartitions(unwrappedLeft.outputPartitioning)
-                .getOrElse(leftPartKeys.size) <
-                PartitioningCollection.numKeyedPartitions(unwrappedRight.outputPartitioning)
-                .getOrElse(rightPartKeys.size)
-            }
-
-            replicateRightSide = !replicateLeftSide
-
-            // Similar to skewed join, we need to check the join type to see whether replication
-            // of partitions can be applied. For instance, replication should not be allowed for
-            // the left-hand side of a left outer join.
-            if (replicateLeftSide && !canReplicateLeft) {
-              logInfo(log"Left-hand side is picked but cannot be applied to join type " +
-                log"'${MDC(LogKeys.JOIN_TYPE, joinType)}'. Skipping partially clustered " +
-                log"distribution.")
-              replicateLeftSide = false
-            } else if (replicateRightSide && !canReplicateRight) {
-              logInfo(log"Right-hand side is picked but cannot be applied to join type " +
-                log"'${MDC(LogKeys.JOIN_TYPE, joinType)}'. Skipping partially clustered " +
-                log"distribution.")
-              replicateRightSide = false
-            } else {
-              // In partially clustered distribution, we should use un-grouped partition values.
-              // The child and the positions projecting its keys come from the same grouping:
-              // the keys from the node's child, the positions from the node itself, falling back
-              // to the spec's when there is no grouping. Like in `applyGroupPartitions`, the
-              // node's positions were computed against the raw partition keys, while the spec's
-              // were computed against the node's already projected report on a re-run.
-              val (partiallyClusteredChild, partiallyClusteredPositions) =
-                if (replicateLeftSide) {
-                  (unwrappedRight,
-                    rightGrouping.flatMap(_._1.joinKeyPositions)
-                      .orElse(rightSpec.joinKeyPositions))
-                } else {
-                  (unwrappedLeft,
-                    leftGrouping.flatMap(_._1.joinKeyPositions)
-                      .orElse(leftSpec.joinKeyPositions))
-                }
-              // The pre-alignment plan of the side that keeps its splits: its partitioning
-              // still holds the original partition keys, one per input split.
-              val originalPartitioning =
-                partiallyClusteredChild.outputPartitioning.asInstanceOf[Expression]
-              // `outputPartitioning` is either a `PartitioningCollection` or a `KeyedPartitioning`
-              // otherwise `createKeyedShuffleSpec()` would have returned `None`.
-              val originalKeyedPartitioning =
-                originalPartitioning.collectFirst { case k: KeyedPartitioning => k }.get
-              val projectedOriginalPartitionKeys = partiallyClusteredPositions
-                .fold(originalKeyedPartitioning.partitionKeys)(
-                  originalKeyedPartitioning.projectKeys(_)._2)
-
-              val numExpectedPartitions =
-                projectedOriginalPartitionKeys.groupBy(identity).view.mapValues(_.size)
-
-              mergedPartitionKeys = mergedPartitionKeys.map { case (key, numParts) =>
-                (key, numExpectedPartitions.getOrElse(key, numParts))
+          // Similar to skewed join, we need to check the join type to see whether replication
+          // of partitions can be applied. For instance, replication should not be allowed for
+          // the left-hand side of a left outer join.
+          if (replicateLeftSide && !canReplicateLeft) {
+            logInfo(log"Left-hand side is picked but cannot be applied to join type " +
+              log"'${MDC(LogKeys.JOIN_TYPE, joinType)}'. Skipping partially clustered " +
+              log"distribution.")
+            replicateLeftSide = false
+          } else if (replicateRightSide && !canReplicateRight) {
+            logInfo(log"Right-hand side is picked but cannot be applied to join type " +
+              log"'${MDC(LogKeys.JOIN_TYPE, joinType)}'. Skipping partially clustered " +
+              log"distribution.")
+            replicateRightSide = false
+          } else {
+            // In partially clustered distribution, we should use un-grouped partition values.
+            // The child and the positions projecting its keys come from the same grouping:
+            // the keys from the node's child, the positions from the node itself, falling back
+            // to the spec's when there is no grouping. Like in `applyGroupPartitions`, the
+            // node's positions were computed against the raw partition keys, while the spec's
+            // were computed against the node's already projected report on a re-run.
+            val (partiallyClusteredChild, partiallyClusteredPositions) =
+              if (replicateLeftSide) {
+                (unwrappedRight,
+                  rightGrouping.flatMap(_._1.joinKeyPositions)
+                    .orElse(rightSpec.joinKeyPositions))
+              } else {
+                (unwrappedLeft,
+                  leftGrouping.flatMap(_._1.joinKeyPositions)
+                    .orElse(leftSpec.joinKeyPositions))
               }
+            // The pre-alignment plan of the side that keeps its splits: its partitioning
+            // still holds the original partition keys, one per input split.
+            val originalPartitioning =
+              partiallyClusteredChild.outputPartitioning.asInstanceOf[Expression]
+            // `outputPartitioning` is either a `PartitioningCollection` or a `KeyedPartitioning`
+            // otherwise `createKeyedShuffleSpecs()` would have returned nothing.
+            val originalKeyedPartitioning =
+              originalPartitioning.collectFirst { case k: KeyedPartitioning => k }.get
+            val projectedOriginalPartitionKeys = partiallyClusteredPositions
+              .fold(originalKeyedPartitioning.partitionKeys)(
+                originalKeyedPartitioning.projectKeys(_)._2)
 
-              logInfo(log"After applying partially clustered distribution, there are " +
-                log"${MDC(LogKeys.NUM_PARTITIONS, mergedPartitionKeys.map(_._2).sum)} partitions.")
-              applyPartialClustering = true
+            val numExpectedPartitions =
+              projectedOriginalPartitionKeys.groupBy(identity).view.mapValues(_.size)
+
+            mergedPartitionKeys = mergedPartitionKeys.map { case (key, numParts) =>
+              (key, numExpectedPartitions.getOrElse(key, numParts))
             }
+
+            logInfo(log"After applying partially clustered distribution, there are " +
+              log"${MDC(LogKeys.NUM_PARTITIONS, mergedPartitionKeys.map(_._2).sum)} partitions.")
+            applyPartialClustering = true
           }
         }
-
-        // Now we need to push-down the common partition information to the `GroupPartitionsExec`s.
-        newLeft = applyGroupPartitions(left, leftSpec.joinKeyPositions, mergedPartitionKeys,
-          leftReducers, distributePartitions = applyPartialClustering && !replicateLeftSide)
-        newRight = applyGroupPartitions(right, rightSpec.joinKeyPositions, mergedPartitionKeys,
-          rightReducers, distributePartitions = applyPartialClustering && !replicateRightSide)
       }
+
+      // Now we need to push-down the common partition information to the `GroupPartitionsExec`s.
+      newLeft = applyGroupPartitions(left, leftSpec.joinKeyPositions, mergedPartitionKeys,
+        leftReducers, distributePartitions = applyPartialClustering && !replicateLeftSide)
+      newRight = applyGroupPartitions(right, rightSpec.joinKeyPositions, mergedPartitionKeys,
+        rightReducers, distributePartitions = applyPartialClustering && !replicateRightSide)
     }
 
-    if (isCompatible) Some(Seq(newLeft, newRight)) else None
+    if (compatibleAsIs || pushCommonValues) Some(Seq(newLeft, newRight)) else None
   }
 
   private def checkShufflePartitionIdPassThroughCompatible(
@@ -863,20 +912,14 @@ case class EnsureRequirements(
         joinKeyPositions = g.joinKeyPositions.orElse(joinKeyPositions),
         expectedPartitionKeys = Some(mergedPartitionKeys),
         // Unlike `joinKeyPositions`, these need no `orElse`. A re-run with reducers never reaches
-        // here. Both sides then report the same reduced keys, so `isCompatible` above is true and
-        // the whole block is skipped.
+        // here. Both sides then report the same reduced keys, so `compatibleAsIs` holds and the
+        // push branch is skipped.
         reducers = reducers,
         distributePartitions = distributePartitions)
     }.getOrElse {
       GroupPartitionsExec(plan, joinKeyPositions, Some(mergedPartitionKeys), reducers,
         distributePartitions)
     }
-  }
-
-  // Flattens a (possibly nested) `ShuffleSpecCollection` into its member specs.
-  private def flattenSpec(spec: ShuffleSpec): Seq[ShuffleSpec] = spec match {
-    case ShuffleSpecCollection(specs) => specs.flatMap(flattenSpec)
-    case other => Seq(other)
   }
 
   /**
@@ -896,13 +939,17 @@ case class EnsureRequirements(
   }
 
   /**
-   * Tries to create a [[KeyedShuffleSpec]] from the input partitioning and distribution, if the
-   * partitioning is a [[KeyedPartitioning]] (either directly or indirectly), and satisfies the
-   * given distribution.
+   * Every [[KeyedShuffleSpec]] the input partitioning can offer for the given distribution, one per
+   * [[KeyedPartitioning]] in it that satisfies it and passes the co-partition key requirement
+   * below. That requirement is on by default and is what usually leaves a collection with a single
+   * candidate. A [[PartitioningCollection]] yields them in member order, nested collections
+   * included, and the caller picks. Returning only the first would decide by enumeration order
+   * which member the join is planned on, and only the caller comparing the two sides knows which
+   * member pairs with the other side's.
    */
-  private def createKeyedShuffleSpec(
+  private def createKeyedShuffleSpecs(
       partitioning: Partitioning,
-      distribution: ClusteredDistribution): Option[KeyedShuffleSpec] = {
+      distribution: ClusteredDistribution): Seq[KeyedShuffleSpec] = {
     def tryCreate(partitioning: KeyedPartitioning): Option[KeyedShuffleSpec] = {
       // The config requires all the cluster keys to be covered by the partition keys, to avoid
       // the skew of joining on keys that are coarser than the join keys. Key order and duplicated
@@ -917,17 +964,17 @@ case class EnsureRequirements(
       if (partitioning.satisfies(distribution) &&
           (!SQLConf.get.getConf(SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION) ||
             allClusterKeysCovered)) {
-        Some(partitioning.createShuffleSpec(distribution).asInstanceOf[KeyedShuffleSpec])
+        Some(partitioning.createShuffleSpec(distribution))
       } else {
         None
       }
     }
 
     partitioning match {
-      case p: KeyedPartitioning => tryCreate(p)
+      case p: KeyedPartitioning => tryCreate(p).toSeq
       case PartitioningCollection(partitionings) =>
-        partitionings.collectFirst(Function.unlift(createKeyedShuffleSpec(_, distribution)))
-      case _ => None
+        partitionings.flatMap(createKeyedShuffleSpecs(_, distribution))
+      case _ => Nil
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -1079,11 +1079,11 @@ class KeyGroupedPartitioningSuite
 
   test("SPARK-59045: reduced expression is retargeted per KeyedPartitioning") {
     // A chained SPJ's output partitioning reports one `KeyedPartitioning` per join side, but the
-    // reduced expression is derived from the single spec that `createKeyedShuffleSpec` picks
-    // (`collectFirst`). Re-targeting it at each `KeyedPartitioning`'s own key attribute keeps the
-    // other sides' partitionings intact - otherwise a GROUP BY on the other side's key no longer
-    // sees a partitioning on it and the query shuffles (0 shuffles on base and here, 1 if the
-    // use-site re-targeting is dropped).
+    // reduced expression is derived from the one member `checkKeyGroupCompatible` paired this side
+    // on. Re-targeting it at each `KeyedPartitioning`'s own key attribute keeps the other sides'
+    // partitionings intact - otherwise a GROUP BY on the other side's key no longer sees a
+    // partitioning on it and the query shuffles (0 shuffles on base and here, 1 if the use-site
+    // re-targeting is dropped).
     val cols = Array(Column.create("id", LongType), Column.create("data", StringType))
     createTable("b16", cols, Array(bucket(16, "id")))
     createTable("b8", cols, Array(bucket(8, "id")))
@@ -3809,11 +3809,11 @@ class KeyGroupedPartitioningSuite
     // `arrive_time` is selected twice under two aliases, so the projected partitioning is a
     // `PartitioningCollection` whose members cover different numbers of the join keys: one covers
     // (id, t1), another only id. Each member's spec is projected onto its own subset, so the specs
-    // disagree on `numPartitions`, and asking the collection for one partitioning fails with
-    // "expected all specs in the collection to have the same number of partitions".
+    // disagree on `numPartitions`, and there is no one partitioning the collection could answer
+    // for. Since SPARK-59256 it cannot be asked for one at all.
     //
-    // `EnsureRequirements` now resolves the member the two sides agreed on before it asks, so the
-    // keyed side is grouped on both join keys and the shuffled side is laid out on those same keys.
+    // `EnsureRequirements` resolves the member the two sides agreed on before it asks, so the
+    // shuffled side is laid out on the keys the keyed side actually reports.
     val items_partitions = Array(identity("id"), identity("arrive_time"))
     createTable(items, itemsColumns, items_partitions)
 
@@ -3842,10 +3842,16 @@ class KeyGroupedPartitioningSuite
            |JOIN testcat.ns.$purchases p ON i.id = p.item_id AND i.t1 = p.time
            |""".stripMargin)
       val plan = df.queryExecution.executedPlan
-      val positions = collectAllGroupPartitions(plan).flatMap(_.joinKeyPositions)
-      assert(positions === Seq(Seq(0, 1)),
-        "the keyed side must be grouped on both join keys, the finest granularity available")
-      assert(collectAllShuffles(plan).size == 1, "only the unpartitioned side shuffles")
+      // The keyed side needs no grouping node: the member covering both join keys is already the
+      // scan's layout. What pins the choice is where the other side lands - that member has one
+      // partition per (id, arrive_time) pair, four of them, while the `id`-only member would put
+      // the shuffle on the three distinct ids.
+      assert(collectAllGroupPartitions(plan).isEmpty,
+        "the member covering both join keys is already the scan's layout")
+      val shuffles = collectAllShuffles(plan)
+      assert(shuffles.size == 1, "only the unpartitioned side shuffles")
+      assert(shuffles.map(_.outputPartitioning.numPartitions) === Seq(4),
+        "the shuffled side must land on the member covering both join keys")
       checkAnswer(df, Seq(
         Row(1, java.sql.Timestamp.valueOf("2020-01-01 00:00:00"),
           java.sql.Timestamp.valueOf("2020-01-01 00:00:00"), 40.0, 42.0),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder, TransformExpression}
-import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, KeyedPartitioning, KeyedShuffleSpec, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, KeyedPartitioning, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, BucketReducer, Reducer}
 import org.apache.spark.sql.execution.{DummySparkPlan, LeafExecNode, SafeForKWayMerge}
@@ -502,7 +502,6 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
 
     withSQLConf(SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
       val spec = partitioning.createShuffleSpec(ClusteredDistribution(Seq(exprA)))
-        .asInstanceOf[KeyedShuffleSpec]
       assert(spec.joinKeyPositions === Some(Seq(0)))
 
       val gpe = GroupPartitionsExec(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -1478,9 +1478,11 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       val smj = SortMergeJoinExec(Seq(id, t1), Seq(id, t1), Inner, None, keyed, unpartitioned)
       val planned = EnsureRequirements.apply(smj).asInstanceOf[SortMergeJoinExec]
 
-      // The keyed side is grouped on both join keys, which is the finest member.
-      assert(groupPartitionsNodes(planned.left).map(_.joinKeyPositions) === Seq(Some(Seq(0, 1))),
-        "the keyed side must be grouped on the member covering both join keys")
+      // The keyed side needs no grouping node at all: the member covering both join keys is already
+      // the child's layout, so its spec reports no projection. Picking the coarse member instead
+      // would project onto `id` alone and insert a node carrying `Some(Seq(0))`.
+      assert(groupPartitionsNodes(planned.left).isEmpty,
+        "the member covering both join keys is already the child's layout")
       // And the shuffled side lands on that same member. Reading the collection instead would take
       // whichever member came first and could put the two sides on different key sets.
       val shuffles = planned.right.collect { case s: ShuffleExchangeExec => s }
@@ -1540,6 +1542,290 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         case k: KeyedPartitioning => k.expressions == Seq(iL) || k.expressions == Seq(iR)
         case _ => false
       }, "each side must end up grouped on its own cogroup key")
+    }
+  }
+
+  test("SPARK-59256: a collection is ranked on its best member, not on whichever came first") {
+    val id = AttributeReference("id", IntegerType)()
+    val t1 = AttributeReference("t1", IntegerType)()
+    val t2 = AttributeReference("t2", IntegerType)()
+    // Clustering on (id, t1). The collection's first member matches `id` only and keeps two
+    // partitions, the second covers both positions and keeps five. Reading the first member's
+    // count ranks this child at 2 and loses to the hashed child's 3, even though the member the
+    // shuffle would actually be built from offers 5.
+    val keys = Seq(InternalRow(1, 1), InternalRow(1, 2), InternalRow(1, 3),
+      InternalRow(2, 1), InternalRow(2, 2))
+    val keyed = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(id, t2), keys),
+        KeyedPartitioning(Seq(id, t1), keys))))
+    val hashed = DummySparkPlan(outputPartitioning = HashPartitioning(Seq(id, t1), 3))
+    val distribution = ClusteredDistribution(Seq(id, t1))
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      // Pin the premise, ordered: the coarse member really is the one a head read would take.
+      val memberPartitions = keyed.outputPartitioning.createShuffleSpec(distribution)
+        .flatten.map(_.numPartitions)
+      assert(memberPartitions === Seq(2, 5))
+
+      val parent = DummySparkPlan(
+        children = Seq(keyed, hashed),
+        requiredChildDistribution = Seq(distribution, distribution),
+        requiredChildOrdering = Seq(Nil, Nil))
+      val planned = EnsureRequirements.apply(parent)
+      assert(planned.children.head.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "the keyed side wins the ranking, so it is not re-shuffled")
+      val shuffles = planned.children(1).collect { case s: ShuffleExchangeExec => s }
+      assert(shuffles.map(_.outputPartitioning.numPartitions) === Seq(5),
+        "the hashed side lands on the keyed side's finest member")
+    }
+  }
+
+  test("SPARK-59256: the join is planned on a member pair, not on each side's first member") {
+    val aL = AttributeReference("aL", IntegerType)()
+    val bL = AttributeReference("bL", IntegerType)()
+    val cL = AttributeReference("cL", IntegerType)()
+    val aR = AttributeReference("aR", IntegerType)()
+    val bR = AttributeReference("bR", IntegerType)()
+    val cR = AttributeReference("cR", IntegerType)()
+    // The join keys are wider than the partitioning arity, so a member can satisfy the distribution
+    // without covering every join key.
+    val keys = Seq(InternalRow(1, 1), InternalRow(1, 2), InternalRow(2, 1), InternalRow(2, 2))
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aL, bL), keys),
+        KeyedPartitioning(Seq(aL, cL), keys))))
+    // The b-member and the c-member are in the opposite order here.
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aR, cR), keys),
+        KeyedPartitioning(Seq(aR, bR), keys))))
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false") {
+      val smj = SortMergeJoinExec(
+        Seq(aL, bL, cL), Seq(aR, bR, cR), Inner, None, left, right)
+      val planned = EnsureRequirements.apply(smj)
+
+      // Taking each side's first member pairs (aL, bL) with (aR, cR), which do not agree on their
+      // keys, so `checkKeyGroupCompatible` declines. `v2BucketingShuffleEnabled` is left off on
+      // purpose: a keyed spec cannot be a shuffle reference without it, so the decline costs both
+      // children a shuffle rather than a grouping node. Pairing finds (aL, bL) with (aR, bR),
+      // co-partitioned as they stand, so neither side moves.
+      assert(planned.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "the paired members are co-partitioned, so neither side is shuffled")
+      assert(groupPartitionsNodes(planned).isEmpty,
+        "and co-partitioned as they stand, so no grouping node is needed either")
+    }
+  }
+
+  test("SPARK-59256: the finest agreeing pair wins, not the first one") {
+    val aL = AttributeReference("aL", IntegerType)()
+    val bL = AttributeReference("bL", IntegerType)()
+    val zL = AttributeReference("zL", IntegerType)()
+    val aR = AttributeReference("aR", IntegerType)()
+    val bR = AttributeReference("bR", IntegerType)()
+    val wR = AttributeReference("wR", IntegerType)()
+    // Each side leads with a member whose second expression is not a join key, so it projects onto
+    // `a` alone, and follows with one covering both. Both pairings agree on the keys, so the choice
+    // is the ranking's: the coarse pair leaves 2 partitions a side, the fine one 4 and 2.
+    val leftKeys =
+      Seq(InternalRow(1, 10), InternalRow(1, 11), InternalRow(2, 20), InternalRow(2, 21))
+    val rightKeys = Seq(InternalRow(1, 10), InternalRow(2, 20))
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aL, zL), leftKeys),
+        KeyedPartitioning(Seq(aL, bL), leftKeys))))
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aR, wR), rightKeys),
+        KeyedPartitioning(Seq(aR, bR), rightKeys))))
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false") {
+      val smj = SortMergeJoinExec(Seq(aL, bL), Seq(aR, bR), Inner, None, left, right)
+      val planned = EnsureRequirements.apply(smj)
+
+      assert(planned.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "both pairings agree on the keys, so neither side is shuffled either way")
+      // The fine pair's members are each their child's own layout, so no projection is reported and
+      // the nodes only align to the merged keys. Taking the first agreeing pair instead groups both
+      // sides on `a` alone, i.e. positions `Some(Seq(0))`.
+      assert(groupPartitionsNodes(planned).map(_.joinKeyPositions) === Seq(None, None),
+        "the join must be planned on the pair that keeps the most partitions")
+    }
+  }
+
+  test("SPARK-59256: a tie goes to the pair the children already report") {
+    val aL = AttributeReference("aL", IntegerType)()
+    val bL = AttributeReference("bL", IntegerType)()
+    val zL = AttributeReference("zL", IntegerType)()
+    val aR = AttributeReference("aR", IntegerType)()
+    val bR = AttributeReference("bR", IntegerType)()
+    val wR = AttributeReference("wR", IntegerType)()
+    // As in the test above, each side leads with a member whose second expression is not a join
+    // key. Here the key it drops is functionally determined by the one it keeps, so the coarse
+    // member projects onto as many groups as the identity member has and the ranking cannot
+    // separate the two pairings. Only the identity pair is co-partitioned as it stands.
+    val keys = Seq(InternalRow(1, 10), InternalRow(2, 20))
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aL, zL), keys),
+        KeyedPartitioning(Seq(aL, bL), keys))))
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aR, wR), keys),
+        KeyedPartitioning(Seq(aR, bR), keys))))
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false") {
+      // Pin the premise, ordered: the coarse member comes first and offers the same parallelism, so
+      // the rank is a tie and enumeration order would decide it.
+      val memberPartitions = left.outputPartitioning
+        .createShuffleSpec(ClusteredDistribution(Seq(aL, bL))).flatten.map(_.numPartitions)
+      assert(memberPartitions === Seq(2, 2))
+
+      val smj = SortMergeJoinExec(Seq(aL, bL), Seq(aR, bR), Inner, None, left, right)
+      val planned = EnsureRequirements.apply(smj)
+
+      assert(planned.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "both pairings agree on the keys, so neither side is shuffled either way")
+      // Taking the coarse pair groups both sides on `a` alone, which drops `b` from the keys the
+      // identity member still declares.
+      assert(groupPartitionsNodes(planned).isEmpty,
+        "the identity pair is co-partitioned as it stands, so nothing is inserted")
+    }
+  }
+
+  test("SPARK-59256: a filtered one-sided join is ranked on the side whose keys survive") {
+    val p = AttributeReference("p", IntegerType)()
+    val q = AttributeReference("q", IntegerType)()
+    val zL = AttributeReference("zL", IntegerType)()
+    val wL = AttributeReference("wL", IntegerType)()
+    val u = AttributeReference("u", IntegerType)()
+    val v = AttributeReference("v", IntegerType)()
+    val zR = AttributeReference("zR", IntegerType)()
+    val wR = AttributeReference("wR", IntegerType)()
+    // Each side offers a member covering the join keys at positions 0 and 1 and one covering them
+    // at 0 and 2, so all four pairings agree on the keys and only the ranking separates them. The
+    // key rows make the two projections differ: 4 and 6 groups on the left, 8 and 4 on the right.
+    val leftKeys = Seq(
+      InternalRow(1, 1, 1), InternalRow(1, 1, 2), InternalRow(1, 2, 3),
+      InternalRow(2, 1, 4), InternalRow(2, 2, 5), InternalRow(2, 2, 6))
+    val rightKeys = Seq(
+      InternalRow(1, 1, 1), InternalRow(1, 2, 1), InternalRow(1, 3, 2), InternalRow(1, 4, 2),
+      InternalRow(2, 1, 1), InternalRow(2, 2, 1), InternalRow(2, 3, 2), InternalRow(2, 4, 2))
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(p, q, wL), leftKeys),
+        KeyedPartitioning(Seq(p, zL, q), leftKeys))))
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(u, zR, v), rightKeys),
+        KeyedPartitioning(Seq(u, v, wR), rightKeys))))
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false") {
+      // A `LeftOuter` join under partition filtering keeps the left's keys and drops the right's,
+      // so the right's count says nothing about what the join gets. Ranking on the larger of the
+      // two takes the left's 4-group member, because the right member it pairs with offers 8.
+      val leftOuter = SortMergeJoinExec(Seq(p, q), Seq(u, v), LeftOuter, None, left, right)
+      val plannedLeft = EnsureRequirements.apply(leftOuter)
+      assert(plannedLeft.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "every pairing agrees on the keys, so neither side is shuffled whichever one wins")
+      assert(groupPartitionsNodes(plannedLeft).map(_.expectedPartitionKeys.map(_.size)) ===
+        Seq(Some(6), Some(6)),
+        "the join runs on the surviving side's best member, not on the dropped side's")
+
+      // The mirror image. `RightOuter` keeps the right's keys, and there the right's 8-group member
+      // wins even though the left member it pairs with offers only 3.
+      val rightOuter = SortMergeJoinExec(Seq(p, q), Seq(u, v), RightOuter, None, left, right)
+      val plannedRight = EnsureRequirements.apply(rightOuter)
+      assert(plannedRight.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+        "and neither side is shuffled here either")
+      assert(groupPartitionsNodes(plannedRight).map(_.expectedPartitionKeys.map(_.size)) ===
+        Seq(Some(8), Some(8)),
+        "the surviving side is the right one now, so its best member decides")
+    }
+  }
+
+  test("SPARK-59256: the pairing reaches a default configuration through a key position swap") {
+    val xL = AttributeReference("xL", IntegerType)()
+    val yL = AttributeReference("yL", IntegerType)()
+    val aR = AttributeReference("aR", IntegerType)()
+    val bR = AttributeReference("bR", IntegerType)()
+    // What a projection over a table partitioned by two transforms of one column produces. For
+    // `SELECT c AS x, c AS y`, `AliasAwareOutputExpression.projectKeyedPartitionings` offers both
+    // aliases at both positions and cross-products them, and the co-partition key requirement,
+    // on by default, keeps the two members that name both attributes. They agree on the function
+    // at each position, as anything the default config can build must, and differ only in which
+    // attribute sits where. That is enough for `areKeysCompatible` to accept one and refuse the
+    // other, and the refused one comes first.
+    val leftKeys = Seq(InternalRow(1, 10), InternalRow(2, 20))
+    val rightKeys = Seq(InternalRow(1, 10), InternalRow(3, 30))
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(days(yL), years(xL)), leftKeys),
+        KeyedPartitioning(Seq(days(xL), years(yL)), leftKeys))))
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = KeyedPartitioning(Seq(days(aR), years(bR)), rightKeys))
+
+    // No `withSQLConf` on purpose. `pushPartValues` is on by default, which is all the push branch
+    // needs, so this is what a user gets out of the box.
+    val smj = SortMergeJoinExec(Seq(xL, yL), Seq(aR, bR), Inner, None, left, right)
+    val planned = EnsureRequirements.apply(smj)
+
+    // Without the pairing, the left's first member is taken and its `days(yL)` is matched against
+    // `days(aR)`, which names the other join key, so the join declines and both sides are shuffled
+    // onto the default partitioning.
+    assert(planned.collect { case s: ShuffleExchangeExec => s }.isEmpty,
+      "the second member pairs with the other side, so neither side is shuffled")
+    assert(groupPartitionsNodes(planned).map(_.expectedPartitionKeys.map(_.size)) ===
+      Seq(Some(3), Some(3)),
+      "both sides are pushed the union of the two key sets")
+  }
+
+  test("SPARK-59256: no agreeing pair leaves the join alone however many members each side has") {
+    val aL = AttributeReference("aL", IntegerType)()
+    val bL = AttributeReference("bL", IntegerType)()
+    val aR = AttributeReference("aR", IntegerType)()
+    val bR = AttributeReference("bR", IntegerType)()
+    // The two sides differ in arity, which `areKeysCompatible` refuses whatever the keys are, so
+    // none of the four pairs agrees and the fallback reports each side's first member. A negative
+    // pin: it holds with the per-side pick too, which is the point - the fallback must not start
+    // claiming a co-partitioning the old code did not claim.
+    val oneKeys = Seq(InternalRow(1), InternalRow(2))
+    val twoKeys = Seq(InternalRow(1, 10), InternalRow(2, 20))
+    val left = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aL), oneKeys),
+        KeyedPartitioning(Seq(bL), oneKeys))))
+    val right = new DummySparkPlanWithBatchScanChild(
+      outputPartitioning = PartitioningCollection.fromPartitionings(Seq(
+        KeyedPartitioning(Seq(aR, bR), twoKeys),
+        KeyedPartitioning(Seq(bR, aR), twoKeys))))
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false") {
+      val smj = SortMergeJoinExec(Seq(aL, bL), Seq(aR, bR), Inner, None, left, right)
+      val planned = EnsureRequirements.apply(smj)
+
+      // The shuffle is what pins this, not the absence of grouping nodes: a fallback that wrongly
+      // claimed compatibility would return the children untouched and skip the push branch, so
+      // there would be no grouping node either way.
+      assert(planned.collect { case s: ShuffleExchangeExec => s }.nonEmpty,
+        "no pair agrees, so the join is not planned as storage-partitioned")
+      assert(groupPartitionsNodes(planned).isEmpty, "and nothing is grouped")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

A `PartitioningCollection` offers several layouts, and which one is right depends on what the other side matched. Four places in `EnsureRequirements` decided it by enumeration order instead, and none of them could see both sides:

1. the per-child branch that shuffles a child read `specs.head` through `ShuffleSpecCollection.createPartitioning` — fixed by #58527;
2. the child ranking, `finalCandidateSpecs.values.maxBy(_.numPartitions)`, reads the collection's `numPartitions`, which is `specs.head`'s;
3. `SinglePartitionShuffleSpec.isCompatibleWith` reads `other.numPartitions`, the same head;
4. `createKeyedShuffleSpec` collapses a collection to one member with `collectFirst`, per side, before either side has seen the other.

This PR is 2, 3 and 4. 2 and 4 were raised by @LuciferYang in review of #58527.

**The type split.** A new `LeafShuffleSpec` sub-trait carries the two single-member methods, and `ShuffleSpec` is sealed:

```
ShuffleSpec (sealed)             isCompatibleWith, canCreatePartitioning, flatten
  <- LeafShuffleSpec             + numPartitions, createPartitioning
       SinglePartitionShuffleSpec, RangeShuffleSpec, HashShuffleSpec,
       NullAwareHashShuffleSpec, CoalescedHashShuffleSpec, KeyedShuffleSpec,
       ShufflePartitionIdPassThroughSpec
  <- ShuffleSpecCollection
```

`ShuffleSpecCollection` loses `createPartitioning`, which had no production caller after #58527, and `numPartitions`, which had two consumers wanting two different aggregations: the child ranking wants the max over the members, and `SinglePartitionShuffleSpec.isCompatibleWith` wants it to hold for every one. Both now say so at the call site. `flatten` replaces a private helper #58527 added to `EnsureRequirements`.

**The pairing.** `createKeyedShuffleSpecs` returns every member's spec, and `checkKeyGroupCompatible` picks the pair that agrees on the keys and offers the most parallelism, with ties going to a pair both children report as it stands. The ranking reads only the side whose keys survive on the join types where the merge drops the other's, and two cases where it stays a heuristic are named in the code comment.

**One thing the pairing needed, which is a small fix of its own.** `joinKeyPositions` could not answer "is this spec the child's own layout", because an identity projection still went through `toGrouped` and reported `Some(0 until n)` even where nothing changed. It now reports `None` there. That also drops a `GroupPartitionsExec` that projects nothing, since the per-child alignment path decides whether to wrap a child by matching on `Some(positions)`.

The reasoning behind each choice is in the code comments rather than here.

### Why are the changes needed?

`isCompatibleWith` succeeds when *any* member matches, which is the whole point of the type. The two single-member questions are not wrong in the same way. `createPartitioning` has no local answer at all, since the right member is the one the other side matched. `numPartitions` has an answer, but two different ones depending on who asks.

For the pairing the cost is concrete: two sides pick members that do not agree, `checkKeyGroupCompatible` declines, and the join loses the storage-partitioned pushdown even though a pairing existed.

### Does this PR introduce _any_ user-facing change?

**Yes**, three of them.

**Plans change out of the box.** `spark.sql.sources.v2.bucketing.pushPartValues.enabled` defaults to **true**, and it is all the push branch in `checkKeyGroupCompatible` needs. Measured with no config set at all, on the key-position-swap shape the tests use: taking each side's first member makes the join decline, `bestSpecOpt` is then empty because a keyed spec cannot be a shuffle reference without `v2BucketingShuffleEnabled` (which *is* off by default), and both children are shuffled onto the default 200 partitions. With the pairing the join runs with no shuffle and two grouping nodes.

The ranking and the `SinglePartitionShuffleSpec` change are no-ops unless `allowKeysSubsetOfPartitionKeys` is on, since `PartitioningCollection` requires its members to agree on `numPartitions` and only that config makes a spec report a different count from its partitioning's.

**Sealing `ShuffleSpec` is a source break** for out-of-tree code that extends it, which has to move to `LeafShuffleSpec`, and removing the collection's two methods is a binary break for old bytecode. Catalyst is in the `defaultExcludes` section of `MimaExcludes` and treated as internals, so CI does not flag it and no excludes are needed, the same as for the `KeyGrouped*` to `Keyed*` rename. Raised by @LuciferYang.

**A new failure mode.** `reducersBothWays` now runs on a pair the old code could not form, so a connector whose `Reducer.resultType()` violates the `r(f1(x)) = f2(x)` contract can raise `storagePartitionJoinIncompatibleReducedTypesError` where the join used to fall back silently. That is what the error exists to catch, but it is newly reachable.

### How was this patch tested?

Eleven new tests, three existing ones re-anchored. **A plain fail-on-base measurement is not available**: the tests name `LeafShuffleSpec`, so they cannot compile against the parent commit. Instead each old decision was reinstated under the new types, one at a time:

| old decision reinstated | tests that fail |
|---|---|
| `maxBy(_.flatten.head.numPartitions)` | the child ranking one |
| per-side `(leftCandidates.head, rightCandidates.head)` | 5 |
| `agreeingPairs.headOption` | 2 |
| ranking without the tie-break | the tie one |
| `max` for every join type | the filtered one-sided one |
| `isCompatibleWith(specs.head)` | the single-partition one |
| reporting `Some(joinKeyPositions)` unconditionally | 4 |

Eight of the eleven discriminate; the other three pin a contract that holds either way and say so in their own comments.

Two changes have no test, both deliberately. The early `return None` when no pair agrees is observationally identical to carrying the head pair to the end, so the only thing to assert on is a log line that no longer appears. And `rank`'s `RightOuter` arm shares a test with the `LeftOuter` one, since the two are mirror images over the same fixture.

Green: `ShuffleSpecSuite`, `DistributionSuite`, `EnsureRequirementsSuite`, `ValidateRequirementsSuite`, `KeyGroupedPartitioningSuite`, `PlannerSuite`, `GroupPartitionsExecSuite`, `ProjectedOrderingAndPartitioningSuite`, 430 tests, plus both `TPCDS*PlanStabilitySuite`. `dev/lint-scala` is clean.

One hunk is a 184-line re-indent, from dropping a guard that became provably true. Read it with `git diff -w`, where it is four added and three removed lines.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
