### PR TITLE
[SPARK-59263][BUILD] Upgrade `compress-lzf` to 1.2.1

### DIFF
--- a/core/benchmarks/LZFBenchmark-jdk21-results.txt
+++ b/core/benchmarks/LZFBenchmark-jdk21-results.txt
@@ -2,18 +2,18 @@
 Benchmark LZFCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 Compress small objects:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Compression 256000000 int values in parallel                610            616           6        419.5           2.4       1.0X
-Compression 256000000 int values single-threaded            577            580           3        443.5           2.3       1.1X
+Compression 256000000 int values in parallel                603            611           9        424.4           2.4       1.0X
+Compression 256000000 int values single-threaded            559            564           5        457.8           2.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 Compress large objects:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Compression 1024 array values in 1 threads                48             53           3          0.0       47285.9       1.0X
-Compression 1024 array values single-threaded             33             34           1          0.0       32317.8       1.5X
+Compression 1024 array values in 1 threads                49             52           2          0.0       47958.5       1.0X
+Compression 1024 array values single-threaded             34             34           0          0.0       32921.4       1.5X
 
 

--- a/core/benchmarks/LZFBenchmark-jdk25-results.txt
+++ b/core/benchmarks/LZFBenchmark-jdk25-results.txt
@@ -2,18 +2,18 @@
 Benchmark LZFCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 Compress small objects:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Compression 256000000 int values in parallel                597            609           8        429.1           2.3       1.0X
-Compression 256000000 int values single-threaded            593            596           2        431.6           2.3       1.0X
+Compression 256000000 int values in parallel                603            615           9        424.3           2.4       1.0X
+Compression 256000000 int values single-threaded            591            598          10        433.2           2.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
+OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1022-azure
 AMD EPYC 7763 64-Core Processor
 Compress large objects:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Compression 1024 array values in 1 threads                47             51           3          0.0       45666.3       1.0X
-Compression 1024 array values single-threaded             32             33           1          0.0       31432.4       1.5X
+Compression 1024 array values in 1 threads                45             52           3          0.0       44214.3       1.0X
+Compression 1024 array values single-threaded             33             34           1          0.0       32021.3       1.4X
 
 

--- a/core/benchmarks/LZFBenchmark-results.txt
+++ b/core/benchmarks/LZFBenchmark-results.txt
@@ -2,18 +2,18 @@
 Benchmark LZFCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
+AMD EPYC 7763 64-Core Processor
 Compress small objects:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Compression 256000000 int values in parallel                521            542          16        491.2           2.0       1.0X
-Compression 256000000 int values single-threaded            522            538          24        490.1           2.0       1.0X
+Compression 256000000 int values in parallel                597            612          12        428.8           2.3       1.0X
+Compression 256000000 int values single-threaded            628            635          11        407.4           2.5       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1022-azure
+AMD EPYC 7763 64-Core Processor
 Compress large objects:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Compression 1024 array values in 1 threads                53             56           3          0.0       51488.0       1.0X
-Compression 1024 array values single-threaded             34             35           0          0.0       33270.0       1.5X
+Compression 1024 array values in 1 threads                48             54           5          0.0       46539.1       1.0X
+Compression 1024 array values single-threaded             33             33           0          0.0       32062.5       1.5X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -61,7 +61,7 @@ commons-lang3/3.20.0//commons-lang3-3.20.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.15.0//commons-text-1.15.0.jar
-compress-lzf/1.2.0//compress-lzf-1.2.0.jar
+compress-lzf/1.2.1//compress-lzf-1.2.1.jar
 curator-client/5.9.0//curator-client-5.9.0.jar
 curator-framework/5.9.0//curator-framework-5.9.0.jar
 curator-recipes/5.9.0//curator-recipes-5.9.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -868,7 +868,7 @@
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `compress-lzf` to 1.2.1.

### Why are the changes needed?

To bring the latest bug fix.
- https://github.com/ning/compress/releases/tag/compress-lzf-1.2.1 (2026-08-02)
  - https://github.com/ning/compress/pull/85 (Handle malformed LZF back references)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5