### PR TITLE
[SPARK-59301][SQL] Unwrap the cast of a DSv2 runtime IN filter before pushing it down

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -169,15 +169,16 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     // 3. this rule doesn't optimize In when `in.list` contains an expression that is not literal.
     case in @ In(Cast(fromExp, toType: NumericType, tz, mode), list @ Seq(firstLit, _*))
       if canImplicitlyCast(fromExp, toType, firstLit.dataType) && in.inSetConvertible =>
-
-      val buildIn = {
-        (nullList: ArrayBuffer[Literal], canCastList: ArrayBuffer[Literal]) =>
-          // cast null value to fromExp.dataType, to make sure the new return list is in the same
-          // data type.
-          val newList = nullList.map(lit => Cast(lit, fromExp.dataType, tz, mode)) ++ canCastList
-          In(fromExp, newList.toSeq)
+      val (nullList, canCastList) = castLiterals(fromExp.dataType, toType, list)
+      if (nullList.isEmpty && canCastList.isEmpty) {
+        // only have cannot cast to fromExp.dataType literals
+        Some(falseIfNotNull(fromExp))
+      } else {
+        // cast null value to fromExp.dataType, to make sure the new return list is in the same
+        // data type.
+        val newList = nullList.map(lit => Cast(lit, fromExp.dataType, tz, mode)) ++ canCastList
+        Some(In(fromExp, newList.toSeq))
       }
-      simplifyIn(fromExp, toType, list, buildIn)
 
     case inSet: InSet =>
       unwrapCastInSet(inSet).map {
@@ -402,21 +403,6 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
           FalseLiteral
         }
       case _ => exp
-    }
-  }
-
-  private def simplifyIn[IN <: Expression](
-      fromExp: Expression,
-      toType: NumericType,
-      list: Seq[Expression],
-      buildExpr: (ArrayBuffer[Literal], ArrayBuffer[Literal]) => IN): Option[Expression] = {
-    val (nullList, canCastList) = castLiterals(fromExp.dataType, toType, list)
-    if (nullList.isEmpty && canCastList.isEmpty) {
-      // only have cannot cast to fromExp.dataType literals
-      Option(falseIfNotNull(fromExp))
-    } else {
-      val unwrapExpr = buildExpr(nullList, canCastList)
-      Option(unwrapExpr)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -109,14 +109,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
       }
   }
 
-  /**
-   * Unwraps the cast in a single expression of the patterns listed in the class doc. Returns
-   * None if the expression is not rewritten.
-   *
-   * Besides the rule, this is also called at runtime to unwrap the cast in a dynamic partition
-   * pruning filter, whose values are only known once its subquery has been evaluated.
-   */
-  private[sql] def unwrapCast(exp: Expression): Option[Expression] = exp match {
+  private def unwrapCast(exp: Expression): Option[Expression] = exp match {
     // Not a canonical form. In this case we first canonicalize the expression by swapping the
     // literal and cast side, then process the result and swap the literal and cast again to
     // restore the original order.
@@ -186,19 +179,12 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
       }
       simplifyIn(fromExp, toType, list, buildIn)
 
-    // The same with `In` expression, the analyzer makes sure that the hset of InSet is already of
-    // the same data type, so simply check `fromExp.dataType` can implicitly cast to `toType` and
-    // both `fromExp.dataType` and `toType` is numeric type or not.
-    case InSet(Cast(fromExp, toType: NumericType, _, _), hset)
-      if hset.nonEmpty && canImplicitlyCast(fromExp, toType, toType) =>
-      val buildInSet =
-        (nullList: ArrayBuffer[Literal], canCastList: ArrayBuffer[Literal]) =>
-          InSet(fromExp, (nullList ++ canCastList).map(_.value).toSet)
-      simplifyIn(
-        fromExp,
-        toType,
-        hset.map(v => Literal.create(v, toType)).toSeq,
-        buildInSet)
+    case inSet: InSet =>
+      unwrapCastInSet(inSet).map {
+        // only have cannot cast to fromExp.dataType literals
+        case (fromExp, values) if values.isEmpty => falseIfNotNull(fromExp)
+        case (fromExp, values) => InSet(fromExp, values)
+      }
 
     case _ => None
   }
@@ -424,7 +410,45 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
       toType: NumericType,
       list: Seq[Expression],
       buildExpr: (ArrayBuffer[Literal], ArrayBuffer[Literal]) => IN): Option[Expression] = {
+    val (nullList, canCastList) = castLiterals(fromExp.dataType, toType, list)
+    if (nullList.isEmpty && canCastList.isEmpty) {
+      // only have cannot cast to fromExp.dataType literals
+      Option(falseIfNotNull(fromExp))
+    } else {
+      val unwrapExpr = buildExpr(nullList, canCastList)
+      Option(unwrapExpr)
+    }
+  }
 
+  /**
+   * Unwraps the cast of `InSet(Cast(fromExp, toType), hset)`. Returns `fromExp` and the values
+   * of `hset` converted to its type, dropping the ones that don't survive the round trip (see
+   * `castLiterals`), so the set is empty when no row can match. Returns None if the cast can't
+   * be unwrapped.
+   *
+   * Besides the rule, this is also used at runtime to unwrap the cast of a dynamic partition
+   * pruning filter, whose values are only known once its subquery has been evaluated.
+   */
+  private[sql] def unwrapCastInSet(inSet: InSet): Option[(Expression, Set[Any])] = inSet match {
+    // The same with `In` expression, the analyzer makes sure that the hset of InSet is already of
+    // the same data type, so simply check `fromExp.dataType` can implicitly cast to `toType` and
+    // both `fromExp.dataType` and `toType` is numeric type or not.
+    case InSet(Cast(fromExp, toType: NumericType, _, _), hset)
+        if hset.nonEmpty && canImplicitlyCast(fromExp, toType, toType) =>
+      val (nullList, canCastList) =
+        castLiterals(fromExp.dataType, toType, hset.map(v => Literal.create(v, toType)).toSeq)
+      Some((fromExp, (nullList ++ canCastList).map(_.value).toSet))
+    case _ => None
+  }
+
+  /**
+   * Casts the literals of an `In`/`InSet` list from `toType` to `fromType`. Returns the null
+   * literals and the literals that can be cast, the others are dropped as explained below.
+   */
+  private def castLiterals(
+      fromType: DataType,
+      toType: NumericType,
+      list: Seq[Expression]): (ArrayBuffer[Literal], ArrayBuffer[Literal]) = {
     // There are 3 kinds of literals in the list:
     // 1. null literals
     // 2. The literals that can cast to fromExp.dataType
@@ -442,7 +466,6 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     //     note that 3.14 will be rounded to 3.14000010... after casting to float
 
     val (nullList, canCastList) = (ArrayBuffer[Literal](), ArrayBuffer[Literal]())
-    val fromType = fromExp.dataType
     val ordering = PhysicalDataType.ordering(toType)
 
     list.foreach {
@@ -454,14 +477,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
           canCastList += Literal(newValue, fromType)
         }
     }
-
-    if (nullList.isEmpty && canCastList.isEmpty) {
-      // only have cannot cast to fromExp.dataType literals
-      Option(falseIfNotNull(fromExp))
-    } else {
-      val unwrapExpr = buildExpr(nullList, canCastList)
-      Option(unwrapExpr)
-    }
+    (nullList, canCastList)
   }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -109,7 +109,14 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
       }
   }
 
-  private def unwrapCast(exp: Expression): Option[Expression] = exp match {
+  /**
+   * Unwraps the cast in a single expression of the patterns listed in the class doc. Returns
+   * None if the expression is not rewritten.
+   *
+   * Besides the rule, this is also called at runtime to unwrap the cast in a dynamic partition
+   * pruning filter, whose values are only known once its subquery has been evaluated.
+   */
+  private[sql] def unwrapCast(exp: Expression): Option[Expression] = exp match {
     // Not a canonical form. In this case we first canonicalize the expression by swapping the
     // literal and cast side, then process the result and swap the literal and cast again to
     // restore the original order.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -27,8 +27,9 @@ import org.apache.spark.internal.LogKeys.EXPR
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier, ResolvedNamespace, ResolvedPartitionSpec, ResolvedPersistentView, ResolvedTable, ResolvedTempView}
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
 import org.apache.spark.sql.catalyst.expressions
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, DynamicPruning, Expression, NamedExpression, Not, Or, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, DynamicPruning, Expression, InSet, IsNull, Literal, NamedExpression, Not, Or, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.optimizer.UnwrapCastInBinaryComparison
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.TreePattern.SCALAR_SUBQUERY
@@ -51,6 +52,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
 import org.apache.spark.sql.metricview.logical.CreateMetricView
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SparkStringUtils
@@ -977,17 +979,34 @@ private[sql] object DataSourceV2Strategy extends Logging {
       None
     case in: InSubqueryExec if in.values().exists(_.isEmpty) =>
       Some(new AlwaysFalse())
-    case in @ InSubqueryExec(PushableColumnAndNestedColumn(name), _, _, _, _, _) =>
+    case in: InSubqueryExec =>
       val values = in.values().getOrElse {
         throw SparkException.internalError(
           s"Can't translate $in to v2 Predicate, no subquery result")
       }
-      val literals = values.map(LiteralValue(_, in.child.dataType))
-      Some(new Predicate("IN", FieldReference(name) +: literals))
-
+      // Type coercion of the join keys may wrap the pruning key in a cast, e.g.
+      // `cast(part_col as bigint) IN (...)` when an INT partition column joins a BIGINT key.
+      // The optimizer can't unwrap it as the values are only known now, so unwrap it here with
+      // the same rule the optimizer applies to `InSet` with literal values.
+      val inSet = InSet(in.child, values.toSet)
+      UnwrapCastInBinaryComparison.unwrapCast(inSet).getOrElse(inSet) match {
+        case InSet(col @ PushableColumnAndNestedColumn(name), hset) =>
+          val literals = hset.toArray.map(LiteralValue(_, col.dataType))
+          Some(new Predicate("IN", FieldReference(name) +: literals))
+        // The rule rewrites the filter to `if(isnull(col), null, false)` when none of the values
+        // is representable in the column type, so no row can match.
+        case And(IsNull(_), Literal(null, BooleanType)) =>
+          Some(new AlwaysFalse())
+        case _ =>
+          unsupportedRuntimeFilter(in)
+      }
     case other =>
-      logWarning(log"Can't translate ${MDC(EXPR, other)} to source filter, unsupported expression")
-      None
+      unsupportedRuntimeFilter(other)
+  }
+
+  private def unsupportedRuntimeFilter(expr: Expression): Option[Predicate] = {
+    logWarning(log"Can't translate ${MDC(EXPR, expr)} to source filter, unsupported expression")
+    None
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.LogKeys.EXPR
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier, ResolvedNamespace, ResolvedPartitionSpec, ResolvedPersistentView, ResolvedTable, ResolvedTempView}
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
 import org.apache.spark.sql.catalyst.expressions
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, DynamicPruning, Expression, InSet, IsNull, Literal, NamedExpression, Not, Or, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, DynamicPruning, Expression, InSet, NamedExpression, Not, Or, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.optimizer.UnwrapCastInBinaryComparison
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
@@ -52,7 +52,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
 import org.apache.spark.sql.metricview.logical.CreateMetricView
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
-import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SparkStringUtils
@@ -979,29 +978,33 @@ private[sql] object DataSourceV2Strategy extends Logging {
       None
     case in: InSubqueryExec if in.values().exists(_.isEmpty) =>
       Some(new AlwaysFalse())
-    case in: InSubqueryExec =>
-      val values = in.values().getOrElse {
-        throw SparkException.internalError(
-          s"Can't translate $in to v2 Predicate, no subquery result")
-      }
-      // Type coercion of the join keys may wrap the pruning key in a cast, e.g.
-      // `cast(part_col as bigint) IN (...)` when an INT partition column joins a BIGINT key.
-      // The optimizer can't unwrap it as the values are only known now, so unwrap it here with
-      // the same rule the optimizer applies to `InSet` with literal values.
-      val inSet = InSet(in.child, values.toSet)
-      UnwrapCastInBinaryComparison.unwrapCast(inSet).getOrElse(inSet) match {
-        case InSet(col @ PushableColumnAndNestedColumn(name), hset) =>
-          val literals = hset.toArray.map(LiteralValue(_, col.dataType))
-          Some(new Predicate("IN", FieldReference(name) +: literals))
-        // The rule rewrites the filter to `if(isnull(col), null, false)` when none of the values
-        // is representable in the column type, so no row can match.
-        case And(IsNull(_), Literal(null, BooleanType)) =>
-          Some(new AlwaysFalse())
+    case in @ InSubqueryExec(PushableColumnAndNestedColumn(name), _, _, _, _, _) =>
+      val literals = subqueryValues(in).map(LiteralValue(_, in.child.dataType))
+      Some(new Predicate("IN", FieldReference(name) +: literals))
+    // Type coercion of the join keys may wrap the pruning key in a cast, e.g.
+    // `cast(part_col as bigint) IN (...)` when an INT partition column joins a BIGINT key.
+    // The optimizer can't unwrap it as the values are only known now, so unwrap it here with
+    // the same code the optimizer applies to `InSet` with literal values.
+    case in @ InSubqueryExec(cast: Cast, _, _, _, _, _) =>
+      UnwrapCastInBinaryComparison.unwrapCastInSet(InSet(cast, subqueryValues(in).toSet)) match {
+        case Some((col @ PushableColumnAndNestedColumn(name), values)) =>
+          if (values.isEmpty) {
+            // no value is representable in the column type, so no row can match
+            Some(new AlwaysFalse())
+          } else {
+            val literals = values.toArray.map(LiteralValue(_, col.dataType))
+            Some(new Predicate("IN", FieldReference(name) +: literals))
+          }
         case _ =>
           unsupportedRuntimeFilter(in)
       }
+
     case other =>
       unsupportedRuntimeFilter(other)
+  }
+
+  private def subqueryValues(in: InSubqueryExec): Array[Any] = in.values().getOrElse {
+    throw SparkException.internalError(s"Can't translate $in to v2 Predicate, no subquery result")
   }
 
   private def unsupportedRuntimeFilter(expr: Expression): Option[Predicate] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode._
 import org.apache.spark.sql.catalyst.optimizer.BuildRight
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, Inner, LeftAnti}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.connector.catalog.{InMemoryTableCatalog, InMemoryTableCatalystRuntimeFilterCatalog, InMemoryTableWithV2FilterCatalog}
+import org.apache.spark.sql.connector.catalog.{BufferedRows, InMemoryTableCatalog, InMemoryTableCatalystRuntimeFilterCatalog, InMemoryTableWithV2FilterCatalog}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
@@ -2725,6 +2725,53 @@ abstract class DynamicPartitionPruningV2Suite extends DynamicPartitionPruningDat
         val scan = collectFactScan(df)
         assert(scan.filteredPartitions.flatten.isEmpty,
           s"expected all partitions pruned by the empty runtime filter, " +
+            s"got ${scan.filteredPartitions.flatten.size} of ${scan.inputPartitions.size}")
+      }
+    }
+  }
+
+  test("SPARK-59301: DPP prunes DSv2 partitions when the pruning key is wrapped in a cast") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      withTable("dim_big") {
+        // the BIGINT keys of NL include one that does not fit in the INT partition column
+        Seq[(Long, String)](
+          (1L, "NL"), (2L, "NL"), (Int.MaxValue + 1L, "NL"), (3L, "DE"), (Int.MaxValue + 2L, "XX"))
+          .toDF("store_id", "country")
+          .write
+          .format(tableFormat)
+          .saveAsTable("dim_big")
+
+        // the BIGINT dim key adds cast(f.store_id as bigint) on the pruning key, which the
+        // runtime filter translation unwraps, dropping the key that does not fit in INT
+        val df = sql(
+          """
+            |SELECT f.date_id, f.store_id FROM fact_sk f
+            |JOIN dim_big s ON f.store_id = s.store_id AND s.country = 'NL'
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df, withSubquery = true, withBroadcast = false)
+        checkAnswer(df, Row(1000, 1) :: Row(1010, 2) :: Row(1020, 2) :: Nil)
+
+        val partitionKeys = collectFactScan(df).filteredPartitions.flatten
+          .map(_.asInstanceOf[BufferedRows].keyString())
+        assert(partitionKeys.toSet === Set("1", "2"),
+          s"expected the runtime filter to keep partitions 1 and 2, got $partitionKeys")
+
+        // no key fits in INT, so no partition can match
+        val df2 = sql(
+          """
+            |SELECT f.date_id, f.store_id FROM fact_sk f
+            |JOIN dim_big s ON f.store_id = s.store_id AND s.country = 'XX'
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df2, withSubquery = true, withBroadcast = false)
+        checkAnswer(df2, Nil)
+
+        val scan = collectFactScan(df2)
+        assert(scan.filteredPartitions.flatten.isEmpty,
+          s"expected all partitions pruned by the runtime filter, " +
             s"got ${scan.filteredPartitions.flatten.size} of ${scan.inputPartitions.size}")
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -26,9 +26,10 @@ import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.catalyst.util.V2ExpressionBuilder
 import org.apache.spark.sql.connector.expressions.{Expression => V2Expression, FieldReference, GeneralScalarExpression, LiteralValue, VariantGet => V2VariantGet}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And => V2And, Not => V2Not, Or => V2Or, Predicate}
+import org.apache.spark.sql.execution.{InSubqueryExec, LocalTableScanExec, SubqueryExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongType, StringType, StructField, StructType, TimestampType, VariantType}
+import org.apache.spark.sql.types.{BooleanType, DoubleType, FloatType, IntegerType, LongType, StringType, StructField, StructType, TimestampType, VariantType}
 import org.apache.spark.unsafe.types.UTF8String
 
 class DataSourceV2StrategySuite extends SharedSparkSession {
@@ -1062,6 +1063,56 @@ class DataSourceV2StrategySuite extends SharedSparkSession {
     assertResult(result) {
       DataSourceV2Strategy.translateFilterV2(catalystFilter)
     }
+  }
+
+  test("SPARK-59301: translate runtime IN filter") {
+    attrInts.foreach { case (attr, name) =>
+      checkRuntimeFilter(runtimeFilter(attr, Array[Any](1, 2)), name,
+        Set(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType)))
+    }
+    // no subquery result, so no row can match
+    assert(DataSourceV2Strategy.translateRuntimeFilterV2(
+      runtimeFilter($"cint".int, Array.empty[Any])).contains(new AlwaysFalse()))
+  }
+
+  test("SPARK-59301: translate runtime IN filter on a cast column") {
+    // the values are converted to the column type, values out of its range are dropped and
+    // nulls are kept, the same as `UnwrapCastInBinaryComparison` does for `InSet`
+    attrInts.foreach { case (attr, name) =>
+      val in = runtimeFilter(Cast(attr, LongType), Array[Any](1L, 2L, Int.MaxValue + 1L, null))
+      checkRuntimeFilter(in, name, Set(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType),
+        LiteralValue(null, IntegerType)))
+    }
+    // values rounded by the conversion are dropped
+    checkRuntimeFilter(runtimeFilter(Cast($"cfloat".float, DoubleType), Array[Any](0.5d, 3.14d)),
+      "cfloat", Set(LiteralValue(0.5f, FloatType)))
+    // no value is representable in the column type, so no row can match
+    assert(DataSourceV2Strategy.translateRuntimeFilterV2(
+      runtimeFilter(Cast($"cint".int, LongType), Array[Any](Int.MaxValue + 1L)))
+      .contains(new AlwaysFalse()))
+    // the cast is not unwrapped when it is lossy
+    assert(DataSourceV2Strategy.translateRuntimeFilterV2(
+      runtimeFilter(Cast($"clong".long, DoubleType), Array[Any](1.0d))).isEmpty)
+    assert(DataSourceV2Strategy.translateRuntimeFilterV2(
+      runtimeFilter(Cast($"cint".int, StringType), Array[Any](UTF8String.fromString("1")))).isEmpty)
+  }
+
+  private def runtimeFilter(child: Expression, values: Array[Any]): InSubqueryExec = {
+    val plan = SubqueryExec("dpp", LocalTableScanExec(Nil, Nil, None))
+    InSubqueryExec(child, plan, ExprId(0), isDynamicPruning = true, resultBroadcast = null,
+      result = values)
+  }
+
+  private def checkRuntimeFilter(
+      in: InSubqueryExec,
+      column: String,
+      values: Set[LiteralValue[_]]): Unit = {
+    val predicate = DataSourceV2Strategy.translateRuntimeFilterV2(in).getOrElse {
+      fail(s"can't translate runtime filter: $in")
+    }
+    assert(predicate.name() == "IN")
+    assert(predicate.children().head == FieldReference(column))
+    assert(predicate.children().tail.toSet == values)
   }
 
   private def checkV2Conversion(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -1070,6 +1070,11 @@ class DataSourceV2StrategySuite extends SharedSparkSession {
       checkRuntimeFilter(runtimeFilter(attr, Array[Any](1, 2)), name,
         Set(LiteralValue(1, IntegerType), LiteralValue(2, IntegerType)))
     }
+    // the values are pushed as given
+    val predicate = DataSourceV2Strategy.translateRuntimeFilterV2(
+      runtimeFilter($"cint".int, Array[Any](2, 1, 2))).get
+    assert(predicate.children().toSeq == Seq(FieldReference("cint"),
+      LiteralValue(2, IntegerType), LiteralValue(1, IntegerType), LiteralValue(2, IntegerType)))
     // no subquery result, so no row can match
     assert(DataSourceV2Strategy.translateRuntimeFilterV2(
       runtimeFilter($"cint".int, Array.empty[Any])).contains(new AlwaysFalse()))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Type coercion of the join keys may wrap the pruning key of dynamic partition pruning (DPP) in a
cast, e.g. `cast(f.store_id as bigint) IN dynamicpruning#1` when an INT partition column joins a
BIGINT key. `DataSourceV2Strategy.translateRuntimeFilterV2` only translated a bare (nested)
column, so such a filter was never pushed to the source and the scan read all partitions.

This PR adds `UnwrapCastInBinaryComparison.unwrapCastInSet`, which unwraps the cast of
`InSet(Cast(col, toType), values)` and returns the column with the values converted to its type.
The rule's own `InSet` branch is rewritten on top of it, so the optimizer and the runtime path
share one function. Values that do not round-trip (out of range, rounded) are dropped and nulls
are kept, so the supported casts are the rule's (numeric and boolean upcasts, excluding the
lossy INT to FLOAT and LONG to FLOAT/DOUBLE).

`translateRuntimeFilterV2` calls it for an `InSubqueryExec` whose child is a `Cast`, once the
subquery result is known:

- when values survive, they are pushed as `IN(col, values)` in the column type;
- when none survives, no row can match and `AlwaysFalse` is pushed;
- when the cast cannot be unwrapped, the filter stays untranslated, as before.

A bare column takes the existing path unchanged.

### Why are the changes needed?

A DSv2 scan showed `dynamicpruningexpression(cast(store_id as bigint) IN ...)` in the plan, yet
the runtime filter never reached the source, so all partitions were scanned.

### Does this PR introduce _any_ user-facing change?

Yes. DSv2 sources now receive runtime IN filters whose pruning key is wrapped in a lossless
numeric cast, so the scan prunes partitions instead of reading all of them. Query results do not
change.

### How was this patch tested?

- New unit tests for `translateRuntimeFilterV2` in `DataSourceV2StrategySuite`: bare and nested
  columns, cast unwrapping with out-of-range, rounded and null values, all values dropped, and
  lossy casts that must not be unwrapped.
- New end-to-end test in `DynamicPartitionPruningV2Suite`, which runs against the in-memory
  tables taking runtime filters as V1 filters and V2 predicates, with AQE on and off. The
  Catalyst-expression variant runs it too but evaluates the cast itself.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1
