### PR TITLE
[SPARK-59051][SQL] Compile JDBC partition bounds with the dialect

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -462,16 +462,15 @@ class OracleIntegrationSuite extends SharedJDBCIntegrationSuite
       // the partition column. E.g. 2018-07-06 cannot be evaluated as Timestamp, and the error
       // message says: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff].
       .option("oracle.jdbc.mapDateToTimestamp", "false")
-      .option("sessionInitStatement", "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'")
       .load()
 
     df1.logicalPlan match {
       case LogicalRelationWithTable(JDBCRelation(_, parts, _, _), _) =>
         val whereClauses = parts.map(_.asInstanceOf[JDBCPartition].whereClause).toSet
         assert(whereClauses === Set(
-          """"D" < '2018-07-11' or "D" is null""",
-          """"D" >= '2018-07-11' AND "D" < '2018-07-15'""",
-          """"D" >= '2018-07-15'"""))
+          """"D" < {d '2018-07-11'} or "D" is null""",
+          """"D" >= {d '2018-07-11'} AND "D" < {d '2018-07-15'}""",
+          """"D" >= {d '2018-07-15'}"""))
     }
     assert(df1.collect().toSet === expectedResult)
 
@@ -484,16 +483,14 @@ class OracleIntegrationSuite extends SharedJDBCIntegrationSuite
       .option("upperBound", "2018-07-27 14:11:05.0")
       .option("numPartitions", 2)
       .option("oracle.jdbc.mapDateToTimestamp", "false")
-      .option("sessionInitStatement",
-        "ALTER SESSION SET NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF'")
       .load()
 
     df2.logicalPlan match {
       case LogicalRelationWithTable(JDBCRelation(_, parts, _, _), _) =>
         val whereClauses = parts.map(_.asInstanceOf[JDBCPartition].whereClause).toSet
         assert(whereClauses === Set(
-          """"T" < '2018-07-15 20:50:32.5' or "T" is null""",
-          """"T" >= '2018-07-15 20:50:32.5'"""))
+          """"T" < {ts '2018-07-15 20:50:32.5'} or "T" is null""",
+          """"T" >= {ts '2018-07-15 20:50:32.5'}"""))
     }
     assert(df2.collect().toSet === expectedResult)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -26,13 +26,13 @@ import org.apache.spark.internal.LogKeys.{CLAUSES, LOWER_BOUND, NEW_VALUE, NUM_P
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.util.{DateFormatter, DateTimeUtils, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, stringToDate, stringToTimestamp, stringToTimestampWithoutTimeZone}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.jdbc.JdbcDialects
+import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DataType, DateType, NumericType, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
@@ -111,8 +111,9 @@ private[sql] object JDBCRelation extends Logging {
       "Operation not allowed: the lower bound of partitioning column is larger than the upper " +
       s"bound. Lower bound: $lowerBound; Upper bound: $upperBound")
 
+    val dialect = JdbcDialects.get(jdbcOptions.url)
     val boundValueToString: Long => String =
-      toBoundValueInWhereClause(_, partitioning.columnType, timeZoneId)
+      toBoundValueInWhereClause(_, partitioning.columnType, timeZoneId, dialect)
     val numPartitions =
       if ((upperBound - lowerBound) >= partitioning.numPartitions || /* check for overflow */
           (upperBound - lowerBound) < 0) {
@@ -216,26 +217,22 @@ private[sql] object JDBCRelation extends Logging {
   private def toBoundValueInWhereClause(
       value: Long,
       columnType: DataType,
-      timeZoneId: String): String = {
-    def dateTimeToString(): String = {
-      val dateTimeStr = columnType match {
+      timeZoneId: String,
+      dialect: JdbcDialect): String = {
+    def compileDateTimeValue(): String = {
+      val dateTimeValue = columnType match {
         case DateType =>
-          DateFormatter().format(value.toInt)
+          java.sql.Date.valueOf(DateTimeUtils.daysToLocalDate(value.toInt))
         case TimestampType =>
-          val timestampFormatter = TimestampFormatter.getFractionFormatter(
-            DateTimeUtils.getZoneId(timeZoneId))
-          timestampFormatter.format(value)
+          DateTimeUtils.microsToInstant(value).atZone(getZoneId(timeZoneId)).toLocalDateTime
         case TimestampNTZType =>
-          // NTZ micros are zoneless wall-clock values; format in UTC so no zone shift is applied.
-          val timestampFormatter = TimestampFormatter.getFractionFormatter(
-            DateTimeUtils.getZoneId("UTC"))
-          timestampFormatter.format(value)
+          DateTimeUtils.microsToLocalDateTime(value)
       }
-      s"'$dateTimeStr'"
+      dialect.compileValue(dateTimeValue).toString
     }
     columnType match {
       case _: NumericType => value.toString
-      case DateType | TimestampType | TimestampNTZType => dateTimeToString()
+      case DateType | TimestampType | TimestampNTZType => compileDateTimeValue()
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -541,6 +541,41 @@ class JDBCSuite extends SharedSparkSession {
     assert(e.getMessage.contains("2018-07-06 10:00:00+05:00"))
   }
 
+  test("SPARK-59051: compile temporal partition bounds with the JDBC dialect") {
+    val testUrl = "jdbc:spark-test:"
+    val quotedColumn = "\"PartitionColumn\""
+    val cases = Seq(
+      (DateType, "2018-07-06", "2018-07-08", "{d '2018-07-07'}"),
+      (TimestampType, "2018-07-06 10:00:00", "2018-07-06 14:00:00",
+        "{ts '2018-07-06 12:00:00.0'}"),
+      (TimestampNTZType, "2018-07-06 10:00:00", "2018-07-06 14:00:00",
+        "{ts '2018-07-06 12:00:00.0'}"))
+
+    JdbcDialects.registerDialectForUrlPrefix(testUrl, OracleDialect())
+    try {
+      cases.foreach { case (dataType, lowerBound, upperBound, compiledMidpoint) =>
+        val schema = StructType(Seq(StructField("PartitionColumn", dataType)))
+        val partitions = JDBCRelation.columnPartition(
+          schema,
+          analysis.caseInsensitiveResolution,
+          "UTC",
+          new JDBCOptions(testUrl, "table", Map(
+            "driver" -> "org.h2.Driver",
+            "lowerBound" -> lowerBound,
+            "upperBound" -> upperBound,
+            "numPartitions" -> "2",
+            "partitionColumn" -> "PartitionColumn")))
+
+        val clauses = partitions.map(_.asInstanceOf[JDBCPartition].whereClause)
+        assert(clauses === Array(
+          s"$quotedColumn < $compiledMidpoint or $quotedColumn is null",
+          s"$quotedColumn >= $compiledMidpoint"))
+      }
+    } finally {
+      JdbcDialects.unregisterDialectForUrlPrefix(testUrl)
+    }
+  }
+
   test("overflow of partition bound difference does not give negative stride") {
     val df = sql("SELECT * FROM partsoverflow")
     checkNumPartitions(df, expectedNumPartitions = 3)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Compile JDBC date and timestamp partition bounds through `JdbcDialect.compileValue`. Oracle predicates now use JDBC escape literals such as `{d '2018-07-11'}` and `{ts '2018-07-15 20:50:32.5'}`.

The change covers `DateType`, `TimestampType`, and `TimestampNTZType`, preserving configured-zone and zoneless bound semantics. The Oracle integration test now checks the compiled predicates and reads the partitioned data without setting NLS date or timestamp formats.

### Why are the changes needed?

Partition bounds currently bypass the dialect and use bare quoted ISO strings. Oracle can reject those strings under its default NLS formats, even though the Oracle dialect already provides portable literal compilation.

### Does this PR introduce _any_ user-facing change?

Yes. Temporal JDBC partition predicates use dialect-specific literals. Numeric bounds are unchanged.

### How was this patch tested?

- Added unit coverage for all three temporal types using the Oracle dialect.
- `build/sbt -Pdocker-integration-tests "sql/Test/testOnly org.apache.spark.sql.jdbc.JDBCSuite"`: 153 tests passed.
- `build/sbt -Pdocker-integration-tests "docker-integration-tests/Test/compile"`: passed.
- `dev/lint-scala`: passed.

The Oracle Docker runtime test is being rerun in CI; it was not run locally because the Docker daemon is unavailable.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5, GPT-6)
