### PR TITLE
[SPARK-59303][K8S] Support `spark.kubernetes.executor.resizeMaxMemory` in `ExecutorResizePlugin`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1876,6 +1876,17 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>4.2.0</td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.executor.resizeMaxMemory</code></td>
+  <td><code>Long.MaxValue</code></td>
+  <td>
+    The upper bound of the executor container memory limit that the resize plugin can grow to.
+    By default, it is <code>Long.MaxValue</code>, which means no upper bound.
+    Takes effect only when <code>org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin</code>
+    is registered via <code>spark.plugins</code>.
+  </td>
+  <td>4.4.0</td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.executor.pvc.resizeInterval</code></td>
   <td><code>5min</code></td>
   <td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{ConfigBindingPolicy, ConfigBuilder, DYN_ALLOCATION_ENABLED}
+import org.apache.spark.network.util.ByteUnit
 
 private[spark] object Config extends Logging {
 
@@ -305,6 +306,15 @@ private[spark] object Config extends Logging {
       .doubleConf
       .checkValue(v => 0 < v && v <= 1, "The factor should be in (0, 1]")
       .createWithDefault(0.1)
+
+  val EXECUTOR_RESIZE_MAX_MEMORY =
+    ConfigBuilder("spark.kubernetes.executor.resizeMaxMemory")
+      .doc("The upper bound of the executor container memory limit that the resize plugin " +
+        "can grow to. By default, it is Long.MaxValue, which means no upper bound.")
+      .version("4.4.0")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(_ > 0, "The maximum memory should be positive")
+      .createWithDefault(Long.MaxValue)
 
   val PVC_RESIZE_INTERVAL =
     ConfigBuilder("spark.kubernetes.executor.pvc.resizeInterval")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
@@ -107,6 +107,11 @@ class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
       .list()
       .getItems.asScala
 
+    // Drop executors that no longer exist so that cappedExecutors does not grow unbounded.
+    cappedExecutors.retainAll(pods.flatMap { p =>
+      Option(p.getMetadata.getLabels.get(SPARK_EXECUTOR_ID_LABEL))
+    }.toSet.asJava)
+
     pods.filter(_.getMetadata.getLabels.get(SPARK_EXECUTOR_ID_LABEL) != null).foreach { pod =>
       val execId = pod.getMetadata.getLabels.get(SPARK_EXECUTOR_ID_LABEL)
       try {
@@ -129,42 +134,44 @@ class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
               c.getResources.getLimits.containsKey("memory")).foreach { c =>
             val limit = Quantity.getAmountInBytes(c.getResources.getLimits.get("memory"))
                 .longValue()
-            if (usage > limit * threshold && limit >= maxMemory) {
-              if (cappedExecutors.add(execId)) {
-                logInfo(log"Skip resizing executor ${MDC(EXECUTOR_ID, execId)} as container " +
-                  log"memory limit ${MDC(MEMORY_SIZE, limit)} already reached the maximum " +
-                  log"${MDC(MAX_MEMORY_SIZE, maxMemory)}.")
-              }
-            } else if (usage > limit * threshold) {
-              val newLimit = math.min((limit * (1.0 + factor)).toLong, maxMemory)
-              val newQuantity = new Quantity(newLimit.toString)
+            if (usage > limit * threshold) {
+              if (limit >= maxMemory) {
+                if (cappedExecutors.add(execId)) {
+                  logInfo(log"Skip resizing executor ${MDC(EXECUTOR_ID, execId)} as container " +
+                    log"memory limit ${MDC(MEMORY_SIZE, limit)} already reached the maximum " +
+                    log"${MDC(MAX_MEMORY_SIZE, maxMemory)}.")
+                }
+              } else {
+                val newLimit = math.min((limit * (1.0 + factor)).toLong, maxMemory)
+                val newQuantity = new Quantity(newLimit.toString)
 
-              logInfo(log"Increase executor ${MDC(EXECUTOR_ID, execId)} container memory " +
-                log"from ${MDC(MEMORY_SIZE, limit)} to ${MDC(MEMORY_SIZE, newLimit)} " +
-                log"as usage ${MDC(MEMORY_SIZE, usage)} exceeded threshold.")
+                logInfo(log"Increase executor ${MDC(EXECUTOR_ID, execId)} container memory " +
+                  log"from ${MDC(MEMORY_SIZE, limit)} to ${MDC(MEMORY_SIZE, newLimit)} " +
+                  log"as usage ${MDC(MEMORY_SIZE, usage)} exceeded threshold.")
 
-              // Patch the pod to update both memory request and limit
-              try {
-                kubernetesClient.pods()
-                  .inNamespace(namespace)
-                  .withName(pod.getMetadata.getName)
-                  .subresource("resize")
-                  .patch(PatchContext.of(PatchType.STRATEGIC_MERGE), new PodBuilder()
-                    .withNewMetadata()
-                    .endMetadata()
-                    .withNewSpec()
-                    .addNewContainer()
-                    .withName(c.getName)
-                    .withNewResources()
-                    .addToLimits("memory", newQuantity)
-                    .addToRequests("memory", newQuantity)
-                    .endResources()
-                    .endContainer()
-                    .endSpec()
-                    .build())
-              } catch {
-                case e: Throwable =>
-                  logInfo(log"Failed to update ${MDC(EXECUTOR_ID, execId)}", e)
+                // Patch the pod to update both memory request and limit
+                try {
+                  kubernetesClient.pods()
+                    .inNamespace(namespace)
+                    .withName(pod.getMetadata.getName)
+                    .subresource("resize")
+                    .patch(PatchContext.of(PatchType.STRATEGIC_MERGE), new PodBuilder()
+                      .withNewMetadata()
+                      .endMetadata()
+                      .withNewSpec()
+                      .addNewContainer()
+                      .withName(c.getName)
+                      .withNewResources()
+                      .addToLimits("memory", newQuantity)
+                      .addToRequests("memory", newQuantity)
+                      .endResources()
+                      .endContainer()
+                      .endSpec()
+                      .build())
+                } catch {
+                  case e: Throwable =>
+                    logInfo(log"Failed to update ${MDC(EXECUTOR_ID, execId)}", e)
+                }
               }
             } else {
               logDebug(log"Executor ${MDC(EXECUTOR_ID, execId)} limit " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.{Map => JMap}
-import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 
 import scala.jdk.CollectionConverters._
 
@@ -31,7 +31,7 @@ import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext,
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{CLASS_NAME, CONFIG, CONFIG2, EXECUTOR_ID, MEMORY_SIZE}
+import org.apache.spark.internal.LogKeys.{CLASS_NAME, CONFIG, CONFIG2, EXECUTOR_ID, MAX_MEMORY_SIZE, MEMORY_SIZE}
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
@@ -46,6 +46,10 @@ class ExecutorResizePlugin extends SparkPlugin {
 
 class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
   private var sparkContext: SparkContext = _
+  private var maxMemory: Long = Long.MaxValue
+
+  // Executors whose memory limit already reached maxMemory, to log the skip only once.
+  private val cappedExecutors = ConcurrentHashMap.newKeySet[String]()
 
   private val periodicService: ScheduledExecutorService =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("executor-resize-plugin")
@@ -63,6 +67,7 @@ class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
       sc.conf.get(EXECUTOR_RESIZE_INTERVAL.key, "1m"))
     val threshold = sc.conf.getDouble(EXECUTOR_RESIZE_THRESHOLD.key, 0.9)
     val factor = sc.conf.getDouble(EXECUTOR_RESIZE_FACTOR.key, 0.1)
+    maxMemory = sc.conf.get(EXECUTOR_RESIZE_MAX_MEMORY)
     val namespace = sc.conf.get(KUBERNETES_NAMESPACE)
 
     // Scheduler is not created yet at init time; resolve it lazily in the periodic task.
@@ -124,8 +129,14 @@ class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
               c.getResources.getLimits.containsKey("memory")).foreach { c =>
             val limit = Quantity.getAmountInBytes(c.getResources.getLimits.get("memory"))
                 .longValue()
-            if (usage > limit * threshold) {
-              val newLimit = (limit * (1.0 + factor)).toLong
+            if (usage > limit * threshold && limit >= maxMemory) {
+              if (cappedExecutors.add(execId)) {
+                logInfo(log"Skip resizing executor ${MDC(EXECUTOR_ID, execId)} as container " +
+                  log"memory limit ${MDC(MEMORY_SIZE, limit)} already reached the maximum " +
+                  log"${MDC(MAX_MEMORY_SIZE, maxMemory)}.")
+              }
+            } else if (usage > limit * threshold) {
+              val newLimit = math.min((limit * (1.0 + factor)).toLong, maxMemory)
               val newQuantity = new Quantity(newLimit.toString)
 
               logInfo(log"Increase executor ${MDC(EXECUTOR_ID, execId)} container memory " +

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePluginSuite.scala
@@ -330,16 +330,26 @@ class ExecutorResizePluginSuite
     val podResource = mock(classOf[SINGLE_POD])
     when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
 
-    val logAppender = new LogAppender
-    withLogAppender(logAppender) {
-      plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
-      plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
+    def countSkipLogs(rounds: Int): Int = {
+      val logAppender = new LogAppender
+      withLogAppender(logAppender) {
+        (1 to rounds).foreach { _ =>
+          plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
+        }
+      }
+      logAppender.loggingEvents
+        .count(_.getMessage.getFormattedMessage.contains("already reached the maximum"))
     }
 
+    // Logged only once across repeated rounds.
+    assert(countSkipLogs(2) === 1)
     verify(podResource, never()).patch(any(), any(classOf[Pod]))
-    val skipLogs = logAppender.loggingEvents
-      .filter(_.getMessage.getFormattedMessage.contains("already reached the maximum"))
-    assert(skipLogs.size === 1)
+
+    // Once the executor disappears, its capped state is forgotten and logged again on return.
+    when(podList.getItems).thenReturn(Collections.emptyList())
+    assert(countSkipLogs(1) === 0)
+    when(podList.getItems).thenReturn(Collections.singletonList(pod))
+    assert(countSkipLogs(2) === 1)
   }
 
   Seq("statefulset", "deployment").foreach { allocator =>

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePluginSuite.scala
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.{ContainerMetrics, PodMetrics}
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.{MetricAPIGroupDSL, PodMetricOperation}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{mock, never, times, verify, when}
 import org.scalatest.BeforeAndAfter
@@ -77,12 +78,23 @@ class ExecutorResizePluginSuite
     when(topOperations.pods()).thenReturn(podMetricOperations)
   }
 
-  private def createPlugin(): ExecutorResizeDriverPlugin = {
+  private def createPlugin(maxMemory: Long = Long.MaxValue): ExecutorResizeDriverPlugin = {
     val plugin = new ExecutorResizeDriverPlugin()
     val scField = plugin.getClass.getDeclaredField("sparkContext")
     scField.setAccessible(true)
     scField.set(plugin, sparkContext)
+    val maxField = plugin.getClass.getDeclaredField("maxMemory")
+    maxField.setAccessible(true)
+    maxField.setLong(plugin, maxMemory)
     plugin
+  }
+
+  private def verifyPatchedMemory(podResource: SINGLE_POD, expected: Long): Unit = {
+    val captor = ArgumentCaptor.forClass(classOf[Pod])
+    verify(podResource, times(1)).patch(any(), captor.capture())
+    val resources = captor.getValue.getSpec.getContainers.get(0).getResources
+    assert(Quantity.getAmountInBytes(resources.getLimits.get("memory")).longValue() === expected)
+    assert(Quantity.getAmountInBytes(resources.getRequests.get("memory")).longValue() === expected)
   }
 
   private def createPodWithMemoryLimit(
@@ -177,7 +189,8 @@ class ExecutorResizePluginSuite
 
     plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
-    verify(podResource, times(1)).patch(any(), any(classOf[Pod]))
+    // 1GB * (1 + 0.1) = 1.1GB
+    verifyPatchedMemory(podResource, 1100000000L)
   }
 
   test("Memory usage exactly at threshold should not trigger resize") {
@@ -286,6 +299,47 @@ class ExecutorResizePluginSuite
     plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource, times(1)).patch(any(), any(classOf[Pod]))
+  }
+
+  test("SPARK-59303: Resize is clamped to resizeMaxMemory") {
+    val plugin = createPlugin(maxMemory = 1050000000L) // 1.05GB cap
+    val pod = createPodWithMemoryLimit(1, "1000000000") // 1GB limit
+    val metrics = createPodMetrics("spark-executor-1", "950000000") // 95% usage
+
+    when(podList.getItems).thenReturn(Collections.singletonList(pod))
+    when(podMetricOperations.metrics(namespace, "spark-executor-1")).thenReturn(metrics)
+
+    val podResource = mock(classOf[SINGLE_POD])
+    when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
+    when(podResource.subresource(anyString())).thenReturn(podResource)
+
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
+
+    // 1GB * (1 + 0.1) = 1.1GB exceeds the cap, so the new limit is clamped to 1.05GB
+    verifyPatchedMemory(podResource, 1050000000L)
+  }
+
+  test("SPARK-59303: Resize is skipped and logged once when limit already at resizeMaxMemory") {
+    val plugin = createPlugin(maxMemory = 1000000000L) // 1GB cap
+    val pod = createPodWithMemoryLimit(1, "1000000000") // 1GB limit
+    val metrics = createPodMetrics("spark-executor-1", "950000000") // 95% usage
+
+    when(podList.getItems).thenReturn(Collections.singletonList(pod))
+    when(podMetricOperations.metrics(namespace, "spark-executor-1")).thenReturn(metrics)
+
+    val podResource = mock(classOf[SINGLE_POD])
+    when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
+
+    val logAppender = new LogAppender
+    withLogAppender(logAppender) {
+      plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
+      plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
+    }
+
+    verify(podResource, never()).patch(any(), any(classOf[Pod]))
+    val skipLogs = logAppender.loggingEvents
+      .filter(_.getMessage.getFormattedMessage.contains("already reached the maximum"))
+    assert(skipLogs.size === 1)
   }
 
   Seq("statefulset", "deployment").foreach { allocator =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a configurable upper bound to `ExecutorResizePlugin`.

| Config | Default |
|---|---|
| `spark.kubernetes.executor.resizeMaxMemory` | `Long.MaxValue` (no upper bound) |

When the computed new memory limit exceeds the cap, it is clamped to the cap. When the current limit is already at or above the cap, the resize is skipped and an INFO message is logged once per executor instead of on every interval.

### Why are the changes needed?

`ExecutorResizePlugin` currently only grows the executor container memory limit with no maximum. As long as usage stays above the threshold, the limit keeps growing without bound. An upper bound lets users adopt the plugin safely with a predictable worst-case memory footprint.

### Does this PR introduce _any_ user-facing change?

No. The new config defaults to `Long.MaxValue`, so the existing behavior is unchanged unless a user sets it.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1