### PR TITLE
[SPARK-58881][CORE] Ignore non-numeric checkpoint part files

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala
@@ -74,7 +74,7 @@ private[spark] class ReliableCheckpointRDD[T: ClassTag](
     // listStatus can throw exception if path does not exist.
     val inputFiles = fs.listStatus(cpath)
       .map(_.getPath)
-      .filter(_.getName.startsWith("part-"))
+      .filter(path => ReliableCheckpointRDD.isCheckpointFile(path.getName))
       .sortBy(_.getName.stripPrefix("part-").toInt)
     // Fail fast if input files are invalid
     inputFiles.zipWithIndex.foreach { case (path, i) =>
@@ -131,6 +131,12 @@ private[spark] class ReliableCheckpointRDD[T: ClassTag](
 }
 
 private[spark] object ReliableCheckpointRDD extends Logging {
+
+  private def isCheckpointFile(fileName: String): Boolean = {
+    val partitionId = fileName.stripPrefix("part-")
+    fileName.startsWith("part-") && partitionId.nonEmpty &&
+      partitionId.forall(c => c >= '0' && c <= '9')
+  }
 
   /**
    * Return the checkpoint file name for the given partition.

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -750,6 +750,26 @@ class CheckpointStorageSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  test("SPARK-58881: ignore non-numeric part files in a checkpoint directory") {
+    withTempDir { checkpointDir =>
+      sc = new SparkContext("local", "test", new SparkConf().set(UI_ENABLED.key, "false"))
+      sc.setCheckpointDir(checkpointDir.toString)
+      val rdd = sc.makeRDD(1 to 20, numSlices = 4)
+      rdd.checkpoint()
+      assert(rdd.collect().toSeq === (1 to 20))
+
+      val checkpointPath = new Path(rdd.getCheckpointFile.get)
+      val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+      Seq("part-00000.bak", "part-backup", "part-").foreach { fileName =>
+        fs.create(new Path(checkpointPath, fileName)).close()
+      }
+
+      val recovered = sc.checkpointFile[Int](checkpointPath.toString)
+      assert(recovered.getNumPartitions === 4)
+      assert(recovered.collect().toSeq === (1 to 20))
+    }
+  }
+
   test("checkpoint path that cannot be created") {
     withTempDir { checkpointDir =>
       // MkdirsFailingFilesystem refuses to create the per-RDD directory and reports it the way


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tighten the checkpoint directory scan so it accepts only file names consisting of `part-` followed by one or more ASCII digits. The existing numeric ordering and contiguous partition validation remain unchanged.

Add a regression test that creates a valid checkpoint, adds `part-00000.bak`, `part-backup`, and `part-` files, and verifies that the checkpoint can still be recovered.

### Why are the changes needed?

`ReliableCheckpointRDD.getPartitions` currently accepts every name starting with `part-` and then parses the suffix as an integer. Leftover or externally created files such as `part-00000.bak` therefore cause an unhelpful `NumberFormatException` and make an otherwise valid checkpoint unreadable.

Spark's own checkpoint files always use a numeric suffix. Ignoring non-numeric names avoids that failure without changing validation for malformed numeric checkpoint layouts.

### Does this PR introduce _any_ user-facing change?

Yes. Reading a checkpoint directory now ignores non-numeric `part-*` files. Numeric checkpoint files continue to be validated for the expected names and contiguous partition sequence.

### How was this patch tested?

Added a regression test and ran:

`build/sbt "core/Test/testOnly org.apache.spark.CheckpointStorageSuite"`

All 9 tests passed. Also ran `dev/lint-scala`; Scalastyle and Scalafmt passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
