### PR TITLE
[SPARK-57128][SQL][TEST] Preserve commas in SQL test settings

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -474,7 +474,7 @@ trait SQLQueryTestHelper extends SQLConfHelper with Logging {
 
   protected def getSparkSettings(comments: Array[String]): Array[(String, String)] = {
     val settingLines = comments.filter(_.startsWith("--SET ")).map(_.substring(6))
-    settingLines.flatMap(_.split(",").map { kv =>
+    settingLines.flatMap(_.split(",(?=[\\w.]+=)").map { kv =>
       val (conf, value) = kv.span(_ != '=')
       conf.trim -> value.substring(1).trim
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelperSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelperSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+
+class SQLQueryTestHelperSuite extends SparkFunSuite with SQLQueryTestHelper {
+
+  test("getSparkSettings: single key=value") {
+    val result = getSparkSettings(Array("--SET spark.sql.foo=1"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1"))
+  }
+
+  test("getSparkSettings: multiple key=value pairs in one --SET") {
+    val result = getSparkSettings(Array("--SET spark.sql.foo=1,spark.sql.bar=2"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1", "spark.sql.bar" -> "2"))
+  }
+
+  test("getSparkSettings: multiple --SET statements") {
+    val result = getSparkSettings(
+      Array("--SET spark.sql.foo=1", "--SET spark.sql.bar=2"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1", "spark.sql.bar" -> "2"))
+  }
+
+  test("getSparkSettings: value containing commas") {
+    val excludedRules =
+      "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation," +
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val result = getSparkSettings(
+      Array(s"--SET spark.sql.optimizer.excludedRules=$excludedRules"))
+    assert(result.toSeq === Seq("spark.sql.optimizer.excludedRules" -> excludedRules))
+  }
+
+  test("getSparkSettings: mixed settings with a comma-containing value") {
+    val excludedRules =
+      "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation," +
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val result = getSparkSettings(
+      Array(s"--SET spark.sql.optimizer.excludedRules=$excludedRules,spark.sql.foo=1"))
+    assert(result.toSeq === Seq(
+      "spark.sql.optimizer.excludedRules" -> excludedRules,
+      "spark.sql.foo" -> "1"))
+  }
+
+  test("getSparkSettings: ignores non --SET comments") {
+    val result = getSparkSettings(
+      Array("-- a comment", "--SET spark.sql.foo=1", "-- another"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1"))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `SQLQueryTestHelper.getSparkSettings` so that a comma is treated as a setting separator only when it is followed by another configuration key. This preserves commas inside configuration values.

### Why are the changes needed?

`--SET` directives can contain values with commas, such as `spark.sql.optimizer.excludedRules`. The previous parser split those values incorrectly.

### Related issue

[SPARK-57128: SQLQueryTestHelper --SET parser cannot handle config values containing commas](https://issues.apache.org/jira/browse/SPARK-57128)

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added focused unit coverage for single and multiple settings, multiple directives, comma-containing values, and unrelated comments.

Ran:

```text
build/sbt 'sql/testOnly org.apache.spark.sql.SQLQueryTestHelperSuite'\n```\n\nAll 6 tests passed.