### PR TITLE
[SPARK-59293][INFRA] Fix update_build_status.yml to map non-standard conclusions

### DIFF
--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -179,14 +179,22 @@ jobs:
 
                       // Keep syncing the status of the checks
                       if (run.data.status == 'completed') {
-                        console.log('    Run ' + cr.id + ': set status (' + run.data.status + ') and conclusion (' + run.data.conclusion + ')')
+                        // PATCH /check-runs accepts only success | failure | neutral |
+                        // cancelled | timed_out | action_required | skipped, but a workflow_run
+                        // may also conclude startup_failure / stale, or report a null conclusion.
+                        // Those all mean the run produced no test result, so they become failure.
+                        const conclusions = ['success', 'failure', 'neutral', 'cancelled',
+                          'timed_out', 'action_required', 'skipped']
+                        const conclusion = conclusions.includes(run.data.conclusion)
+                          ? run.data.conclusion : 'failure'
+                        console.log('    Run ' + cr.id + ': set status (' + run.data.status + ') and conclusion (' + run.data.conclusion + ' -> ' + conclusion + ')')
                         const response = await github.request('PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}', {
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           check_run_id: cr.id,
                           output: cr.output,
                           status: run.data.status,
-                          conclusion: run.data.conclusion,
+                          conclusion: conclusion,
                           details_url: run.data.details_url
                         })
                       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes `update_build_status.yml` so that it coerces non-standard workflow run conclusions to a value accepted by the PATCH /repos/{owner}/{repo}/check-runs/{check_run_id} endpoint. run.data.conclusion is mapped to itself when it is one of the conclusions the endpoint accepts, and to failure otherwise, instead of passing the raw value through. This mirrors the mapping of non-standard run statuses in the else branch a few lines below, added by SPARK-57124.

### Why are the changes needed?

The scheduled job has been failing on every run for quite a while with `startup_failure is not a member of ["success", "failure", "neutral", "cancelled", "timed_out", "action_required", "skipped"].`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 5