### PR TITLE
[SPARK-59286][ML] Optimize NaiveBayesModel transform closures

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -441,36 +441,9 @@ class NaiveBayesModel private[ml] (
   @Since("1.5.0")
   override val numClasses: Int = pi.size
 
-  private def predictRawFunction: Vector => Vector = {
-    $(modelType) match {
-      case Multinomial =>
-        val localPi = pi
-        val localTheta = theta
-        features: Vector =>
-          NaiveBayesModel.multinomialCalculation(features, localPi, localTheta)
-      case Complement =>
-        val localTheta = theta
-        features: Vector =>
-          NaiveBayesModel.complementCalculation(features, localTheta)
-      case Bernoulli =>
-        val (localPiMinusThetaSum, localThetaMinusNegTheta) =
-          NaiveBayesModel.bernoulliPredictionState(pi, theta)
-        features: Vector =>
-          NaiveBayesModel.bernoulliCalculationWithPrecomputedState(
-            features, localPiMinusThetaSum, localThetaMinusNegTheta)
-      case Gaussian =>
-        val localPi = pi
-        val localTheta = theta
-        val localSigma = sigma
-        val localLogVarSum = NaiveBayesModel.gaussianLogVarSum(localSigma)
-        features: Vector =>
-          NaiveBayesModel.gaussianCalculationWithPrecomputedState(
-            features, localPi, localTheta, localSigma, localLogVarSum)
-    }
-  }
-
   override protected def predictRawColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunction
+    val localPredictRaw =
+      NaiveBayesModel.predictRawFunction($(modelType), pi, theta, sigma)
     udf((features: Vector) => localPredictRaw(features)).apply(features)
   }
 
@@ -481,7 +454,8 @@ class NaiveBayesModel private[ml] (
   }
 
   override protected def predictProbabilityColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunction
+    val localPredictRaw =
+      NaiveBayesModel.predictRawFunction($(modelType), pi, theta, sigma)
     udf((features: Vector) => {
       val rawPrediction = localPredictRaw(features)
       NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
@@ -501,7 +475,8 @@ class NaiveBayesModel private[ml] (
   }
 
   override protected def predictionColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunction
+    val localPredictRaw =
+      NaiveBayesModel.predictRawFunction($(modelType), pi, theta, sigma)
     if (isDefined(thresholds)) {
       val localThresholds = getThresholds.clone()
       udf((features: Vector) => {
@@ -564,6 +539,28 @@ class NaiveBayesModel private[ml] (
 @Since("1.6.0")
 object NaiveBayesModel extends MLReadable[NaiveBayesModel] {
   import NaiveBayes._
+
+  private def predictRawFunction(
+      modelType: String,
+      pi: Vector,
+      theta: Matrix,
+      sigma: Matrix): Vector => Vector = {
+    modelType match {
+      case Multinomial =>
+        features: Vector => multinomialCalculation(features, pi, theta)
+      case Complement =>
+        features: Vector => complementCalculation(features, theta)
+      case Bernoulli =>
+        val (piMinusThetaSum, thetaMinusNegTheta) = bernoulliPredictionState(pi, theta)
+        features: Vector =>
+          bernoulliCalculationWithPrecomputedState(
+            features, piMinusThetaSum, thetaMinusNegTheta)
+      case Gaussian =>
+        val logVarSum = gaussianLogVarSum(sigma)
+        features: Vector =>
+          gaussianCalculationWithPrecomputedState(features, pi, theta, sigma, logVarSum)
+    }
+  }
 
   private def multinomialCalculation(
       features: Vector,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -486,72 +486,76 @@ class NaiveBayesModel private[ml] (
   @Since("1.5.0")
   override val numClasses: Int = pi.size
 
-  private def multinomialCalculation(features: Vector) = {
-    requireNonnegativeValues(features)
-    val prob = pi.toDense.copy
-    BLAS.gemv(1.0, theta, features, 1.0, prob)
-    prob
-  }
-
-  private def complementCalculation(features: Vector) = {
-    requireNonnegativeValues(features)
-    val probArray = theta.multiply(features).toArray
-    // the following lines equal to:
-    // val logSumExp = math.log(probArray.map(math.exp).sum)
-    // However, it easily returns Infinity/NaN values.
-    // Here follows 'scipy.special.logsumexp' (which is used in Scikit-Learn's ComplementNB)
-    // to compute the log of the sum of exponentials of elements in a numeric-stable way.
-    val max = probArray.max
-    var sumExp = 0.0
-    var j = 0
-    while (j < probArray.length) {
-      sumExp += math.exp(probArray(j) - max)
-      j += 1
-    }
-    val logSumExp = math.log(sumExp) + max
-
-    j = 0
-    while (j < probArray.length) {
-      probArray(j) -= logSumExp
-      j += 1
-    }
-    Vectors.dense(probArray)
-  }
-
-  private def bernoulliCalculation(features: Vector) = {
-    requireZeroOneBernoulliValues(features)
-    val prob = piMinusThetaSum.copy
-    BLAS.gemv(1.0, thetaMinusNegTheta, features, 1.0, prob)
-    prob
-  }
-
-  private def gaussianCalculation(features: Vector) = {
-    val prob = Array.ofDim[Double](numClasses)
-    var i = 0
-    while (i < numClasses) {
-      var s = 0.0
-      var j = 0
-      while (j < numFeatures) {
-        val d = features(j) - theta(i, j)
-        s += d * d / sigma(i, j)
-        j += 1
-      }
-      prob(i) = pi(i) - (s + logVarSum(i)) / 2
-      i += 1
-    }
-    Vectors.dense(prob)
-  }
-
-  @transient private lazy val predictRawFunc = {
+  @transient private lazy val predictRawFunc: Vector => Vector = {
     $(modelType) match {
       case Multinomial =>
-        features: Vector => multinomialCalculation(features)
+        val localPi = pi
+        val localTheta = theta
+        features: Vector =>
+          NaiveBayesModel.multinomialCalculation(features, localPi, localTheta)
       case Complement =>
-        features: Vector => complementCalculation(features)
+        val localTheta = theta
+        features: Vector =>
+          NaiveBayesModel.complementCalculation(features, localTheta)
       case Bernoulli =>
-        features: Vector => bernoulliCalculation(features)
+        val localPiMinusThetaSum = piMinusThetaSum
+        val localThetaMinusNegTheta = thetaMinusNegTheta
+        features: Vector =>
+          NaiveBayesModel.bernoulliCalculation(
+            features, localPiMinusThetaSum, localThetaMinusNegTheta)
       case Gaussian =>
-        features: Vector => gaussianCalculation(features)
+        val localPi = pi
+        val localTheta = theta
+        val localSigma = sigma
+        val localLogVarSum = logVarSum
+        features: Vector =>
+          NaiveBayesModel.gaussianCalculation(
+            features, localPi, localTheta, localSigma, localLogVarSum)
+    }
+  }
+
+  override protected def predictRawColumn(features: Column): Column = {
+    val localPredictRaw = predictRawFunc
+    udf((features: Vector) => localPredictRaw(features)).apply(features)
+  }
+
+  override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
+    udf((rawPrediction: Vector) =>
+      NaiveBayesModel.raw2probability(rawPrediction)
+    ).apply(rawPrediction)
+  }
+
+  override protected def predictProbabilityColumn(features: Column): Column = {
+    val localPredictRaw = predictRawFunc
+    udf((features: Vector) => {
+      val rawPrediction = localPredictRaw(features)
+      NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
+    }).apply(features)
+  }
+
+  override protected def raw2predictionColumn(rawPrediction: Column): Column = {
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
+      udf((rawPrediction: Vector) => {
+        val probability = NaiveBayesModel.raw2probability(rawPrediction)
+        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+      }).apply(rawPrediction)
+    } else {
+      udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
+    }
+  }
+
+  override protected def predictionColumn(features: Column): Column = {
+    val localPredictRaw = predictRawFunc
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
+      udf((features: Vector) => {
+        val rawPrediction = localPredictRaw(features)
+        val probability = NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
+        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+      }).apply(features)
+    } else {
+      udf((features: Vector) => localPredictRaw(features).argmax.toDouble).apply(features)
     }
   }
 
@@ -559,14 +563,7 @@ class NaiveBayesModel private[ml] (
   override def predictRaw(features: Vector): Vector = predictRawFunc(features)
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
-    rawPrediction match {
-      case dv: DenseVector =>
-        Utils.softmax(dv.values)
-        dv
-      case sv: SparseVector =>
-        throw new RuntimeException("Unexpected error in NaiveBayesModel:" +
-          " raw2probabilityInPlace encountered SparseVector")
-    }
+    NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
   }
 
   private[spark] override def estimatedSize: Long = {
@@ -600,6 +597,90 @@ class NaiveBayesModel private[ml] (
 
 @Since("1.6.0")
 object NaiveBayesModel extends MLReadable[NaiveBayesModel] {
+  import NaiveBayes._
+
+  private def multinomialCalculation(
+      features: Vector,
+      pi: Vector,
+      theta: Matrix): Vector = {
+    requireNonnegativeValues(features)
+    val prob = pi.toDense.copy
+    BLAS.gemv(1.0, theta, features, 1.0, prob)
+    prob
+  }
+
+  private def complementCalculation(features: Vector, theta: Matrix): Vector = {
+    requireNonnegativeValues(features)
+    val probArray = theta.multiply(features).toArray
+    // the following lines equal to:
+    // val logSumExp = math.log(probArray.map(math.exp).sum)
+    // However, it easily returns Infinity/NaN values.
+    // Here follows 'scipy.special.logsumexp' (which is used in Scikit-Learn's ComplementNB)
+    // to compute the log of the sum of exponentials of elements in a numeric-stable way.
+    val max = probArray.max
+    var sumExp = 0.0
+    var j = 0
+    while (j < probArray.length) {
+      sumExp += math.exp(probArray(j) - max)
+      j += 1
+    }
+    val logSumExp = math.log(sumExp) + max
+
+    j = 0
+    while (j < probArray.length) {
+      probArray(j) -= logSumExp
+      j += 1
+    }
+    Vectors.dense(probArray)
+  }
+
+  private def bernoulliCalculation(
+      features: Vector,
+      piMinusThetaSum: DenseVector,
+      thetaMinusNegTheta: Matrix): Vector = {
+    requireZeroOneBernoulliValues(features)
+    val prob = piMinusThetaSum.copy
+    BLAS.gemv(1.0, thetaMinusNegTheta, features, 1.0, prob)
+    prob
+  }
+
+  private def gaussianCalculation(
+      features: Vector,
+      pi: Vector,
+      theta: Matrix,
+      sigma: Matrix,
+      logVarSum: Array[Double]): Vector = {
+    val prob = Array.ofDim[Double](pi.size)
+    var i = 0
+    while (i < pi.size) {
+      var s = 0.0
+      var j = 0
+      while (j < theta.numCols) {
+        val d = features(j) - theta(i, j)
+        s += d * d / sigma(i, j)
+        j += 1
+      }
+      prob(i) = pi(i) - (s + logVarSum(i)) / 2
+      i += 1
+    }
+    Vectors.dense(prob)
+  }
+
+  private def raw2probability(rawPrediction: Vector): Vector = {
+    raw2probabilityInPlace(rawPrediction.copy)
+  }
+
+  private def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
+    rawPrediction match {
+      case dv: DenseVector =>
+        Utils.softmax(dv.values)
+        dv
+      case _: SparseVector =>
+        throw new RuntimeException("Unexpected error in NaiveBayesModel:" +
+          " raw2probabilityInPlace encountered SparseVector")
+    }
+  }
+
   private[ml] case class Data(pi: Vector, theta: Matrix, sigma: Matrix)
 
   private[ml] def serializeData(data: Data, dos: DataOutputStream): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -486,7 +486,7 @@ class NaiveBayesModel private[ml] (
   @Since("1.5.0")
   override val numClasses: Int = pi.size
 
-  @transient private lazy val predictRawFunc: Vector => Vector = {
+  private def predictRawFunction: Vector => Vector = {
     $(modelType) match {
       case Multinomial =>
         val localPi = pi
@@ -515,7 +515,7 @@ class NaiveBayesModel private[ml] (
   }
 
   override protected def predictRawColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunc
+    val localPredictRaw = predictRawFunction
     udf((features: Vector) => localPredictRaw(features)).apply(features)
   }
 
@@ -526,7 +526,7 @@ class NaiveBayesModel private[ml] (
   }
 
   override protected def predictProbabilityColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunc
+    val localPredictRaw = predictRawFunction
     udf((features: Vector) => {
       val rawPrediction = localPredictRaw(features)
       NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
@@ -546,7 +546,7 @@ class NaiveBayesModel private[ml] (
   }
 
   override protected def predictionColumn(features: Column): Column = {
-    val localPredictRaw = predictRawFunc
+    val localPredictRaw = predictRawFunction
     if (isDefined(thresholds)) {
       val localThresholds = getThresholds.clone()
       udf((features: Vector) => {
@@ -560,7 +560,19 @@ class NaiveBayesModel private[ml] (
   }
 
   @Since("3.0.0")
-  override def predictRaw(features: Vector): Vector = predictRawFunc(features)
+  override def predictRaw(features: Vector): Vector = {
+    $(modelType) match {
+      case Multinomial =>
+        NaiveBayesModel.multinomialCalculation(features, pi, theta)
+      case Complement =>
+        NaiveBayesModel.complementCalculation(features, theta)
+      case Bernoulli =>
+        NaiveBayesModel.bernoulliCalculation(
+          features, piMinusThetaSum, thetaMinusNegTheta)
+      case Gaussian =>
+        NaiveBayesModel.gaussianCalculation(features, pi, theta, sigma, logVarSum)
+    }
+  }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
     NaiveBayesModel.raw2probabilityInPlace(rawPrediction)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -435,51 +435,6 @@ class NaiveBayesModel private[ml] (
     this
   }
 
-  /**
-   * Bernoulli scoring requires log(condprob) if 1, log(1-condprob) if 0.
-   * This precomputes log(1.0 - exp(theta)) and its sum which are used for the linear algebra
-   * application of this condition (in predict function).
-   */
-  @transient private lazy val thetaMinusNegTheta = $(modelType) match {
-    case Bernoulli =>
-      theta.map(value => value - math.log1p(-math.exp(value)))
-    case _ =>
-      // This should never happen.
-      throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}. " +
-        "Variables thetaMinusNegTheta should only be precomputed in Bernoulli NB.")
-  }
-
-  @transient private lazy val piMinusThetaSum = $(modelType) match {
-    case Bernoulli =>
-      val negTheta = theta.map(value => math.log1p(-math.exp(value)))
-      val ones = new DenseVector(Array.fill(theta.numCols)(1.0))
-      val piMinusThetaSum = pi.toDense.copy
-      BLAS.gemv(1.0, negTheta, ones, 1.0, piMinusThetaSum)
-      piMinusThetaSum
-    case _ =>
-      // This should never happen.
-      throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}. " +
-        "Variables piMinusThetaSum should only be precomputed in Bernoulli NB.")
-  }
-
-  /**
-   * Gaussian scoring requires sum of log(Variance).
-   * This precomputes sum of log(Variance) which are used for the linear algebra
-   * application of this condition (in predict function).
-   */
-  @transient private lazy val logVarSum = $(modelType) match {
-    case Gaussian =>
-      Array.tabulate(numClasses) { i =>
-        Iterator.range(0, numFeatures).map { j =>
-          math.log(sigma(i, j))
-        }.sum
-      }
-    case _ =>
-      // This should never happen.
-      throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}. " +
-        "Variables logVarSum should only be precomputed in Gaussian NB.")
-  }
-
   @Since("1.6.0")
   override val numFeatures: Int = theta.numCols
 
@@ -498,18 +453,18 @@ class NaiveBayesModel private[ml] (
         features: Vector =>
           NaiveBayesModel.complementCalculation(features, localTheta)
       case Bernoulli =>
-        val localPiMinusThetaSum = piMinusThetaSum
-        val localThetaMinusNegTheta = thetaMinusNegTheta
+        val (localPiMinusThetaSum, localThetaMinusNegTheta) =
+          NaiveBayesModel.bernoulliPredictionState(pi, theta)
         features: Vector =>
-          NaiveBayesModel.bernoulliCalculation(
+          NaiveBayesModel.bernoulliCalculationWithPrecomputedState(
             features, localPiMinusThetaSum, localThetaMinusNegTheta)
       case Gaussian =>
         val localPi = pi
         val localTheta = theta
         val localSigma = sigma
-        val localLogVarSum = logVarSum
+        val localLogVarSum = NaiveBayesModel.gaussianLogVarSum(localSigma)
         features: Vector =>
-          NaiveBayesModel.gaussianCalculation(
+          NaiveBayesModel.gaussianCalculationWithPrecomputedState(
             features, localPi, localTheta, localSigma, localLogVarSum)
     }
   }
@@ -567,10 +522,9 @@ class NaiveBayesModel private[ml] (
       case Complement =>
         NaiveBayesModel.complementCalculation(features, theta)
       case Bernoulli =>
-        NaiveBayesModel.bernoulliCalculation(
-          features, piMinusThetaSum, thetaMinusNegTheta)
+        NaiveBayesModel.bernoulliCalculation(features, pi, theta)
       case Gaussian =>
-        NaiveBayesModel.gaussianCalculation(features, pi, theta, sigma, logVarSum)
+        NaiveBayesModel.gaussianCalculation(features, pi, theta, sigma)
     }
   }
 
@@ -646,7 +600,18 @@ object NaiveBayesModel extends MLReadable[NaiveBayesModel] {
     Vectors.dense(probArray)
   }
 
-  private def bernoulliCalculation(
+  private def bernoulliPredictionState(
+      pi: Vector,
+      theta: Matrix): (DenseVector, Matrix) = {
+    val negTheta = theta.map(value => math.log1p(-math.exp(value)))
+    val thetaMinusNegTheta = theta.map(value => value - math.log1p(-math.exp(value)))
+    val ones = new DenseVector(Array.fill(theta.numCols)(1.0))
+    val piMinusThetaSum = pi.toDense.copy
+    BLAS.gemv(1.0, negTheta, ones, 1.0, piMinusThetaSum)
+    (piMinusThetaSum, thetaMinusNegTheta)
+  }
+
+  private def bernoulliCalculationWithPrecomputedState(
       features: Vector,
       piMinusThetaSum: DenseVector,
       thetaMinusNegTheta: Matrix): Vector = {
@@ -656,7 +621,44 @@ object NaiveBayesModel extends MLReadable[NaiveBayesModel] {
     prob
   }
 
-  private def gaussianCalculation(
+  private def bernoulliCalculation(
+      features: Vector,
+      pi: Vector,
+      theta: Matrix): Vector = {
+    requireZeroOneBernoulliValues(features)
+    val prob = Array.ofDim[Double](pi.size)
+    var i = 0
+    while (i < pi.size) {
+      var score = pi(i)
+      var j = 0
+      while (j < theta.numCols) {
+        val thetaValue = theta(i, j)
+        score += (if (features(j) == 1.0) {
+          thetaValue
+        } else {
+          math.log1p(-math.exp(thetaValue))
+        })
+        j += 1
+      }
+      prob(i) = score
+      i += 1
+    }
+    Vectors.dense(prob)
+  }
+
+  private def gaussianLogVarSum(sigma: Matrix): Array[Double] = {
+    Array.tabulate(sigma.numRows) { i =>
+      var sum = 0.0
+      var j = 0
+      while (j < sigma.numCols) {
+        sum += math.log(sigma(i, j))
+        j += 1
+      }
+      sum
+    }
+  }
+
+  private def gaussianCalculationWithPrecomputedState(
       features: Vector,
       pi: Vector,
       theta: Matrix,
@@ -673,6 +675,28 @@ object NaiveBayesModel extends MLReadable[NaiveBayesModel] {
         j += 1
       }
       prob(i) = pi(i) - (s + logVarSum(i)) / 2
+      i += 1
+    }
+    Vectors.dense(prob)
+  }
+
+  private def gaussianCalculation(
+      features: Vector,
+      pi: Vector,
+      theta: Matrix,
+      sigma: Matrix): Vector = {
+    val prob = Array.ofDim[Double](pi.size)
+    var i = 0
+    while (i < pi.size) {
+      var s = 0.0
+      var j = 0
+      while (j < theta.numCols) {
+        val d = features(j) - theta(i, j)
+        val variance = sigma(i, j)
+        s += d * d / variance + math.log(variance)
+        j += 1
+      }
+      prob(i) = pi(i) - s / 2
       i += 1
     }
     Vectors.dense(prob)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reduces the transform closure size of `NaiveBayesModel` for multinomial, complement,
Bernoulli, and Gaussian models.

The column-expression prediction hooks snapshot only the immutable state needed by the selected
model type. Companion-object helpers perform raw prediction and probability conversion without
retaining the complete model and its parameter graph. The existing single-instance prediction
methods delegate to the same helpers.

The model no longer caches prediction functions or Bernoulli and Gaussian auxiliary state in
transient lazy fields. Transform-specific derived state is prepared once while constructing the
scoring expression, while single-instance prediction computes directly from the fitted parameters.

### Why are the changes needed?

The default probabilistic classifier hooks invoke bound model methods. Their UDF closures therefore
retain the complete `NaiveBayesModel` even though scoring only needs its fitted vectors, matrices,
model-specific derived state, and optional thresholds. This adds avoidable driver memory pressure
for long-lived Spark Connect servers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The following checks passed:

```
build/sbt mllib/compile
build/sbt 'mllib/testOnly org.apache.spark.ml.classification.NaiveBayesSuite'
```

`NaiveBayesSuite` ran 17 tests covering all four model types. No new tests were added because its
existing model tests and `testPredictMethods` coverage exercise raw prediction, probability, and
prediction output paths.

A temporary local probe used a deterministic three-class model with 1,024 features for each model
type. It extracted each `ScalaUDF.function` from the analyzed transform plan and serialized it with
Spark's closure serializer. The former bound-model hooks were recreated in a temporary subclass.
"All" serializes the functions for raw-prediction, probability, and prediction together.

| Model/output | Before | After | Reduction |
|---|---:|---:|---:|
| Multinomial raw prediction | 30,140 B | 27,140 B | 10.0% |
| Multinomial probability | 30,147 B | 27,148 B | 9.9% |
| Multinomial prediction | 30,077 B | 27,184 B | 9.6% |
| Multinomial all | 30,699 B | 27,380 B | 10.8% |
| Complement raw prediction | 30,140 B | 27,002 B | 10.4% |
| Complement probability | 30,147 B | 27,010 B | 10.4% |
| Complement prediction | 30,077 B | 27,046 B | 10.1% |
| Complement all | 30,699 B | 27,242 B | 11.3% |
| Bernoulli raw prediction | 30,140 B | 27,145 B | 9.9% |
| Bernoulli probability | 30,147 B | 27,153 B | 9.9% |
| Bernoulli prediction | 30,077 B | 27,189 B | 9.6% |
| Bernoulli all | 30,699 B | 27,385 B | 10.8% |
| Gaussian raw prediction | 54,716 B | 51,812 B | 5.3% |
| Gaussian probability | 54,723 B | 51,820 B | 5.3% |
| Gaussian prediction | 54,653 B | 51,856 B | 5.1% |
| Gaussian all | 55,275 B | 52,052 B | 5.8% |

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
