### PR TITLE
[SPARK-59299][SQL][TESTS] Add missing ASOF JOIN parser unit tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1081,6 +1081,18 @@ class PlanParserSuite extends AnalysisTest {
           usingColumns = Some(Seq("b"))).select(star()))
 
       assertEqual(
+        "select * from t asof join u match_condition (t.a >= u.a) using (a, b)",
+        AsOfJoin.fromMatchCondition(
+          table("t"),
+          table("u"),
+          $"t.a",
+          GreaterThanOrEqualOp,
+          $"u.a",
+          None,
+          Inner,
+          usingColumns = Some(Seq("a", "b"))).select(star()))
+
+      assertEqual(
         "select * from t asof join u match_condition (u.a <= t.a)",
         AsOfJoin.fromMatchCondition(
           table("t"),
@@ -1271,6 +1283,24 @@ class PlanParserSuite extends AnalysisTest {
             fragment = "asof join u match_condition (t.a >= u.a or t.b >= u.b)",
             start = 16,
             stop = 69)))
+    }
+  }
+
+  test("asof join - non-comparison match condition rejected") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
+      // A MATCH_CONDITION that is not a top-level comparison (here a bare column reference)
+      // is rejected, and the original expression text is echoed back as the operator.
+      checkError(
+        exception = parseException(
+          "select * from t asof join u match_condition (t.a)"),
+        condition = "ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR",
+        sqlState = Some("42K0E"),
+        parameters = Map("operator" -> "t.a"),
+        queryContext = Array(
+          ExpectedContext(
+            fragment = "asof join u match_condition (t.a)",
+            start = 16,
+            stop = 48)))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1090,6 +1090,68 @@ class PlanParserSuite extends AnalysisTest {
           $"t.a",
           None,
           Inner).select(star()))
+
+      assertEqual(
+        "select * from t asof join u match_condition (t.a > u.a)",
+        AsOfJoin.fromMatchCondition(
+          table("t"),
+          table("u"),
+          $"t.a",
+          GreaterThanOp,
+          $"u.a",
+          None,
+          Inner).select(star()))
+
+      assertEqual(
+        "select * from t asof join u match_condition (t.a < u.a)",
+        AsOfJoin.fromMatchCondition(
+          table("t"),
+          table("u"),
+          $"t.a",
+          LessThanOp,
+          $"u.a",
+          None,
+          Inner).select(star()))
+
+      assertEqual(
+        "select * from t inner asof join u match_condition (t.a >= u.a)",
+        AsOfJoin.fromMatchCondition(
+          table("t"),
+          table("u"),
+          $"t.a",
+          GreaterThanOrEqualOp,
+          $"u.a",
+          None,
+          Inner).select(star()))
+
+      assertEqual(
+        "select * from t left outer asof join u match_condition (t.a >= u.a)",
+        AsOfJoin.fromMatchCondition(
+          table("t"),
+          table("u"),
+          $"t.a",
+          GreaterThanOrEqualOp,
+          $"u.a",
+          None,
+          LeftOuter).select(star()))
+    }
+  }
+
+  test("asof join - struct match condition") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
+      // A multi-column MATCH_CONDITION: `(a, b)` parses to a row constructor (CreateStruct),
+      // and the top-level comparison must still be extracted as the match operator so that
+      // STRUCT operands compare lexicographically (see the SQL reference for ASOF JOIN).
+      assertEqual(
+        "select * from t asof join u match_condition ((t.a, t.b) >= (u.a, u.b))",
+        AsOfJoin.fromMatchCondition(
+          table("t"),
+          table("u"),
+          CreateStruct($"t.a" :: $"t.b" :: Nil),
+          GreaterThanOrEqualOp,
+          CreateStruct($"u.a" :: $"u.b" :: Nil),
+          None,
+          Inner).select(star()))
     }
   }
 
@@ -1193,6 +1255,22 @@ class PlanParserSuite extends AnalysisTest {
             fragment = "asof join u match_condition (t.a >= u.a and t.b >= u.b)",
             start = 16,
             stop = 70)))
+    }
+  }
+
+  test("asof join - disjunction match condition rejected") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
+      checkError(
+        exception = parseException(
+          "select * from t asof join u match_condition (t.a >= u.a or t.b >= u.b)"),
+        condition = "ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR",
+        sqlState = Some("42K0E"),
+        parameters = Map("operator" -> "OR"),
+        queryContext = Array(
+          ExpectedContext(
+            fragment = "asof join u match_condition (t.a >= u.a or t.b >= u.b)",
+            start = 16,
+            stop = 69)))
     }
   }
 


### PR DESCRIPTION
PlanParserSuite covers SQL ASOF JOIN parsing (SPARK-58122) but was missing several cases relative to the ASOF JOIN SQL reference. Add:

- positive parsing of the `>` and `<` match operators (only `>=`/`<=` were covered);
- a STRUCT/tuple MATCH_CONDITION `(a, b) >= (c, d)` (row constructor -> CreateStruct);
- explicit `INNER ASOF` and `LEFT OUTER ASOF` join types;
- rejection of a top-level `OR` in MATCH_CONDITION.
- a multi-column USING (a, b) clause (only single-column USING was covered);
- rejection of a non-comparison MATCH_CONDITION (e.g. a bare column).

No production code changes.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Test-only change. `PlanParserSuite` covers SQL `ASOF JOIN` parsing (added in SPARK-58122) but
was missing several cases relative to the `ASOF JOIN` SQL reference. This adds them; there are
**no production code changes**:

- **Positive parsing of the `>` and `<` match operators.** The suite only asserted `>=` and
  `<=`; `>` (`GreaterThanOp`) and `<` (`LessThanOp`) — the strictly-preceding / strictly-following
  directions — were not pinned.
- **STRUCT / tuple `MATCH_CONDITION`.** New `test("asof join - struct match condition")` for
  `MATCH_CONDITION ((t.a, t.b) >= (u.a, u.b))`, which parses to a row constructor (`CreateStruct`)
  on each side; the test pins that the top-level comparison is still extracted as the match
  operator (lexicographic multi-column match).
- **Explicit `INNER ASOF` and `LEFT OUTER ASOF` join types.** Only implicit `INNER` and bare
  `LEFT` were covered.
- **Rejection of a top-level `OR` in `MATCH_CONDITION`.** New
  `test("asof join - disjunction match condition rejected")`, mirroring the existing `AND` test;
  it exercises the previously untested `Or` branch of the
  `ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR` error path.
- **Multi-column `USING (a, b)`.** The suite only pinned single-column `USING (b)`; this adds a
    positive parse of `MATCH_CONDITION (t.a >= u.a) USING (a, b)`, asserting the join carries
    `usingColumns = Some(Seq("a", "b"))`.
- **Rejection of a non-comparison `MATCH_CONDITION`.** New
    `test("asof join - non-comparison match condition rejected")` for `MATCH_CONDITION (t.a)` (a bare
    column, no top-level comparison); it exercises the `getOriginalText` fallback of the
    `ASOF_JOIN_MATCH_CONDITION_INVALID_OPERATOR` error path (the operator text `t.a` is echoed back),
    which none of the existing operator-rejection tests reach.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These are behaviors the `ASOF JOIN` SQL reference specifies but that were not covered by the
parser unit tests, so regressions in them would go undetected. In particular, two of the four
permitted match operators (`>`, `<`) and the multi-column STRUCT `MATCH_CONDITION` (a documented
feature) had no positive parser test, and the explicit join-type keywords and top-level-`OR`
rejection were unexercised.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Test-only change. Ran the affected suite:

    build/mvn -pl sql/catalyst -am -Dtest=none \
      -DwildcardSuites=org.apache.spark.sql.catalyst.parser.PlanParserSuite test

`PlanParserSuite` passes: `Tests: succeeded 108, failed 0, canceled 0, ignored 0, pending 0`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Claude Opus 4.8)