### PR TITLE
[SPARK-59297][SQL][TESTS] Cover nanosecond precisions 7 and 8 in RowToColumnConverter round-trip tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RowToColumnConverterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RowToColumnConverterSuite.scala
@@ -131,16 +131,18 @@ class RowToColumnConverterSuite extends SparkFunSuite {
   }
 
   test("TimestampNTZNanosType column roundtrip") {
-    val t = TimestampNTZNanosType(9)
-    val schema = StructType(Seq(StructField("ts", t)))
-    val values = Seq(
-      TimestampNanosVal.fromParts(0L, 0.toShort),
-      TimestampNanosVal.fromParts(1_000_000L, 999.toShort),
-      TimestampNanosVal.fromParts(-1L, 123.toShort))
-    val rows = values.map(v => InternalRow(v))
-    val vectors = convertRows(rows, schema)
-    values.zipWithIndex.foreach { case (v, i) =>
-      assert(vectors.head.getTimestampNTZNanos(i) === v)
+    Seq(7, 8, 9).foreach { precision =>
+      val t = TimestampNTZNanosType(precision)
+      val schema = StructType(Seq(StructField("ts", t)))
+      val values = Seq(
+        TimestampNanosVal.fromParts(0L, 0.toShort),
+        TimestampNanosVal.fromParts(1_000_000L, 999.toShort),
+        TimestampNanosVal.fromParts(-1L, 123.toShort))
+      val rows = values.map(v => InternalRow(v))
+      val vectors = convertRows(rows, schema)
+      values.zipWithIndex.foreach { case (v, i) =>
+        assert(vectors.head.getTimestampNTZNanos(i) === v)
+      }
     }
   }
 
@@ -158,16 +160,18 @@ class RowToColumnConverterSuite extends SparkFunSuite {
   }
 
   test("TimestampLTZNanosType column roundtrip") {
-    val t = TimestampLTZNanosType(9)
-    val schema = StructType(Seq(StructField("ts", t)))
-    val values = Seq(
-      TimestampNanosVal.fromParts(0L, 0.toShort),
-      TimestampNanosVal.fromParts(1_000_000L, 999.toShort),
-      TimestampNanosVal.fromParts(-1L, 123.toShort))
-    val rows = values.map(v => InternalRow(v))
-    val vectors = convertRows(rows, schema)
-    values.zipWithIndex.foreach { case (v, i) =>
-      assert(vectors.head.getTimestampLTZNanos(i) === v)
+    Seq(7, 8, 9).foreach { precision =>
+      val t = TimestampLTZNanosType(precision)
+      val schema = StructType(Seq(StructField("ts", t)))
+      val values = Seq(
+        TimestampNanosVal.fromParts(0L, 0.toShort),
+        TimestampNanosVal.fromParts(1_000_000L, 999.toShort),
+        TimestampNanosVal.fromParts(-1L, 123.toShort))
+      val rows = values.map(v => InternalRow(v))
+      val vectors = convertRows(rows, schema)
+      values.zipWithIndex.foreach { case (v, i) =>
+        assert(vectors.head.getTimestampLTZNanos(i) === v)
+      }
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Parameterize the `TimestampNTZNanosType` and `TimestampLTZNanosType` round-trip tests in `RowToColumnConverterSuite` over `Seq(7, 8, 9)` instead of only precision 9, mirroring the adjacent `TimeType column roundtrip` test. Test-only; no production change.

### Why are the changes needed?
The row-to-column converter (vectorized execution / columnar projection) was only asserted at nanosecond precision 9, leaving precisions 7 and 8 unexercised.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
`RowToColumnConverterSuite` passes at all three precisions; `sql/Test/scalastyle` is clean.

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Code 