### PR TITLE
[SPARK-58996][SQL][4.2] Fix SPJ partially clustered data correctness when EnsureRequirements re-runs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -789,6 +789,28 @@ case class PartitioningCollection(partitionings: Seq[Partitioning])
     super.legacyWithNewChildren(newChildren).asInstanceOf[PartitioningCollection]
 }
 
+object PartitioningCollection {
+  /**
+   * One [[KeyedPartitioning]] standing for every one in this partitioning, if there is any. By the
+   * invariant in the class doc, any of them describes the layout.
+   */
+  private[physical] def representativeOf(p: Partitioning): Option[KeyedPartitioning] = p match {
+    case k: KeyedPartitioning => Some(k)
+    case pc: PartitioningCollection =>
+      pc.partitionings.iterator.flatMap(representativeOf).nextOption()
+    case _ => None
+  }
+
+  /**
+   * The number of partitions of the keyed members of `partitioning`, if it has any. A
+   * collection requires all of its members to agree on the count, keyed or not, so the answer
+   * is `partitioning.numPartitions` whenever a keyed member exists; the representative only
+   * decides whether there is one.
+   */
+  private[sql] def numKeyedPartitions(partitioning: Partitioning): Option[Int] =
+    representativeOf(partitioning).map(_.numPartitions)
+}
+
 /**
  * Represents a partitioning where rows are collected, transformed and broadcasted to each
  * node in the cluster.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -282,7 +282,10 @@ case class EnsureRequirements(
             child match {
               case ShuffleExchangeExec(_, c, so, ps) =>
                 ShuffleExchangeExec(newPartitioning, c, so, ps)
-              case gpe: GroupPartitionsExec => ShuffleExchangeExec(newPartitioning, gpe.child)
+              case gpe: GroupPartitionsExec =>
+                // Strip every grouping this rule inserted (they can stack on a re-run): a
+                // replicating one repeats every row, so none of them may feed the shuffle.
+                ShuffleExchangeExec(newPartitioning, unwrapGroupPartitions(gpe))
               case _ => ShuffleExchangeExec(newPartitioning, child)
             }
           }
@@ -621,8 +624,13 @@ case class EnsureRequirements(
             logInfo(log"Skipping partially clustered distribution as it cannot be applied for " +
               log"join type '${MDC(LogKeys.JOIN_TYPE, joinType)}'")
           } else {
-            val unwrappedLeft = unwrapGroupPartitions(left)
-            val unwrappedRight = unwrapGroupPartitions(right)
+            // The pre-alignment plan of each side and the grouping this rule inserted over it,
+            // are read once: the statistics and the original partition keys below come from the
+            // plan, the positions projecting them from the grouping.
+            val leftGrouping = innermostGroupPartition(left)
+            val rightGrouping = innermostGroupPartition(right)
+            val unwrappedLeft = leftGrouping.map(_._1.child).getOrElse(left)
+            val unwrappedRight = rightGrouping.map(_._1.child).getOrElse(right)
 
             val leftLink = unwrappedLeft.logicalLink
             val rightLink = unwrappedRight.logicalLink
@@ -644,11 +652,18 @@ case class EnsureRequirements(
                    |""".stripMargin)
               leftLink.get.stats.sizeInBytes < rightLink.get.stats.sizeInBytes
             } else {
-              // As a simple heuristic, we pick the side with fewer number of partitions
-              // to apply the grouping & replication of partitions
+              // As a simple heuristic, we pick the side with fewer partitions to apply the
+              // grouping & replication of partitions. The counts read the
+              // pre-alignment plans, for the same reason the statistics do: on a re-run both
+              // aligned reports hold the same number of keys, so comparing them decides nothing.
+              // This also changes a first pass, which compared the aligned report's distinct
+              // keys rather than the splits behind them.
               logInfo("Using number of partitions to determine which side of join " +
                   "to fully cluster partition values")
-              leftPartKeys.size < rightPartKeys.size
+              PartitioningCollection.numKeyedPartitions(unwrappedLeft.outputPartitioning)
+                .getOrElse(leftPartKeys.size) <
+                PartitioningCollection.numKeyedPartitions(unwrappedRight.outputPartitioning)
+                .getOrElse(rightPartKeys.size)
             }
 
             replicateRightSide = !replicateLeftSide
@@ -667,23 +682,31 @@ case class EnsureRequirements(
                 log"distribution.")
               replicateRightSide = false
             } else {
-              // In partially clustered distribution, we should use un-grouped partition values
-              val (partiallyClusteredChild, partiallyClusteredSpec) = if (replicateLeftSide) {
-                (unwrappedRight, rightSpec)
-              } else {
-                (unwrappedLeft, leftSpec)
-              }
-              // Original `KeyedPartitioning` can be obtained from the child directly if the child
-              // satisfied the distribution requirement; or from the child's child if it didn't as
-              // the child must be a `GroupPartitionsExec` inserted by `EnsureRequirement`
-              // to satisfy the distribution requirement.
+              // In partially clustered distribution, we should use un-grouped partition values.
+              // The child and the positions projecting its keys come from the same grouping:
+              // the keys from the node's child, the positions from the node itself, falling back
+              // to the spec's when there is no grouping. Like in `applyGroupPartitions`, the
+              // node's positions were computed against the raw partition keys, while the spec's
+              // were computed against the node's already projected report on a re-run.
+              val (partiallyClusteredChild, partiallyClusteredPositions) =
+                if (replicateLeftSide) {
+                  (unwrappedRight,
+                    rightGrouping.flatMap(_._1.joinKeyPositions)
+                      .orElse(rightSpec.joinKeyPositions))
+                } else {
+                  (unwrappedLeft,
+                    leftGrouping.flatMap(_._1.joinKeyPositions)
+                      .orElse(leftSpec.joinKeyPositions))
+                }
+              // The pre-alignment plan of the side that keeps its splits: its partitioning
+              // still holds the original partition keys, one per input split.
               val originalPartitioning =
                 partiallyClusteredChild.outputPartitioning.asInstanceOf[Expression]
               // `outputPartitioning` is either a `PartitioningCollection` or a `KeyedPartitioning`
               // otherwise `createKeyedShuffleSpec()` would have returned `None`.
               val originalKeyedPartitioning =
                 originalPartitioning.collectFirst { case k: KeyedPartitioning => k }.get
-              val projectedOriginalPartitionKeys = partiallyClusteredSpec.joinKeyPositions
+              val projectedOriginalPartitionKeys = partiallyClusteredPositions
                 .fold(originalKeyedPartitioning.partitionKeys)(
                   originalKeyedPartitioning.projectKeys(_)._2)
 
@@ -741,19 +764,79 @@ case class EnsureRequirements(
   }
 
   /**
-   * Unwraps a GroupPartitionsExec to get the underlying child plan.
+   * The innermost `GroupPartitionsExec` reachable from `plan` by descending only through nodes
+   * this rule itself inserted above it, together with a function rebuilding the traversed local
+   * sorts over a replacement node. `None` when no `GroupPartitionsExec` is reachable.
+   *
+   * The descent only traverses a `GroupPartitionsExec` and a *local* `SortExec`. That bound is a
+   * decision, not an omission: a `GroupPartitionsExec` hidden behind any other node belongs to a
+   * different operator, and reusing it would move that operator's alignment. Instrumentation of
+   * the descent over `KeyGroupedPartitioningSuite` found these non-`SortExec` shapes hiding a
+   * node: `Project > SortMergeJoin > Sort > GroupPartitions` and `Project > Filter > Window >
+   * WindowGroupLimit > GroupPartitions`, where refusing to descend is right every time. A global
+   * `SortExec` also stops the descent: it requires `OrderedDistribution`, which a
+   * `KeyedPartitioning` can satisfy (behind `spark.sql.sources.v2.bucketing.sorting.enabled`)
+   * through a `GroupPartitionsExec` built to emit the partition keys in sorted order, and
+   * reusing that node for a join would destroy the ordering it exists to provide.
    */
-  private def unwrapGroupPartitions(plan: SparkPlan): SparkPlan = plan match {
-    case g: GroupPartitionsExec => g.child
-    case other => other
+  private def innermostGroupPartition(
+      plan: SparkPlan): Option[(GroupPartitionsExec, SparkPlan => SparkPlan)] = plan match {
+    case g: GroupPartitionsExec =>
+      // When groupings stack, the outer one is the wrap this invocation's distribution step
+      // just added; the one below is inherited from an earlier pass and owns the alignment to
+      // preserve. Keep the descent below the outer node and drop it.
+      innermostGroupPartition(g.child).orElse(Some((g, identity[SparkPlan])))
+    case s: SortExec if !s.global =>
+      innermostGroupPartition(s.child).map { case (g, rebuild) =>
+        (g, (newChild: SparkPlan) => s.withNewChildren(Seq(rebuild(newChild))))
+      }
+    case _ => None
   }
+
+  /**
+   * Rewrites the innermost `GroupPartitionsExec` in `plan` with `f` and drops any redundant
+   * grouping stacked above it, per the descent of [[innermostGroupPartition]]. Returns `None`
+   * when `plan` holds no `GroupPartitionsExec`, leaving it to the caller to create one.
+   *
+   * This is what makes the rule idempotent for storage-partitioned joins. `EnsureRequirements`
+   * is re-run on plans it already produced: `AdaptiveSparkPlanExec` builds one instance of this
+   * rule, and `ConvertSortMergeJoinToShuffledHashJoin` and `OptimizeSkewedJoin` hand the whole
+   * tree back to it after rewriting some other join, all within one
+   * `queryStagePreparationRules` pass. A join child then arrives as
+   * `SortExec(GroupPartitionsExec(...))` rather than a bare scan, and the distribution step adds
+   * a plain `GroupPartitionsExec` on top, because a partially clustered `KeyedPartitioning`
+   * reports `isGrouped = false` by design and so is only satisfied "after grouping". Rewriting
+   * that outer node instead of the one below it re-derives the alignment from an already-aligned
+   * layout and duplicates rows; descending to the innermost node and dropping what sits above it
+   * reproduces the plan a single pass would have produced.
+   *
+   * Dropping a grouping is safe because only `applyGroupPartitions` calls this, reached from
+   * `checkKeyGroupCompatible`, which runs for joins alone: every `GroupPartitionsExec` a join
+   * child carries is this rule's own. A single-child operator genuinely needs its non-grouped
+   * input grouped and takes the wrap in the children loop instead; `withJoinKeyPositions`, which
+   * other multi-child operators reach, does not reuse at depth.
+   */
+  private[exchange] def rewriteGroupPartitions(plan: SparkPlan)(
+      f: GroupPartitionsExec => GroupPartitionsExec): Option[SparkPlan] =
+    innermostGroupPartition(plan).map { case (g, rebuild) =>
+      val rewritten = f(g)
+      rewritten.copyTagsFrom(g)
+      rebuild(rewritten)
+    }
+
+  /**
+   * Unwraps the groupings and local sorts this rule inserted over a child, down to the
+   * pre-alignment plan, per the descent of [[innermostGroupPartition]]. Peeling one level stops
+   * at the local sort this rule added, leaving the earlier pass's alignment in place.
+   */
+  private def unwrapGroupPartitions(plan: SparkPlan): SparkPlan =
+    innermostGroupPartition(plan).map(_._1.child).getOrElse(plan)
 
   /**
    * Applies or updates `GroupPartitionsExec` with the given parameters.
    *
-   * `GroupPartitionsExec` can be either the given plan node (child of the join inserted by
-   * `EnsureRequirement`) if the original child didn't satisfy the distribution requirement; or we
-   * can create a new one specifically for this join.
+   * Reuses the node this rule inserted over the join child in an earlier pass, per the descent
+   * of [[innermostGroupPartition]], and creates a new one when the child carries none.
    */
   private def applyGroupPartitions(
       plan: SparkPlan,
@@ -761,18 +844,18 @@ case class EnsureRequirements(
       mergedPartitionKeys: Seq[(InternalRowComparableWrapper, Int)],
       reducers: Option[Seq[Option[KeyReducer]]],
       distributePartitions: Boolean): SparkPlan = {
-    plan match {
-      case g: GroupPartitionsExec =>
-        val newGroupPartitions = g.copy(
-          joinKeyPositions = joinKeyPositions,
-          expectedPartitionKeys = Some(mergedPartitionKeys),
-          reducers = reducers,
-          distributePartitions = distributePartitions)
-        newGroupPartitions.copyTagsFrom(g)
-        newGroupPartitions
-      case _ =>
-        GroupPartitionsExec(plan, joinKeyPositions, Some(mergedPartitionKeys), reducers,
-          distributePartitions)
+    rewriteGroupPartitions(plan) { g =>
+      g.copy(
+        joinKeyPositions = g.joinKeyPositions.orElse(joinKeyPositions),
+        expectedPartitionKeys = Some(mergedPartitionKeys),
+        // Unlike `joinKeyPositions`, these need no `orElse`. A re-run with reducers never reaches
+        // here. Both sides then report the same reduced keys, so `isCompatible` above is true and
+        // the whole block is skipped.
+        reducers = reducers,
+        distributePartitions = distributePartitions)
+    }.getOrElse {
+      GroupPartitionsExec(plan, joinKeyPositions, Some(mergedPartitionKeys), reducers,
+        distributePartitions)
     }
   }
 
@@ -786,8 +869,11 @@ case class EnsureRequirements(
 
   /**
    * Applies join key positions to a plan by wrapping or updating GroupPartitionsExec.
+   *
+   * Unlike `applyGroupPartitions`, this does not descend: it serves every multi-child operator,
+   * not just joins, so a `GroupPartitionsExec` below the top is not known to be this rule's own.
    */
-  private def withJoinKeyPositions(plan: SparkPlan, positions: Seq[Int]): SparkPlan = {
+  private[exchange] def withJoinKeyPositions(plan: SparkPlan, positions: Seq[Int]): SparkPlan = {
     plan match {
       case g: GroupPartitionsExec =>
         val newGroupPartitions = g.copy(joinKeyPositions = Some(positions))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -3525,6 +3525,149 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
     }
   }
 
+  test("SPARK-58996: partially clustered join keeps its row count when EnsureRequirements " +
+      "re-runs") {
+    // The storage-partitioned join branch has no shuffle of its own, so the re-run of
+    // `EnsureRequirements` (triggered by the other branch below) reaches it. With
+    // `numRowsPerSplit = 1` the two id = 1 rows end up in two splits, which is what makes
+    // partial clustering replicate a side across two expected partitions. Regrouping that
+    // replicated layout on the second pass concatenated the replicas and replicated again,
+    // duplicating every id = 1 row.
+    val spColumns = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("sp1", spColumns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.sp1 VALUES (1, 'aa'), (1, 'ab'), (2, 'bb')")
+    createTable("sp2", spColumns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.sp2 VALUES (1, 'p'), (2, 'q')")
+
+    // Unpartitioned, so this branch's join materializes shuffle stages and is converted to a
+    // shuffled hash join, which hands the whole plan back to `EnsureRequirements`.
+    createTable("np1", spColumns, Array.empty)
+    sql("INSERT INTO testcat.ns.np1 VALUES (7, 'x')")
+    createTable("np2", spColumns, Array.empty)
+    sql("INSERT INTO testcat.ns.np2 VALUES (7, 'y')")
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true",
+        SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "100m") {
+      val df = sql(
+        """
+          |SELECT /*+ MERGE(a, b) */ a.id AS k
+          |FROM testcat.ns.sp1 a JOIN testcat.ns.sp2 b ON a.id = b.id
+          |UNION ALL
+          |SELECT c.id AS k
+          |FROM testcat.ns.np1 c JOIN testcat.ns.np2 d ON c.id = d.id
+          |""".stripMargin)
+      checkAnswer(df, Seq(Row(1L), Row(1L), Row(2L), Row(7L)))
+
+      // The re-run must leave the storage-partitioned side shuffle-free, with the single
+      // grouping per child the first pass built: a grouping stacked over another re-derives the
+      // alignment from an already-aligned layout and duplicates rows.
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "the storage-partitioned join must stay shuffle-free")
+      val groupPartitions = collectGroupPartitions(df.queryExecution.executedPlan)
+      assert(groupPartitions.nonEmpty, "the storage-partitioned join must keep its groupings")
+      groupPartitions.foreach { g =>
+        assert(collectAllGroupPartitions(g.child).isEmpty,
+          s"a GroupPartitionsExec must not be stacked over another:\n${g.treeString}")
+      }
+    }
+  }
+
+  test("SPARK-58996: partially clustered join keeps its replicate-side choice when " +
+      "EnsureRequirements re-runs") {
+    // The smaller side is replicated, chosen by plan statistics on the first pass. On the re-run
+    // the statistics must be read from the pre-alignment plan again: reading them from the
+    // aligned layout skips the statistics branch and deterministically flips the choice. With
+    // rows on both sides of the multi-split key the flip already gives wrong results on master;
+    // with the smaller side holding five splits for id = 1, the flip also turns it into the
+    // distributing side against an expected count of one, which `padTo` overflows into an
+    // unequal number of partitions per join side.
+    val spColumns = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("sp_small", spColumns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.sp_small VALUES " +
+        "(1, 'a1'), (1, 'a2'), (1, 'a3'), (1, 'a4'), (1, 'a5'), (2, 'b')")
+    createTable("sp_large", spColumns, Array(identity("id")))
+    sql("INSERT INTO testcat.ns.sp_large VALUES " +
+        "(1, 'p'), (2, 'q1'), (2, 'q2'), (2, 'q3'), (2, 'q4'), (2, 'q5'), (3, 'r')")
+
+    createTable("np1", spColumns, Array.empty)
+    sql("INSERT INTO testcat.ns.np1 VALUES (7, 'x')")
+    createTable("np2", spColumns, Array.empty)
+    sql("INSERT INTO testcat.ns.np2 VALUES (7, 'y')")
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true",
+        SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "100m") {
+      val df = sql(
+        """
+          |SELECT /*+ MERGE(a, b) */ a.id AS k
+          |FROM testcat.ns.sp_small a JOIN testcat.ns.sp_large b ON a.id = b.id
+          |UNION ALL
+          |SELECT c.id AS k
+          |FROM testcat.ns.np1 c JOIN testcat.ns.np2 d ON c.id = d.id
+          |""".stripMargin)
+      checkAnswer(df, Seq.fill(5)(Row(1L)) ++ Seq.fill(5)(Row(2L)) :+ Row(7L))
+
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "the storage-partitioned join must stay shuffle-free")
+      assert(collectGroupPartitions(df.queryExecution.executedPlan).nonEmpty,
+        "the storage-partitioned join must keep its groupings")
+    }
+  }
+
+  test("SPARK-58996: partially clustered subset-key join keeps its join key positions when " +
+      "EnsureRequirements re-runs") {
+    // The left table is partitioned by (extra, id) and the join uses only `id`, the second
+    // partition key, so the first pass stores positions that project the raw partition keys down
+    // to the join key. On the re-run the incoming positions are computed against the node's
+    // already projected report and must not overwrite the stored ones: applied to the raw keys
+    // again they would project a second time and group by the wrong key, and every expected key
+    // misses. The second split for id = 1 makes the test fail on master too, where the stacked
+    // re-grouping duplicates rows. The query must also select `extra`, or column pruning drops
+    // it from the scan output and the scan stops reporting its partitioning at all.
+    createTable("multi_part",
+      Array(Column.create("id", LongType), Column.create("extra", LongType),
+        Column.create("data", StringType)),
+      Array(identity("extra"), identity("id")))
+    sql("INSERT INTO testcat.ns.multi_part VALUES (1, 10, 'x'), (1, 11, 'x2'), (2, 20, 'y')")
+    createTable("single_part",
+      Array(Column.create("id", LongType), Column.create("data", StringType)),
+      Array(identity("id")))
+    sql("INSERT INTO testcat.ns.single_part VALUES (1, 'p'), (2, 'q')")
+
+    val spColumns = Array(Column.create("id", LongType), Column.create("data", StringType))
+    createTable("np1", spColumns, Array.empty)
+    sql("INSERT INTO testcat.ns.np1 VALUES (7, 'x')")
+    createTable("np2", spColumns, Array.empty)
+    sql("INSERT INTO testcat.ns.np2 VALUES (7, 'y')")
+
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+        // Co-partition elimination normally requires the partition keys to equal the join keys;
+        // the left side is partitioned by (extra, id) for a join on `id`, so relax that here.
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
+        SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "100m") {
+      val df = sql(
+        """
+          |SELECT /*+ MERGE(a, b) */ a.id AS k, a.extra AS e
+          |FROM testcat.ns.multi_part a JOIN testcat.ns.single_part b ON a.id = b.id
+          |UNION ALL
+          |SELECT c.id AS k, 0L AS e
+          |FROM testcat.ns.np1 c JOIN testcat.ns.np2 d ON c.id = d.id
+          |""".stripMargin)
+      checkAnswer(df, Seq(Row(1L, 10L), Row(1L, 11L), Row(2L, 20L), Row(7L, 0L)))
+
+      assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+        "the storage-partitioned join must stay shuffle-free")
+      assert(collectGroupPartitions(df.queryExecution.executedPlan).nonEmpty,
+        "the storage-partitioned join must keep its groupings")
+    }
+  }
+
   test("SPARK-48949: test partition filters with compatible transforms") {
     val items_partitions = Array(bucket(8, "id"))
     createTable(items, itemsColumns, items_partitions)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -27,6 +27,8 @@ import org.apache.spark.sql.catalyst.optimizer.BuildRight
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.physical.{SinglePartition, _}
 import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.execution.{BinaryExecNode, DummySparkPlan, LeafExecNode, SafeForKWayMerge, SortExec, UnaryExecNode}
 import org.apache.spark.sql.execution.SparkPlan
@@ -1909,6 +1911,244 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         DummyPassthroughUnaryExec(SortExec(ordering, global = false, child = gpe)))
         .exists(anyGpeEnabled))
     }
+  }
+
+  test("SPARK-58996: only a local sort is looked through when reusing GroupPartitionsExec") {
+    // A global `SortExec` requires `OrderedDistribution`, which a `KeyedPartitioning` can satisfy
+    // (behind `spark.sql.sources.v2.bucketing.sorting.enabled`) through a `GroupPartitionsExec`
+    // built to emit the partition keys in sorted order. Reusing that node for a join would
+    // overwrite its `expectedPartitionKeys` and clear `distributePartitions`, destroying the
+    // ordering it exists to provide. Only a local sort may be looked through.
+    val leaf = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(InternalRow(1), InternalRow(2))))
+    val gpe = GroupPartitionsExec(leaf)
+    val ordering = Seq(SortOrder(exprA, Ascending))
+    def mark(g: GroupPartitionsExec): GroupPartitionsExec = g.copy(distributePartitions = true)
+
+    // A bare GroupPartitionsExec is rewritten in place.
+    EnsureRequirements.rewriteGroupPartitions(gpe)(mark) match {
+      case Some(g: GroupPartitionsExec) => assert(g.distributePartitions)
+      case other => fail(s"expected a rewritten GroupPartitionsExec, got $other")
+    }
+
+    // A local sort is looked through and the GroupPartitionsExec below it is rewritten.
+    val localSort = SortExec(ordering, global = false, gpe)
+    EnsureRequirements.rewriteGroupPartitions(localSort)(mark) match {
+      case Some(SortExec(_, false, g: GroupPartitionsExec, _)) => assert(g.distributePartitions)
+      case other => fail(s"expected the local sort to be looked through, got $other")
+    }
+
+    // A grouping stacked over another is dropped and the node below is rewritten.
+    EnsureRequirements.rewriteGroupPartitions(GroupPartitionsExec(localSort))(mark) match {
+      case Some(SortExec(_, false, g: GroupPartitionsExec, _)) =>
+        assert(g.distributePartitions, "the stacked grouping must be dropped and the node " +
+          "below it rewritten")
+      case other => fail(s"expected the stacked grouping to be dropped, got $other")
+    }
+
+    // A global sort is not looked through, so the caller wraps instead of reusing.
+    val globalSort = SortExec(ordering, global = true, gpe)
+    assert(EnsureRequirements.rewriteGroupPartitions(globalSort)(mark).isEmpty,
+      "a GroupPartitionsExec below a global sort must never be reused")
+  }
+
+  test("SPARK-58996: withJoinKeyPositions reuses only a topmost GroupPartitionsExec") {
+    // Non-join multi-child operators (a cogroup, say) reach `withJoinKeyPositions`, so it must
+    // not descend to a node that may belong to another operator: over anything but a topmost
+    // `GroupPartitionsExec` it wraps, leaving the nodes below untouched.
+    val leaf = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(InternalRow(1), InternalRow(2))))
+    val gpe = GroupPartitionsExec(leaf)
+    val ordering = Seq(SortOrder(exprA, Ascending))
+
+    // A topmost GroupPartitionsExec is rewritten in place.
+    EnsureRequirements.withJoinKeyPositions(gpe, Seq(0)) match {
+      case g: GroupPartitionsExec => assert(g.joinKeyPositions === Some(Seq(0)))
+      case other => fail(s"expected a rewritten GroupPartitionsExec, got $other")
+    }
+
+    // A GroupPartitionsExec below a local sort is left alone; a new node wraps the sort.
+    EnsureRequirements.withJoinKeyPositions(SortExec(ordering, global = false, gpe), Seq(0))
+      match {
+      case g: GroupPartitionsExec =>
+        assert(g.joinKeyPositions === Some(Seq(0)))
+        g.child match {
+          case SortExec(_, false, childGpe: GroupPartitionsExec, _) =>
+            assert(childGpe.joinKeyPositions.isEmpty,
+              "the GroupPartitionsExec below the sort must stay untouched")
+          case other => fail(s"expected the sort to be wrapped, got $other")
+        }
+      case other => fail(s"expected a wrapping GroupPartitionsExec, got $other")
+    }
+  }
+
+  test("SPARK-58996: reusing a GroupPartitionsExec keeps its tags") {
+    // Tags are instance state that a `copy` does not carry, so every rewrite must copy them
+    // back onto the new node.
+    val tag = TreeNodeTag[String]("test tag")
+    val leaf = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(InternalRow(1), InternalRow(2))))
+    val gpe = GroupPartitionsExec(leaf)
+    gpe.setTagValue(tag, "kept")
+    val ordering = Seq(SortOrder(exprA, Ascending))
+
+    // The join path: a bare node and one behind a local sort.
+    EnsureRequirements.rewriteGroupPartitions(gpe)(_.copy(distributePartitions = true)) match {
+      case Some(g: GroupPartitionsExec) => assert(g.getTagValue(tag) === Some("kept"))
+      case other => fail(s"expected a rewritten GroupPartitionsExec, got $other")
+    }
+    EnsureRequirements.rewriteGroupPartitions(SortExec(ordering, global = false, gpe))(
+      _.copy(distributePartitions = true)) match {
+      case Some(SortExec(_, false, g: GroupPartitionsExec, _)) =>
+        assert(g.getTagValue(tag) === Some("kept"))
+      case other => fail(s"expected the local sort to be looked through, got $other")
+    }
+
+    // The non-join path: a topmost node is rewritten in place.
+    EnsureRequirements.withJoinKeyPositions(gpe, Seq(0)) match {
+      case g: GroupPartitionsExec => assert(g.getTagValue(tag) === Some("kept"))
+      case other => fail(s"expected a rewritten GroupPartitionsExec, got $other")
+    }
+  }
+
+  test("SPARK-58996: the shuffle site strips every grouping the rule inserted") {
+    // When a join child that already carries the rule's groupings must be re-shuffled, every
+    // grouping is stripped down to the pre-alignment plan: a replicating grouping repeats every
+    // row, so none of them may feed the shuffle. End-to-end this site only sees the stacked
+    // shape if a first pass succeeds with SPJ and a second pass gives it up, which no query
+    // reaches today; this pins the site itself so the descent cannot silently rot. With only a
+    // one-level peel the shuffle would land over the local sort and the grouping below it.
+    val leaf = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(Seq(exprA), Seq(InternalRow(1), InternalRow(1))))
+    val inner = GroupPartitionsExec(leaf, expectedPartitionKeys = Some(Seq(
+      (InternalRowComparableWrapper(InternalRow(1), Seq(exprA)), 2))))
+    assert(!inner.outputPartitioning.asInstanceOf[KeyedPartitioning].isGrouped,
+      "precondition: the inner grouping reports a non-grouped partitioning")
+    val ordering = Seq(SortOrder(exprA, Ascending))
+    val stackedChild = SortExec(ordering, global = false, inner)
+
+    val distribution = ClusteredDistribution(Seq(exprA))
+    val sibling = DummySparkPlan(outputPartitioning = HashPartitioning(Seq(exprA), 4))
+    val parent = DummySparkPlan(
+      children = Seq(stackedChild, sibling),
+      requiredChildDistribution = Seq(distribution, distribution),
+      requiredChildOrdering = Seq(Nil, Nil))
+
+    EnsureRequirements.apply(parent).children.head match {
+      case s: ShuffleExchangeExec =>
+        assert(s.child eq leaf,
+          s"every grouping the rule inserted must be stripped before the shuffle:\n" +
+            s"${s.treeString}")
+      case other => fail(s"expected the stacked child to be re-shuffled, got $other")
+    }
+  }
+
+  test("SPARK-58996: the replicate-side fallback counts pre-alignment partitions") {
+    // The replicate side is chosen by plan statistics; when there is none (the dummy plans carry
+    // no `logicalLink`, which forces the fallback), the side with fewer partitions is picked.
+    // The counts must come from the pre-alignment partitioning. On a re-run the join children
+    // arrive already aligned -- a local sort over an aligned `GroupPartitionsExec` -- and both
+    // aligned reports hold the same keys, so counting them decides nothing. On a bare first pass
+    // the pre-fix count read the aligned report's distinct keys, because the children loop had
+    // already wrapped the non-grouped side, and picked a different side wherever one holds more
+    // than one split per key. Both shapes read the choice back off the `distributePartitions`
+    // flags.
+    def distribute(child: SparkPlan): Boolean = child.collectFirst {
+      case g: GroupPartitionsExec => g
+    }.get.distributePartitions
+
+    def flags(smj: SparkPlan): (Boolean, Boolean) =
+      withSQLConf(
+          SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true") {
+        val Seq(newLeft, newRight) = EnsureRequirements.apply(smj).children
+        (distribute(newLeft), distribute(newRight))
+      }
+
+    // The re-run shape: each child is the output of a first pass, a local sort over an aligned
+    // `GroupPartitionsExec`.
+    def distributeFlags(
+        leftKeys: Seq[InternalRow], leftSplits: Int,
+        rightKeys: Seq[InternalRow], rightSplits: Int): (Boolean, Boolean) = {
+      def alignedChild(expr: AttributeReference, keys: Seq[InternalRow], splits: Int) = {
+        val leaf = DummySparkPlan(outputPartitioning = KeyedPartitioning(Seq(expr), keys))
+        val gpe = GroupPartitionsExec(leaf,
+          expectedPartitionKeys = Some(Seq(
+            (InternalRowComparableWrapper(InternalRow(1), Seq(expr)), splits))))
+        SortExec(Seq(SortOrder(expr, Ascending)), global = false, gpe)
+      }
+      flags(SortMergeJoinExec(Seq(exprA), Seq(exprB), Inner, None,
+        alignedChild(exprA, leftKeys, leftSplits), alignedChild(exprB, rightKeys, rightSplits)))
+    }
+
+    // The bare first-pass shape: the children are the scans themselves.
+    def firstPassFlags(
+        leftKeys: Seq[InternalRow], rightKeys: Seq[InternalRow]): (Boolean, Boolean) =
+      flags(SortMergeJoinExec(Seq(exprA), Seq(exprB), Inner, None,
+        DummySparkPlan(outputPartitioning = KeyedPartitioning(Seq(exprA), leftKeys)),
+        DummySparkPlan(outputPartitioning = KeyedPartitioning(Seq(exprB), rightKeys))))
+
+    // Re-run shape. The left side holds one partition against three on the right: it is
+    // replicated, so it does not distribute. Counting the aligned reports instead sees one key
+    // on both sides and always picks the right side.
+    assert(distributeFlags(
+      leftKeys = Seq(InternalRow(1)), leftSplits = 1,
+      rightKeys = Seq(InternalRow(1), InternalRow(1), InternalRow(1)), rightSplits = 3) ===
+        ((false, true)))
+
+    // The mirrored control: the right side is replicated.
+    assert(distributeFlags(
+      leftKeys = Seq(InternalRow(1), InternalRow(1), InternalRow(1)), leftSplits = 3,
+      rightKeys = Seq(InternalRow(1)), rightSplits = 1) ===
+        ((true, false)))
+
+    // Bare first pass where the pre-fix count disagrees: the left side holds three splits under
+    // one distinct key, the right two splits under two keys. The pre-fix count saw one distinct
+    // key against two and replicated the left side; the pre-alignment count replicates the side
+    // with fewer splits.
+    assert(firstPassFlags(
+      leftKeys = Seq(InternalRow(1), InternalRow(1), InternalRow(1)),
+      rightKeys = Seq(InternalRow(1), InternalRow(2))) ===
+        ((true, false)))
+
+    // The first-pass control where both counts agree.
+    assert(firstPassFlags(
+      leftKeys = Seq(InternalRow(1), InternalRow(2)),
+      rightKeys = Seq(InternalRow(1), InternalRow(2), InternalRow(3))) ===
+        ((false, true)))
+  }
+
+  test("SPARK-58996: a single-child operator over a partially clustered layout still gets " +
+      "grouped") {
+    // A partially clustered `GroupPartitionsExec` reports a non-grouped partitioning by design,
+    // so an operator above it that needs `ClusteredDistribution` (an aggregate or a window, say)
+    // must still have that partitioning grouped -- stacking a second `GroupPartitionsExec` here
+    // is legitimate. See the aggregate and window cases in `KeyGroupedPartitioningSuite`.
+    //
+    // With one child the multi-child block never runs, so this does not exercise
+    // `rewriteGroupPartitions`: it pins the intentional non-idempotence of the children loop's
+    // wrap for single-child operators. If that wrap were "generalized" into a reuse of the node
+    // below, the returned child would stay non-grouped and this assertion would fail, which is
+    // exactly what the `rewriteGroupPartitions` scaladoc argues must not happen.
+    val leaf = DummySparkPlan(
+      outputPartitioning = KeyedPartitioning(
+        Seq(exprA), Seq(InternalRow(1), InternalRow(1), InternalRow(2))))
+    val keys = Seq(
+      (InternalRowComparableWrapper(InternalRow(1), Seq(exprA)), 2),
+      (InternalRowComparableWrapper(InternalRow(2), Seq(exprA)), 1))
+    val gpe = GroupPartitionsExec(leaf, expectedPartitionKeys = Some(keys))
+    assert(!gpe.outputPartitioning.asInstanceOf[KeyedPartitioning].isGrouped,
+      "precondition: a partially clustered GroupPartitionsExec is not grouped")
+
+    val distribution = ClusteredDistribution(Seq(exprA))
+    val parent = DummySparkPlan(
+      children = Seq(gpe),
+      requiredChildDistribution = Seq(distribution),
+      requiredChildOrdering = Seq(Nil))
+
+    val newChild = EnsureRequirements.apply(parent).children.head
+    assert(newChild.outputPartitioning.satisfies(distribution),
+      s"EnsureRequirements must satisfy the required distribution:\n${newChild.treeString}")
   }
 
   private def anyGpeEnabled(plan: SparkPlan): Boolean =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Backport of SPARK-58996 (apache/spark#58279, already merged to master, `branch-4.x` and `branch-4.3`) to `branch-4.2`.

`EnsureRequirements` is not idempotent for a storage-partitioned join under a partially clustered distribution: re-running it on a plan it already produced stacks a second `GroupPartitionsExec` over the first and duplicates rows. The fix makes the rule reuse the grouping an earlier pass inserted instead of re-deriving the alignment from an already-aligned layout:

- `innermostGroupPartition` descends only through a `GroupPartitionsExec` and the local `SortExec` this rule itself added; both the rewrite and the reads below go through it.
- `rewriteGroupPartitions` rewrites the innermost node and drops redundant groupings stacked above it, reproducing the plan a single pass would have produced.
- `unwrapGroupPartitions` peels to the pre-alignment plan so the statistics and original partition keys are read from that plan on every pass.
- `applyGroupPartitions` keeps the `joinKeyPositions` a reused node already holds (they were computed against the raw partition keys) instead of re-projecting a second time.
- `withJoinKeyPositions`, which every multi-child operator reaches and not just joins, reuses only a topmost `GroupPartitionsExec`.
- The `ShuffleExchangeExec` site strips every grouping this rule inserted before re-shuffling.

On `branch-4.2` this additionally introduces a small `PartitioningCollection` companion object (with `representativeOf` and `numKeyedPartitions`) in `partitioning.scala`, mirroring master; `branch-4.2`'s `PartitioningCollection` has no companion object yet.

### Why are the changes needed?

The join returns duplicated rows when AQE re-runs `EnsureRequirements`. The re-run is not an AQE quirk: `AdaptiveSparkPlanExec` builds one rule instance, and `ConvertSortMergeJoinToShuffledHashJoin` and `OptimizeSkewedJoin` hand the whole tree back to it after rewriting some other join, all within one `queryStagePreparationRules` pass. A join child then arrives as `SortExec(GroupPartitionsExec(...))`; the partially clustered `KeyedPartitioning` reports `isGrouped = false` by design, so the distribution step adds a plain `GroupPartitionsExec` on top, and `applyGroupPartitions` rewrites that fresh outer node instead of the inherited one. A replicating grouping repeats every row, so the row set is emitted twice. Reproduction:

```
spark.sql.sources.v2.bucketing.enabled=true
spark.sql.sources.v2.bucketing.pushPartValues.enabled=true
spark.sql.sources.v2.bucketing.partiallyClusteredDistribution.enabled=true
spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold=100m
```

```sql
CREATE TABLE sp1 (id BIGINT, data STRING) PARTITIONED BY (id);
INSERT INTO sp1 VALUES (1, 'aa'), (1, 'ab'), (2, 'bb');   -- two splits for id = 1

CREATE TABLE sp2 (id BIGINT, data STRING) PARTITIONED BY (id);
INSERT INTO sp2 VALUES (1, 'p'), (2, 'q');

CREATE TABLE np1 (id BIGINT, data STRING); INSERT INTO np1 VALUES (7, 'x');
CREATE TABLE np2 (id BIGINT, data STRING); INSERT INTO np2 VALUES (7, 'y');

SELECT /*+ MERGE(a, b) */ a.id AS k FROM sp1 a JOIN sp2 b ON a.id = b.id
UNION ALL
SELECT c.id AS k FROM np1 c JOIN np2 d ON c.id = d.id;
```

returns `(1, 1, 1, 1, 2, 7)` instead of `(1, 1, 2, 7)`.

### Does this PR introduce _any_ user-facing change?

Yes. It fixes wrong results (duplicated rows) for a storage-partitioned join under a partially clustered distribution when AQE re-runs `EnsureRequirements`. As on master, the partition-count fallback that picks the replicate side when there are no plan statistics now compares the pre-alignment split counts instead of the aligned report's distinct keys, which can change the replicated side on a first pass.

### How was this patch tested?

- `KeyGroupedPartitioningSuite`: new tests for the row count, the replicate-side choice, and the subset-key join key positions under an `EnsureRequirements` re-run. The subset-key test sets `spark.sql.requireAllClusterKeysForCoPartition=false`, because on `branch-4.2` a join on a subset of the partition keys only engages storage-partitioned join with that config off.
- `EnsureRequirementsSuite`: new unit tests for the local-sort reuse bound, topmost-only `withJoinKeyPositions` reuse, tag preservation, the shuffle site, the fallback counting, and the intentional single-child wrap.
- Both suites pass on `branch-4.2`.
