### PR TITLE
[SPARK-59277][SQL][HIVE] Support first-class CHAR/VARCHAR in Hive extensions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -201,7 +201,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
   private lazy val outputFieldWriters: Seq[String => Any] = output.map { attr =>
     val converter = CatalystTypeConverters.createToCatalystConverter(attr.dataType)
     attr.dataType match {
-      case StringType => wrapperConvertException(data => data, converter)
+      case _: StringType => wrapperConvertException(data => data, converter)
       case BooleanType => wrapperConvertException(data => data.toBoolean, converter)
       case ByteType => wrapperConvertException(data => data.toByte, converter)
       case BinaryType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -86,6 +86,24 @@ abstract class BaseScriptTransformationSuite extends QueryTest {
     assert(uncaughtExceptionHandler.exception.isEmpty)
   }
 
+  test("SPARK-59277: TRANSFORM output supports first-class CHAR/VARCHAR without SerDe") {
+    assume(TestUtils.testCommandAvailable("/bin/bash"))
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val input = Seq(("ab", "xyz")).toDF("c", "v")
+      checkAnswer(
+        input,
+        (child: SparkPlan) => createScriptTransformationExec(
+          script = "cat",
+          output = Seq(
+            AttributeReference("c", CharType(4, "UTF8_LCASE"))(),
+            AttributeReference("v", VarcharType(5, "UNICODE_CI"))()),
+          child = child,
+          ioschema = defaultIOSchema),
+        Seq(Row("ab  ", "xyz")))
+    }
+    assert(uncaughtExceptionHandler.exception.isEmpty)
+  }
+
   test("script transformation should not swallow errors from upstream operators (no serde)") {
     assume(TestUtils.testCommandAvailable("/bin/bash"))
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.common.`type`.{HiveChar, HiveDecimal, HiveInterval
 import org.apache.hadoop.hive.serde2.{io => hiveIo}
 import org.apache.hadoop.hive.serde2.objectinspector.{StructField => HiveStructField, _}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
-import org.apache.hadoop.hive.serde2.typeinfo.{DecimalTypeInfo, TypeInfoFactory}
+import org.apache.hadoop.hive.serde2.typeinfo.{CharTypeInfo, DecimalTypeInfo, TypeInfoFactory, VarcharTypeInfo}
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.execution.datasources.DaysWritable
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.TimestampNanosVal
@@ -102,10 +103,6 @@ import org.apache.spark.unsafe.types.UTF8String
  *   Map: java.util.Map
  *   Struct: Object[] / java.util.List / java POJO
  *   Union: class StandardUnion { byte tag; Object object }
- *
- * NOTICE: HiveVarchar/HiveChar is not supported by catalyst, it will be simply considered as
- *  String type.
- *
  *
  * 2. Hive ObjectInspector is a group of flexible APIs to inspect value in different data
  *  representation, and developers can extend those API as needed, so technically,
@@ -280,7 +277,6 @@ private[hive] trait HiveInspectors {
       (o: Any) =>
         x.getWritableConstantValue
     case x: PrimitiveObjectInspector => x match {
-      // TODO we don't support the HiveVarcharObjectInspector yet.
       case _: StringObjectInspector if x.preferWritable() =>
         withNullSafe(o => getStringWritable(o))
       case _: StringObjectInspector =>
@@ -313,21 +309,28 @@ private[hive] trait HiveInspectors {
         withNullSafe(o => getByteWritable(o))
       case _: ByteObjectInspector =>
         withNullSafe(o => o.asInstanceOf[java.lang.Byte])
-        // To spark HiveVarchar and HiveChar are same as string
-      case _: HiveVarcharObjectInspector if x.preferWritable() =>
-        withNullSafe(o => getStringWritable(o))
-      case _: HiveVarcharObjectInspector =>
+      case hvoi: HiveVarcharObjectInspector if x.preferWritable() =>
+        val length = hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength
         withNullSafe { o =>
-            val s = o.asInstanceOf[UTF8String].toString
-            new HiveVarchar(s, s.length)
+          val varchar = new HiveVarchar(o.asInstanceOf[UTF8String].toString, length)
+          new hiveIo.HiveVarcharWritable(varchar)
         }
-      case _: HiveCharObjectInspector if x.preferWritable() =>
-        withNullSafe(o => getStringWritable(o))
-      case _: HiveCharObjectInspector =>
+      case hvoi: HiveVarcharObjectInspector =>
+        val length = hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength
         withNullSafe { o =>
-            val s = o.asInstanceOf[UTF8String].toString
-            new HiveChar(s, s.length)
-          }
+          new HiveVarchar(o.asInstanceOf[UTF8String].toString, length)
+        }
+      case hcoi: HiveCharObjectInspector if x.preferWritable() =>
+        val length = hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength
+        withNullSafe { o =>
+          val char = new HiveChar(o.asInstanceOf[UTF8String].toString, length)
+          new hiveIo.HiveCharWritable(char)
+        }
+      case hcoi: HiveCharObjectInspector =>
+        val length = hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength
+        withNullSafe { o =>
+          new HiveChar(o.asInstanceOf[UTF8String].toString, length)
+        }
       case _: JavaHiveDecimalObjectInspector =>
         withNullSafe(o =>
           HiveDecimal.create(o.asInstanceOf[Decimal].toJavaBigDecimal))
@@ -939,7 +942,14 @@ private[hive] trait HiveInspectors {
     case MapType(keyType, valueType, _) =>
       ObjectInspectorFactory.getStandardMapObjectInspector(
         toInspector(keyType), toInspector(valueType))
-    case StringType => PrimitiveObjectInspectorFactory.javaStringObjectInspector
+    // Hive object inspectors preserve the CHAR/VARCHAR length but have no collation metadata.
+    case c: CharType =>
+      PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(
+        TypeInfoFactory.getCharTypeInfo(c.length))
+    case v: VarcharType =>
+      PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(
+        TypeInfoFactory.getVarcharTypeInfo(v.length))
+    case _: StringType => PrimitiveObjectInspectorFactory.javaStringObjectInspector
     case IntegerType => PrimitiveObjectInspectorFactory.javaIntObjectInspector
     case DoubleType => PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
     case BooleanType => PrimitiveObjectInspectorFactory.javaBooleanObjectInspector
@@ -986,7 +996,11 @@ private[hive] trait HiveInspectors {
    * @return Hive java objectinspector (recursively).
    */
   def toInspector(expr: Expression): ObjectInspector = expr match {
-    case Literal(value, StringType) =>
+    case Literal(value, c: CharType) =>
+      getHiveCharWritableConstantObjectInspector(value, c.length)
+    case Literal(value, v: VarcharType) =>
+      getHiveVarcharWritableConstantObjectInspector(value, v.length)
+    case Literal(value, _: StringType) =>
       getStringWritableConstantObjectInspector(value)
     case Literal(value, IntegerType) =>
       getIntWritableConstantObjectInspector(value)
@@ -1088,10 +1102,14 @@ private[hive] trait HiveInspectors {
         inspectorToDataType(m.getMapValueObjectInspector))
     case _: WritableStringObjectInspector => StringType
     case _: JavaStringObjectInspector => StringType
-    case _: WritableHiveVarcharObjectInspector => StringType
-    case _: JavaHiveVarcharObjectInspector => StringType
-    case _: WritableHiveCharObjectInspector => StringType
-    case _: JavaHiveCharObjectInspector => StringType
+    // Hive object inspectors cannot represent collations, so Hive function results use the
+    // default collation while preserving CHAR/VARCHAR length under first-class semantics.
+    case hvoi: HiveVarcharObjectInspector if SQLConf.get.charVarcharFirstClassTypes =>
+      VarcharType(hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength)
+    case _: HiveVarcharObjectInspector => StringType
+    case hcoi: HiveCharObjectInspector if SQLConf.get.charVarcharFirstClassTypes =>
+      CharType(hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength)
+    case _: HiveCharObjectInspector => StringType
     case _: WritableIntObjectInspector => IntegerType
     case _: JavaIntObjectInspector => IntegerType
     case _: WritableDoubleObjectInspector => DoubleType
@@ -1130,6 +1148,32 @@ private[hive] trait HiveInspectors {
   private def getStringWritableConstantObjectInspector(value: Any): ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.stringTypeInfo, getStringWritable(value))
+
+  private def getHiveCharWritableConstantObjectInspector(
+      value: Any,
+      length: Int): ObjectInspector = {
+    val writable = if (value == null) {
+      null
+    } else {
+      new hiveIo.HiveCharWritable(
+        new HiveChar(value.asInstanceOf[UTF8String].toString, length))
+    }
+    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
+      TypeInfoFactory.getCharTypeInfo(length), writable)
+  }
+
+  private def getHiveVarcharWritableConstantObjectInspector(
+      value: Any,
+      length: Int): ObjectInspector = {
+    val writable = if (value == null) {
+      null
+    } else {
+      new hiveIo.HiveVarcharWritable(
+        new HiveVarchar(value.asInstanceOf[UTF8String].toString, length))
+    }
+    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
+      TypeInfoFactory.getVarcharTypeInfo(length), writable)
+  }
 
   private def getIntWritableConstantObjectInspector(value: Any): ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
@@ -1296,7 +1340,9 @@ private[hive] trait HiveInspectors {
       case IntegerType => intTypeInfo
       case LongType => longTypeInfo
       case ShortType => shortTypeInfo
-      case StringType => stringTypeInfo
+      case c: CharType => getCharTypeInfo(c.length)
+      case v: VarcharType => getVarcharTypeInfo(v.length)
+      case _: StringType => stringTypeInfo
       case d: DecimalType => decimalTypeInfo(d)
       case DateType => dateTypeInfo
       case TimestampType => timestampTypeInfo

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -312,7 +312,7 @@ private[hive] trait HiveInspectors {
       case hvoi: HiveVarcharObjectInspector if x.preferWritable() =>
         val length = hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength
         dataType match {
-          case v: VarcharType if SQLConf.get.charVarcharFirstClassTypes =>
+          case v: VarcharType =>
             withNullSafe { o =>
               val checked = CharVarcharCodegenUtils.varcharTypeWriteSideCheck(
                 o.asInstanceOf[UTF8String], v.length)
@@ -324,7 +324,7 @@ private[hive] trait HiveInspectors {
       case hvoi: HiveVarcharObjectInspector =>
         val length = hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength
         dataType match {
-          case v: VarcharType if SQLConf.get.charVarcharFirstClassTypes =>
+          case v: VarcharType =>
             withNullSafe { o =>
               val checked = CharVarcharCodegenUtils.varcharTypeWriteSideCheck(
                 o.asInstanceOf[UTF8String], v.length)
@@ -339,7 +339,7 @@ private[hive] trait HiveInspectors {
       case hcoi: HiveCharObjectInspector if x.preferWritable() =>
         val length = hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength
         dataType match {
-          case c: CharType if SQLConf.get.charVarcharFirstClassTypes =>
+          case c: CharType =>
             withNullSafe { o =>
               val checked = CharVarcharCodegenUtils.charTypeWriteSideCheck(
                 o.asInstanceOf[UTF8String], c.length)
@@ -351,7 +351,7 @@ private[hive] trait HiveInspectors {
       case hcoi: HiveCharObjectInspector =>
         val length = hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength
         dataType match {
-          case c: CharType if SQLConf.get.charVarcharFirstClassTypes =>
+          case c: CharType =>
             withNullSafe { o =>
               val checked = CharVarcharCodegenUtils.charTypeWriteSideCheck(
                 o.asInstanceOf[UTF8String], c.length)
@@ -841,8 +841,9 @@ private[hive] trait HiveInspectors {
    * Catalyst `dataType` to preserve nanosecond timestamp precision. The plain
    * `unwrapperFor(ObjectInspector)` cannot do this because a Hive `TimestampObjectInspector`
    * maps to micros by default; here the nanos timestamp types are produced as `TimestampNanosVal`,
-   * recursing through array/map/struct so nested nanos timestamps round-trip correctly. Any other
-   * type is delegated to the `ObjectInspector`-only overload.
+   * recursing through array/map/struct so nested nanos timestamps round-trip correctly. CHAR and
+   * VARCHAR targets also apply their read-side length and padding checks. Any other type is
+   * delegated to the `ObjectInspector`-only overload.
    */
   def unwrapperFor(objectInspector: ObjectInspector, dataType: DataType): Any => Any =
     (objectInspector, dataType) match {
@@ -951,6 +952,19 @@ private[hive] trait HiveInspectors {
         val unwrapper = unwrapperFor(oi)
         (value: Any, row: InternalRow, ordinal: Int) => row(ordinal) = unwrapper(value)
     }
+
+  /**
+   * Builds an in-place unwrapper that also honors target-type-specific conversions.
+   */
+  def unwrapperFor(
+      field: HiveStructField,
+      dataType: DataType): (Any, InternalRow, Int) => Unit = dataType match {
+    case _: CharType | _: VarcharType =>
+      val unwrapper = unwrapperFor(field.getFieldObjectInspector, dataType)
+      (value: Any, row: InternalRow, ordinal: Int) => row(ordinal) = unwrapper(value)
+    case _ =>
+      unwrapperFor(field)
+  }
 
   def wrap(a: Any, oi: ObjectInspector, dataType: DataType): AnyRef = {
     wrapperFor(oi, dataType)(a).asInstanceOf[AnyRef]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -959,7 +959,7 @@ private[hive] trait HiveInspectors {
   def unwrapperFor(
       field: HiveStructField,
       dataType: DataType): (Any, InternalRow, Int) => Unit = dataType match {
-    case _: CharType | _: VarcharType =>
+    case dt if CharVarcharUtils.hasCharVarchar(dt) =>
       val unwrapper = unwrapperFor(field.getFieldObjectInspector, dataType)
       (value: Any, row: InternalRow, ordinal: Int) => row(ordinal) = unwrapper(value)
     case _ =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -311,25 +311,57 @@ private[hive] trait HiveInspectors {
         withNullSafe(o => o.asInstanceOf[java.lang.Byte])
       case hvoi: HiveVarcharObjectInspector if x.preferWritable() =>
         val length = hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength
-        withNullSafe { o =>
-          val varchar = new HiveVarchar(o.asInstanceOf[UTF8String].toString, length)
-          new hiveIo.HiveVarcharWritable(varchar)
+        dataType match {
+          case v: VarcharType if SQLConf.get.charVarcharFirstClassTypes =>
+            withNullSafe { o =>
+              val checked = CharVarcharCodegenUtils.varcharTypeWriteSideCheck(
+                o.asInstanceOf[UTF8String], v.length)
+              new hiveIo.HiveVarcharWritable(new HiveVarchar(checked.toString, length))
+            }
+          case _ =>
+            withNullSafe(o => getStringWritable(o))
         }
       case hvoi: HiveVarcharObjectInspector =>
         val length = hvoi.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength
-        withNullSafe { o =>
-          new HiveVarchar(o.asInstanceOf[UTF8String].toString, length)
+        dataType match {
+          case v: VarcharType if SQLConf.get.charVarcharFirstClassTypes =>
+            withNullSafe { o =>
+              val checked = CharVarcharCodegenUtils.varcharTypeWriteSideCheck(
+                o.asInstanceOf[UTF8String], v.length)
+              new HiveVarchar(checked.toString, length)
+            }
+          case _ =>
+            withNullSafe { o =>
+              val value = o.asInstanceOf[UTF8String].toString
+              new HiveVarchar(value, value.length)
+            }
         }
       case hcoi: HiveCharObjectInspector if x.preferWritable() =>
         val length = hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength
-        withNullSafe { o =>
-          val char = new HiveChar(o.asInstanceOf[UTF8String].toString, length)
-          new hiveIo.HiveCharWritable(char)
+        dataType match {
+          case c: CharType if SQLConf.get.charVarcharFirstClassTypes =>
+            withNullSafe { o =>
+              val checked = CharVarcharCodegenUtils.charTypeWriteSideCheck(
+                o.asInstanceOf[UTF8String], c.length)
+              new hiveIo.HiveCharWritable(new HiveChar(checked.toString, length))
+            }
+          case _ =>
+            withNullSafe(o => getStringWritable(o))
         }
       case hcoi: HiveCharObjectInspector =>
         val length = hcoi.getTypeInfo.asInstanceOf[CharTypeInfo].getLength
-        withNullSafe { o =>
-          new HiveChar(o.asInstanceOf[UTF8String].toString, length)
+        dataType match {
+          case c: CharType if SQLConf.get.charVarcharFirstClassTypes =>
+            withNullSafe { o =>
+              val checked = CharVarcharCodegenUtils.charTypeWriteSideCheck(
+                o.asInstanceOf[UTF8String], c.length)
+              new HiveChar(checked.toString, length)
+            }
+          case _ =>
+            withNullSafe { o =>
+              val value = o.asInstanceOf[UTF8String].toString
+              new HiveChar(value, value.length)
+            }
         }
       case _: JavaHiveDecimalObjectInspector =>
         withNullSafe(o =>
@@ -832,6 +864,26 @@ private[hive] trait HiveInspectors {
             null
           }
         }
+      case (_, c: CharType) =>
+        val unwrapper = unwrapperFor(objectInspector)
+        data: Any => {
+          val value = unwrapper(data).asInstanceOf[UTF8String]
+          if (value == null) {
+            null
+          } else {
+            CharVarcharCodegenUtils.charTypeReadSideCheck(value, c.length)
+          }
+        }
+      case (_, v: VarcharType) =>
+        val unwrapper = unwrapperFor(objectInspector)
+        data: Any => {
+          val value = unwrapper(data).asInstanceOf[UTF8String]
+          if (value == null) {
+            null
+          } else {
+            CharVarcharCodegenUtils.varcharTypeReadSideCheck(value, v.length)
+          }
+        }
       case (li: ListObjectInspector, ArrayType(elementType, _)) =>
         val unwrapper = unwrapperFor(li.getListElementObjectInspector, elementType)
         data: Any => {
@@ -945,10 +997,10 @@ private[hive] trait HiveInspectors {
     // Hive object inspectors preserve the CHAR/VARCHAR length but have no collation metadata.
     case c: CharType =>
       PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(
-        TypeInfoFactory.getCharTypeInfo(c.length))
+        toHiveCharTypeInfo(c))
     case v: VarcharType =>
       PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(
-        TypeInfoFactory.getVarcharTypeInfo(v.length))
+        toHiveVarcharTypeInfo(v))
     case _: StringType => PrimitiveObjectInspectorFactory.javaStringObjectInspector
     case IntegerType => PrimitiveObjectInspectorFactory.javaIntObjectInspector
     case DoubleType => PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
@@ -988,6 +1040,20 @@ private[hive] trait HiveInspectors {
       messageParameters = Map("typeName" -> toSQLType(dataType)))
   }
 
+  private def toHiveCharTypeInfo(dataType: CharType): CharTypeInfo = {
+    if (dataType.length < 1 || dataType.length > HiveChar.MAX_CHAR_LENGTH) {
+      throw unsupportedHiveType(dataType)
+    }
+    TypeInfoFactory.getCharTypeInfo(dataType.length)
+  }
+
+  private def toHiveVarcharTypeInfo(dataType: VarcharType): VarcharTypeInfo = {
+    if (dataType.length < 1 || dataType.length > HiveVarchar.MAX_VARCHAR_LENGTH) {
+      throw unsupportedHiveType(dataType)
+    }
+    TypeInfoFactory.getVarcharTypeInfo(dataType.length)
+  }
+
   /**
    * Map the catalyst expression to ObjectInspector, however,
    * if the expression is `Literal` or foldable, a constant writable object inspector returns;
@@ -997,9 +1063,9 @@ private[hive] trait HiveInspectors {
    */
   def toInspector(expr: Expression): ObjectInspector = expr match {
     case Literal(value, c: CharType) =>
-      getHiveCharWritableConstantObjectInspector(value, c.length)
+      getHiveCharWritableConstantObjectInspector(value, c)
     case Literal(value, v: VarcharType) =>
-      getHiveVarcharWritableConstantObjectInspector(value, v.length)
+      getHiveVarcharWritableConstantObjectInspector(value, v)
     case Literal(value, _: StringType) =>
       getStringWritableConstantObjectInspector(value)
     case Literal(value, IntegerType) =>
@@ -1151,28 +1217,32 @@ private[hive] trait HiveInspectors {
 
   private def getHiveCharWritableConstantObjectInspector(
       value: Any,
-      length: Int): ObjectInspector = {
+      dataType: CharType): ObjectInspector = {
     val writable = if (value == null) {
       null
     } else {
+      val checked = CharVarcharCodegenUtils.charTypeWriteSideCheck(
+        value.asInstanceOf[UTF8String], dataType.length)
       new hiveIo.HiveCharWritable(
-        new HiveChar(value.asInstanceOf[UTF8String].toString, length))
+        new HiveChar(checked.toString, dataType.length))
     }
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.getCharTypeInfo(length), writable)
+      toHiveCharTypeInfo(dataType), writable)
   }
 
   private def getHiveVarcharWritableConstantObjectInspector(
       value: Any,
-      length: Int): ObjectInspector = {
+      dataType: VarcharType): ObjectInspector = {
     val writable = if (value == null) {
       null
     } else {
+      val checked = CharVarcharCodegenUtils.varcharTypeWriteSideCheck(
+        value.asInstanceOf[UTF8String], dataType.length)
       new hiveIo.HiveVarcharWritable(
-        new HiveVarchar(value.asInstanceOf[UTF8String].toString, length))
+        new HiveVarchar(checked.toString, dataType.length))
     }
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.getVarcharTypeInfo(length), writable)
+      toHiveVarcharTypeInfo(dataType), writable)
   }
 
   private def getIntWritableConstantObjectInspector(value: Any): ObjectInspector =
@@ -1340,8 +1410,8 @@ private[hive] trait HiveInspectors {
       case IntegerType => intTypeInfo
       case LongType => longTypeInfo
       case ShortType => shortTypeInfo
-      case c: CharType => getCharTypeInfo(c.length)
-      case v: VarcharType => getVarcharTypeInfo(v.length)
+      case c: CharType => toHiveCharTypeInfo(c)
+      case v: VarcharType => toHiveVarcharTypeInfo(v)
       case _: StringType => stringTypeInfo
       case d: DecimalType => decimalTypeInfo(d)
       case DateType => dateTypeInfo

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationExec.scala
@@ -75,7 +75,9 @@ private[hive] case class HiveScriptTransformationExec(
       val mutableRow = new SpecificInternalRow(output.map(_.dataType))
 
       @transient
-      lazy val unwrappers = outputSoi.getAllStructFieldRefs.asScala.map(unwrapperFor)
+      lazy val unwrappers = outputSoi.getAllStructFieldRefs.asScala.zip(output).map {
+        case (field, attr) => unwrapperFor(field.getFieldObjectInspector, attr.dataType)
+      }
 
       override def hasNext: Boolean = {
         if (completed) {
@@ -130,7 +132,7 @@ private[hive] case class HiveScriptTransformationExec(
           if (dataList.get(i) == null) {
             mutableRow.setNullAt(i)
           } else {
-            unwrappers(i)(dataList.get(i), mutableRow, i)
+            mutableRow.update(i, unwrappers(i)(dataList.get(i)))
           }
           i += 1
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationExec.scala
@@ -76,7 +76,7 @@ private[hive] case class HiveScriptTransformationExec(
 
       @transient
       lazy val unwrappers = outputSoi.getAllStructFieldRefs.asScala.zip(output).map {
-        case (field, attr) => unwrapperFor(field.getFieldObjectInspector, attr.dataType)
+        case (field, attr) => unwrapperFor(field, attr.dataType)
       }
 
       override def hasNext: Boolean = {
@@ -132,7 +132,7 @@ private[hive] case class HiveScriptTransformationExec(
           if (dataList.get(i) == null) {
             mutableRow.setNullAt(i)
           } else {
-            mutableRow.update(i, unwrappers(i)(dataList.get(i)))
+            unwrappers(i)(dataList.get(i), mutableRow, i)
           }
           i += 1
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
@@ -162,9 +162,12 @@ class HiveGenericUDFEvaluator(
   }
 
   @transient
-  private lazy val unwrapper: Any => Any = unwrapperFor(returnInspector)
+  private lazy val catalystReturnType = inspectorToDataType(returnInspector)
 
-  override def returnType: DataType = inspectorToDataType(returnInspector)
+  @transient
+  private lazy val unwrapper: Any => Any = unwrapperFor(returnInspector, catalystReturnType)
+
+  override def returnType: DataType = catalystReturnType
 
   def setArg(index: Int, arg: Any): Unit =
     deferredObjects(index).asInstanceOf[DeferredObjectAdapter].set(() => arg)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFEvaluators.scala
@@ -112,7 +112,9 @@ class HiveSimpleUDFEvaluator(
 }
 
 class HiveGenericUDFEvaluator(
-    funcWrapper: HiveFunctionWrapper, children: Seq[Expression])
+    funcWrapper: HiveFunctionWrapper,
+    children: Seq[Expression],
+    resolvedReturnType: Option[DataType])
   extends HiveUDFEvaluatorBase[GenericUDF](funcWrapper, children) {
 
   // SPARK-58792: copied expression nodes (e.g. via withNewChildrenInternal) share one
@@ -161,8 +163,8 @@ class HiveGenericUDFEvaluator(
     case (inspect, child) => new DeferredObjectAdapter(inspect, child.dataType)
   }
 
-  @transient
-  private lazy val catalystReturnType = inspectorToDataType(returnInspector)
+  private lazy val catalystReturnType =
+    resolvedReturnType.getOrElse(inspectorToDataType(returnInspector))
 
   @transient
   private lazy val unwrapper: Any => Any = unwrapperFor(returnInspector, catalystReturnType)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -114,7 +114,10 @@ private[hive] case class HiveSimpleUDF(
 }
 
 private[hive] case class HiveGenericUDF(
-    name: String, funcWrapper: HiveFunctionWrapper, children: Seq[Expression])
+    name: String,
+    funcWrapper: HiveFunctionWrapper,
+    children: Seq[Expression],
+    resolvedDataType: Option[DataType] = None)
   extends Expression
   with HiveInspectors
   with UserDefinedExpression {
@@ -130,10 +133,12 @@ private[hive] case class HiveGenericUDF(
   override def foldable: Boolean = evaluator.isUDFDeterministic &&
     evaluator.returnInspector.isInstanceOf[ConstantObjectInspector]
 
-  override lazy val dataType: DataType = inspectorToDataType(evaluator.returnInspector)
+  override lazy val dataType: DataType = resolvedDataType.getOrElse(evaluator.returnType)
 
-  @transient
-  private lazy val evaluator = new HiveGenericUDFEvaluator(funcWrapper, children)
+  // The evaluator carries the return type resolved during analysis. Its mutable Hive state is
+  // transient and is rebuilt on the executor, but the resolved Catalyst type must not be.
+  private lazy val evaluator =
+    new HiveGenericUDFEvaluator(funcWrapper, children, resolvedDataType)
 
   override def eval(input: InternalRow): Any = {
     children.zipWithIndex.foreach {
@@ -155,7 +160,7 @@ private[hive] case class HiveGenericUDF(
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
-    copy(children = newChildren)
+    copy(children = newChildren, resolvedDataType = Some(dataType))
 
   protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val refEvaluator = ctx.addReferenceObj("evaluator", evaluator)
@@ -333,7 +338,8 @@ private[hive] case class HiveUDAFFunction(
     children: Seq[Expression],
     isUDAFBridgeRequired: Boolean = false,
     mutableAggBufferOffset: Int = 0,
-    inputAggBufferOffset: Int = 0)
+    inputAggBufferOffset: Int = 0,
+    resolvedDataTypes: Option[(DataType, DataType)] = None)
   extends TypedImperativeAggregate[HiveUDAFBuffer]
   with HiveInspectors
   with UserDefinedExpression {
@@ -341,10 +347,14 @@ private[hive] case class HiveUDAFFunction(
   final override val nodePatterns: Seq[TreePattern] = Seq(USER_DEFINED_AGGREGATION)
 
   override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate =
-    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+    copy(
+      mutableAggBufferOffset = newMutableAggBufferOffset,
+      resolvedDataTypes = Some(catalystDataTypes))
 
   override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate =
-    copy(inputAggBufferOffset = newInputAggBufferOffset)
+    copy(
+      inputAggBufferOffset = newInputAggBufferOffset,
+      resolvedDataTypes = Some(catalystDataTypes))
 
   // Hive `ObjectInspector`s for all child expressions (input parameters of the function).
   @transient
@@ -387,10 +397,13 @@ private[hive] case class HiveUDAFFunction(
       evaluator.init(GenericUDAFEvaluator.Mode.FINAL, Array(partial1HiveEvaluator.objectInspector)))
   }
 
-  // Spark SQL data type of partial aggregation results
-  @transient
-  private lazy val partialResultDataType =
-    inspectorToDataType(partial1HiveEvaluator.objectInspector)
+  // Resolve both Catalyst types together during analysis so the partial type is serialized with
+  // the expression instead of being rebuilt from the executor's SQLConf.
+  private lazy val catalystDataTypes = resolvedDataTypes.getOrElse((
+    inspectorToDataType(partial1HiveEvaluator.objectInspector),
+    inspectorToDataType(finalHiveEvaluator.objectInspector)))
+
+  private def partialResultDataType: DataType = catalystDataTypes._1
 
   // Wrapper functions used to wrap Spark SQL input arguments into Hive specific format.
   @transient
@@ -409,7 +422,7 @@ private[hive] case class HiveUDAFFunction(
 
   override def nullable: Boolean = true
 
-  override lazy val dataType: DataType = inspectorToDataType(finalHiveEvaluator.objectInspector)
+  override lazy val dataType: DataType = catalystDataTypes._2
 
   override def prettyName: String = name
 
@@ -552,7 +565,7 @@ private[hive] case class HiveUDAFFunction(
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
-    copy(children = newChildren)
+    copy(children = newChildren, resolvedDataTypes = Some(catalystDataTypes))
 }
 
 case class HiveUDAFBuffer(buf: AggregationBuffer, canDoMerge: Boolean)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -212,7 +212,8 @@ private[hive] case class HiveGenericUDF(
 private[hive] case class HiveGenericUDTF(
     name: String,
     funcWrapper: HiveFunctionWrapper,
-    children: Seq[Expression])
+    children: Seq[Expression],
+    resolvedElementSchema: Option[StructType] = None)
   extends Generator with HiveInspectors with CodegenFallback with UserDefinedExpression {
 
   @transient
@@ -238,10 +239,12 @@ private[hive] case class HiveGenericUDTF(
   @transient
   protected lazy val collector = new UDTFCollector
 
-  override lazy val elementSchema = StructType(outputInspector.getAllStructFieldRefs.asScala.map {
-    field => StructField(field.getFieldName, inspectorToDataType(field.getFieldObjectInspector),
-      nullable = true)
-  }.toArray)
+  override lazy val elementSchema = resolvedElementSchema.getOrElse {
+    StructType(outputInspector.getAllStructFieldRefs.asScala.map {
+      field => StructField(field.getFieldName, inspectorToDataType(field.getFieldObjectInspector),
+        nullable = true)
+    }.toArray)
+  }
 
   @transient
   private lazy val inputDataTypes: Array[DataType] = children.map(_.dataType).toArray
@@ -291,7 +294,7 @@ private[hive] case class HiveGenericUDTF(
   override def prettyName: String = name
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
-    copy(children = newChildren)
+    copy(children = newChildren, resolvedElementSchema = Some(elementSchema))
 }
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -245,7 +245,7 @@ private[hive] case class HiveGenericUDTF(
   private lazy val wrappers = children.map(x => wrapperFor(toInspector(x), x.dataType)).toArray
 
   @transient
-  private lazy val unwrapper = unwrapperFor(outputInspector)
+  private lazy val unwrapper = unwrapperFor(outputInspector, elementSchema)
 
   @transient
   private lazy val inputProjection = new InterpretedProjection(children)
@@ -399,7 +399,7 @@ private[hive] case class HiveUDAFFunction(
   // Unwrapper function used to unwrap final aggregation result objects returned by Hive UDAFs into
   // Spark SQL specific format.
   @transient
-  private lazy val resultUnwrapper = unwrapperFor(finalHiveEvaluator.objectInspector)
+  private lazy val resultUnwrapper = unwrapperFor(finalHiveEvaluator.objectInspector, dataType)
 
   @transient
   private lazy val cached: Array[AnyRef] = new Array[AnyRef](children.length)
@@ -507,7 +507,8 @@ private[hive] case class HiveUDAFFunction(
 
   // Helper class used to de/serialize Hive UDAF `AggregationBuffer` objects
   private class AggregationBufferSerDe {
-    private val partialResultUnwrapper = unwrapperFor(partial1HiveEvaluator.objectInspector)
+    private val partialResultUnwrapper =
+      unwrapperFor(partial1HiveEvaluator.objectInspector, partialResultDataType)
 
     private val partialResultWrapper =
       wrapperFor(partial1HiveEvaluator.objectInspector, partialResultDataType)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.{CharTypeInfo, DecimalTypeInfo, VarcharTypeInfo}
 import org.apache.hadoop.io.LongWritable
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.{AnalysisException, Row, TestUserClassUDT}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -322,15 +322,19 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
         VarcharType(7, "UNICODE_CI")).foreach { dataType =>
         val inspector = toInspector(dataType)
         val value = UTF8String.fromString(dataType match {
-          case _: CharType => "ab   "
+          case _: CharType => "ab"
           case _: VarcharType => "abc"
         })
+        val expectedValue = dataType match {
+          case _: CharType => UTF8String.fromString("ab   ")
+          case _: VarcharType => value
+        }
         val expectedType = dataType match {
           case c: CharType => CharType(c.length)
           case v: VarcharType => VarcharType(v.length)
         }
         assert(inspectorToDataType(inspector) === expectedType)
-        assert(unwrap(wrap(value, inspector, dataType), inspector) === value)
+        assert(unwrap(wrap(value, inspector, dataType), inspector) === expectedValue)
       }
     }
   }
@@ -340,7 +344,18 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
       val dataType = StructType(Seq(
         StructField("chars", ArrayType(CharType(4))),
         StructField("varchars", MapType(IntegerType, VarcharType(8)))))
-      assert(inspectorToDataType(toInspector(dataType)) === dataType)
+      val inspector = toInspector(dataType)
+      assert(inspectorToDataType(inspector) === dataType)
+
+      val input = InternalRow(
+        new GenericArrayData(Array[Any](UTF8String.fromString("a"))),
+        ArrayBasedMapData(
+          Array[Any](1),
+          Array[Any](UTF8String.fromString("value"))))
+      val result = unwrapperFor(inspector, dataType)(
+        wrap(input, inspector, dataType)).asInstanceOf[InternalRow]
+      assert(result.getArray(0).getUTF8String(0) === UTF8String.fromString("a   "))
+      assert(result.getMap(1).valueArray().getUTF8String(0) === UTF8String.fromString("value"))
     }
   }
 
@@ -351,6 +366,12 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
         val inspector = toInspector(Literal.create(value, dataType))
         assert(inspector.isInstanceOf[ConstantObjectInspector])
         assert(inspectorToDataType(inspector) === dataType)
+        val expected = dataType match {
+          case _: CharType => UTF8String.fromString("abc  ")
+          case _: VarcharType => value
+        }
+        assert(unwrapperFor(inspector, dataType)(
+          inspector.asInstanceOf[ConstantObjectInspector].getWritableConstantValue) === expected)
       }
     }
   }
@@ -359,6 +380,46 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
     withFirstClassCharVarchar(enabled = false) {
       Seq[DataType](CharType(5), VarcharType(7)).foreach { dataType =>
         assert(inspectorToDataType(toInspector(dataType)) === StringType)
+      }
+    }
+  }
+
+  test("SPARK-59277: Hive CHAR/VARCHAR boundaries enforce Spark length semantics") {
+    withFirstClassCharVarchar(enabled = true) {
+      val varchar = VarcharType(3)
+      val varcharInspector = toInspector(varchar)
+      checkError(
+        exception = intercept[SparkRuntimeException] {
+          wrap(UTF8String.fromString("abcd"), varcharInspector, varchar)
+        },
+        condition = "EXCEED_LIMIT_LENGTH",
+        parameters = Map("limit" -> "3"))
+
+      val char = CharType(5)
+      val charUnwrapper =
+        unwrapperFor(PrimitiveObjectInspectorFactory.javaStringObjectInspector, char)
+      assert(charUnwrapper("ab") === UTF8String.fromString("ab   "))
+      checkError(
+        exception = intercept[SparkRuntimeException] {
+          charUnwrapper("abcdef")
+        },
+        condition = "EXCEED_LIMIT_LENGTH",
+        parameters = Map("limit" -> "5"))
+    }
+  }
+
+  test("SPARK-59277: Hive object inspectors reject unsupported CHAR/VARCHAR lengths") {
+    withFirstClassCharVarchar(enabled = true) {
+      Seq[DataType](CharType(0), CharType(256), VarcharType(65536)).foreach { dataType =>
+        val expectedParams = Map("typeName" -> s"\"${dataType.sql}\"")
+        checkError(
+          exception = intercept[AnalysisException](toInspector(dataType)),
+          condition = "UNSUPPORTED_DATATYPE",
+          parameters = expectedParams)
+        checkError(
+          exception = intercept[AnalysisException](dataType.toTypeInfo),
+          condition = "UNSUPPORTED_DATATYPE",
+          parameters = expectedParams)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.io.LongWritable
 import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.{AnalysisException, Row, TestUserClassUDT}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.{Literal, SpecificInternalRow}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData, MapData}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -356,6 +356,16 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
         wrap(input, inspector, dataType)).asInstanceOf[InternalRow]
       assert(result.getArray(0).getUTF8String(0) === UTF8String.fromString("a   "))
       assert(result.getMap(1).valueArray().getUTF8String(0) === UTF8String.fromString("value"))
+
+      val outerType = StructType(Seq(StructField("nested", dataType)))
+      val outerInspector = toInspector(outerType).asInstanceOf[StructObjectInspector]
+      val field = outerInspector.getAllStructFieldRefs.get(0)
+      val targetRow = new SpecificInternalRow(Seq(dataType))
+      unwrapperFor(field, dataType)(wrap(input, inspector, dataType), targetRow, 0)
+      val nestedResult = targetRow.getStruct(0, dataType.length)
+      assert(nestedResult.getArray(0).getUTF8String(0) === UTF8String.fromString("a   "))
+      assert(
+        nestedResult.getMap(1).valueArray().getUTF8String(0) === UTF8String.fromString("value"))
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
@@ -21,10 +21,10 @@ import java.util
 
 import org.apache.hadoop.hive.ql.udf.UDAFPercentile
 import org.apache.hadoop.hive.serde2.io.DoubleWritable
-import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, ObjectInspectorFactory, PrimitiveObjectInspector, StructObjectInspector}
+import org.apache.hadoop.hive.serde2.objectinspector.{ConstantObjectInspector, ObjectInspector, ObjectInspectorFactory, PrimitiveObjectInspector, StructObjectInspector}
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.ObjectInspectorOptions
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
-import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo
+import org.apache.hadoop.hive.serde2.typeinfo.{CharTypeInfo, DecimalTypeInfo, VarcharTypeInfo}
 import org.apache.hadoop.io.LongWritable
 
 import org.apache.spark.SparkFunSuite
@@ -32,9 +32,17 @@ import org.apache.spark.sql.{AnalysisException, Row, TestUserClassUDT}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData, MapData}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
+
+  private def withFirstClassCharVarchar(enabled: Boolean)(f: => Unit): Unit = {
+    val conf = new SQLConf
+    conf.setConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS, enabled)
+    SQLConf.withExistingConf(conf)(f)
+  }
 
   def unwrap(data: Any, oi: ObjectInspector): Any = {
     val unwrapper = unwrapperFor(oi)
@@ -290,6 +298,69 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
     val typeInfo2 = oi2.getTypeInfo.asInstanceOf[DecimalTypeInfo]
     assert(typeInfo2.precision() === 18)
     assert(typeInfo2.scale() === 10)
+  }
+
+  test("SPARK-59277: Hive object inspectors preserve CHAR/VARCHAR type information") {
+    withFirstClassCharVarchar(enabled = true) {
+      Seq[DataType](CharType(5), VarcharType(7)).foreach { dataType =>
+        val inspector = toInspector(dataType).asInstanceOf[PrimitiveObjectInspector]
+        assert(inspectorToDataType(inspector) === dataType)
+        dataType match {
+          case c: CharType =>
+            assert(inspector.getTypeInfo.asInstanceOf[CharTypeInfo].getLength === c.length)
+          case v: VarcharType =>
+            assert(inspector.getTypeInfo.asInstanceOf[VarcharTypeInfo].getLength === v.length)
+        }
+      }
+    }
+  }
+
+  test("SPARK-59277: Hive object inspectors accept collated CHAR/VARCHAR values") {
+    withFirstClassCharVarchar(enabled = true) {
+      Seq[DataType](
+        CharType(5, "UTF8_LCASE"),
+        VarcharType(7, "UNICODE_CI")).foreach { dataType =>
+        val inspector = toInspector(dataType)
+        val value = UTF8String.fromString(dataType match {
+          case _: CharType => "ab   "
+          case _: VarcharType => "abc"
+        })
+        val expectedType = dataType match {
+          case c: CharType => CharType(c.length)
+          case v: VarcharType => VarcharType(v.length)
+        }
+        assert(inspectorToDataType(inspector) === expectedType)
+        assert(unwrap(wrap(value, inspector, dataType), inspector) === value)
+      }
+    }
+  }
+
+  test("SPARK-59277: Hive object inspectors support nested CHAR/VARCHAR") {
+    withFirstClassCharVarchar(enabled = true) {
+      val dataType = StructType(Seq(
+        StructField("chars", ArrayType(CharType(4))),
+        StructField("varchars", MapType(IntegerType, VarcharType(8)))))
+      assert(inspectorToDataType(toInspector(dataType)) === dataType)
+    }
+  }
+
+  test("SPARK-59277: Hive constant inspectors preserve CHAR/VARCHAR type information") {
+    withFirstClassCharVarchar(enabled = true) {
+      Seq[DataType](CharType(5), VarcharType(7)).foreach { dataType =>
+        val value = UTF8String.fromString("abc")
+        val inspector = toInspector(Literal.create(value, dataType))
+        assert(inspector.isInstanceOf[ConstantObjectInspector])
+        assert(inspectorToDataType(inspector) === dataType)
+      }
+    }
+  }
+
+  test("SPARK-59277: Hive CHAR/VARCHAR inspectors remain STRING under legacy semantics") {
+    withFirstClassCharVarchar(enabled = false) {
+      Seq[DataType](CharType(5), VarcharType(7)).foreach { dataType =>
+        assert(inspectorToDataType(toInspector(dataType)) === StringType)
+      }
+    }
   }
 
   test("SPARK-57556: TIME type is unsupported in Hive object inspectors") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveScalaReflectionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveScalaReflectionSuite.scala
@@ -29,7 +29,7 @@ class HiveScalaReflectionSuite extends SparkFunSuite {
 
   test("SPARK-38510: ScalaReflection.getConstructorParameterNames should work for classes with " +
     "cyclic annotation references") {
-    assert(Seq("name", "funcWrapper", "children") ===
+    assert(Seq("name", "funcWrapper", "children", "resolvedDataType") ===
       ScalaReflection.getConstructorParameterNames(classOf[HiveGenericUDF]))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType._
 import org.apache.spark.sql.types.YearMonthIntervalType._
@@ -369,6 +370,27 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
           |FROM v
         """.stripMargin)
       checkAnswer(query, identity, df.select($"c", $"d", $"e").collect().toImmutableArraySeq)
+    }
+  }
+
+  test("SPARK-59277: TRANSFORM supports nested collated CHAR/VARCHAR with Hive SerDe") {
+    assume(TestUtils.testCommandAvailable("/bin/bash"))
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      val query = sql(
+        """
+          |SELECT TRANSFORM(
+          |  array(CAST('ab' AS CHAR(4) COLLATE UTF8_LCASE)),
+          |  named_struct('value', CAST('xyz' AS VARCHAR(6) COLLATE UNICODE_CI)))
+          |USING 'cat'
+          |AS (
+          |  chars ARRAY<CHAR(4) COLLATE UTF8_LCASE>,
+          |  nested STRUCT<value: VARCHAR(6) COLLATE UNICODE_CI>)
+          |FROM VALUES (1) input(dummy)
+          |""".stripMargin)
+      assert(query.schema.map(_.dataType) === Seq(
+        ArrayType(CharType(4, "UTF8_LCASE")),
+        StructType(Seq(StructField("value", VarcharType(6, "UNICODE_CI"))))))
+      checkAnswer(query, Row(Seq("ab  "), Row("xyz")))
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{CharType, VarcharType}
 import org.apache.spark.tags.SlowHiveTest
 
 @SlowHiveTest
@@ -196,6 +197,25 @@ class HiveUDAFSuite extends QueryTest
         checkAnswer(
           spark.sql("SELECT default.myDoubleAvg(value) as my_avg from temp"),
           Row(105.0))
+      }
+    }
+  }
+
+  test("SPARK-59277: Hive UDAF supports first-class CHAR/VARCHAR") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      Seq(
+        ("CHAR(5) COLLATE UTF8_LCASE", CharType(5), Row("def  ")),
+        ("VARCHAR(7) COLLATE UNICODE_CI", VarcharType(7), Row("def"))
+      ).foreach { case (dataType, expectedType, expectedRow) =>
+        val aggregate = sql(
+          s"""SELECT hive_max(value)
+             |FROM VALUES
+             |  (CAST('abc' AS $dataType)),
+             |  (CAST('def' AS $dataType))
+             |AS input(value)
+             |""".stripMargin)
+        assert(aggregate.schema.head.dataType === expectedType)
+        checkAnswer(aggregate, expectedRow)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -943,19 +943,31 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
   }
 
   test("SPARK-59277: persisted views use their captured Hive conversion types") {
-    withUserDefinedFunction("hive_upper" -> false, "hive_max" -> false) {
-      withView("first_class_hive_view", "legacy_hive_view") {
+    withUserDefinedFunction(
+        "hive_upper" -> false,
+        "hive_max" -> false,
+        "hive_explode" -> false) {
+      withView("first_class_hive_view", "first_class_hive_udtf_view", "legacy_hive_view") {
         sql(s"CREATE FUNCTION hive_upper AS '${classOf[GenericUDFUpper].getName}'")
         sql(s"CREATE FUNCTION hive_max AS '${classOf[GenericUDAFMax].getName}'")
+        sql(s"CREATE FUNCTION hive_explode AS '${classOf[GenericUDTFExplode].getName}'")
         val query =
           """SELECT
             |  hive_upper(CAST('Ab' AS CHAR(5))) AS scalar_value,
             |  hive_max(CAST('cd' AS CHAR(4))) AS aggregate_value""".stripMargin
+        val udtfQuery =
+          """SELECT value
+            |FROM (
+            |  SELECT array(CAST('xy' AS CHAR(5))) AS values
+            |) input
+            |LATERAL VIEW hive_explode(values) exploded AS value
+            |""".stripMargin
 
         withSQLConf(
             SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true",
             SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
           sql(s"CREATE VIEW first_class_hive_view AS $query")
+          sql(s"CREATE VIEW first_class_hive_udtf_view AS $udtfQuery")
         }
         withSQLConf(
             SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
@@ -963,6 +975,10 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
           val result = sql("SELECT * FROM first_class_hive_view")
           assert(result.schema.map(_.dataType) === Seq(StringType, StringType))
           checkAnswer(result, Row("AB   ", "cd  "))
+
+          val udtfResult = sql("SELECT * FROM first_class_hive_udtf_view")
+          assert(udtfResult.schema.head.dataType === StringType)
+          checkAnswer(udtfResult, Row("xy   "))
         }
 
         withSQLConf(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.hive.HiveGenericUDF
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestUDTFJar}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{CharType, TimestampType, TimeType, VarcharType}
+import org.apache.spark.sql.types.{CharType, StringType, TimestampType, TimeType, VarcharType}
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
@@ -894,9 +894,21 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
 
   test("SPARK-59277: Hive UDF and UDTF support first-class CHAR/VARCHAR") {
     withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
-      withUserDefinedFunction("hive_upper" -> true, "hive_explode" -> true) {
+      withUserDefinedFunction(
+          "hive_simple_concat" -> true,
+          "hive_upper" -> true,
+          "hive_explode" -> true) {
+        sql(s"CREATE TEMPORARY FUNCTION hive_simple_concat AS " +
+          s"'${classOf[UDFStringString].getName}'")
         sql(s"CREATE TEMPORARY FUNCTION hive_upper AS '${classOf[GenericUDFUpper].getName}'")
         sql(s"CREATE TEMPORARY FUNCTION hive_explode AS '${classOf[GenericUDTFExplode].getName}'")
+
+        val simple = sql(
+          """SELECT hive_simple_concat(
+            |  CAST('A' AS CHAR(3)),
+            |  CAST('b' AS VARCHAR(2))) AS value""".stripMargin)
+        assert(simple.schema.head.dataType === StringType)
+        checkAnswer(simple, Row("A b"))
 
         val scalar = sql(
           "SELECT hive_upper(CAST('Ab' AS CHAR(5) COLLATE UTF8_LCASE)) AS value")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.hive.HiveGenericUDF
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestUDTFJar}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{TimestampType, TimeType}
+import org.apache.spark.sql.types.{CharType, TimestampType, TimeType, VarcharType}
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
@@ -890,6 +890,30 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
            |         now())""".stripMargin).collect().length == 1)
     }
     hiveContext.reset()
+  }
+
+  test("SPARK-59277: Hive UDF and UDTF support first-class CHAR/VARCHAR") {
+    withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+      withUserDefinedFunction("hive_upper" -> true, "hive_explode" -> true) {
+        sql(s"CREATE TEMPORARY FUNCTION hive_upper AS '${classOf[GenericUDFUpper].getName}'")
+        sql(s"CREATE TEMPORARY FUNCTION hive_explode AS '${classOf[GenericUDTFExplode].getName}'")
+
+        val scalar = sql(
+          "SELECT hive_upper(CAST('Ab' AS CHAR(5) COLLATE UTF8_LCASE)) AS value")
+        assert(scalar.schema.head.dataType === CharType(5))
+        checkAnswer(scalar, Row("AB   "))
+
+        val table = sql(
+          """SELECT value
+            |FROM (
+            |  SELECT array(CAST('abc' AS VARCHAR(7) COLLATE UNICODE_CI)) AS values
+            |) input
+            |LATERAL VIEW hive_explode(values) exploded AS value
+            |""".stripMargin)
+        assert(table.schema.head.dataType === VarcharType(7))
+        checkAnswer(table, Row("abc"))
+      }
+    }
   }
 
   test("SPARK-58792: copied HiveGenericUDF nodes must not share a mutable GenericUDF") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -928,6 +928,58 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton {
     }
   }
 
+  test("SPARK-59277: Hive UDF supports preserved CHAR without standard semantics") {
+    withSQLConf(
+        SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true",
+        SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false") {
+      withUserDefinedFunction("hive_upper" -> true) {
+        sql(s"CREATE TEMPORARY FUNCTION hive_upper AS '${classOf[GenericUDFUpper].getName}'")
+
+        val result = sql("SELECT hive_upper(CAST('Ab' AS CHAR(5))) AS value")
+        assert(result.schema.head.dataType === CharType(5))
+        checkAnswer(result, Row("AB   "))
+      }
+    }
+  }
+
+  test("SPARK-59277: persisted views use their captured Hive conversion types") {
+    withUserDefinedFunction("hive_upper" -> false, "hive_max" -> false) {
+      withView("first_class_hive_view", "legacy_hive_view") {
+        sql(s"CREATE FUNCTION hive_upper AS '${classOf[GenericUDFUpper].getName}'")
+        sql(s"CREATE FUNCTION hive_max AS '${classOf[GenericUDAFMax].getName}'")
+        val query =
+          """SELECT
+            |  hive_upper(CAST('Ab' AS CHAR(5))) AS scalar_value,
+            |  hive_max(CAST('cd' AS CHAR(4))) AS aggregate_value""".stripMargin
+
+        withSQLConf(
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "true") {
+          sql(s"CREATE VIEW first_class_hive_view AS $query")
+        }
+        withSQLConf(
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "false") {
+          val result = sql("SELECT * FROM first_class_hive_view")
+          assert(result.schema.map(_.dataType) === Seq(StringType, StringType))
+          checkAnswer(result, Row("AB   ", "cd  "))
+        }
+
+        withSQLConf(
+            SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING.key -> "true",
+            SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "false",
+            SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO.key -> "false") {
+          sql(s"CREATE VIEW legacy_hive_view AS $query")
+        }
+        withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
+          val result = sql("SELECT * FROM legacy_hive_view")
+          assert(result.schema.map(_.dataType) === Seq(StringType, StringType))
+          checkAnswer(result, Row("AB", "cd"))
+        }
+      }
+    }
+  }
+
   test("SPARK-58792: copied HiveGenericUDF nodes must not share a mutable GenericUDF") {
     val tsAttr = AttributeReference("ts", TimestampType, nullable = false)()
     val constTs = Literal(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support first-class CHAR/VARCHAR across Hive extension boundaries when first-class semantics are enabled:

- Convert Catalyst CHAR/VARCHAR to Hive CHAR/VARCHAR object inspectors while preserving length.
- Convert Hive CHAR/VARCHAR inspectors back to first-class Catalyst types for UDF, UDAF, and UDTF results.
- Wrap Java and writable Hive CHAR/VARCHAR values using their declared lengths.
- Preserve constant and nested CHAR/VARCHAR inspector shapes.
- Support CHAR/VARCHAR output from script TRANSFORM with and without Hive SerDe.
- Continue exposing Hive CHAR/VARCHAR results as STRING under legacy semantics.

Hive object inspectors cannot carry Spark collation metadata. Collated inputs are accepted, while Hive function results retain the CHAR/VARCHAR length with the default collation.

JIRA: https://issues.apache.org/jira/browse/SPARK-59277

### Why are the changes needed?

With `spark.sql.charVarchar.standardSemantics.enabled=true`, Catalyst keeps CHAR/VARCHAR as first-class types. Hive extension paths still handled them as unsupported types or downgraded Hive CHAR/VARCHAR results to STRING. This prevented Hive UDF/UDAF/UDTF functions and script TRANSFORM from operating consistently on scalar, collated, and nested CHAR/VARCHAR values.

### Does this PR introduce _any_ user-facing change?

Yes. When first-class CHAR/VARCHAR semantics are enabled, Hive UDF/UDAF/UDTF functions and script TRANSFORM now accept and return CHAR/VARCHAR values while preserving declared lengths. Legacy flag-off behavior remains unchanged.

### How was this patch tested?

Added focused coverage for:

- Java, writable, constant, collated, and nested Hive object inspectors.
- Legacy STRING fallback.
- Hive scalar UDF, UDAF, and UDTF execution.
- Script TRANSFORM with Hive SerDe and without SerDe.

Ran:

```
sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 \
  -Dsbt.override.build.repos=true \
  'hive/testOnly org.apache.spark.sql.hive.HiveInspectorSuite org.apache.spark.sql.hive.execution.HiveUDFSuite org.apache.spark.sql.hive.execution.HiveUDAFSuite org.apache.spark.sql.hive.execution.HiveScriptTransformationSuite -- -z SPARK-59277'

sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 \
  -Dsbt.override.build.repos=true \
  'sql/testOnly org.apache.spark.sql.execution.SparkScriptTransformationSuite -- -z SPARK-59277'

dev/scalastyle sql
```

These suites currently contain 32 uniquely named SPARK-59277 tests. HiveScriptTransformationSuite also inherits the 8 no-SerDe cases, so a full `-z SPARK-59277` run executes 40 tests. The latest focused runs at HEAD d9044026aa2 passed (SparkScriptTransformationSuite 8/8, plus the Hive suites). Scala style checks passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Auto
