### PR TITLE
[SPARK-59048][ML][FOLLOWUP] Correct transform method documentation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -124,8 +124,8 @@ abstract class ProbabilisticClassifier[
  *     <td>Set</td>
  *     <td>Set</td>
  *     <td>Set</td>
- *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> =>
- *       <code>raw2predictionColumn</code></td>
+ *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> and
+ *       <code>predictRawColumn</code> => <code>raw2predictionColumn</code></td>
  *   </tr>
  * </table>
  *

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -124,8 +124,8 @@ abstract class ProbabilisticClassifier[
  *     <td>Set</td>
  *     <td>Set</td>
  *     <td>Set</td>
- *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> and
- *       <code>predictRawColumn</code> => <code>raw2predictionColumn</code></td>
+ *     <td><code>predictRawColumn</code> => <code>raw2probabilityColumn</code> &amp;
+ *       <code>raw2predictionColumn</code></td>
  *   </tr>
  * </table>
  *


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct the `ProbabilisticClassificationModel` Scaladoc table for the case where raw prediction,
probability, and prediction output columns are all enabled. The table now shows that
`raw2probabilityColumn` and `raw2predictionColumn` both consume the output of `predictRawColumn`.

### Why are the changes needed?

The existing table incorrectly presents probability and prediction generation as a serial chain.
`ProbabilisticClassificationModel.transform` builds both columns directly from the raw-prediction
column.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not tested because this is a Scaladoc-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
