### PR TITLE
[SPARK-59304][K8S] Support `spark.kubernetes.executor.pvc.resizeMaxStorage` in `ExecutorPVCResizePlugin`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1906,6 +1906,17 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td>4.2.0</td>
 </tr>
+<tr>
+  <td><code>spark.kubernetes.executor.pvc.resizeMaxStorage</code></td>
+  <td><code>Long.MaxValue</code></td>
+  <td>
+    The upper bound of the PVC storage request that the resize plugin can grow to.
+    By default, it is <code>Long.MaxValue</code>, which means no upper bound.
+    Takes effect only when <code>org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin</code>
+    is registered via <code>spark.plugins</code>.
+  </td>
+  <td>4.4.0</td>
+</tr>
 </table>
 
 #### Pod template properties

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{ConfigBindingPolicy, ConfigBuilder, DYN_ALLOCATION_ENABLED}
+import org.apache.spark.network.util.ByteUnit
 
 private[spark] object Config extends Logging {
 
@@ -332,6 +333,15 @@ private[spark] object Config extends Logging {
       .doubleConf
       .checkValue(v => 0 < v && v <= 1, "The factor should be in (0, 1]")
       .createWithDefault(1.0)
+
+  val PVC_RESIZE_MAX_STORAGE =
+    ConfigBuilder("spark.kubernetes.executor.pvc.resizeMaxStorage")
+      .doc("The upper bound of the PVC storage request that the resize plugin can grow to. " +
+        "By default, it is Long.MaxValue, which means no upper bound.")
+      .version("4.4.0")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(_ > 0, "The maximum storage should be positive")
+      .createWithDefault(Long.MaxValue)
 
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePlugin.scala
@@ -31,7 +31,7 @@ import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext,
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{CONFIG, CONFIG2, CURRENT_DISK_SIZE, ORIGINAL_DISK_SIZE, PVC_METADATA_NAME}
+import org.apache.spark.internal.LogKeys.{CONFIG, CONFIG2, CURRENT_DISK_SIZE, MAX_SIZE, ORIGINAL_DISK_SIZE, PVC_METADATA_NAME}
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -65,9 +65,12 @@ class ExecutorPVCResizeDriverPlugin extends DriverPlugin with Logging {
   private var namespace: String = _
   private var threshold: Double = _
   private var factor: Double = _
+  private var maxStorage: Long = Long.MaxValue
 
   private val latestReports = new ConcurrentHashMap[String, PVCDiskUsageReport]()
   private val failedPvcs = ConcurrentHashMap.newKeySet[String]()
+  // PVCs whose storage request already reached maxStorage, to log the skip only once.
+  private val cappedPvcs = ConcurrentHashMap.newKeySet[String]()
   private val requestedSizes = new ConcurrentHashMap[String, Long]()
 
   private val periodicService: ScheduledExecutorService =
@@ -88,6 +91,7 @@ class ExecutorPVCResizeDriverPlugin extends DriverPlugin with Logging {
     }
     threshold = sc.conf.get(PVC_RESIZE_THRESHOLD)
     factor = sc.conf.get(PVC_RESIZE_FACTOR)
+    maxStorage = sc.conf.get(PVC_RESIZE_MAX_STORAGE)
     namespace = sc.conf.get(KUBERNETES_NAMESPACE)
     sparkContext = sc
 
@@ -187,7 +191,15 @@ class ExecutorPVCResizeDriverPlugin extends DriverPlugin with Logging {
           s"(spec=$current, status=$capacity); skip.")
         return
       }
-      val newSize = (current * (1.0 + factor)).toLong
+      if (current >= maxStorage) {
+        if (cappedPvcs.add(pvcName)) {
+          logInfo(log"Skip resizing PVC ${MDC(PVC_METADATA_NAME, pvcName)} as storage " +
+            log"${MDC(CURRENT_DISK_SIZE, current)} already reached the maximum " +
+            log"${MDC(MAX_SIZE, maxStorage)}.")
+        }
+        return
+      }
+      val newSize = math.min((current * (1.0 + factor)).toLong, maxStorage)
       if (requestedSizes.get(pvcName) == newSize) return
       logInfo(log"Increase PVC ${MDC(PVC_METADATA_NAME, pvcName)} storage " +
         log"from ${MDC(ORIGINAL_DISK_SIZE, current)} to " +

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
@@ -255,6 +255,19 @@ class ExecutorPVCResizePluginSuite
     assert(patchedStorage(resource) === 1050000000L)
   }
 
+  test("SPARK-59304: Resize is not clamped when new size is below resizeMaxStorage") {
+    val plugin = createPlugin(threshold = 0.9, factor = 0.1, maxStorage = 2000000000L) // 2GB
+    val pod = createPodWithPVC(1, "pvc-1", "/data")
+    when(podList.getItems).thenReturn(Collections.singletonList(pod))
+    val resource = mockPvcResource("pvc-1", "1000000000") // 1GB
+    plugin.receive(PVCDiskUsageReport("1", 0.95)) // 95%
+
+    plugin.checkAndResizePVCs()
+
+    // 1GB * (1 + 0.1) = 1.1GB is below the 2GB cap, so it is applied as-is.
+    assert(patchedStorage(resource) === 1100000000L)
+  }
+
   test("SPARK-59304: Resize is skipped and logged once when storage already at resizeMaxStorage") {
     val plugin = createPlugin(maxStorage = 1000000000L) // 1GB cap
     val pod = createPodWithPVC(1, "pvc-1", "/data")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
@@ -73,14 +73,23 @@ class ExecutorPVCResizePluginSuite
 
   private def createPlugin(
       threshold: Double = 0.9,
-      factor: Double = 0.1): ExecutorPVCResizeDriverPlugin = {
+      factor: Double = 0.1,
+      maxStorage: Long = Long.MaxValue): ExecutorPVCResizeDriverPlugin = {
     val plugin = new ExecutorPVCResizeDriverPlugin()
     val cls = plugin.getClass
     setField(cls, plugin, "sparkContext", sparkContext)
     setField(cls, plugin, "namespace", namespace)
     setField(cls, plugin, "threshold", threshold)
     setField(cls, plugin, "factor", factor)
+    setField(cls, plugin, "maxStorage", maxStorage)
     plugin
+  }
+
+  private def patchedStorage(resource: Resource[PersistentVolumeClaim]): Long = {
+    val captor = ArgumentCaptor.forClass(classOf[PersistentVolumeClaim])
+    verify(resource, times(1)).patch(any(), captor.capture())
+    Quantity.getAmountInBytes(
+      captor.getValue.getSpec.getResources.getRequests.get("storage")).longValue()
   }
 
   private def setField(cls: Class[_], obj: Any, name: String, value: Any): Unit = {
@@ -231,6 +240,38 @@ class ExecutorPVCResizePluginSuite
 
     // Only one patch attempt despite two check rounds.
     verify(resource, times(1)).patch(any(), any(classOf[PersistentVolumeClaim]))
+  }
+
+  test("SPARK-59304: Resize is clamped to resizeMaxStorage") {
+    val plugin = createPlugin(threshold = 0.9, factor = 0.1, maxStorage = 1050000000L) // 1.05GB
+    val pod = createPodWithPVC(1, "pvc-1", "/data")
+    when(podList.getItems).thenReturn(Collections.singletonList(pod))
+    val resource = mockPvcResource("pvc-1", "1000000000") // 1GB
+    plugin.receive(PVCDiskUsageReport("1", 0.95)) // 95%
+
+    plugin.checkAndResizePVCs()
+
+    // 1GB * (1 + 0.1) = 1.1GB exceeds the cap, so the new size is clamped to 1.05GB
+    assert(patchedStorage(resource) === 1050000000L)
+  }
+
+  test("SPARK-59304: Resize is skipped and logged once when storage already at resizeMaxStorage") {
+    val plugin = createPlugin(maxStorage = 1000000000L) // 1GB cap
+    val pod = createPodWithPVC(1, "pvc-1", "/data")
+    when(podList.getItems).thenReturn(Collections.singletonList(pod))
+    val resource = mockPvcResource("pvc-1", "1000000000") // 1GB
+    plugin.receive(PVCDiskUsageReport("1", 0.95)) // 95%
+
+    val logAppender = new LogAppender
+    withLogAppender(logAppender) {
+      plugin.checkAndResizePVCs()
+      plugin.checkAndResizePVCs()
+    }
+
+    verify(resource, never()).patch(any(), any(classOf[PersistentVolumeClaim]))
+    val skipLogs = logAppender.loggingEvents
+      .filter(_.getMessage.getFormattedMessage.contains("already reached the maximum"))
+    assert(skipLogs.size === 1)
   }
 
   test("Pod with no PVC volume triggers no patch") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a configurable upper bound to `ExecutorPVCResizePlugin` so that the PVC storage request cannot grow beyond a given size.

| Config | Default |
| --- | --- |
| `spark.kubernetes.executor.pvc.resizeMaxStorage` | `Long.MaxValue` (no upper bound) |

- When the computed new storage request (`current * (1 + resizeFactor)`) exceeds the cap, it is clamped to the cap.
- When the current storage request is already at or above the cap, the resize is skipped and an INFO message is logged once per PVC.

This is a sub-task of SPARK-55555 (Support heterogeneous K8s executor management).

### Why are the changes needed?

Currently, the plugin only grows the PVC storage request by `resizeFactor` whenever the usage ratio exceeds the threshold, with no maximum. An upper bound gives users a predictable worst-case storage footprint per executor PVC.

### Does this PR introduce _any_ user-facing change?

No. The new config defaults to `Long.MaxValue`, which preserves the existing behavior.

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1