### PR TITLE
[MINOR][SQL] Remove stale "Hash is not implemented" comment for nanosecond timestamp physical types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -174,8 +174,6 @@ case object PhysicalCalendarIntervalType extends PhysicalCalendarIntervalType
  *
  * Storage layout is identical to [[PhysicalTimestampLTZNanosType]]; both types exist so the
  * NTZ/LTZ distinction propagates through the physical-type system to consumers that need it.
- *
- * Hash is not implemented yet and will be added in a follow-up issue.
  */
 class PhysicalTimestampNTZNanosType() extends PhysicalDataType {
   override private[sql] type InternalType = TimestampNanosVal
@@ -192,8 +190,6 @@ case object PhysicalTimestampNTZNanosType extends PhysicalTimestampNTZNanosType
  *
  * Storage layout is identical to [[PhysicalTimestampNTZNanosType]]; both types exist so the
  * NTZ/LTZ distinction propagates through the physical-type system to consumers that need it.
- *
- * Hash is not implemented yet and will be added in a follow-up issue.
  */
 class PhysicalTimestampLTZNanosType() extends PhysicalDataType {
   override private[sql] type InternalType = TimestampNanosVal


### PR DESCRIPTION

### What changes were proposed in this pull request?
Delete the obsolete scaladoc line from PhysicalTimestampNTZNanosType and PhysicalTimestampLTZNanosType. Hashing for the nanosecond carrier (TimestampNanosVal.hashCode) is implemented and is used by hash aggregate/join, DISTINCT, and set membership, so the "Hash is not implemented yet" note is false and misleading.

### Why are the changes needed?
Update the scaladocs.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Linter.


### Was this patch authored or co-authored using generative AI tooling?
No.
