### PR TITLE
[SPARK-59175][SQL] Extract the whole GROUP BY expression when a select item combines it with a window function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3544,7 +3544,9 @@ class Analyzer(
      *          seq of non-window expressions)
      */
     private def extract(
-        expressions: Seq[NamedExpression]): (Seq[NamedExpression], Seq[NamedExpression]) = {
+        expressions: Seq[NamedExpression],
+        groupExpressions: Seq[Expression] = Nil)
+      : (Seq[NamedExpression], Seq[NamedExpression]) = {
       // First, we partition the input expressions to two part. For the first part,
       // every expression in it contain at least one WindowExpression.
       // Expressions in the second part do not have any WindowExpression.
@@ -3625,6 +3627,16 @@ class Analyzer(
           case agg: AggregateExpression if !seenWindowAggregates.contains(agg) =>
             extractedExprMap.getOrElseUpdate(agg.canonicalized,
               Alias(agg, s"_w${extractedExprMap.size}")()).toAttribute
+
+          // Extracts a non-window sub-expression that matches a grouping expression as a whole
+          // (e.g. UPPER(country) when the query groups by UPPER(country)). Without this, the
+          // transform would descend into it and extract its underlying attributes (e.g. country),
+          // which are not part of the GROUP BY clause and would make the child Aggregate invalid
+          // (SPARK-59175). Bare grouping attributes are left to the `Attribute` case below.
+          case e: Expression
+              if !e.isInstanceOf[Attribute] && !e.foldable && !hasWindowFunction(e) &&
+                groupExpressions.exists(_.semanticEquals(e)) =>
+            getOrExtract(e, e)
 
           // Extracts other attributes
           case attr: Attribute => extractExpr(attr)
@@ -3732,7 +3744,7 @@ class Analyzer(
             throw QueryCompilationErrors.lateralColumnAliasInAggWithWindowAndHavingUnsupportedError(
               lcaRef.nameParts)
         })
-        val (windowExpressions, aggregateExpressions) = extract(aggregateExprs)
+        val (windowExpressions, aggregateExpressions) = extract(aggregateExprs, groupingExprs)
         // Create an Aggregate operator to evaluate aggregation functions.
         val withAggregate = Aggregate(groupingExprs, aggregateExpressions, child)
         // Add a Filter operator for conditions in the Having clause.
@@ -3751,7 +3763,7 @@ class Analyzer(
         if hasWindowFunction(aggregateExprs) &&
           a.expressions.forall(_.resolved) &&
           !aggregateExprs.exists(_.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE)) =>
-        val (windowExpressions, aggregateExpressions) = extract(aggregateExprs)
+        val (windowExpressions, aggregateExpressions) = extract(aggregateExprs, groupingExprs)
         // Create an Aggregate operator to evaluate aggregation functions.
         val withAggregate = Aggregate(groupingExprs, aggregateExpressions, child)
         // Add Window operators.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -1874,6 +1874,66 @@ class DataFrameWindowFunctionsSuite extends SharedSparkSession
       }
     }
   }
+
+  test("SPARK-59175: select item combining a window function with the GROUP BY expression") {
+    withTempView("events") {
+      sql("SELECT * FROM VALUES ('us'), ('US'), ('us'), ('ca'), ('CA'), ('mx'), ('br') " +
+        "AS t(country)").createOrReplaceTempView("events")
+
+      // The window function and the grouping expression UPPER(country) appear in the same select
+      // item. The grouping expression must be pushed into the child Aggregate as a whole; before
+      // the fix the raw `country` column was pushed instead, failing with MISSING_AGGREGATION.
+      val groupByExpr = sql(
+        """
+          |WITH ranked AS (
+          |  SELECT
+          |    CASE
+          |      WHEN ROW_NUMBER() OVER (ORDER BY COUNT(1) DESC) <= 2 THEN UPPER(country)
+          |      ELSE 'Other'
+          |    END AS bucket,
+          |    COUNT(1) AS events
+          |  FROM events
+          |  GROUP BY UPPER(country)
+          |)
+          |SELECT bucket, SUM(events) AS events
+          |FROM ranked
+          |GROUP BY bucket
+          |""".stripMargin)
+      checkAnswer(groupByExpr, Seq(Row("US", 3), Row("CA", 2), Row("Other", 2)))
+
+      // Grouping by the bare column while referencing a function of it in the same window item
+      // must keep working: `country` is a grouping column, so it is extracted directly and
+      // UPPER(country) is evaluated above the Window. The `country` tiebreak keeps ROW_NUMBER
+      // deterministic across the count ties.
+      val groupByColumn = sql(
+        """
+          |SELECT
+          |  CASE
+          |    WHEN ROW_NUMBER() OVER (ORDER BY COUNT(1) DESC, country) <= 2 THEN UPPER(country)
+          |    ELSE 'Other'
+          |  END AS bucket,
+          |  COUNT(1) AS events
+          |FROM events
+          |GROUP BY country
+          |""".stripMargin)
+      checkAnswer(groupByColumn,
+        Seq(Row("US", 2), Row("CA", 1), Row("Other", 1), Row("Other", 1),
+          Row("Other", 1), Row("Other", 1)))
+
+      // The window function in a separate select item from the grouping expression already worked
+      // and must remain correct.
+      val separateItems = sql(
+        """
+          |SELECT
+          |  UPPER(country) AS bucket,
+          |  ROW_NUMBER() OVER (ORDER BY COUNT(1) DESC, UPPER(country)) AS rn
+          |FROM events
+          |GROUP BY UPPER(country)
+          |""".stripMargin)
+      checkAnswer(separateItems,
+        Seq(Row("US", 1), Row("CA", 2), Row("BR", 3), Row("MX", 4)))
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
**What changes were proposed in this pull request?**                                                                                                                                                               
                                                                                                                                                                                                                 
  When a select item mixes a window function with the GROUP BY expression (e.g. CASE WHEN ROW_NUMBER() OVER (...) <= 2 THEN UPPER(country) ... END with GROUP BY UPPER(country)), the ExtractWindowExpressions  rule builds an Aggregate under the Window and decides which inputs the Aggregate must output.                                                                                                                  
                                                                                                                                                                                                                 
  While scanning that select item, the rule had no case for a plain expression like UPPER(country), so it looked inside it and pushed down the raw column country instead of the whole UPPER(country). The  resulting Aggregate outputs a country column that is not in the GROUP BY, which is an invalid plan.                                                                                                            
                                                                                                                                                                                                                 
  This PR passes the grouping expressions to extract and adds a case that pushes a sub-expression down as a whole when it matches a grouping expression. The Aggregate now outputs UPPER(country) instead of  country. Bare grouping columns keep their existing behavior, so only queries that used to fail are affected.

  **Why are the changes needed?**                                                                                                                                                                                    
                                                                                                                                                                                                                 
  The query is valid SQL but fails analysis with:                                                                                                                                                                                                                                                                                                                                                                         
  [MISSING_AGGREGATION] The non-aggregating expression "country" is based on columns which are not participating in the GROUP BY clause. SQLSTATE: 42803                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  This is wrong: country is never selected directly, only UPPER(country), which is the GROUP BY expression.

**Does this PR introduce any user-facing change?**                                                                                                                                                                 
                                                                                                                                                                                                                 
  Yes. A query that combines a window function with the GROUP BY expression in the same select item used to fail with MISSING_AGGREGATION; it now runs and returns the correct result. Queries that already      
  worked are unaffected.

**How was this patch tested?**                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Added a test in DataFrameWindowFunctionsSuite covering the reported query plus two regression cases (grouping by the bare column, and the window function in a separate select item).                                                                                         
                                                                                                                                                                                                                 
  **Was this patch authored or co-authored using generative AI tooling?**                                                                                                                                            
                                                                                                                                                                                                                 
  No