### PR TITLE
[SPARK-59310][SQL] Report driver-side grouping metrics for GroupPartitionsExec

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -368,6 +368,9 @@ Here is the list of SQL metrics:
 <tr><td> <code>avg hash probe bucket list iters</code> </td><td> the average bucket list iterations per lookup during aggregation </td><td> HashAggregate </td></tr>
 <tr><td> <code>data size of build side</code> </td><td> the size of built hash map </td><td> ShuffledHashJoin </td></tr>
 <tr><td> <code>time to build hash map</code> </td><td> the time spent on building hash map </td><td> ShuffledHashJoin </td></tr>
+<tr><td> <code>number of pruned input partitions</code> </td><td> the number of input partitions skipped because the join proved their partition key cannot produce output </td><td> GroupPartitions </td></tr>
+<tr><td> <code>number of replicated input partition reads</code> </td><td> the number of extra reads of input partitions caused by replicating a key group across the other side's partitions </td><td> GroupPartitions </td></tr>
+<tr><td> <code>max partitions per group</code> </td><td> the largest number of input partitions one output partition holds; large values indicate a skewed partition key </td><td> GroupPartitions </td></tr>
 <tr><td> <code>task commit time</code> </td><td> the time spent on committing the output of a task after the writes succeed </td><td> any write operation on a file-based table </td></tr>
 <tr><td> <code>job commit time</code> </td><td> the time spent on committing the output of a job after the writes succeed </td><td> any write operation on a file-based table </td></tr>
 <tr><td> <code>data sent to Python workers</code> </td><td> the number of bytes of serialized data sent to the Python workers </td><td> Python UDFs, Pandas UDFs, Pandas Functions API and Python Data Source </td></tr>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{IdentityReducer, KeyedPartitioning, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
-import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{SafeForKWayMerge, SparkPlan, SQLExecution, UnaryExecNode}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -152,22 +153,52 @@ case class GroupPartitionsExec(
     })
   }
 
-  /** Aligns partitions based on `expectedPartitionKeys` and clustering mode. */
-  private def alignToExpectedKeys(keyMap: Map[InternalRowComparableWrapper, Seq[Int]]) = {
+  /**
+   * Aligns partitions based on `expectedPartitionKeys` and clustering mode.
+   *
+   * Returns the aligned groups, whether their keys ended up unique, and two counts, both in
+   * input partition reads relative to the baseline of every input being read exactly once.
+   * The pruned count is the reads that never happen: inputs of a key the alignment never
+   * references. The join proved such keys cannot produce output, e.g. an inner join keeps
+   * only the intersection. Which keys are expected is orthogonal to the mode: an
+   * `OrderedDistribution` producer expects the child's own keys and so never prunes, while a
+   * join producer can prune in either mode. The replicated count is the reads that happen
+   * again: in the replicate mode of partial clustering every expected partition of a held key
+   * re-reads all its splits, counted beyond the first pass (3 splits over 2 slots count 3).
+   * Total input reads = `numInputPartitions` - pruned + replicated.
+   */
+  private def alignToExpectedKeys(
+      keyMap: Map[InternalRowComparableWrapper, Seq[Int]],
+      numInputPartitions: Int) = {
     var isGrouped = true
+    var numReplicatedPartitions = 0
+    // Splits the alignment references, accumulated over the expected keys. Every producer of
+    // `expectedPartitionKeys` deduplicates the keys, so no split is counted twice here.
+    var numMatchedPartitions = 0
     val alignedPartitions = expectedPartitionKeys.get.flatMap { case (key, numSplits) =>
+      // Every producer derives the split counts from a `groupBy` size or the literal 1; a
+      // non-positive count would emit a different partition count for the key than the other
+      // side expects, breaking the pairing this alignment exists for.
+      assert(numSplits > 0, s"expected partition key split count must be positive: $numSplits")
       if (numSplits > 1) isGrouped = false
       val splits = keyMap.getOrElse(key, Seq.empty)
+      numMatchedPartitions += splits.size
       if (distributePartitions) {
         // Distribute splits across expected partitions, padding with empty sequences
         val paddedSplits = splits.map(Seq(_)).padTo(numSplits, Seq.empty)
         paddedSplits.map((key, _))
       } else {
+        // The slots beyond the first re-read the whole group. A key this side does not hold
+        // has no splits to re-read, so the product is 0 and no explicit guard is needed.
+        numReplicatedPartitions += (numSplits - 1) * splits.size
         // Replicate all splits to each expected partition
         Seq.fill(numSplits)((key, splits))
       }
     }
-    (alignedPartitions, isGrouped)
+    // The keyMap groups partition every input index, so the pruned inputs are the total minus
+    // the matched.
+    val numPrunedPartitions = numInputPartitions - numMatchedPartitions
+    (alignedPartitions, isGrouped, numPrunedPartitions, numReplicatedPartitions)
   }
 
   /**
@@ -214,11 +245,12 @@ case class GroupPartitionsExec(
 
     val keyToPartitionIndices = reducedKeys.zipWithIndex.groupMap(_._1)(_._2)
 
-    val (partitions, isGrouped) = if (expectedPartitionKeys.isDefined) {
-      alignToExpectedKeys(keyToPartitionIndices)
-    } else {
-      (groupAndSortByKeys(keyToPartitionIndices, reducedDataTypes), true)
-    }
+    val (partitions, isGrouped, numPrunedPartitions, numReplicatedPartitions) =
+      if (expectedPartitionKeys.isDefined) {
+        alignToExpectedKeys(keyToPartitionIndices, childKp.numPartitions)
+      } else {
+        (groupAndSortByKeys(keyToPartitionIndices, reducedDataTypes), true, 0, 0)
+      }
 
     // Both cheap terms come first, so the scan below runs only where a merge is possible. A
     // grouping that left the keys as they are groups the child's own key values, and one of those
@@ -247,7 +279,8 @@ case class GroupPartitionsExec(
         group.tail.exists(childKeys(_) != first)
       }
     }
-    PartitionGrouping(partitions, isGrouped, isCollapsed, keysRewritten)
+    PartitionGrouping(partitions, isGrouped, isCollapsed, keysRewritten,
+      childKp.numPartitions, numPrunedPartitions, numReplicatedPartitions)
   }
 
   /**
@@ -276,6 +309,34 @@ case class GroupPartitionsExec(
     grouping.partitions
 
   @transient private lazy val hasCoalescing: Boolean = groupedPartitions.exists(_._2.size > 1)
+
+  // All values are computed on the driver by `grouping`, so they are reported through
+  // `sendDriverMetrics` rather than task-side accumulators. Registration reads constructor
+  // parameters only: pruning and replication are facts of the alignment path and are registered
+  // only in the modes that produce them, while coalescing can happen in any mode and reports 0
+  // when nothing merged.
+  @transient override lazy val metrics: Map[String, SQLMetric] = Map(
+    "numInputPartitions" -> SQLMetrics.createMetric(sparkContext, "number of input partitions"),
+    "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions"),
+    "numEmptyPartitions" -> SQLMetrics.createMetric(sparkContext, "number of empty partitions"),
+    "numCoalescedPartitions" ->
+      SQLMetrics.createMetric(sparkContext, "number of coalesced partitions"),
+    "maxPartitionsPerGroup" ->
+      SQLMetrics.createMetric(sparkContext, "max partitions per group")) ++ {
+    if (expectedPartitionKeys.isDefined && !distributePartitions) {
+      Map("numReplicatedPartitions" -> SQLMetrics.createMetric(sparkContext,
+        "number of replicated input partition reads"))
+    } else {
+      Map.empty[String, SQLMetric]
+    }
+  } ++ {
+    if (expectedPartitionKeys.isDefined) {
+      Map("numPrunedPartitions" ->
+        SQLMetrics.createMetric(sparkContext, "number of pruned input partitions"))
+    } else {
+      Map.empty[String, SQLMetric]
+    }
+  }
 
   // Whether the child subtree is safe to use with SortedMergeCoalescedRDD (k-way merge).
   //
@@ -367,7 +428,47 @@ case class GroupPartitionsExec(
   private[v2] def kWayMergeOrdering: Seq[SortOrder] =
     child.outputOrdering.map(_.copy(sameOrderExpressions = Seq.empty))
 
+  private def sendDriverMetrics(): Unit = {
+    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    val driverAccumUpdates = ArrayBuffer.empty[(Long, Long)]
+    def set(name: String, value: Long): Unit = {
+      val metric = metrics(name)
+      metric.set(value)
+      driverAccumUpdates += (metric.id -> value)
+    }
+    // A single pass for the three per-group counts; an empty group and a coalesced one are
+    // mutually exclusive.
+    var numEmptyPartitions = 0
+    var numCoalescedPartitions = 0
+    var maxPartitionsPerGroup = 0
+    groupedPartitions.foreach { case (_, group) =>
+      val size = group.size
+      if (size == 0) {
+        numEmptyPartitions += 1
+      } else if (size > 1) {
+        numCoalescedPartitions += 1
+      }
+      if (size > maxPartitionsPerGroup) {
+        maxPartitionsPerGroup = size
+      }
+    }
+    set("numInputPartitions", grouping.numInputPartitions)
+    set("numPartitions", groupedPartitions.size)
+    set("numEmptyPartitions", numEmptyPartitions)
+    set("numCoalescedPartitions", numCoalescedPartitions)
+    set("maxPartitionsPerGroup", maxPartitionsPerGroup)
+    if (expectedPartitionKeys.isDefined && !distributePartitions) {
+      set("numReplicatedPartitions", grouping.numReplicatedPartitions)
+    }
+    if (expectedPartitionKeys.isDefined) {
+      set("numPrunedPartitions", grouping.numPrunedPartitions)
+    }
+    SQLMetrics.postDriverMetricsUpdatedByValue(
+      sparkContext, executionId, driverAccumUpdates.toSeq)
+  }
+
   override protected def doExecute(): RDD[InternalRow] = {
+    sendDriverMetrics()
     if (groupedPartitions.isEmpty) {
       sparkContext.emptyRDD
     } else if (usesSortedMerge) {
@@ -387,6 +488,7 @@ case class GroupPartitionsExec(
   override def supportsColumnar: Boolean = child.supportsColumnar && !usesSortedMerge
 
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    sendDriverMetrics()
     if (groupedPartitions.isEmpty) {
       sparkContext.emptyRDD
     } else {
@@ -464,12 +566,20 @@ case class GroupPartitionsExec(
   }
 }
 
-/** What a [[GroupPartitionsExec]] computes once and reports from several members. */
+/**
+ * What a [[GroupPartitionsExec]] computes once and reports from several members.
+ * `numInputPartitions` is the child's split count; the last two fields count the alignment's
+ * effect on the reads of those splits (see `alignToExpectedKeys`), and are 0 outside the
+ * alignment path.
+ */
 private case class PartitionGrouping(
     partitions: Seq[(InternalRowComparableWrapper, Seq[Int])],
     isGrouped: Boolean,
     isCollapsed: Boolean,
-    keysRewritten: Boolean)
+    keysRewritten: Boolean,
+    numInputPartitions: Int,
+    numPrunedPartitions: Int,
+    numReplicatedPartitions: Int)
 
 /**
  * A PartitionCoalescer that groups partitions according to a pre-computed grouping plan.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -171,7 +171,7 @@ case class GroupPartitionsExec(
       keyMap: Map[InternalRowComparableWrapper, Seq[Int]],
       numInputPartitions: Int) = {
     var isGrouped = true
-    var numReplicatedPartitions = 0
+    var numReplicatedPartitionReads = 0
     // Splits the alignment references, accumulated over the expected keys. Every producer of
     // `expectedPartitionKeys` deduplicates the keys, so no split is counted twice here.
     var numMatchedPartitions = 0
@@ -190,7 +190,7 @@ case class GroupPartitionsExec(
       } else {
         // The slots beyond the first re-read the whole group. A key this side does not hold
         // has no splits to re-read, so the product is 0 and no explicit guard is needed.
-        numReplicatedPartitions += (numSplits - 1) * splits.size
+        numReplicatedPartitionReads += (numSplits - 1) * splits.size
         // Replicate all splits to each expected partition
         Seq.fill(numSplits)((key, splits))
       }
@@ -198,7 +198,7 @@ case class GroupPartitionsExec(
     // The keyMap groups partition every input index, so the pruned inputs are the total minus
     // the matched.
     val numPrunedPartitions = numInputPartitions - numMatchedPartitions
-    (alignedPartitions, isGrouped, numPrunedPartitions, numReplicatedPartitions)
+    (alignedPartitions, isGrouped, numPrunedPartitions, numReplicatedPartitionReads)
   }
 
   /**
@@ -245,7 +245,7 @@ case class GroupPartitionsExec(
 
     val keyToPartitionIndices = reducedKeys.zipWithIndex.groupMap(_._1)(_._2)
 
-    val (partitions, isGrouped, numPrunedPartitions, numReplicatedPartitions) =
+    val (partitions, isGrouped, numPrunedPartitions, numReplicatedPartitionReads) =
       if (expectedPartitionKeys.isDefined) {
         alignToExpectedKeys(keyToPartitionIndices, childKp.numPartitions)
       } else {
@@ -280,7 +280,7 @@ case class GroupPartitionsExec(
       }
     }
     PartitionGrouping(partitions, isGrouped, isCollapsed, keysRewritten,
-      childKp.numPartitions, numPrunedPartitions, numReplicatedPartitions)
+      numPrunedPartitions, numReplicatedPartitionReads)
   }
 
   /**
@@ -312,9 +312,11 @@ case class GroupPartitionsExec(
 
   // All values are computed on the driver by `grouping`, so they are reported through
   // `sendDriverMetrics` rather than task-side accumulators. Registration reads constructor
-  // parameters only: pruning and replication are facts of the alignment path and are registered
-  // only in the modes that produce them, while coalescing can happen in any mode and reports 0
-  // when nothing merged.
+  // parameters only: replication needs an expected key with several slots, which the expected
+  // keys themselves show. Pruning is registered over the whole alignment path; the ordering
+  // producer expects the child's own keys and so never prunes, but no constructor parameter
+  // separates it from the join producers that can. Coalescing can happen in any mode and
+  // reports 0 when nothing merged.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map(
     "numInputPartitions" -> SQLMetrics.createMetric(sparkContext, "number of input partitions"),
     "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions"),
@@ -323,8 +325,8 @@ case class GroupPartitionsExec(
       SQLMetrics.createMetric(sparkContext, "number of coalesced partitions"),
     "maxPartitionsPerGroup" ->
       SQLMetrics.createMetric(sparkContext, "max partitions per group")) ++ {
-    if (expectedPartitionKeys.isDefined && !distributePartitions) {
-      Map("numReplicatedPartitions" -> SQLMetrics.createMetric(sparkContext,
+    if (expectedPartitionKeys.exists(_.exists(_._2 > 1)) && !distributePartitions) {
+      Map("numReplicatedPartitionReads" -> SQLMetrics.createMetric(sparkContext,
         "number of replicated input partition reads"))
     } else {
       Map.empty[String, SQLMetric]
@@ -431,8 +433,10 @@ case class GroupPartitionsExec(
   private def sendDriverMetrics(): Unit = {
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     val driverAccumUpdates = ArrayBuffer.empty[(Long, Long)]
-    def set(name: String, value: Long): Unit = {
-      val metric = metrics(name)
+    // `metrics` is the single source of truth for what this node reports: an unregistered name
+    // is skipped here instead of its registration condition being repeated. `SparkPlan.execute`
+    // memoizes `doExecute` per instance, so this posts at most once.
+    def set(name: String, value: Long): Unit = metrics.get(name).foreach { metric =>
       metric.set(value)
       driverAccumUpdates += (metric.id -> value)
     }
@@ -452,17 +456,13 @@ case class GroupPartitionsExec(
         maxPartitionsPerGroup = size
       }
     }
-    set("numInputPartitions", grouping.numInputPartitions)
+    set("numInputPartitions", child.outputPartitioning.numPartitions)
     set("numPartitions", groupedPartitions.size)
     set("numEmptyPartitions", numEmptyPartitions)
     set("numCoalescedPartitions", numCoalescedPartitions)
     set("maxPartitionsPerGroup", maxPartitionsPerGroup)
-    if (expectedPartitionKeys.isDefined && !distributePartitions) {
-      set("numReplicatedPartitions", grouping.numReplicatedPartitions)
-    }
-    if (expectedPartitionKeys.isDefined) {
-      set("numPrunedPartitions", grouping.numPrunedPartitions)
-    }
+    set("numReplicatedPartitionReads", grouping.numReplicatedPartitionReads)
+    set("numPrunedPartitions", grouping.numPrunedPartitions)
     SQLMetrics.postDriverMetricsUpdatedByValue(
       sparkContext, executionId, driverAccumUpdates.toSeq)
   }
@@ -567,19 +567,17 @@ case class GroupPartitionsExec(
 }
 
 /**
- * What a [[GroupPartitionsExec]] computes once and reports from several members.
- * `numInputPartitions` is the child's split count; the last two fields count the alignment's
- * effect on the reads of those splits (see `alignToExpectedKeys`), and are 0 outside the
- * alignment path.
+ * What a [[GroupPartitionsExec]] computes once and reports from several members. The last two
+ * fields count the alignment's effect on the reads of the child's splits (see
+ * `alignToExpectedKeys`), and are 0 outside the alignment path.
  */
 private case class PartitionGrouping(
     partitions: Seq[(InternalRowComparableWrapper, Seq[Int])],
     isGrouped: Boolean,
     isCollapsed: Boolean,
     keysRewritten: Boolean,
-    numInputPartitions: Int,
     numPrunedPartitions: Int,
-    numReplicatedPartitions: Int)
+    numReplicatedPartitionReads: Int)
 
 /**
  * A PartitionCoalescer that groups partitions according to a pre-computed grouping plan.

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -45,6 +45,8 @@ import org.apache.spark.sql.execution.{
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation, GroupPartitionsExec}
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec, ShuffleExchangeLike, ValidateRequirements}
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, ShuffledJoin, SortMergeJoinExec}
+import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.functions.{col, max}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf._
@@ -370,7 +372,7 @@ trait KeyGroupedPartitioningRuntimeFilterTests extends KeyGroupedPartitioningSui
 
 @ExtendedSQLTest
 class KeyGroupedPartitioningSuite
-  extends KeyGroupedPartitioningSuiteBase with ExplainSuiteHelper {
+  extends KeyGroupedPartitioningSuiteBase with ExplainSuiteHelper with SQLMetricsTestUtils {
   private val functions = Seq(
     UnboundYearsFunction,
     UnboundDaysFunction,
@@ -824,6 +826,199 @@ class KeyGroupedPartitioningSuite
     nodes.map(_.outputPartitioning)
       .flatMap(physical.PartitioningCollection.flatten)
       .collect { case kp: physical.KeyedPartitioning => kp }
+  }
+
+  /** Reads one metric of a plan-graph node back from the status store values. */
+  private def metricValue(
+      metricValues: Map[Long, String], node: SparkPlanGraphNode, name: String): String = {
+    val metric = node.metrics.find(_.name == name).getOrElse {
+      val names = node.metrics.map(_.name).mkString(", ")
+      fail(s"metric '$name' missing on ${node.name}: $names")
+    }
+    metricValues(metric.accumulatorId).replaceAll(",", "")
+  }
+
+  test("SPARK-59310: an inner join intersection prunes both sides") {
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true") {
+      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
+        createTable(items, itemsColumns, Array(identity("id")))
+        sql(s"INSERT INTO testcat.ns.$items VALUES " +
+            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 'aa', 41.0, cast('2020-01-15' as timestamp)), " +
+            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+            s"(2, 'bb', 10.5, cast('2020-01-01' as timestamp)), " +
+            s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        createTable(purchases, purchasesColumns, Array(identity("item_id")))
+        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
+            s"(1, 42.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 44.0, cast('2020-01-15' as timestamp)), " +
+            s"(1, 45.0, cast('2020-01-15' as timestamp)), " +
+            s"(2, 11.0, cast('2020-01-01' as timestamp)), " +
+            s"(4, 19.5, cast('2020-02-01' as timestamp))")
+
+        // The sides hold different keys ({1,2,3} vs {1,2,4}), so grouping alone cannot align
+        // them and the join pushes the inner intersection {1,2} down as the expected keys.
+        // Each side then coalesces its duplicate-key splits (items merges two groups of two,
+        // purchases one group of three) and prunes the one split of its unmatched key
+        // (items key 3, purchases key 4); nothing is empty or replicated.
+        // Both AQE arms run their own query and read their own execution's plan graph and
+        // metric values: the reporting chain must work with and without AQE.
+        Seq(false, true).foreach { aqeEnabled =>
+          withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqeEnabled.toString) {
+            val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
+              "ON i.id = p.item_id")
+            val previousExecutionIds = currentExecutionIds()
+            checkAnswer(df, Seq.fill(6)(Row(1L)) ++ Seq.fill(2)(Row(2L)))
+            val executionIds = currentExecutionIds().diff(previousExecutionIds)
+            assert(executionIds.size === 1)
+            val executionId = executionIds.head
+
+            // The metrics must survive the full reporting path: set on the driver during
+            // doExecute, posted to the listener bus, and readable back from the status store
+            // the SQL UI renders.
+            val metricValues = statusStore.executionMetrics(executionId)
+            val groupNodes =
+              statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
+            assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
+            groupNodes.foreach { node =>
+              assert(metricValue(metricValues, node, "number of input partitions") === "5")
+              assert(metricValue(metricValues, node, "number of partitions") === "2")
+              assert(metricValue(metricValues, node, "number of empty partitions") === "0")
+              assert(metricValue(metricValues, node, "number of pruned input partitions") === "1")
+              assert(!node.metrics.exists(
+                _.name == "number of replicated input partition reads"),
+                "no expected key carries multiple slots, so the metric stays unregistered")
+            }
+            assert(groupNodes.map(metricValue(metricValues, _, "number of coalesced partitions"))
+              .sorted === Seq("1", "2"))
+            assert(groupNodes.map(metricValue(metricValues, _, "max partitions per group"))
+              .sorted === Seq("2", "3"))
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-59310: a disjoint inner join prunes both sides to empty end to end") {
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true") {
+      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
+        createTable(items, itemsColumns, Array(identity("id")))
+        sql(s"INSERT INTO testcat.ns.$items VALUES " +
+            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp))")
+        createTable(purchases, purchasesColumns, Array(identity("item_id")))
+        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
+            s"(3, 42.0, cast('2020-01-01' as timestamp)), " +
+            s"(4, 44.0, cast('2020-01-15' as timestamp))")
+
+        // The key sets {1, 2} and {3, 4} are disjoint, so the inner join's intersection is
+        // empty: the alignment emits no output partition on either side, each side prunes both
+        // of its inputs, and doExecute takes the empty-RDD branch. The metrics are sent before
+        // that branch, so the total pruning still reaches the store. Both AQE arms run their
+        // own query and read their own execution's plan graph and metric values.
+        Seq(false, true).foreach { aqeEnabled =>
+          withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqeEnabled.toString) {
+            val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
+              "ON i.id = p.item_id")
+            val previousExecutionIds = currentExecutionIds()
+            checkAnswer(df, Nil)
+            val executionIds = currentExecutionIds().diff(previousExecutionIds)
+            assert(executionIds.size === 1)
+            val executionId = executionIds.head
+
+            val metricValues = statusStore.executionMetrics(executionId)
+            val groupNodes =
+              statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
+            assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
+            groupNodes.foreach { node =>
+              assert(metricValue(metricValues, node, "number of input partitions") === "2")
+              assert(metricValue(metricValues, node, "number of partitions") === "0")
+              assert(metricValue(metricValues, node, "number of pruned input partitions") === "2")
+              assert(metricValue(metricValues, node, "number of empty partitions") === "0")
+              assert(metricValue(metricValues, node, "number of coalesced partitions") === "0")
+              assert(metricValue(metricValues, node, "max partitions per group") === "0")
+              assert(!node.metrics.exists(
+                _.name == "number of replicated input partition reads"),
+                "an empty intersection carries no key with multiple slots")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-59310: partial clustering replicates the smaller side") {
+    withSQLConf(
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true") {
+      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
+        createTable(items, itemsColumns, Array(identity("id")))
+        sql(s"INSERT INTO testcat.ns.$items VALUES " +
+            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 'aa', 41.0, cast('2020-01-02' as timestamp)), " +
+            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+            s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        createTable(purchases, purchasesColumns, Array(identity("item_id")))
+        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
+            s"(1, 45.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 50.0, cast('2020-01-02' as timestamp)), " +
+            s"(1, 55.0, cast('2020-01-02' as timestamp)), " +
+            s"(2, 15.0, cast('2020-01-02' as timestamp)), " +
+            s"(2, 20.0, cast('2020-01-03' as timestamp)), " +
+            s"(2, 22.0, cast('2020-01-03' as timestamp)), " +
+            s"(3, 20.0, cast('2020-02-01' as timestamp))")
+
+        // Partial clustering picks the side with fewer splits to replicate: items (4 splits,
+        // key 1 x2, key 2 x1, key 3 x1) groups per key and copies each group into every
+        // expected slot, while purchases (7 splits) keeps them, one per slot. The slots come
+        // from purchases: key 1 x3, key 2 x3, key 3 x1. Items' extra reads: (3-1) x 2 splits
+        // for key 1, (3-1) x 1 for key 2, none for key 3's single slot. Both AQE arms run
+        // their own query and read their own execution's plan graph and metric values.
+        Seq(false, true).foreach { aqeEnabled =>
+          withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqeEnabled.toString) {
+            val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
+              "ON i.id = p.item_id")
+            val previousExecutionIds = currentExecutionIds()
+            checkAnswer(df, Seq.fill(6)(Row(1L)) ++ Seq.fill(3)(Row(2L)) ++ Seq(Row(3L)))
+            val executionIds = currentExecutionIds().diff(previousExecutionIds)
+            assert(executionIds.size === 1)
+            val executionId = executionIds.head
+
+            val metricValues = statusStore.executionMetrics(executionId)
+            val groupNodes =
+              statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
+            assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
+            val byInputPartitions = groupNodes.map { node =>
+              metricValue(metricValues, node, "number of input partitions") -> node
+            }.toMap
+            assert(byInputPartitions.keySet === Set("4", "7"))
+            val replicatedSide = byInputPartitions("4")
+            val distributeSide = byInputPartitions("7")
+            Seq(replicatedSide, distributeSide).foreach { node =>
+              assert(metricValue(metricValues, node, "number of partitions") === "7")
+              assert(metricValue(metricValues, node, "number of empty partitions") === "0")
+              assert(metricValue(metricValues, node, "number of pruned input partitions") === "0")
+            }
+            assert(metricValue(metricValues, replicatedSide,
+              "number of replicated input partition reads") === "6")
+            assert(!distributeSide.metrics.exists(
+              _.name == "number of replicated input partition reads"),
+              "the distribute side holds one split per slot and registers no replicated metric")
+            assert(metricValue(metricValues, replicatedSide,
+              "number of coalesced partitions") === "3",
+              "the three copies of key 1's two-split group each merge their splits")
+            assert(metricValue(metricValues, replicatedSide, "max partitions per group") === "2")
+            assert(metricValue(metricValues, distributeSide,
+              "number of coalesced partitions") === "0")
+            assert(metricValue(metricValues, distributeSide, "max partitions per group") === "1")
+          }
+        }
+      }
+    }
   }
 
   test("partitioned join: exact distribution (same number of buckets) from both sides") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -18,17 +18,22 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, KeyedPartitioning, KeyedShuffleSpec, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
+import org.apache.spark.sql.connector.KeyGroupedPartitioningSuiteBase
 import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, BucketReducer, Reducer}
+import org.apache.spark.sql.connector.expressions.Expressions.identity
 import org.apache.spark.sql.execution.{DummySparkPlan, LeafExecNode, SafeForKWayMerge}
+import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
+import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
-class GroupPartitionsExecSuite extends SharedSparkSession {
+class GroupPartitionsExecSuite
+  extends KeyGroupedPartitioningSuiteBase with SQLMetricsTestUtils {
 
   private val exprA = AttributeReference("a", IntegerType)()
   private val exprB = AttributeReference("b", IntegerType)()
@@ -36,6 +41,16 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
 
   private def row(a: Int): InternalRow = InternalRow.fromSeq(Seq(a))
   private def row(a: Int, b: Int): InternalRow = InternalRow.fromSeq(Seq(a, b))
+
+  /** Reads one metric of a plan-graph node back from the status store values. */
+  private def metricValue(
+      metricValues: Map[Long, String], node: SparkPlanGraphNode, name: String): String = {
+    val metric = node.metrics.find(_.name == name).getOrElse {
+      val names = node.metrics.map(_.name).mkString(", ")
+      fail(s"metric '$name' missing on ${node.name}: $names")
+    }
+    metricValues(metric.accumulatorId).replaceAll(",", "")
+  }
 
   test("SPARK-59057: the output flag reports what this node's grouping merges") {
     // Keys [(1,1), (1,2), (2,1)] projected onto position 0 give [1, 1, 2]. The first two groups
@@ -523,6 +538,281 @@ class GroupPartitionsExecSuite extends SharedSparkSession {
     assert(gpe.groupedPartitions.forall(_._2.size <= 1), "expected non-coalescing")
     withSQLConf(SQLConf.V2_BUCKETING_PRESERVE_ORDERING_ON_COALESCE_ENABLED.key -> "true") {
       assert(gpe.tryEnableSortedMerge().isEmpty)
+    }
+  }
+
+  test("SPARK-59310: basic counts without alignment") {
+    // Keys [1, 2, 1]: 3 input splits, key 1 coalesces partitions 0 and 2, 2 output partitions.
+    val child = ExecutableKeyedLeaf(KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(1))))
+    val gpe = GroupPartitionsExec(child)
+    gpe.execute()
+
+    assert(gpe.metrics("numInputPartitions").value === 3)
+    assert(gpe.metrics("numPartitions").value === 2)
+    assert(gpe.metrics("numEmptyPartitions").value === 0)
+    assert(gpe.metrics("numCoalescedPartitions").value === 1)
+    assert(gpe.metrics("maxPartitionsPerGroup").value === 2)
+    // Without expectedPartitionKeys there is no alignment, so its metrics stay unregistered.
+    assert(!gpe.metrics.contains("numPrunedPartitions"))
+    assert(!gpe.metrics.contains("numReplicatedPartitions"))
+  }
+
+  test("SPARK-59310: zero coalesced without duplicate keys") {
+    val child = ExecutableKeyedLeaf(KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(3))))
+    val gpe = GroupPartitionsExec(child)
+    gpe.execute()
+
+    assert(gpe.metrics("numCoalescedPartitions").value === 0)
+    assert(gpe.metrics("numPartitions").value === 3)
+    assert(gpe.metrics("maxPartitionsPerGroup").value === 1)
+  }
+
+  test("SPARK-59310: distribute alignment pads and never replicates") {
+    // Child splits: key 1 -> [0], key 2 -> [1, 2]. Expected: key 1 x1, key 2 x3, key 3 x1.
+    // Key 2 spreads its 2 splits over 3 expected partitions (one empty pad) and key 3 has no
+    // split (one more empty), so 5 output partitions with 2 empty and nothing coalesced.
+    def keyOf(a: Int): InternalRowComparableWrapper =
+      InternalRowComparableWrapper(row(a), Seq(exprA))
+    val child = ExecutableKeyedLeaf(KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(2))))
+    val gpe = GroupPartitionsExec(child,
+      expectedPartitionKeys = Some(Seq(keyOf(1) -> 1, keyOf(2) -> 3, keyOf(3) -> 1)),
+      distributePartitions = true)
+    gpe.execute()
+
+    assert(gpe.metrics("numInputPartitions").value === 3)
+    assert(gpe.metrics("numPartitions").value === 5)
+    assert(gpe.metrics("numEmptyPartitions").value === 2)
+    assert(gpe.metrics("numPrunedPartitions").value === 0)
+    assert(gpe.metrics("numCoalescedPartitions").value === 0, "distribute never coalesces")
+    assert(!gpe.metrics.contains("numReplicatedPartitions"), "distribute never replicates")
+  }
+
+  test("SPARK-59310: alignment prunes unmatched keys, pads missing ones") {
+    // The expected keys carry key 1 and a key-3 slot the child does not hold, as an inner
+    // join's intersection combined with the other side's layout would. The 2 splits of key 2
+    // cannot produce join output and never enter the alignment; the missing key 3 pads two
+    // empty output partitions, and being empty, replicates nothing despite its 2 slots.
+    def keyOf(a: Int): InternalRowComparableWrapper =
+      InternalRowComparableWrapper(row(a), Seq(exprA))
+    val child = ExecutableKeyedLeaf(KeyedPartitioning(Seq(exprA), Seq(row(1), row(2), row(2))))
+    val gpe = GroupPartitionsExec(child,
+      expectedPartitionKeys = Some(Seq(keyOf(1) -> 1, keyOf(3) -> 2)))
+    gpe.execute()
+
+    assert(gpe.metrics("numInputPartitions").value === 3)
+    assert(gpe.metrics("numPartitions").value === 3)
+    assert(gpe.metrics("numPrunedPartitions").value === 2)
+    assert(gpe.metrics("numEmptyPartitions").value === 2)
+    assert(gpe.metrics("numCoalescedPartitions").value === 0)
+    assert(gpe.metrics("maxPartitionsPerGroup").value === 1)
+    assert(gpe.metrics("numReplicatedPartitions").value === 0,
+      "empty groups replicate nothing, and the single-split key 1 has no copy")
+  }
+
+  test("SPARK-59310: replicate alignment counts the reads beyond the first") {
+    // The other join side expects 2 partitions for key 1, so this side's splits for the key are
+    // replicated to both: the slot beyond the first re-reads both splits, 2 extra input
+    // partition reads. Each output partition also coalesces the 2 splits of the key.
+    def keyOf(a: Int): InternalRowComparableWrapper =
+      InternalRowComparableWrapper(row(a), Seq(exprA))
+    val child = ExecutableKeyedLeaf(KeyedPartitioning(Seq(exprA), Seq(row(1), row(1))))
+    val gpe = GroupPartitionsExec(child, expectedPartitionKeys = Some(Seq(keyOf(1) -> 2)))
+    gpe.execute()
+
+    assert(gpe.metrics("numInputPartitions").value === 2)
+    assert(gpe.metrics("numPartitions").value === 2)
+    assert(gpe.metrics("numReplicatedPartitions").value === 2)
+    assert(gpe.metrics("numCoalescedPartitions").value === 2, "both copies merge the 2 splits")
+    assert(gpe.metrics("maxPartitionsPerGroup").value === 2)
+    assert(gpe.metrics("numEmptyPartitions").value === 0)
+    assert(gpe.metrics("numPrunedPartitions").value === 0)
+  }
+
+  test("SPARK-59310: an inner join intersection prunes both sides") {
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
+        createTable(items, itemsColumns, Array(identity("id")))
+        sql(s"INSERT INTO testcat.ns.$items VALUES " +
+            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 'aa', 41.0, cast('2020-01-15' as timestamp)), " +
+            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+            s"(2, 'bb', 10.5, cast('2020-01-01' as timestamp)), " +
+            s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        createTable(purchases, purchasesColumns, Array(identity("item_id")))
+        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
+            s"(1, 42.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 44.0, cast('2020-01-15' as timestamp)), " +
+            s"(1, 45.0, cast('2020-01-15' as timestamp)), " +
+            s"(2, 11.0, cast('2020-01-01' as timestamp)), " +
+            s"(4, 19.5, cast('2020-02-01' as timestamp))")
+
+        // The sides hold different keys ({1,2,3} vs {1,2,4}), so grouping alone cannot align
+        // them and the join pushes the inner intersection {1,2} down as the expected keys.
+        // Each side then coalesces its duplicate-key splits (items merges two groups of two,
+        // purchases one group of three) and prunes the one split of its unmatched key
+        // (items key 3, purchases key 4); nothing is empty or replicated.
+        // Both AQE arms: the query has no shuffle, so the executed nodes and their accumulator
+        // ids are the same with and without AQE, and the reporting chain must work in both.
+        Seq(false, true).foreach { aqeEnabled =>
+          withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqeEnabled.toString) {
+            val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
+              "ON i.id = p.item_id")
+            val previousExecutionIds = currentExecutionIds()
+            checkAnswer(df, Seq.fill(6)(Row(1L)) ++ Seq.fill(2)(Row(2L)))
+            val executionIds = currentExecutionIds().diff(previousExecutionIds)
+            assert(executionIds.size === 1)
+            val executionId = executionIds.head
+
+            // The metrics must survive the full reporting path: set on the driver during
+            // doExecute, posted to the listener bus, and readable back from the status store
+            // the SQL UI renders.
+            val metricValues = statusStore.executionMetrics(executionId)
+            val groupNodes =
+              statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
+            assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
+            groupNodes.foreach { node =>
+              assert(metricValue(metricValues, node, "number of input partitions") === "5")
+              assert(metricValue(metricValues, node, "number of partitions") === "2")
+              assert(metricValue(metricValues, node, "number of empty partitions") === "0")
+              assert(metricValue(metricValues, node, "number of pruned input partitions") === "1")
+              assert(metricValue(metricValues, node,
+                "number of replicated input partition reads") === "0",
+                "no expected key carries multiple splits, so nothing is replicated")
+            }
+            assert(groupNodes.map(metricValue(metricValues, _, "number of coalesced partitions"))
+              .sorted === Seq("1", "2"))
+            assert(groupNodes.map(metricValue(metricValues, _, "max partitions per group"))
+              .sorted === Seq("2", "3"))
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-59310: a disjoint inner join prunes both sides to empty end to end") {
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
+        createTable(items, itemsColumns, Array(identity("id")))
+        sql(s"INSERT INTO testcat.ns.$items VALUES " +
+            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp))")
+        createTable(purchases, purchasesColumns, Array(identity("item_id")))
+        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
+            s"(3, 42.0, cast('2020-01-01' as timestamp)), " +
+            s"(4, 44.0, cast('2020-01-15' as timestamp))")
+
+        // The key sets {1, 2} and {3, 4} are disjoint, so the inner join's intersection is
+        // empty: the alignment emits no output partition on either side, each side prunes both
+        // of its inputs, and doExecute takes the empty-RDD branch. The metrics are sent before
+        // that branch, so the total pruning still reaches the store.
+        val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
+          "ON i.id = p.item_id")
+        val previousExecutionIds = currentExecutionIds()
+        checkAnswer(df, Nil)
+        val executionIds = currentExecutionIds().diff(previousExecutionIds)
+        assert(executionIds.size === 1)
+        val executionId = executionIds.head
+
+        val metricValues = statusStore.executionMetrics(executionId)
+        val groupNodes =
+          statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
+        assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
+        groupNodes.foreach { node =>
+          assert(metricValue(metricValues, node, "number of input partitions") === "2")
+          assert(metricValue(metricValues, node, "number of partitions") === "0")
+          assert(metricValue(metricValues, node, "number of pruned input partitions") === "2")
+          assert(metricValue(metricValues, node, "number of empty partitions") === "0")
+          assert(metricValue(metricValues, node, "number of coalesced partitions") === "0")
+          assert(metricValue(metricValues, node, "max partitions per group") === "0")
+          assert(metricValue(metricValues, node,
+            "number of replicated input partition reads") === "0")
+        }
+      }
+    }
+  }
+
+  test("SPARK-59310: partial clustering replicates the smaller side") {
+    withSQLConf(
+        SQLConf.V2_BUCKETING_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
+        createTable(items, itemsColumns, Array(identity("id")))
+        sql(s"INSERT INTO testcat.ns.$items VALUES " +
+            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 'aa', 41.0, cast('2020-01-02' as timestamp)), " +
+            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+            s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        createTable(purchases, purchasesColumns, Array(identity("item_id")))
+        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
+            s"(1, 45.0, cast('2020-01-01' as timestamp)), " +
+            s"(1, 50.0, cast('2020-01-02' as timestamp)), " +
+            s"(1, 55.0, cast('2020-01-02' as timestamp)), " +
+            s"(2, 15.0, cast('2020-01-02' as timestamp)), " +
+            s"(2, 20.0, cast('2020-01-03' as timestamp)), " +
+            s"(2, 22.0, cast('2020-01-03' as timestamp)), " +
+            s"(3, 20.0, cast('2020-02-01' as timestamp))")
+
+        // Partial clustering picks the side with fewer splits to replicate: items (4 splits,
+        // key 1 x2, key 2 x1, key 3 x1) groups per key and copies each group into every
+        // expected slot, while purchases (7 splits) keeps them, one per slot. The slots come
+        // from purchases: key 1 x3, key 2 x3, key 3 x1. Items' extra reads: (3-1) x 2 splits
+        // for key 1, (3-1) x 1 for key 2, none for key 3's single slot.
+        val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
+          "ON i.id = p.item_id")
+        val previousExecutionIds = currentExecutionIds()
+        checkAnswer(df, Seq.fill(6)(Row(1L)) ++ Seq.fill(3)(Row(2L)) ++ Seq(Row(3L)))
+        val executionIds = currentExecutionIds().diff(previousExecutionIds)
+        assert(executionIds.size === 1)
+        val executionId = executionIds.head
+
+        val metricValues = statusStore.executionMetrics(executionId)
+        val groupNodes =
+          statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
+        assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
+        val byInputPartitions = groupNodes.map { node =>
+          metricValue(metricValues, node, "number of input partitions") -> node
+        }.toMap
+        assert(byInputPartitions.keySet === Set("4", "7"))
+        val replicatedSide = byInputPartitions("4")
+        val distributeSide = byInputPartitions("7")
+        Seq(replicatedSide, distributeSide).foreach { node =>
+          assert(metricValue(metricValues, node, "number of partitions") === "7")
+          assert(metricValue(metricValues, node, "number of empty partitions") === "0")
+          assert(metricValue(metricValues, node, "number of pruned input partitions") === "0")
+        }
+        assert(metricValue(metricValues, replicatedSide,
+          "number of replicated input partition reads") === "6")
+        assert(!distributeSide.metrics.exists(
+          _.name == "number of replicated input partition reads"),
+          "the distribute side holds one split per slot and registers no replicated metric")
+        assert(metricValue(metricValues, replicatedSide, "number of coalesced partitions") === "3",
+          "the three copies of key 1's two-split group each merge their splits")
+        assert(metricValue(metricValues, replicatedSide, "max partitions per group") === "2")
+        assert(metricValue(metricValues, distributeSide, "number of coalesced partitions") === "0")
+        assert(metricValue(metricValues, distributeSide, "max partitions per group") === "1")
+      }
+    }
+  }
+
+  private case class ExecutableKeyedLeaf(kp: KeyedPartitioning)
+    extends LeafExecNode with SafeForKWayMerge {
+    override def outputPartitioning: Partitioning = kp
+    override def output: Seq[Attribute] = Seq(AttributeReference("a", IntegerType)())
+    override protected def doExecute(): RDD[InternalRow] = {
+      val n = kp.numPartitions
+      sparkContext.parallelize(0 until n, n).map(i => InternalRow(i))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExecSuite.scala
@@ -17,23 +17,19 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, KeyedPartitioning, KeyedShuffleSpec, KeyReducer, Partitioning, PartitioningCollection, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
-import org.apache.spark.sql.connector.KeyGroupedPartitioningSuiteBase
 import org.apache.spark.sql.connector.catalog.functions.{BucketFunction, BucketReducer, Reducer}
-import org.apache.spark.sql.connector.expressions.Expressions.identity
 import org.apache.spark.sql.execution.{DummySparkPlan, LeafExecNode, SafeForKWayMerge}
-import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
-import org.apache.spark.sql.execution.ui.SparkPlanGraphNode
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
-class GroupPartitionsExecSuite
-  extends KeyGroupedPartitioningSuiteBase with SQLMetricsTestUtils {
+class GroupPartitionsExecSuite extends SharedSparkSession {
 
   private val exprA = AttributeReference("a", IntegerType)()
   private val exprB = AttributeReference("b", IntegerType)()
@@ -41,16 +37,6 @@ class GroupPartitionsExecSuite
 
   private def row(a: Int): InternalRow = InternalRow.fromSeq(Seq(a))
   private def row(a: Int, b: Int): InternalRow = InternalRow.fromSeq(Seq(a, b))
-
-  /** Reads one metric of a plan-graph node back from the status store values. */
-  private def metricValue(
-      metricValues: Map[Long, String], node: SparkPlanGraphNode, name: String): String = {
-    val metric = node.metrics.find(_.name == name).getOrElse {
-      val names = node.metrics.map(_.name).mkString(", ")
-      fail(s"metric '$name' missing on ${node.name}: $names")
-    }
-    metricValues(metric.accumulatorId).replaceAll(",", "")
-  }
 
   test("SPARK-59057: the output flag reports what this node's grouping merges") {
     // Keys [(1,1), (1,2), (2,1)] projected onto position 0 give [1, 1, 2]. The first two groups
@@ -554,7 +540,7 @@ class GroupPartitionsExecSuite
     assert(gpe.metrics("maxPartitionsPerGroup").value === 2)
     // Without expectedPartitionKeys there is no alignment, so its metrics stay unregistered.
     assert(!gpe.metrics.contains("numPrunedPartitions"))
-    assert(!gpe.metrics.contains("numReplicatedPartitions"))
+    assert(!gpe.metrics.contains("numReplicatedPartitionReads"))
   }
 
   test("SPARK-59310: zero coalesced without duplicate keys") {
@@ -584,7 +570,7 @@ class GroupPartitionsExecSuite
     assert(gpe.metrics("numEmptyPartitions").value === 2)
     assert(gpe.metrics("numPrunedPartitions").value === 0)
     assert(gpe.metrics("numCoalescedPartitions").value === 0, "distribute never coalesces")
-    assert(!gpe.metrics.contains("numReplicatedPartitions"), "distribute never replicates")
+    assert(!gpe.metrics.contains("numReplicatedPartitionReads"), "distribute never replicates")
   }
 
   test("SPARK-59310: alignment prunes unmatched keys, pads missing ones") {
@@ -605,7 +591,7 @@ class GroupPartitionsExecSuite
     assert(gpe.metrics("numEmptyPartitions").value === 2)
     assert(gpe.metrics("numCoalescedPartitions").value === 0)
     assert(gpe.metrics("maxPartitionsPerGroup").value === 1)
-    assert(gpe.metrics("numReplicatedPartitions").value === 0,
+    assert(gpe.metrics("numReplicatedPartitionReads").value === 0,
       "empty groups replicate nothing, and the single-split key 1 has no copy")
   }
 
@@ -621,199 +607,11 @@ class GroupPartitionsExecSuite
 
     assert(gpe.metrics("numInputPartitions").value === 2)
     assert(gpe.metrics("numPartitions").value === 2)
-    assert(gpe.metrics("numReplicatedPartitions").value === 2)
+    assert(gpe.metrics("numReplicatedPartitionReads").value === 2)
     assert(gpe.metrics("numCoalescedPartitions").value === 2, "both copies merge the 2 splits")
     assert(gpe.metrics("maxPartitionsPerGroup").value === 2)
     assert(gpe.metrics("numEmptyPartitions").value === 0)
     assert(gpe.metrics("numPrunedPartitions").value === 0)
-  }
-
-  test("SPARK-59310: an inner join intersection prunes both sides") {
-    withSQLConf(
-        SQLConf.V2_BUCKETING_ENABLED.key -> "true",
-        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
-        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true",
-        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
-        createTable(items, itemsColumns, Array(identity("id")))
-        sql(s"INSERT INTO testcat.ns.$items VALUES " +
-            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
-            s"(1, 'aa', 41.0, cast('2020-01-15' as timestamp)), " +
-            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
-            s"(2, 'bb', 10.5, cast('2020-01-01' as timestamp)), " +
-            s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
-        createTable(purchases, purchasesColumns, Array(identity("item_id")))
-        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-            s"(1, 42.0, cast('2020-01-01' as timestamp)), " +
-            s"(1, 44.0, cast('2020-01-15' as timestamp)), " +
-            s"(1, 45.0, cast('2020-01-15' as timestamp)), " +
-            s"(2, 11.0, cast('2020-01-01' as timestamp)), " +
-            s"(4, 19.5, cast('2020-02-01' as timestamp))")
-
-        // The sides hold different keys ({1,2,3} vs {1,2,4}), so grouping alone cannot align
-        // them and the join pushes the inner intersection {1,2} down as the expected keys.
-        // Each side then coalesces its duplicate-key splits (items merges two groups of two,
-        // purchases one group of three) and prunes the one split of its unmatched key
-        // (items key 3, purchases key 4); nothing is empty or replicated.
-        // Both AQE arms: the query has no shuffle, so the executed nodes and their accumulator
-        // ids are the same with and without AQE, and the reporting chain must work in both.
-        Seq(false, true).foreach { aqeEnabled =>
-          withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqeEnabled.toString) {
-            val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
-              "ON i.id = p.item_id")
-            val previousExecutionIds = currentExecutionIds()
-            checkAnswer(df, Seq.fill(6)(Row(1L)) ++ Seq.fill(2)(Row(2L)))
-            val executionIds = currentExecutionIds().diff(previousExecutionIds)
-            assert(executionIds.size === 1)
-            val executionId = executionIds.head
-
-            // The metrics must survive the full reporting path: set on the driver during
-            // doExecute, posted to the listener bus, and readable back from the status store
-            // the SQL UI renders.
-            val metricValues = statusStore.executionMetrics(executionId)
-            val groupNodes =
-              statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
-            assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
-            groupNodes.foreach { node =>
-              assert(metricValue(metricValues, node, "number of input partitions") === "5")
-              assert(metricValue(metricValues, node, "number of partitions") === "2")
-              assert(metricValue(metricValues, node, "number of empty partitions") === "0")
-              assert(metricValue(metricValues, node, "number of pruned input partitions") === "1")
-              assert(metricValue(metricValues, node,
-                "number of replicated input partition reads") === "0",
-                "no expected key carries multiple splits, so nothing is replicated")
-            }
-            assert(groupNodes.map(metricValue(metricValues, _, "number of coalesced partitions"))
-              .sorted === Seq("1", "2"))
-            assert(groupNodes.map(metricValue(metricValues, _, "max partitions per group"))
-              .sorted === Seq("2", "3"))
-          }
-        }
-      }
-    }
-  }
-
-  test("SPARK-59310: a disjoint inner join prunes both sides to empty end to end") {
-    withSQLConf(
-        SQLConf.V2_BUCKETING_ENABLED.key -> "true",
-        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
-        SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true",
-        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
-      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
-        createTable(items, itemsColumns, Array(identity("id")))
-        sql(s"INSERT INTO testcat.ns.$items VALUES " +
-            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
-            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp))")
-        createTable(purchases, purchasesColumns, Array(identity("item_id")))
-        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-            s"(3, 42.0, cast('2020-01-01' as timestamp)), " +
-            s"(4, 44.0, cast('2020-01-15' as timestamp))")
-
-        // The key sets {1, 2} and {3, 4} are disjoint, so the inner join's intersection is
-        // empty: the alignment emits no output partition on either side, each side prunes both
-        // of its inputs, and doExecute takes the empty-RDD branch. The metrics are sent before
-        // that branch, so the total pruning still reaches the store.
-        val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
-          "ON i.id = p.item_id")
-        val previousExecutionIds = currentExecutionIds()
-        checkAnswer(df, Nil)
-        val executionIds = currentExecutionIds().diff(previousExecutionIds)
-        assert(executionIds.size === 1)
-        val executionId = executionIds.head
-
-        val metricValues = statusStore.executionMetrics(executionId)
-        val groupNodes =
-          statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
-        assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
-        groupNodes.foreach { node =>
-          assert(metricValue(metricValues, node, "number of input partitions") === "2")
-          assert(metricValue(metricValues, node, "number of partitions") === "0")
-          assert(metricValue(metricValues, node, "number of pruned input partitions") === "2")
-          assert(metricValue(metricValues, node, "number of empty partitions") === "0")
-          assert(metricValue(metricValues, node, "number of coalesced partitions") === "0")
-          assert(metricValue(metricValues, node, "max partitions per group") === "0")
-          assert(metricValue(metricValues, node,
-            "number of replicated input partition reads") === "0")
-        }
-      }
-    }
-  }
-
-  test("SPARK-59310: partial clustering replicates the smaller side") {
-    withSQLConf(
-        SQLConf.V2_BUCKETING_ENABLED.key -> "true",
-        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
-        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "true",
-        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
-      withTable(s"testcat.ns.$items", s"testcat.ns.$purchases") {
-        createTable(items, itemsColumns, Array(identity("id")))
-        sql(s"INSERT INTO testcat.ns.$items VALUES " +
-            s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
-            s"(1, 'aa', 41.0, cast('2020-01-02' as timestamp)), " +
-            s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
-            s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
-        createTable(purchases, purchasesColumns, Array(identity("item_id")))
-        sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-            s"(1, 45.0, cast('2020-01-01' as timestamp)), " +
-            s"(1, 50.0, cast('2020-01-02' as timestamp)), " +
-            s"(1, 55.0, cast('2020-01-02' as timestamp)), " +
-            s"(2, 15.0, cast('2020-01-02' as timestamp)), " +
-            s"(2, 20.0, cast('2020-01-03' as timestamp)), " +
-            s"(2, 22.0, cast('2020-01-03' as timestamp)), " +
-            s"(3, 20.0, cast('2020-02-01' as timestamp))")
-
-        // Partial clustering picks the side with fewer splits to replicate: items (4 splits,
-        // key 1 x2, key 2 x1, key 3 x1) groups per key and copies each group into every
-        // expected slot, while purchases (7 splits) keeps them, one per slot. The slots come
-        // from purchases: key 1 x3, key 2 x3, key 3 x1. Items' extra reads: (3-1) x 2 splits
-        // for key 1, (3-1) x 1 for key 2, none for key 3's single slot.
-        val df = sql(s"SELECT i.id FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
-          "ON i.id = p.item_id")
-        val previousExecutionIds = currentExecutionIds()
-        checkAnswer(df, Seq.fill(6)(Row(1L)) ++ Seq.fill(3)(Row(2L)) ++ Seq(Row(3L)))
-        val executionIds = currentExecutionIds().diff(previousExecutionIds)
-        assert(executionIds.size === 1)
-        val executionId = executionIds.head
-
-        val metricValues = statusStore.executionMetrics(executionId)
-        val groupNodes =
-          statusStore.planGraph(executionId).nodes.filter(_.name == "GroupPartitions")
-        assert(groupNodes.size === 2, "one GroupPartitionsExec per join side")
-        val byInputPartitions = groupNodes.map { node =>
-          metricValue(metricValues, node, "number of input partitions") -> node
-        }.toMap
-        assert(byInputPartitions.keySet === Set("4", "7"))
-        val replicatedSide = byInputPartitions("4")
-        val distributeSide = byInputPartitions("7")
-        Seq(replicatedSide, distributeSide).foreach { node =>
-          assert(metricValue(metricValues, node, "number of partitions") === "7")
-          assert(metricValue(metricValues, node, "number of empty partitions") === "0")
-          assert(metricValue(metricValues, node, "number of pruned input partitions") === "0")
-        }
-        assert(metricValue(metricValues, replicatedSide,
-          "number of replicated input partition reads") === "6")
-        assert(!distributeSide.metrics.exists(
-          _.name == "number of replicated input partition reads"),
-          "the distribute side holds one split per slot and registers no replicated metric")
-        assert(metricValue(metricValues, replicatedSide, "number of coalesced partitions") === "3",
-          "the three copies of key 1's two-split group each merge their splits")
-        assert(metricValue(metricValues, replicatedSide, "max partitions per group") === "2")
-        assert(metricValue(metricValues, distributeSide, "number of coalesced partitions") === "0")
-        assert(metricValue(metricValues, distributeSide, "max partitions per group") === "1")
-      }
-    }
-  }
-
-  private case class ExecutableKeyedLeaf(kp: KeyedPartitioning)
-    extends LeafExecNode with SafeForKWayMerge {
-    override def outputPartitioning: Partitioning = kp
-    override def output: Seq[Attribute] = Seq(AttributeReference("a", IntegerType)())
-    override protected def doExecute(): RDD[InternalRow] = {
-      val n = kp.numPartitions
-      sparkContext.parallelize(0 until n, n).map(i => InternalRow(i))
-    }
   }
 }
 
@@ -824,4 +622,15 @@ private case class DummyLeafSparkPlan(
   override protected def doExecute(): RDD[InternalRow] =
     throw new UnsupportedOperationException
   override def output: Seq[Attribute] = Seq.empty
+}
+
+/** An executable leaf reporting one partition per partition key, for metric value tests. */
+private case class ExecutableKeyedLeaf(kp: KeyedPartitioning)
+  extends LeafExecNode with SafeForKWayMerge {
+  override def outputPartitioning: Partitioning = kp
+  override def output: Seq[Attribute] = Seq(AttributeReference("a", IntegerType)())
+  override protected def doExecute(): RDD[InternalRow] = {
+    val n = kp.numPartitions
+    SparkContext.getActive.get.parallelize(0 until n, n).map(i => InternalRow(i))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`GroupPartitionsExec` computes the whole partition alignment on the driver but reported
nothing. This PR adds seven driver-side metrics, set in `doExecute`/`doExecuteColumnar` and
posted through `SQLMetrics.postDriverMetricsUpdatedByValue`, following
`AQEShuffleReadExec.sendDriverMetrics`:

| metric | UI description | registered |
|---|---|---|
| `numInputPartitions` | number of input partitions | always |
| `numPartitions` | number of partitions (output) | always |
| `numEmptyPartitions` | number of empty partitions | always |
| `numCoalescedPartitions` | number of coalesced partitions | always |
| `maxPartitionsPerGroup` | max partitions per group | always |
| `numPrunedPartitions` | number of pruned input partitions | alignment path |
| `numReplicatedPartitionReads` | number of replicated input partition reads | replicate mode, only when an expected key carries multiple slots |

Semantics, all in input partition reads against the baseline of every input being read once:

- pruned: inputs of a key the alignment never references. The join proved such keys cannot
  produce output, e.g. an inner join keeps only the intersection (`mergeAndDedupPartitions`
  with `spark.sql.sources.v2.bucketing.partitionFilter.enabled`).
- replicated: reads beyond the first pass. In the replicate mode of partial clustering every
  expected partition of a held key re-reads all its splits, so a key with 3 splits over 2
  slots counts 3. The two close the accounting: total input reads = `numInputPartitions` -
  pruned + replicated, which is what explains an inflated scan row count.
- coalesced counts output groups merging more than one input, so a replicated copy of a
  multi-split group is counted by both, by design (one says "merges inputs", the other says
  "is a redundant re-read").

The pruned and replicated counts are accumulated in the existing single pass of
`alignToExpectedKeys` (pruned as total minus matched, relying on the producers
deduplicating the expected keys). Registration reads constructor parameters only, so
rendering a plan never forces the grouping. An `assert(numSplits > 0)` pins the expected-key
split-count contract the derivation relies on.

`sendDriverMetrics` skips names the metrics map does not hold, so registration is the single
source of truth for what is reported. The two accounting metrics and `max partitions per
group` are documented in the SQL metrics table of `docs/web-ui.md`.

No plan shape, result, or explain/description change; the metrics are additive.

### Why are the changes needed?

The alignment decisions this node makes are invisible today:

- partial clustering replicates a side's key groups, re-reading data; the only symptom is an
  inflated scan `numOutputRows` with nothing to explain the multiplier;
- an inner join's intersection prunes whole input partitions at runtime; nothing reports how
  much of a side was skipped;
- distribute-mode padding, coalescing, and per-key group skew (a key holding many splits
  becomes one big task) have no counters either.

These are exactly the numbers needed to tell whether an SPJ alignment saved work or
amplified it.

### Does this PR introduce _any_ user-facing change?

Yes, additive: the SQL UI shows the metrics above on `GroupPartitions` nodes of
storage-partitioned join plans (and single-child grouping plans). No behavior, plan, or
result change compared to released versions.

### How was this patch tested?

New tests in `GroupPartitionsExecSuite`:

- unit: plain-grouping counts; zero coalesced without duplicate keys; distribute alignment
  padding; intersection pruning plus missing-key padding (replicated stays 0 for an empty
  group); replicate alignment read counts, including the coalesced/replicated overlap;
- end to end through the SQL status store (`planGraph` + `executionMetrics`), in
  `KeyGroupedPartitioningSuite`, each run with AQE on and off: an inner join whose sides hold
  different keys prunes both sides; a disjoint inner join whose intersection is empty, where
  both sides prune every input and still report from the empty-RDD branch; a partial
  clustering join where the smaller side replicates (`replicated = (3-1)*2 + (3-1)*1 = 6`,
  distribute side registers no replicated metric). The two-sided e2e assertions identify each
  side by its input-partition count, so a change in the replicate-side heuristic fails loudly
  instead of drifting.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (qwen3.8-max)

