### PR TITLE
[SPARK-56548][CORE] Replace modulo with bitmask in BloomFilter hot paths

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BitArray.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BitArray.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 final class BitArray {
   private final long[] data;
   private long bitCount;
+  private final long bitSizeMask;
 
   static int numWords(long numBits) {
     if (numBits <= 0) {
@@ -48,6 +49,8 @@ final class BitArray {
       bitCount += Long.bitCount(word);
     }
     this.bitCount = bitCount;
+    long bitSize = (long) data.length * Long.SIZE;
+    this.bitSizeMask = bitSize > 0 && (bitSize & (bitSize - 1)) == 0 ? bitSize - 1 : 0;
   }
 
   /** Returns true if the bit changed value. */
@@ -67,6 +70,15 @@ final class BitArray {
   /** Number of bits */
   long bitSize() {
     return (long) data.length * Long.SIZE;
+  }
+
+  /**
+   * Returns {@code bitSize() - 1} when the number of bits is a power of two, and 0 otherwise.
+   * Reducing a non-negative hash with such a mask is exactly equivalent to taking it modulo
+   * {@link #bitSize()}, but does not need a division. See {@link BloomFilterBase#bitIndex}.
+   */
+  long bitSizeMask() {
+    return bitSizeMask;
   }
 
   /** Number of set bits (1s) */

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterBase.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterBase.java
@@ -105,6 +105,39 @@ abstract class BloomFilterBase extends BloomFilter {
     return new HiLoHash(h1, h2);
   }
 
+  /**
+   * Reduces a non-negative {@code hash} into a bit index of a bit array of {@code bitSize} bits.
+   *
+   * <p>A bloom filter probe performs this reduction once per hash function, so it sits in the
+   * hottest loop of both {@code put} and {@code mightContain}. {@code bitSize} is not a compile
+   * time constant, so {@code hash % bitSize} compiles down to a hardware division. When the bit
+   * size is a power of two - which the Spark SQL runtime bloom filter sizes are, see
+   * {@code spark.sql.optimizer.runtime.bloomFilter.numBits} - taking a non-negative value modulo
+   * it is exactly the same as masking off the low bits, so {@code bitSizeMask} lets us skip the
+   * division. The mask is 0 when the bit size is not a power of two, in which case we fall back
+   * to the modulo.
+   *
+   * @param bitSizeMask {@link BitArray#bitSizeMask()} of the bit array being indexed
+   */
+  protected static long bitIndex(long hash, long bitSize, long bitSizeMask) {
+    return bitSizeMask != 0 ? hash & bitSizeMask : hash % bitSize;
+  }
+
+  /**
+   * Same as {@link #bitIndex(long, long, long)}, for a non-negative {@code hash} that fits in an
+   * int. A bit size that fits in an int as well lets the fallback use a 32 bit division, which is
+   * cheaper than the 64 bit one that widening the operands would otherwise require.
+   */
+  protected static long bitIndex(int hash, long bitSize, long bitSizeMask) {
+    if (bitSizeMask != 0) {
+      return hash & bitSizeMask;
+    } else if (bitSize <= Integer.MAX_VALUE) {
+      return hash % (int) bitSize;
+    } else {
+      return hash % bitSize;
+    }
+  }
+
   protected abstract boolean scatterHashAndSetAllBits(HiLoHash inputHash);
 
   protected abstract boolean scatterHashAndGetAllBits(HiLoHash inputHash);

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
@@ -32,6 +32,7 @@ class BloomFilterImpl extends BloomFilterBase implements Serializable {
     int h2 = inputHash.lo();
 
     long bitSize = bits.bitSize();
+    long bitSizeMask = bits.bitSizeMask();
     boolean bitsChanged = false;
     for (int i = 1; i <= numHashFunctions; i++) {
       int combinedHash = h1 + (i * h2);
@@ -39,7 +40,7 @@ class BloomFilterImpl extends BloomFilterBase implements Serializable {
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;
       }
-      bitsChanged |= bits.set(combinedHash % bitSize);
+      bitsChanged |= bits.set(bitIndex(combinedHash, bitSize, bitSizeMask));
     }
     return bitsChanged;
   }
@@ -49,13 +50,14 @@ class BloomFilterImpl extends BloomFilterBase implements Serializable {
     int h2 = inputHash.lo();
 
     long bitSize = bits.bitSize();
+    long bitSizeMask = bits.bitSizeMask();
     for (int i = 1; i <= numHashFunctions; i++) {
       int combinedHash = h1 + (i * h2);
       // Flip all the bits if it's negative (guaranteed positive number)
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;
       }
-      if (!bits.get(combinedHash % bitSize)) {
+      if (!bits.get(bitIndex(combinedHash, bitSize, bitSizeMask))) {
         return false;
       }
     }

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImplV2.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImplV2.java
@@ -52,6 +52,7 @@ class BloomFilterImplV2 extends BloomFilterBase implements Serializable {
     int h2 = inputHash.lo();
 
     long bitSize = bits.bitSize();
+    long bitSizeMask = bits.bitSizeMask();
     boolean bitsChanged = false;
 
     // Integer.MAX_VALUE takes care of scrambling the higher four bytes of combinedHash
@@ -62,7 +63,7 @@ class BloomFilterImplV2 extends BloomFilterBase implements Serializable {
       // Flip all the bits if it's negative (guaranteed positive number)
       long combinedIndex = combinedHash < 0 ? ~combinedHash : combinedHash;
 
-      bitsChanged |= bits.set(combinedIndex % bitSize);
+      bitsChanged |= bits.set(bitIndex(combinedIndex, bitSize, bitSizeMask));
     }
     return bitsChanged;
   }
@@ -72,6 +73,7 @@ class BloomFilterImplV2 extends BloomFilterBase implements Serializable {
     int h2 = inputHash.lo();
 
     long bitSize = bits.bitSize();
+    long bitSizeMask = bits.bitSizeMask();
 
     // Integer.MAX_VALUE takes care of scrambling the higher four bytes of combinedHash
     long combinedHash = (long) h1 * Integer.MAX_VALUE;
@@ -81,7 +83,7 @@ class BloomFilterImplV2 extends BloomFilterBase implements Serializable {
       // Flip all the bits if it's negative (guaranteed positive number)
       long combinedIndex = combinedHash < 0 ? ~combinedHash : combinedHash;
 
-      if (!bits.get(combinedIndex % bitSize)) {
+      if (!bits.get(bitIndex(combinedIndex, bitSize, bitSizeMask))) {
         return false;
       }
     }

--- a/common/sketch/src/test/java/org/apache/spark/util/sketch/BloomFilterBitIndexSuite.java
+++ b/common/sketch/src/test/java/org/apache/spark/util/sketch/BloomFilterBitIndexSuite.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.sketch;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Checks that reducing a hash with {@link BloomFilterBase#bitIndex} always agrees with the modulo
+ * it replaces, so that the bit positions of a bloom filter are unchanged by the masking fast path.
+ */
+public class BloomFilterBitIndexSuite {
+
+  private static final int NUM_SAMPLES = 10000;
+
+  @Test
+  public void testBitSizeMaskIsSetOnlyForPowerOfTwoBitSizes() {
+    // A BitArray rounds up to whole 64 bit words, so its bit size is a power of two exactly when
+    // its word count is.
+    assertEquals((1L << 20) - 1, new BitArray(1L << 20).bitSizeMask());
+    assertEquals(64 - 1, new BitArray(1).bitSizeMask());
+    // 65 bits are rounded up to two whole words, which is 128 bits.
+    assertEquals(128 - 1, new BitArray(65).bitSizeMask());
+    assertEquals(0, new BitArray(192).bitSizeMask());
+    assertEquals(0, new BitArray(1000000).bitSizeMask());
+  }
+
+  @Test
+  public void testBitSizeMaskSurvivesSerDe() throws IOException {
+    BitArray bits = new BitArray(1L << 20);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    bits.writeTo(new DataOutputStream(out));
+    BitArray deserialized =
+      BitArray.readFrom(new DataInputStream(new ByteArrayInputStream(out.toByteArray())));
+
+    assertEquals(bits.bitSize(), deserialized.bitSize());
+    assertEquals(bits.bitSizeMask(), deserialized.bitSizeMask());
+  }
+
+  @Test
+  public void testLongBitIndexMatchesModulo() {
+    Random r = new Random(37);
+    for (long numBits : new long[] {1L << 10, 1L << 23, 1L << 26, 64, 1024 + 64, 12345 * 64L}) {
+      BitArray bits = new BitArray(numBits);
+      long bitSize = bits.bitSize();
+      long mask = bits.bitSizeMask();
+
+      for (long hash : new long[] {0, 1, 63, 64, bitSize - 1, bitSize, Long.MAX_VALUE}) {
+        assertEquals(hash % bitSize, BloomFilterBase.bitIndex(hash, bitSize, mask));
+      }
+      for (int i = 0; i < NUM_SAMPLES; i++) {
+        // The scatter loops flip negative hashes before reducing them, so only non-negative
+        // values ever reach `bitIndex`.
+        long hash = r.nextLong() & Long.MAX_VALUE;
+        assertEquals(hash % bitSize, BloomFilterBase.bitIndex(hash, bitSize, mask));
+      }
+    }
+  }
+
+  @Test
+  public void testIntBitIndexMatchesModulo() {
+    Random r = new Random(37);
+    for (long numBits : new long[] {1L << 10, 1L << 23, 64, 1024 + 64, 12345 * 64L}) {
+      BitArray bits = new BitArray(numBits);
+      long bitSize = bits.bitSize();
+      long mask = bits.bitSizeMask();
+
+      for (int hash : new int[] {0, 1, 63, 64, Integer.MAX_VALUE}) {
+        assertEquals(hash % bitSize, BloomFilterBase.bitIndex(hash, bitSize, mask));
+      }
+      for (int i = 0; i < NUM_SAMPLES; i++) {
+        int hash = r.nextInt() & Integer.MAX_VALUE;
+        assertEquals(hash % bitSize, BloomFilterBase.bitIndex(hash, bitSize, mask));
+      }
+    }
+  }
+
+  @Test
+  public void testIntBitIndexMatchesModuloForBitSizesBeyondIntRange() {
+    // Allocating such a bit array is not possible, but the reduction still has to be correct for
+    // a bit size that does not fit in an int.
+    long bitSize = Integer.MAX_VALUE + 64L;
+    Random r = new Random(37);
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      int hash = r.nextInt() & Integer.MAX_VALUE;
+      assertEquals(hash % bitSize, BloomFilterBase.bitIndex(hash, bitSize, 0));
+    }
+  }
+}

--- a/common/sketch/src/test/scala/org/apache/spark/util/sketch/BloomFilterSuite.scala
+++ b/common/sketch/src/test/scala/org/apache/spark/util/sketch/BloomFilterSuite.scala
@@ -144,6 +144,27 @@ class BloomFilterSuite extends AnyFunSuite { // scalastyle:ignore funsuite
 
   testItemType[String]("String", 100000) { r => r.nextString(r.nextInt(512)) }
 
+  // The Spark SQL runtime bloom filter sizes are powers of two, see
+  // `spark.sql.optimizer.runtime.bloomFilter.numBits`, which is the case where the bit index is
+  // computed with a mask rather than a modulo.
+  Seq(BloomFilter.Version.V1, BloomFilter.Version.V2).foreach { version =>
+    Seq(1L << 20, (1L << 20) + 64L).foreach { numBits =>
+      val sizeName = if (numBits == (numBits & -numBits)) "power of two" else "non power of two"
+      test(s"$version - $sizeName bit size - $numBits") {
+        val r = new Random(37)
+        val numInsertion = 10000
+        val allItems = Set.fill(2 * numInsertion)(r.nextLong()).take(numInsertion)
+
+        val filter = BloomFilter.create(version, numInsertion, numBits, 0)
+        allItems.foreach(filter.putLong)
+
+        // false negative is not allowed, whichever way the bit index was computed.
+        assert(allItems.forall(filter.mightContainLong))
+        checkSerDe(filter)
+      }
+    }
+  }
+
   test("incompatible merge") {
     intercept[IncompatibleMergeException] {
       BloomFilter.create(1000).mergeInPlace(null)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/SparkBloomFilterBenchmark.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/SparkBloomFilterBenchmark.scala
@@ -229,6 +229,58 @@ object SparkBloomFilterBenchmark extends BenchmarkBase {
     benchmark.run()
   }
 
+  /**
+   * Compares a bit size that is a power of two, where the bit index of a hash is computed with a
+   * mask, against one that is 64 bits larger and therefore has to use a modulo. The two filters
+   * hold practically the same number of bits, so what the comparison shows is the cost of the
+   * reduction itself. The Spark SQL runtime bloom filter sizes are powers of two, see
+   * `spark.sql.optimizer.runtime.bloomFilter.numBits`.
+   */
+  private def benchmarkBitSizeShape(numItems: Int, valuesPerIteration: Int): Unit = {
+    val pow2Bits = java.lang.Long.highestOneBit(optimalNumOfBits(numItems, 0.03) - 1) << 1
+    val nonPow2Bits = pow2Bits + 64
+    val sizes = Seq("power of two" -> pow2Bits, "non power of two" -> nonPow2Bits)
+
+    val putBenchmark = new Benchmark(
+      s"Put Operation - $numItems items, $pow2Bits bits vs $nonPow2Bits bits",
+      valuesPerIteration,
+      output = output)
+
+    for (version <- Seq(V1, V2); (sizeName, numBits) <- sizes) {
+      putBenchmark.addCase(s"$version - $sizeName", 3) { _ =>
+        val bf = create(version, numItems, numBits, DEFAULT_SEED)
+        var i = 0
+        while (i < valuesPerIteration) {
+          bf.put(i.toLong)
+          i += 1
+        }
+      }
+    }
+    putBenchmark.run()
+
+    val testItems = (0 until valuesPerIteration).map(_.toLong).toArray
+    val queryBenchmark = new Benchmark(
+      s"MightContain Operation - $numItems items, $pow2Bits bits vs $nonPow2Bits bits",
+      valuesPerIteration,
+      output = output)
+
+    for (version <- Seq(V1, V2); (sizeName, numBits) <- sizes) {
+      queryBenchmark.addTimerCase(s"$version - $sizeName", 3) { timer =>
+        val bf = create(version, numItems, numBits, DEFAULT_SEED)
+        testItems.foreach(bf.put(_))
+
+        timer.startTiming()
+        var i = 0
+        while (i < valuesPerIteration) {
+          bf.mightContain(testItems(i))
+          i += 1
+        }
+        timer.stopTiming()
+      }
+    }
+    queryBenchmark.run()
+  }
+
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
 
     runBenchmark("Put Operation - Small Scale") {
@@ -307,6 +359,11 @@ object SparkBloomFilterBenchmark extends BenchmarkBase {
       benchmarkBinaryMightContainOperation(MEDIUM_ITEMS, 100000, 0.01, 0.5)  // Low FPP
       benchmarkBinaryMightContainOperation(MEDIUM_ITEMS, 100000, 0.03, 0.5)  // Default FPP
       benchmarkBinaryMightContainOperation(MEDIUM_ITEMS, 100000, 0.05, 0.5)  // High FPP
+    }
+
+    runBenchmark("Bit Size Shape Impact") {
+      benchmarkBitSizeShape(MEDIUM_ITEMS, 100000)
+      benchmarkBitSizeShape(LARGE_ITEMS, 1000000)
     }
 
     runBenchmark("Hit Rate Impact on Binary Operations") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Both bloom filter implementations reduce a hash into a bit index with `hash % bitSize`, once per hash function, in the innermost loop of `put` and `mightContain`:

```java
// BloomFilterImplV2#scatterHashAndSetAllBits
long combinedIndex = combinedHash < 0 ? ~combinedHash : combinedHash;
bitsChanged |= bits.set(combinedIndex % bitSize);
```

`bitSize` is a field rather than a compile time constant, so this compiles down to a hardware division on every probe.

`BitArray` rounds its allocation up to whole 64 bit words, so its bit size is a power of two for a wide range of requested sizes. Taking a non-negative value modulo a power of two is exactly masking off its low bits, and both implementations already flip negative hashes before reducing them.

This PR:

- caches the mask (`bitSize - 1` when the bit size is a power of two, 0 otherwise) in `BitArray`. It is computed in the single private constructor that every construction path funnels through, including `BitArray#readFrom`, so no deserialization path can miss it.
- routes both scatter loops of `BloomFilterImpl` (V1) and `BloomFilterImplV2` through a new `BloomFilterBase#bitIndex`, which masks when the mask is set and falls back to the modulo otherwise. The condition is loop invariant, so it is hoisted out of the loop.
- lets the V1 fallback use a 32 bit division when its hash and the bit size both fit in an int, instead of widening both to a 64 bit one. V1's `combinedHash` is an `int`, so today it pays a 64 bit division to reduce a 32 bit value.

The bit positions produced are unchanged, so there is no new `BloomFilter.Version`, no change to serialized filters, no change to the memory footprint and no change to the false positive rate.

### Why are the changes needed?

This is the hottest loop of the runtime bloom filter used by `bloom_filter_agg` / `might_contain` for join pushdown, and the reduction happens once per hash function per row.

The Spark SQL runtime bloom filter sizes are powers of two, so the masking path is what those filters take: `spark.sql.optimizer.runtime.bloomFilter.numBits` defaults to `8388608` (2^23) and `spark.sql.optimizer.runtime.bloomFilter.maxNumBits` to `67108864` (2^26).

Benchmark, on the power of two sizes (`Bit Size Shape Impact` section added to `SparkBloomFilterBenchmark`), per row nanoseconds, lower is better. Two runs after the change are given because these numbers carry a few percent of run to run noise:

| Case | before | after (run 1 / run 2) |
| --- | --- | --- |
| Put, 100k items, 2^20 bits, V1 | 36.2 | 27.6 / 29.5 |
| Put, 100k items, 2^20 bits, V2 | 35.7 | 32.5 / 29.3 |
| Put, 1M items, 2^23 bits, V1 | 38.9 | 35.6 / 35.7 |
| Put, 1M items, 2^23 bits, V2 | 39.1 | 36.2 / 36.1 |
| MightContain, 100k items, 2^20 bits, V1 | 14.7 | 13.7 / 13.6 |
| MightContain, 100k items, 2^20 bits, V2 | 14.4 | 13.1 / 13.1 |
| MightContain, 1M items, 2^23 bits, V1 | 13.7 | 13.3 / 13.3 |
| MightContain, 1M items, 2^23 bits, V2 | 13.4 | 12.5 / 12.5 |

The benchmark compares a filter of `2^k` bits against one of `2^k + 64` bits, which hold practically the same number of bits but take the masking and the modulo path respectively. As a control, the same benchmark on unmodified `master` puts the two within 1-3% of each other for every case above, so the gap is the change rather than the bit size shape. The non power of two cases are unchanged by this PR, as expected.

These numbers are from an Apple silicon machine, whose divider is comparatively fast; the benchmark result files are not regenerated here, since that should happen on the standard benchmark hardware.

### Does this PR introduce _any_ user-facing change?

No. The bit indices, and therefore the contents of every bloom filter, are identical to before.

### How was this patch tested?

New `BloomFilterBitIndexSuite`, which pins down the equivalence the change rests on:

- the mask is set exactly for power of two bit sizes, including the rounding up to whole words,
- the mask survives a `BitArray` write/read round trip,
- `bitIndex(hash, bitSize, mask) == hash % bitSize` for 10000 random hashes plus the edge values, over both power of two and non power of two bit sizes, for the `long` and the `int` overload, and for a bit size beyond the int range.

New cases in `BloomFilterSuite` covering V1 and V2 against a power of two and a non power of two bit size: no false negatives, plus a serialization round trip.

Existing suites: `sketch/test` (44 tests) and `BloomFilterAggregateQuerySuite` (11 tests) pass.

Benchmark cases added to `SparkBloomFilterBenchmark`; the result files should be regenerated through the GitHub Actions benchmark workflow for a consistent environment.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
