### PR TITLE
[SPARK-59316][K8S][DOCS] Remove the obsolete `-Pvolcano` build instruction from K8s docs

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -2142,13 +2142,6 @@ Spark allows users to specify a custom Kubernetes schedulers.
   kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.14.2/installer/volcano-development.yaml
   ```
 
-##### Build
-To create a Spark distribution along with Volcano support like those distributed by the Spark [Downloads page](https://spark.apache.org/downloads.html), also see more in ["Building Spark"](https://spark.apache.org/docs/latest/building-spark.html):
-
-```bash
-./dev/make-distribution.sh --name custom-spark --pip --r --tgz -Psparkr -Phive -Phive-thriftserver -Pkubernetes -Pvolcano
-```
-
 ##### Usage
 Spark on Kubernetes allows using Volcano as a custom scheduler. Users can use Volcano to
 support more advanced resource scheduling: queue scheduling, resource reservation, priority scheduling, and more.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the obsolete `Build` section which tells users to build a custom distribution with `-Pvolcano` from the Volcano scheduler part of `docs/running-on-kubernetes.md`.

### Why are the changes needed?

The `volcano` profile has been enabled by default since [SPARK-54916](https://issues.apache.org/jira/browse/SPARK-54916), which was released in [v4.2.0](https://github.com/apache/spark/releases/tag/v4.2.0) (2026-07-11). A custom build is no longer needed.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change.

### How was this patch tested?

Manual review of the generated documentation.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5