### PR TITLE
[SPARK-59292][CONNECT][PYTHON] Add a client-side deadline to ML cache cleanup RPCs

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1737,7 +1737,13 @@ class SparkConnectClient(object):
     def _execute_cleanup_command(
         self, command: pb2.Command, timeout: Optional[float]
     ) -> pb2.ExecutePlanResponse:
-        """Execute a best-effort cleanup command once with a bounded deadline."""
+        """Execute a best-effort cleanup command once with a bounded deadline.
+
+        This is shared by cached-relation release from ``CachedRemoteRelation.__del__`` and by
+        targeted or session-wide ML cache cleanup. Both operations are safe to abandon because
+        their server-side state is also released when the session ends. The non-reattachable call
+        ensures that its timeout bounds the cleanup instead of starting another deadline interval.
+        """
         req = self._execute_plan_request_with_metadata()
         self._set_command_in_plan(req.plan, command)
 
@@ -1746,8 +1752,8 @@ class SparkConnectClient(object):
             req = hook.on_execute_plan(req)
             req.operation_id = operation_id
 
-        # Cleanup can run from a finalizer or at interpreter exit, where the generated
-        # unary-stream call is unreliable. These commands return a single response.
+        # Relation and ML cache cleanup can run from a finalizer or at interpreter exit, where the
+        # generated unary-stream call is unreliable. Both commands return a single response.
         channel = self._channel.unary_unary(
             "/spark.connect.SparkConnectService/ExecutePlan",
             request_serializer=pb2.ExecutePlanRequest.SerializeToString,

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1734,39 +1734,6 @@ class SparkConnectClient(object):
         except Exception as error:
             self._handle_error(error, req.operation_id)
 
-    def _execute_cleanup_command(
-        self, command: pb2.Command, timeout: Optional[float]
-    ) -> pb2.ExecutePlanResponse:
-        """Execute a best-effort cleanup command once with a bounded deadline.
-
-        This is shared by cached-relation release from ``CachedRemoteRelation.__del__`` and by
-        targeted or session-wide ML cache cleanup. Both operations are safe to abandon because
-        their server-side state is also released when the session ends. The non-reattachable call
-        ensures that its timeout bounds the cleanup instead of starting another deadline interval.
-        """
-        req = self._execute_plan_request_with_metadata()
-        self._set_command_in_plan(req.plan, command)
-
-        operation_id = req.operation_id
-        for hook in self._session_hooks:
-            req = hook.on_execute_plan(req)
-            req.operation_id = operation_id
-
-        # Relation and ML cache cleanup can run from a finalizer or at interpreter exit, where the
-        # generated unary-stream call is unreliable. Both commands return a single response.
-        channel = self._channel.unary_unary(
-            "/spark.connect.SparkConnectService/ExecutePlan",
-            request_serializer=pb2.ExecutePlanRequest.SerializeToString,
-            response_deserializer=pb2.ExecutePlanResponse.FromString,
-        )
-        response = channel(
-            req,
-            metadata=self._execute_plan_metadata(req.operation_id),
-            timeout=timeout,
-        )
-        self._verify_response_integrity(response)
-        return cast(pb2.ExecutePlanResponse, response)
-
     def _builder_metadata(self) -> List[Tuple[str, str]]:
         return [
             (key, value)
@@ -2624,15 +2591,12 @@ class SparkConnectClient(object):
                 command.ml_command.delete.evict_only = evict_only
                 self._ml_cache_rpc_thread = threading.get_ident()
                 try:
-                    response = self._execute_cleanup_command(
-                        command, self._rpc_deadlines.release_ml_cache
-                    )
+                    ml_command_result = self._execute_ml_cache_command(command)
                 finally:
                     self._ml_cache_rpc_thread = None
 
-                if response.HasField("ml_command_result"):
-                    deleted = response.ml_command_result.operator_info.obj_ref.id.split(",")
-                    return cast(List[str], deleted)
+                if ml_command_result is not None:
+                    return ml_command_result.operator_info.obj_ref.id.split(",")
             return []
         except Exception:
             return []
@@ -2671,11 +2635,47 @@ class SparkConnectClient(object):
             command.ml_command.clean_cache.SetInParent()
             self._ml_cache_rpc_thread = threading.get_ident()
             try:
-                self._execute_cleanup_command(command, self._rpc_deadlines.release_ml_cache)
+                self._execute_ml_cache_command(command)
             finally:
                 self._ml_cache_rpc_thread = None
         except Exception:
             pass
+
+    def _execute_ml_cache_command(self, command: pb2.Command) -> Optional[pb2.MlCommandResult]:
+        """Execute an ML cache cleanup command once with a bounded deadline.
+
+        This is used by targeted model deletion and session-wide ML cache cleanup. Both are
+        best-effort releases whose server-side state is also removed when the session ends. Use a
+        non-reattachable ExecutePlan call so its deadline bounds the cleanup, and consume the full
+        response stream because ML commands can return more than one response.
+        """
+        req = self._execute_plan_request_with_metadata()
+        self._set_command_in_plan(req.plan, command)
+
+        operation_id = req.operation_id
+        for hook in self._session_hooks:
+            req = hook.on_execute_plan(req)
+            req.operation_id = operation_id
+
+        with disable_gc():
+            responses = iter(
+                self._stub.ExecutePlan(
+                    req,
+                    metadata=self._execute_plan_metadata(req.operation_id),
+                    timeout=self._rpc_deadlines.release_ml_cache,
+                )
+            )
+
+        ml_command_result = None
+        while True:
+            try:
+                with disable_gc():
+                    response = next(responses)
+                self._verify_response_integrity(response)
+                if response.HasField("ml_command_result"):
+                    ml_command_result = response.ml_command_result
+            except StopIteration:
+                return ml_command_result
 
     def _get_ml_cache_info(self) -> List[str]:
         command = pb2.Command()

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1734,6 +1734,33 @@ class SparkConnectClient(object):
         except Exception as error:
             self._handle_error(error, req.operation_id)
 
+    def _execute_cleanup_command(
+        self, command: pb2.Command, timeout: Optional[float]
+    ) -> pb2.ExecutePlanResponse:
+        """Execute a best-effort cleanup command once with a bounded deadline."""
+        req = self._execute_plan_request_with_metadata()
+        self._set_command_in_plan(req.plan, command)
+
+        operation_id = req.operation_id
+        for hook in self._session_hooks:
+            req = hook.on_execute_plan(req)
+            req.operation_id = operation_id
+
+        # Cleanup can run from a finalizer or at interpreter exit, where the generated
+        # unary-stream call is unreliable. These commands return a single response.
+        channel = self._channel.unary_unary(
+            "/spark.connect.SparkConnectService/ExecutePlan",
+            request_serializer=pb2.ExecutePlanRequest.SerializeToString,
+            response_deserializer=pb2.ExecutePlanResponse.FromString,
+        )
+        response = channel(
+            req,
+            metadata=self._execute_plan_metadata(req.operation_id),
+            timeout=timeout,
+        )
+        self._verify_response_integrity(response)
+        return cast(pb2.ExecutePlanResponse, response)
+
     def _builder_metadata(self) -> List[Tuple[str, str]]:
         return [
             (key, value)
@@ -2591,12 +2618,14 @@ class SparkConnectClient(object):
                 command.ml_command.delete.evict_only = evict_only
                 self._ml_cache_rpc_thread = threading.get_ident()
                 try:
-                    ml_command_result = self._execute_ml_cache_command(command)
+                    response = self._execute_cleanup_command(
+                        command, self._rpc_deadlines.release_ml_cache
+                    )
                 finally:
                     self._ml_cache_rpc_thread = None
 
-                if ml_command_result is not None:
-                    deleted = ml_command_result.operator_info.obj_ref.id.split(",")
+                if response.HasField("ml_command_result"):
+                    deleted = response.ml_command_result.operator_info.obj_ref.id.split(",")
                     return cast(List[str], deleted)
             return []
         except Exception:
@@ -2636,47 +2665,11 @@ class SparkConnectClient(object):
             command.ml_command.clean_cache.SetInParent()
             self._ml_cache_rpc_thread = threading.get_ident()
             try:
-                self._execute_ml_cache_command(command)
+                self._execute_cleanup_command(command, self._rpc_deadlines.release_ml_cache)
             finally:
                 self._ml_cache_rpc_thread = None
         except Exception:
             pass
-
-    def _execute_ml_cache_command(self, command: pb2.Command) -> Optional[pb2.MlCommandResult]:
-        """Execute a best-effort ML cache cleanup command with a bounded deadline."""
-        req = self._execute_plan_request_with_metadata()
-        self._set_command_in_plan(req.plan, command)
-
-        operation_id = req.operation_id
-        for hook in self._session_hooks:
-            req = hook.on_execute_plan(req)
-            req.operation_id = operation_id
-
-        try:
-            for attempt in self._retrying():
-                with attempt:
-                    # Use a unary call for cleanup that can run from a finalizer or at interpreter
-                    # exit. A normal reattachable ExecutePlan would restart its per-stream deadline
-                    # indefinitely, while the generated unary-stream call is unreliable during
-                    # interpreter shutdown. ML cache eviction is best effort and also happens when
-                    # the server releases the session, so abandoning it on timeout is safe.
-                    channel = self._channel.unary_unary(
-                        "/spark.connect.SparkConnectService/ExecutePlan",
-                        request_serializer=pb2.ExecutePlanRequest.SerializeToString,
-                        response_deserializer=pb2.ExecutePlanResponse.FromString,
-                    )
-                    response = channel(
-                        req,
-                        metadata=self._execute_plan_metadata(req.operation_id),
-                        timeout=self._rpc_deadlines.release_ml_cache,
-                    )
-                    self._verify_response_integrity(response)
-                    if response.HasField("ml_command_result"):
-                        return cast(pb2.MlCommandResult, response.ml_command_result)
-                    return None
-            raise SparkConnectException("Invalid state during retry exception handling.")
-        except Exception as error:
-            self._handle_error(error, req.operation_id)
 
     def _get_ml_cache_info(self) -> List[str]:
         command = pb2.Command()

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -144,13 +144,12 @@ class RpcDeadlines:
     stream to resume receiving results. Non-reattachable query ExecutePlan calls have no deadline
     because a timeout there would kill the execution with no recovery path.
 
-    Note on ``release_relation``: the RemoveRemoteCachedRelation cleanup command is sent over a
-    blocking, non-reattachable ExecutePlan call issued from
-    :meth:`CachedRemoteRelation.__del__`. Unlike a query ExecutePlan, a timeout here does not kill
-    any recoverable execution -- it only abandons a best-effort cache eviction that the server also
-    performs independently -- so this call is given a bounded deadline. Without it the finalizer
-    can block forever if the release response is never delivered, which (on the foreachBatch
-    Connect path) stalls the streaming query indefinitely.
+    Note on ``release_relation`` and ``release_ml_cache``: these best-effort cleanup commands are
+    sent over blocking, non-reattachable ExecutePlan calls. Unlike a query ExecutePlan, a timeout
+    here does not kill any recoverable execution -- it only abandons cache eviction, and the server
+    also releases the cached state when the session ends -- so these calls are given bounded
+    deadlines. Without them a finalizer or interpreter-exit cleanup can block forever if the
+    release response is never delivered.
     """
 
     reattachable_execute_plan: Optional[float] = 10 * 60  # 10 min
@@ -165,6 +164,7 @@ class RpcDeadlines:
     get_status: Optional[float] = 10 * 60  # 10 min
     fetch_error_details: Optional[float] = 10 * 60  # 10 min
     release_relation: Optional[float] = 60  # 1 min; short: per-batch finalizer
+    release_ml_cache: Optional[float] = 60  # 1 min; best-effort cleanup
 
     def __post_init__(self) -> None:
         for field in fields(self):
@@ -196,6 +196,7 @@ class RpcDeadlines:
             get_status=None,
             fetch_error_details=None,
             release_relation=None,
+            release_ml_cache=None,
         )
 
 
@@ -877,7 +878,8 @@ class SparkConnectClient(object):
             ([1KB, max batch size on server]). Otherwise, the server's maximum batch size is used.
         rpc_deadlines : RpcDeadlines, optional
             Per-RPC gRPC call timeouts in seconds (10 min for most RPCs,
-            1 hour for analyze/addArtifacts, none for non-reattachable execute).
+            1 hour for analyze/addArtifacts, 1 min for best-effort release calls,
+            none for non-reattachable query execute).
             Use :meth:`RpcDeadlines.disabled` to turn off all deadlines.
         max_retry_exception_elapsed_time : float, optional
             Maximum cumulative elapsed time in seconds the client will keep retrying a
@@ -2589,14 +2591,11 @@ class SparkConnectClient(object):
                 command.ml_command.delete.evict_only = evict_only
                 self._ml_cache_rpc_thread = threading.get_ident()
                 try:
-                    _, properties, _ = self.execute_command(command)
+                    ml_command_result = self._execute_ml_cache_command(command)
                 finally:
                     self._ml_cache_rpc_thread = None
 
-                assert properties is not None
-
-                if properties is not None and "ml_command_result" in properties:
-                    ml_command_result = properties["ml_command_result"]
+                if ml_command_result is not None:
                     deleted = ml_command_result.operator_info.obj_ref.id.split(",")
                     return cast(List[str], deleted)
             return []
@@ -2637,11 +2636,47 @@ class SparkConnectClient(object):
             command.ml_command.clean_cache.SetInParent()
             self._ml_cache_rpc_thread = threading.get_ident()
             try:
-                self.execute_command(command)
+                self._execute_ml_cache_command(command)
             finally:
                 self._ml_cache_rpc_thread = None
         except Exception:
             pass
+
+    def _execute_ml_cache_command(self, command: pb2.Command) -> Optional[pb2.MlCommandResult]:
+        """Execute a best-effort ML cache cleanup command with a bounded deadline."""
+        req = self._execute_plan_request_with_metadata()
+        self._set_command_in_plan(req.plan, command)
+
+        operation_id = req.operation_id
+        for hook in self._session_hooks:
+            req = hook.on_execute_plan(req)
+            req.operation_id = operation_id
+
+        try:
+            for attempt in self._retrying():
+                with attempt:
+                    # Use a unary call for cleanup that can run from a finalizer or at interpreter
+                    # exit. A normal reattachable ExecutePlan would restart its per-stream deadline
+                    # indefinitely, while the generated unary-stream call is unreliable during
+                    # interpreter shutdown. ML cache eviction is best effort and also happens when
+                    # the server releases the session, so abandoning it on timeout is safe.
+                    channel = self._channel.unary_unary(
+                        "/spark.connect.SparkConnectService/ExecutePlan",
+                        request_serializer=pb2.ExecutePlanRequest.SerializeToString,
+                        response_deserializer=pb2.ExecutePlanResponse.FromString,
+                    )
+                    response = channel(
+                        req,
+                        metadata=self._execute_plan_metadata(req.operation_id),
+                        timeout=self._rpc_deadlines.release_ml_cache,
+                    )
+                    self._verify_response_integrity(response)
+                    if response.HasField("ml_command_result"):
+                        return cast(pb2.MlCommandResult, response.ml_command_result)
+                    return None
+            raise SparkConnectException("Invalid state during retry exception handling.")
+        except Exception as error:
+            self._handle_error(error, req.operation_id)
 
     def _get_ml_cache_info(self) -> List[str]:
         command = pb2.Command()

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -51,7 +51,6 @@ from pyspark.sql.column import Column
 from pyspark.sql.connect.conversion import storage_level_to_proto
 from pyspark.sql.connect.expressions import Expression, SubqueryExpression
 from pyspark.sql.connect.logging import logger
-from pyspark.sql.connect.proto import base_pb2 as spark_dot_connect_dot_base__pb2
 from pyspark.sql.connect.types import UnparsedDataType, pyspark_types_to_proto_types
 from pyspark.sql.types import DataType, StructType
 from pyspark.storagelevel import StorageLevel
@@ -760,29 +759,8 @@ class CachedRemoteRelation(LogicalPlan):
         if session is not None and not session.client.is_closed and self._relation_id is not None:
             try:
                 command = RemoveRemoteCachedRelation(self).command(session=session.client)
-                req = session.client._execute_plan_request_with_metadata()
-                if session.client._user_id:
-                    req.user_context.user_id = session.client._user_id
-                req.plan.command.CopyFrom(command)
-
                 for attempt in session.client._retrying():
                     with attempt:
-                        # !!HACK ALERT!!
-                        # unary_stream does not work on Python's exit for an unknown reasons
-                        # Therefore, here we open unary_unary channel instead.
-                        # See also :class:`SparkConnectServiceStub`.
-                        request_serializer = (
-                            spark_dot_connect_dot_base__pb2.ExecutePlanRequest.SerializeToString
-                        )
-                        response_deserializer = (
-                            spark_dot_connect_dot_base__pb2.ExecutePlanResponse.FromString
-                        )
-                        channel = session.client._channel.unary_unary(
-                            "/spark.connect.SparkConnectService/ExecutePlan",
-                            request_serializer=request_serializer,
-                            response_deserializer=response_deserializer,
-                        )
-                        metadata = session.client._execute_plan_metadata(req.operation_id)
                         # Bound this blocking call with a client-side deadline. It is issued from a
                         # finalizer with no other timeout at any layer; without a deadline it can
                         # block forever if the response is never delivered, which stalls the
@@ -791,7 +769,7 @@ class CachedRemoteRelation(LogicalPlan):
                         # timeout here is non-fatal: the eviction is best effort and the server
                         # performs it independently, so on timeout we log and move on.
                         timeout = session.client._rpc_deadlines.release_relation
-                        channel(req, metadata=metadata, timeout=timeout)  # type: ignore[arg-type]
+                        session.client._execute_cleanup_command(command, timeout)
             except Exception as e:
                 logger.warning(f"RemoveRemoteCachedRelation failed with exception: {e}.")
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -51,6 +51,7 @@ from pyspark.sql.column import Column
 from pyspark.sql.connect.conversion import storage_level_to_proto
 from pyspark.sql.connect.expressions import Expression, SubqueryExpression
 from pyspark.sql.connect.logging import logger
+from pyspark.sql.connect.proto import base_pb2 as spark_dot_connect_dot_base__pb2
 from pyspark.sql.connect.types import UnparsedDataType, pyspark_types_to_proto_types
 from pyspark.sql.types import DataType, StructType
 from pyspark.storagelevel import StorageLevel
@@ -759,8 +760,29 @@ class CachedRemoteRelation(LogicalPlan):
         if session is not None and not session.client.is_closed and self._relation_id is not None:
             try:
                 command = RemoveRemoteCachedRelation(self).command(session=session.client)
+                req = session.client._execute_plan_request_with_metadata()
+                if session.client._user_id:
+                    req.user_context.user_id = session.client._user_id
+                req.plan.command.CopyFrom(command)
+
                 for attempt in session.client._retrying():
                     with attempt:
+                        # !!HACK ALERT!!
+                        # unary_stream does not work on Python's exit for an unknown reasons
+                        # Therefore, here we open unary_unary channel instead.
+                        # See also :class:`SparkConnectServiceStub`.
+                        request_serializer = (
+                            spark_dot_connect_dot_base__pb2.ExecutePlanRequest.SerializeToString
+                        )
+                        response_deserializer = (
+                            spark_dot_connect_dot_base__pb2.ExecutePlanResponse.FromString
+                        )
+                        channel = session.client._channel.unary_unary(
+                            "/spark.connect.SparkConnectService/ExecutePlan",
+                            request_serializer=request_serializer,
+                            response_deserializer=response_deserializer,
+                        )
+                        metadata = session.client._execute_plan_metadata(req.operation_id)
                         # Bound this blocking call with a client-side deadline. It is issued from a
                         # finalizer with no other timeout at any layer; without a deadline it can
                         # block forever if the response is never delivered, which stalls the
@@ -769,7 +791,7 @@ class CachedRemoteRelation(LogicalPlan):
                         # timeout here is non-fatal: the eviction is best effort and the server
                         # performs it independently, so on timeout we log and move on.
                         timeout = session.client._rpc_deadlines.release_relation
-                        session.client._execute_cleanup_command(command, timeout)
+                        channel(req, metadata=metadata, timeout=timeout)  # type: ignore[arg-type]
             except Exception as e:
                 logger.warning(f"RemoveRemoteCachedRelation failed with exception: {e}.")
 

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -994,7 +994,10 @@ class SparkConnectClientTestCase(unittest.TestCase):
 
             def fake_call(req, metadata=None, timeout="unset"):
                 captured["timeout"] = timeout
-                return proto.ExecutePlanResponse()
+                return proto.ExecutePlanResponse(
+                    session_id=client._session_id,
+                    operation_id=req.operation_id,
+                )
 
             client._channel = MagicMock()
             client._channel.unary_unary.return_value = fake_call
@@ -1048,7 +1051,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertEqual(client._delete_ml_cache(["model-id"]), ["model-id"])
         cleanup_command = proto.Command()
         cleanup_command.ml_command.clean_cache.SetInParent()
-        client._execute_ml_cache_command(cleanup_command)
+        client._execute_cleanup_command(cleanup_command, client._rpc_deadlines.release_ml_cache)
         self.assertEqual(
             captured,
             [
@@ -1059,7 +1062,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         client.close()
 
         client, captured = make_client(RpcDeadlines.disabled())
-        client._execute_ml_cache_command(cleanup_command)
+        client._execute_cleanup_command(cleanup_command, client._rpc_deadlines.release_ml_cache)
         self.assertIsNone(captured[0]["timeout"])
         client.close()
 

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -1011,6 +1011,58 @@ class SparkConnectClientTestCase(unittest.TestCase):
         rel.__del__()
         self.assertIsNone(captured["timeout"])
 
+    def test_ml_cache_cleanup_uses_release_ml_cache_deadline(self):
+        """Best-effort ML cache release commands must use their dedicated deadline."""
+        from unittest.mock import MagicMock
+
+        def make_client(deadlines):
+            client = SparkConnectClient(
+                "sc://foo/",
+                rpc_deadlines=deadlines,
+                retry_policy=dict(max_retries=0),
+            )
+            captured = []
+
+            def fake_call(req, metadata=None, timeout="unset"):
+                command = req.plan.command.ml_command
+                captured.append(
+                    {
+                        "delete": command.HasField("delete"),
+                        "clean_cache": command.HasField("clean_cache"),
+                        "timeout": timeout,
+                    }
+                )
+                response = proto.ExecutePlanResponse(
+                    session_id=client._session_id,
+                    operation_id=req.operation_id,
+                )
+                if command.HasField("delete"):
+                    response.ml_command_result.operator_info.obj_ref.id = "model-id"
+                return response
+
+            client._channel = MagicMock()
+            client._channel.unary_unary.return_value = fake_call
+            return client, captured
+
+        client, captured = make_client(RpcDeadlines(release_ml_cache=44.0))
+        self.assertEqual(client._delete_ml_cache(["model-id"]), ["model-id"])
+        cleanup_command = proto.Command()
+        cleanup_command.ml_command.clean_cache.SetInParent()
+        client._execute_ml_cache_command(cleanup_command)
+        self.assertEqual(
+            captured,
+            [
+                {"delete": True, "clean_cache": False, "timeout": 44.0},
+                {"delete": False, "clean_cache": True, "timeout": 44.0},
+            ],
+        )
+        client.close()
+
+        client, captured = make_client(RpcDeadlines.disabled())
+        client._execute_ml_cache_command(cleanup_command)
+        self.assertIsNone(captured[0]["timeout"])
+        client.close()
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SparkConnectClientReattachTestCase(unittest.TestCase):

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -1028,42 +1028,74 @@ class SparkConnectClientTestCase(unittest.TestCase):
 
             def fake_call(req, metadata=None, timeout="unset"):
                 command = req.plan.command.ml_command
-                captured.append(
-                    {
-                        "delete": command.HasField("delete"),
-                        "clean_cache": command.HasField("clean_cache"),
-                        "timeout": timeout,
-                    }
-                )
+                call = {
+                    "delete": command.HasField("delete"),
+                    "clean_cache": command.HasField("clean_cache"),
+                    "timeout": timeout,
+                    "responses": 0,
+                }
+                captured.append(call)
                 response = proto.ExecutePlanResponse(
                     session_id=client._session_id,
                     operation_id=req.operation_id,
                 )
                 if command.HasField("delete"):
                     response.ml_command_result.operator_info.obj_ref.id = "model-id"
-                return response
 
-            client._channel = MagicMock()
-            client._channel.unary_unary.return_value = fake_call
+                def responses():
+                    call["responses"] += 1
+                    yield response
+                    call["responses"] += 1
+                    yield proto.ExecutePlanResponse(
+                        session_id=client._session_id,
+                        operation_id=req.operation_id,
+                        result_complete=proto.ExecutePlanResponse.ResultComplete(),
+                    )
+
+                return responses()
+
+            client._stub = MagicMock()
+            client._stub.ExecutePlan.side_effect = fake_call
             return client, captured
 
         client, captured = make_client(RpcDeadlines(release_ml_cache=44.0))
         self.assertEqual(client._delete_ml_cache(["model-id"]), ["model-id"])
         cleanup_command = proto.Command()
         cleanup_command.ml_command.clean_cache.SetInParent()
-        client._execute_cleanup_command(cleanup_command, client._rpc_deadlines.release_ml_cache)
+        client._execute_ml_cache_command(cleanup_command)
         self.assertEqual(
             captured,
             [
-                {"delete": True, "clean_cache": False, "timeout": 44.0},
-                {"delete": False, "clean_cache": True, "timeout": 44.0},
+                {
+                    "delete": True,
+                    "clean_cache": False,
+                    "timeout": 44.0,
+                    "responses": 2,
+                },
+                {
+                    "delete": False,
+                    "clean_cache": True,
+                    "timeout": 44.0,
+                    "responses": 2,
+                },
             ],
         )
         client.close()
 
         client, captured = make_client(RpcDeadlines.disabled())
-        client._execute_cleanup_command(cleanup_command, client._rpc_deadlines.release_ml_cache)
+        client._execute_ml_cache_command(cleanup_command)
         self.assertIsNone(captured[0]["timeout"])
+        self.assertEqual(captured[0]["responses"], 2)
+        client.close()
+
+        # Cleanup is best effort, so transient failures are not retried.
+        client = SparkConnectClient("sc://foo/")
+        client._stub = MagicMock()
+        client._stub.ExecutePlan.side_effect = TestException(
+            "unavailable", grpc.StatusCode.UNAVAILABLE
+        )
+        self.assertEqual(client._delete_ml_cache(["model-id"]), [])
+        client._stub.ExecutePlan.assert_called_once()
         client.close()
 
 

--- a/python/pyspark/sql/tests/connect/client/test_client_retries.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_retries.py
@@ -402,6 +402,7 @@ class SparkConnectClientRetriesTestCase(unittest.TestCase):
         self.assertIsNone(d.get_status)
         self.assertIsNone(d.fetch_error_details)
         self.assertIsNone(d.release_relation)
+        self.assertIsNone(d.release_ml_cache)
 
     def test_rpc_deadlines_defaults_are_set(self):
         """RpcDeadlines() default instance should have documented timeout values."""
@@ -418,6 +419,7 @@ class SparkConnectClientRetriesTestCase(unittest.TestCase):
         self.assertEqual(d.get_status, 10 * 60)
         self.assertEqual(d.fetch_error_details, 10 * 60)
         self.assertEqual(d.release_relation, 60)
+        self.assertEqual(d.release_ml_cache, 60)
 
     def test_rpc_deadlines_preserves_existing_positional_arguments(self):
         """New deadline fields should not shift existing positional arguments."""
@@ -427,6 +429,7 @@ class SparkConnectClientRetriesTestCase(unittest.TestCase):
         self.assertEqual(d.get_status, 10)
         self.assertEqual(d.fetch_error_details, 11)
         self.assertEqual(d.release_relation, 60)
+        self.assertEqual(d.release_ml_cache, 60)
 
     def test_rpc_deadlines_rejects_non_positive_values(self):
         """RpcDeadlines should raise ValueError for any non-None field that is <= 0."""


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a dedicated `RpcDeadlines.release_ml_cache` deadline, defaulting to 60 seconds, for the
best-effort Spark Connect ML cache deletion and cleanup RPCs.

Route `_delete_ml_cache` and `_cleanup_ml_cache` through a bounded, non-reattachable `ExecutePlan`
call shared with cached-relation cleanup. ML cache cleanup makes one attempt and then abandons the
best-effort release on failure. The deadline can be disabled with `RpcDeadlines.disabled()`.

This follows the cleanup deadline model introduced by SPARK-58846 in #58085.

### Why are the changes needed?

SPARK-57655 added a same-thread re-entrancy guard for ML cache cleanup after a rare gRPC deadlock,
but the outer cleanup RPC can still block indefinitely if its response is never delivered.
`_delete_ml_cache` can run from a `RemoteModelRef` finalizer, and `_cleanup_ml_cache` runs during
client shutdown, so an unbounded call can hang a test or process indefinitely.

The normal reattachable `ExecutePlan` deadline does not bound the total cleanup time because it
reattaches and starts a new deadline interval. ML cache eviction is best effort, and cached state
is also released when the server session ends, so these cleanup calls can safely use a bounded,
non-reattachable deadline.

### Does this PR introduce _any_ user-facing change?

Yes. Spark Connect ML cache deletion and cleanup now time out after 60 seconds by default instead
of potentially blocking indefinitely. Users can configure the timeout with
`RpcDeadlines(release_ml_cache=<seconds>)` or disable it with `RpcDeadlines.disabled()`.

### How was this patch tested?

Added a regression test that verifies both ML cache deletion and full cleanup forward the
configured deadline, and that `RpcDeadlines.disabled()` forwards no deadline. Updated the existing
default, disabled, and positional-argument deadline tests.

Ran:

```bash
python/run-tests -p 1 --testnames pyspark.sql.tests.connect.client.test_client,pyspark.sql.tests.connect.client.test_client_retries
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
