### PR TITLE
[SPARK-59296][CORE] Apply OIDC provider-declared properties on the driver by separating provider selection from credential resolution

### DIFF
--- a/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
+++ b/connector/credential-aws-integration-tests/src/test/scala/org/apache/spark/security/aws/integrationtest/OidcCredentialE2ESuite.scala
@@ -194,7 +194,7 @@ class OidcCredentialE2ESuite
   // -------------------------------------------------------------------------
 
   /**
-   * Test 1: Basic OIDC credential propagation flow.
+   * Test 1a: Basic OIDC credential propagation flow.
    *
    * Scenario:
    *  1. A Spark job runs on Minikube with spark.security.oidc.enabled=true.
@@ -208,6 +208,26 @@ class OidcCredentialE2ESuite
     val outputPath = s"s3a://$s3Bucket/e2e-basic-${UUID.randomUUID().toString.take(8)}/"
     // A fixed executor count (this test does not use dynamic allocation).
     val conf = baseSparkConf().set("spark.executor.instances", "1")
+
+    runOidcJobAndVerify(conf, outputPath)
+  }
+
+  /**
+   * Test 1b: A user-provided fs.s3a.aws.credentials.provider is respected.
+   *
+   * The primary path (Test 1a) leaves the provider unset so Spark auto-configures it.
+   * Here we explicitly set it to the OIDC provider and verify the job still succeeds,
+   * exercising the "user override is not overwritten" branch of the auto-config logic
+   * (UserCredentialManager only applies additionalSparkProperties when the key is not
+   * already set). The read/write path is identical because the explicit value equals
+   * what auto-config would have chosen.
+   */
+  test("OIDC credential propagation: explicit provider is respected", oidcE2eTag) {
+    val outputPath = s"s3a://$s3Bucket/e2e-explicit-${UUID.randomUUID().toString.take(8)}/"
+    val conf = baseSparkConf()
+      .set("spark.executor.instances", "1")
+      .set("spark.hadoop.fs.s3a.aws.credentials.provider",
+        "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider")
 
     runOidcJobAndVerify(conf, outputPath)
   }
@@ -443,11 +463,12 @@ class OidcCredentialE2ESuite
       .set("spark.hadoop.fs.s3a.endpoint", s3Endpoint)
       .set("spark.hadoop.fs.s3a.path.style.access", "true")
       .set("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
-      // Explicitly select the OIDC credential provider for S3A. The provider is
-      // registered by the credential-aws module; setting it explicitly avoids
-      // relying on defaulting behaviour and makes the test intent clear.
-      .set("spark.hadoop.fs.s3a.aws.credentials.provider",
-        "org.apache.spark.security.aws.SparkOidcAwsCredentialsProvider")
+      // Intentionally do NOT set spark.hadoop.fs.s3a.aws.credentials.provider here.
+      // This is the primary, documented usage: with OIDC credential propagation
+      // enabled and no explicit provider set, Spark auto-configures the S3A
+      // credentials provider (SparkOidcAwsCredentialsProvider) on both the driver
+      // and executors. Leaving it unset exercises that auto-config path end to end,
+      // including driver-side S3A access (e.g. output-path existence checks).
   }
 
   private def runOidcJobAndVerify(conf: SparkAppConf, outputPath: String): Unit = {

--- a/core/src/main/java/org/apache/spark/security/CredentialProvider.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProvider.java
@@ -104,22 +104,47 @@ public interface CredentialProvider extends AutoCloseable {
 
   /**
    * Returns additional Spark configuration properties that should be set when this
-   * provider is active.
+   * provider is selected for use.
    * <p>
-   * This method is called after {@link #init(Map)} and a successful
-   * {@link #resolve(UserContext, URI)} invocation. Implementations may
-   * assume that provider state is fully initialized when this is called.
+   * This declares static wiring that a job needs whenever this provider is selected (for
+   * example, the Hadoop credentials provider class for a particular filesystem scheme). It must
+   * return a constant, self-contained value: it must not depend on {@link #init(Map)} having run,
+   * on {@link #resolve(UserContext, URI)}, or on any network I/O. The credential management layer
+   * calls it at provider <em>selection</em> time, which may be before {@code init()} and before
+   * any credential has been resolved; implementations must therefore not require initialized
+   * state here.
    * <p>
-   * The credential management layer applies these entries to {@code SparkConf} after
-   * successful startup, only if the user has not already set them explicitly. This
-   * allows provider modules to declare executor-side wiring (e.g., the Hadoop
-   * credentials provider class for a particular filesystem scheme) without requiring
-   * core to have vendor-specific knowledge.
+   * The credential management layer applies these entries to {@code SparkConf} only if the
+   * user has not already set them explicitly. Application happens on both the driver and the
+   * executors, before the components that consume the configuration are initialized:
+   * <ul>
+   *   <li>On the driver, they are applied early in {@code SparkContext} initialization, before
+   *       the driver's Hadoop {@code Configuration} and other components derived from the
+   *       configuration are materialized, so driver-side access uses them too.</li>
+   *   <li>On the executors, they are delivered as part of the executor configuration before
+   *       the executor environment is built.</li>
+   * </ul>
+   * This lets provider modules declare wiring without requiring core to have vendor-specific
+   * knowledge. The properties are applied once, at selection time; they are not re-applied on
+   * subsequent credential renewals (they are static wiring, unlike the rotating credentials).
+   * <p>
+   * A provider is "selected" for a scheme when it is chosen by the loader's binding policy:
+   * either it is named explicitly via {@code spark.security.oidc.provider.<scheme>}, or it is
+   * the sole candidate registered for the scheme. When multiple candidates exist for a scheme
+   * and none is explicitly configured, no provider is selected for that scheme and these
+   * properties are not applied (the ambiguity must be resolved via explicit configuration).
+   * <p>
+   * The properties declared here are applied for a <em>selected</em> provider, independent of
+   * whether a credential has been (or will be) resolved for it. This is intentional: the wiring
+   * is what a job needs in order to use the provider, and it is applied before resolution so it
+   * is effective on the driver. A provider selected here whose {@code resolve()} later fails will
+   * still have contributed its wiring; this matches the executor side, where the same properties
+   * are delivered regardless of per-scheme resolution outcome.
    * <p>
    * Keys must use the {@code spark.} prefix to be effective (SparkConf convention).
-   * Keys with the {@code spark.hadoop.} prefix are propagated to executor-side
-   * Hadoop {@code Configuration} with the prefix stripped. Other {@code spark.*}
-   * keys are applied as Spark-internal configuration.
+   * Keys with the {@code spark.hadoop.} prefix reach the Hadoop {@code Configuration} (on both
+   * driver and executors) with the prefix stripped. Other {@code spark.*} keys are applied as
+   * Spark configuration.
    * <p>
    * The default implementation returns an empty map (no additional properties).
    *

--- a/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
+++ b/core/src/main/java/org/apache/spark/security/CredentialProviderLoader.java
@@ -134,6 +134,78 @@ public final class CredentialProviderLoader {
         throw new IllegalStateException("Credential providers have already been closed");
       }
     }
+    Optional<CredentialProvider> selectedOpt = selectProvider(scheme, conf);
+    if (selectedOpt.isEmpty()) {
+      return Optional.empty();
+    }
+    CredentialProvider selected = selectedOpt.get();
+
+    // Initialize exactly once under the lock (first-conf-wins).
+    // Only pass spark.security.oidc.* keys to init() to avoid leaking secrets
+    // from other subsystems to third-party ServiceLoader providers. This follows the
+    // precedent of DataSourceV2Utils.extractSessionConfigs() which scopes configuration
+    // to a specific prefix. We keep the full key (unlike extractSessionConfigs which
+    // strips the prefix) so providers can distinguish sub-keys unambiguously.
+    synchronized (this) {
+      // Re-check under the initialization lock in case closeAll() ran during selection.
+      if (providersClosed) {
+        throw new IllegalStateException("Credential providers have already been closed");
+      }
+      if (!initializedProviders.contains(selected)) {
+        Map<String, String> filteredConf = new HashMap<>();
+        for (Map.Entry<String, String> entry : conf.entrySet()) {
+          if (entry.getKey().startsWith(OIDC_CONF_PREFIX)) {
+            filteredConf.put(entry.getKey(), entry.getValue());
+          }
+        }
+        selected.init(Collections.unmodifiableMap(filteredConf));
+        initializedProviders.add(selected);
+      }
+    }
+    return Optional.of(selected);
+  }
+
+  /**
+   * Selects the {@link CredentialProvider} for the given URI scheme <em>without</em>
+   * initializing it, applying the same Binding Policy A as {@link #providerFor(String, Map)}.
+   * <p>
+   * This is intended for the provider <em>selection</em> phase, which only needs a provider's
+   * {@link CredentialProvider#additionalSparkProperties()} -- a static declaration that does not
+   * depend on {@link CredentialProvider#init(Map)} having run. Because {@code init()} on the
+   * shipped AWS provider builds an STS client (which can trigger AWS SDK region resolution and
+   * EC2 IMDS network calls), skipping {@code init()} here keeps the selection phase free of
+   * network I/O and side effects. Actual initialization happens later, once, via
+   * {@link #providerFor(String, Map)} during credential resolution.
+   *
+   * @param scheme the URI scheme (e.g., "s3a"); normalized to lowercase
+   * @param conf Spark configuration properties as a string map
+   * @return the selected (uninitialized) provider, or empty if no provider supports the scheme
+   * @throws IllegalArgumentException if explicit selection names an unknown or non-supporting
+   *     class, or if multiple candidates exist without explicit selection
+   * @throws IllegalStateException if providers have already been closed or if a provider returns
+   *     null from {@code supportedSchemes()}
+   */
+  public Optional<CredentialProvider> selectProviderForProperties(
+      String scheme, Map<String, String> conf) {
+    Objects.requireNonNull(scheme, "scheme must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    if (scheme.isEmpty()) {
+      throw new IllegalArgumentException("scheme must not be empty");
+    }
+    synchronized (this) {
+      if (providersClosed) {
+        throw new IllegalStateException("Credential providers have already been closed");
+      }
+    }
+    return selectProvider(scheme, conf);
+  }
+
+  /**
+   * Applies Binding Policy A to choose the provider for a scheme, without initializing it.
+   * Shared by {@link #providerFor(String, Map)} (which additionally initializes the selected
+   * provider) and {@link #selectProviderForProperties(String, Map)} (which does not).
+   */
+  private Optional<CredentialProvider> selectProvider(String scheme, Map<String, String> conf) {
     String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
     List<CredentialProvider> providers = getProviders();
 
@@ -179,29 +251,6 @@ public final class CredentialProviderLoader {
       throw new IllegalArgumentException(
           "Multiple credential providers found for scheme '" + normalizedScheme
               + "'. Set " + confKey + " to one of: " + candidateNames);
-    }
-
-    // Initialize exactly once under the lock (first-conf-wins).
-    // Only pass spark.security.oidc.* keys to init() to avoid leaking secrets
-    // from other subsystems to third-party ServiceLoader providers. This follows the
-    // precedent of DataSourceV2Utils.extractSessionConfigs() which scopes configuration
-    // to a specific prefix. We keep the full key (unlike extractSessionConfigs which
-    // strips the prefix) so providers can distinguish sub-keys unambiguously.
-    synchronized (this) {
-      // Re-check under the initialization lock in case closeAll() ran during selection.
-      if (providersClosed) {
-        throw new IllegalStateException("Credential providers have already been closed");
-      }
-      if (!initializedProviders.contains(selected)) {
-        Map<String, String> filteredConf = new HashMap<>();
-        for (Map.Entry<String, String> entry : conf.entrySet()) {
-          if (entry.getKey().startsWith(OIDC_CONF_PREFIX)) {
-            filteredConf.put(entry.getKey(), entry.getValue());
-          }
-        }
-        selected.init(Collections.unmodifiableMap(filteredConf));
-        initializedProviders.add(selected);
-      }
     }
     return Optional.of(selected);
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -43,6 +43,7 @@ import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFor
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.{LocalSparkCluster, SparkHadoopUtil}
+import org.apache.spark.deploy.security.UserCredentialManager
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.{Executor, ExecutorMetrics, ExecutorMetricsSource}
 import org.apache.spark.input.{FixedLengthBinaryInputFormat, PortableDataStream, StreamInputFormat, WholeTextFileInputFormat}
@@ -63,6 +64,7 @@ import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils, StandaloneSchedulerBackend}
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
+import org.apache.spark.security.CredentialProviderLoader
 import org.apache.spark.shuffle.ShuffleDataIOUtils
 import org.apache.spark.shuffle.api.ShuffleDriverComponents
 import org.apache.spark.status.{AppStatusSource, AppStatusStore}
@@ -222,6 +224,13 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _progressBar: Option[ConsoleProgressBar] = None
   private var _ui: Option[SparkUI] = None
   private var _hadoopConfiguration: Configuration = _
+
+  // The CredentialProviderLoader created by the OIDC selection phase (applyProviderProperties),
+  // retained so the later credential resolution phase (UserCredentialManager, started by the
+  // scheduler backend) reuses the same loader. None when OIDC credential propagation is
+  // disabled or in local mode (the selection phase is skipped and allocates no loader).
+  // SparkContext is the single owner of this loader and is responsible for closing it in stop().
+  private var _userCredentialProviderLoader: Option[CredentialProviderLoader] = None
   private var _executorMemory: Int = _
   private var _schedulerBackend: SchedulerBackend = _
   private var _taskScheduler: TaskScheduler = _
@@ -337,6 +346,12 @@ class SparkContext(config: SparkConf) extends Logging {
    */
   def hadoopConfiguration: Configuration = _hadoopConfiguration
 
+  // The CredentialProviderLoader from the OIDC selection phase, reused by the credential
+  // resolution phase so providers are initialized exactly once. Null if OIDC is disabled or
+  // before initialization. Internal.
+  private[spark] def userCredentialProviderLoader: Option[CredentialProviderLoader] =
+    _userCredentialProviderLoader
+
   private[spark] def executorMemory: Int = _executorMemory
 
   // Environment variables to pass to our executors.
@@ -432,6 +447,18 @@ class SparkContext(config: SparkConf) extends Logging {
     }
     // This should be set as early as possible.
     SparkContext.enableMagicCommitterIfNeeded(_conf)
+
+    // OIDC credential propagation: provider SELECTION phase. When enabled (and not in local
+    // mode), discover the credential provider(s) for the configured scheme(s) and apply their
+    // declared Spark properties (e.g. the S3A credentials provider class) into _conf, so that
+    // the driver's Hadoop Configuration built later -- and other config-derived components --
+    // pick them up. This is done here, at the "as early as possible" slot, so the applied keys
+    // are visible to the spark.logConf dump and to any Hadoop Configuration built during
+    // createSparkEnv (e.g. by SecurityManager). It performs no credential resolution and no
+    // network I/O (providers are selected without init()); actual acquisition happens later in
+    // the scheduler backend (UserCredentialManager). Any returned loader is retained so the
+    // resolution phase reuses it, and SparkContext closes it in stop().
+    _userCredentialProviderLoader = UserCredentialManager.applyProviderProperties(_conf, isLocal)
 
     SparkContext.supplementJavaModuleOptions(_conf)
     SparkContext.supplementJavaIPv6Options(_conf)
@@ -2646,6 +2673,16 @@ class SparkContext(config: SparkConf) extends Logging {
     }
     Utils.tryLogNonFatalError {
       FallbackStorage.cleanUp(_conf, _hadoopConfiguration)
+    }
+    // Close the credential provider loader created by the OIDC selection phase. SparkContext is
+    // the single owner: UserCredentialManager.stop() no longer closes it. This covers every
+    // path, including a normal run (the resolution phase used this same loader), a
+    // construction failure after the selection phase ran, and (defensively) any other case,
+    // so providers that allocate resources in init() do not leak. closeAll() is idempotent.
+    _userCredentialProviderLoader.foreach { loader =>
+      Utils.tryLogNonFatalError {
+        loader.closeAll()
+      }
     }
     Utils.tryLogNonFatalError {
       _eventLogger.foreach(_.stop())

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -347,8 +347,8 @@ class SparkContext(config: SparkConf) extends Logging {
   def hadoopConfiguration: Configuration = _hadoopConfiguration
 
   // The CredentialProviderLoader from the OIDC selection phase, reused by the credential
-  // resolution phase so providers are initialized exactly once. Null if OIDC is disabled or
-  // before initialization. Internal.
+  // resolution phase so providers are initialized exactly once. `None` when OIDC credential
+  // propagation is disabled, in local mode, or before initialization. Internal.
   private[spark] def userCredentialProviderLoader: Option[CredentialProviderLoader] =
     _userCredentialProviderLoader
 

--- a/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
@@ -279,17 +279,27 @@ private[spark] class UserCredentialManager(
           } else {
             credentialMap.put(scheme, credential)
 
-            // Fallback wiring for a provider that actually resolved a credential. Idempotent
-            // with the selection phase (guarded by !contains); only on initial acquisition.
-            if (applyProperties) {
-              applyResolvedProviderProperties(scheme, provider)
-            }
-
             val expiry = credential.getExpiresAt
             if (expiry != null) {
               earliestExpiry = earliestExpiry match {
                 case Some(existing) if existing.isBefore(expiry) => Some(existing)
                 case _ => Some(expiry)
+              }
+            }
+
+            // Fallback wiring for a provider that actually resolved a credential. Idempotent
+            // with the selection phase (guarded by !contains); only on initial acquisition.
+            // Isolated in its own catch so that a throwing additionalSparkProperties() does not
+            // discard the credential we just resolved (which is already in credentialMap with
+            // its expiry accounted for above) or get misreported as a resolution failure.
+            if (applyProperties) {
+              try {
+                applyResolvedProviderProperties(scheme, provider)
+              } catch {
+                case NonFatal(e) =>
+                  logWarning(log"Resolved a credential for scheme ${MDC(LogKeys.URI, scheme)} " +
+                    log"but failed to apply its declared Spark properties; the credential is " +
+                    log"still used, but its provider wiring may be missing.", e)
               }
             }
           }

--- a/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/UserCredentialManager.scala
@@ -65,6 +65,10 @@ private[spark] class UserCredentialManager(
     credentialProviderLoader: CredentialProviderLoader)
   extends Logging {
 
+  // Auxiliary constructor used only by tests, which construct the manager directly with a
+  // default CredentialProviderLoader. Production code goes through
+  // UserCredentialManager.create(...) (which passes the loader from the selection phase),
+  // so it does not use this constructor.
   def this(
       sparkConf: SparkConf,
       tokenIngestor: TokenIngestor,
@@ -121,7 +125,7 @@ private[spark] class UserCredentialManager(
       log"${MDC(LogKeys.PRINCIPAL, ctx.getPrincipal)} " +
       log"(issuer: ${MDC(LogKeys.URI, ctx.getIssuer)})")
 
-    val (credentials, earliestExpiry, activeProviders) = resolveCredentials(ctx)
+    val (credentials, earliestExpiry) = resolveCredentials(ctx, applyProperties = true)
     val serialized = UserCredentialManager.serializeUserCredentials(credentials)
     val version = credentialVersion.incrementAndGet()
 
@@ -141,70 +145,36 @@ private[spark] class UserCredentialManager(
     logInfo(log"Credential acquisition successful. Next renewal in " +
       log"${MDC(LogKeys.TIME_UNITS, UIUtils.formatDuration(renewalDelay))}.")
 
-    // Apply additional Spark properties declared by active providers.
-    // Only providers that successfully resolved credentials contribute properties.
-    // This allows provider modules to wire executor-side configuration
-    // (e.g., fs.s3a.aws.credentials.provider) without core having
-    // vendor-specific knowledge. Properties are only set if the user
-    // has not already configured them explicitly.
-    for (provider <- activeProviders) {
-      try {
-        val props = provider.additionalSparkProperties()
-        if (props != null) {
-          props.forEach { (key, value) =>
-            if (!sparkConf.contains(key)) {
-              sparkConf.set(key, value)
-              logInfo(log"Auto-configured ${MDC(LogKeys.CONFIG, key)} from " +
-                log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)}")
-            } else {
-              logDebug(log"Skipped ${MDC(LogKeys.CONFIG, key)} from " +
-                log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)} " +
-                log"(already configured)")
-            }
-          }
-        }
-      } catch {
-        case scala.util.control.NonFatal(e) =>
-          logWarning(log"Failed to apply additionalSparkProperties from " +
-            log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)}. " +
-            log"Skipping.", e)
-      }
-    }
+    // Provider-declared additional Spark properties (CredentialProvider
+    // .additionalSparkProperties()) are primarily applied earlier, during the selection phase
+    // (UserCredentialManager.applyProviderProperties), which runs before SparkContext
+    // materializes the driver's Hadoop Configuration -- that is what makes them effective on
+    // the driver. As a fallback, resolveCredentials(applyProperties = true) above also applies
+    // them here for any provider that actually resolved a credential (idempotent under
+    // !sparkConf.contains(key)), covering the case where selection could not apply them.
+    // Renewals do not re-apply them (they are static wiring, not rotating credentials).
 
     (version, serialized)
   }
 
   def stop(): Unit = {
-    var interrupted = false
     if (renewalExecutor != null) {
       renewalExecutor.shutdownNow()
       try {
         if (!renewalExecutor.awaitTermination(
             UserCredentialManager.RENEWAL_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-          logWarning(log"Timed out waiting for credential renewal to stop; " +
-            log"closing credential providers while renewal may still be running.")
+          logWarning(log"Timed out waiting for credential renewal to stop.")
         }
       } catch {
         case e: InterruptedException =>
-          interrupted = true
           logWarning(log"Interrupted while waiting for credential renewal to stop.", e)
+          Thread.currentThread().interrupt()
       }
     }
-    // Close all initialized credential providers to release resources (e.g., HTTP clients).
-    // This loader belongs to this manager, so closing it cannot affect a later SparkContext.
-    try {
-      credentialProviderLoader.closeAll()
-    } catch {
-      case e: InterruptedException =>
-        interrupted = true
-        logWarning(log"Interrupted while closing credential providers during shutdown.", e)
-      case NonFatal(e) =>
-        logWarning(log"Error closing credential providers during shutdown.", e)
-    } finally {
-      if (interrupted) {
-        Thread.currentThread().interrupt()
-      }
-    }
+    // Note: the CredentialProviderLoader is NOT closed here. It is owned and closed by
+    // SparkContext (which created it in the selection phase and shares this same instance),
+    // so that there is a single owner of closeAll(). Closing it here as well would risk a
+    // renewal task (if still shutting down) racing against an already-closed loader.
   }
 
   /**
@@ -224,7 +194,7 @@ private[spark] class UserCredentialManager(
         log"${MDC(LogKeys.PRINCIPAL, ctx.getPrincipal)} " +
         log"(issuer: ${MDC(LogKeys.URI, ctx.getIssuer)})")
 
-      val (credentials, earliestExpiry, _) = resolveCredentials(ctx)
+      val (credentials, earliestExpiry) = resolveCredentials(ctx, applyProperties = false)
       val serialized = UserCredentialManager.serializeUserCredentials(credentials)
       val version = credentialVersion.incrementAndGet()
 
@@ -273,14 +243,22 @@ private[spark] class UserCredentialManager(
   /**
    * Resolve credentials for all schemes that have registered providers.
    *
+   * @param applyProperties If true (the initial acquisition from [[start]]), re-apply each
+   *   resolved provider's [[CredentialProvider#additionalSparkProperties]] into `sparkConf`,
+   *   guarded by `!sparkConf.contains(key)` so user-set values and values already applied by the
+   *   selection phase are preserved. This is a fallback for the case where the selection phase
+   *   could not apply them (e.g. it failed for that scheme): a provider that actually resolves a
+   *   credential here is definitely "used", so its wiring should be in place. It is idempotent
+   *   with the selection phase. Renewal passes false: the properties are static wiring and are
+   *   not re-applied on renewals.
    * @return Tuple of (UserCredentials, earliest expiry across all service credentials)
    */
   private def resolveCredentials(
-      ctx: UserContext): (UserCredentials, Option[Instant], Seq[CredentialProvider]) = {
+      ctx: UserContext,
+      applyProperties: Boolean): (UserCredentials, Option[Instant]) = {
     val schemes = discoverSchemes()
 
     val credentialMap = new mutable.HashMap[String, ServiceCredential]()
-    val activeProviders = new mutable.ArrayBuffer[CredentialProvider]()
     var earliestExpiry: Option[Instant] = None
 
     for (scheme <- schemes) {
@@ -300,7 +278,12 @@ private[spark] class UserCredentialManager(
               log"returned null; skipping.")
           } else {
             credentialMap.put(scheme, credential)
-            activeProviders += provider
+
+            // Fallback wiring for a provider that actually resolved a credential. Idempotent
+            // with the selection phase (guarded by !contains); only on initial acquisition.
+            if (applyProperties) {
+              applyResolvedProviderProperties(scheme, provider)
+            }
 
             val expiry = credential.getExpiresAt
             if (expiry != null) {
@@ -327,7 +310,20 @@ private[spark] class UserCredentialManager(
           "Check that providers are on the classpath and configured correctly.")
     }
 
-    (new UserCredentials(credentialMap.asJava), earliestExpiry, activeProviders.toSeq)
+    (new UserCredentials(credentialMap.asJava), earliestExpiry)
+  }
+
+  /**
+   * Apply a resolved provider's declared Spark properties into `sparkConf`, only for keys not
+   * already set (by the user or by the earlier selection phase). Note: on the driver these no
+   * longer reach the already-materialized Hadoop `Configuration`; the selection phase is what
+   * makes them effective on the driver. This is a best-effort fallback so that a provider that
+   * resolves here still contributes its executor-facing wiring even if selection could not.
+   */
+  private def applyResolvedProviderProperties(
+      scheme: String, provider: CredentialProvider): Unit = {
+    UserCredentialManager.applyDeclaredProperties(
+      sparkConf, provider, scheme, "after successful resolution")
   }
 
   /**
@@ -345,15 +341,9 @@ private[spark] class UserCredentialManager(
    * logging a warning and continuing with remaining schemes.
    */
   private def discoverSchemes(): Set[String] = {
-    // Extract explicitly configured scheme names.
-    // Keys are of the form spark.security.oidc.provider.<scheme> or
-    // spark.security.oidc.provider.<scheme>.<subkey>. We extract only the first
-    // segment after the prefix to get the scheme name.
-    val providerPrefix = "spark.security.oidc.provider."
-    val explicitSchemes = credentialConfMap.asScala
-      .filter { case (k, _) => k.startsWith(providerPrefix) }
-      .map { case (k, _) => k.stripPrefix(providerPrefix).split('.').head }
-      .toSet
+    // Explicitly configured scheme names, from keys of the form
+    // spark.security.oidc.provider.<scheme>(.<subkey>). Shared with the selection phase.
+    val explicitSchemes = UserCredentialManager.explicitSchemesFrom(credentialConfMap)
 
     if (explicitSchemes.nonEmpty) {
       explicitSchemes
@@ -436,7 +426,7 @@ private[spark] class UserCredentialManager(
 
 }
 
-private[spark] object UserCredentialManager {
+private[spark] object UserCredentialManager extends Logging {
 
   private val RENEWAL_SHUTDOWN_TIMEOUT_SECONDS = 10L
 
@@ -480,14 +470,31 @@ private[spark] object UserCredentialManager {
    *
    * @param sparkConf The Spark configuration
    * @param onCredentialsUpdate Callback to propagate credentials to executors
+   * @param loader The [[CredentialProviderLoader]] from the selection phase
+   *               ([[applyProviderProperties]]), passed as an `Option`. When OIDC is enabled it
+   *               must be `Some` (the selection phase, which runs earlier and is skipped only
+   *               when OIDC is disabled or in local mode, produced it); reusing that same
+   *               instance ensures providers are discovered and initialized exactly once, so the
+   *               resolution phase reuses the already-selected providers. It is an error for the
+   *               loader to be `None` while OIDC is enabled and a resolution phase is expected.
    * @return Some(manager) if enabled, None otherwise
    */
   def create(
       sparkConf: SparkConf,
-      onCredentialsUpdate: (Long, Array[Byte]) => Unit): Option[UserCredentialManager] = {
+      onCredentialsUpdate: (Long, Array[Byte]) => Unit,
+      loader: Option[CredentialProviderLoader]): Option[UserCredentialManager] = {
     if (!sparkConf.get(SECURITY_OIDC_ENABLED)) {
       None
     } else {
+      // Enforce the invariant explicitly rather than silently allocating a fresh loader (which
+      // SparkContext would not own and therefore never close, leaking provider resources).
+      val selectionLoader = loader.getOrElse {
+        throw new IllegalStateException(
+          "OIDC credential propagation is enabled but no CredentialProviderLoader was produced " +
+            "by the selection phase. This indicates the selection phase " +
+            "(UserCredentialManager.applyProviderProperties) did not run before the resolution " +
+            "phase, which should not happen outside local mode.")
+      }
       val tokenFile = sparkConf.get(SECURITY_OIDC_IDENTITY_TOKEN_FILE).getOrElse {
         throw new IllegalArgumentException(
           s"${SECURITY_OIDC_IDENTITY_TOKEN_FILE.key} must be set when " +
@@ -495,8 +502,149 @@ private[spark] object UserCredentialManager {
       }
 
       val tokenIngestor = new FileTokenIngestor(Paths.get(tokenFile))
-      Some(new UserCredentialManager(sparkConf, tokenIngestor, onCredentialsUpdate))
+      Some(new UserCredentialManager(
+        sparkConf, tokenIngestor, onCredentialsUpdate, selectionLoader))
     }
+  }
+
+  /**
+   * Selection phase of OIDC credential propagation, run early during `SparkContext`
+   * initialization (before the driver's Hadoop `Configuration` is materialized).
+   *
+   * When OIDC credential propagation is enabled, this discovers the `CredentialProvider` for
+   * each unambiguously-resolvable scheme (without initializing it) and applies the provider's
+   * [[CredentialProvider#additionalSparkProperties]] declarations into `sparkConf` (only for
+   * keys the user has not already set). This is the driver-side counterpart to the executor
+   * path (where these properties travel via `SparkAppConfig` before the executor's environment
+   * is built): applying them into `sparkConf` here -- before `SparkContext` materializes the
+   * driver's Hadoop `Configuration` and other config-derived components -- lets driver-side
+   * access (e.g. output-path existence checks, the commit protocol) use the propagated
+   * credentials rather than falling back to the default credential chain.
+   *
+   * This phase performs NO credential resolution and NO network I/O: it only reads the static
+   * `additionalSparkProperties()` declaration, obtained via
+   * [[CredentialProviderLoader#selectProviderForProperties]] which selects the provider
+   * WITHOUT calling `init()`. Actual provider initialization and credential acquisition (and
+   * renewal) happen later in [[start]] on the scheduler backend. This separation of provider
+   * SELECTION from credential RESOLUTION is intentional.
+   *
+   * The phase is skipped entirely when `isLocal` is true: `LocalSchedulerBackend` does not start
+   * a [[UserCredentialManager]], so no resolution phase follows and no credentials are ever
+   * populated. Wiring a provider class into the driver's Hadoop `Configuration` in that case
+   * would make driver-side access fail (the provider would find no credentials) instead of
+   * falling back to the default chain. (Running credential resolution in local mode -- for
+   * parity with `HadoopDelegationTokenManager`, which does run in `LocalSchedulerBackend` -- is
+   * left to a follow-up.)
+   *
+   * Scheme selection is limited to schemes for which a provider is UNAMBIGUOUSLY selected:
+   * either an explicitly-configured scheme (`spark.security.oidc.provider.<scheme>`) or a
+   * scheme with exactly one candidate provider on the classpath. Schemes with multiple
+   * candidates and no explicit configuration are skipped here (there is no basis to choose
+   * which provider's properties to apply); they are left to [[start]], where `providerFor`
+   * raises a clear error prompting explicit configuration.
+   *
+   * @param sparkConf The Spark configuration to apply properties into. Not modified when OIDC
+   *                  credential propagation is disabled or when `isLocal` is true.
+   * @param isLocal Whether the application runs in local mode (no scheduler backend that starts
+   *                a resolution phase).
+   * @return `Some(loader)` with the [[CredentialProviderLoader]] used, to be passed to
+   *         [[create]] so the resolution phase reuses the same loader; `None` when OIDC is
+   *         disabled or when `isLocal` is true (no loader is allocated in those cases).
+   */
+  def applyProviderProperties(
+      sparkConf: SparkConf,
+      isLocal: Boolean): Option[CredentialProviderLoader] = {
+    if (!sparkConf.get(SECURITY_OIDC_ENABLED) || isLocal) {
+      return None
+    }
+
+    val loader = new CredentialProviderLoader()
+    val confMap = sparkConf.getAll
+      .filter { case (k, _) => k.startsWith("spark.security.oidc.") }
+      .toMap.asJava
+
+    // Determine candidate schemes: explicitly-configured schemes take precedence; otherwise
+    // fall back to all schemes discoverable on the classpath (single-candidate schemes are the
+    // intended zero-config case).
+    val explicitSchemes = explicitSchemesFrom(confMap)
+    val schemes =
+      if (explicitSchemes.nonEmpty) explicitSchemes
+      else loader.discoverAllSchemes().asScala.toSet
+
+    for (scheme <- schemes) {
+      try {
+        val providerOpt = loader.selectProviderForProperties(scheme, confMap)
+        if (providerOpt.isPresent) {
+          val provider = providerOpt.get()
+          val props = provider.additionalSparkProperties()
+          if (props != null && !props.isEmpty) {
+            applyDeclaredProperties(sparkConf, provider, scheme, "selection phase")
+            // The wiring is in place, but the credentials it points at are not populated until
+            // the resolution phase runs at scheduler-backend start. Any driver-side access to
+            // this scheme that happens earlier in SparkContext construction (e.g. fetching
+            // spark.jars / spark.files on this scheme) will fail to resolve credentials until
+            // then. Log this so the eventual failure (including a ClassNotFoundException on
+            // executors when the provider class is not on their classpath) is easy to trace.
+            logInfo(log"Driver-side access to scheme ${MDC(LogKeys.URI, scheme)} will use OIDC " +
+              log"credentials once they are acquired at scheduler start; access before that " +
+              log"point (e.g. spark.jars/spark.files on this scheme) cannot be authenticated yet.")
+          }
+        }
+      } catch {
+        case NonFatal(e) =>
+          // Ambiguous selection (multiple candidates, no explicit config) or a misbehaving
+          // provider. We cannot apply this provider's properties, and -- unlike before -- the
+          // resolution phase does not re-derive them from selection, so warn rather than hide
+          // this at DEBUG. The resolution phase (start()) still applies properties for any
+          // provider whose resolve() succeeds (idempotent under !contains), so a transient
+          // failure here does not necessarily mean the wiring is lost for the whole application;
+          // an ambiguous-scheme error, however, will resurface there as a clear failure.
+          logWarning(log"Could not apply provider-declared properties for scheme " +
+            log"${MDC(LogKeys.URI, scheme)} during the selection phase; if this scheme is " +
+            log"actually used, credential resolution will report the underlying error.", e)
+      }
+    }
+    Some(loader)
+  }
+
+  /**
+   * Apply a provider's declared additional Spark properties
+   * ([[CredentialProvider#additionalSparkProperties]]) into `sparkConf`, only for keys the user
+   * (or an earlier phase) has not already set. Shared by the selection phase
+   * ([[applyProviderProperties]]) and the initial-acquisition fallback in [[start]]
+   * ([[applyResolvedProviderProperties]]) so the two apply properties identically. The `reason`
+   * is included in the per-key INFO log to distinguish the two call sites.
+   */
+  private def applyDeclaredProperties(
+      sparkConf: SparkConf,
+      provider: CredentialProvider,
+      scheme: String,
+      reason: String): Unit = {
+    val props = provider.additionalSparkProperties()
+    if (props != null && !props.isEmpty) {
+      props.forEach { (key, value) =>
+        if (!sparkConf.contains(key)) {
+          sparkConf.set(key, value)
+          logInfo(log"Set ${MDC(LogKeys.CONFIG, key)} from " +
+            log"${MDC(LogKeys.CLASS_NAME, provider.getClass.getName)} " +
+            log"(scheme: ${MDC(LogKeys.URI, scheme)}, ${MDC(LogKeys.REASON, reason)}).")
+        }
+      }
+    }
+  }
+
+  /**
+   * Extracts explicitly-configured scheme names from OIDC configuration, i.e. the {@code
+   * <scheme>} segment of keys of the form {@code spark.security.oidc.provider.<scheme>} (or
+   * {@code ...<scheme>.<subkey>}). Shared by the selection phase and the instance-level
+   * [[discoverSchemes]] so the two stay in sync.
+   */
+  private def explicitSchemesFrom(confMap: java.util.Map[String, String]): Set[String] = {
+    val providerPrefix = "spark.security.oidc.provider."
+    confMap.asScala
+      .filter { case (k, _) => k.startsWith(providerPrefix) }
+      .map { case (k, _) => k.stripPrefix(providerPrefix).split('.').head }
+      .toSet
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -702,12 +702,17 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     // KubernetesClusterSchedulerBackend.stop already anticipates). Otherwise the
     // UserCredentialManager renewal thread would be left running while SparkContext.stop()
     // closes the shared CredentialProviderLoader, causing the renewal task to fail repeatedly
-    // against an already-closed loader.
+    // against an already-closed loader. The two stops are independent so that a failure in one
+    // does not skip the other.
     try {
       stopExecutors()
     } finally {
-      stopTokenManager()
-      stopUserCredentialManager()
+      Utils.tryLogNonFatalError {
+        stopTokenManager()
+      }
+      Utils.tryLogNonFatalError {
+        stopUserCredentialManager()
+      }
     }
     try {
       if (driverEndpoint != null) {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -697,9 +697,18 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   override def stop(): Unit = {
     reviveThread.shutdownNow()
     cleanupService.foreach(_.shutdownNow())
-    stopExecutors()
-    stopTokenManager()
-    stopUserCredentialManager()
+    // Ensure the token and user-credential managers are always stopped, even if stopExecutors()
+    // throws (e.g. the StopExecutors ask times out during shutdown, which
+    // KubernetesClusterSchedulerBackend.stop already anticipates). Otherwise the
+    // UserCredentialManager renewal thread would be left running while SparkContext.stop()
+    // closes the shared CredentialProviderLoader, causing the renewal task to fail repeatedly
+    // against an already-closed loader.
+    try {
+      stopExecutors()
+    } finally {
+      stopTokenManager()
+      stopUserCredentialManager()
+    }
     try {
       if (driverEndpoint != null) {
         driverEndpoint.askSync[Boolean](StopDriver)
@@ -1249,12 +1258,16 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * Called from start(), independently of Kerberos/HadoopDelegationTokenManager.
    */
   private def setupUserCredentialManager(): Unit = {
+    // Reuse the loader from SparkContext's selection phase (Some when OIDC is enabled and not
+    // in local mode; None otherwise). Passing the Option straight through keeps SparkContext as
+    // the single owner of the loader: create() enforces that an enabled configuration has a
+    // loader, rather than silently allocating one here that no one would close.
     userCredentialManager = UserCredentialManager.create(conf, { (version, credentials) =>
       // Send to DriverEndpoint to ensure thread-safe access to executorDataMap.
       // This mirrors HadoopDelegationTokenManager's pattern of sending
       // UpdateDelegationTokens via schedulerRef.
       driverEndpoint.send(UpdateUserCredentials(version, credentials))
-    })
+    }, scheduler.sc.userCredentialProviderLoader)
     userCredentialManager.foreach { manager =>
       val (version, initialCredentials) = manager.start()
       // Store initial credentials synchronously so they are available for SparkAppConfig

--- a/core/src/test/java/org/apache/spark/security/CredentialProviderLoaderSuite.java
+++ b/core/src/test/java/org/apache/spark/security/CredentialProviderLoaderSuite.java
@@ -231,6 +231,42 @@ public class CredentialProviderLoaderSuite {
   }
 
   @Test
+  public void testSelectProviderForPropertiesDoesNotInitialize() {
+    // The selection phase uses selectProviderForProperties, which must NOT call init().
+    Optional<CredentialProvider> selected = loader.selectProviderForProperties("fake", Map.of());
+    assertTrue(selected.isPresent());
+    FakeCredentialProvider fake = (FakeCredentialProvider) selected.get();
+    assertEquals(0, fake.getInitCount(),
+        "selectProviderForProperties must not initialize the provider");
+    // additionalSparkProperties() is a static declaration and is available without init().
+    assertEquals("org.apache.spark.security.FakeExecutorCredentialProvider",
+        fake.additionalSparkProperties().get("spark.hadoop.fs.fake.credentials.provider"));
+  }
+
+  @Test
+  public void testSelectThenProviderForInitializesOnceOnSameInstance() {
+    // Mirrors the real flow: selection (no init) followed by resolution (init once). The same
+    // cached instance must be reused, so init runs exactly once across both phases.
+    Optional<CredentialProvider> selected = loader.selectProviderForProperties("fake", Map.of());
+    Optional<CredentialProvider> resolved = loader.providerFor("fake", Map.of());
+    assertTrue(selected.isPresent());
+    assertTrue(resolved.isPresent());
+    assertSame(selected.get(), resolved.get(),
+        "selection and resolution must share the same cached provider instance");
+    FakeCredentialProvider fake = (FakeCredentialProvider) resolved.get();
+    assertEquals(1, fake.getInitCount(),
+        "init() should run exactly once across selection + resolution");
+  }
+
+  @Test
+  public void testSelectProviderForPropertiesRejectsAmbiguousScheme() {
+    // "shared" has two candidates; without explicit config, selection is ambiguous and must
+    // throw the same way providerFor does (so the selection phase can catch and skip it).
+    assertThrows(IllegalArgumentException.class,
+        () -> loader.selectProviderForProperties("shared", Map.of()));
+  }
+
+  @Test
   public void testNullSupportedSchemesThrowsClearError() {
     // Inject a provider that returns null from supportedSchemes() to verify the guard.
     CredentialProvider nullSchemesProvider = new CredentialProvider() {

--- a/core/src/test/java/org/apache/spark/security/FakeCredentialProvider.java
+++ b/core/src/test/java/org/apache/spark/security/FakeCredentialProvider.java
@@ -79,7 +79,12 @@ public class FakeCredentialProvider implements CredentialProvider {
 
   @Override
   public Map<String, String> additionalSparkProperties() {
-    return Map.of("spark.hadoop.fs.fake.credentials.provider",
-        "org.apache.spark.security.FakeExecutorCredentialProvider");
+    return Map.of(
+        // A spark.hadoop.* property (reaches the Hadoop Configuration with the prefix stripped).
+        "spark.hadoop.fs.fake.credentials.provider",
+        "org.apache.spark.security.FakeExecutorCredentialProvider",
+        // A non-Hadoop spark.* property, to verify the wiring is type-agnostic (applied as
+        // ordinary Spark configuration, not only spark.hadoop.*).
+        "spark.fake.credentials.enabled", "true");
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/security/OidcCredentialIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/OidcCredentialIntegrationSuite.scala
@@ -509,7 +509,8 @@ class OidcCredentialIntegrationSuite extends SparkFunSuite {
       .set(NETWORK_AUTH_ENABLED, true)
       .set(NETWORK_CRYPTO_ENABLED, true)
 
-    val oidcManager = UserCredentialManager.create(conf, (_, _) => ())
+    val oidcManager = UserCredentialManager.create(
+      conf, (_, _) => (), Some(new CredentialProviderLoader()))
     assert(oidcManager.isEmpty, "OIDC manager should not be created when disabled")
 
     val dtManager = new HadoopDelegationTokenManager(conf, hadoopConf, mockRef)

--- a/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
@@ -318,13 +318,15 @@ class UserCredentialManagerSuite extends SparkFunSuite {
     val conf = new SparkConf(loadDefaults = false)
       .set(SECURITY_OIDC_ENABLED, false)
 
-    val result = UserCredentialManager.create(conf, (_: Long, _: Array[Byte]) => ())
+    val result = UserCredentialManager.create(
+      conf, (_: Long, _: Array[Byte]) => (), Some(new CredentialProviderLoader()))
     assert(result.isEmpty)
   }
 
   test("UserCredentialManager.create returns Some when enabled with valid config") {
     val conf = createSparkConf()
-    val result = UserCredentialManager.create(conf, (_: Long, _: Array[Byte]) => ())
+    val result = UserCredentialManager.create(
+      conf, (_: Long, _: Array[Byte]) => (), Some(new CredentialProviderLoader()))
     assert(result.isDefined)
   }
 
@@ -334,7 +336,8 @@ class UserCredentialManagerSuite extends SparkFunSuite {
     // Deliberately not setting SECURITY_OIDC_IDENTITY_TOKEN_FILE
 
     val ex = intercept[IllegalArgumentException] {
-      UserCredentialManager.create(conf, (_: Long, _: Array[Byte]) => ())
+      UserCredentialManager.create(
+        conf, (_: Long, _: Array[Byte]) => (), Some(new CredentialProviderLoader()))
     }
     assert(ex.getMessage.contains("spark.security.oidc.identityToken.file"))
   }
@@ -355,6 +358,76 @@ class UserCredentialManagerSuite extends SparkFunSuite {
       val (_, result) = manager.start()
       assert(result != null)
       assert(callbackCount === 1, "callback should be invoked once on start")
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("start() applies a resolved provider's declared properties as a fallback") {
+    // Simulate the case where the selection phase did NOT apply the properties (here we simply
+    // never call applyProviderProperties, so conf has no wiring). start() must apply them for a
+    // provider whose resolve() succeeds, guarded by !contains, so the wiring is still in place.
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    val ctx = createUserContext(expiresInSeconds = 60)
+    assert(!conf.contains("spark.hadoop.fs.fake.credentials.provider"))
+
+    val manager = new UserCredentialManager(conf, createIngestor(ctx), (_, _) => ())
+    try {
+      manager.start()
+      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
+        "org.apache.spark.security.FakeExecutorCredentialProvider",
+        "start() should apply declared properties for a provider that resolved")
+      assert(conf.get("spark.fake.credentials.enabled") === "true")
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("start() does not overwrite properties already applied by the selection phase") {
+    // If the selection phase (or the user) already set the key, the start() fallback must not
+    // overwrite it (idempotent under !contains).
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    conf.set("spark.hadoop.fs.fake.credentials.provider", "already.Set.By.Selection")
+    val ctx = createUserContext(expiresInSeconds = 60)
+
+    val manager = new UserCredentialManager(conf, createIngestor(ctx), (_, _) => ())
+    try {
+      manager.start()
+      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") === "already.Set.By.Selection",
+        "start() fallback must not overwrite an already-applied value")
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("renewal does not re-apply provider-declared properties") {
+    // Properties are static wiring applied only on initial acquisition (applyProperties=true in
+    // start()); renewals pass applyProperties=false. Overwrite the value after start() and
+    // confirm a subsequent renewal leaves the overwrite intact.
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    // Short expiry so a renewal fires quickly.
+    val ctx = createUserContext(expiresInSeconds = 6)
+    val callbackCount = new AtomicInteger()
+
+    val manager = new UserCredentialManager(
+      conf, createIngestor(ctx), (_, _) => { callbackCount.incrementAndGet() })
+    try {
+      manager.start()
+      assert(callbackCount.get() === 1)
+      // Overwrite the key that start() applied; a renewal must NOT re-apply the provider's value.
+      conf.set("spark.hadoop.fs.fake.credentials.provider", "overwritten.After.Start")
+      // Wait for at least one renewal (callbackCount > 1).
+      eventually(timeout(20.seconds)) {
+        assert(callbackCount.get() > 1, "at least one renewal should have fired")
+      }
+      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") === "overwritten.After.Start",
+        "renewal must not re-apply provider-declared properties")
     } finally {
       manager.stop()
     }
@@ -506,17 +579,23 @@ class UserCredentialManagerSuite extends SparkFunSuite {
 
     manager.start()
 
-    // Get the FakeCredentialProvider instance to verify close was called
+    // Get the FakeCredentialProvider instance to verify close semantics.
     val providerOpt = loader.providerFor("fake",
       new util.HashMap[String, String]())
     assert(providerOpt.isPresent)
     val fakeProvider = providerOpt.get().asInstanceOf[FakeCredentialProvider]
     assert(fakeProvider.getCloseCount === 0, "close() not yet called before stop()")
 
+    // stop() only shuts down renewal; it does NOT close the loader. SparkContext is the single
+    // owner of the loader and closes it via closeAll() (this avoids double-close / a leaked
+    // renewal thread racing an already-closed loader).
     manager.stop()
+    assert(fakeProvider.getCloseCount === 0,
+      "stop() must not close providers; the loader owner (SparkContext) does")
 
+    loader.closeAll()
     assert(fakeProvider.getCloseCount === 1,
-      "stop() should close initialized providers exactly once")
+      "loader.closeAll() should close initialized providers exactly once")
   }
 
   test("a later manager uses fresh credential providers after stop") {
@@ -535,6 +614,8 @@ class UserCredentialManagerSuite extends SparkFunSuite {
     val firstProvider = firstLoader.providerFor("fake",
       new util.HashMap[String, String]()).get().asInstanceOf[FakeCredentialProvider]
     firstManager.stop()
+    // stop() does not close; the owner closes the loader.
+    firstLoader.closeAll()
     assert(firstProvider.getCloseCount === 1)
 
     val secondLoader = new CredentialProviderLoader()
@@ -551,10 +632,11 @@ class UserCredentialManagerSuite extends SparkFunSuite {
       assert(secondProvider.getCloseCount === 0)
     } finally {
       secondManager.stop()
+      secondLoader.closeAll()
     }
   }
 
-  test("stop() waits for credential renewal before closing providers") {
+  test("stop() waits for credential renewal to finish before returning") {
     val conf = createSparkConf()
     val ctx = createUserContext(expiresInSeconds = 6)
     val callbackCount = new AtomicInteger()
@@ -599,7 +681,7 @@ class UserCredentialManagerSuite extends SparkFunSuite {
       assert(renewalInterrupted.await(10, TimeUnit.SECONDS))
       assert(stopThread.isAlive, "stop() should wait for credential renewal to finish")
       assert(provider.getCloseCount === 0,
-        "stop() should not close providers while credential renewal is still running")
+        "stop() should not close providers (the loader owner does)")
     } finally {
       releaseRenewal.countDown()
       stopThread.join(10000)
@@ -607,94 +689,106 @@ class UserCredentialManagerSuite extends SparkFunSuite {
 
     assert(renewalCompleted.await(10, TimeUnit.SECONDS))
     assert(!stopThread.isAlive, "stop() should finish after credential renewal exits")
+    // stop() only waits for renewal; it does not close the loader.
+    assert(provider.getCloseCount === 0,
+      "stop() must not close providers; SparkContext (the loader owner) does")
+    loader.closeAll()
     assert(provider.getCloseCount === 1,
-      "stop() should close providers after credential renewal exits")
+      "loader.closeAll() closes providers after renewal has exited")
   }
 
-  // ========== additionalSparkProperties application ==========
+  // ========== additionalSparkProperties application (selection phase) ==========
 
-  test("start() applies additionalSparkProperties from active providers") {
+  test("applyProviderProperties applies additionalSparkProperties from selected providers") {
     val conf = createSparkConf()
     conf.set("spark.security.oidc.provider.fake",
       "org.apache.spark.security.FakeCredentialProvider")
-    val ctx = createUserContext()
 
-    val manager = new UserCredentialManager(
-      conf, createIngestor(ctx), (_, _) => ())
+    val loader = UserCredentialManager.applyProviderProperties(conf, isLocal = false)
+    assert(loader.isDefined, "a loader should be returned when OIDC is enabled and not local")
 
-    try {
-      manager.start()
-      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
-        "org.apache.spark.security.FakeExecutorCredentialProvider")
-    } finally {
-      manager.stop()
-    }
+    // spark.hadoop.* property is applied ...
+    assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
+      "org.apache.spark.security.FakeExecutorCredentialProvider")
+    // ... and so is a non-Hadoop spark.* property (type-agnostic; this is what lets
+    // arbitrary provider-declared driver-side wiring, not just Hadoop FS config, take effect).
+    assert(conf.get("spark.fake.credentials.enabled") === "true")
   }
 
-  test("start() does not overwrite user-set properties") {
+  test("applyProviderProperties auto-selects a single-candidate scheme with no explicit config") {
+    // Zero-config path: no spark.security.oidc.provider.<scheme> is set, so the loader falls
+    // back to discoverAllSchemes(). "fake" has exactly one candidate (FakeCredentialProvider),
+    // so it must be auto-selected and its declared properties applied.
+    val conf = createSparkConf()
+
+    val loader = UserCredentialManager.applyProviderProperties(conf, isLocal = false)
+    assert(loader.isDefined)
+    assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
+      "org.apache.spark.security.FakeExecutorCredentialProvider")
+    assert(conf.get("spark.fake.credentials.enabled") === "true")
+  }
+
+  test("applyProviderProperties is a no-op and returns None when OIDC is disabled") {
+    val conf = new SparkConf(false)
+      .set(SECURITY_OIDC_ENABLED, false)
+    val loader = UserCredentialManager.applyProviderProperties(conf, isLocal = false)
+    assert(loader.isEmpty, "no loader should be allocated when OIDC is disabled")
+    assert(!conf.contains("spark.hadoop.fs.fake.credentials.provider"))
+    assert(!conf.contains("spark.fake.credentials.enabled"))
+  }
+
+  test("applyProviderProperties is a no-op and returns None in local mode") {
+    // Even with OIDC enabled, local mode has no scheduler backend that starts the resolution
+    // phase, so wiring a provider would leave driver-side access unable to resolve credentials.
+    // The selection phase must be skipped and no loader allocated.
     val conf = createSparkConf()
     conf.set("spark.security.oidc.provider.fake",
       "org.apache.spark.security.FakeCredentialProvider")
-    // User explicitly sets the property before start()
+    val loader = UserCredentialManager.applyProviderProperties(conf, isLocal = true)
+    assert(loader.isEmpty, "no loader should be allocated in local mode")
+    assert(!conf.contains("spark.hadoop.fs.fake.credentials.provider"))
+    assert(!conf.contains("spark.fake.credentials.enabled"))
+  }
+
+  test("applyProviderProperties does not overwrite user-set properties") {
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.fake",
+      "org.apache.spark.security.FakeCredentialProvider")
+    // User explicitly sets the property beforehand.
     conf.set("spark.hadoop.fs.fake.credentials.provider", "user.Custom")
-    val ctx = createUserContext()
 
-    val manager = new UserCredentialManager(
-      conf, createIngestor(ctx), (_, _) => ())
+    UserCredentialManager.applyProviderProperties(conf, isLocal = false)
 
-    try {
-      manager.start()
-      // User-set value must NOT be overwritten
-      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") === "user.Custom")
-    } finally {
-      manager.stop()
-    }
+    // User-set value must NOT be overwritten; the unset one is still applied.
+    assert(conf.get("spark.hadoop.fs.fake.credentials.provider") === "user.Custom")
+    assert(conf.get("spark.fake.credentials.enabled") === "true")
   }
 
-  test("start() handles provider returning null from additionalSparkProperties") {
-    // AnotherFakeCredentialProvider uses default (empty map), not null.
-    // This test verifies the defensive null check doesn't crash
-    // with a provider that inherits the default empty map.
+  test("applyProviderProperties skips ambiguous schemes without failing") {
+    // Two providers register scheme "shared"; with no explicit provider.shared config the
+    // selection is ambiguous. applyProviderProperties must not throw (SparkContext init must
+    // not fail here); the ambiguity is surfaced later, in the resolution phase.
     val conf = createSparkConf()
-    conf.set("spark.security.oidc.provider.fake",
-      "org.apache.spark.security.FakeCredentialProvider")
-    val ctx = createUserContext()
-
-    val manager = new UserCredentialManager(
-      conf, createIngestor(ctx), (_, _) => ())
-
-    try {
-      // Should not throw
-      manager.start()
-      assert(conf.contains("spark.hadoop.fs.fake.credentials.provider"))
-    } finally {
-      manager.stop()
-    }
+    // Do not set spark.security.oidc.provider.shared -> ambiguous for "shared".
+    // No exception should escape.
+    UserCredentialManager.applyProviderProperties(conf, isLocal = false)
+    // Nothing asserted about "shared"; the point is that the call returned normally.
   }
 
-  test("start() succeeds when a provider throws from additionalSparkProperties") {
-    // AnotherFakeCredentialProvider is configured to throw; FakeCredentialProvider should
-    // still have its properties applied (exception isolation via NonFatal catch).
+  test("applyProviderProperties succeeds when a provider throws from additionalSparkProperties") {
     val conf = createSparkConf()
     conf.set("spark.security.oidc.provider.fake",
       "org.apache.spark.security.FakeCredentialProvider")
     conf.set("spark.security.oidc.provider.shared",
       "org.apache.spark.security.AnotherFakeCredentialProvider")
-    val ctx = createUserContext()
 
     AnotherFakeCredentialProvider.throwOnProperties = true
     try {
-      val manager = new UserCredentialManager(
-        conf, createIngestor(ctx), (_, _) => ())
-      try {
-        // start() must not fail even though AnotherFakeCredentialProvider throws
-        manager.start()
-        // FakeCredentialProvider's property must still be applied
-        assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
-          "org.apache.spark.security.FakeExecutorCredentialProvider")
-      } finally {
-        manager.stop()
-      }
+      // Must not fail even though AnotherFakeCredentialProvider throws; FakeCredentialProvider's
+      // properties must still be applied (per-provider exception isolation).
+      UserCredentialManager.applyProviderProperties(conf, isLocal = false)
+      assert(conf.get("spark.hadoop.fs.fake.credentials.provider") ===
+        "org.apache.spark.security.FakeExecutorCredentialProvider")
     } finally {
       AnotherFakeCredentialProvider.throwOnProperties = false
     }

--- a/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/UserCredentialManagerSuite.scala
@@ -433,6 +433,33 @@ class UserCredentialManagerSuite extends SparkFunSuite {
     }
   }
 
+  test("start() keeps a resolved credential even if applying its properties throws") {
+    // If a resolved provider's additionalSparkProperties() throws during the start() fallback,
+    // the credential it resolved must still be used (start() succeeds), not discarded or
+    // misreported as a resolution failure. Use the "shared" scheme bound explicitly to
+    // AnotherFakeCredentialProvider, whose resolve() succeeds but whose
+    // additionalSparkProperties() throws when throwOnProperties is set.
+    val conf = createSparkConf()
+    conf.set("spark.security.oidc.provider.shared",
+      "org.apache.spark.security.AnotherFakeCredentialProvider")
+    val ctx = createUserContext(expiresInSeconds = 60)
+    val callbackCount = new AtomicInteger()
+
+    AnotherFakeCredentialProvider.throwOnProperties = true
+    val manager = new UserCredentialManager(
+      conf, createIngestor(ctx), (_, _) => { callbackCount.incrementAndGet() })
+    try {
+      // Must not throw: the credential resolved successfully; only property application failed.
+      val (_, serialized) = manager.start()
+      assert(serialized != null)
+      assert(callbackCount.get() === 1,
+        "initial credentials should still be propagated despite the property-application failure")
+    } finally {
+      AnotherFakeCredentialProvider.throwOnProperties = false
+      manager.stop()
+    }
+  }
+
   test("stop() after start() does not throw") {
     val conf = createSparkConf()
     conf.set("spark.security.oidc.provider.fake",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Split OIDC credential propagation into a provider *selection* phase and a credential resolution phase, so that provider-declared properties (`CredentialProvider.additionalSparkProperties()`, e.g. the S3A credentials-provider class) take effect on the driver, not only on executors.

- Selection phase (`UserCredentialManager.applyProviderProperties`) runs early in `SparkContext` initialization, before the driver's Hadoop `Configuration` is materialized, and applies the declared `spark.*` properties into `SparkConf` (only for keys the user has not already set). It selects providers without initializing them, so it performs no network I/O; it is skipped in local mode, where no resolution phase follows.
- Resolution phase (`UserCredentialManager.start()`) is unchanged in timing: it still runs on the scheduler backend and performs the token load, `resolve()`, executor propagation, and renewal.
- The `CredentialProviderLoader` is created once in the selection phase, owned and closed by `SparkContext`, and reused by the resolution phase so providers are initialized exactly once.

This keeps credential resolution late (as with `HadoopDelegationTokenManager`) while making the
provider *wiring* effective on the driver in time for driver-side storage access.

### Limitations

Two driver-side, early-startup cases are not covered and will be documented in the OIDC user guide (a separate docs PR):

- **Access during `SparkContext` construction.** The provider wiring is applied early, but the credentials it points at are not resolved until the scheduler backend starts. Driver-side storage access that happens in between -- notably fetching `spark.jars` / `spark.files` from a credential-served scheme such as `s3a://` -- runs before the credentials exist. The selection phase logs a line noting this. Prefer `local://` for such resources.
- **Hadoop `FileSystem` cache in Kubernetes cluster mode.** The driver pod runs `SparkSubmit` in the same JVM; it downloads `--jars` / `--files` before provider selection and caches a `FileSystem` per (scheme, authority, user). Later driver access to a bucket `SparkSubmit` already touched reuses that cached `FileSystem` under the pod identity, producing a mixed-identity job (not a failure). Prefer `local://` for these resources, or set `spark.hadoop.fs.s3a.impl.disable.cache=true`.

### Why are the changes needed?
With OIDC enabled and no explicit `fs.s3a.aws.credentials.provider` (the documented usage), the provider-declared S3A wiring reached executors but not the driver, because it was applied after the driver's Hadoop `Configuration` had already been materialized. Driver-side storage access then fell back to the default credential chain (e.g. the node instance profile), causing 403s or access under the wrong identity.
This completes a goal the SPIP (SPARK-57703) already stated: "a Spark driver on Kubernetes accesses S3 as the pod's service account, not as the user who submitted the job" is the problem it set out to solve. The initial implementation delivered the executor propagation mechanism, but the wiring that lets the driver itself use the resolved credentials was applied too late in initialization. This PR closes that gap.

### Does this PR introduce _any_ user-facing change?
Yes (behavior only; no public API added or removed, and the feature is unreleased). With OIDC enabled and no explicit `fs.s3a.aws.credentials.provider`, driver-side storage access now uses the propagated OIDC credentials instead of falling back to the default chain. The unreleased `@DeveloperApi` `CredentialProvider.additionalSparkProperties()` contract is clarified accordingly.

### How was this patch tested?
- New and updated unit tests in `CredentialProviderLoaderSuite` and `UserCredentialManagerSuite` cover the selection/resolution split (selection does not initialize providers, providers are initialized exactly once, local-mode and disabled are no-ops, user-set values are not overridden, and the loader is closed by its single owner).
- `OidcCredentialIntegrationSuite` and the `credential-aws` module tests pass; `dev/lint-scala` and `dev/lint-java` pass.
- Manually verified end to end on real AWS EKS + STS + S3 (cluster mode, no explicit provider): the driver acquires OIDC credentials, reads/writes S3, and propagates to executors.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
