### PR TITLE
[SPARK-59288][ML] Optimize FMClassificationModel transform closures

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/FMClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/FMClassifier.scala
@@ -32,6 +32,7 @@ import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions.udf
 import org.apache.spark.storage.StorageLevel
 
 /**
@@ -291,22 +292,71 @@ class FMClassificationModel private[classification] (
       probability, predictionColName, $(labelCol), weightColName)
   }
 
+  override protected def predictRawColumn(features: Column): Column = {
+    val localIntercept = intercept
+    val localLinear = linear
+    val localFactors = factors
+    udf((features: Vector) =>
+      FMClassificationModel.predictRaw(features, localIntercept, localLinear, localFactors)
+    ).apply(features)
+  }
+
+  override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
+    udf((rawPrediction: Vector) =>
+      FMClassificationModel.raw2probability(rawPrediction)
+    ).apply(rawPrediction)
+  }
+
+  override protected def predictProbabilityColumn(features: Column): Column = {
+    val localIntercept = intercept
+    val localLinear = linear
+    val localFactors = factors
+    udf((features: Vector) => {
+      val rawPrediction =
+        FMClassificationModel.predictRaw(features, localIntercept, localLinear, localFactors)
+      FMClassificationModel.raw2probabilityInPlace(rawPrediction)
+    }).apply(features)
+  }
+
+  override protected def raw2predictionColumn(rawPrediction: Column): Column = {
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
+      udf((rawPrediction: Vector) => {
+        val probability = FMClassificationModel.raw2probability(rawPrediction)
+        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+      }).apply(rawPrediction)
+    } else {
+      udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
+    }
+  }
+
+  override protected def predictionColumn(features: Column): Column = {
+    val localIntercept = intercept
+    val localLinear = linear
+    val localFactors = factors
+    if (isDefined(thresholds)) {
+      val localThresholds = getThresholds.clone()
+      udf((features: Vector) => {
+        val rawPrediction =
+          FMClassificationModel.predictRaw(features, localIntercept, localLinear, localFactors)
+        val probability = FMClassificationModel.raw2probabilityInPlace(rawPrediction)
+        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
+      }).apply(features)
+    } else {
+      udf((features: Vector) =>
+        FMClassificationModel.predictRaw(
+          features, localIntercept, localLinear, localFactors).argmax.toDouble
+      ).apply(features)
+    }
+  }
+
   @Since("3.0.0")
   override def predictRaw(features: Vector): Vector = {
-    val rawPrediction = getRawPrediction(features, intercept, linear, factors)
-    Vectors.dense(Array(-rawPrediction, rawPrediction))
+    FMClassificationModel.predictRaw(features, intercept, linear, factors)
   }
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
-    rawPrediction match {
-      case dv: DenseVector =>
-        dv.values(1) = 1.0 / (1.0 + math.exp(-dv.values(1)))
-        dv.values(0) = 1.0 - dv.values(1)
-        dv
-      case sv: SparseVector =>
-        throw new RuntimeException("Unexpected error in FMClassificationModel:" +
-          " raw2probabilityInPlace encountered SparseVector")
-    }
+    FMClassificationModel.raw2probabilityInPlace(rawPrediction)
   }
 
   @Since("3.0.0")
@@ -374,6 +424,31 @@ class FMClassificationModel private[classification] (
 
 @Since("3.0.0")
 object FMClassificationModel extends MLReadable[FMClassificationModel] {
+  private def predictRaw(
+      features: Vector,
+      intercept: Double,
+      linear: Vector,
+      factors: Matrix): Vector = {
+    val rawPrediction = getRawPrediction(features, intercept, linear, factors)
+    Vectors.dense(Array(-rawPrediction, rawPrediction))
+  }
+
+  private def raw2probability(rawPrediction: Vector): Vector = {
+    raw2probabilityInPlace(rawPrediction.copy)
+  }
+
+  private def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
+    rawPrediction match {
+      case dv: DenseVector =>
+        dv.values(1) = 1.0 / (1.0 + math.exp(-dv.values(1)))
+        dv.values(0) = 1.0 - dv.values(1)
+        dv
+      case _: SparseVector =>
+        throw new RuntimeException("Unexpected error in FMClassificationModel:" +
+          " raw2probabilityInPlace encountered SparseVector")
+    }
+  }
+
   private[ml] case class Data(
     intercept: Double,
     linear: Vector,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reduces the transform closure size of `FMClassificationModel`.

The column-expression prediction hooks snapshot only the intercept, linear coefficients, factor
matrix, and optional thresholds needed by each requested output column. Companion-object helpers
perform raw prediction and probability conversion without retaining the complete Spark ML model
or its parameter graph.

### Why are the changes needed?

The default probabilistic classifier hooks invoke bound model methods. Their UDF closures therefore
retain the complete `FMClassificationModel` even though scoring only needs its fitted coefficients
and a small amount of immutable prediction state. This adds avoidable driver memory pressure for
long-lived Spark Connect servers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The following checks passed:

```
build/sbt mllib/compile
build/sbt 'mllib/testOnly org.apache.spark.ml.classification.FMClassifierSuite'
```

`FMClassifierSuite` ran 16 tests, including its explicit threshold tests. No new tests were added
because its existing `testPredictMethods` coverage exercises every combination of raw-prediction,
probability, and prediction output columns, in addition to single-instance prediction and model
persistence.

A temporary local probe used a deterministic model with 1,024 features and 8 factors. It extracted
each `ScalaUDF.function` from the analyzed transform plan and serialized it with Spark's closure
serializer. The former bound-model hooks were recreated in a temporary subclass. "All" serializes
the functions for raw-prediction, probability, and prediction together.

| Model/output | Before | After | Reduction |
|---|---:|---:|---:|
| Raw prediction | 81,509 B | 76,466 B | 6.2% |
| Probability | 81,516 B | 76,474 B | 6.2% |
| Prediction | 81,446 B | 76,440 B | 6.1% |
| All | 82,052 B | 76,706 B | 6.5% |

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
