### PR TITLE
[SPARK-59327][BUILD] Add config test module

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -169,8 +169,8 @@ jobs:
             docs=false
             java25=false
           fi
-          build=`./dev/is-changed.py -m "core,unsafe,kvstore,avro,utils,utils-java,network-common,network-shuffle,repl,launcher,examples,sketch,variant,api,catalyst,hive-thriftserver,mllib-local,mllib,graphx,streaming,sql-kafka-0-10,streaming-kafka-0-10,streaming-kinesis-asl,credential-aws,kubernetes,hadoop-cloud,spark-ganglia-lgpl,profiler,protobuf,yarn,connect,sql,hive,pipelines"`
-          build_core_utils=`./dev/is-changed.py -m "core,unsafe,kvstore,utils,utils-java,network-common,network-shuffle,sketch,variant,launcher"`
+          build=`./dev/is-changed.py -m "core,unsafe,kvstore,avro,utils,utils-java,config,network-common,network-shuffle,repl,launcher,examples,sketch,variant,api,catalyst,hive-thriftserver,mllib-local,mllib,graphx,streaming,sql-kafka-0-10,streaming-kafka-0-10,streaming-kinesis-asl,credential-aws,kubernetes,hadoop-cloud,spark-ganglia-lgpl,profiler,protobuf,yarn,connect,sql,hive,pipelines"`
+          build_core_utils=`./dev/is-changed.py -m "core,unsafe,kvstore,utils,utils-java,config,network-common,network-shuffle,sketch,variant,launcher"`
           precondition="
             {
               \"build\": \"$build\",
@@ -289,7 +289,7 @@ jobs:
         # Note that the modules below are from sparktestsupport/modules.py.
         modules:
           - >-
-            core, unsafe, kvstore, utils, utils-java,
+            core, unsafe, kvstore, utils, utils-java, config,
             network-common, network-shuffle, sketch, variant, launcher
           - >-
             api, catalyst, hive-thriftserver
@@ -341,7 +341,7 @@ jobs:
           # Skip the core/utils group when a PR doesn't touch those modules (e.g. SQL-only or
           # PySpark-only changes). The precondition is opt-out: omitted means run (so periodic
           # full-build workflows that set only "build": "true" keep running this entry).
-          - modules: ${{ fromJson(needs.precondition.outputs.required).build-core-utils == 'false' && 'core, unsafe, kvstore, utils, utils-java, network-common, network-shuffle, sketch, variant, launcher' }}
+          - modules: ${{ fromJson(needs.precondition.outputs.required).build-core-utils == 'false' && 'core, unsafe, kvstore, utils, utils-java, config, network-common, network-shuffle, sketch, variant, launcher' }}
     env:
       MODULES_TO_TEST: ${{ matrix.modules }}
       EXCLUDED_TAGS: ${{ matrix.excluded-tags }}

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -154,7 +154,7 @@ jobs:
           - hive2.3
         modules:
           - >-
-            core,launcher,common#unsafe,common#kvstore,common#network-common,common#network-shuffle,common#sketch,common#utils,common#utils-java,common#variant
+            core,launcher,common#unsafe,common#kvstore,common#network-common,common#network-shuffle,common#sketch,common#utils,common#utils-java,common#config,common#variant
           - >-
             graphx,streaming,hadoop-cloud
           - >-

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -205,6 +205,17 @@ tags = Module(
     ],
 )
 
+config = Module(
+    name="config",
+    dependencies=[tags],
+    source_file_regexes=[
+        "common/config/",
+    ],
+    sbt_test_goals=[
+        "config/test",
+    ],
+)
+
 utils_java = Module(
     name="utils-java",
     dependencies=[tags],
@@ -218,7 +229,7 @@ utils_java = Module(
 
 utils = Module(
     name="utils",
-    dependencies=[tags, utils_java],
+    dependencies=[tags, utils_java, config],
     source_file_regexes=[
         "common/utils/",
     ],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new `config` test module that runs the `config/test` sbt goal (which runs `ConfigRegistrySuite`).

### Why are the changes needed?

When this new suite was added in #53488 I believe it was left out of the test modules by mistake.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Confirmed that `ConfigRegistrySuite` now [runs on CI][1].

[1]: https://github.com/nchammas/spark/actions/runs/34184737093/job/101933969437#step:12:397

### Was this patch authored or co-authored using generative AI tooling?

I wrote this patch with assistance from GitHub Copilot.
