### PR TITLE
[SPARK-59281][DOCS] Add nanosecond-precision timestamp types to the SQL data types reference table

### DIFF
--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -179,6 +179,8 @@ You can access them by doing
 |**BooleanType**|Boolean|BooleanType|
 |**TimestampType**|java.time.Instant or java.sql.Timestamp|TimestampType|
 |**TimestampNTZType**|java.time.LocalDateTime|TimestampNTZType|
+|**TimestampLTZNanosType(precision)**|java.time.Instant|TimestampLTZNanosType(precision)|
+|**TimestampNTZNanosType(precision)**|java.time.LocalDateTime|TimestampNTZNanosType(precision)|
 |**DateType**|java.time.LocalDate or java.sql.Date|DateType|
 |**TimeType**|java.time.LocalTime|TimeType|
 |**YearMonthIntervalType**|java.time.Period|YearMonthIntervalType|


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add TimestampLTZNanosType(precision) / TimestampNTZNanosType(precision) rows to the Scala data-type table in docs/sql-ref-datatypes.md. The types are described in prose but were absent from the reference table, so readers scanning the table could not find them or their java.time mappings.

Python and Java rows are intentionally omitted: PySpark support is still in flight under SPARK-57462, and DataTypes.java has no nanos factory yet.


### Why are the changes needed?
Allow users to find the type mappings.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
Co-Authored-By: Claude Opus 5
