### PR TITLE
[SPARK-59212][K8S][INFRA][4.3] Pin the Minikube container runtime to docker in K8s CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1589,6 +1589,10 @@ jobs:
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           kubernetes-version: "1.36.0"
+          # Minikube 1.39.0 changed the default container runtime to containerd. The image
+          # builds below go through `minikube docker-env`, which needs a real Docker daemon
+          # in the node, so pin the runtime rather than inherit the default.
+          container-runtime: docker
           # GitHub Actions limit 4C/16G, limit to 2C/6G for better resource statistic
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           cpus: 2


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport the applicable part of #58502 (`680855bea73`) to `branch-4.3` by passing `container-runtime: docker` to the Minikube setup used by the Kubernetes integration test job.

The OIDC E2E job updated by the master change does not exist on `branch-4.3`, so this backport changes only the Kubernetes integration test job.

### Why are the changes needed?

Minikube 1.39.0 changed its default container runtime from Docker to containerd. The Kubernetes integration test builds Spark images through `minikube docker-env`, but the containerd Docker shim does not implement enough of the Docker API for Buildx. Image construction therefore fails while booting BuildKit with:

```
failed to inspect pulled image moby/buildkit:buildx-stable-1: Error response from daemon: 404 page not found
```

This currently breaks the `branch-4.3` Kubernetes integration check, as seen in [this CI run](https://github.com/szehon-ho/spark/actions/runs/33897666594/job/101109172055). Pinning the runtime to Docker restores the real Docker daemon expected by the image build.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Parsed `.github/workflows/build_and_test.yml` with Ruby YAML to verify its syntax.
- Ran `git diff --check`.
- The Kubernetes integration CI job exercises the affected image-build path.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)